### PR TITLE
sparse_sdpa: in-kernel block-cyclic index remap

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_sparse_sdpa_multidevice.py
+++ b/tests/nightly/blackhole/sdpa/test_sparse_sdpa_multidevice.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""sparse_sdpa block-cyclic remap — MULTI-DEVICE (sp>1) coverage (Blackhole only).
+
+The single-device suite (test_sparse_sdpa.py) can only smoke the block-cyclic path at sp=1, where the remap
+is the identity. The real natural->physical PERMUTATION arithmetic only runs when sp>1 (the cache is striped
+over >1 SP shard), which needs a real SP mesh — hence this separate module with a `mesh_device` fixture (the
+single-device file pins `use_module_device` and can't host one).
+
+Setup mirrors the DeepSeek chunked-prefill producer: the kv cache is stored block-cyclic across `sp` shards
+(see models/.../mla/utils.py::blockcyclic_positions, replicated here so the test has no model dependency); the
+queries for one chunk are SP-sharded on seq (chunk_local rows per chip). `indices` are NATURAL token positions;
+the kernel remaps each to its physical page. The op must therefore match the natural-order golden.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import make_inputs, golden, pcc
+
+K_DIM = 576  # head dim (q/kv width)
+V_DIM = 512  # V width / output width (op arg)
+
+
+def _blockcyclic_positions(sp, chunk_size_global, seq_len_cache):
+    """Natural global position held by each physical block-cyclic row r (the inverse the kernel must apply).
+    Mirrors models/demos/deepseek_v3_d_p/tt/mla/utils.py::blockcyclic_positions — kept local so this ttnn op
+    test does not depend on the model."""
+    seq_len_local = seq_len_cache // sp
+    chunk_local = chunk_size_global // sp
+    c = torch.arange(sp).repeat_interleave(seq_len_local)
+    lr = torch.arange(seq_len_local).repeat(sp)
+    slab, off = lr // chunk_local, lr % chunk_local
+    return slab * chunk_size_global + c * chunk_local + off
+
+
+def _to_blockcyclic(kv_natural, sp, chunk_size_global):
+    """Reorder a natural [T, D] kv cache into block-cyclic slab-major layout: physical row r holds natural
+    token p[r]. Returns [1, 1, T, D]."""
+    T = kv_natural.shape[0]
+    p = _blockcyclic_positions(sp, chunk_size_global, T)
+    return kv_natural[p].reshape(1, 1, T, K_DIM)
+
+
+# sp is DERIVED from mesh axis 0; tp = mesh_size/sp (== 1 here). chunk_local is fixed and T spans >1 slab per
+# shard (slabs = (T/sp)/chunk_local: sp=2 -> 4 slabs, sp=4 -> 2 slabs) so the permutation is non-trivial.
+@run_for_blackhole()
+@pytest.mark.parametrize("mesh_device", [(2, 1), (4, 1)], indirect=True, ids=["sp2", "sp4"])
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [(lambda s: 10**9, "all_valid"), (lambda s: 1 + (s * 3) % 20, "boundary")],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_block_cyclic_sp_multi(mesh_device, nv_fn, nv_id):
+    sp = tuple(mesh_device.shape)[0]
+    H, T, TOPK, kc = 32, 256, 64, 32
+    chunk_local = 32  # per-chip query rows == one chunk's per-shard length (the op's chunk_local cross-check)
+    chunk_size_global = sp * chunk_local
+    Sq = sp * chunk_local  # global query count this chunk (chunk_local per chip)
+    assert (T // sp) % chunk_local == 0 and (T // sp) // chunk_local > 1, "need >1 slab to exercise the remap"
+
+    # Natural-order reference inputs; golden runs the full Sq queries against the natural cache.
+    q, kv_nat, indices = make_inputs(H, Sq, T, TOPK, K_DIM, nv_fn, seed=sp)
+    ref = golden(q, kv_nat, indices, K_DIM**-0.5, V_DIM)
+
+    # Device: block-cyclic kv REPLICATED; q + natural indices SP-sharded on seq (dim 2) across mesh axis 0.
+    kv_bc = _to_blockcyclic(kv_nat[0, 0], sp, chunk_size_global)
+    mesh_shape = tuple(mesh_device.shape)
+    shard_seq = ttnn.ShardTensor2dMesh(mesh_device, dims=(2, None), mesh_shape=mesh_shape)
+    common = dict(layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    tt_q = ttnn.from_torch(q.to(torch.bfloat16), dtype=ttnn.bfloat16, mesh_mapper=shard_seq, **common)
+    tt_kv = ttnn.from_torch(
+        kv_bc.to(torch.bfloat16), dtype=ttnn.bfloat16, mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device), **common
+    )
+    tt_idx = ttnn.from_torch(indices.to(torch.int32), dtype=ttnn.uint32, mesh_mapper=shard_seq, **common)
+
+    tt_out = ttnn.transformer.sparse_sdpa(
+        tt_q,
+        tt_kv,
+        tt_idx,
+        V_DIM,
+        scale=K_DIM**-0.5,
+        k_chunk_size=kc,
+        block_cyclic_sp_axis=0,  # sp read from mesh axis 0
+        block_cyclic_chunk_local=chunk_local,
+    )
+    # Concat the per-chip seq shards (mesh axis 0 -> tensor dim 2) back to the full [1, H, Sq, V_DIM].
+    out = ttnn.to_torch(
+        tt_out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_shape)
+    )
+    p = pcc(out, ref)
+    assert p >= 0.99, f"PCC {p:.5f} (sp={sp}, {nv_id})"

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -128,9 +128,9 @@ def test_sparse_sdpa_oversized_persistent_kv(device):
 # ---- to smoke the whole BC path here (API, the chunk_local cross-check, the BC_ENABLE kernel branch). All remap
 # ---- constants incl. BC_SHARD_STRIDE_GAP (= T/sp - chunk_local) are compile-time, with cache length T folded into the program hash, so
 # ---- each DISTINCT cache size T is its own program (the cache is expected to be a consistent-size prealloc).
-# ---- The sp>1 PERMUTATION arithmetic needs a real SP mesh (e.g. a 2-device p300); that multi-device coverage is
-# ---- a planned follow-up (it must live in its own module — a mesh_device fixture can't share this single-device
-# ---- use_module_device file). ----
+# ---- The sp>1 PERMUTATION arithmetic needs a real SP mesh; that multi-device coverage lives in
+# ---- tests/nightly/blackhole/sdpa/test_sparse_sdpa_multidevice.py (run on QuietBox-2 in BH post-commit — a
+# ---- mesh_device fixture can't share this single-device use_module_device file). ----
 @run_for_blackhole()
 def test_sparse_sdpa_block_cyclic_sp1_identity(device):
     """sp=1 (read from the 1x1 device-mesh): block-cyclic == natural, so the op must reproduce the natural golden

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -124,9 +124,9 @@ def test_sparse_sdpa_oversized_persistent_kv(device):
 
 # ---- block-cyclic remap: indices are NATURAL token positions but the kv cache is stored block-cyclic. `sp` is
 # ---- DERIVED from the mesh (block_cyclic_sp_axis = the mesh axis the cache was striped over). On ONE device the
-# ---- mesh is 1x1 so sp=1 and the remap reduces to identity (BC_K=0, c=0 => page=n) — enough to smoke the whole
-# ---- BC path here (API, the chunk_local cross-check, the BC_ENABLE kernel branch). All remap constants incl.
-# ---- BC_DELTA (= T/sp - chunk_local) are compile-time, with the cache length T folded into the program hash, so
+# ---- mesh is 1x1 so sp=1 and the remap reduces to identity (shard=0 and BC_SLAB_STRIDE_GAP=0 => page=n) — enough
+# ---- to smoke the whole BC path here (API, the chunk_local cross-check, the BC_ENABLE kernel branch). All remap
+# ---- constants incl. BC_SHARD_STRIDE_GAP (= T/sp - chunk_local) are compile-time, with cache length T folded into the program hash, so
 # ---- each DISTINCT cache size T is its own program (the cache is expected to be a consistent-size prealloc).
 # ---- The sp>1 PERMUTATION arithmetic needs a real SP mesh (e.g. a 2-device p300); that multi-device coverage is
 # ---- a planned follow-up (it must live in its own module — a mesh_device fixture can't share this single-device
@@ -134,8 +134,8 @@ def test_sparse_sdpa_oversized_persistent_kv(device):
 @run_for_blackhole()
 def test_sparse_sdpa_block_cyclic_sp1_identity(device):
     """sp=1 (read from the 1x1 device-mesh): block-cyclic == natural, so the op must reproduce the natural golden
-    while exercising the BC_ENABLE path, across cache sizes T. Since T is hashed for this path (BC_DELTA is a
-    compile-time define), each distinct T is a DISTINCT program — asserted below."""
+    while exercising the BC_ENABLE path, across cache sizes T. Since T is hashed for this path (BC_SHARD_STRIDE_GAP
+    is a compile-time define), each distinct T is a DISTINCT program — asserted below."""
     H, S, TOPK, kc = 32, 64, 64, 32
     Ts = (256, 512, 1024)
     device.clear_program_cache()
@@ -153,7 +153,7 @@ def test_sparse_sdpa_block_cyclic_sp1_identity(device):
         )
         p = pcc(ttnn.to_torch(out), golden(q, kv, indices, K_DIM**-0.5, V_DIM))
         assert p >= 0.99, f"PCC {p:.5f} (sp=1 identity block-cyclic, T={T})"
