### PR TITLE
Fix ttsim conv failures

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
@@ -11,19 +12,19 @@
 
 void kernel_main() {
 
-    const uint32_t src_addr                 = get_arg_val<uint32_t>(0);
-    const uint32_t block_height             = get_arg_val<uint32_t>(2);
-    const uint32_t block_width_bytes        = get_arg_val<uint32_t>(3);
-    const uint32_t padded_block_width_bytes = get_arg_val<uint32_t>(4);
-    const bool aligned                      = static_cast<bool>(get_arg_val<uint32_t>(5));
-    const uint32_t aligned_input_width_offset_bytes = get_arg_val<uint32_t>(6);
-    const uint32_t aligned_block_width_bytes = get_arg_val<uint32_t>(7);
-    const uint32_t aligned_offset           = get_arg_val<uint32_t>(8);
-    const uint32_t start_id                 = get_arg_val<uint32_t>(9);
+    const std::uint32_t src_addr = get_arg_val<std::uint32_t>(0);
+    const std::uint32_t input_width_bytes = get_arg_val<std::uint32_t>(1);
+    const std::uint32_t block_height = get_arg_val<std::uint32_t>(2);
+    const std::uint32_t block_width_bytes = get_arg_val<std::uint32_t>(3);
+    const std::uint32_t padded_block_width_bytes = get_arg_val<std::uint32_t>(4);
+    const bool aligned = static_cast<bool>(get_arg_val<std::uint32_t>(5));
+    const std::uint32_t aligned_input_width_offset_bytes = get_arg_val<std::uint32_t>(6);
+    const std::uint32_t aligned_offset = get_arg_val<std::uint32_t>(8);
+    const std::uint32_t start_id = get_arg_val<std::uint32_t>(9);
 
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
-    constexpr uint32_t num_trids = get_compile_time_arg_val(2);
+    constexpr std::uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr std::uint32_t cb_id_in1 = get_compile_time_arg_val(1);
+    constexpr std::uint32_t num_trids = get_compile_time_arg_val(2);
     constexpr auto src_args = TensorAccessorArgs<3>();
 
     Noc noc;
@@ -31,62 +32,79 @@ void kernel_main() {
     CircularBuffer cb_in1(cb_id_in1);
 
     const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes);
-    uint32_t stick_id = start_id;
+    std::uint32_t stick_id = start_id;
     cb_in0.reserve_back(block_height);
+
+    const std::uint32_t input_block_start_bytes = aligned_input_width_offset_bytes + aligned_offset;
+    const std::uint32_t input_bytes_remaining =
+        input_block_start_bytes < input_width_bytes ? input_width_bytes - input_block_start_bytes : 0;
+    const std::uint32_t valid_block_width_bytes =
+        input_bytes_remaining < block_width_bytes ? input_bytes_remaining : block_width_bytes;
+    const std::uint32_t valid_aligned_block_width_bytes = aligned_offset + valid_block_width_bytes;
+
+    if (valid_block_width_bytes < padded_block_width_bytes) {
+        noc.async_write_zeros(cb_in0, block_height * padded_block_width_bytes);
+        noc.write_zeros_l1_barrier();
+    }
+    if (valid_block_width_bytes == 0) {
+        cb_in0.push_back(block_height);
+        return;
+    }
+
     if (aligned) {
-        uint32_t dest_off = 0;
-        for (uint32_t h = 0; h < block_height; ++h) {
-            noc.async_read(s0, cb_in0, block_width_bytes, {.page_id = stick_id}, {.offset_bytes = dest_off});
+        std::uint32_t dest_off = 0;
+        for (std::uint32_t h = 0; h < block_height; ++h) {
+            noc.async_read(s0, cb_in0, valid_block_width_bytes, {.page_id = stick_id}, {.offset_bytes = dest_off});
             stick_id++;
             dest_off += padded_block_width_bytes;
         }
         noc.async_read_barrier();
     } else {
-        enum SlotState : uint8_t {
+        enum SlotState : std::uint8_t {
             IDLE = 0,
             SRC_PENDING = 1,
             SCRATCH_READY = 2,
             SCRATCH_PENDING = 3
         };
 
-        constexpr uint32_t trid_base = 1;
+        constexpr std::uint32_t trid_base = 1;
 
         cb_in1.reserve_back(num_trids);
-        uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_in1).fifo_page_size;
+        std::uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_in1).fifo_page_size;
         SlotState slot_states[num_trids];
-        uint32_t dest_offsets[num_trids];
-        uint32_t scratch_offsets[num_trids];
+        std::uint32_t dest_offsets[num_trids];
+        std::uint32_t scratch_offsets[num_trids];
 
         // Initialize slots
-        for (uint32_t i = 0; i < num_trids; i++) {
+        for (std::uint32_t i = 0; i < num_trids; i++) {
             slot_states[i] = SlotState::IDLE;
             scratch_offsets[i] = i * scratch_cb_page_size;
         }
 
         // Local NoC coordinates for the scratch->dest reads.
         UnicastEndpoint self_ep;
-        const uint32_t my_noc_x = my_x[noc.get_noc_id()];
-        const uint32_t my_noc_y = my_y[noc.get_noc_id()];
+        const std::uint32_t my_noc_x = my_x[noc.get_noc_id()];
+        const std::uint32_t my_noc_y = my_y[noc.get_noc_id()];
         // Base L1 address of the scratch CB
-        const uint32_t scratch_l1_base = cb_in1.get_write_ptr();
+        const std::uint32_t scratch_l1_base = cb_in1.get_write_ptr();
 
-        uint32_t dest_off = 0;         // running offset into cb_in0
-        uint32_t rows_issued = 0;      // Number of src->scratch transfers started
-        uint32_t rows_completed = 0;   // Number of scratch->dest transfers completed
+        std::uint32_t dest_off = 0;         // running offset into cb_in0
+        std::uint32_t rows_issued = 0;      // Number of src->scratch transfers started
+        std::uint32_t rows_completed = 0;   // Number of scratch->dest transfers completed
 
         while (rows_completed < block_height) {
-            for (uint32_t slot = 0; slot < num_trids; slot++) {
-                uint32_t active_trid = trid_base + slot;
+            for (std::uint32_t slot = 0; slot < num_trids; slot++) {
+                std::uint32_t active_trid = trid_base + slot;
 
                 if (slot_states[slot] == SlotState::IDLE && rows_issued < block_height) {
                     // Start new src->scratch transfer (TRID-tagged).
                     noc.async_read<NocOptions::TXN_ID>(
                         s0,
                         cb_in1,
-                        aligned_block_width_bytes,
+                        valid_aligned_block_width_bytes,
                         {.page_id = stick_id},
                         {.offset_bytes = scratch_offsets[slot]},
-                        NocOptVals{.trid = static_cast<uint8_t>(active_trid)});
+                        NocOptVals{.trid = static_cast<std::uint8_t>(active_trid)});
                     dest_offsets[slot] = dest_off;
                     slot_states[slot] = SlotState::SRC_PENDING;
 
@@ -105,12 +123,12 @@ void kernel_main() {
                     noc.async_read<NocOptions::TXN_ID>(
                         self_ep,
                         cb_in0,
-                        block_width_bytes,
+                        valid_block_width_bytes,
                         {.noc_x = my_noc_x,
                          .noc_y = my_noc_y,
                          .addr = scratch_l1_base + scratch_offsets[slot] + aligned_offset},
                         {.offset_bytes = dest_offsets[slot]},
-                        NocOptVals{.trid = static_cast<uint8_t>(active_trid)});
+                        NocOptVals{.trid = static_cast<std::uint8_t>(active_trid)});
 
                     slot_states[slot] = SlotState::SCRATCH_PENDING;
                 }
@@ -133,8 +151,8 @@ void kernel_main() {
     noc.set_async_read_state<NocOptions::TXN_ID>(
         self_ep,
         /*size_bytes=*/0,
-        {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
-         .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+        {.noc_x = (std::uint32_t)my_x[noc.get_noc_id()],
+         .noc_y = (std::uint32_t)my_y[noc.get_noc_id()],
          .addr = 0},
         NocOptVals{.trid = 0});
     cb_in0.push_back(block_height);


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes https://github.com/tenstorrent/tt-metal/issues/48492

**Primary Issue**: row-major interleaved_to_sharded was reading the padded shard width from DRAM instead of only the logical row width. In the failing conv1d case, each input row had 6 valid bytes but a 32-byte
  DRAM-aligned page, so the reader pulled in 26 stale, unwritten DRAM bytes per row.

**Fix**: the sharded reader now clamps each row read to the valid logical byte count and explicitly zero-fills the padded output region in L1. This defines conv’s padded channels without relying on stale
  DRAM contents or simulator-only DRAM clearing.

### Notes for reviewers
