### PR TITLE
fix: account for crashes of llk tests against ttsim

### DIFF
--- a/.github/workflows/llk-ttsim-regression.yaml
+++ b/.github/workflows/llk-ttsim-regression.yaml
@@ -114,6 +114,14 @@ jobs:
           if [[ -f "${RESULTS_DIR}/latest.html" ]]; then
             cp -L "${RESULTS_DIR}/latest.html" "${ARTIFACT_DIR}/ttsim-${{ matrix.architecture }}.html"
           fi
+          # Record how many tests were *enumerated* (collected) so downstream
+          # jobs can compute crashed = enumerated − finished without re-running
+          # collection. A tiny count file keeps the artifact lean (the full
+          # node-id list can be tens of thousands of lines).
+          if [[ -f "${RESULTS_DIR}/latest.collected.txt" ]]; then
+            wc -l < "${RESULTS_DIR}/latest.collected.txt" | tr -d ' ' \
+              > "${ARTIFACT_DIR}/ttsim-${{ matrix.architecture }}.enumerated"
+          fi
           # Include the version pin so the weekly digest can read the
           # simulator version from the artifact (no extra checkout needed).
           VERSION_FILE="${GITHUB_WORKSPACE}/${{ env.LLK_PATH }}/tests/ttsim-version"
@@ -146,6 +154,7 @@ jobs:
         env:
           ARCH: ${{ matrix.architecture }}
           XML_PATH: ttsim-report-${{ matrix.architecture }}/ttsim-${{ matrix.architecture }}.xml
+          ENUM_PATH: ttsim-report-${{ matrix.architecture }}/ttsim-${{ matrix.architecture }}.enumerated
         run: |
           set -euo pipefail
 
@@ -160,7 +169,7 @@ jobs:
 
           if [[ ! -f "$XML_PATH" ]]; then
             echo "No JUnit XML found at $XML_PATH — the regression likely never produced a report." >> "$GITHUB_STEP_SUMMARY"
-            for k in total ran passed failed errored skipped pass_pct; do
+            for k in total ran passed failed errored skipped pass_pct enumerated finished crashed; do
               echo "${k}=0" >> "$GITHUB_OUTPUT"
             done
             echo "status=no-report" >> "$GITHUB_OUTPUT"
@@ -187,12 +196,30 @@ jobs:
           passed = max(ran - failed, 0)
           pass_pct = (100.0 * passed / ran) if ran else 0.0
 
+          # "finished" = tests that produced a JUnit testcase (== total here);
+          # "crashed" = enumerated − finished, i.e. tests that were collected
+          # but whose worker died before recording a result. enumerated comes
+          # from the count file staged alongside the XML; if it is missing we
+          # leave both blank so the summary shows "n/a" rather than a wrong 0.
+          enumerated = None
+          enum_path = os.environ.get("ENUM_PATH", "")
+          if enum_path and os.path.isfile(enum_path):
+              try:
+                  enumerated = int(open(enum_path).read().strip())
+              except (ValueError, OSError):
+                  enumerated = None
+          finished = total
+          crashed = max(enumerated - finished, 0) if enumerated is not None else None
+
           print(f"total={total}")
           print(f"ran={ran}")
           print(f"passed={passed}")
           print(f"failed={failed}")
           print(f"skipped={skipped}")
           print(f"pass_pct={pass_pct:.1f}")
+          print(f"enumerated={'' if enumerated is None else enumerated}")
+          print(f"finished={finished}")
+          print(f"crashed={'' if crashed is None else crashed}")
           print("status=parsed")
           PY
 
@@ -200,6 +227,9 @@ jobs:
 
           # shellcheck source=/dev/null
           source /tmp/ttsim-summary.env
