### PR TITLE
[Feature] indexer_score: block-split scheduler to fill idle grid rows on short sequences

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -788,7 +788,7 @@ def test_indexer_score_perf(device, case_id, heads):
 
 # ---------------------------------------------------------------------------
 # sp_rank 7 perf helpers (tracy device profiler; no accuracy check). math_util = matmul FLOPs /
-# (cores x device cycles x matmul peak); duration from tracy, FLOPs from shape. Consumed by the three
+# (cores x device cycles x matmul peak); duration from tracy, FLOPs from shape. Consumed by the DSA
 # band checks in test_indexer_score_math_util (run with INDEXER_SCORE_PERF_CHECKS=1).
 # ---------------------------------------------------------------------------
 SP7_CHUNK_START = GLX_HISTORY + 7 * GLX_SQ  # fullest causal case (99.5% valid)
@@ -828,6 +828,55 @@ def test_indexer_score_sp7_perf_impl(device, case_id, heads):
     for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
         ttnn.experimental.indexer_score_dsa(
             q_dev, k_dev, w_dev, chunk_start_idx=SP7_CHUNK_START, program_config=cfg
+        ).deallocate()
+    ttnn.synchronize_device(device)
+
+
+# Short-query-chunk perf: the SAME two deployments (GLM5, DSv32) on the SAME keys (T=56320), but resharded
+# TP=1 / SP=32 instead of the deployed TP=4 / SP=8. Two things change together:
+#   - SP=32 splits the 5120-query prefill chunk 32 ways -> 160 q/device (vs GLX_SQ=640 at SP=8): a SHORT chunk.
+#   - TP=1 puts every index head on the one device (no tensor-parallel head split), so the per-device head
+#     count is 4x the deployed TP=4 count: GLM5 8h -> 32h (glm5_tp1), DSv32 16h -> 64h (dsv32_tp1).
+# So these are exactly GLM5/DSv32 at TP=1/SP=32 -- many heads AND a short sequence. At QC=1 the 160-query
+# chunk is 5 q-groups -> only 5 of the 10 grid rows, which is what the block-split scheduler fills
+# (num_blocks=2 -> 110 cores). chunk_start at the end of the keys = fullest causal. Resharding preserves the
+# per-device heads x queries product (4x heads x 1/4 queries), so glm5_tp1 has essentially the same matmul
+# FLOPs and wall-clock as the deployed glm5 8h/640 once the grid is filled.
+SHORT_SQ = 160  # 5 q-tile-rows: 5120-query prefill chunk / SP=32
+SHORT_CHUNK_START = GLX_T - SHORT_SQ  # 56160: queries at the end of the all-gathered keys (fullest causal)
+
+
+def short_valid_tiles():
+    """Causal-valid output tiles V for the 160-query chunk at SHORT_CHUNK_START: sum_s min(Tt, chunk_t+s+1)."""
+    chunk_t = SHORT_CHUNK_START // 32
+    tt_tiles = GLX_T // 32
+    sqt = SHORT_SQ // 32
+    return sum(min(tt_tiles, chunk_t + s + 1) for s in range(sqt))
+
+
+def short_config(heads):
+    """QC=1 (q_chunk=32): the 160-query chunk makes 5 q-groups, half the 10-row grid -> block-split fills it.
+    head_group_size=0 keeps all heads resident; k_chunk is the largest that fits L1 at this head count -- the
+    4x head count from TP=1 leaves no room for the deployed KC, so KC=8 (k_chunk=256) at <=32 heads (glm5_tp1)
+    and the smaller KC=4 (k_chunk=128) at 64 heads (dsv32_tp1). KC does not change the core count here
+    (band_count stays >> cols, so num_blocks=2 -> 110 cores either way)."""
+    return ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=256 if heads <= 32 else 128, head_group_size=0)
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
+@pytest.mark.parametrize("case_id, heads", [("dsv32_tp1", 64), ("glm5_tp1", 32)], ids=["dsv32_tp1", "glm5_tp1"])
+def test_indexer_score_short_seq_perf_impl(device, case_id, heads):
+    """Inner test profiled by tracy: GLM5/DSv32 resharded TP=1/SP=32 -- a SHORT 160-query chunk (QC=1) that
+    under-fills the grid, so the block-split scheduler replicates each q-group across num_blocks=2 row-blocks
+    (110 cores). bf16 q + bfp8 k. No accuracy check."""
+    q, k, w = make_inputs(heads, GLX_DIM, SHORT_SQ, GLX_T)
+    q_dev = to_device(q, device, dtype=ttnn.bfloat16)
+    k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
+    w_dev = to_device(w, device)
+    cfg = short_config(heads)
+    for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
+        ttnn.experimental.indexer_score_dsa(
+            q_dev, k_dev, w_dev, chunk_start_idx=SHORT_CHUNK_START, program_config=cfg
         ).deallocate()
     ttnn.synchronize_device(device)
 
