### PR TITLE
[Bug fix] Fix LLK perf-CSV data quality: schema contamination and duplicate rows

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -715,6 +715,10 @@ def counter_report(request, worker_id):
     if PerfConfig.TEST_COUNTER == 0:
         return
 
+    temp_report.assert_single_schema(
+        context=f"{test_module} counters (worker {worker_id})"
+    )
+
     counters_path = TestConfig.PERF_DATA_DIR / f"{test_module}.{worker_id}.counters.csv"
 
     if counters_path.exists():
@@ -740,6 +744,11 @@ def perf_report(request, worker_id):
 
     if PerfConfig.TEST_COUNTER == 0:
         return
+
+    # Fail loud before writing: a single CSV must hold exactly one column schema.
+    # More than one means two unrelated tests/ops share this module (split them
+    # into separate files) or one test emits inconsistent columns across its sweep.
+    temp_report.assert_single_schema(context=f"{test_module} (worker {worker_id})")
 
     raw_path = TestConfig.PERF_DATA_DIR / f"{test_module}.{worker_id}.csv"
     post_path = TestConfig.PERF_DATA_DIR / f"{test_module}.{worker_id}.post.csv"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -217,6 +217,70 @@ def get_unique_base_names(input_dir: Path):
     return sorted(unique_bases)
 
 
+def _collapse_duplicate_keys(frame: pd.DataFrame, label: str) -> pd.DataFrame:
+    """Collapse rows sharing the same (sweep-params, marker) key into a single row.
+
+    Two distinct sweep variants can resolve to an identical recorded key when the
+    harness normalizes a parameter before recording it (e.g. dest_acc forced from
+    No to Yes for an outlier format combo in TestConfig). Such rows are repeated
+    measurements of the same effective kernel, so their metric columns are averaged
+    into one row.
+
+    A warning is always emitted when duplicates are found, and it flags how many
+    collapsed keys disagreed on a metric value: a differing same-key pair is usually
+    benign run-to-run noise, but it is also the signature of a test that failed to
+    record a parameter that actually changes the kernel, so it should not pass
+    silently.
+    """
+    if frame.empty or "marker" not in frame.columns:
+        return frame
+
+    try:
+        marker_pos = frame.columns.get_loc("marker")
+        key_cols = list(frame.columns[: marker_pos + 1])
+        value_cols = [c for c in frame.columns if c not in key_cols]
+
+        # dropna=False: NaN-valued sweep columns are legitimate keys (pandas would
+        # otherwise drop those groups entirely).
+        group_sizes = frame.groupby(key_cols, dropna=False, sort=False).size()
+        dup_groups = group_sizes[group_sizes > 1]
+        if dup_groups.empty:
+            return frame
+
+        numeric_cols = [
+            c for c in value_cols if pd.api.types.is_numeric_dtype(frame[c])
+        ]
+        differing = 0
+        if numeric_cols:
+            nunique = frame.groupby(key_cols, dropna=False, sort=False)[
+                numeric_cols
+            ].nunique()
+            differing = int((nunique > 1).any(axis=1).sum())
+
+        logger.warning(
+            "{}: collapsing {} duplicate (sweep-params, marker) key(s) spanning "
+            "{} rows into one row each (mean of metric columns); {} key(s) had "
+            "differing metric values (run-to-run noise, or a distinguishing "
+            "parameter not recorded as a column).",
+            label,
+            int(len(dup_groups)),
+            int(dup_groups.sum()),
+            differing,
+        )
+
+        agg = {c: ("mean" if c in numeric_cols else "first") for c in value_cols}
+        collapsed = (
+            frame.groupby(key_cols, dropna=False, sort=False).agg(agg).reset_index()
+        )
+        # Restore the original column order (groupby/agg reorders columns).
+        return collapsed[list(frame.columns)]
+    except Exception as e:
+        logger.warning(
+            "{}: duplicate-key collapse skipped due to error: {}", label, e
+        )
+        return frame
+
+
 def combine_perf_reports():
     """
     Combine performance report CSV files into two files per base name:
@@ -269,6 +333,9 @@ def combine_perf_reports():
                 continue
 
             combined_regular = pd.concat(dfs_regular, ignore_index=True)
+            combined_regular = _collapse_duplicate_keys(
+                combined_regular, f"{base_name}.csv"
+            )
             combined_regular = combined_regular.sort_values(
                 by=combined_regular.columns.tolist()
             ).reset_index(drop=True)
@@ -289,6 +356,9 @@ def combine_perf_reports():
                 continue
 
             combined_post = pd.concat(dfs_post, ignore_index=True)
+            combined_post = _collapse_duplicate_keys(
+                combined_post, f"{base_name}.post.csv"
+            )
             combined_post = combined_post.sort_values(
                 by=combined_post.columns.tolist()
             ).reset_index(drop=True)
@@ -305,6 +375,9 @@ def combine_perf_reports():
 
             if dfs_counters:
                 combined_counters = pd.concat(dfs_counters, ignore_index=True)
+                combined_counters = _collapse_duplicate_keys(
+                    combined_counters, f"{base_name}.counters.csv"
+                )
                 combined_counters = combined_counters.sort_values(
                     by=combined_counters.columns.tolist()
                 ).reset_index(drop=True)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -80,6 +80,15 @@ def _postprocess_tile_loop(frame: pd.DataFrame) -> pd.DataFrame:
     return frame
 
 
+class PerfSchemaError(AssertionError):
+    """
+    Raised when a single perf report (one CSV) accumulates more than one column
+    schema. Stacking rows with different column sets NaN-fills the gaps, producing
+    a ragged, schema-contaminated artifact that breaks strict-JSON dashboards and
+    the compare feature. We fail loud so the contaminated CSV is never shipped.
+    """
+
+
 class PerfReport:
     """
     Lazy evaluation container for performance benchmark data.