-    # T is hashed for the block-cyclic path (compile-time BC_DELTA), so each distinct cache size is its own program.
+    # T is hashed for the block-cyclic path (compile-time BC_SHARD_STRIDE_GAP), so each distinct cache size is its own program.
     n = device.num_program_cache_entries()
     assert n == len(Ts), f"block-cyclic should hash cache size T: got {n} program-cache entries (expected {len(Ts)})"
 

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -122,6 +122,61 @@ def test_sparse_sdpa_oversized_persistent_kv(device):
     assert n == 1, f"oversized persistent kv reuse recompiled: {n} program-cache entries (expected 1)"
 
 
+# ---- block-cyclic remap: indices are NATURAL token positions but the kv cache is stored block-cyclic. `sp` is
+# ---- DERIVED from the mesh (block_cyclic_sp_axis = the mesh axis the cache was striped over). On ONE device the
+# ---- mesh is 1x1 so sp=1 and the remap reduces to identity (BC_K=0, c=0 => page=n) — enough to smoke the whole
+# ---- BC path here (API, the chunk_local cross-check, the BC_ENABLE kernel branch). All remap constants incl.
+# ---- BC_DELTA (= T/sp - chunk_local) are compile-time, with the cache length T folded into the program hash, so
+# ---- each DISTINCT cache size T is its own program (the cache is expected to be a consistent-size prealloc).
+# ---- The sp>1 PERMUTATION arithmetic needs a real SP mesh (e.g. a 2-device p300); that multi-device coverage is
+# ---- a planned follow-up (it must live in its own module — a mesh_device fixture can't share this single-device
+# ---- use_module_device file). ----
+@run_for_blackhole()
+def test_sparse_sdpa_block_cyclic_sp1_identity(device):
+    """sp=1 (read from the 1x1 device-mesh): block-cyclic == natural, so the op must reproduce the natural golden
+    while exercising the BC_ENABLE path, across cache sizes T. Since T is hashed for this path (BC_DELTA is a
+    compile-time define), each distinct T is a DISTINCT program — asserted below."""
+    H, S, TOPK, kc = 32, 64, 64, 32
+    Ts = (256, 512, 1024)
+    device.clear_program_cache()
+    for T in Ts:
+        q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK, seed=T)
+        out = ttnn.transformer.sparse_sdpa(
+            to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16),
+            to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16),  # sp=1 => block-cyclic order == natural
+            to_dev(indices.to(torch.int32), device, ttnn.uint32),
+            V_DIM,
+            scale=K_DIM**-0.5,
+            k_chunk_size=kc,
+            block_cyclic_sp_axis=0,
+            block_cyclic_chunk_local=S,  # == q_isl (sp=1, tp=1)
+        )
+        p = pcc(ttnn.to_torch(out), golden(q, kv, indices, K_DIM**-0.5, V_DIM))
+        assert p >= 0.99, f"PCC {p:.5f} (sp=1 identity block-cyclic, T={T})"
+    # T is hashed for the block-cyclic path (compile-time BC_DELTA), so each distinct cache size is its own program.
+    n = device.num_program_cache_entries()
+    assert n == len(Ts), f"block-cyclic should hash cache size T: got {n} program-cache entries (expected {len(Ts)})"
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_block_cyclic_chunk_local_rejected(device, expect_error):
+    """The chunk_local cross-check rejects a value that is neither q_isl nor tp*q_isl — the footgun guard. On a
+    single device sp=1/tp=1, so the only legal chunk_local is q_isl (= S); any other value must raise."""
+    H, S, T, TOPK, kc = 32, 64, 256, 64, 32
+    q, kv_nat, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK, seed=1)
+    with expect_error(RuntimeError, "block_cyclic_chunk_local"):
+        ttnn.transformer.sparse_sdpa(
+            to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16),
+            to_dev(kv_nat.to(torch.bfloat16), device, ttnn.bfloat16),
+            to_dev(indices.to(torch.int32), device, ttnn.uint32),
+            V_DIM,
+            scale=K_DIM**-0.5,
+            k_chunk_size=kc,
+            block_cyclic_sp_axis=0,
+            block_cyclic_chunk_local=S - 16,  # != S (=q_isl); rejected before dispatch
+        )
+
+
 def _indexed_inputs(H, S, T, TOPK, B, seed=0):
     gen = torch.Generator().manual_seed(seed)
     q = torch.randn(1, H, S, K_DIM, generator=gen, dtype=torch.float32)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
