### PR TITLE
Revert "#45821: clear program cache on MeshDevice reconfiguration (#47921)"

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -16,11 +16,9 @@
 #include <tt-metalium/dispatch_core_common.hpp>
 #include "gmock/gmock.h"
 #include "hostdevcommon/common_values.hpp"
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_config.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/program_cache.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/maybe_remote.hpp>
 #include "impl/context/metal_context.hpp"
@@ -167,22 +165,6 @@ TEST_F(MeshDevice1x8ReshapeTest, From1x8To2x4ThenBackTo1x8) {
 
     mesh_device_->reshape(MeshShape(1, 8));
     EXPECT_EQ(mesh_device_->get_device_ids(), original_order);
-}
-
-TEST_F(MeshDevice1x8ReshapeTest, ReshapeClearsProgramCache) {
-    // Reshape remaps device order, so stale cached programs must be dropped.
-
-    // Inserts a dummy entry so num_program_cache_entries() > 0 without dispatching a workload.
-    mesh_device_->get_program_cache().insert(
-        tt::tt_metal::program_cache::detail::ProgramCacheKey{1, "reconfig_regression_dummy"},
-        tt::tt_metal::program_cache::detail::CachedProgramFactory(
-            tt::tt_metal::program_cache::detail::CachedProgram<int>(tt::tt_metal::CreateProgram(), 0), 0));
-
-    EXPECT_GT(mesh_device_->num_program_cache_entries(), 0u);
-
-    mesh_device_->reshape(MeshShape(2, 4));
-
-    EXPECT_EQ(mesh_device_->num_program_cache_entries(), 0u);
 }
 
 TEST_F(MeshDevice1x8ReshapeTest, InvalidTotalDeviceCount) {

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -31,7 +31,6 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/program_cache.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
@@ -43,44 +42,6 @@ namespace {
 
 namespace tt::tt_metal {
 using MeshSubDeviceTestSuite = GenericMeshDeviceFixture;
-
-TEST_F(MeshSubDeviceTestSuite, LoadSubDeviceManagerClearsProgramCache) {
-    // Loading a manager may remap SubDeviceId -> worker cores, so cached programs must be dropped.
-    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
-    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
-    auto sub_device_manager = mesh_device_->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-
-    // Inserts a dummy entry so num_program_cache_entries() > 0 without dispatching a workload.
-    mesh_device_->get_program_cache().insert(
-        ::tt::tt_metal::program_cache::detail::ProgramCacheKey{1, "reconfig_regression_dummy"},
-        ::tt::tt_metal::program_cache::detail::CachedProgramFactory(
-            ::tt::tt_metal::program_cache::detail::CachedProgram<int>(::tt::tt_metal::CreateProgram(), 0), 0));
-
-    EXPECT_GT(mesh_device_->num_program_cache_entries(), 0u);
-
-    mesh_device_->load_sub_device_manager(sub_device_manager);
-
-    EXPECT_EQ(mesh_device_->num_program_cache_entries(), 0u);
-}
-
-TEST_F(MeshSubDeviceTestSuite, ClearLoadedSubDeviceManagerClearsProgramCache) {
-    // Reverting to the default manager remaps worker cores, so cached programs must be dropped.
-    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
-    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
-    auto sub_device_manager = mesh_device_->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-    mesh_device_->load_sub_device_manager(sub_device_manager);
-
-    // Inserts a dummy entry so num_program_cache_entries() > 0 without dispatching a workload.
-    mesh_device_->get_program_cache().insert(
-        ::tt::tt_metal::program_cache::detail::ProgramCacheKey{1, "reconfig_regression_dummy"},
-        ::tt::tt_metal::program_cache::detail::CachedProgramFactory(
-            ::tt::tt_metal::program_cache::detail::CachedProgram<int>(::tt::tt_metal::CreateProgram(), 0), 0));
-    EXPECT_GT(mesh_device_->num_program_cache_entries(), 0u);
-
-    mesh_device_->clear_loaded_sub_device_manager();
-
-    EXPECT_EQ(mesh_device_->num_program_cache_entries(), 0u);
-}
 
 TEST_F(MeshSubDeviceTestSuite, SyncWorkloadsOnSubDevice) {
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -876,7 +876,6 @@ void MeshDeviceImpl::reshape(const MeshShape& new_shape) {
     }
     auto new_view = std::make_unique<MeshDeviceView>(new_shape, new_device_order, new_fabric_node_ids);
     view_ = std::move(new_view);
-    clear_program_cache();  // Reshape remaps device order
 }
 
 bool MeshDeviceImpl::close() {
@@ -1104,13 +1103,11 @@ void MeshDeviceImpl::load_sub_device_manager(SubDeviceManagerId sub_device_manag
     auto lock = lock_api();
     validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
-    clear_program_cache();  // Manager switch may remap SubDeviceId
 }
 void MeshDeviceImpl::clear_loaded_sub_device_manager() {
     auto lock = lock_api();
     validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->clear_loaded_sub_device_manager();
-    clear_program_cache();  // possibility of remapping worker cores baked into cached programs.
 }
 
 CoreCoord MeshDeviceImpl::dram_grid_size() const {


### PR DESCRIPTION
### PR Category
Bug fix

## Summary
Reverts #47921 (`14c8ead`) to fix the **P0** DS-prefill chunk-processing regression in #48294: chunk time jumped from ~1.3s to ~70s.

#47921 made the `MeshDevice` reconfiguration APIs (`reshape()`, `load_sub_device_manager()`, `clear_loaded_sub_device_manager()`) **auto-clear the program cache**. The pipelined prefill runner reconfigures the mesh on its hot path, so every chunk now hits an empty cache and **recompiles every program** — hence the ~50x slowdown.

Bisect confirms `14c8ead` is the sole commit between last-good `ec9a6b3` and first-bad `14c8ead`.

## Changes
- Revert the 3 auto-clear calls in `MeshDeviceImpl::reshape()` / `load_sub_device_manager()` / `clear_loaded_sub_device_manager()`, plus the two unit tests added in #47921.
- The public `clear_program_cache()` API is unchanged — callers that need it can still clear manually.

## Trade-off / follow-up
This re-opens the correctness hazard #47921 set out to address (stale cached programs surviving a reconfig, since device-global state is not part of the cache key). The revert is the agreed path to unblock the disaggregated-prefill 06/30 deadline; a non-regressing fix for #45821 should be re-landed as a follow-up (e.g. clear only on the reconfig paths that actually remap, or fold the relevant state into the cache key).

Closes #48294

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/revert-47921-clear-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/revert-47921-clear-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/revert-47921-clear-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/revert-47921-clear-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/revert-47921-clear-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/revert-47921-clear-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/revert-47921-clear-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/revert-47921-clear-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/revert-47921-clear-cache)