@@ -95,10 +104,85 @@ class PerfReport:
     ):
         self._frames = frames or [pd.DataFrame()]
         self._masks = masks or [pd.Series()]
+        # signature (frozenset of columns) -> {label, columns, sample} for the
+        # FIRST frame seen with that schema. Populated on append() and never
+        # cleared by frame()/post_process(), so the homogeneity check survives
+        # the lazy frame collapsing.
+        self._schema_registry: dict[frozenset, dict] = {}
 
-    def append(self, frame: pd.DataFrame):
+    def append(self, frame: pd.DataFrame, label: str | None = None):
         self._frames.append(frame)
         self._masks.append(pd.Series(True, index=frame.index))
+        self._register_schema(frame, label)
+
+    def _register_schema(self, frame: pd.DataFrame, label: str | None):
+        if frame.empty:
+            return
+        sig = frozenset(frame.columns)
+        if sig in self._schema_registry:
+            return
+        # Identify a frame by its sweep-parameter columns (everything before the
+        # "marker" column) so the error can point the author at the offending test.
+        if "marker" in frame.columns:
+            sweep_cols = list(frame.columns[: frame.columns.get_loc("marker")])
+        else:
+            sweep_cols = list(frame.columns)
+        sample = frame.iloc[0][sweep_cols].to_dict() if sweep_cols else {}
+        self._schema_registry[sig] = {
+            "label": label,
+            "columns": list(frame.columns),
+            "sample": sample,
+        }
+
+    def assert_single_schema(self, context: str = ""):
+        """
+        Fail loud if this report mixes more than one column schema.
+
+        A sound perf CSV has exactly one homogeneous column set. More than one
+        means either (a) a single test emits different columns across its sweep,
+        or (b) two unrelated ops/families share the file. Both are actionable by
+        the test author; we refuse to write the contaminated artifact.
+        """
+        schemas = self._schema_registry
+        if len(schemas) <= 1:
+            return
+
+        sigs = list(schemas.keys())
+        common = sigs[0]
+        for s in sigs[1:]:
+            common = common & s
+
+        lines = [
+            f"Perf report schema contamination in {context or 'report'}: "
+            f"{len(schemas)} incompatible column schemas were appended to a single CSV.",
+            "",
+            "Every perf CSV must have ONE homogeneous column set. Stacking rows with "
+            "different columns NaN-fills the gaps, yielding a ragged artifact that "
+            "breaks strict-JSON dashboards and the compare feature.",
+            "",
+        ]
+        for i, info in enumerate(schemas.values(), 1):
+            unique = sorted(frozenset(info["columns"]) - common)
+            lines.append(f"  Schema #{i} (source: {info['label']}):")
+            lines.append(
+                "    distinguishing columns: "
+                + (
+                    str(unique)
+                    if unique
+                    else "<none — differs only by stat/metric columns>"
+                )
+            )
+            lines.append(f"    example params: {info['sample']}")
+        lines += [
+            "",
+            "Fix one of two ways:",
+            "  (a) One test emitting different columns across parametrizations — usually a "
+            "template/runtime param that is None for some sweep values and set for others "
+            "(e.g. MATH_OP's pool_type). Make the param set consistent across the sweep.",
+            "  (b) Two genuinely different ops/families share the same py file — split them "
+            "into separate test files, one schema per file.",
+        ]
+        raise PerfSchemaError("\n".join(lines))
 
     def frame(self) -> pd.DataFrame:
         # merge
