### PR TITLE
[skip ci] Distinguish Blackhole board variants in sweep results labels

### DIFF
--- a/.github/actions/sweep-run-analysis/scripts/push_sweep_results.py
+++ b/.github/actions/sweep-run-analysis/scripts/push_sweep_results.py
@@ -106,7 +106,15 @@ def _short_hardware_label(card_type: str) -> str:
         return "N300"
     if "n150" in ct or "1 device" in ct:
         return "N150"
-    if "blackhole" in ct or "p150b" in ct:
+    # Distinguish the blackhole boards (card_type is e.g. "blackhole (p150b)",
+    # "blackhole (p100a)", "blackhole (P300)") instead of collapsing to "BH".
+    if "p100" in ct:
+        return "P100a"
+    if "p300" in ct:
+        return "P300a"
+    if "p150" in ct:
+        return "P150b"
+    if "blackhole" in ct:
         return "BH"
     if "galaxy" in ct:
         return "Galaxy"


### PR DESCRIPTION
## Summary

Split `_short_hardware_label()` in `push_sweep_results.py` to distinguish Blackhole board variants (P100a, P300a, P150b) instead of collapsing them all to "BH".

Extracted from #45410 as a standalone change.

## Changes

**`.github/actions/sweep-run-analysis/scripts/push_sweep_results.py`**

The `card_type` string is e.g. `"blackhole (p150b)"`, `"blackhole (p100a)"`, `"blackhole (P300)"`. The old code collapsed all of these to `"BH"`. The new code checks for the specific board variant first, falling back to generic `"BH"` only if none match.

## Test plan
- [ ] Verify sweep summary labels show P100a/P300a/P150b instead of BH

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/distinguish-bh-board-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/distinguish-bh-board-variants)