+
+          enumerated_disp="${enumerated:-}"; [[ -z "$enumerated_disp" ]] && enumerated_disp="n/a"
+          crashed_disp="${crashed:-}";       [[ -z "$crashed_disp" ]] && crashed_disp="n/a"
 
           {
             echo "## ttsim regression: ${ARCH}"
@@ -209,11 +239,13 @@ jobs:
             echo "| Metric | Value |"
             echo "|---|---:|"
             echo "| 🏷️ ttsim version | v${TTSIM_VERSION} |"
-            echo "| 🔢 Total | ${total} |"
+            echo "| 🧮 Enumerated | ${enumerated_disp} |"
+            echo "| 🏁 Finished | ${finished} |"
             echo "| ▶️ Ran | ${ran} |"
             echo "| ✅ Passed | ${passed} |"
             echo "| ❌ Failed | ${failed} |"
             echo "| ⏩ Skipped | ${skipped} |"
+            echo "| 💥 Crashed | ${crashed_disp} |"
             echo "| 📈 Pass rate | ${pass_pct}% |"
             echo ""
             echo "HTML report: available in the \`ttsim-report-${ARCH}\` artifact of this run."

--- a/.github/workflows/llk-ttsim-weekly.yaml
+++ b/.github/workflows/llk-ttsim-weekly.yaml
@@ -129,7 +129,15 @@ jobs:
                   if TTSIM_VERSION != "unknown":
                       break
 
-          def summarize(xml_path: Path):
+          def read_enumerated(enum_path: Path):
+              # The regression job stages a tiny count file next to the XML
+              # holding how many tests pytest --collect-only enumerated.
+              try:
+                  return int(enum_path.read_text().strip())
+              except (ValueError, OSError):
+                  return None
+
+          def summarize(xml_path: Path, enum_path: Path):
               if not xml_path.is_file():
                   return None
               root = ET.parse(xml_path).getroot()
@@ -142,26 +150,38 @@ jobs:
               ran = max(total - skipped, 0)
               passed = max(ran - failed, 0)
               pct = (100.0 * passed / ran) if ran else 0.0
+              # "finished" = testcases recorded in the XML; "crashed" =
+              # enumerated − finished (collected but never reported because the
+              # worker died first). enumerated may be unavailable on older runs.
+              finished = total
+              enumerated = read_enumerated(enum_path)
+              crashed = max(enumerated - finished, 0) if enumerated is not None else None
               return dict(total=total, ran=ran, passed=passed, failed=failed,
-                          skipped=skipped, pass_pct=pct)
+                          skipped=skipped, pass_pct=pct, finished=finished,
+                          enumerated=enumerated, crashed=crashed)
 
           archs = [
-              ("Blackhole", Path("reports/blackhole/ttsim-blackhole.xml")),
-              ("Wormhole",  Path("reports/wormhole/ttsim-wormhole.xml")),
+              ("Blackhole", Path("reports/blackhole/ttsim-blackhole.xml"),
+                            Path("reports/blackhole/ttsim-blackhole.enumerated")),
+              ("Wormhole",  Path("reports/wormhole/ttsim-wormhole.xml"),
+                            Path("reports/wormhole/ttsim-wormhole.enumerated")),
           ]
 
           lines = []
-          for label, xml in archs:
-              s = summarize(xml)
+          for label, xml, enum in archs:
+              s = summarize(xml, enum)
               if s is None:
                   lines.append(f"• *{label}*: no report produced (infra error — see run logs).")
               else:
+                  crashed_txt = "n/a" if s["crashed"] is None else str(s["crashed"])
                   lines.append(
                       f"• *{label}*: "
                       f"✅ {s['passed']}/{s['ran']} passing "
                       f"({s['pass_pct']:.1f}%) · "
                       f"❌ {s['failed']} failed · "
-                      f"⏩ {s['skipped']} skipped"
+                      f"⏩ {s['skipped']} skipped · "
+                      f"🏁 {s['finished']} finished · "
+                      f"💥 {crashed_txt} crashed"
                   )
 
           header = f"📊 *LLK ttsim weekly digest (v{TTSIM_VERSION})* 📊"

--- a/.github/workflows/llk-ttsim-weekly.yaml
+++ b/.github/workflows/llk-ttsim-weekly.yaml
@@ -147,15 +147,19 @@ jobs:
                   total   += int(s.attrib.get("tests",    0) or 0)
                   failed  += int(s.attrib.get("failures", 0) or 0)
                   skipped += int(s.attrib.get("skipped",  0) or 0)
-              ran = max(total - skipped, 0)
-              passed = max(ran - failed, 0)
-              pct = (100.0 * passed / ran) if ran else 0.0
               # "finished" = testcases recorded in the XML; "crashed" =
               # enumerated − finished (collected but never reported because the
               # worker died first). enumerated may be unavailable on older runs.
               finished = total
               enumerated = read_enumerated(enum_path)
               crashed = max(enumerated - finished, 0) if enumerated is not None else None
+              # Include crashed tests in the denominator to match the HTML report's
+              # treatment of crashed tests as non-passing (render_ttsim_report.py:341-345).
+              ran = max(total - skipped, 0)
+              if crashed is not None and crashed > 0:
+                  ran += crashed
+              passed = max(ran - failed - (crashed or 0), 0)
+              pct = (100.0 * passed / ran) if ran else 0.0
               return dict(total=total, ran=ran, passed=passed, failed=failed,
                           skipped=skipped, pass_pct=pct, finished=finished,
                           enumerated=enumerated, crashed=crashed)