@@ -275,10 +359,43 @@ def _collapse_duplicate_keys(frame: pd.DataFrame, label: str) -> pd.DataFrame:
         # Restore the original column order (groupby/agg reorders columns).
         return collapsed[list(frame.columns)]
     except Exception as e:
-        logger.warning(
-            "{}: duplicate-key collapse skipped due to error: {}", label, e
-        )
+        logger.warning("{}: duplicate-key collapse skipped due to error: {}", label, e)
         return frame
+
+
+def _assert_combined_schema(dfs: list[pd.DataFrame], label: str):
+    """
+    Fail loud if per-worker files for one test disagree on columns.
+
+    Each worker file already passed the per-report schema guard, so each is
+    internally homogeneous — but pytest-xdist can split one test's sweep across
+    workers, and if that test emits inconsistent columns (e.g. a param that is
+    None for some sweep values) the workers diverge only here. Stacking them
+    would NaN-fill the gaps, so we refuse instead of shipping a ragged CSV.
+    """
+    schemas = {}
+    for df in dfs:
+        if df.empty:
+            continue
+        schemas.setdefault(frozenset(df.columns), list(df.columns))
+    if len(schemas) <= 1:
+        return
+
+    sigs = list(schemas.keys())
+    common = sigs[0]
+    for s in sigs[1:]:
+        common = common & s
+    detail = "; ".join(
+        f"schema #{i}: +{sorted(frozenset(cols) - common) or '<none>'}"
+        for i, cols in enumerate(schemas.values(), 1)
+    )
+    raise PerfSchemaError(
+        f"Perf report schema contamination in combined '{label}': "
+        f"{len(schemas)} different column schemas across worker files ({detail}). "
+        "A single test is emitting inconsistent columns across its sweep, or two "
+        "tests with different schemas share this file — split them into separate "
+        "files (one schema per file)."
+    )
 
 
 def combine_perf_reports():
@@ -332,6 +449,7 @@ def combine_perf_reports():
             if len(dfs_regular) == 0:
                 continue
 
