### PR TITLE
[skip ci] Run super pod/super cluster tests in the morning

### DIFF
--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -48,8 +48,8 @@ on:
           # - sp4_deepseek
 
   schedule:
-    # Run daily at 11 AM UTC
-    - cron: "0 11 * * 1-5"
+    # Run daily at 5 AM UTC
+    - cron: "0 5 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -5,11 +5,6 @@ on:
   schedule:
     - cron: "0 5 * * *" # Runs every day at 5:00 AM UTC
   workflow_dispatch:
-    inputs:
-      note:
-        description: 'This workflow can be run between 12 PM and 4 PM UTC'
-        required: false
-        default: ""
 
 run-name: Fabric Test on a BH Quad
 jobs:

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -3,7 +3,7 @@ name: "Fabric Test on a BH Quad"
 
 on:
   schedule:
-    - cron: "0 11 * * 1-5" # Runs weekdays at 11:00 AM UTC
+    - cron: "0 5 * * *" # Runs every day at 5:00 AM UTC
   workflow_dispatch:
     inputs:
       note:


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary
As we now have dedicated hardware for quad tests, I want to move them to run daily in the morning so we can check regression at beginning of the day

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dpopov-change-exabox-tests-cronjob-start)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dpopov-change-exabox-tests-cronjob-start)