### PR TITLE
[Bug fix] - pass sub_core_grids in sampling masking (fixes  #48308 )

### DIFF
--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -482,6 +482,7 @@ class Sampling1D(LightweightModule):
             [valid_logits, masked_tail_logits],
             dim=3,
             memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
         )
         ttnn.deallocate(valid_logits)
         ttnn.deallocate(tail_logits)

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -436,18 +436,28 @@ class Sampling1D(LightweightModule):
             return self._mask_invalid_vocab_tail_logits(logits)
         if self._invalid_vocab_mask is None:
             return logits
-        return ttnn.add(logits, self._invalid_vocab_mask, memory_config=logits.memory_config())
+        return ttnn.add(
+            logits,
+            self._invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.config.sub_core_grids,
+        )
 
     def _mask_invalid_vocab_tail_logits(self, logits):
+        cfg = self.config
         tail_width = self._invalid_vocab_tail_width
         local_width = logits.shape[-1]
         valid_width = local_width - tail_width
         if tail_width <= 0 or valid_width < 0:
             return self._mask_invalid_vocab_logits_fallback(logits)
         if valid_width == 0:
-            return ttnn.add(logits, self._invalid_vocab_tail_mask, memory_config=logits.memory_config())
+            return ttnn.add(
+                logits,
+                self._invalid_vocab_tail_mask,
+                memory_config=logits.memory_config(),
+                sub_core_grids=cfg.sub_core_grids,
+            )
 
-        cfg = self.config
         valid_logits = ttnn.slice(
             logits,
             [0, 0, 0, 0],
@@ -462,7 +472,12 @@ class Sampling1D(LightweightModule):
             memory_config=logits.memory_config(),
             sub_core_grids=cfg.sub_core_grids,
         )