@@ -19,6 +19,25 @@ constexpr uint32_t K_TRID_RING = 4;
 // trid ring: idx_ptr[base + p] -> k_cb at byte offset p * k_row_bytes, for p in [lo, hi). Used by the
 // reader for its half [half, valid) and by the writer for its half [0, half). `page_offset` selects the
 // batch slot of an indexed KV cache (cache_batch_idx * T); 0 for a single [1,1,T,K_DIM] cache.
+//
+// When BC_ENABLE is defined, the kv cache is stored block-cyclic across SP shards (the DeepSeek
+// chunked-prefill KVPE cache), so the natural-position index n is remapped to its physical page on the fly via
+// invP (the inverse of blockcyclic_positions). Natural order is slab-major (chunk after chunk, shard-within);
+// the physical buffer is shard-major (each shard's whole region, slabs-within). Decompose n into its block,
+// then re-encode by adjusting the per-shard and per-slab strides:
+//   block_idx = n / BC_CHUNK_LOCAL;  slab = block_idx / BC_SP;  shard = block_idx % BC_SP
+//   page = n + shard*BC_SHARD_STRIDE_GAP - slab*BC_SLAB_STRIDE_GAP
+// All factory compile-time defines (the cache length T is folded into the program hash for this path, so the
+// whole remap is compile-time-constant arithmetic — no runtime arg):
+//   BC_SP               = sp (number of SP shards)
+//   BC_CHUNK_LOCAL      = chunk_local (rows one chunk writes into one shard = chunk_size_global / sp)
+//   BC_SHARD_STRIDE_GAP = shard_len - chunk_local : the physical buffer reserves shard_len (= T/sp) rows per
+//                         shard, so consecutive shards sit that much further apart than in natural order
+//                         (chunk_local) -> push shard s forward by shard*gap.
+//   BC_SLAB_STRIDE_GAP  = chunk_global - chunk_local = chunk_local*(sp-1) : consecutive chunks (slabs) are
+//                         chunk_global apart in natural order but only chunk_local apart physically -> pull
+//                         slab s back by slab*gap.
+// Sentinels (0xFFFFFFFF) never reach here — the reader only gathers the valid (< nv) prefix.
 template <typename Accessor>
 FORCE_INLINE void trid_ring_gather(
     Noc& noc,
@@ -39,8 +58,16 @@ FORCE_INLINE void trid_ring_gather(
             experimental::async_read_barrier_with_trid(noc, trid);  // free this trid slot before reuse
         }
         experimental::set_read_trid(noc, trid);
-        noc.async_read(
-            kv, k_cb, k_row_bytes, {.page_id = page_offset + idx_ptr[base + p]}, {.offset_bytes = p * k_row_bytes});
+        uint32_t page = idx_ptr[base + p];
+#ifdef BC_ENABLE
+        // natural index n -> block-cyclic physical row (invP). All terms compile-time (T is hashed), so this is
+        // one compile-time divide (mul+shift) + shift/mask. See the header comment for the layout reasoning.
+        const uint32_t block_idx = page / BC_CHUNK_LOCAL;  // = slab*BC_SP + shard (natural-order block index)
+        const uint32_t slab = block_idx / BC_SP;
+        const uint32_t shard = block_idx - slab * BC_SP;
+        page = page + shard * BC_SHARD_STRIDE_GAP - slab * BC_SLAB_STRIDE_GAP;
+#endif
+        noc.async_read(kv, k_cb, k_row_bytes, {.page_id = page_offset + page}, {.offset_bytes = p * k_row_bytes});
     }
     const uint32_t to_drain = (cnt < D) ? cnt : D;
     for (uint32_t d = 0; d < to_drain; ++d) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
@@ -38,6 +38,19 @@ constexpr uint32_t K_TRID_RING = 4;
 //                         chunk_global apart in natural order but only chunk_local apart physically -> pull
 //                         slab s back by slab*gap.
 // Sentinels (0xFFFFFFFF) never reach here — the reader only gathers the valid (< nv) prefix.
