### PR TITLE
ULP for uniform outputs and fix invalid-bcast error assertions

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_bcast_ext.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_bcast_ext.py
@@ -11,6 +11,7 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 )
 from models.common.utility_functions import torch_random
 from models.common.utility_functions import divup
+from models.common.utility_functions import comp_pcc
 from itertools import product as parameters
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -52,17 +53,16 @@ binary_fns = {
     "ttnn_fn",
     binary_fns,
 )
-def test_binary_scalar_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
+def test_binary_scalar_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device, expect_error):
     torch.manual_seed(0)
     ttnn_op = getattr(ttnn, ttnn_fn)
 
     _, a_tt = rand_bf16_gen(a_shape, device)
     _, b_tt = rand_bf16_gen(b_shape, device)
 
-    with pytest.raises(RuntimeError) as e:
+    with expect_error(RuntimeError, r"Broadcasting rule violation|Invalid subtile broadcast type"):
         cq_id = 0
         _ = ttnn_op(a_tt, b_tt, queue_id=cq_id)
-        assert "Broadcasting rule violation" in str(e.value)
 
 
 @pytest.mark.parametrize(
@@ -77,7 +77,7 @@ def test_binary_scalar_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
     "ttnn_fn",
     binary_fns,
 )
-def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, device):
+def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, device, expect_error):
     torch.manual_seed(0)
     ttnn_op = getattr(ttnn, ttnn_fn)
 
@@ -85,8 +85,9 @@ def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, d
     _, input_tensor_b = rand_bf16_gen(b_shape, device)
     _, out_tt = rand_bf16_gen(out_shape, device)
 
-    with pytest.raises(
-        RuntimeError, match=r"Shape of Output tensor.+ provided does not match the broadcasted output shape .+"
+    with expect_error(
+        RuntimeError,
+        r"Shape of Output tensor.+ provided does not match the broadcasted output shape .+",
     ):
         cq_id = 0
         ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)
@@ -159,6 +160,35 @@ def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY
     pt = torch.rand(shape, dtype=torch.bfloat16) * (max - min) + min
     tt = ttnn.from_torch(pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=memory_config)
     return pt, tt
