### PR TITLE
[LLK] [SAN] Pack should not require and Uninit

### DIFF
--- a/tt_metal/tt-llk/common/sanitizer/types.h
+++ b/tt_metal/tt-llk/common/sanitizer/types.h
@@ -351,7 +351,7 @@ enum class Operation : std::uint32_t
     // PACK EXU (TRISC2)
 
     // sstanisic todo: contract cannot be enforced if Pack has an uninit, without killing performance
-    Pack         = OperationUtil::make(OperationUtil::ExecutionUnit::PACK, OperationUtil::NativeThread::TRISC2, OperationUtil::ExpectUninit::Yes, 1),
+    Pack         = OperationUtil::make(OperationUtil::ExecutionUnit::PACK, OperationUtil::NativeThread::TRISC2, OperationUtil::ExpectUninit::No, 1),
     PackUntilize = OperationUtil::make(OperationUtil::ExecutionUnit::PACK, OperationUtil::NativeThread::TRISC2, OperationUtil::ExpectUninit::Yes, 2),
 };
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -527,7 +527,8 @@ inline void _llk_pack_init_(
  */
 inline void _llk_pack_uninit_()
 {
-    llk::san::operation_uninit<llk::san::Operation::Pack>();
+    // sstanisic todo: contract cannot be enforced if Pack has an uninit, without killing performance
+    // llk::san::operation_uninit<llk::san::Operation::Pack>();
 
     // No state to restore - Blackhole pack_init sets PAC X counter to FACE_C_DIM - 1 which is the default.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -435,7 +435,8 @@ inline void _llk_pack_init_(
  */
 inline void _llk_pack_uninit_()
 {
-    llk::san::operation_uninit<llk::san::Operation::Pack>();
+    // sstanisic todo: contract cannot be enforced if Pack has an uninit, without killing performance
+    // llk::san::operation_uninit<llk::san::Operation::Pack>();
 }
 
 /**


### PR DESCRIPTION

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Workaround


### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
When an operation has an UNINIT, Sanitizer requires that you can't RECONFIG between the INIT and UNINIT. 
This is to prevent the case:
- `INIT -> RECONFIG -> EXECUTE -> UNINIT`

Where the RECONFIG reverts the Restorable state set in INIT prematurely, leading to a incorrect during EXECUTE.

The proper solution would be to:
1.  remove `pack_uninit` OR
2.  force use of RECONFIG -> INIT -> EXECUTE -> UNINIT.

The second solution however can't be implemented, because it would cause a large performance regression, because most kernels currently do:

- `INIT -> RECONFIG -> EXECUTE -> RECONFIG -> EXECUTE` - which is incorrect
- `RECONFIG -> INIT -> EXECUTE -> UNINIT -> RECONFIG -> INIT -> EXECUTE -> UNINIT` -  which contains many redundant INIT calls compared to the current implementation. 

Current workaround is to pretend that pack doesn't have an UNINIT, because in that case it is valid to RECONFIGURE after an INIT, because of the presumption that the INIT doesn't touch Restorable state 


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk/san/pr/pack-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk/san/pr/pack-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk/san/pr/pack-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk/san/pr/pack-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk/san/pr/pack-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk/san/pr/pack-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk/san/pr/pack-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk/san/pr/pack-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk/san/pr/pack-uninit)