### PR TITLE
#48451: adjust kernel_lib for quasar not having fast tilize and block formats

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.hpp
@@ -20,9 +20,10 @@ ALWI uint32_t get_full_tile_size(DataFormat format);
 
 ALWI constexpr bool is_block_float_format(uint32_t format);
 
-#ifndef ARCH_QUASAR
+// Arch-independent CB FIFO arithmetic; needed by the regular tilize path on Quasar (no fast tilize).
 ALWI uint32_t get_dfb_num_pages(uint32_t dfb_id);
 
+#ifndef ARCH_QUASAR
 template <DataFormat format>
 ALWI bool is_valid_dfb_tile_page_size(uint32_t dfb_id);
 

--- a/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.inl
@@ -5,6 +5,11 @@
 // Do not include directly - include dfb_helpers_compute.hpp instead
 
 #include "api/compute/cb_api.h"
+#ifdef ARCH_QUASAR
+// ckernel::trisc::tile_counters — the per-Tensix HW tile-counter registers that hold each DFB's
+// capacity in entries/pages (the same source DataflowBuffer's reserve/wait/pop assert against).
+#include "ckernel_trisc_common.h"
+#endif
 
 namespace compute_kernel_lib {
 
@@ -58,17 +63,22 @@ ALWI constexpr bool is_block_float_format(uint32_t format) {
     return format == 2 || format == 3 || format == 11 || format == 6 || format == 7 || format == 15;
 }
 
-// Needed by the regular tilize path on Quasar (no fast tilize) — used only by debug capacity ASSERTs.
+// Returns the DFB's capacity in entries (pages) — used by the debug capacity ASSERTs in the
+// tilize/untilize/reduce helpers (both `>=` and the `% tiles_per_bulk == 0` check in reduce).
 ALWI uint32_t get_dfb_num_pages(uint32_t dfb_id) {
 #ifdef ARCH_QUASAR
-    // Quasar compute kernels use the DFB interface (g_dfb_interface), NOT cb_interface — the latter is
-    // undefined on the Quasar TRISC link (only the data-movement firmware defines it). get_dfb_num_pages
-    // is only consumed by the `>=` capacity ASSERTs in the tilize/untilize/reduce helpers; return a max
-    // sentinel so those pass without referencing cb_interface. The real DFB capacity is validated
-    // host-side via DataflowBufferSpec num_entries. TODO: read the DFB ring depth if a device-side
-    // runtime check is ever wanted (ring_size is a per-TC byte span, not a page count).
-    (void)dfb_id;
-    return 0xFFFFFFFFu;
+    // Quasar compute kernels track DFB state in g_dfb_interface, NOT cb_interface (the latter is
+    // undefined on the Quasar TRISC link). The buffer's capacity in entries/pages lives in the HW
+    // tile-counter register — exactly the value DataflowBuffer's reserve_back/wait_front/pop_front
+    // assert against (see dataflow_buffer.inl), so read it the same way. A max sentinel would be
+    // wrong for the `num_pages % tiles_per_bulk == 0` check in reduce_helpers_compute.inl. There is
+    // no compile-time per-DFB capacity descriptor (the JIT emits tile format/dims only, not ring
+    // depth), and even WH/BH derive this at runtime from cb_interface — so this is the runtime
+    // equivalent. tile_counters is a per-Tensix register shared across TRISCs, set at DFB init.
+    const LocalDFBInterface& dfb = get_local_dfb_interface(dfb_id);
+    const dfb::PackedTileCounter ptc = dfb.tc_slots[dfb.tc_idx].packed_tile_counter;
+    const uint8_t tc_id = dfb::get_counter_id(ptc);
+    return ckernel::trisc::tile_counters[tc_id].f.buf_capacity;
 #else
     auto& cb = get_local_cb_interface(dfb_id);
     return cb.fifo_size / cb.fifo_page_size;

--- a/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.inl
@@ -58,15 +58,27 @@ ALWI constexpr bool is_block_float_format(uint32_t format) {
     return format == 2 || format == 3 || format == 11 || format == 6 || format == 7 || format == 15;
 }
 
+// Needed by the regular tilize path on Quasar (no fast tilize) — used only by debug capacity ASSERTs.
+ALWI uint32_t get_dfb_num_pages(uint32_t dfb_id) {
+#ifdef ARCH_QUASAR
+    // Quasar compute kernels use the DFB interface (g_dfb_interface), NOT cb_interface — the latter is
+    // undefined on the Quasar TRISC link (only the data-movement firmware defines it). get_dfb_num_pages
+    // is only consumed by the `>=` capacity ASSERTs in the tilize/untilize/reduce helpers; return a max
+    // sentinel so those pass without referencing cb_interface. The real DFB capacity is validated
+    // host-side via DataflowBufferSpec num_entries. TODO: read the DFB ring depth if a device-side
+    // runtime check is ever wanted (ring_size is a per-TC byte span, not a page count).
+    (void)dfb_id;
+    return 0xFFFFFFFFu;
+#else
+    auto& cb = get_local_cb_interface(dfb_id);
+    return cb.fifo_size / cb.fifo_page_size;
+#endif
+}
+
 #ifndef ARCH_QUASAR
 // CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT value (= 4): fifo_page_size is stored in
 // 16-byte units on WH/BH, so shifting left by 4 converts to bytes.
 constexpr uint32_t DFB_COMPUTE_ADDR_SHIFT = 4; // almeet
-
-ALWI uint32_t get_dfb_num_pages(uint32_t dfb_id) {
-    auto& cb = get_local_cb_interface(dfb_id);
-    return cb.fifo_size / cb.fifo_page_size;
-}
 
 template <DataFormat format>
 ALWI bool is_valid_dfb_tile_page_size(uint32_t dfb_id) {

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -46,6 +46,11 @@ constexpr bool is_fp32_output_format() {
 
 template <uint32_t block_width_tiles, uint32_t input_dfb, uint32_t output_dfb>
 constexpr bool can_use_fast_tilize() {
+#ifdef ARCH_QUASAR
+    // Quasar has no fast-tilize LLK (and per the LLK team it never will) — only regular tilize.
+    // Always take the regular tilize_init/tilize_block/tilize_uninit path below.
+    return false;
+#else
     // Float32 OUTPUT is unsupported: fast-tilize's pack path uses Read_32b=0
     // (bf16-stride stepping through DEST), which truncates fp32 DEST to bf16.
     // That truncation is acceptable for bf16/bfp output but destroys precision
@@ -53,6 +58,7 @@ constexpr bool can_use_fast_tilize() {
     // (see attn_matmul_fp32 regression).
     return block_width_tiles < 256 && dfb_has_32x32_tiles<output_dfb>() && !get_dst_full_sync_enabled() &&
            has_supported_fast_tilize_format<input_dfb>() && !is_fp32_output_format<output_dfb>();
+#endif
 }
 
 // =============================================================================
@@ -135,7 +141,13 @@ ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages)
             } else
 #endif
             {
+#ifndef ARCH_QUASAR  // Quasar has no fast tilize (use_fast is always false here); keep the name out of the parse
                 fast_tilize_init(input_dfb, block_width_tiles, output_dfb);
+#else
+                // Unreachable: can_use_fast_tilize() returns false on Quasar so use_fast is always false.
+                // Trap (watcher/runtime assert) in case this path is ever reached.
+                ASSERT(false);
+#endif
             }
         } else {
             tilize_init(input_dfb, block_width_tiles, output_dfb);
@@ -178,7 +190,13 @@ ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages)
         out_dfb.reserve_back(block_width_tiles);
 
         if constexpr (use_fast) {
+#ifndef ARCH_QUASAR  // Quasar has no fast tilize (use_fast is always false here); keep the name out of the parse
             fast_tilize_block(input_dfb, block_width_tiles, output_dfb);
+#else
+            // Unreachable: can_use_fast_tilize() returns false on Quasar so use_fast is always false.
+            // Trap (watcher/runtime assert) in case this path is ever reached.
+            ASSERT(false);
+#endif
         } else {
             tilize_block(input_dfb, block_width_tiles, output_dfb);
         }
@@ -196,7 +214,13 @@ ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages)
         init_uninit_mode == tilize_config::InitUninitMode::InitAndUninit ||
         init_uninit_mode == tilize_config::InitUninitMode::UninitOnly) {
         if constexpr (use_fast) {
+#ifndef ARCH_QUASAR  // Quasar has no fast tilize (use_fast is always false here); keep the name out of the parse
             fast_tilize_uninit(input_dfb, output_dfb, block_width_tiles);
+#else
+            // Unreachable: can_use_fast_tilize() returns false on Quasar so use_fast is always false.
+            // Trap (watcher/runtime assert) in case this path is ever reached.
+            ASSERT(false);
+#endif
         } else {
             tilize_uninit(input_dfb, output_dfb);
         }

--- a/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
@@ -28,9 +28,15 @@ constexpr bool has_supported_fast_untilize_format() {
     // Production untilize is bit-exact for Float32 today. The fast fp32 LLK path
     // is native fp32 DEST but still narrows input through the current SrcA route,
     // so keep fp32 out of automatic selection until that path is lossless.
-    constexpr bool supported_input = input_format == static_cast<uint32_t>(DataFormat::Float16_b) ||
-                                     input_format == static_cast<uint32_t>(DataFormat::Bfp8_b) ||
-                                     input_format == static_cast<uint32_t>(DataFormat::Bfp4_b);
+    constexpr bool supported_input = input_format == static_cast<uint32_t>(DataFormat::Float16_b)
+#ifndef ARCH_QUASAR
+                                     // Block-float formats (Bfp8_b/Bfp4_b) don't exist in the Quasar
+                                     // DataFormat enum; guard the references (fast untilize is disabled
+                                     // on Quasar anyway via can_use_fast_untilize -> false below).
+                                     || input_format == static_cast<uint32_t>(DataFormat::Bfp8_b) ||
+                                     input_format == static_cast<uint32_t>(DataFormat::Bfp4_b)
+#endif
+        ;
     constexpr bool supported_output = output_format == static_cast<uint32_t>(DataFormat::Float16_b);
 
     return supported_input && supported_output;


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Adjustments for future architecture

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #48451 

Quasar does not have fast tilize and block formats. Adjust kernel_lib accordingly.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-48446_kernel_lib_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-48446_kernel_lib_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-48446_kernel_lib_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-48446_kernel_lib_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-48446_kernel_lib_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-48446_kernel_lib_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-48446_kernel_lib_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-48446_kernel_lib_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-48446_kernel_lib_qsr)