+
+
+def assert_inplace_binary_matches(torch_output_tensor, output_tensor, *, pcc_threshold=0.99):
+    # Contract: both tensors must have the same shape.
+    assert list(torch_output_tensor.shape) == list(
+        output_tensor.shape
+    ), f"Shape mismatch: golden {list(torch_output_tensor.shape)} vs device {list(output_tensor.shape)}"
+
+    if torch_output_tensor.numel() == 0:
+        return
+
+    golden_uniform = torch.max(torch_output_tensor) == torch.min(torch_output_tensor)
+    device_uniform = torch.max(output_tensor) == torch.min(output_tensor)
+
+    if golden_uniform and device_uniform:
+        if not torch.isfinite(torch_output_tensor.flatten()[0]) or not torch.isfinite(output_tensor.flatten()[0]):
+            assert torch.equal(torch_output_tensor, output_tensor), (
+                f"Non-finite uniform tensors differ: golden={torch_output_tensor.flatten()[0]}, "
+                f"device={output_tensor.flatten()[0]}"
+            )
+            return
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=4)
+        return
+
+    # If only one tensor is constant (or neither), ttnn.pearson_correlation_coefficient can return a
+    # MaskedConstant false-pass of 1.0. Use comp_pcc which has the correct allclose fallback for
+    # zero-variance inputs.
+    pcc_passed, pcc_val = comp_pcc(torch_output_tensor, output_tensor, pcc=pcc_threshold)
+    assert pcc_passed, f"PCC {pcc_val:.6f} < threshold {pcc_threshold}"
 
 
 @pytest.mark.parametrize(
@@ -654,25 +684,17 @@ def test_inplace_binary_ops_with_tensor(a_shape, b_shape, ttnn_fn, activations, 
         activations=post,
     )
     output_tensor = ttnn.to_torch(input_tensor_a)
-    assert output_tensor.shape == torch_output_tensor.shape
 
-    def compare(output_tensor, torch_output_tensor):
-        imprecise_cases = {
-            *parameters(
-                {"logaddexp2_"},
-                {exp_floor_lhs_exp_rhs, no_activations, sin_rhs, log_lhs_sqrt_abs_post, square_lhs},
-            ),
-            *parameters({"bias_gelu_"}, {no_activations, sin_rhs, square_lhs}),
-            *parameters({"gt_", "le_", "ge_", "lt_"}, {sin_rhs, square_lhs}),
-        }
-
-        return (
-            ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.98
-            if (ttnn_fn, activations) in imprecise_cases
-            else ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
-        )
-
-    assert compare(output_tensor, torch_output_tensor)
+    imprecise_cases = {
+        *parameters(
+            {"logaddexp2_"},
+            {exp_floor_lhs_exp_rhs, no_activations, sin_rhs, log_lhs_sqrt_abs_post, square_lhs},
+        ),
+        *parameters({"bias_gelu_"}, {no_activations, sin_rhs, square_lhs}),
+        *parameters({"gt_", "le_", "ge_", "lt_"}, {sin_rhs, square_lhs}),
+    }
+    pcc_threshold = 0.98 if (ttnn_fn, activations) in imprecise_cases else 0.999
+    assert_inplace_binary_matches(torch_output_tensor, output_tensor, pcc_threshold=pcc_threshold)
 
 
 @pytest.mark.parametrize(
@@ -771,8 +793,7 @@ def test_inplace_binary_with_scalar(a_shape, scalar, ttnn_fn, device):
 
     ttnn_op(input_tensor_a, scalar)
     output_tensor = ttnn.to_torch(input_tensor_a)
-    assert output_tensor.shape == torch_output_tensor.shape
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99
+    assert_inplace_binary_matches(torch_output_tensor, output_tensor, pcc_threshold=0.99)
 
 
 profile_a_b_shape_pairs = [

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_bcast_ext.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_bcast_ext.py
@@ -164,9 +164,9 @@ def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY
 
 def assert_inplace_binary_matches(torch_output_tensor, output_tensor, *, pcc_threshold=0.99):
     # Contract: both tensors must have the same shape.
-    assert list(torch_output_tensor.shape) == list(
-        output_tensor.shape
-    ), f"Shape mismatch: golden {list(torch_output_tensor.shape)} vs device {list(output_tensor.shape)}"
+    assert (
+        torch_output_tensor.shape == output_tensor.shape
+    ), f"Shape mismatch: golden {torch_output_tensor.shape} vs device {output_tensor.shape}"
 
     if torch_output_tensor.numel() == 0:
         return
@@ -184,9 +184,7 @@ def assert_inplace_binary_matches(torch_output_tensor, output_tensor, *, pcc_thr
         assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=4)
         return
 
-    # If only one tensor is constant (or neither), ttnn.pearson_correlation_coefficient can return a
-    # MaskedConstant false-pass of 1.0. Use comp_pcc which has the correct allclose fallback for
-    # zero-variance inputs.
+    # If one tensor is constant (or neither), comp_pcc falls back to allclose.
     pcc_passed, pcc_val = comp_pcc(torch_output_tensor, output_tensor, pcc=pcc_threshold)
     assert pcc_passed, f"PCC {pcc_val:.6f} < threshold {pcc_threshold}"
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/48326

### PR Category
Test Only

### Summary

Follow-up test fixes for `test_binary_bcast_ext.py` after #42848 (`comp_pcc` no longer false-passes constant tensors with PCC = 1.0). Full file run: **34 failures** → fixed with stricter but correct assertions. No kernel behavior changes.

| Test | Failures | Fix |
|------|----------|-----|
| `test_inplace_binary_ops_with_tensor` | 8 | Shared helper: ULP when both outputs are uniform (finite) |
| `test_inplace_binary_with_scalar` | 4 | Same helper — uniform `squared_difference_` with `a_shape=[1,1,1,1]` |
| `test_inplace_binary_with_scalar` | 3 | Same helper — `divide_` + `scalar=0.0` → uniform `inf`; `torch.equal` instead of ULP |
| `test_binary_scalar_ops_invalid_bcast` | 19 | Accept both valid `binary_ng` error messages via `expect_error` |

**Shared assertion:** `assert_inplace_binary_matches` — used by both inplace tests above.

1. Both tensors uniform + **finite** → `assert_with_ulp(..., ulp_threshold=4)`
2. Both tensors uniform + **non-finite** (`inf`/`nan`) → `torch.equal` (ULP rejects non-finite by default)
3. Non-uniform → PCC ≥ threshold (0.999 / 0.98 / 0.99 per test)

### Uniform-output comparisons (12 failures: 8 tensor + 4 scalar)

Fused SFPU activations + scalar RHS broadcast collapse to uniform bf16 tensors. Device matches golden within **1–4 bf16 ULP** (expected vs sequential PyTorch reference); old PCC reported 1.0 and masked the drift.

**`test_inplace_binary_ops_with_tensor` (8):**

| # | Op | Activations | Shapes (a × b) | Golden | TTNN | Max ULP |
|---|-----|-------------|----------------|--------|------|---------|
| 1 | `divide_` | `(FLOOR, EXP), (EXP,), ()` | `[5,3,32,32]` × `[1,1,1,1]` | 2.9375 | 2.9219 | 1 |
| 2 | `mul_` | same | same | 1.5547 | 1.5469 | 1 |
| 3 | `bias_gelu_` | `(FLOOR,), (CEIL,), (COS,)` | `[5,3,32,32]` × `[1,1,1,1]` | 0.6719 | 0.6680 | 1 |
| 4 | `bias_gelu_` | same | `[5,1,1,128]` × `[5,1,1,1]` | 0.6719 | 0.6680 | 1 |
| 5 | `sub_` | `(FLOOR, EXP), (EXP,), ()` | `[5,3,32,32]` × `[1,1,1,1]` | −0.5547 | −0.5469 | 2 |
| 6 | `squared_difference_` | same | same | 0.3066 | 0.2988 | 4 |
| 7 | `rsub_` | same | same | 0.5547 | 0.5469 | 2 |
| 8 | `add_` | same | same | 2.5625 | 2.5469 | 1 |

**`test_inplace_binary_with_scalar` (4):** `squared_difference_`, `a_shape=[1,1,1,1]`, all 4 scalars in `[-0.25, -16.5, 0.05, 19.0]` — same uniform-output / ULP pattern (scalar op on 1-element tensor → constant result).

### Non-finite uniform outputs (3 failures)

**`test_inplace_binary_with_scalar`:** `divide_` + `scalar=0.0` → both golden and device produce uniform `inf`.

`assert_with_ulp` rejects non-finite values by default (`allow_nonfinite=False`). Fix: when both tensors are uniform and non-finite, assert `torch.equal` instead.

| Shape | Golden | Device |
|-------|--------|--------|
| `[1,1,1,1]` | `inf` | `inf` |
| `[16,1]` | `inf` | `inf` |
| `[1,1,32]` | `inf` | `inf` |

Note: `scalar=0.0` + `a_shape=[5,3,128,64]` / `[5,3,32,32]` / `[920,1,256]` already passed — inputs are not uniform, so PCC/allclose applies and mixed finite/`inf` elements are handled there.

### Invalid-broadcast assertions (19 failures)

**Assertion:** migrate `pytest.raises` → `expect_error` (pre-commit `prefer-expect-error`); match `Broadcasting rule violation|Invalid subtile broadcast type`.

All 19 failures: shape `[1, 1, 31, 32] × [5, 3, 32, 32]` × every op in `binary_fns`. `binary_ng` rejects via subtile validation (`Invalid subtile broadcast type` at `binary_ng_device_operation.cpp:225`); other invalid-bcast shape pairs still throw `Broadcasting rule violation`. Old test only checked `RuntimeError` type — message check was dead code.

`test_binary_opt_output_invalid_bcast` also moved to `expect_error` (output-shape regex unchanged).

### Pipeline status

- [ ] Sanity
- [x] BHPC
- [x] Nightly for eltwise ops

### Test results
<img width="1202" height="61" alt="Screenshot 2026-06-30 at 11 19 44 AM" src="https://github.com/user-attachments/assets/06301467-eb6a-47d6-b9e4-94c991f8310f" />



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/binary_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/binary_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/binary_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/binary_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/binary_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/binary_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/binary_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/binary_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/binary_ext)