@@ -890,6 +939,42 @@ def test_indexer_score_streaming_qmcast_uneven_bands(device):
     assert head_group < heads, "must be streaming (HB < Hi)"
     assert cols_used > 1, f"need >1 column for q-mcast: cols_used={cols_used}"
     assert max_bands > min_bands, f"need an uneven band split: U={U}, cols_used={cols_used}"
+
+    _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
+
+
+# ---------------------------------------------------------------------------
+# Block-split grid fill (accuracy): short sequences (group_count < grid.y) leave grid rows idle, so each
+# q-group is replicated across num_blocks row-blocks with its band range split across them (a band-chunk
+# per block). This is the path with BOTH group_rows>1 (per-block k-mcast is a contiguous vertical rect)
+# AND num_blocks>1 (two-or-more mcast rectangles per column, disjoint output columns, no reduce) -- the
+# genmcast prime case only exercises group_rows==1 (k-mcast off). Same exact -inf + PCC + neg-gate check.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group",
+    [
+        (8, 128, 160, 2816, 1024, 32, 64, 0),  # G=5 -> group_rows=5, num_blocks=2 (target 64h/160 shape)
+        (8, 128, 64, 3584, 1536, 32, 64, 0),  # G=2 -> group_rows=2, num_blocks=5 (deep split, 2 rows/block)
+        (8, 128, 96, 2176, 768, 32, 64, 0),  # G=3 -> group_rows=3, num_blocks=3 (9 rows used)
+        (8, 128, 160, 2880, 1024, 32, 128, 0),  # G=5, num_blocks=2 + KC not dividing Tt (partial last band)
+    ],
+    ids=["fill_5x2", "fill_2x5", "fill_3x3", "fill_5x2_partial"],
+)
+def test_indexer_score_block_split_fill(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
+    """Under-filled short sequences split each q-group's bands across num_blocks row-blocks to use the idle
+    rows. Asserts the shape really hits the block-split-with-k-mcast regime (group_rows>1 AND num_blocks>1),
+    then checks exact causality + PCC. The scheduler/mcast change is head-independent, so heads=8 (L1-safe)
+    exercises it fully."""
+    grid = device.compute_with_storage_grid_size()
+    QC, KC = q_chunk // 32, k_chunk // 32
+    group_count = (sq // 32) // QC
+    band_count = ((t // 32) + KC - 1) // KC
+    group_rows = max(d for d in range(1, min(group_count, grid.y) + 1) if group_count % d == 0)
+    cols_used = min(band_count, grid.x)
+    num_blocks = max(1, min(grid.y // group_rows, band_count // cols_used))
+    # Precondition: this is the target regime -- per-block k-mcast (>1 row/block) AND >1 band-row-block.
+    assert group_rows > 1, f"need a multi-row block for k-mcast: group_rows={group_rows}"
+    assert num_blocks > 1, f"need block replication: num_blocks={num_blocks}"
 
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
 
@@ -1167,8 +1252,9 @@ def test_indexer_score_msa_m3_perf_impl(device):
 
 
 # ---------------------------------------------------------------------------
-# The three math-utilization band checks (CI-gated by INDEXER_SCORE_PERF_CHECKS=1): GLM5, DSv32, and
-# MiniMax-M3, all at the deployed HiFi2 dtypes (bf16 q + bfp8 k), sp_rank 7. Each spawns its perf_impl
+# The math-utilization band checks (CI-gated by INDEXER_SCORE_PERF_CHECKS=1), all at the deployed HiFi2 dtypes
+# (bf16 q + bfp8 k): the deployed TP=4/SP=8 shapes GLM5, DSv32 and MiniMax-M3 at sp_rank 7, plus the resharded
+# TP=1/SP=32 grid-fill shapes glm5_tp1 and dsv32_tp1 (block-split, fullest causal). Each spawns its perf_impl
 # under tracy, reads the min DEVICE KERNEL DURATION, computes math_util = matmul FLOPs / (cores x device
 # cycles x matmul peak), and asserts it within +/- INDEXER_PERF_MARGIN of the value measured on a Blackhole
 # dev board. mm_flops is a thunk so the shape-derived FLOP count is evaluated at run time.
@@ -1198,6 +1284,25 @@ _MATH_UTIL_CASES = [
         lambda: m3_valid_tiles() * (32 * 32) * (2 * M3_DIM),
         43.55,
     ),
+    # Block-split grid fill: GLM5/DSv32 resharded TP=1/SP=32 -- a short 160-query chunk (QC=1, 5 q-groups) the
+    # scheduler spreads across num_blocks=2 row-blocks (110 cores); without the fill these would use only 55
+    # cores at ~half the util. These guard the feature's headline shapes. glm5_tp1 (32h) preserves the deployed
+    # glm5 8h/640 per-device work, so it matches that wall-clock once the grid is full; its util tracks DSv32
+    # (shared KC=8, matmul-bound). dsv32_tp1 (64h) carries twice the heads.
+    (
+        "dsv32_tp1",
+        "test_indexer_score_short_seq_perf_impl[dsv32_tp1]",
+        "ttnn_indexer_score_short_seq",
+        lambda: indexer_mm_flops(short_valid_tiles(), 64),
+        77.31,
+    ),
+    (
+        "glm5_tp1",
+        "test_indexer_score_short_seq_perf_impl[glm5_tp1]",
+        "ttnn_indexer_score_short_seq",
+        lambda: indexer_mm_flops(short_valid_tiles(), 32),
+        75.54,
+    ),
 ]
 
 
@@ -1211,9 +1316,10 @@ _MATH_UTIL_CASES = [
     ids=[c[0] for c in _MATH_UTIL_CASES],
 )
 def test_indexer_score_math_util(case_id, perf_id, subdir, mm_flops_thunk, expected_util):
-    """GLM5 / DSv32 / MiniMax-M3 sp_rank-7 HiFi2 (bf16 q, bfp8 k) matmul math utilization via tracy, asserted
-    within +/- INDEXER_PERF_MARGIN. Spawns the case's perf_impl under the profiler and compares the achieved
-    math_util to the expected value (measured on a BH dev board)."""
+    """Per-deployment HiFi2 (bf16 q, bfp8 k) matmul math utilization via tracy, asserted within +/-
+    INDEXER_PERF_MARGIN: GLM5 / DSv32 / MiniMax-M3 at the deployed TP=4/SP=8, plus glm5_tp1 / dsv32_tp1 at the
+    resharded TP=1/SP=32 grid-fill shapes. Spawns the case's perf_impl under the profiler and compares the
+    achieved math_util to the expected value (measured on a BH dev board)."""
     from tracy.process_model_log import run_device_profiler
     from tests.nightly.sdpa_perf_utils import post_process_ops_log
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 
-#include "kernels/indexer_score_work_split.hpp"  // banded grid mapping (rows_for_groups / cols_for_bands)
+#include "kernels/indexer_score_work_split.hpp"  // banded grid mapping (banded_core_count)
 #include "ttnn/operations/ccl/ccl_common.hpp"    // get_linearized_index_from_physical_coord
 
 namespace ttnn::operations::experimental::indexer_score {
@@ -358,15 +358,14 @@ IndexerScoreDeviceOperation::create_op_performance_model(
     const uint64_t num_mul_adds =
         2ull * valid_tiles * Hi * B * static_cast<uint64_t>(tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * D;
 
-    // Cores used: the banded schedule's rows_for_groups x cols_for_bands rectangle (shares the factory's
-    // mapping, so this equals tracy's CORE COUNT).
+    // Cores used: the banded schedule's (group_rows x row_blocks) x cols rectangle, via the same helper the
+    // factory uses (block-split included), so this equals tracy's CORE COUNT.
     const uint32_t QC = attrs.program_config.q_chunk_size / tt::constants::TILE_HEIGHT;
     const uint32_t KC = attrs.program_config.k_chunk_size / tt::constants::TILE_WIDTH;
     const uint32_t group_count = Sqt / QC;
     const uint32_t band_count = units_in_group(KC, Tt);  // ceil(Tt/KC); shared with the factory
     const auto grid = q.device()->compute_with_storage_grid_size();
-    const uint64_t num_cores =
-        static_cast<uint64_t>(rows_for_groups(group_count, grid.y)) * cols_for_bands(band_count, grid.x);
+    const uint64_t num_cores = banded_core_count(group_count, band_count, grid.x, grid.y);
 
     // Blackhole matmul peak: 4096 mul-adds/cycle/core at LoFi, scaled by the fidelity multiplier.
     const auto math_fidelity = std::get<0>(ttnn::get_compute_kernel_config_args(arch, attrs.compute_kernel_config));

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -148,31 +148,52 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
 
     // ---- banded-product schedule -------------------------------------------------------------
     // groups -> rows (phase-stack when group_count > grid_y), bands -> columns (each owns a contiguous chunk).
+    // When the group dimension leaves grid rows idle (short sequences: group_count < grid_y), replicate each
+    // group across num_blocks row-blocks and split its band range across them (a band-chunk per block). Cells
+    // in different blocks write disjoint output columns -- no cross-core reduce -- and each block's k-mcast
+    // stays a contiguous per-column rectangle (a block's group_rows rows share that block's band-chunk).
     const uint32_t group_count = Sqt / QC;
     const uint32_t band_count = units_in_group(KC, Tt);  // ceil(Tt/KC)
     const auto grid = q.device()->compute_with_storage_grid_size();
     const uint32_t grid_x = grid.x, grid_y = grid.y;
 
-    const uint32_t rows_used = rows_for_groups(group_count, grid_y);
+    const uint32_t group_rows = rows_for_groups(group_count, grid_y);
     const uint32_t cols_used = cols_for_bands(band_count, grid_x);
+    // Row-block replication factor (shared with the perf model so their core counts can't drift): fill the
+    // idle rows (grid_y / group_rows), but never finer than one band per (block, column) cell. num_blocks==1
+    // is the original single-band-row schedule -- the deployed long-sequence cases, where group_rows fills
+    // grid_y.
+    const uint32_t num_blocks = band_row_blocks(group_count, band_count, grid_x, grid_y);
+    const uint32_t rows_used = group_rows * num_blocks;
     const uint32_t num_cores = rows_used * cols_used;
+    // Phase-stack count: groups dealt round-robin onto the group_rows rows (1 when group_rows == group_count).
+    const uint32_t num_groups = group_count / group_rows;
 
-    // Even band split across the used columns: the first (band_count % cols_used) columns get one extra.
-    std::vector<uint32_t> col_band_start(cols_used), col_band_size(cols_used);
+    // 2-D band deal: bands split into num_blocks contiguous blocks (front blocks get the remainder), each
+    // block split across cols_used columns (front columns get the remainder). Indexed [block][col]; with
+    // num_blocks==1 this is exactly the original per-column split over the whole band range.
+    std::vector<std::vector<uint32_t>> band_start(num_blocks, std::vector<uint32_t>(cols_used));
+    std::vector<std::vector<uint32_t>> band_size(num_blocks, std::vector<uint32_t>(cols_used));
     {
-        const uint32_t bands_per_col = band_count / cols_used, extra = band_count % cols_used;
-        uint32_t off = 0;
-        for (uint32_t col = 0; col < cols_used; ++col) {
-            col_band_size[col] = bands_per_col + (col < extra ? 1u : 0u);
-            col_band_start[col] = off;
-            off += col_band_size[col];
+        const uint32_t bands_per_block = band_count / num_blocks, blk_extra = band_count % num_blocks;
+        uint32_t blk_off = 0;
+        for (uint32_t blk = 0; blk < num_blocks; ++blk) {
+            const uint32_t blk_bands = bands_per_block + (blk < blk_extra ? 1u : 0u);
+            const uint32_t bands_per_col = blk_bands / cols_used, extra = blk_bands % cols_used;
+            uint32_t off = blk_off;
+            for (uint32_t col = 0; col < cols_used; ++col) {
+                band_size[blk][col] = bands_per_col + (col < extra ? 1u : 0u);
+                band_start[blk][col] = off;
+                off += band_size[blk][col];
+            }
+            blk_off += blk_bands;
         }
     }
-    // rows_used divides group_count, so every row runs the same num_groups (k-mcast lockstep).
-    const uint32_t num_groups = group_count / rows_used;
-    // Widest column's band count: the streaming q-mcast pad target (the kernels pad each row to max_bands
-    // with q-only phantom bands so the rendezvous stays uniform).
-    const uint32_t max_bands = (band_count + cols_used - 1) / cols_used;
+    // Widest cell's band count: the streaming q-mcast pad target (the kernels pad each row to max_bands with
+    // q-only phantom bands so the rendezvous stays uniform). Widest block has ceil(band_count/num_blocks)
+    // bands; its widest column ceil(that/cols_used).
+    const uint32_t bands_in_widest_block = (band_count + num_blocks - 1) / num_blocks;
+    const uint32_t max_bands = (bands_in_widest_block + cols_used - 1) / cols_used;
 
     const CoreRange core_rect(CoreCoord{0, 0}, CoreCoord{cols_used - 1, rows_used - 1});
     const CoreRangeSet core_ranges(core_rect);
@@ -185,8 +206,9 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
         }
     }
 
-    // k-mcast needs >1 row down a column; q/w-mcast needs >1 column along a row (both HB-independent).
-    const uint32_t k_mcast_on = (rows_used > 1) ? 1u : 0u;
+    // k-mcast shares a block's band-chunk down its group_rows rows; q/w-mcast needs >1 column along a row
+    // (both HB-independent).
+    const uint32_t k_mcast_on = (group_rows > 1) ? 1u : 0u;
     const uint32_t q_mcast_on = (cols_used > 1) ? 1u : 0u;
 
     // 3 semaphores per active direction: send (receivers ready), recv (sender relays valid in), valid
@@ -235,12 +257,14 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     // One-line schedule/mcast summary (per cache miss) for profiling.
     log_debug(
         tt::LogOp,
-        "indexer_score schedule: G={} U={} grid={}x{} rows_used={} cols_used={} num_groups={} "
-        "max_bands={} stream_heads={} k_mcast={} q_mcast={}",
+        "indexer_score schedule: G={} U={} grid={}x{} group_rows={} num_blocks={} rows_used={} cols_used={} "
+        "num_groups={} max_bands={} stream_heads={} k_mcast={} q_mcast={}",
         group_count,
         band_count,
         grid_x,
         grid_y,
+        group_rows,
+        num_blocks,
         rows_used,
         cols_used,
         num_groups,
@@ -378,21 +402,25 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
         const uint32_t q_py = u32(phys[row][0].y);
         const uint32_t q_diag = std::min<uint32_t>(row, cols_used - 1);  // diagonal sender column
         const CoreCoord q_sender = phys[row][q_diag];
+        // This row's band-chunk block and its row base within the grid. The k-mcast spans only the block's
+        // group_rows rows; row % group_rows is the group this row computes (same in every block).
+        const uint32_t block = row / group_rows;
+        const uint32_t block_base = block * group_rows;
         for (uint32_t col = 0; col < cols_used; ++col) {
-            // physical bbox of this column down the used rows (k mcast rect); px constant down the column.
-            uint32_t k_ys = u32(phys[0][col].y), k_ye = u32(phys[0][col].y);
-            for (uint32_t bbox_row = 0; bbox_row < rows_used; ++bbox_row) {
+            // physical bbox of this column down the block's rows (k mcast rect); px constant down the column.
+            uint32_t k_ys = u32(phys[block_base][col].y), k_ye = u32(phys[block_base][col].y);
+            for (uint32_t bbox_row = block_base; bbox_row < block_base + group_rows; ++bbox_row) {
                 k_ys = std::min<uint32_t>(k_ys, u32(phys[bbox_row][col].y));
                 k_ye = std::max<uint32_t>(k_ye, u32(phys[bbox_row][col].y));
             }
-            const uint32_t k_px = u32(phys[0][col].x);
-            const CoreCoord k_sender = phys[0][col];
+            const uint32_t k_px = u32(phys[block_base][col].x);
+            const CoreCoord k_sender = phys[block_base][col];
 
             const CoreCoord core{col, row};
             cores.push_back(core);
-            // max_bands is uniform (the row's widest column); streaming pads its band loop to it.
+            // max_bands is uniform (global widest cell); streaming pads its band loop to it.
             const std::array<uint32_t, 6> sched = {
-                row, rows_used, num_groups, col_band_start[col], col_band_size[col], max_bands};
+                row % group_rows, group_rows, num_groups, band_start[block][col], band_size[block][col], max_bands};
 
             std::vector<uint32_t> reader_rt = {q.buffer()->address(), k.buffer()->address(), w.buffer()->address()};
             reader_rt.insert(reader_rt.end(), sched.begin(), sched.end());
@@ -412,15 +440,16 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
                 reader_rt.push_back(u32(s.y));
                 reader_rt.push_back(ndst);
             };
-            // K column: sender row 0, receivers rows [1, rows_used); vertical rect spanning the column.
+            // K column: per row-block, sender is the block's top row, receivers the rest of the block;
+            // vertical rect spanning only the block's group_rows rows.
             push_mcast_dir(
-                k_mcast_on ? (row == 0 ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
+                k_mcast_on ? (row == block_base ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
                 k_px,
                 k_ys,
                 k_px,
                 k_ye,
                 k_sender,
-                rows_used - 1);
+                group_rows - 1);
             // Q/W row: sender on the diagonal column, receivers the rest of the row; horizontal rect.
             push_mcast_dir(
                 q_mcast_on ? (col == q_diag ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
@@ -55,4 +55,22 @@ constexpr uint32_t rows_for_groups(uint32_t groups, uint32_t grid_y) { return la
 /** Grid columns for U k-bands: min(U, grid_x); spare columns idle when U < grid_x. */
 constexpr uint32_t cols_for_bands(uint32_t bands, uint32_t grid_x) { return bands < grid_x ? bands : grid_x; }
 
+/** Row-block replication factor: when G groups under-fill the grid rows (short sequences), replicate each
+ *  group across this many row-blocks and split its band range across them, filling the idle rows. Capped by
+ *  the idle-row count (grid_y / group_rows) and by one band per (block, column) cell (bands / cols), so it is
+ *  always >= 1. 1 == the single-band-row schedule (deployed long-sequence cases, where group_rows == grid_y). */
+constexpr uint32_t band_row_blocks(uint32_t groups, uint32_t bands, uint32_t grid_x, uint32_t grid_y) {
+    const uint32_t fill = grid_y / rows_for_groups(groups, grid_y);  // idle-row fill factor
+    const uint32_t deep = bands / cols_for_bands(bands, grid_x);     // never finer than one band per cell
+    const uint32_t blocks = fill < deep ? fill : deep;
+    return blocks < 1u ? 1u : blocks;
+}
+
+/** Cores the banded schedule lights up: (group_rows * row_blocks) rows x cols columns. Single-sourced so the
+ *  factory's core rectangle and the perf model's core count cannot drift. */
+constexpr uint32_t banded_core_count(uint32_t groups, uint32_t bands, uint32_t grid_x, uint32_t grid_y) {
+    return rows_for_groups(groups, grid_y) * band_row_blocks(groups, bands, grid_x, grid_y) *
+           cols_for_bands(bands, grid_x);
+}
+
 }  // namespace ttnn::operations::experimental::indexer_score


### PR DESCRIPTION
## Summary

At higher sequence parallelism (**SP=32**) and lower tensor parallelism (**TP=1**), GLM5 and DSv32 shard to a **160-query** chunk per device with all index heads resident (TP=1 means no tensor-parallel head split).

`indexer_score` under-utilizes the grid at this shape. The scheduler maps q-groups → grid rows and k-bands → grid columns; 160 queries at QC=1 yields only 5 q-groups → 5 of the 10 grid rows (**55 of 110 cores**), with the k-bands serialized down the columns. Since k-bands are a column-only axis they cannot reach the idle rows, and the q-group axis is bounded by the sequence length, so the op runs on roughly half the grid.

**Fix:** a block-split scheduler replicates each q-group across `num_blocks` row-blocks and splits its band range across them, filling the idle rows. Each block's k-mcast remains a contiguous rectangle and blocks write disjoint output columns, so there is **no cross-core reduction and no additional k DRAM reads**. This is a factory-only change (kernels untouched), and `num_blocks==1` (the deployed long-sequence shapes) is byte-identical to the previous schedule.

Also fixes `create_op_performance_model`, whose core count omitted the `num_blocks` factor (under-counting cores on exactly these shapes). The factory and perf model now share `band_row_blocks()` / `banded_core_count()` so the two counts cannot drift.

## Performance

Blackhole P150, HiFi2 (bf16 q + bfp8 k), min device kernel duration. Both shapes are GLM5/DSv32 resharded TP=1/SP=32 (160-query chunk), now filling all 110 cores:

| Case | Heads | Cores | Device time | Math util |
|------|-------|-------|-------------|-----------|
| `glm5_tp1` (GLM5 @ TP1/SP32) | 32 | 110 | 0.321 ms | 75.54% |
| `dsv32_tp1` (DSv32 @ TP1/SP32) | 64 | 110 | 0.627 ms | 77.31% |

Without the fill these used only 55 cores at ~half the util (64h/160: 1.277 ms → 0.658 ms, 1.94×). Both are now regression-guarded by `test_indexer_score_math_util[glm5_tp1|dsv32_tp1]`; the deployed glm5/dsv32 band checks are unchanged.

## Pipelines

- Blackhole post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/28353694832
- L2 nightly (experimental only): https://github.com/tenstorrent/tt-metal/actions/runs/28353699891
- Device perf (op tests only): https://github.com/tenstorrent/tt-metal/actions/runs/28353704873
