### PR TITLE
[tt_dit] Use cached HF weights for Galaxy Wan2.2 perf test (#46086)

### DIFF
--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -39,6 +39,7 @@
 - name: Galaxy DiT Wan2.2 model perf tests
   cmd: |
     export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
+    export HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub
     pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "wh_4x8_sp1tp0 and resolution_720p and t2v" --timeout=1200
   model: wan2-2
   skus:


### PR DESCRIPTION
Fixes #46086.

The Galaxy Wan2.2 720p perf test re-downloaded the model from the HF Hub on every run because, unlike the Flux.1 and Motif perf entries, its command did not set HF_HUB_CACHE. 

- galaxy_perf_tests.yaml: point the Wan2.2 cmd at the weight cache via HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub, matching Flux.1/Motif.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/wan22-galaxy-hf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/wan22-galaxy-hf-cache)