+            _assert_combined_schema(dfs_regular, f"{base_name}.csv")
             combined_regular = pd.concat(dfs_regular, ignore_index=True)
             combined_regular = _collapse_duplicate_keys(
                 combined_regular, f"{base_name}.csv"
@@ -355,6 +473,7 @@ def combine_perf_reports():
             if len(dfs_post) == 0:
                 continue
 
+            _assert_combined_schema(dfs_post, f"{base_name}.post.csv")
             combined_post = pd.concat(dfs_post, ignore_index=True)
             combined_post = _collapse_duplicate_keys(
                 combined_post, f"{base_name}.post.csv"
@@ -618,7 +737,7 @@ class PerfConfig(TestConfig):
         other_cols = [c for c in combined.columns if not c.startswith("TEXT_SIZE(")]
         combined = combined[other_cols + text_size_cols]
 
-        perf_report.append(combined)
+        perf_report.append(combined, label=self.test_name)
 
         # Append raw counter data to the separate counter report
         if counter_results_list and PerfConfig.COUNTER_REPORT is not None:
@@ -629,4 +748,4 @@ class PerfConfig(TestConfig):
                 counter_results_list,
             )
             counter_combined = sweep.merge(counter_run_results, how="cross")
-            PerfConfig.COUNTER_REPORT.append(counter_combined)
+            PerfConfig.COUNTER_REPORT.append(counter_combined, label=self.test_name)

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -10,7 +10,6 @@ from helpers.llk_params import (
     FastMode,
     MathOperation,
     PerfRunType,
-    ReducePool,
     StableSort,
     Transpose,
 )
@@ -29,7 +28,6 @@ from helpers.test_variant_parameters import (
     TILE_COUNT,
     UNPACK_TRANS_FACES,
     UNPACK_TRANS_WITHIN_FACE,
-    generate_input_dim,
 )
 
 _OPS_WITHOUT_DEST_ACC = {
@@ -184,57 +182,6 @@ def test_perf_eltwise_unary_sfpu(
         ),
         unpack_to_dest=unpack_to_dest,
         dest_acc=dest_acc,
-    )
-
-    configuration.run(perf_report)
-
-
-@pytest.mark.perf
-@parametrize(
-    formats=input_output_formats(
-        [DataFormat.Float32],
-        same=True,
-    ),
-    dest_acc=[DestAccumulation.Yes],
-    mathop=[MathOperation.ReduceRow],
-    reduce_pool=[ReducePool.Max],
-    loop_factor=list(range(10, 201, 10)),
-)
-def test_perf_sfpu_reduce_row_max(
-    perf_report, formats, dest_acc, mathop, reduce_pool, loop_factor
-):
-    input_dimensions = [32, 32]
-    tile_count = 1
-
-    configuration = PerfConfig(
-        "sources/sfpu_reduce_row_max_perf.cpp",
-        formats,
-        run_types=[
-            PerfRunType.MATH_ISOLATE,
-        ],
-        templates=[
-            MATH_OP(mathop=mathop, pool_type=reduce_pool),
-            APPROX_MODE(ApproximationMode.No),
-            generate_input_dim(input_dimensions, input_dimensions),
-        ],
-        runtimes=[
-            TILE_COUNT(tile_count),
-            LOOP_FACTOR(loop_factor),
-        ],
-        variant_stimuli=StimuliConfig(
-            None,
-            formats.input_format,
-            None,
-            formats.input_format,
-            formats.output_format,
-            tile_count_A=tile_count,
-            tile_count_B=tile_count,
-            tile_count_res=tile_count,
-        ),
-        unpack_to_dest=True,
-        dest_acc=dest_acc,
-        disable_format_inference=True,
-        compile_time_formats=True,
     )
 
     configuration.run(perf_report)

--- a/tt_metal/tt-llk/tests/python_tests/perf_fast_tilize_full.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_fast_tilize_full.py
@@ -30,7 +30,7 @@ from helpers.test_variant_parameters import (
 @skip_for_wormhole
 @skip_for_quasar
 @parametrize(
-    formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32]),
+    formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32], same=True),
     rt_dim=[1],
     ct_dim=[1, 2, 3, 4, 5, 6, 7, 8],
 )

