### PR TITLE
#48372: Fix t3k ring-joint SDPA program-cache test (assert 3 == 1)

### DIFF
--- a/tests/nightly/t3000/ccl/test_ring_attention_all_gather.py
+++ b/tests/nightly/t3000/ccl/test_ring_attention_all_gather.py
@@ -350,7 +350,7 @@ def test_ring_attention_all_gather(
 @pytest.mark.parametrize(
     "enable_trace, num_iters",
     [
-        (False, 1),
+        (False, 3),
     ],
     ids=["check"],
 )
@@ -383,36 +383,28 @@ def test_ring_attention_all_gather_program_cache(
 ):
     submesh_device = create_ring_attention_submesh(mesh_device, rp_axis, rp_factor, up_factor)
 
-    dummy_tensors = []
-    for i in range(3):
-        dummy_tensors.append(
-            ttnn.from_torch(
-                torch.rand(ag_output_shape),
-                device=submesh_device,
-                layout=layout,
-                dtype=ag_input_dtype,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    submesh_device, mesh_shape=tuple(submesh_device.shape), dims=[None, None]
-                ),
-            )
-        )
-        run_ring_attention_all_gather_impl(
-            submesh_device,
-            ag_output_shape,
-            ag_num_inputs,
-            rp_axis,
-            rp_factor,
-            up_factor,
-            num_links,
-            ag_input_dtype,
-            layout,
-            mem_config_input,
-            mem_config_ag,
-            all_gather_topology=all_gather_topology,
-            enable_trace=enable_trace,
-            num_iters=num_iters,
-            pcc_threshold=pcc_threshold,
-        )
-        ttnn.synchronize_device(submesh_device)
+    # Run the op num_iters (>1) times within a SINGLE run_ring_attention_all_gather_impl invocation. The op
+    # must be exercised under one sub-device-manager lifetime: run_ring_attention_all_gather_impl loads a
+    # sub-device manager on entry, which clears the program cache (mesh_device.cpp clear_program_cache on
+    # manager switch), so looping the whole helper would clear the cache between calls and defeat the reuse
+    # check. The impl's internal loop runs the op num_iters times with distinct per-iter persistent buffers
+    # and global semaphores, so cache reuse is still validated against address variation.
+    run_ring_attention_all_gather_impl(
+        submesh_device,
+        ag_output_shape,
+        ag_num_inputs,
+        rp_axis,
+        rp_factor,
+        up_factor,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        pcc_threshold=pcc_threshold,
+    )
 
     assert submesh_device.cache_entries_counter.total == 1

--- a/tests/nightly/t3000/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/t3000/ccl/test_ring_joint_attention.py
@@ -6,8 +6,6 @@ import os
 import math
 from itertools import product
 
-import torch
-
 import ttnn
 from loguru import logger
 import pytest
@@ -201,7 +199,7 @@ def test_ring_joint_sdpa(
     ],
     ids=["sd35"],
 )
-@pytest.mark.parametrize("n_iters, trace_enabled", [(1, False)], ids=["no_trace"])
+@pytest.mark.parametrize("n_iters, trace_enabled", [(3, False)], ids=["no_trace"])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "device_params, all_gather_topology",
@@ -263,38 +261,32 @@ def test_ring_joint_sdpa_program_cache(
     skip_check = False
 
     submesh.cache_entries_counter = CacheEntriesCounter(submesh)
-    dummy_tensors = []
-    for i in range(3):
-        dummy_tensors.append(
-            ttnn.from_torch(
-                torch.rand((b, nh, seq_len, d)),
-                device=submesh,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=dtype,
-                mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=[None, None]),
-            )
-        )
-
-        run_ring_joint_sdpa(
-            submesh,
-            b,
-            nh,
-            seq_len,
-            seq_len,
-            joint_seq_len,
-            d,
-            q_chunk_size,
-            k_chunk_size,
-            dtype,
-            n_iters,
-            trace_enabled,
-            num_links,
-            rp_axis,
-            up_axis,
-            all_gather_topology,
-            skip_check,
-            pcc_threshold,
-        )
+    # Run the op n_iters (>1) times within a SINGLE run_ring_joint_sdpa invocation. The op must be
+    # exercised under one sub-device-manager lifetime: run_ring_joint_sdpa loads a sub-device manager
+    # on entry, which clears the program cache (mesh_device.cpp clear_program_cache on manager switch),
+    # so looping the whole helper would clear the cache between calls and defeat the reuse check.
+    # run_ring_joint_sdpa's internal loop runs the op n_iters times with distinct per-iter persistent
+    # buffers and global semaphores, so cache reuse is still validated against address variation.
+    run_ring_joint_sdpa(
+        submesh,
+        b,
+        nh,
+        seq_len,
+        seq_len,
+        joint_seq_len,
+        d,
+        q_chunk_size,
+        k_chunk_size,
+        dtype,
+        n_iters,
+        trace_enabled,
+        num_links,
+        rp_axis,
+        up_axis,
+        all_gather_topology,
+        skip_check,
+        pcc_threshold,
+    )
 
     assert submesh.cache_entries_counter.total == 1
 


### PR DESCRIPTION
## Summary

Two t3k CCL program-cache tests failed with `assert 3 == 1` on T3K E2E. Both have the same root cause: the helper was looped 3×, and each call reloads the sub-device manager which clears the program cache (#47921), so every run recompiled instead of reusing the cached program. Fix in both: run the op `n_iters=3` within a **single** helper invocation (one sub-device-manager lifetime), where the helper's internal loop already uses distinct per-iter persistent buffers and global semaphores — so cache reuse is still validated against address variation.

1. **`test_ring_joint_sdpa_program_cache`** (`tests/nightly/t3000/ccl/test_ring_joint_attention.py`) — same root cause and fix as **#48383**, which patched only the blackhole copy of the test; this applies the identical change to the t3000 file it missed.
2. **`test_ring_attention_all_gather_program_cache`** (`tests/nightly/t3000/ccl/test_ring_attention_all_gather.py`) — the sibling t3k test hit the identical `3 == 1` regression and was caught failing in the first E2E run; fixed the same way (separate commit).

## Test

Local T3K verification (all pass):
- `test_ring_joint_sdpa_program_cache` — 3 passed (sd35 × bf16/bf8_b/bf4_b)
- `test_ring_attention_all_gather_program_cache` — 6 passed (bf16/bf8_b/bf4_b × rp2/rp4)

T3K E2E pipeline runs:
- New run (this fix, commit `d07ee52`): https://github.com/tenstorrent/tt-metal/actions/runs/28362744820
- Prior run (surfaced the all-gather failure): https://github.com/tenstorrent/tt-metal/actions/runs/28354147355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/fix-t3k-ring-joint-sdpa-program-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/fix-t3k-ring-joint-sdpa-program-cache)
