### PR TITLE
Suppress empty std(...) columns in single-run perf CSVs

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -182,6 +182,20 @@ def _stats_timings(perf_data: pd.DataFrame) -> pd.DataFrame:
     columns += [f"{stat}({col})" for col in timings for stat in ["mean", "std"]]
 
     result.columns = columns
+
+    # std is undefined for a single sample, so with the default run_count=1 every
+    # marker has one observation and the std(...) columns come back entirely NaN.
+    # Drop those all-empty std(...) columns so single-run reports don't carry
+    # structurally empty data; tests that repeat measurements (run_count>=2) keep
+    # their populated std columns untouched.
+    empty_std_columns = [
+        col
+        for col in result.columns
+        if col.startswith("std(") and result[col].isna().all()
+    ]
+    if empty_std_columns:
+        result = result.drop(columns=empty_std_columns)
+
     return result
 
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The "LLK perf" nightly per-test CSVs carry `std(<metric>)` columns that are 100%
empty (`NaN`). The profiler-stats path (`_stats_timings` in `helpers/profiler.py`)
builds a `std(...)` column for every timing via `groupby("marker").agg(["mean",
"std"])` regardless of sample count — but the default `run_count=1` gives one
observation per marker, so std (ddof=1) is undefined and the columns ship empty.
(The hardware-counter path already guards on ≥2 samples.)

This drops `std(...)` columns that are entirely empty after aggregation. Tests
that repeat measurements (`run_count>=2`, e.g. `perf_fast_tilize`,
`perf_unpack_a_bcast_eltwise`) keep their populated std untouched.

Fixes #48470

### Notes for reviewers
- One-spot change in `_stats_timings`, the shared chokepoint for all profiler std
  columns (`L1_TO_L1`, the isolate stats, `L1_CONGESTION`).
- Only *entirely*-empty std columns are dropped — a partially-populated std column
  (mixed sample counts) is preserved.
- No product/runtime code; confined to `tt_metal/tt-llk/tests/python_tests` perf
  infrastructure.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrsmanovic/llk-perf-std-suppress-empty)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrsmanovic/llk-perf-std-suppress-empty)