--- a/tt_metal/tt-llk/tests/python_tests/perf_sfpu_reduce_row_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_sfpu_reduce_row_max.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from helpers.format_config import DataFormat
+from helpers.llk_params import (
+    ApproximationMode,
+    DestAccumulation,
+    MathOperation,
+    PerfRunType,
+    ReducePool,
+)
+from helpers.param_config import input_output_formats, parametrize
+from helpers.perf import PerfConfig
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    LOOP_FACTOR,
+    MATH_OP,
+    TILE_COUNT,
+    generate_input_dim,
+)
+
+
+@pytest.mark.perf
+@parametrize(
+    formats=input_output_formats(
+        [DataFormat.Float32],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.Yes],
+    mathop=[MathOperation.ReduceRow],
+    reduce_pool=[ReducePool.Max],
+    loop_factor=list(range(10, 201, 10)),
+)
+def test_perf_sfpu_reduce_row_max(
+    perf_report, formats, dest_acc, mathop, reduce_pool, loop_factor
+):
+    input_dimensions = [32, 32]
+    tile_count = 1
+
+    configuration = PerfConfig(
+        "sources/sfpu_reduce_row_max_perf.cpp",
+        formats,
+        run_types=[
+            PerfRunType.MATH_ISOLATE,
+        ],
+        templates=[
+            MATH_OP(mathop=mathop, pool_type=reduce_pool),
+            APPROX_MODE(ApproximationMode.No),
+            generate_input_dim(input_dimensions, input_dimensions),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_count),
+            LOOP_FACTOR(loop_factor),
+        ],
+        variant_stimuli=StimuliConfig(
+            None,
+            formats.input_format,
+            None,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_count,
+            tile_count_B=tile_count,
+            tile_count_res=tile_count,
+        ),
+        unpack_to_dest=True,
+        dest_acc=dest_acc,
+        disable_format_inference=True,
+        compile_time_formats=True,
+    )
+
+    configuration.run(perf_report)

--- a/tt_metal/tt-llk/tests/python_tests/perf_unpack_a_bcast_eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_unpack_a_bcast_eltwise.py
@@ -34,7 +34,6 @@ from helpers.test_variant_parameters import (
     ],
     input_dimensions=[
         [128, 32],
-        [32, 128],
         [64, 128],
     ],
 )


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The "LLK perf" nightly (`.github/workflows/llk-perf.yaml`) ships per-test
performance CSVs with two data-quality defects on **both blackhole and wormhole**:

1. **Schema contamination** — a `ReduceRow`/`ReducePool.Max` sweep (60 rows) was
   misrouted into `perf_eltwise_unary_sfpu.post.csv`, welding two incompatible
   column schemas into one file and leaving every cross-schema cell as `NaN`.
2. **Duplicate `(sweep-params, marker)` rows** — several tests emit the same key
   twice within a single runner; some byte-identical, some with **differing
   metric values** (non-deterministic measurement).

This PR fixes both at the harness source:
- **Splits** the misrouted reduce sweep into its own `perf_sfpu_reduce_row_max.py`,
  so each module's CSV holds a single homogeneous schema.
- **Adds a fail-loud schema guard** (`PerfReport.assert_single_schema` + a
  cross-worker check in `combine_perf_reports`) that refuses to write a
  contaminated CSV and names the offending schemas — a regression now fails CI
  instead of silently shipping a ragged file.
- **De-duplicates** in `combine_perf_reports`: same-key rows collapse to one
  (mean of the metric columns), always emitting a **warning** on every collapse
  that reports how many collapsed keys disagreed on a metric value, so
  measurement instability is surfaced instead of keeping an arbitrary row.
- **Removes** the two coverage overlaps that produced duplicates at the source
  (`perf_fast_tilize_full` `same=True`; `perf_unpack_a_bcast_eltwise` redundant
  shape).

Fixes #48427

### Notes for reviewers
- Two commits: the fix (split + de-dup + overlap removal) and the fail-loud guard.
- Focus on the **guard's failure mode** — it raises *before* any CSV is written
  and names the conflicting schemas; confirm it won't trip on legitimate
  single-schema files.
- The de-dup **warns on every collapsed key**, flagging how many disagreed on a
  metric value; check the mean-of-metrics behavior suits downstream consumers.
- Changes are confined to `tt_metal/tt-llk/tests/python_tests` perf infrastructure
  — no product/runtime code. Full evidence, reproduction, and the per-test
  inventory live in issue #48427.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrsmanovic/llk-perf-data-quality-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrsmanovic/llk-perf-data-quality-fixes)