-        masked_tail_logits = ttnn.add(tail_logits, self._invalid_vocab_tail_mask, memory_config=logits.memory_config())
+        masked_tail_logits = ttnn.add(
+            tail_logits,
+            self._invalid_vocab_tail_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
         masked_logits = ttnn.concat(
             [valid_logits, masked_tail_logits],
             dim=3,
@@ -476,7 +491,12 @@ class Sampling1D(LightweightModule):
     def _mask_invalid_vocab_logits_fallback(self, logits):
         if self._invalid_vocab_mask is None:
             return logits
-        return ttnn.add(logits, self._invalid_vocab_mask, memory_config=logits.memory_config())
+        return ttnn.add(
+            logits,
+            self._invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.config.sub_core_grids,
+        )
 
     def _can_slice_valid_vocab_for_argmax(self):
         cfg = self.config

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -420,6 +420,7 @@ class TTSampling(LightweightModule):
             [valid_logits, masked_tail_logits],
             dim=3,
             memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
         )
         ttnn.deallocate(valid_logits)
         ttnn.deallocate(tail_logits)

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -375,7 +375,12 @@ class TTSampling(LightweightModule):
             return self._mask_invalid_vocab_tail_logits(logits)
         if self.tt_invalid_vocab_mask is None:
             return logits
-        return ttnn.add(logits, self.tt_invalid_vocab_mask, memory_config=logits.memory_config())
+        return ttnn.add(
+            logits,
+            self.tt_invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
 
     def _mask_invalid_vocab_tail_logits(self, logits):
         tail_width = self._invalid_vocab_tail_width
@@ -384,7 +389,12 @@ class TTSampling(LightweightModule):
         if tail_width <= 0 or valid_width < 0:
             return self._mask_invalid_vocab_logits_fallback(logits)
         if valid_width == 0:
-            return ttnn.add(logits, self.tt_invalid_vocab_tail_mask, memory_config=logits.memory_config())
+            return ttnn.add(
+                logits,
+                self.tt_invalid_vocab_tail_mask,
+                memory_config=logits.memory_config(),
+                sub_core_grids=self.sub_core_grids,
+            )
 
         valid_logits = ttnn.slice(
             logits,
@@ -401,7 +411,10 @@ class TTSampling(LightweightModule):
             sub_core_grids=self.sub_core_grids,
         )
         masked_tail_logits = ttnn.add(
-            tail_logits, self.tt_invalid_vocab_tail_mask, memory_config=logits.memory_config()
+            tail_logits,
+            self.tt_invalid_vocab_tail_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
         )
         masked_logits = ttnn.concat(
             [valid_logits, masked_tail_logits],
@@ -416,7 +429,12 @@ class TTSampling(LightweightModule):
     def _mask_invalid_vocab_logits_fallback(self, logits):
         if self.tt_invalid_vocab_mask is None:
             return logits
-        return ttnn.add(logits, self.tt_invalid_vocab_mask, memory_config=logits.memory_config())
+        return ttnn.add(
+            logits,
+            self.tt_invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
 
     def _can_slice_valid_vocab_for_argmax(self):
         return self.vocab_size < self.padded_vocab_size and self.vocab_size % ttnn.TILE_SIZE == 0

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -726,18 +726,38 @@ def test_sampling1d_padded_tail_with_sub_core_grids_runs(ttnn_mesh_device):
         sub_core_grid_topk=sub_core_grids,
         start_core=ttnn.CoreCoord(0, 0),
     )
+    sampler.load_device_buffers()
 
-    logits_host = torch.zeros((1, 1, B, padded_vocab_size), dtype=torch.bfloat16)
+    logits_host = torch.full((1, 1, B, padded_vocab_size), -1.0, dtype=torch.bfloat16)
+    logits_host[..., valid_vocab_size:] = 0.0
     logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
 
     cluster_shape = tuple(ttnn_mesh_device.shape)
     k, p, temp = _make_sampling_params(
         ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
     )
-    tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
-    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B]
 
-    assert tokens_host.numel() == B
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    worker_sub_device = ttnn.SubDevice([sub_core_grids])
+    sub_device_manager = ttnn_mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    stall_group_set = False
+    manager_loaded = False
+    try:
+        ttnn_mesh_device.load_sub_device_manager(sub_device_manager)
+        manager_loaded = True
+        ttnn_mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+        stall_group_set = True
+
+        tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+        tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+        assert torch.all(tokens_host < valid_vocab_size)
+    finally:
+        if stall_group_set:
+            ttnn_mesh_device.reset_sub_device_stall_group()
+        if manager_loaded:
+            ttnn_mesh_device.clear_loaded_sub_device_manager()
+        ttnn_mesh_device.remove_sub_device_manager(sub_device_manager)
 
 
 @pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -26,6 +26,10 @@ QWEN3_32B = "Qwen/Qwen3-32B"
 _slow = pytest.mark.slow
 
 
+def _sub_core_grids_for_32_users():
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))})
+
+
 def _list_collected_sampling_cases() -> list[pytest.param]:
     """
     Collected from TTTv1 demo runs (Phase B of test_case_collection.md).
@@ -706,6 +710,34 @@ def test_sampling1d_topk_masks_qwen3_32b_padded_tail(ttnn_mesh_device):
     tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
 
     assert torch.all(tokens_host < valid_vocab_size)
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_padded_tail_with_sub_core_grids_runs(ttnn_mesh_device):
+    B = 32
+    valid_vocab_size = 151936
+    padded_vocab_size = 152064
+    sub_core_grids = _sub_core_grids_for_32_users()
+    sampler = Sampling1D(
+        vocab_size=padded_vocab_size,
+        valid_vocab_size=valid_vocab_size,
+        mesh_device=ttnn_mesh_device,
+        sub_core_grids=sub_core_grids,
+        sub_core_grid_topk=sub_core_grids,
+        start_core=ttnn.CoreCoord(0, 0),
+    )
+
+    logits_host = torch.zeros((1, 1, B, padded_vocab_size), dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+    tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B]
+
+    assert tokens_host.numel() == B
 
 
 @pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)


### PR DESCRIPTION
### PR Category
Bug fix
### Summary
Fixes #48308 

### Notes for reviewers
-

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/fix-48308-sampling-sub-core-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/fix-48308-sampling-sub-core-grids)