+
+// natural (logical) index n -> block-cyclic physical row (invP). See the file header for the layout
+// reasoning. Parameterized (rather than reading the BC_* defines directly) so other block-cyclic gather
+// kernels (e.g. the indexer) can reuse the same remap. All args are compile-time constants at the call
+// site, so this folds to one compile-time divide (mul+shift) + shift/mask.
+FORCE_INLINE uint32_t logical_to_chunked_physical(
+    uint32_t n, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
+    const uint32_t block_idx = n / chunk_local;  // = slab*sp + shard (natural-order block index)
+    const uint32_t slab = block_idx / sp;
+    const uint32_t shard = block_idx - slab * sp;
+    return n + shard * shard_stride_gap - slab * slab_stride_gap;
+}
+
 template <typename Accessor>
 FORCE_INLINE void trid_ring_gather(
     Noc& noc,
@@ -62,10 +75,7 @@ FORCE_INLINE void trid_ring_gather(
 #ifdef BC_ENABLE
         // natural index n -> block-cyclic physical row (invP). All terms compile-time (T is hashed), so this is
         // one compile-time divide (mul+shift) + shift/mask. See the header comment for the layout reasoning.
-        const uint32_t block_idx = page / BC_CHUNK_LOCAL;  // = slab*BC_SP + shard (natural-order block index)
-        const uint32_t slab = block_idx / BC_SP;
-        const uint32_t shard = block_idx - slab * BC_SP;
-        page = page + shard * BC_SHARD_STRIDE_GAP - slab * BC_SLAB_STRIDE_GAP;
+        page = logical_to_chunked_physical(page, BC_CHUNK_LOCAL, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP);
 #endif
         noc.async_read(kv, k_cb, k_row_bytes, {.page_id = page_offset + page}, {.offset_bytes = p * k_row_bytes});
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
@@ -56,6 +56,8 @@ void kernel_main() {
     const uint32_t tok_count = get_arg_val<uint32_t>(4);
     // Indexed KV cache: page offset (cache_batch_idx * T) selecting the cache's batch slot; 0 if not indexed.
     const uint32_t kv_batch_page_offset = get_arg_val<uint32_t>(5);
+    // Block-cyclic remap (BC_ENABLE): all its constants are compile-time defines (the cache length T is hashed
+    // for this path), so there is no runtime arg to read here. See sparse_sdpa_gather.hpp for the remap.
 
     constexpr uint32_t q_row_bytes = k_dim * q_elem_bytes;     // Q row (bf16)
     constexpr uint32_t k_row_bytes = k_dim * kv_elem_bytes;    // K row (native dtype: fp8 or bf16)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -41,6 +41,8 @@ void kernel_main() {
     const uint32_t kv_addr = get_arg_val<uint32_t>(3);  // dual-NoC K-half gather
     // Indexed KV cache: page offset (cache_batch_idx * T) selecting the cache's batch slot; 0 if not indexed.
     const uint32_t kv_batch_page_offset = get_arg_val<uint32_t>(4);
+    // Block-cyclic remap (BC_ENABLE): all its constants are compile-time defines (the cache length T is hashed
+    // for this path) — no runtime arg here. See sparse_sdpa_gather.hpp for the remap.
 
     constexpr uint32_t row_bytes = vDHt * tt::constants::TILE_WIDTH * out_elem_bytes;  // V_DIM bytes per head-row
     constexpr uint32_t block_tiles = (H / tt::constants::TILE_HEIGHT) * vDHt;          // Sqt*vDHt: the [H,V_DIM] block

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -105,6 +105,8 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     // Block-cyclic remap: indices are natural positions; the kernel maps them to physical pages with sp and
     // chunk_local. seq_len_local = T/sp and slabs = seq_len_local/chunk_local must be integral. (sp and
     // chunk_local were already resolved+cross-checked at the ttnn entry; these are the device-side backstops.)
+    // Miss-only is sufficient: sp, chunk_local AND T are all folded into the program hash (see
+    // compute_program_hash), so a cache HIT has identical values already validated by the miss that built it.
     if (attrs.has_block_cyclic()) {
         const auto& bc = attrs.block_cyclic.value();
         const uint32_t T = kv.logical_shape()[2];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -102,6 +102,21 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     // to. No valid-length bound is needed — reads are index-driven (indices < populated length, sentinels mark
     // unused slots), so the unpopulated suffix is never addressed.
     validate_non_hashed(attrs, t);
+    // Block-cyclic remap: indices are natural positions; the kernel maps them to physical pages with sp and
+    // chunk_local. seq_len_local = T/sp and slabs = seq_len_local/chunk_local must be integral. (sp and
+    // chunk_local were already resolved+cross-checked at the ttnn entry; these are the device-side backstops.)
+    if (attrs.has_block_cyclic()) {
+        const auto& bc = attrs.block_cyclic.value();
+        const uint32_t T = kv.logical_shape()[2];
+        TT_FATAL(bc.sp > 0, "block_cyclic.sp must be > 0");
+        TT_FATAL(bc.chunk_local > 0, "block_cyclic.chunk_local must be > 0");
+        TT_FATAL(T % bc.sp == 0, "kv length T ({}) must be divisible by block_cyclic.sp ({})", T, bc.sp);
+        TT_FATAL(
+            (T / bc.sp) % bc.chunk_local == 0,
+            "seq_len_local (T/sp = {}) must be divisible by block_cyclic.chunk_local ({})",
+            T / bc.sp,
+            bc.chunk_local);
+    }
     TT_FATAL(is.rank() == 4 && is[0] == 1 && is[1] == 1 && is[2] == S, "indices must be [1,1,S,TOPK]");
     const uint32_t TOPK = is[3];
     TT_FATAL(S > 0 && TOPK > 0, "S/TOPK must be > 0");
@@ -191,12 +206,20 @@ ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAPar
         // kv.memory_config(): an ND-sharded kv produces different TensorAccessor compile-time args than an
         // interleaved one, so they must be distinct programs.
         t.kv.memory_config(),
-        // kv.logical_shape() only when sharded (see above); a fixed sentinel otherwise so interleaved T does
-        // not recompile.
-        t.kv.memory_config().is_sharded() ? t.kv.logical_shape() : tt::tt_metal::Shape{},
+        // kv.logical_shape() when sharded (see above) OR block-cyclic: the block-cyclic remap bakes BC_SHARD_STRIDE_GAP
+        // (= T/sp - chunk_local) as a compile-time define, so the cache length T must be in the hash (a
+        // different cache size is a distinct program). A plain interleaved kv keeps T out of the hash (sentinel
+        // shape) so changing T does not recompile.
+        (t.kv.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.kv.logical_shape() : tt::tt_metal::Shape{},
         // Only whether kv is indexed (not which slot): cache_batch_idx's VALUE is a dynamic runtime arg
         // (see get_dynamic_runtime_args), so indexing into a different slot reuses the same program.
         attrs.has_indexed_kv_cache(),
+        // Block-cyclic remap: enable gates a compile-time #ifdef; sp, chunk_local and the two T-derived stride
+        // gaps are ALL compile-time defines (so distinct sp/chunk_local/cache-size are distinct programs — T is
+        // hashed above). No runtime remap arg.
+        attrs.has_block_cyclic(),
+        attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
+        attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
         t.indices.logical_shape(),
         t.indices.dtype());
 }
@@ -206,22 +229,24 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAOperation::get_dynamic_ru
     const SparseSDPAInputs& t,
     Tensor& /*output*/,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Non-indexed: the gather page offset is the baked 0 from create_descriptor (and the non-indexed program
-    // is never shared with an indexed one — has_indexed_kv_cache() is in the hash — so nothing to re-apply).
-    if (!attrs.has_indexed_kv_cache()) {
+    // kv_batch_page_offset = cache_batch_idx*T depends on the runtime SLOT (and T, which is NOT hashed for an
+    // interleaved kv), so the same program is reused across slots/T — create_descriptor bakes it at build time
+    // and on a program-cache HIT it would be STALE, so re-apply it from the current slot/T every dispatch. The
+    // block-cyclic remap needs NOTHING here: all its constants are compile-time defines (T is hashed for that
+    // path, so a different cache size is a different program). Non-indexed programs have nothing to re-apply.
+    const bool indexed = attrs.has_indexed_kv_cache();
+    if (!indexed) {
         return {};
     }
-    // Indexed: re-apply kv_batch_page_offset = cache_batch_idx * T to the reader (kernel 0, arg 5) and writer
-    // (kernel 1, arg 4) on every dispatch. The value is the same on every core but the slot is per-core, so
-    // emit one entry per core per kernel. The core partition mirrors the factory exactly.
     const uint32_t T = t.kv.logical_shape()[2];
     const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value() * T;
     const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
     const uint32_t num_cores = grid.x * grid.y;
     // Arg slots/kernel indices are defined once in sparse_sdpa_rt (header), shared with the program factory's
-    // emit order so a reorder can't silently desync this re-apply path from the factory.
+    // emit order so a reorder can't silently desync this re-apply path from the factory. The value is the same
+    // on every core but the slot is per-core, so emit one entry per core per kernel.
     std::vector<tt::tt_metal::DynamicRuntimeArg> args;
-    args.reserve(2 * num_cores);
+    args.reserve(static_cast<size_t>(2) * num_cores);
     for (uint32_t i = 0; i < num_cores; ++i) {
         const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         args.push_back(
@@ -248,7 +273,8 @@ Tensor sparse_sdpa(
     uint32_t v_dim,
     uint32_t k_chunk_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
-    std::optional<uint32_t> cache_batch_idx) {
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<BlockCyclicLayout> block_cyclic) {
     using OperationType = ttnn::prim::SparseSDPAOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -257,6 +283,7 @@ Tensor sparse_sdpa(
             .k_chunk_size = k_chunk_size,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
+            .block_cyclic = block_cyclic,
         },
         OperationType::tensor_args_t{
             .q = q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -19,8 +19,10 @@ namespace ttnn::prim {
 
 // Reader/writer runtime-arg layout — single source of truth shared by the program factory (which EMITS the
 // args in create_descriptor) and get_dynamic_runtime_args (which RE-APPLIES the indexed-cache page offset to
-// the cached program). kv_batch_page_offset is the LAST positional arg of each kernel's list; if that order
-// changes in the factory, update these indices here, or the dynamic re-apply silently writes the wrong slot.
+// the cached program). kv_batch_page_offset sits at the fixed index below and is the only re-applied arg. If
+// the order before kv_batch_page_offset changes in the factory, update these indices here, or the dynamic
+// re-apply silently writes the wrong slot. (The block-cyclic remap constants are all compile-time defines, with
+// the cache length T folded into the program hash, so there is no block-cyclic runtime arg to track.)
 namespace sparse_sdpa_rt {
 inline constexpr uint32_t kReaderKernelIdx = 0;
 inline constexpr uint32_t kWriterKernelIdx = 1;
@@ -68,6 +70,7 @@ Tensor sparse_sdpa(
     uint32_t v_dim,
     uint32_t k_chunk_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
-    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+    std::optional<uint32_t> cache_batch_idx = std::nullopt,
+    std::optional<BlockCyclicLayout> block_cyclic = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -10,6 +10,21 @@
 
 namespace ttnn::prim {
 
+// Block-cyclic KV layout. When set, the gathered `indices` are NATURAL token positions, but the kv cache is
+// stored block-cyclic across `sp` SP shards with per-shard chunk `chunk_local` (the DeepSeek chunked-prefill
+// KVPE cache, written by update_padded_kv_cache). The gather kernels remap each natural index -> physical page
+// id on the fly (invP, the inverse of the cache writer's blockcyclic_positions), so the host does NOT have to
+// reorder the kv buffer back to natural order before the op.
+//
+// Both fields are resolved+validated at the ttnn entry (ttnn::transformer::sparse_sdpa): `sp` is read from the
+// mesh axis the cache was striped over (so the caller cannot pass an sp that disagrees with the device), and
+// `chunk_local` is cross-checked against q's per-chip seq length. `sp` is folded into the program hash here
+// (BC_SP is a compile-time define), so it must be the resolved value, not a mesh axis index.
+struct BlockCyclicLayout {
+    uint32_t sp;           // SP shard count the cache was written across (resolved from the mesh)
+    uint32_t chunk_local;  // per-shard chunk length (chunk_size_global / sp == per-chip seq_len_local)
+};
+
 // Sparse MLA prefill (DeepSeek DSA).
 struct SparseSDPAParams {
     float scale = 1.0f;  // compile-time (folded into the program hash)
@@ -21,6 +36,12 @@ struct SparseSDPAParams {
     // (excluded from the program hash, re-applied every dispatch), so changing it does NOT recompile.
     std::optional<uint32_t> cache_batch_idx = std::nullopt;
     bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
+    // Block-cyclic index remap (see BlockCyclicLayout). Fully compile-time: the enable bit, sp, chunk_local,
+    // and the T-derived BC_SHARD_STRIDE_GAP (= T/sp - chunk_local) are all program defines, and the cache length T is
+    // folded into the hash for this path — so a different cache size is a distinct program (no runtime remap
+    // arg). Assumes a consistent-size preallocated cache (per-size recompile, once, is acceptable).
+    std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
+    bool has_block_cyclic() const { return block_cyclic.has_value(); }
 };
 
 struct SparseSDPAInputs {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -202,6 +202,19 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     {
         std::map<std::string, std::string> rdefs{
             {"CB_KREQ", std::to_string(cb_kreq)}, {"CB_KACK", std::to_string(cb_kack)}};
+        if (attrs.has_block_cyclic()) {
+            // Gate the natural->block-cyclic page-id remap (see sparse_sdpa_gather.hpp). ALL constants are
+            // compile-time (the cache length T is folded into the program hash for this path), so the remap is
+            // one mul+shift divide + shift/mask. BC_SHARD_STRIDE_GAP = T/sp - chunk_local (= shard_len - chunk_local).
+            const uint32_t bc_sp = attrs.block_cyclic->sp;
+            const uint32_t bc_chunk_local = attrs.block_cyclic->chunk_local;
+            const uint32_t bc_seq_len_local = t.kv.logical_shape()[2] / bc_sp;
+            rdefs["BC_ENABLE"] = "1";
+            rdefs["BC_CHUNK_LOCAL"] = std::to_string(bc_chunk_local);
+            rdefs["BC_SP"] = std::to_string(bc_sp);
+            rdefs["BC_SLAB_STRIDE_GAP"] = std::to_string(bc_chunk_local * (bc_sp - 1));
+            rdefs["BC_SHARD_STRIDE_GAP"] = std::to_string(bc_seq_len_local - bc_chunk_local);
+        }
         reader_desc.defines = tt::tt_metal::KernelDescriptor::Defines(rdefs.begin(), rdefs.end());
     }
 
@@ -220,6 +233,16 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
             {"CB_IDX", std::to_string(cb_idx)},
             {"K_DIM", std::to_string(k_dim)},
             {"KV_ELEM_BYTES", std::to_string(kv_elem_bytes)}};
+        if (attrs.has_block_cyclic()) {
+            const uint32_t bc_sp = attrs.block_cyclic->sp;
+            const uint32_t bc_chunk_local = attrs.block_cyclic->chunk_local;
+            const uint32_t bc_seq_len_local = t.kv.logical_shape()[2] / bc_sp;
+            wdefs["BC_ENABLE"] = "1";  // see reader defines: all remap constants are compile-time (T hashed)
+            wdefs["BC_CHUNK_LOCAL"] = std::to_string(bc_chunk_local);
+            wdefs["BC_SP"] = std::to_string(bc_sp);
+            wdefs["BC_SLAB_STRIDE_GAP"] = std::to_string(bc_chunk_local * (bc_sp - 1));
+            wdefs["BC_SHARD_STRIDE_GAP"] = std::to_string(bc_seq_len_local - bc_chunk_local);
+        }
         writer_desc.defines = tt::tt_metal::KernelDescriptor::Defines(wdefs.begin(), wdefs.end());
     }
 
@@ -279,13 +302,15 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     // (so changing the slot doesn't recompile). 0 when not indexed (kv is a single [1,1,T,K_DIM] cache).
     const uint32_t kv_T = t.kv.logical_shape()[2];
     const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value_or(0) * kv_T;
+    // Block-cyclic remap needs NO runtime arg: all its constants are compile-time defines (the cache length T
+    // is hashed for the block-cyclic path; see the define blocks above).
     for (uint32_t i = 0; i < num_cores; ++i) {
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t tok_start = i * base + std::min(i, extra);
         uint32_t tok_count = base + (i < extra ? 1u : 0u);
-        // kv_batch_page_offset is the LAST positional arg of each list; its index is encoded once in
-        // sparse_sdpa_rt::k{Reader,Writer}BatchOffsetArg (used by get_dynamic_runtime_args to re-apply it on a
-        // cache hit). If you reorder these lists, update those constants or the re-apply targets the wrong slot.
+        // kv_batch_page_offset sits at a fixed index (sparse_sdpa_rt::k{Reader,Writer}BatchOffsetArg), re-applied
+        // on a cache hit by get_dynamic_runtime_args (the slot changes per dispatch). If you reorder the args
+        // before it, update those constants or the re-apply targets the wrong slot.
         reader_desc.emplace_runtime_args(core, {q_buf, kv_buf, idx_buf, tok_start, tok_count, kv_batch_page_offset});
         writer_desc.emplace_runtime_args(
             core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});  // kv_buf: writer K-half gather

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -204,7 +204,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     // cache length T is folded into the program hash for this path), so the remap is one mul+shift divide +
     // shift/mask. Stride gaps: BC_SHARD_STRIDE_GAP = T/sp - chunk_local (= shard_len - chunk_local);
     // BC_SLAB_STRIDE_GAP = chunk_local*(sp-1).
-    const auto add_bc_defines = [&](std::map<std::string, std::string>& defs) {
+    const auto add_bc_defines = [&attrs, &t](std::map<std::string, std::string>& defs) {
         if (!attrs.has_block_cyclic()) {
             return;
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -199,22 +199,28 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
     // Dual-NoC K gather: reader + writer each gather half the rows on their own NoC. The new CB ids are
     // passed as defines (kept off the positional compile-arg blocks, which the kernels index tightly).
+    // Gate the natural->block-cyclic page-id remap (see sparse_sdpa_gather.hpp). The reader and writer take the
+    // SAME defines, so one helper populates both to keep them in lockstep. ALL constants are compile-time (the
+    // cache length T is folded into the program hash for this path), so the remap is one mul+shift divide +
+    // shift/mask. Stride gaps: BC_SHARD_STRIDE_GAP = T/sp - chunk_local (= shard_len - chunk_local);
+    // BC_SLAB_STRIDE_GAP = chunk_local*(sp-1).
+    const auto add_bc_defines = [&](std::map<std::string, std::string>& defs) {
+        if (!attrs.has_block_cyclic()) {
+            return;
+        }
+        const uint32_t bc_sp = attrs.block_cyclic->sp;
+        const uint32_t bc_chunk_local = attrs.block_cyclic->chunk_local;
+        const uint32_t bc_seq_len_local = t.kv.logical_shape()[2] / bc_sp;
+        defs["BC_ENABLE"] = "1";
+        defs["BC_CHUNK_LOCAL"] = std::to_string(bc_chunk_local);
+        defs["BC_SP"] = std::to_string(bc_sp);
+        defs["BC_SLAB_STRIDE_GAP"] = std::to_string(bc_chunk_local * (bc_sp - 1));
+        defs["BC_SHARD_STRIDE_GAP"] = std::to_string(bc_seq_len_local - bc_chunk_local);
+    };
     {
         std::map<std::string, std::string> rdefs{
             {"CB_KREQ", std::to_string(cb_kreq)}, {"CB_KACK", std::to_string(cb_kack)}};
-        if (attrs.has_block_cyclic()) {
-            // Gate the natural->block-cyclic page-id remap (see sparse_sdpa_gather.hpp). ALL constants are
-            // compile-time (the cache length T is folded into the program hash for this path), so the remap is
-            // one mul+shift divide + shift/mask. BC_SHARD_STRIDE_GAP = T/sp - chunk_local (= shard_len - chunk_local).
-            const uint32_t bc_sp = attrs.block_cyclic->sp;
-            const uint32_t bc_chunk_local = attrs.block_cyclic->chunk_local;
-            const uint32_t bc_seq_len_local = t.kv.logical_shape()[2] / bc_sp;
-            rdefs["BC_ENABLE"] = "1";
-            rdefs["BC_CHUNK_LOCAL"] = std::to_string(bc_chunk_local);
-            rdefs["BC_SP"] = std::to_string(bc_sp);
-            rdefs["BC_SLAB_STRIDE_GAP"] = std::to_string(bc_chunk_local * (bc_sp - 1));
-            rdefs["BC_SHARD_STRIDE_GAP"] = std::to_string(bc_seq_len_local - bc_chunk_local);
-        }
+        add_bc_defines(rdefs);
         reader_desc.defines = tt::tt_metal::KernelDescriptor::Defines(rdefs.begin(), rdefs.end());
     }
 
@@ -233,16 +239,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
             {"CB_IDX", std::to_string(cb_idx)},
             {"K_DIM", std::to_string(k_dim)},
             {"KV_ELEM_BYTES", std::to_string(kv_elem_bytes)}};
-        if (attrs.has_block_cyclic()) {
-            const uint32_t bc_sp = attrs.block_cyclic->sp;
-            const uint32_t bc_chunk_local = attrs.block_cyclic->chunk_local;
-            const uint32_t bc_seq_len_local = t.kv.logical_shape()[2] / bc_sp;
-            wdefs["BC_ENABLE"] = "1";  // see reader defines: all remap constants are compile-time (T hashed)
-            wdefs["BC_CHUNK_LOCAL"] = std::to_string(bc_chunk_local);
-            wdefs["BC_SP"] = std::to_string(bc_sp);
-            wdefs["BC_SLAB_STRIDE_GAP"] = std::to_string(bc_chunk_local * (bc_sp - 1));
-            wdefs["BC_SHARD_STRIDE_GAP"] = std::to_string(bc_seq_len_local - bc_chunk_local);
-        }
+        add_bc_defines(wdefs);  // same block-cyclic remap defines as the reader
         writer_desc.defines = tt::tt_metal::KernelDescriptor::Defines(wdefs.begin(), wdefs.end());
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -342,6 +342,14 @@ void bind_sdpa(nb::module_& mod) {
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional).
             cache_batch_idx (int, optional): select the batch slot of a shared [B, 1, T, K_DIM] kv cache.
                 It is a dynamic runtime arg, so changing it (or T) does not recompile the kernels.
+            block_cyclic_sp_axis (int, optional): when set (with block_cyclic_chunk_local), `indices` are NATURAL
+                token positions and kv is stored block-cyclic across an SP-sharded cache; the kernel remaps each
+                index natural->physical page on the fly (no host reorder needed). This is the MESH axis the cache
+                was striped over: `sp` is read from the mesh shape on that axis (the op derives it, so it cannot
+                disagree with the device). T % sp == 0 required. Both must be set together.
+            block_cyclic_chunk_local (int, optional): the per-shard chunk length (chunk_size_global / sp).
+                Required iff block_cyclic_sp_axis is set. Cross-checked against q's per-chip seq length: must be
+                q_isl or tp*q_isl (tp = mesh_size/sp) — the only two values it can legally take.
 
         Returns:
             ttnn.Tensor: [1, H, S, v_dim] ROW-MAJOR, DRAM interleaved; dtype matches q (bf16->bf16, fp8->fp8).
@@ -355,7 +363,9 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("scale") = nb::none(),
         nb::arg("k_chunk_size") = 128,
         nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("cache_batch_idx") = nb::none());
+        nb::arg("cache_batch_idx") = nb::none(),
+        nb::arg("block_cyclic_sp_axis") = nb::none(),
+        nb::arg("block_cyclic_chunk_local") = nb::none());
 
     const auto* const chunked_doc =
         R"doc(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/transformer/sdpa/sparse_sdpa.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp"
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <cmath>
 
 namespace ttnn::transformer {
@@ -17,9 +18,41 @@ ttnn::Tensor sparse_sdpa(
     std::optional<float> scale,
     uint32_t k_chunk_size,
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    std::optional<uint32_t> cache_batch_idx) {
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> block_cyclic_sp_axis,
+    std::optional<uint32_t> block_cyclic_chunk_local) {
     const uint32_t k_dim = q.logical_shape()[3];  // head dim, from the tensor
     const float resolved_scale = scale.value_or(1.0f / std::sqrt(static_cast<float>(k_dim)));
+
+    // Block-cyclic remap: sp_axis and chunk_local must be provided together (or neither). `sp` is DERIVED from
+    // the mesh (the cache's stripe count == the size of the SP mesh axis), so a caller cannot pass an sp that
+    // disagrees with the device; `chunk_local` is then cross-checked against q's per-chip seq length.
+    TT_FATAL(
+        block_cyclic_sp_axis.has_value() == block_cyclic_chunk_local.has_value(),
+        "sparse_sdpa: block_cyclic_sp_axis and block_cyclic_chunk_local must both be set or both unset");
+    std::optional<ttnn::prim::BlockCyclicLayout> block_cyclic = std::nullopt;
+    if (block_cyclic_sp_axis.has_value()) {
+        const auto mesh_shape = q.device()->get_view().shape();
+        const uint32_t sp_axis = block_cyclic_sp_axis.value();
+        TT_FATAL(
+            sp_axis < mesh_shape.dims(),
+            "sparse_sdpa: block_cyclic_sp_axis ({}) out of range for mesh rank {}",
+            sp_axis,
+            mesh_shape.dims());
+        const uint32_t sp = mesh_shape[sp_axis];
+        const uint32_t tp = static_cast<uint32_t>(mesh_shape.mesh_size()) / sp;  // remaining (TP) device count
+        const uint32_t chunk_local = block_cyclic_chunk_local.value();
+        // chunk_local is one of exactly two values: q's per-chip seq length (no head->seq reshard) or tp*q_isl
+        // (reshard slices q's seq across TP, leaving the cache's chunk_local unchanged). Anything else is a bug.
+        const uint32_t q_isl = q.logical_shape()[2];
+        TT_FATAL(
+            chunk_local == q_isl || chunk_local == q_isl * tp,
+            "sparse_sdpa: block_cyclic_chunk_local ({}) must be q_isl ({}) or tp*q_isl ({})",
+            chunk_local,
+            q_isl,
+            q_isl * tp);
+        block_cyclic = ttnn::prim::BlockCyclicLayout{sp, chunk_local};
+    }
 
     // fp8 q/kv must be tilized through a 32-bit dest accumulator, so default fp32_dest_acc_en on for fp8.
     const bool any_fp8 = (kv.dtype() == ttnn::DataType::FP8_E4M3) || (q.dtype() == ttnn::DataType::FP8_E4M3);
@@ -31,7 +64,8 @@ ttnn::Tensor sparse_sdpa(
         /*default_fp32_acc=*/any_fp8,
         /*default_l1_acc=*/false);
 
-    return ttnn::prim::sparse_sdpa(q, kv, indices, resolved_scale, v_dim, k_chunk_size, kernel_config, cache_batch_idx);
+    return ttnn::prim::sparse_sdpa(
+        q, kv, indices, resolved_scale, v_dim, k_chunk_size, kernel_config, cache_batch_idx, block_cyclic);
 }
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
@@ -24,6 +24,17 @@ namespace ttnn::transformer {
 // to (indices are page ids within that slot). kv may then also be ND-sharded across DRAM banks. The value is
 // a dynamic runtime arg, so changing the slot (or the cache length T) does not recompile the kernels.
 //
+// block_cyclic_sp_axis / block_cyclic_chunk_local: when both set, `indices` are NATURAL token positions but kv
+// is stored block-cyclic across an SP-sharded cache (the DeepSeek chunked-prefill KVPE cache). The gather
+// kernels remap each index natural -> physical page on the fly, so the caller does NOT need to reorder kv back
+// to natural order. Both must be set together.
+//   block_cyclic_sp_axis    : the MESH axis the cache was striped over. `sp` is read from mesh shape on that
+//                             axis (the op derives it, so a caller cannot pass an sp inconsistent with the
+//                             device); T % sp == 0 required.
+//   block_cyclic_chunk_local: the per-shard chunk length (chunk_size_global / sp). Cross-checked at the entry
+//                             against q's per-chip seq length: must equal q_isl or tp*q_isl (tp = mesh/sp),
+//                             the only two values it can legally take (post-reshard q is sliced by tp).
+//
 // Producer preconditions (NOT validated per-element): sentinels are a contiguous tail, every row has >= 1
 // valid key, and all non-sentinel indices are < T.
 ttnn::Tensor sparse_sdpa(
@@ -34,6 +45,8 @@ ttnn::Tensor sparse_sdpa(
     std::optional<float> scale = std::nullopt,
     uint32_t k_chunk_size = 128,
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+    std::optional<uint32_t> cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
+    std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);
 
 }  // namespace ttnn::transformer


### PR DESCRIPTION
## What

Move the DeepSeek chunked-prefill block-cyclic → natural KV reorder out of the host and **into the `sparse_sdpa` gather kernel** as an inverse-permutation (invP) index remap. The KVPE cache is stored block-cyclic across SP shards, but the indexer emits natural-position top-k indices, so callers previously reordered the whole `[1,1,T,576]` prefix to natural order every layer (`sp*slabs` slices + 1 concat). Now each natural index is remapped to its physical page id on the fly inside the gather, so the buffer stays block-cyclic and the host reorder is eliminated.

**Op-side change only** (kernels + device op + binding + unit tests). The DeepSeek model wiring lands separately.

## API (opt-in; default off → byte-identical kernel for every other caller)

- **`block_cyclic_sp_axis`** — the *mesh axis* the cache was striped over. `sp` is read from the mesh shape on that axis at the ttnn entry (`q.device()->get_view()`), so a caller **cannot pass an `sp` that disagrees with the device**.
- **`block_cyclic_chunk_local`** — the per-shard chunk length (`chunk_size_global/sp`). Cross-checked at the entry against `q`: must equal `q_isl` or `tp*q_isl` (`tp = mesh_size/sp`) — the only two values it can legally take (post head→seq reshard `q` is sliced by `tp`).

Both descriptors are validated against ground truth rather than trusted.

## How

Natural order is **slab-major** (chunk after chunk, shard-within); the physical buffer is **shard-major** (each shard's whole region, slabs-within), so the remap is a transpose of the `(slab, shard)` axes:
```
block_idx = n / BC_CHUNK_LOCAL;  slab = block_idx / BC_SP;  shard = block_idx % BC_SP
page      = n + shard*BC_SHARD_STRIDE_GAP - slab*BC_SLAB_STRIDE_GAP
```
- `BC_SHARD_STRIDE_GAP = shard_len − chunk_local` (physical buffer reserves `shard_len = T/sp` rows per shard, so shards sit further apart than natural)
- `BC_SLAB_STRIDE_GAP  = chunk_global − chunk_local = chunk_local*(sp−1)` (chunks are `chunk_global` apart in natural order, only `chunk_local` apart physically)

**All remap constants are compile-time `#define`s — no runtime remap arg.** The cache length `T` is folded into the program hash for the block-cyclic path (a different cache size is a distinct program; consistent-size preallocated cache assumed), so the only `T`-dependent constant (`BC_SHARD_STRIDE_GAP`) is compile-time too. This removes the runtime arg, the per-dispatch re-apply, and **the whole stale-`bc_delta` bug class**.

`page_offset (= cache_batch_idx*T)` is added **after** the remap, so block-cyclic composes with an indexed shared cache (select slot, then remap within slot). Sentinels (`0xFFFFFFFF`) never reach the remap (reader gathers only the valid `< nv` prefix).

## Testing (this PR — single device)

- `test_sparse_sdpa_block_cyclic_sp1_identity` — `sp=1` (from the 1×1 device-mesh) reduces the remap to identity (`page=n`), smoking the whole BC path (API, `BC_ENABLE` kernel branch) and asserting PCC vs the natural golden across `T ∈ {256,512,1024}` → **one program per cache size** (`T` is hashed).
- `test_sparse_sdpa_block_cyclic_chunk_local_rejected` — the `chunk_local` guard rejects an out-of-contract value before dispatch.

Measured downstream (one 5120-tok chunk @ 50k cache): PCC bit-identical to the host-reorder path; per-layer device time deepseek_v32 (4×2) −698µs (−2.6%), glm_5.1 (2×4 reshard) −663µs (−3.1%); `sparse_sdpa` itself unchanged (invP hidden under the NoC-bound gather).

## TODO (follow-up PRs)

The `sp=1` tests cover the path but **not the `sp>1` permutation arithmetic** (the `shard*GAP` / `slab*GAP` terms are ×0 at `sp=1`). Deferred to keep this PR small:

- [ ] **Multi-device mesh test** (own module — a `mesh_device` fixture can't share the single-device `use_module_device` file): real `sp>1` **PCC** on a 2-device `(1,2)` mesh (p300), validating `invP` row mapping + the reshard validation branch (`chunk_local == tp*q_isl`, `tp>1`). Mirror the existing single-device coverage dimensions: **PCC, determinism, perf**.
- [ ] **`block_cyclic` + `cache_batch_idx` together** — a multi-user, preallocated, block-cyclic cache indexed by `cache_batch_idx` (no host-side slot slice): assert the `page_offset` selects the slot and the remap stays within-slot.
- [ ] Wire the mesh test into a multi-card CI leg (`bh_p300` / `bh_loudbox`).
- [ ] **Optimize the KV all-gather (communication).** The model gathers the *entire preallocated* cache every chunk (bandwidth ∝ prealloc size, not populated). Trim each SP shard to its populated head `[0, end_pos/sp)` before the all-gather → gather ∝ `end_pos`. **This requires moving `T` back to a runtime arg** (see design note).


## Design note — KV all-gather layout & communication (follow-up)

The model gathers the block-cyclic KVPE cache before this op (`_gather_kvpe_prefix`): `to_memory_config(DRAM)` → SP `all_gather(dim=2)`.

**Layout after the all-gather** — `[1,1,T,576]`, replicated to every chip, **device-major / slab-minor**. Row `r` holds:
```
device c = r // (T/sp);  local = r % (T/sp);  slab = local // chunk_local;  off = local % chunk_local
natural token = slab*chunk_global + c*chunk_local + off          (= blockcyclic_positions)
```
i.e. each SP shard's *strided* subset is concatenated back-to-back — the block-cyclic order this op's remap inverts. Example (`sp=2, chunk_local=2`, 2 slabs): natural `0,1,2,3,4,5,6,7` is physically `0,1,4,5,2,3,6,7`.

**Communication is not optimal.** The all-gather moves the **entire preallocated cache every chunk** — bandwidth ∝ prealloc size, *not* populated length. A 100k cache filled in 5k chunks re-gathers 100k each iteration, replicating the unpopulated tail (which `sparse_sdpa` never addresses, since indices are `< populated`). Because slabs fill in order, each shard's populated rows are the contiguous head `[0, end_pos/sp)`, so slicing each shard *before* the all-gather would cut the gather to ∝ `end_pos`.

**That trim requires moving `T` back to a runtime arg.** This PR makes the remap constants (incl. `BC_SHARD_STRIDE_GAP = T/sp − chunk_local`) compile-time by **hashing `T`** (assumes a consistent-size prealloc). A trimmed gather makes `T = end_pos` grow per chunk, so `BC_SHARD_STRIDE_GAP` would have to be **runtime again** (recomputed from the live `T` each dispatch) — i.e. revert the compile-time-`T` decision for the block-cyclic path. The deeper alternative is to skip the all-gather entirely and have the op consume the SP-sharded cache directly (bigger op change). **Recommendation:** when the trimmed gather (the larger win) lands, move `T` / `BC_SHARD_STRIDE_GAP` to a runtime arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-blockcyclic-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/sparse-sdpa-blockcyclic-remap)