--- a/tt_metal/tt-llk/tests/render_ttsim_report.py
+++ b/tt_metal/tt-llk/tests/render_ttsim_report.py
@@ -548,10 +548,11 @@ def render(
     # Conditional bits that only appear when a collected baseline was supplied.
     if have_collected:
         summary_cols = "240px repeat(5, 1fr)"
+        crash_pct = pct(crashed, total)
         crashed_card = (
             f'<div class="card kpi bad"><div class="label">Crashed</div>'
             f'<div class="big bad">{crashed}</div>'
-            f'<div class="sub">enumerated − finished</div></div>'
+            f'<div class="sub">{crash_pct:.1f}%</div></div>'
         )
         crash_th = "<th class='num'>Crash</th>"
         crashed_nav = "<a href='#crashed'>Crashed</a>"
@@ -563,7 +564,7 @@ def render(
             if crashed
             else ""
         )
-        total_label = "Enumerated"
+        total_label = "Total"
         total_sub_extra = (
             "<div class='sub'>"
             + f"{recorded} finished"

--- a/tt_metal/tt-llk/tests/render_ttsim_report.py
+++ b/tt_metal/tt-llk/tests/render_ttsim_report.py
@@ -551,15 +551,33 @@ def render(
         crashed_card = (
             f'<div class="card kpi bad"><div class="label">Crashed</div>'
             f'<div class="big bad">{crashed}</div>'
-            f'<div class="sub">collected − recorded</div></div>'
+            f'<div class="sub">enumerated − finished</div></div>'
         )
         crash_th = "<th class='num'>Crash</th>"
         crashed_nav = "<a href='#crashed'>Crashed</a>"
+        # "Enumerated" = tests pytest --collect-only listed; "finished" = tests
+        # that produced a JUnit result (passed/failed/skipped); the difference
+        # is the crashed gap.
+        count_summary = f"{total} enumerated · {recorded} finished" + (
+            f" · <span style='color:#ffd5d5;font-weight:600'>{crashed} crashed</span>"
+            if crashed
+            else ""
+        )
+        total_label = "Enumerated"
+        total_sub_extra = (
+            "<div class='sub'>"
+            + f"{recorded} finished"
+            + (f" · <span class='bad'>{crashed} crashed</span>" if crashed else "")
+            + "</div>"
+        )
     else:
         summary_cols = "240px repeat(4, 1fr)"
         crashed_card = ""
         crash_th = ""
         crashed_nav = ""
+        count_summary = f"{total} tests"
+        total_label = "Total"
+        total_sub_extra = ""
 
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
@@ -751,7 +769,7 @@ def render(
   <div class="hero-inner">
     <div class="brand">
       <h1>ttsim regression</h1>
-      <div class="meta">{html.escape(xml_path.name)} · {total} tests · {wall_time_str_full or (cases_time_str + " test-time")}</div>
+      <div class="meta">{html.escape(xml_path.name)} · {count_summary} · {wall_time_str_full or (cases_time_str + " test-time")}</div>
     </div>
     <div class="passrate">
       <div class="passrate-num">{pass_pct:.1f}%</div>
@@ -790,7 +808,7 @@ def render(
           </div>
         </div>
       </div>
-      <div class="card kpi"><div class="label">Total</div><div class="big">{total}</div><div class="sub" title="Σ test-time = sum of per-test durations from JUnit. Wall-clock = end-to-end runtime estimated from the suite's timestamp and the XML mtime.">{("wall " + wall_time_str + " · ") if wall_time_str else ""}Σ test {cases_time_str}</div></div>
+      <div class="card kpi"><div class="label">{total_label}</div><div class="big">{total}</div><div class="sub" title="Σ test-time = sum of per-test durations from JUnit. Wall-clock = end-to-end runtime estimated from the suite's timestamp and the XML mtime.">{("wall " + wall_time_str + " · ") if wall_time_str else ""}Σ test {cases_time_str}</div>{total_sub_extra}</div>
       <div class="card kpi ok"><div class="label">Passed</div><div class="big ok">{passed}</div><div class="sub">{pass_pct:.1f}%</div></div>
       <div class="card kpi bad"><div class="label">Failed</div><div class="big bad">{failed + errored}</div><div class="sub">{fail_pct:.1f}%</div></div>
       {crashed_card}

--- a/tt_metal/tt-llk/tests/render_ttsim_report.py
+++ b/tt_metal/tt-llk/tests/render_ttsim_report.py
@@ -555,7 +555,7 @@ def render(
             f'<div class="sub">{crash_pct:.1f}%</div></div>'
         )
         crash_th = "<th class='num'>Crash</th>"
-        crashed_nav = "<a href='#crashed'>Crashed</a>"
+        crashed_nav = "<a href='#crashed'>Crashed</a>" if rows_crash else ""
         # "Enumerated" = tests pytest --collect-only listed; "finished" = tests
         # that produced a JUnit result (passed/failed/skipped); the difference
         # is the crashed gap.

--- a/tt_metal/tt-llk/tests/render_ttsim_report.py
+++ b/tt_metal/tt-llk/tests/render_ttsim_report.py
@@ -773,7 +773,7 @@ def render(
       <div class="meta">{html.escape(xml_path.name)} · {count_summary} · {wall_time_str_full or (cases_time_str + " test-time")}</div>
     </div>
     <div class="passrate">
-      <div class="passrate-num">{pass_pct:.1f}%</div>
+      <div class="passrate-num">{pass_pct:.2f}%</div>
       <div class="passrate-label">{passed} of {ran} tests passed</div>
     </div>
   </div>
@@ -803,7 +803,7 @@ def render(
         <div class="donut">
           <div class="center">
             <div>
-              <div class="pct">{pass_pct:.0f}%</div>
+              <div class="pct">{pass_pct:.2f}%</div>
               <div class="ctxt">passing</div>
             </div>
           </div>

--- a/tt_metal/tt-llk/tests/render_ttsim_report.py
+++ b/tt_metal/tt-llk/tests/render_ttsim_report.py
@@ -58,6 +58,7 @@ class FileStats:
     failed: int = 0
     skipped: int = 0
     errored: int = 0
+    crashed: int = 0
     cases: list[Case] = field(default_factory=list)
 
 
@@ -181,6 +182,92 @@ def parse(xml_path: Path) -> tuple[list[FileStats], list[Case], RunMeta]:
     return sorted(by_file.values(), key=lambda s: s.file), all_cases, meta
 
 
+def mangle_test_address(address: str) -> tuple[str, str]:
+    """Map a pytest node ID to the (classname, name) pytest writes to JUnit XML.
+
+    This mirrors `_pytest.junitxml.mangle_test_address`: the file portion has
+    its path separators turned into dots and the `.py` suffix stripped, the
+    parametrization (`[...]`) is re-attached to the leaf, the leaf becomes
+    `name`, and everything before it joins with dots into `classname`. Keeping
+    this in lockstep is what lets us match collected node IDs against the
+    `Case.classname`/`Case.name` produced by `parse()`.
+    """
+    path, open_bracket, params = address.partition("[")
+    names = path.split("::")
+    names[0] = names[0].replace("/", ".")
+    names[0] = re.sub(r"\.py$", "", names[0])
+    names[-1] += open_bracket + params
+    return ".".join(names[:-1]), names[-1]
+
+
+def load_collected(path: Path) -> list[str]:
+    """Read pytest `--collect-only -q` output into a list of node IDs.
+
+    Only lines that look like a test node ID (contain `.py::`) are kept, so any
+    stray log lines or the trailing "N tests collected" summary are ignored.
+    """
+    ids: list[str] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if ".py::" in line:
+            ids.append(line)
+    return ids
+
+
+def compute_crashed(
+    files: list[FileStats],
+    all_cases: list[Case],
+    collected_path: Path,
+) -> list[Case]:
+    """Diff the expected (collected) tests against the recorded ones.
+
+    Anything pytest said it would run but that never produced a `<testcase>` in
+    the JUnit XML is treated as crashed: the worker died (segfault, OOM-kill,
+    timeout-killed worker, ttsim hard-exit during collection/setup, …) before
+    the result could be written, so `--forked` never converted it into a normal
+    failure. Returns the synthetic crashed `Case`s and folds their counts into
+    the per-file stats so the per-file table stays consistent.
+    """
+    expected: dict[tuple[str, str], str] = {}
+    for nid in load_collected(collected_path):
+        expected[mangle_test_address(nid)] = nid
+
+    recorded = {(c.classname, c.name) for c in all_cases}
+    missing = sorted(
+        ((key, nid) for key, nid in expected.items() if key not in recorded),
+        key=lambda x: x[1],
+    )
+
+    file_map = {f.file: f for f in files}
+    crashed_cases: list[Case] = []
+    for (classname, name), _nid in missing:
+        case = Case(
+            classname=classname,
+            name=name,
+            duration=0.0,
+            outcome="crashed",
+            short=(
+                "No result recorded — the test was collected but never produced "
+                "a JUnit entry. The worker process likely crashed before "
+                "reporting (ttsim hard-exit, segfault, OOM-kill, or "
+                "timeout-killed worker)."
+            ),
+            stdout="",
+        )
+        crashed_cases.append(case)
+        stats = file_map.get(classname)
+        if stats is None:
+            stats = FileStats(classname)
+            file_map[classname] = stats
+            files.append(stats)
+        stats.total += 1
+        stats.crashed += 1
+        stats.cases.append(case)
+
+    files.sort(key=lambda s: s.file)
+    return crashed_cases
+
+
 def pct(n: int, d: int) -> float:
     return 100.0 * n / d if d else 0.0
 
@@ -200,8 +287,16 @@ def render(
     all_cases: list[Case],
     xml_path: Path,
     meta: RunMeta,
+    crashed_cases: Optional[list[Case]] = None,
+    have_collected: bool = False,
 ) -> str:
-    total = len(all_cases)
+    crashed_cases = crashed_cases or []
+    crashed = len(crashed_cases)
+    recorded = len(all_cases)
+    # When a collected baseline is supplied, `total` is the version-independent
+    # expected count (recorded + crashed); otherwise it falls back to whatever
+    # the XML recorded.
+    total = recorded + crashed
     passed = sum(1 for c in all_cases if c.outcome == "passed")
     failed = sum(1 for c in all_cases if c.outcome == "failed")
     skipped = sum(1 for c in all_cases if c.outcome == "skipped")
@@ -243,9 +338,12 @@ def render(
     else:
         wall_time_str_full = wall_time_str
 
-    ran = passed + failed + errored
+    # Crashed tests count as non-passing: they were supposed to run but the
+    # worker died before recording a result.
+    bad = failed + errored + crashed
+    ran = passed + bad
     pass_pct = pct(passed, ran)
-    fail_pct = pct(failed + errored, ran)
+    fail_pct = pct(bad, ran)
     skip_pct = pct(skipped, total)
 
     # Donut: build CSS conic-gradient
@@ -254,7 +352,7 @@ def render(
         parts = []
         for color, n in [
             ("var(--ok)", passed),
-            ("var(--bad)", failed + errored),
+            ("var(--bad)", bad),
         ]:
             if n == 0:
                 continue
@@ -267,17 +365,20 @@ def render(
 
     rows_files = []
     for s in files:
+        file_bad = s.failed + s.errored + s.crashed
+        crash_cell = f"<td class='num bad'>{s.crashed}</td>" if have_collected else ""
         rows_files.append(
             f"<tr>"
             f"<td>{html.escape(s.file)}</td>"
             f"<td class='num'>{s.total}</td>"
             f"<td class='num ok'>{s.passed}</td>"
             f"<td class='num bad'>{s.failed + s.errored}</td>"
+            f"{crash_cell}"
             f"<td class='num warn'>{s.skipped}</td>"
             f"<td class='barcell'>"
             f"  <div class='filebar'>"
             f"    <span class='seg ok'   style='width:{pct(s.passed, s.total):.1f}%'></span>"
-            f"    <span class='seg bad'  style='width:{pct(s.failed + s.errored, s.total):.1f}%'></span>"
+            f"    <span class='seg bad'  style='width:{pct(file_bad, s.total):.1f}%'></span>"
             f"    <span class='seg warn' style='width:{pct(s.skipped, s.total):.1f}%'></span>"
             f"  </div>"
             f"</td>"
@@ -367,6 +468,49 @@ def render(
             f"</details>"
         )
 
+    # Crashed tests: collected by pytest but absent from the JUnit XML. Grouped
+    # by file so a worker that took out a whole file is obvious at a glance.
+    crashed_by_file: Counter[str] = Counter()
+    for c in crashed_cases:
+        crashed_by_file[c.classname] += 1
+    rows_crash = []
+    for classname, n in crashed_by_file.most_common():
+        names = sorted(c.name for c in crashed_cases if c.classname == classname)
+        shown = names[:200]
+        more = len(names) - len(shown)
+        tests_html = (
+            "<ul class='siglist'>"
+            + "".join(f"<li><code>{html.escape(nm)}</code></li>" for nm in shown)
+            + (f"<li><i>… {more} more</i></li>" if more > 0 else "")
+            + "</ul>"
+        )
+        rows_crash.append(
+            f"<tr class='sigrow'>"
+            f"<td class='num'>{n}</td>"
+            f"<td class='sigcell'>"
+            f"  <details><summary><code>{html.escape(classname)}</code></summary>{tests_html}</details>"
+            f"</td>"
+            f"</tr>"
+        )
+    crashed_section = (
+        (
+            f"<h2 id='crashed'>Crashed tests "
+            f"<span class='hcount'>{crashed} collected but not recorded</span></h2>"
+            "<div class='card empty' style='text-align:left'>"
+            "These tests were enumerated by <code>pytest --collect-only</code> "
+            "but produced no JUnit entry, so the worker almost certainly crashed "
+            "before reporting (ttsim hard-exit, segfault, OOM-kill, or a "
+            "timeout-killed worker). They are the gap between the expected and "
+            "recorded test counts.</div>"
+            "<table class='datatable' style='margin-top:12px'>"
+            "<thead><tr><th class='num'>Count</th>"
+            "<th>File <span class='hint'>(click to list affected tests)</span></th></tr></thead>"
+            "<tbody>" + "".join(rows_crash) + "</tbody></table>"
+        )
+        if (have_collected and rows_crash)
+        else ""
+    )
+
     cat_section = (
         (
             "<table class='datatable'>"
@@ -400,6 +544,22 @@ def render(
         if rows_sig
         else ""
     )
+
+    # Conditional bits that only appear when a collected baseline was supplied.
+    if have_collected:
+        summary_cols = "240px repeat(5, 1fr)"
+        crashed_card = (
+            f'<div class="card kpi bad"><div class="label">Crashed</div>'
+            f'<div class="big bad">{crashed}</div>'
+            f'<div class="sub">collected − recorded</div></div>'
+        )
+        crash_th = "<th class='num'>Crash</th>"
+        crashed_nav = "<a href='#crashed'>Crashed</a>"
+    else:
+        summary_cols = "240px repeat(4, 1fr)"
+        crashed_card = ""
+        crash_th = ""
+        crashed_nav = ""
 
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
@@ -614,11 +774,12 @@ def render(
     {("<a href='#signatures'>Signatures</a>") if rows_sig else ""}
     <a href="#files">Files</a>
     <a href="#failures">Failures</a>
+    {crashed_nav}
   </div>
 </nav>
 <main>
   <section id="summary">
-    <div class="row summary">
+    <div class="row summary" style="grid-template-columns: {summary_cols};">
       <div class="card donut-wrap">
         <div class="donut">
           <div class="center">
@@ -632,6 +793,7 @@ def render(
       <div class="card kpi"><div class="label">Total</div><div class="big">{total}</div><div class="sub" title="Σ test-time = sum of per-test durations from JUnit. Wall-clock = end-to-end runtime estimated from the suite's timestamp and the XML mtime.">{("wall " + wall_time_str + " · ") if wall_time_str else ""}Σ test {cases_time_str}</div></div>
       <div class="card kpi ok"><div class="label">Passed</div><div class="big ok">{passed}</div><div class="sub">{pass_pct:.1f}%</div></div>
       <div class="card kpi bad"><div class="label">Failed</div><div class="big bad">{failed + errored}</div><div class="sub">{fail_pct:.1f}%</div></div>
+      {crashed_card}
       <div class="card kpi warn"><div class="label">Skipped</div><div class="big warn">{skipped}</div><div class="sub">{skip_pct:.1f}%</div></div>
     </div>
   </section>
@@ -648,7 +810,7 @@ def render(
   <section id="files">
     <h2>Per-file breakdown</h2>
     <table class="datatable">
-      <thead><tr><th>File</th><th class='num'>Total</th><th class='num'>Pass</th><th class='num'>Fail</th><th class='num'>Skip</th><th class='sharecol'>Distribution</th></tr></thead>
+      <thead><tr><th>File</th><th class='num'>Total</th><th class='num'>Pass</th><th class='num'>Fail</th>{crash_th}<th class='num'>Skip</th><th class='sharecol'>Distribution</th></tr></thead>
       <tbody>{"".join(rows_files)}</tbody>
     </table>
   </section>
@@ -660,6 +822,8 @@ def render(
     </div>
     <div id="cases">{"".join(rows_fail) if rows_fail else "<div class='card empty'>No failures.</div>"}</div>
   </section>
+
+  {f"<section id='crashed-section'>{crashed_section}</section>" if crashed_section else ""}
 </main>
 <script>
 (() => {{
@@ -702,6 +866,16 @@ def main() -> int:
         "xml", type=Path, help="JUnit XML produced by run_ttsim_regression.sh"
     )
     p.add_argument("html", type=Path, help="Output HTML path")
+    p.add_argument(
+        "--collected",
+        type=Path,
+        default=None,
+        help=(
+            "Optional file of pytest node IDs (from `pytest --collect-only -q`) "
+            "listing every test that was expected to run. Tests in this file "
+            "that have no testcase in the XML are reported as crashed."
+        ),
+    )
     args = p.parse_args()
 
     if not args.xml.is_file():
@@ -709,11 +883,30 @@ def main() -> int:
         return 2
 
     files, cases, meta = parse(args.xml)
-    out = render(files, cases, args.xml, meta)
+
+    crashed_cases: list[Case] = []
+    have_collected = False
+    if args.collected is not None and args.collected.is_file():
+        have_collected = True
+        crashed_cases = compute_crashed(files, cases, args.collected)
+    elif args.collected is not None:
+        sys.stderr.write(
+            f"WARNING: collected file not found, skipping gap analysis: {args.collected}\n"
+        )
+
+    out = render(
+        files,
+        cases,
+        args.xml,
+        meta,
+        crashed_cases=crashed_cases,
+        have_collected=have_collected,
+    )
     args.html.write_text(out, encoding="utf-8")
+    crashed_note = f", {len(crashed_cases)} crashed" if have_collected else ""
     print(
         f"Wrote {args.html} ({os.path.getsize(args.html)} bytes, "
-        f"{len(cases)} cases across {len(files)} files)"
+        f"{len(cases)} cases across {len(files)} files{crashed_note})"
     )
     return 0
 

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -263,20 +263,37 @@ fi
 # Enumerate the expected test set (stable denominator)
 # ──────────────────────────────────────────────────────────────
 # `--collect-only` lists the tests pytest *would* run for this selection. This
-# set is pure Python parametrization and therefore identical across ttsim
-# versions, so it gives us a version-independent denominator. The renderer
-# diffs it against the testcases actually recorded in the JUnit XML; anything
-# collected but never recorded is counted as "crashed" (a hard crash that took
-# down the worker before its result could be written, so --forked never turned
-# it into a normal failure). We deliberately omit --run-simulator: collection
-# only needs the parametrization, and the flag would force conftest to load and
-# init the ttsim .so at import time, which just makes enumeration slower.
+# set is pure static parametrization (there is no pytest_generate_tests, and
+# pytest_collection_modifyitems no-ops without --test-order-file) and therefore
+# identical across ttsim versions, so it gives us a version-independent
+# denominator. The renderer diffs it against the testcases actually recorded in
+# the JUnit XML; anything collected but never recorded is counted as "crashed"
+# (a hard crash that took down the worker before its result could be written,
+# so --forked never turned it into a normal failure).
+#
+# We avoid --run-simulator here (it would load+init the ttsim .so just to
+# enumerate). Instead:
+#   * CHIP_ARCH=<arch> lets conftest import without probing for a real device
+#     (helpers.device runs get_all_cores() at import → get_chip_architecture(),
+#     which short-circuits on CHIP_ARCH instead of calling check_context()).
+#   * --compile-producer puts conftest in BuildMode.PRODUCE, which is the only
+#     mode that skips *both* check_context() calls in pytest_configure
+#     (override_gprs_used_by_tensix_dump and the device/simulator init block).
+# --collect-only never executes a test, so producer mode compiles nothing and
+# the selected set matches the real run (build mode / run_simulator only affect
+# runtime, never collection).
+case "$ARCHITECTURE" in
+    blackhole|bh)                 COLLECT_CHIP_ARCH=blackhole ;;
+    wormhole|wormhole_b0|wh)      COLLECT_CHIP_ARCH=wormhole ;;
+    *)                            COLLECT_CHIP_ARCH="$ARCHITECTURE" ;;
+esac
 COLLECT_CMD=(
     "pytest"
     --collect-only
     -q
     -p no:sugar
     -o log_cli=false
+    --compile-producer
     -m "$MARKER_EXPR"
 )
 if [[ ${#TEST_PATHS[@]} -gt 0 ]]; then
@@ -290,7 +307,7 @@ collected_count=0
 collect_exit=0
 (
     cd "$TESTS_DIR"
-    "${COLLECT_CMD[@]}"
+    CHIP_ARCH="$COLLECT_CHIP_ARCH" "${COLLECT_CMD[@]}"
 ) 2>/dev/null | grep -E '\.py::' >"$COLLECTED_PATH" || collect_exit=$?
 # `grep` returns 1 when it matches nothing; only treat a missing/empty file as
 # a real failure so the run still proceeds (gap analysis is best-effort).

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -21,8 +21,14 @@ RESULTS_DIR="${TESTS_DIR}/ttsim_results"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 XML_PATH="${RESULTS_DIR}/ttsim_${TIMESTAMP}.xml"
 HTML_PATH="${RESULTS_DIR}/ttsim_${TIMESTAMP}.html"
+COLLECTED_PATH="${RESULTS_DIR}/ttsim_${TIMESTAMP}.collected.txt"
 LATEST_XML="${RESULTS_DIR}/latest.xml"
 LATEST_HTML="${RESULTS_DIR}/latest.html"
+LATEST_COLLECTED="${RESULTS_DIR}/latest.collected.txt"
+
+# Marker expression shared by the collection pass and the real run so the
+# "expected" denominator and the "recorded" results select the exact same set.
+MARKER_EXPR="not quasar and not nightly and not perf and not accuracy"
 
 WORKERS="${WORKERS:-10}"
 TIMEOUT="${TIMEOUT:-300}"
@@ -227,7 +233,7 @@ PYTEST_BASE_ARGS=(
     --run-simulator
     --timeout="$TIMEOUT"
     --forked
-    -m "not quasar and not nightly and not perf and not accuracy"
+    -m "$MARKER_EXPR"
     --junit-xml="$XML_PATH"
     # ttsim writes via printf (stdout), so caplog and stderr are always
     # empty for these tests. Capture only stdout to keep the XML and the
@@ -254,6 +260,49 @@ if [[ "$WORKERS" -gt 0 ]]; then
 fi
 
 # ──────────────────────────────────────────────────────────────
+# Enumerate the expected test set (stable denominator)
+# ──────────────────────────────────────────────────────────────
+# `--collect-only` lists the tests pytest *would* run for this selection. This
+# set is pure Python parametrization and therefore identical across ttsim
+# versions, so it gives us a version-independent denominator. The renderer
+# diffs it against the testcases actually recorded in the JUnit XML; anything
+# collected but never recorded is counted as "crashed" (a hard crash that took
+# down the worker before its result could be written, so --forked never turned
+# it into a normal failure). We deliberately omit --run-simulator: collection
+# only needs the parametrization, and the flag would force conftest to load and
+# init the ttsim .so at import time, which just makes enumeration slower.
+COLLECT_CMD=(
+    "pytest"
+    --collect-only
+    -q
+    -p no:sugar
+    -o log_cli=false
+    -m "$MARKER_EXPR"
+)
+if [[ ${#TEST_PATHS[@]} -gt 0 ]]; then
+    COLLECT_CMD+=("${TEST_PATHS[@]}")
+fi
+if [[ ${#PYTEST_ARGS[@]} -gt 0 ]]; then
+    COLLECT_CMD+=("${PYTEST_ARGS[@]}")
+fi
+
+collected_count=0
+collect_exit=0
+(
+    cd "$TESTS_DIR"
+    "${COLLECT_CMD[@]}"
+) 2>/dev/null | grep -E '\.py::' >"$COLLECTED_PATH" || collect_exit=$?
+# `grep` returns 1 when it matches nothing; only treat a missing/empty file as
+# a real failure so the run still proceeds (gap analysis is best-effort).
+if [[ -s "$COLLECTED_PATH" ]]; then
+    collected_count="$(wc -l <"$COLLECTED_PATH" | tr -d ' ')"
+else
+    echo "WARNING: test collection produced no node IDs (exit=$collect_exit);" >&2
+    echo "         crashed-test gap analysis will be skipped." >&2
+    rm -f "$COLLECTED_PATH"
+fi
+
+# ──────────────────────────────────────────────────────────────
 # Banner
 # ──────────────────────────────────────────────────────────────
 echo "============================================================"
@@ -266,6 +315,7 @@ echo " SFPLOADMACRO   : disabled=${DISABLE_SFPLOADMACRO}"
 echo " Workers (-n)   : ${WORKERS}"
 echo " Per-test fork  : on"
 echo " Timeout        : ${TIMEOUT}s"
+echo " Tests collected: ${collected_count}"
 echo " JUnit XML      : ${XML_PATH}"
 echo " HTML report    : ${HTML_PATH}"
 echo " Test paths     : ${TEST_PATHS[*]:-<all>}"
@@ -305,7 +355,13 @@ if [[ -f "$XML_PATH" ]]; then
     rendered=0
     if [[ -x "$RENDERER" || -f "$RENDERER" ]] \
        && python3 -c "import junitparser" &>/dev/null; then
-        if python3 "$RENDERER" "$XML_PATH" "$HTML_PATH"; then
+        RENDER_CMD=(python3 "$RENDERER" "$XML_PATH" "$HTML_PATH")
+        # Pass the expected-test list so the renderer can flag the
+        # collected-but-unrecorded gap as crashed tests.
+        if [[ -s "$COLLECTED_PATH" ]]; then
+            RENDER_CMD+=(--collected "$COLLECTED_PATH")
+        fi
+        if "${RENDER_CMD[@]}"; then
             rendered=1
         fi
     fi
@@ -317,6 +373,7 @@ if [[ -f "$XML_PATH" ]]; then
     if [[ $rendered -eq 1 ]]; then
         ln -sfn "$(basename "$XML_PATH")"  "$LATEST_XML"
         ln -sfn "$(basename "$HTML_PATH")" "$LATEST_HTML"
+        [[ -s "$COLLECTED_PATH" ]] && ln -sfn "$(basename "$COLLECTED_PATH")" "$LATEST_COLLECTED"
     else
         echo ""
         echo "WARNING: no HTML renderer available; only XML produced." >&2

--- a/tt_metal/tt-llk/tests/ttsim-version
+++ b/tt_metal/tt-llk/tests/ttsim-version
@@ -1,8 +1,8 @@
-# ttsim release 1.9.0
+# ttsim release 1.9.2
 
 ttsim_repo='https://github.com/tenstorrent/ttsim'
-ttsim_version='1.9.0'
+ttsim_version='1.9.2'
 ttsim_tag="v${ttsim_version}"
 ttsim_hashtype='sha256'
-ttsim_wh_so_hash='537979a52066a5410e421d1189718727524d97042de7f404901f82d5d20c2256'
-ttsim_bh_so_hash='ac4f993eb8d0a4b13c012d91e2d69c705e476b72129a488edfce0323604ebccf'
+ttsim_wh_so_hash='420877c24c1d0fe7291096f35b43914403ae523c1645ea61f9502e5c796e88f0'
+ttsim_bh_so_hash='63c90b3081eb8ab64024204200160dc43a7c3878fb4f50e7ff03732199e9e3d5'


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Previous version of workflows did not capture information on the total number of tests being run and wasn’t capturing detailed information on tests, so if the test would crash pytest process we wouldn’t register it as failed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/account-for-crashes-with-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/account-for-crashes-with-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/account-for-crashes-with-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/account-for-crashes-with-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/account-for-crashes-with-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/account-for-crashes-with-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/account-for-crashes-with-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/account-for-crashes-with-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/account-for-crashes-with-ttsim)