### PR TITLE
#48455: update dmk and qa_hal to deal with XIPify issue on Quasar

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -69,12 +69,23 @@ uint32_t _start() {
     extern uint32_t __ldm_tdata_start[];
     extern uint32_t __ldm_tdata_end[];
 
+    // Materialize __tdata_lma's address exactly once. The two references below (do_crt1 in the
+    // thread-0 branch and do_thread_crt1) otherwise emit two R_RISCV_HI20 relocations for
+    // __tdata_lma. On Quasar the XIP relocation pass (ElfFile::Impl::XIPify) pairs HI20<->LO12
+    // heuristically (each LO12 to the nearest preceding HI20); when the second HI20 lands in a loop
+    // tail with its LO12 reached via a back-edge it is left orphaned, throwing "R_RISCV_HI20
+    // relocation ... has no matching R_RISCV_LO12". The asm barrier makes the pointer opaque so the
+    // compiler keeps a single materialization (one HI20) and reuses the register/spill instead of
+    // re-emitting a lui/addi pair.
+    uint32_t* tdata_lma = __tdata_lma;
+    asm volatile("" : "+r"(tdata_lma));
+
     if (hartid == thread_0_hartid) {
-        do_crt1(&__tdata_lma[__ldm_tdata_end - __ldm_tdata_start]);
+        do_crt1(&tdata_lma[__ldm_tdata_end - __ldm_tdata_start]);
         (*GET_MAILBOX_ADDRESS_DEV(shared_globals_ready))[hartid] = SHARED_GLOBALS_READY_GO;
     }
 
-    do_thread_crt1(__tdata_lma);
+    do_thread_crt1(tdata_lma);
 
     // Wait until first thread in the group has set its slot to GO.
     while ((*GET_MAILBOX_ADDRESS_DEV(shared_globals_ready))[thread_0_hartid] != SHARED_GLOBALS_READY_GO) {

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -91,6 +91,13 @@ public:
     using HalJitBuildQueryBase::HalJitBuildQueryBase;
     std::string linker_flags(const Params& params) const override {
         std::string flags;
+        // Quasar XIP (QuasarDataMovementKernel::read_binaries -> ElfFile::Impl::XIPify) pairs each
+        // R_RISCV_HI20 with its R_RISCV_LO12 and throws "HI20 has no matching LO12" if it can't.
+        // Linker relaxation can orphan a crt0 TLS-init __tdata_lma HI20 (its LO12 lands past a JAL in a
+        // different basic block), which trips that check on essentially every kernel. Disable linker
+        // relaxation so HI20/LO12 stay paired/adjacent. The assembler still emits R_RISCV_RELAX relocs
+        // (which XIPify's check_relaxed expects); --no-relax only stops the linker from acting on them.
+        flags += "-Wl,--no-relax ";
         if (params.processor_class == HalProcessorClassType::DM) {
             if (params.is_fw) {
                 flags += fmt::format("-Wl,--defsym=__fw_text={} ", MEM_DM_FIRMWARE_BASE);


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #48455 

AI generated details: 

[Quasar] Work around XIPify HI20/LO12 pairing failure on DM-kernel load

binaries fails in the XIP relocation pass with:

  TT_THROW @ tt_metal/llrt/tt_elffile.cpp:
    .../writer_pad_dims_rm_sharded/<hash>/dm3/dm3.elf:
      R_RISCV_HI20 relocation at 0x... has no matching R_RISCV_LO12

  This blocked the resnet50/quasar bring-up on the simulator (first seen loading
  the move reader reader_unary_local_l1_copy_backwards on dm2, then the pad
  writer writer_pad_dims_rm_sharded on dm3). This PR is a downstream workaround
  so Quasar DM kernels load; the underlying bug is in XIPify and is tracked
  separately (see "Underlying issue" below).

  Root cause

  ElfFile::Impl::XIPify() pairs each R_RISCV_HI20 with an R_RISCV_LO12 using a
  heuristic backward search and throws if it can't find a match (the code itself
  notes the ABS pairing is heuristic and would need CFG construction to be
  exact).

```
  The DM-kernel crt0 _start (dmk.cc) materializes the address of __tdata_lma
  twice ?~@~T once for do_crt1 (thread-0 TLS image copy) and once for do_thread_crt1
  ?~@~T emitting two R_RISCV_HI20 relocations to the same symbol. The heuristic
  attaches both nearby LO12s to the first HI20, leaving the second one orphaned
  ?~F~R throw. Linker relaxation independently aggravates this by moving a HI20's
  matching LO12 across a basic-block boundary. The failure is
  binary-layout-dependent (it did not hit every DM kernel).
```
  Changes
```
  1. tt_metal/hw/firmware/src/tt-2xx/dmk.cc ?~@~T materialize __tdata_lma exactly
  once in _start:
  uint32_t* tdata_lma = __tdata_lma;
  asm volatile("" : "+r"(tdata_lma));   // opaque barrier: forbid 
  re-materialization
  ... do_crt1(&tdata_lma[...]); ... do_thread_crt1(tdata_lma);
  The barrier makes the pointer opaque so the compiler keeps a single
  materialization (one HI20) and reuses the register/spill instead of emitting a
  second lui. This is the primary fix ?~@~T it removes the duplicate-HI20 pattern
  XIPify can't pair.

  2. tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp ?~@~T disable linker relaxation for
  Quasar kernel links:
  flags += "-Wl,--no-relax ";   // in HalJitBuildQueryQuasar::linker_flags
  Keeps HI20/LO12 pairs adjacent so XIPify can match them, a standard XIP-safety
  measure. The assembler still emits R_RISCV_RELAX relocs (which XIPify's
  check_relaxed expects); --no-relax only stops the linker from acting on them.
  Quasar-only (this HAL is not used by WH/BH).

  ?~V~N Note: --no-relax alone did not fix the _start case (the duplicate 
  ?~V~N __tdata_lma HI20 is codegen, not relaxation), so both changes are included.
```
  Underlying issue (for the runtime team)

  The real fix belongs in XIPify (tt_elffile.cpp): make HI20?~F~TLO12 pairing
  tolerate multiple HI20s to the same symbol (CFG-aware, or treat an orphan HI20
  as low-bits-known). A standalone reproducer is in test_xipify_bug.py (a
  single ttnn.experimental.quasar.pad on a height-sharded RM tensor ?~F~R
  pad_rm_sharded_height_only DM kernels). With this PR's dmk.cc workaround in
  place the repro passes; reverting the _start change reproduces the throw.
  Tracked in #48466



### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-48455_xipify_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-48455_xipify_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-48455_xipify_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-48455_xipify_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-48455_xipify_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-48455_xipify_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-48455_xipify_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-48455_xipify_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-48455_xipify_qsr)