### PR TITLE
#48446: adjust tilize api for quasar

### DIFF
--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -302,12 +302,15 @@ unpack_tilizeA_B_block(
 #pragma GCC diagnostic pop
 }
 
+#endif  // ifndef ARCH_QUASAR
+
 // clang-format off
 /**
  * Uninitializes the tilize operation before re-initializing for another operation.
  *
  * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
  * as a part of tt-metal#22904.
+ * NOTE: Does nothing on Quasar because there is no persistent tilize unpack/pack state to undo.
  *
  * Return value: None
  *
@@ -317,8 +320,6 @@ unpack_tilizeA_B_block(
  * | Function   | ocb    | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
-
-#endif  // ifndef ARCH_QUASAR
 
 ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
 #ifndef ARCH_QUASAR

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -231,6 +231,14 @@ ALWI void tilize_block(
     }
 }
 
+#ifdef ARCH_QUASAR
+// Quasar regular-tilize uninit. Quasar has no llk_unpack_tilize_uninit, and its tilize_init is
+// lightweight (llk_unpack_tilize_init + generic datacopy init, no PackMode::Tilize / state_configure),
+// so there is no persistent tilize unpack/pack state to undo here <E2><80><94> the next op's init reconfigures
+// srcA.
+ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {}
+#endif
+
 #ifndef ARCH_QUASAR
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -231,14 +231,6 @@ ALWI void tilize_block(
     }
 }
 
-#ifdef ARCH_QUASAR
-// Quasar regular-tilize uninit. Quasar has no llk_unpack_tilize_uninit, and its tilize_init is
-// lightweight (llk_unpack_tilize_init + generic datacopy init, no PackMode::Tilize / state_configure),
-// so there is no persistent tilize unpack/pack state to undo here <E2><80><94> the next op's init reconfigures
-// srcA.
-ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {}
-#endif
-
 #ifndef ARCH_QUASAR
 
 // clang-format off
@@ -326,13 +318,18 @@ unpack_tilizeA_B_block(
  */
 // clang-format on
 
+#endif  // ifndef ARCH_QUASAR
+
 ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
+#ifndef ARCH_QUASAR
     UNPACK((llk_unpack_tilize_uninit(icb)));
+#endif
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init<PackMode::Default>(ocb)));
 #endif
 }
 
+#ifndef ARCH_QUASAR
 // clang-format off
 /**
  * Uninitializes the tilize operation and reconfigures the unpacker with CB data types.


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #48446 

Quasar code does not have fast tilize and needs to use regular tilize. The api does not have an uninit for tilize on Quasar. Adding an uninit. The uninit does nothing but is used in upstream code that is run for all architectures.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-48446_fast_tilize_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-48446_fast_tilize_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-48446_fast_tilize_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-48446_fast_tilize_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-48446_fast_tilize_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-48446_fast_tilize_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-48446_fast_tilize_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-48446_fast_tilize_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-48446_fast_tilize_qsr)