### PR TITLE
[Feature] indexer_score: slab-aware K addressing (block-cyclic cache)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -122,6 +122,16 @@ def _extra_kwargs(program_config, compute_kernel_config):
     return kwargs
 
 
+def _slab_kwargs(slab_sp, sq, mid_slab_boundary=False):
+    """Build the explicit slab op-args from a simulated SP `slab_sp` and the q seq len. The slab layout is now
+    PASSED, not derived: slab_sp = the SP the cache was gathered across, slab_chunk_size = slab_sp*sq (the
+    gathered chunk). None -> contiguous (no slab args). mid_slab_boundary=True simulates this single device as
+    the boundary chip whose queries straddle a cache-slab boundary."""
+    if slab_sp is None:
+        return {}
+    return {"slab_sp": slab_sp, "slab_chunk_size": slab_sp * sq, "mid_slab_boundary": mid_slab_boundary}
+
+
 def run_dsa(
     q,
     k,
@@ -132,16 +142,23 @@ def run_dsa(
     q_dtype=ttnn.bfloat16,
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
+    proxy_ring_size=None,
+    proxy_mid_slab=False,
+    kv_len=None,
 ):
     """Run indexer_score_dsa (relu + learned gates + head-sum) and return the bf16 score as torch.
 
-    q (srcB) and k (srcA) may be bfp8_b; weights stay bf16.
+    q (srcB) and k (srcA) may be bfp8_b; weights stay bf16. proxy_ring_size simulates a ring_size-way slab K
+    layout on one chip (single-chip testing only); proxy_mid_slab makes it the straddling boundary chip.
+    kv_len = the valid key prefix (real ISL); keys past it are masked.
     """
     out = ttnn.experimental.indexer_score_dsa(
         to_device(q, device, dtype=q_dtype),
         to_device(k, device, dtype=k_dtype),
         to_device(w, device),
         chunk_start_idx=chunk_start,
+        **({} if kv_len is None else {"kv_len": kv_len}),
+        **_slab_kwargs(proxy_ring_size, q.shape[-2], proxy_mid_slab),
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
@@ -159,10 +176,12 @@ def run_msa(
     q_dtype=ttnn.bfloat16,
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
+    proxy_ring_size=None,
 ):
     """Run indexer_score_msa (raw dot, constant `scale` gate, per-group planes) and return torch.
 
     No weights tensor: M3 has no learned gates, only `scale` (run as a constant gate in-op).
+    proxy_ring_size simulates a ring_size-way slab K layout on one chip (single-chip testing only).
     """
     out = ttnn.experimental.indexer_score_msa(
         to_device(q, device, dtype=q_dtype),
@@ -171,6 +190,7 @@ def run_msa(
         scale=scale,
         num_groups=num_groups,
         block_size=block_size,
+        **_slab_kwargs(proxy_ring_size, q.shape[-2]),
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
@@ -238,11 +258,21 @@ def test_indexer_score_accuracy(device, sp_rank, q_dtype, case_id, heads):
     below the bf16 sum's noise). Negative gates keep -inf padding distinguishable from low scores.
     """
     chunk_start = GLX_HISTORY + sp_rank * GLX_SQ
-    q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    q, k_nat, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    # Slab-aware by default: GLX_SQ=640 / GLX_T=56320 picks ring=8 -> the actual deployed slab (chunk=5120).
+    k, ring = _slabify(k_nat, GLX_SQ, GLX_T)
     out = run_dsa(
-        q, k, w, chunk_start, device, program_config=glx_config(heads), q_dtype=q_dtype, k_dtype=ttnn.bfloat8_b
+        q,
+        k,
+        w,
+        chunk_start,
+        device,
+        program_config=glx_config(heads),
+        q_dtype=q_dtype,
+        k_dtype=ttnn.bfloat8_b,
+        proxy_ring_size=ring,
     )
-    ref = indexer_score_dsa_ref(q, k, w, chunk_start)
+    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
     assert_indexer_match(out, ref, GLX_SQ, GLX_T, check_neg=True)
 
 
@@ -254,11 +284,17 @@ def test_indexer_score_accuracy(device, sp_rank, q_dtype, case_id, heads):
 MINI = dict(heads=64, dim=128, sq=64, t=256)  # 64 heads, D=128, Sq=2 tiles, T=8 tiles
 
 
-def _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
+def _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group, slab=True):
+    # Slab-aware by DEFAULT: the K cache is the deployed (block-cyclic) layout, so build it as a slab (per-shape
+    # ring; a shape too small for a non-trivial slab falls back to contiguous) and let the op read it back in
+    # natural order. The reference is over the natural-order k, so the slab read must reproduce it.
+    # slab=False exercises the CONTIGUOUS K path: no slab args passed -> the reader's SLAB_KTILE is the identity
+    # (byte-identical binary), chunk_start deduces from Sq, no straddle. Same reference either way.
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
-    q, k, w = make_inputs(heads, dim, sq, t)
-    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg)
-    ref = indexer_score_dsa_ref(q, k, w, chunk_start)
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t) if slab else (k_nat, None)
+    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring)
+    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
     assert_indexer_match(out, ref, sq, t, check_neg=True)
 
 
@@ -320,6 +356,27 @@ def test_indexer_score_shapes(device, heads, dim, sq, t, chunk_start, q_chunk, k
     """Shape/geometry coverage: prefill corners, single/partial k-tiles, narrow/wide head dims, KC not
     dividing Tt (partial last unit), and a multicore QC=2 split."""
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
+
+
+# Contiguous (non-slab) K cache: tests are slab-aware by default, but the op must ALSO handle a plain
+# contiguous K (no slab_sp / slab_chunk_size passed -> identity SLAB_KTILE, no invP, no straddle). A few
+# representative shapes through the slab=False path guard that the contiguous reader binary still matches the
+# reference (and that the slab args are truly optional, not silently required).
+@pytest.mark.parametrize(
+    "heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group",
+    [
+        (64, 128, 128, 128, 0, 32, 32, 0),  # prefill square: fully-causal triangle, no history
+        (64, 128, 64, 256, 128, 32, 32, 0),  # mid-buffer chunk_start with history
+        (64, 128, 64, 160, 96, 32, 128, 0),  # KC does not divide Tt (partial last unit)
+        (64, 128, 64, 256, 160, 64, 128, 16),  # QC=2 + KC=4 + head streaming, diagonal mid-group
+        (16, 128, 128, 2048, 512, 64, 32, 0),  # multicore QC=2 split across cores
+    ],
+    ids=["prefill_square", "mid_history", "kc_partial", "qc2_kc4_stream", "multicore"],
+)
+def test_indexer_score_contiguous_kcache(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
+    """CONTIGUOUS K cache (no slab args): the op must read plain natural-order K with the identity SLAB_KTILE
+    and match the reference, across prefill/history/partial-KC/streaming/multicore shapes."""
+    _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group, slab=False)
 
 
 # Indexed KV cache: k is a shared [B, 1, T, D] cache and cache_batch_idx selects the batch slot to score.
@@ -534,9 +591,10 @@ def test_indexer_score_runtime_kv_len(device, q_chunk, k_chunk, head_group):
 
 
 def test_indexer_score_rejects_bad_kv_len(device, expect_error):
-    """kv_len must be tile-aligned, within (0, T], and leave room for the causal window
-    (chunk_start + Sq <= kv_len). Each violation is rejected -- on a WARM cache too, since kv_len is excluded
-    from the hash and re-validated on a program-cache hit (validate_on_program_cache_hit)."""
+    """kv_len must be within (0, T]. Each violation is rejected -- on a WARM cache too, since kv_len is excluded
+    from the hash and re-validated on a program-cache hit (validate_on_program_cache_hit). NOTE: kv_len need
+    NOT be tile-aligned (a sub-tile valid length is masked per-column, see test_indexer_score_sub_tile_kv_len),
+    and a causal window past kv_len is NOT rejected (the padded-chunk case, see test_indexer_score_partial_isl)."""
     c = KV_LEN
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
     q, w, k = _kv_len_inputs()
@@ -546,11 +604,103 @@ def test_indexer_score_rejects_bad_kv_len(device, expect_error):
     ttnn.experimental.indexer_score_dsa(
         q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=128
     )
-    for bad, why in [(c["t"] + 32, "above T"), (100, "not tile-aligned"), (32, "causal window > kv_len")]:
+    for bad, why in [(c["t"] + 32, "above T"), (0, "zero")]:
         with expect_error(RuntimeError, "kv_len"):
             ttnn.experimental.indexer_score_dsa(
                 q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=bad
             )
+
+
+@pytest.mark.parametrize("proxy_ring_size", [None, 4], ids=["contiguous", "slab_ring4"])
+@pytest.mark.parametrize("kv_len", [100, 200, 228], ids=["100", "200", "228"])
+def test_indexer_score_sub_tile_kv_len(device, kv_len, proxy_ring_size):
+    """Sub-tile valid length: kv_len is NOT a multiple of 32. The last valid tile (floor(kv_len/32)) is
+    partial -- its columns [kv_len%32, 32) are pad and get the per-column -inf mask (mirrors ring_mla's
+    global_n_partial_col), L1-accumulated onto whatever causal mask that tile already carries. chunk_start >=
+    kv_len so causality masks nothing inside [0, kv_len) -- isolates the sub-tile boundary. Run contiguous and
+    on a 4-way slab (the mask is applied in natural order after the slab read). Only [0, kv_len) is meaningful;
+    [kv_len, ceil(kv_len/32)*32) must be exactly -inf; the rest is the stale, sliced-off tail."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 512
+    chunk_start = 256  # >= every kv_len here, so each query sees all valid keys (no causal mask within [0,kv_len))
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k = k_nat if proxy_ring_size is None else _to_slab(k_nat, proxy_ring_size, proxy_ring_size * sq)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, kv_len=kv_len, proxy_ring_size=proxy_ring_size)
+
+    ref = indexer_score_dsa_ref(q, k_nat[:, :, :kv_len, :], w, chunk_start)  # [1,1,sq,kv_len], all valid
+    assert out.shape == (1, 1, sq, t)
+    assert_indexer_match(out[:, :, :, :kv_len], ref, sq, kv_len, check_neg=True)
+    # the partial boundary tile's pad columns [kv_len, ceil(kv_len/32)*32) must be exactly -inf
+    boundary = ((kv_len + 31) // 32) * 32
+    assert torch.all(out[:, :, :, kv_len:boundary] <= torch.finfo(torch.bfloat16).min), "sub-tile pad not masked"
+
+
+@pytest.mark.parametrize("proxy_ring_size", [None, 8], ids=["contiguous", "slab_ring8"])
+def test_indexer_score_partial_isl(device, proxy_ring_size):
+    """Padded chunk: the real ISL (kv_len) is smaller than what the queries' causal window reaches, exactly
+    the ring_mla partially-filled-chunk case. The fixed chunk is padded, so query positions (chunk_start + s)
+    extend PAST the valid keys; those keys must be masked (-inf) and only [0, kv_len) is real. Run both on a
+    contiguous cache and a simulated 8-way slab (proxy), since the kv_len mask is applied in natural order
+    after the slab read.
+
+    Geometry mirrors sp=8 / chunk=5120 / isl=1024 scaled down: chunk_start places the queries well past the
+    1024-key valid prefix, so every query attends to ALL kv_len valid keys (no causal masking within them),
+    and everything past kv_len is -inf."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 2048
+    kv_len, chunk_start = 1024, 1024  # valid prefix 1024; queries at [1024, 1088) -> all 1024 keys in the past
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k = k_nat if proxy_ring_size is None else _to_slab(k_nat, proxy_ring_size, proxy_ring_size * sq)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, kv_len=kv_len, proxy_ring_size=proxy_ring_size)
+
+    # Only [0, kv_len) is meaningful (the tail past kv_len is the stale, sliced-off region, same kv_len
+    # contract as test_indexer_score_runtime_kv_len). chunk_start=1024 >= kv_len so no key is causally masked
+    # within [0, kv_len) -- every query sees all 1024 valid keys. The op MUST NOT have errored on the window
+    # extending past kv_len (the relaxed validation), and the valid prefix must match the reference.
+    ref = indexer_score_dsa_ref(q, k_nat[:, :, :kv_len, :], w, chunk_start)  # [1,1,sq,kv_len], no -inf inside
+    assert out.shape == (1, 1, sq, t)
+    assert_indexer_match(out[:, :, :, :kv_len], ref, sq, kv_len, check_neg=True)
+
+
+def _boundary_chip_positions(chunk_start, ring, sq):
+    """Per-query global token positions for the mid-slab BOUNDARY chip, mirroring the op's host rotation
+    (device_causal_geometry) and update_padded_kv_cache's update_idxt. The test picks chunk_start so device 0
+    IS the boundary chip (boundary_chip == 0, boundary_offset != 0): its q-rows straddle a slab boundary, so
+    rows >= (chunk_local - boundary_offset) jump by (chunk - chunk_local). Returns a [sq] position tensor."""
+    chunk = ring * sq
+    chunk_local = sq  # chunk / ring
+    boundary_chip = (chunk_start // chunk_local) % ring
+    boundary_offset = chunk_start % chunk_local
+    assert boundary_chip == 0 and boundary_offset != 0, "test geometry must put the straddle on device 0"
+    base = (chunk_start // chunk) * chunk + boundary_offset  # this device's q-row-0 global position
+    s = torch.arange(sq)
+    straddle_row = chunk_local - boundary_offset
+    return base + s + torch.where(s >= straddle_row, chunk - chunk_local, 0)
+
+
+@pytest.mark.parametrize("chunk_start", [32, 544], ids=["slab0", "slab1"])
+def test_indexer_score_mid_slab_boundary(device, chunk_start):
+    """Mid-slab boundary chip: chunk_start is NOT a chunk multiple (boundary_offset != 0), so this device's
+    queries straddle a slab boundary and the causal diagonal JUMPS by (chunk - chunk_local) at the straddle
+    row -- exactly update_padded_kv_cache's update_idxt rotation. K is the 8-way slab (read back natural via
+    invP); the reference applies the straddled per-query positions over natural-order K. ring=8, sq=64 (2
+    q-tiles), chunk=512: both keep device 0 the boundary chip (boundary_offset=32, straddle after tile 1);
+    slab0 (cs=32) is in the first slab, slab1 (cs=544) one chunk in (exercises the boundary_slab term)."""
+    ring, sq, dim, t = 8, 64, GLX_DIM, 2048
+    q, k_nat, w = make_inputs(64, dim, sq, t)
+    k = _to_slab(k_nat, ring, ring * sq)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring, proxy_mid_slab=True)
+
+    # Reference over natural-order K with the straddled per-query causal positions.
+    pos = _boundary_chip_positions(chunk_start, ring, sq)
+    q_f, k_f, w_f = q.float(), k_nat.float(), w.float()
+    score = torch.zeros(1, sq, t)
+    for h in range(64):
+        score += torch.relu(q_f[:, h] @ k_f[:, 0].transpose(-2, -1)) * w_f[:, h]
+    future = torch.arange(t).unsqueeze(0) > pos.unsqueeze(1)
+    ref = score.masked_fill(future, float("-inf")).unsqueeze(1)
+    assert_indexer_match(out, ref, sq, t, check_neg=True)
 
 
 @pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
@@ -561,7 +711,10 @@ def test_indexer_score_determinism(device, case_id, heads):
     num_iterations = 10
     chunk_start = GLX_HISTORY + 7 * GLX_SQ  # sp_rank 7: fullest causal case
     cfg = glx_config(heads)
-    q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    q, k_nat, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    # Slab-aware by default (GLX -> ring=8, the deployed slab); determinism holds regardless of layout.
+    k, ring = _slabify(k_nat, GLX_SQ, GLX_T)
+    proxy = _slab_kwargs(ring, GLX_SQ)
     # Upload once; the same device tensors are reused across all iterations.
     q_dev = to_device(q, device, dtype=ttnn.bfloat16)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
@@ -570,7 +723,9 @@ def test_indexer_score_determinism(device, case_id, heads):
     reference = None
     for i in range(num_iterations):
         out = ttnn.to_torch(
-            ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
+            ttnn.experimental.indexer_score_dsa(
+                q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg, **proxy
+            )
         )
         if reference is None:
             reference = out
@@ -608,11 +763,34 @@ def test_indexer_score_msa_compute_paths(device, q_chunk, k_chunk, head_group):
     heads, dim, sq, t, chunk_start = MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"], 128
     scale = dim**-0.5
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
-    q, k, _ = make_inputs(heads, dim, sq, t)
-    out = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default
+    out = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg, proxy_ring_size=ring)
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # MSA's constant gate = scale
-    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start)
     assert_indexer_match(out, ref, sq, t)
+
+
+@pytest.mark.parametrize("block_size", [0, 64], ids=["unpooled", "pool64"])
+def test_indexer_score_msa_contiguous_kcache(device, block_size):
+    """CONTIGUOUS K cache on the MSA path (no slab args -> identity SLAB_KTILE): raw-dot scores, and the
+    block-max-pool must still pool token-contiguous blocks correctly when K is plain natural order. Uses the
+    proven-fitting heads=4/t=2048 pool shape (KC=1024 -> blocks_per_unit=16, a multiple of 8)."""
+    heads, dim, sq, t, chunk_start = 4, GLX_DIM, 128, 2048, 512
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    unpooled = run_msa(q, k_nat, chunk_start, device, scale=scale, program_config=cfg)  # contiguous: no slab args
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+    assert_indexer_match(unpooled, indexer_score_msa_ref(q, k_nat, w_scale, chunk_start), sq, t)
+    if block_size:
+        # Pool the op's OWN unpooled output (not an FP ref) so the contiguous-read pool is pinned exactly,
+        # free of bf16 matmul noise that can flip a block's argmax to a near-equal neighbor.
+        pooled = run_msa(q, k_nat, chunk_start, device, scale=scale, block_size=block_size, program_config=cfg)
+        ref = msa_block_max_pool(unpooled.float(), block_size, chunk_start)
+        masked = ref == float("-inf")
+        assert torch.equal(pooled <= torch.finfo(torch.bfloat16).min, masked)
+        assert torch.equal(pooled[~masked].float(), ref[~masked])
 
 
 def test_indexer_score_dsa_msa_differ(device):
@@ -641,10 +819,21 @@ def test_indexer_score_m3_per_group(device, k_dtype, q_dtype, sp_rank):
     chunk_start = GLX_HISTORY + sp_rank * GLX_SQ
     scale = dim**-0.5
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=512, head_group_size=0)
-    q, k, _ = make_inputs(heads, dim, sq, t)
-    out = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg, q_dtype=q_dtype, k_dtype=k_dtype)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default: GLX shape -> ring=8 (the deployed slab)
+    out = run_msa(
+        q,
+        k,
+        chunk_start,
+        device,
+        scale=scale,
+        program_config=cfg,
+        q_dtype=q_dtype,
+        k_dtype=k_dtype,
+        proxy_ring_size=ring,
+    )
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start)
     assert_indexer_match(out, ref, sq, t)
 
 
@@ -665,10 +854,13 @@ def test_indexer_score_multigroup(device, heads, num_groups):
     dim, sq, t, chunk_start = 128, 64, 256, 128
     scale = dim**-0.5
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)  # all resident, KC=2
-    q, k, _ = make_inputs(heads, dim, sq, t)
-    out = run_msa(q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default
+    out = run_msa(
+        q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg, proxy_ring_size=ring
+    )
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # MSA's constant gate = scale
-    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, num_groups)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start, num_groups)
     assert_grouped_match(out, ref, num_groups, sq, t)
 
 
@@ -681,10 +873,13 @@ def test_indexer_score_multigroup_m3(device):
     sq, t, chunk_start = 128, 256, 128
     scale = dim**-0.5
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=64, head_group_size=0)
-    q, k, _ = make_inputs(heads, dim, sq, t)
-    out = run_msa(q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default
+    out = run_msa(
+        q, k, chunk_start, device, scale=scale, num_groups=num_groups, program_config=cfg, proxy_ring_size=ring
+    )
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, num_groups)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start, num_groups)
     assert_grouped_match(out, ref, num_groups, sq, t)
 
 
@@ -696,10 +891,13 @@ def test_indexer_score_multigroup_equals_single(device):
     heads, dim, sq, t, chunk_start = 4, 128, 64, 256, 128
     scale = 1.0  # same constant gate for grouped and single so the comparison is exact
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
-    q, k, _ = make_inputs(heads, dim, sq, t)
-    grouped = run_msa(q, k, chunk_start, device, scale=scale, num_groups=heads, program_config=cfg)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default; same slab K + proxy for grouped and single
+    grouped = run_msa(
+        q, k, chunk_start, device, scale=scale, num_groups=heads, program_config=cfg, proxy_ring_size=ring
+    )
     for g in range(heads):
-        single = run_msa(q[:, g : g + 1], k, chunk_start, device, scale=scale, program_config=cfg)
+        single = run_msa(q[:, g : g + 1], k, chunk_start, device, scale=scale, program_config=cfg, proxy_ring_size=ring)
         assert torch.equal(grouped[:, g : g + 1], single), f"group {g} plane != single-head op"
 
 
@@ -736,9 +934,10 @@ def test_indexer_score_compute_kernel_config(device, math_fidelity):
     heads, dim, sq, t, chunk_start = MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"], 128
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
     ckc = ttnn.init_device_compute_kernel_config(device.arch(), math_fidelity=math_fidelity)
-    q, k, w = make_inputs(heads, dim, sq, t)
-    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, compute_kernel_config=ckc)
-    ref = indexer_score_dsa_ref(q, k, w, chunk_start)
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default
+    out = run_dsa(q, k, w, chunk_start, device, program_config=cfg, compute_kernel_config=ckc, proxy_ring_size=ring)
+    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
     assert_indexer_match(out, ref, sq, t, check_neg=True)
 
 
@@ -945,12 +1144,17 @@ QB_T = QB_HISTORY + QB_CHUNK  # 28160 all-gathered keys (880 tiles)
 
 
 def _shard_1d(mesh_device, heads, seed):
-    """SP=4 inputs: q/w sharded along seq (each device its own 640 rows), k replicated. Deployed dtypes."""
+    """SP=4 inputs: q/w sharded along seq (each device its own 640 rows), k replicated. Deployed dtypes.
+
+    The K cache slab layout is passed explicitly to the op (slab_sp=QB_SP, slab_chunk_size=QB_CHUNK), so the
+    replicated k is built as a slab with that exact layout; the op reads it back in natural token order,
+    matching the natural-order per-SP reference (over k_g)."""
     q_g, k_g, w_g = _global_inputs(heads, QB_CHUNK, QB_T, seed)
+    k_slab = _to_slab(k_g, QB_SP, QB_CHUNK)  # the (slab_sp=QB_SP, chunk=QB_CHUNK) layout passed to the op
     shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
     w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    k_dev = _to_mesh(mesh_device, k_slab, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
     return q_g, k_g, w_g, q_dev, k_dev, w_dev
 
 
@@ -961,9 +1165,11 @@ def test_indexer_score_qb_per_device_chunk_start(mesh_device, case_id, heads):
     Validate each device's output against its own chunk_start reference."""
     q_g, k_g, w_g, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=42)
 
-    # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY (sp_ring = 4 devices,
-    # cluster_axis unset), then device r gets base + r*Sq. No chunk_start passed at all.
-    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, program_config=glx_config(heads))
+    # slab layout passed explicitly (slab_sp=QB_SP, slab_chunk_size=QB_CHUNK). chunk_start_idx OMITTED -> the
+    # op deduces base = T - slab_chunk_size = QB_HISTORY, then device r gets base + r*Sq (cluster_axis unset).
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev, k_dev, w_dev, program_config=glx_config(heads), slab_sp=QB_SP, slab_chunk_size=QB_CHUNK
+    )
     out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
 
     ref = _per_sp_ref(q_g, k_g, w_g, QB_SP, QB_HISTORY)
@@ -983,7 +1189,13 @@ def test_indexer_score_qb_one_compile_all_chunk_starts(mesh_device, case_id, hea
     entries_before = mesh_device.num_program_cache_entries()
     for base in bases:
         ttnn.experimental.indexer_score_dsa(
-            q_dev, k_dev, w_dev, chunk_start_idx=base, program_config=glx_config(heads)
+            q_dev,
+            k_dev,
+            w_dev,
+            chunk_start_idx=base,
+            program_config=glx_config(heads),
+            slab_sp=QB_SP,
+            slab_chunk_size=QB_CHUNK,
         ).deallocate()
 
     added = mesh_device.num_program_cache_entries() - entries_before
@@ -1017,6 +1229,9 @@ def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
     partial head-sum, which the test sums back (the TP all-reduce) and validates per SP rank against
     its own full-head, own-chunk_start reference."""
     q_g, k_g, w_g = _global_inputs(heads, QB2_CHUNK, QB2_T, seed=42)
+    # slab layout passed explicitly (slab_sp=QB2_SP, slab_chunk_size=QB2_CHUNK); the replicated k is built as a
+    # slab with that exact layout and read back in natural order.
+    k_slab = _to_slab(k_g, QB2_SP, QB2_CHUNK)
 
     # q/w: seq (dim 2) sharded along the SP axis, heads (dim 1) along the TP axis. k replicated.
     mesh_shape = tuple(mesh_device.shape)
@@ -1024,17 +1239,18 @@ def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
     shard_qw = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_qw)
     w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_qw)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    k_dev = _to_mesh(mesh_device, k_slab, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
 
-    # chunk_start_idx OMITTED: the op deduces base = T - sp_ring*Sq, where sp_ring is the mesh extent
-    # along cluster_axis (2, the SP axis) -- NOT the total device count (4). Device (sp, tp) then gets
-    # chunk_start = base + sp*Sq -- identical for both TP devices at SP position sp.
+    # chunk_start_idx OMITTED: the op deduces base = T - slab_chunk_size = QB_HISTORY. Device (sp, tp) then
+    # gets chunk_start = base + sp*Sq (sp = index along cluster_axis) -- identical for both TP devices at sp.
     out = ttnn.experimental.indexer_score_dsa(
         q_dev,
         k_dev,
         w_dev,
         cluster_axis=QB2_SP_AXIS,
         program_config=glx_config(heads // QB2_TP),  # per-device head count
+        slab_sp=QB2_SP,
+        slab_chunk_size=QB2_CHUNK,
     )
     # Concat SP shards along seq (dim 2) and the TP head-partials along the size-1 head dim (dim 1), then
     # SUM the partials (the TP all-reduce) -> full [1,1,1280,T] score.
@@ -1071,14 +1287,21 @@ def test_indexer_score_msa_qb_per_device_chunk_start(mesh_device):
     """MSA over 4 BH devices (SP=4), each deriving its own chunk_start from its coordinate (cluster_axis
     unset -> linear order). Raw dot + constant scale, num_groups=1 -> one head-summed [1,1,Sq,T] plane."""
     q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
+    k_slab = _to_slab(k_g, QB_SP, QB_CHUNK)  # slab built to the explicit (slab_sp=QB_SP, chunk=QB_CHUNK) layout
     shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    k_dev = _to_mesh(mesh_device, k_slab, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
 
-    # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY, then device r gets
+    # chunk_start_idx OMITTED -> the op deduces base = T - slab_chunk_size = QB_HISTORY, then device r gets
     # base + r*Sq (r = linearized index, cluster_axis unset). The constant gate is synthesized per-device.
     out = ttnn.experimental.indexer_score_msa(
-        q_dev, k_dev, scale=M3_QB_SCALE, num_groups=1, program_config=glx_config(M3_QB_HEADS)
+        q_dev,
+        k_dev,
+        scale=M3_QB_SCALE,
+        num_groups=1,
+        program_config=glx_config(M3_QB_HEADS),
+        slab_sp=QB_SP,
+        slab_chunk_size=QB_CHUNK,
     )
     out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
 
@@ -1092,15 +1315,16 @@ def test_indexer_score_msa_qb_sp2_tp2(mesh_device):
     M3 index heads split across TP. Each device head-sums its half (num_groups=1); the test sums the TP
     partials (the all-reduce) and validates per SP rank against its own raw-dot, own-chunk_start reference."""
     q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB2_CHUNK, QB2_T, seed=42)
+    k_slab = _to_slab(k_g, QB2_SP, QB2_CHUNK)  # slab built to the explicit (slab_sp=QB2_SP, chunk=QB2_CHUNK)
 
     # q: seq (dim 2) sharded along the SP axis, heads (dim 1) along the TP axis. k replicated.
     mesh_shape = tuple(mesh_device.shape)
     q_dims = _axis_dims(sp_dim=2, tp_dim=1)
     shard_q = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=q_dims)
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_q)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    k_dev = _to_mesh(mesh_device, k_slab, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
 
-    # chunk_start_idx OMITTED: base deduced as T - sp_ring*Sq, sp_ring = mesh extent along cluster_axis (2,
+    # chunk_start_idx OMITTED: base deduced as T - slab_chunk_size; per device chunk_start = base + sp*Sq (2,
     # the SP axis). Device (sp, tp) gets chunk_start = base + sp*Sq -- identical for both TP devices at sp.
     out = ttnn.experimental.indexer_score_msa(
         q_dev,
@@ -1109,12 +1333,27 @@ def test_indexer_score_msa_qb_sp2_tp2(mesh_device):
         scale=M3_QB_SCALE,
         num_groups=1,
         program_config=glx_config(M3_QB_HEADS // QB2_TP),  # per-device head count
+        slab_sp=QB2_SP,
+        slab_chunk_size=QB2_CHUNK,
     )
     out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=q_dims))
     out_t = out_t.float().sum(dim=1, keepdim=True)  # TP all-reduce: sum the head-partials
 
     ref = _msa_per_sp_ref(q_g, k_g, QB2_SP, QB_HISTORY)
     assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)
+
+
+def test_indexer_score_rejects_partial_slab_args(device, expect_error):
+    """slab_sp and slab_chunk_size define the cache's slab layout and must be passed TOGETHER -- passing only
+    one is a caller error (the per-shard width chunk/sp is undefined). Host-side guard, so a single chip
+    suffices."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 512
+    q, k, w = make_inputs(heads, dim, sq, t)
+    q_dev, k_dev, w_dev = to_device(q, device), to_device(k, device), to_device(w, device)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    for kwargs in [{"slab_sp": 4}, {"slab_chunk_size": 256}]:
+        with expect_error(RuntimeError, "together"):
+            ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=0, program_config=cfg, **kwargs)
 
 
 # MiniMax M3 MSA math-utilization perf check (tracy; no accuracy check). ONE device of an SP=8 x TP=4 mesh:
@@ -1265,7 +1504,8 @@ def test_indexer_score_block_pool(device, k_dtype, num_groups):
     heads, dim, sq, t = 4, GLX_DIM, 128, 2048
     chunk_start = 512  # leaves fully-future blocks for early queries + a straddling block
     scale = dim**-0.5
-    q, k, _ = make_inputs(heads, dim, sq, t)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default (pool over token-contiguous blocks of slab K)
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
     out = run_msa(
         q,
@@ -1277,9 +1517,10 @@ def test_indexer_score_block_pool(device, k_dtype, num_groups):
         block_size=BLOCK_POOL_BS,
         k_dtype=k_dtype,
         program_config=cfg,
+        proxy_ring_size=ring,
     )
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, num_groups, block_size=BLOCK_POOL_BS)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start, num_groups, block_size=BLOCK_POOL_BS)
     assert_pooled_match(out, ref, num_groups, sq, t // BLOCK_POOL_BS, pcc_floor=0.995)
 
 
@@ -1291,7 +1532,8 @@ def test_indexer_score_block_pool_m3(device, k_dtype, sp_rank):
     heads, dim, sq, t = 4, GLX_DIM, GLX_SQ, GLX_T
     chunk_start = GLX_HISTORY + sp_rank * GLX_SQ
     scale = 1.0 / (dim**0.5)
-    q, k, _ = make_inputs(heads, dim, sq, t)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default: GLX shape -> ring=8 (the deployed slab)
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
     out = run_msa(
         q,
@@ -1303,9 +1545,10 @@ def test_indexer_score_block_pool_m3(device, k_dtype, sp_rank):
         block_size=BLOCK_POOL_BS,
         k_dtype=k_dtype,
         program_config=cfg,
+        proxy_ring_size=ring,
     )
     w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = indexer_score_msa_ref(q, k, w_scale, chunk_start, heads, block_size=BLOCK_POOL_BS)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start, heads, block_size=BLOCK_POOL_BS)
     # 0.995 floor: block-max amplifies the bf16 raw-dot error; the exact pool logic is pinned by the -inf
     # map here and by test_indexer_score_block_pool_exact_vs_unpooled.
     assert_pooled_match(out, ref, heads, sq, t // BLOCK_POOL_BS, pcc_floor=0.995)
@@ -1317,10 +1560,13 @@ def test_indexer_score_block_pool_exact_vs_unpooled(device):
     differs). Isolates the fused pool from the bf16 q.kT error that relaxes the fp32-reference comparison."""
     heads, dim, sq, t = 4, GLX_DIM, 128, 2048
     chunk_start = 512
-    q, k, _ = make_inputs(heads, dim, sq, t)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default; same slab K + proxy for both device runs
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
-    unpooled = run_msa(q, k, chunk_start, device, num_groups=heads, program_config=cfg)
-    pooled = run_msa(q, k, chunk_start, device, num_groups=heads, block_size=BLOCK_POOL_BS, program_config=cfg)
+    unpooled = run_msa(q, k, chunk_start, device, num_groups=heads, program_config=cfg, proxy_ring_size=ring)
+    pooled = run_msa(
+        q, k, chunk_start, device, num_groups=heads, block_size=BLOCK_POOL_BS, program_config=cfg, proxy_ring_size=ring
+    )
     # torch max over the op's own [1,G,Sq,T] scores, with the same forced-local (+inf) the pooled path applies.
     ref = msa_block_max_pool(unpooled.float(), BLOCK_POOL_BS, chunk_start)
     masked = ref == float("-inf")
@@ -1347,10 +1593,20 @@ def test_indexer_score_block_pool_large_blocks_per_unit(device, num_groups, bloc
     free of bf16 matmul noise, confirming the fallback lands each block max in col 0 as the writer expects."""
     heads, dim, sq, t = 4, GLX_DIM, 128, 2048
     chunk_start = 512
-    q, k, _ = make_inputs(heads, dim, sq, t)
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k, ring = _slabify(k_nat, sq, t)  # slab-aware by default; same slab K + proxy for both device runs
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=k_chunk_size, head_group_size=0)
-    unpooled = run_msa(q, k, chunk_start, device, num_groups=num_groups, program_config=cfg)
-    pooled = run_msa(q, k, chunk_start, device, num_groups=num_groups, block_size=block_size, program_config=cfg)
+    unpooled = run_msa(q, k, chunk_start, device, num_groups=num_groups, program_config=cfg, proxy_ring_size=ring)
+    pooled = run_msa(
+        q,
+        k,
+        chunk_start,
+        device,
+        num_groups=num_groups,
+        block_size=block_size,
+        program_config=cfg,
+        proxy_ring_size=ring,
+    )
     ref = msa_block_max_pool(unpooled.float(), block_size, chunk_start)
     masked = ref == float("-inf")
     assert torch.equal(pooled <= torch.finfo(torch.bfloat16).min, masked)
@@ -1377,3 +1633,139 @@ def test_indexer_score_block_pool_validation(device, expect_error, block_size, k
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=k_chunk_size, head_group_size=0)
     with expect_error(RuntimeError, match):
         run_msa(q, k, 512, device, num_groups=heads, block_size=block_size, program_config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# Slab (per-SP-shard) K layout. Chunked prefill packs each SP shard's per-chunk slab (slab_chunk_size/slab_sp
+# keys) back-to-back, so the gathered [B,1,T,D] k is in a PERMUTED physical order and the reader reads it back
+# in natural token order (invP per tile) -- scores (and the block-max-pool over token-contiguous blocks) come
+# out correct. The slab layout is PASSED EXPLICITLY (slab_sp = the SP the cache was gathered across,
+# slab_chunk_size = the global chunk), NOT derived -- decoupled from how this op splits Q. These tests pass
+# slab_sp / slab_chunk_size = ring_size*Sq via _slab_kwargs to exercise a real SP slab on one chip.
+# ---------------------------------------------------------------------------
+def _slab_positions(ring_size, chunk, t):
+    """P[r] = natural token position physically stored at slab row r. Physical row r (shard c = r//sll, local
+    row lr = r%sll) holds natural token (lr//cl)*chunk + c*cl + (lr%cl), where sll = T/ring_size (per-shard
+    local length), cl = chunk/ring_size (per-shard slab width). This is the layout the in-kernel invP inverts.
+    Canonical (production) version: models/demos/deepseek_v3_d_p/tt/mla/utils.py::blockcyclic_positions; kept
+    local here so this op unit test has no model dependency."""
+    sll, cl = t // ring_size, chunk // ring_size
+    c = torch.arange(ring_size).repeat_interleave(sll)
+    lr = torch.arange(sll).repeat(ring_size)
+    return (lr // cl) * chunk + c * cl + (lr % cl)
+
+
+def _to_slab(k_nat, ring_size, chunk):
+    """Permute a natural-order [1,1,T,D] k into its slab physical layout: k_slab[r] = k_nat[P[r]]."""
+    t = k_nat.shape[2]
+    P = _slab_positions(ring_size, chunk, t)
+    k_slab = k_nat.clone()
+    k_slab[0, 0] = k_nat[0, 0][P]
+    return k_slab
+
+
+def _default_slab_ring(sq, t, cap=8):
+    """Pick a ring_size so a single-chip functional test exercises the slab read BY DEFAULT: the largest
+    ring in [2, cap] whose slab chunk (ring*sq) divides T AND leaves >= 2 global chunks (so the permutation is
+    NON-trivial -- a single chunk is the identity). Returns 1 when no such ring exists (T too small), i.e. the
+    test runs contiguous = the degenerate slab. So routing a test through this is safe: ring 1 is a no-op."""
+    best = 1
+    for r in range(2, cap + 1):
+        chunk = r * sq
+        if chunk <= t and t % chunk == 0 and t // chunk >= 2:
+            best = r
+    return best
+
+
+def _slabify(k_nat, sq, t):
+    """Return (k_for_device, proxy_ring_size) for a default-slab functional test: permute k into the slab
+    layout for the picked ring (proxy passed to the op so it reads back in natural order), or pass through
+    contiguous with proxy None when no non-trivial ring fits the shape."""
+    ring = _default_slab_ring(sq, t)
+    if ring == 1:
+        return k_nat, None
+    return _to_slab(k_nat, ring, ring * sq), ring
+
+
+# Simulated SP ring sizes; the chunk is derived per test as ring_size * Sq (so it divides T below).
+SLAB_RINGS = [4, 8]
+SLAB_IDS = ["ring4", "ring8"]
+
+
+@pytest.mark.parametrize("ring_size", SLAB_RINGS, ids=SLAB_IDS)
+@pytest.mark.parametrize("chunk_start", [0, 1024], ids=["cs0", "cs1024"])
+def test_indexer_score_dsa_slab(device, ring_size, chunk_start):
+    """DSA over a slab K cache, SINGLE CHIP: physical K is permuted; slab_sp / slab_chunk_size = ring_size*Sq
+    are passed explicitly to describe a real ring_size-way SP slab, so the reader presents K in natural token
+    order and the score matches the contiguous-K reference exactly (same -inf map + PCC >= 0.999)."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 2048
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)  # slab_chunk_size passed to the op = ring_size*Sq
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    out = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring_size)
+    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
+    assert_indexer_match(out, ref, sq, t, check_neg=True)
+
+
+@pytest.mark.parametrize("ring_size", SLAB_RINGS, ids=SLAB_IDS)
+@pytest.mark.parametrize("block_size", [0, BLOCK_POOL_BS], ids=["unpooled", "pooled"])
+def test_indexer_score_msa_slab(device, block_size, ring_size):
+    """MSA per-group scoring over a slab K cache, SINGLE CHIP. block_size=0 -> [1,G,Sq,T] planes; >0 ->
+    block-max-pool (the M3 crux: a pooled block is block_size CONTIGUOUS tokens, scattered across the physical
+    buffer, so only reading in natural order pools the right token range). Both match the contiguous-K ref."""
+    heads, dim, sq, t, chunk_start = 4, GLX_DIM, 128, 2048, 512
+    scale = dim**-0.5
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    out = run_msa(
+        q,
+        k_slab,
+        chunk_start,
+        device,
+        scale=scale,
+        num_groups=heads,
+        block_size=block_size,
+        program_config=cfg,
+        proxy_ring_size=ring_size,
+    )
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start, heads, block_size=block_size)
+    if block_size:
+        assert_pooled_match(out, ref, heads, sq, t // block_size, pcc_floor=0.995)
+    else:
+        assert_grouped_match(out, ref, heads, sq, t)
+
+
+def test_indexer_score_slab_remap_matters(device):
+    """The remap is load-bearing: with the proxy the permuted cache reads correctly; WITHOUT it the deduction
+    is the identity (one chip -> ring_size=1), so the permuted cache is read as-is and the scores are wrong (a
+    token permutation). Confirms the slab handling is not a no-op."""
+    ring_size = 8
+    heads, dim, sq, t, chunk_start = 64, GLX_DIM, 64, 2048, 1024
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
+    masked = ref == float("-inf")
+    b = ref[~masked].flatten().float()
+
+    good = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring_size)
+    pcc_good = torch.corrcoef(torch.stack([good[~masked].flatten().float(), b]))[0, 1].item()
+    assert pcc_good >= 0.999, f"slab proxy PCC {pcc_good} < 0.999"
+
+    # No proxy on one chip -> ring_size=1 identity -> permuted cache read as-is. -inf map is positional
+    # (same), but the visible scores are permuted -> far below the floor.
+    bad = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg)
+    pcc_bad = torch.corrcoef(torch.stack([bad[~masked].flatten().float(), b]))[0, 1].item()
+    assert pcc_bad < 0.99, f"identity read of a permuted cache unexpectedly matched (PCC {pcc_bad})"
+
+
+def test_indexer_score_slab_rejects_bad_chunk(device, expect_error):
+    """A derived chunk (= ring_size*Sq) that does not divide T is rejected loudly so a bad layout can't
+    silently mis-address K. Here ring_size=5, Sq=64 -> chunk=320, which does not divide T=2048."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 2048
+    q, k, w = make_inputs(heads, dim, sq, t)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=256, head_group_size=0)
+    with expect_error(RuntimeError, "must divide T"):
+        run_dsa(q, k, w, 0, device, program_config=cfg, proxy_ring_size=5)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -80,7 +80,9 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
     if (attrs.kv_len.has_value()) {
         const uint32_t T = k.logical_shape()[2];
         const uint32_t kv_len = attrs.kv_len.value();
-        TT_FATAL(kv_len % tt::constants::TILE_WIDTH == 0, "indexer_score kv_len {} must be tile-aligned", kv_len);
+        // kv_len need NOT be tile-aligned: a sub-tile valid length (real ISL not a multiple of 32) is masked
+        // per-column in the last valid tile (cols [kv_len%32, 32) -> -inf), mirroring ring_mla's
+        // global_n_partial_col. Only (0, T] is required.
         TT_FATAL(
             kv_len > 0 && kv_len <= T,
             "indexer_score kv_len {} must be in (0, T={}] (the allocated k length)",
@@ -89,8 +91,13 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
     }
 }
 
-// Runs on miss AND hit (chunk_start is hash-excluded). All chunk_start checks in one place: base alignment
-// and the fullest device's window against T and (when set) kv_len.
+// Runs on miss AND hit (chunk_start is hash-excluded). Base alignment + the fullest device's window vs T.
+// NOTE: the window is intentionally NOT bounded by kv_len. With a partially-filled (padded) chunk -- the real
+// ISL is smaller than the fixed chunk, so kv_len < the chunk extent -- the padded-query devices legitimately
+// have causal windows that reach past the valid prefix. That is correct, not an error: keys at positions
+// >= kv_len are masked (kv_len caps each cell's valid columns) and the padded queries' output is discarded.
+// So kv_len purely masks keys; only the allocated-buffer bound (window <= T) is enforced here. This mirrors
+// ring_mla, whose valid region is the contiguous prefix [0, kv_len) and whose pad is dropped by masking.
 void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args_t& t) {
     const uint32_t Sq = t.q.logical_shape()[2];
     const uint32_t T = t.k.logical_shape()[2];
@@ -108,20 +115,36 @@ void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args
         T,
         attrs.chunk_start_idx,
         Sq);
-    // Causal window must also stay inside the valid prefix.
-    if (attrs.kv_len.has_value()) {
-        const uint32_t kv_len = attrs.kv_len.value();
-        TT_FATAL(
-            max_cs + Sq <= kv_len,
-            "fullest-device causal window [{}, {}+{}) exceeds kv_len={} (cannot attend past the valid keys; "
-            "base={}, per-rank stride Sq={})",
-            max_cs,
-            max_cs,
-            Sq,
-            kv_len,
-            attrs.chunk_start_idx,
-            Sq);
+}
+// Slab layout (slab_sp / slab_chunk_size, passed by the caller): ring_size/chunk are hashed and bake invP's
+// divisors into the reader, so the per-shard slab must be tile-aligned and tile the cache evenly -- miss-only
+// (a hit can't differ). Sq <= cl bounds a device's queries to at most one cache-slab crossing (one straddle).
+void validate_slab(const operation_attributes_t& attrs, const tensor_args_t& t) {
+    if (!attrs.slab.has_value()) {
+        return;
     }
+    const uint32_t ring = attrs.slab->ring_size;
+    const uint32_t chunk = attrs.slab->chunk_size;
+    const uint32_t T = t.k.logical_shape()[2];
+    const uint32_t Sq = t.q.logical_shape()[2];
+    TT_FATAL(ring >= 1, "slab ring_size (slab_sp) must be >= 1 (got {})", ring);
+    TT_FATAL(chunk > 0 && chunk % ring == 0, "slab chunk_size {} must be > 0 and divisible by slab_sp {}", chunk, ring);
+    const uint32_t chunk_local = chunk / ring;
+    TT_FATAL(
+        chunk_local % tt::constants::TILE_WIDTH == 0,
+        "slab per-shard width chunk_size/slab_sp ({}) must be tile-aligned",
+        chunk_local);
+    TT_FATAL(
+        T % chunk == 0,
+        "slab chunk_size {} must divide T {} (the cache must be a whole number of global chunks)",
+        chunk,
+        T);
+    TT_FATAL(
+        Sq <= chunk_local,
+        "Sq ({}) must be <= the slab per-shard width chunk_size/slab_sp ({}); a device's queries may cross at "
+        "most one cache-slab boundary (one straddle). A coarser indexer SP (Sq > cl) is not yet supported.",
+        Sq,
+        chunk_local);
 }
 }  // namespace
 
@@ -148,6 +171,11 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         attrs.cluster_axis.value_or(0u),
         attrs.has_indexed_kv_cache(),
         attrs.has_runtime_kv_len(),
+        // The slab layout bakes invP divisors into the reader as compile-time defines, so ring_size/chunk
+        // must be hashed (a contiguous vs slab read, or a different slab shape, is a different binary).
+        attrs.has_slab(),
+        attrs.slab.has_value() ? attrs.slab->ring_size : 0u,
+        attrs.slab.has_value() ? attrs.slab->chunk_size : 0u,
         tensor_args);
 }
 
@@ -186,6 +214,7 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     // slot/kv_len runtime values are re-checked every dispatch.
     validate_static(attrs, tensor_args);
     validate_runtime_values(attrs, tensor_args);
+    validate_slab(attrs, tensor_args);
 
     // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
     TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4, "q, k must be rank 4");
@@ -394,7 +423,9 @@ IndexerScoreDeviceOperation::invoke(
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<SlabLayout> slab,
+    bool mid_slab_boundary) {
     return {
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
@@ -407,7 +438,9 @@ IndexerScoreDeviceOperation::invoke(
             .program_config = program_config,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
-            .kv_len = kv_len},
+            .kv_len = kv_len,
+            .slab = slab,
+            .mid_slab_boundary = mid_slab_boundary},
         tensor_args_t{.q = q, .k = k, .weights = weights}};
 }
 
@@ -433,31 +466,47 @@ ttnn::Tensor launch_indexer_score(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> slab_sp,
+    std::optional<uint32_t> slab_chunk_size,
+    bool mid_slab_boundary) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
+    using ttnn::operations::experimental::indexer_score::SlabLayout;
 
-    // base = rank 0's absolute chunk_start. Omit it on a mesh -> deduce base = T - sp_ring*Sq (assumes K is
-    // history + the full SP-gathered chunk). Caveats: the deduced window ends at T (incompatible with a
-    // growing kv_len < T -- pass chunk_start_idx there); omitting on one chip now gives base = T - Sq, not 0.
+    const uint32_t Sq = q.logical_shape()[2];
+
+    // The K-cache slab layout is PASSED, not derived: slab_sp = the SP the cache was gathered across (the
+    // cache's own SP, independent of how THIS op splits Q) and slab_chunk_size = the global chunk granularity.
+    // Both must be given together; slab_sp <= 1 (or unset) means contiguous K (no remap).
+    TT_FATAL(
+        slab_sp.has_value() == slab_chunk_size.has_value(),
+        "indexer_score: slab_sp and slab_chunk_size must be passed together (got slab_sp={}, slab_chunk_size={})",
+        slab_sp.has_value(),
+        slab_chunk_size.has_value());
+    const std::optional<SlabLayout> slab =
+        (slab_sp.has_value() && *slab_sp > 1)
+            ? std::optional<SlabLayout>{SlabLayout{.ring_size = *slab_sp, .chunk_size = *slab_chunk_size}}
+            : std::nullopt;
+
+    // base = the absolute chunk_start of this op's rank 0. Omit it -> deduce: with a slab the gathered chunk is
+    // slab_chunk_size, so base = T - slab_chunk_size; contiguous -> base = T - Sq (single device). The deduced
+    // window ends at T (incompatible with a growing kv_len < T -- pass chunk_start_idx there).
     uint32_t base = 0;
     if (chunk_start_idx.has_value()) {
         base = *chunk_start_idx;
     } else {
-        const uint32_t Sq = q.logical_shape()[2];
         const uint32_t T = k.logical_shape()[2];
-        // sp_ring = max_rank + 1 (get_linearized_index returns coord-min; get_topological_dimension would
-        // over-count on a nonzero-offset sub-mesh). max_linearized_rank is shared with the validated window.
-        const uint32_t sp_ring =
-            ttnn::operations::experimental::indexer_score::max_linearized_rank(q, cluster_axis) + 1;
+        const uint32_t window = slab.has_value() ? slab->chunk_size : Sq;
         TT_FATAL(
-            T >= sp_ring * Sq,
-            "indexer_score: cannot deduce chunk_start_idx -- T={} < sp_ring({})*Sq({}). Pass chunk_start_idx "
-            "explicitly if K does not equal history + the SP-gathered chunk.",
+            T >= window,
+            "indexer_score: cannot deduce chunk_start_idx -- T={} < {}={}. Pass chunk_start_idx explicitly if K "
+            "does not equal history + the gathered chunk.",
             T,
-            sp_ring,
-            Sq);
-        base = T - sp_ring * Sq;
+            slab.has_value() ? "slab_chunk_size" : "Sq",
+            window);
+        base = T - window;
     }
+
     // Default math_fidelity follows the matmul-input dtypes (both bfp8 -> LoFi, else HiFi2); a caller config
     // overrides per field. fp32-dest acc / full-sync default off (the only modes the custom LLK is validated for).
     const bool both_bfp8 = q.dtype() == DataType::BFLOAT8_B && k.dtype() == DataType::BFLOAT8_B;
@@ -483,7 +532,9 @@ ttnn::Tensor launch_indexer_score(
         resolved,
         cache_batch_idx,
         kv_len,
-        cluster_axis);
+        cluster_axis,
+        slab,
+        mid_slab_boundary);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
@@ -498,7 +549,10 @@ ttnn::Tensor indexer_score_dsa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> slab_sp,
+    std::optional<uint32_t> slab_chunk_size,
+    bool mid_slab_boundary) {
     // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling. Reads its real weights tensor.
     return launch_indexer_score(
         q,
@@ -514,7 +568,10 @@ ttnn::Tensor indexer_score_dsa(
         compute_kernel_config,
         cache_batch_idx,
         kv_len,
-        cluster_axis);
+        cluster_axis,
+        slab_sp,
+        slab_chunk_size,
+        mid_slab_boundary);
 }
 
 ttnn::Tensor indexer_score_msa(
@@ -526,7 +583,10 @@ ttnn::Tensor indexer_score_msa(
     uint32_t block_size,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> slab_sp,
+    std::optional<uint32_t> slab_chunk_size,
+    bool mid_slab_boundary) {
     // M3 has no learned gates, only a 1/sqrt(d) scale. Rather than materialize a constant [B,Hi,Sq,1] gate
     // tensor (an extra fill op dispatched every call), the reader fills cb_w with `scale` in L1 in-kernel
     // (synthesize_gate); q is passed as the unused weights placeholder so the op infra still has a valid
@@ -545,7 +605,10 @@ ttnn::Tensor indexer_score_msa(
         compute_kernel_config,
         /*cache_batch_idx=*/std::nullopt,
         /*kv_len=*/std::nullopt,
-        cluster_axis);
+        cluster_axis,
+        slab_sp,
+        slab_chunk_size,
+        mid_slab_boundary);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -53,7 +53,9 @@ struct IndexerScoreDeviceOperation {
         const DeviceComputeKernelConfig& compute_kernel_config,
         std::optional<uint32_t> cache_batch_idx,
         std::optional<uint32_t> kv_len,
-        std::optional<uint32_t> cluster_axis);
+        std::optional<uint32_t> cluster_axis,
+        std::optional<SlabLayout> slab,
+        bool mid_slab_boundary);
 };
 
 }  // namespace ttnn::operations::experimental::indexer_score
@@ -63,6 +65,13 @@ namespace ttnn::experimental {
 // Two public frontends over one shared device op: the lightning indexer's two flavours differ only in
 // fixed knobs, so each gets its own callable. Both share the program factory + 3 kernels (flavour = compile-
 // time args) and produce a row-major bf16 score. Causality: key t visible to query s iff t <= chunk_start + s.
+//
+// SLAB K LAYOUT: the gathered K cache is a per-SP-shard slab (chunked prefill + SP all-gather), so the reader
+// reads it back in natural token order via an invP remap. The layout is PASSED EXPLICITLY -- slab_sp (the SP
+// the cache was gathered across) and slab_chunk_size (the global chunk granularity) -- because the cache's
+// slab is independent of how THIS op splits Q (e.g. an SP=8 cache scored by an SP=32 indexer). Both unset (or
+// slab_sp==1) = contiguous K (no remap). mid_slab_boundary is a single-chip-only test opt-in for the
+// boundary-chip straddle.
 
 // DeepSeek-V3.2 DSA / GLM-5 (ttnn.experimental.indexer_score_dsa):
 //   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
@@ -78,7 +87,10 @@ ttnn::Tensor indexer_score_dsa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_len = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt);
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<uint32_t> slab_sp = std::nullopt,
+    std::optional<uint32_t> slab_chunk_size = std::nullopt,
+    bool mid_slab_boundary = false);
 
 // MiniMax-M3 MSA (ttnn.experimental.indexer_score_msa):
 //   score[b, g, s, t] = sum_{h in group g} (q[b,h,s,:] . k[b,t,:]) * scale
@@ -98,6 +110,9 @@ ttnn::Tensor indexer_score_msa(
     uint32_t block_size = 0,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt);
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<uint32_t> slab_sp = std::nullopt,
+    std::optional<uint32_t> slab_chunk_size = std::nullopt,
+    bool mid_slab_boundary = false);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -27,6 +27,21 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
     return cfg.head_group_size == 0 ? Hi : static_cast<uint32_t>(cfg.head_group_size);
 }
 
+// Slab (per-SP-shard) K cache layout. Chunked prefill stores each of `ring_size` SP shards' per-chunk slab
+// (chunk_size/ring_size keys) back-to-back in its local cache, so after the SP all-gather the [B,1,T,D] k
+// holds keys in a PERMUTED physical order: physical row r holds the natural token at
+// P[r] = (lr/cl)*chunk_size + c*cl + (lr%cl), where c = r/sll, lr = r%sll, sll = T/ring_size,
+// cl = chunk_size/ring_size. The reader reads K back in LOGICAL token order (invP per tile), so the causal
+// mask and block-max-pool -- both keyed on the logical column -- stay byte-identical and the score columns
+// come out in natural token order. PASSED EXPLICITLY by the caller (slab_sp / slab_chunk_size), NOT derived
+// from the mesh: the cache's slab layout (how K was gathered) is independent of how THIS op splits Q -- e.g.
+// a cache gathered with SP=8 (chunk_size/8 per shard) may be scored by an SP=32 indexer with a smaller Sq.
+// Hashed (it shapes the reader binary). ring_size == 1 is the identity, represented as no slab at all.
+struct SlabLayout {
+    uint32_t ring_size;   // SP shard count the cache was gathered across (the cache's SP, NOT this op's SP)
+    uint32_t chunk_size;  // global prefill chunk granularity (elements); per-shard slab = chunk_size/ring_size
+};
+
 struct operation_attributes_t {
     // Absolute chunk_start of rank 0. Rank r uses chunk_start_idx + r*Sq; the per-device value is derived
     // host-side and passed to compute as a RUNTIME arg (hash-excluded), so distinct values reuse one program.
@@ -62,6 +77,17 @@ struct operation_attributes_t {
     // reuses ONE program. grid/work-split/output width stay keyed on the hashed T. nullopt == T.
     std::optional<uint32_t> kv_len{std::nullopt};
     bool has_runtime_kv_len() const { return kv_len.has_value(); }
+    // Resolved slab (per-SP-shard) K layout. When set, the reader remaps each logical k-tile to its physical
+    // (permuted) tile, presenting K in natural token order. HASHED (ring_size/chunk_size shape the reader
+    // binary via compile-time defines, so the contiguous path stays byte-identical). nullopt == contiguous K
+    // (which is also what ring_size == 1 resolves to, since that is the identity permutation).
+    std::optional<SlabLayout> slab{std::nullopt};
+    bool has_slab() const { return slab.has_value(); }
+    // Single-chip mid-slab boundary opt-in. On one chip chunk_start is this device's position and is linear by
+    // default; when set, the boundary-chip straddle is applied (offset = chunk_start % cl, cl = the cache's
+    // per-shard slab width). NOT hashed -- only shifts the hash-excluded straddle runtime args. Ignored on a
+    // mesh, where the straddle is derived from the per-device position. SINGLE-CHIP TESTING ONLY.
+    bool mid_slab_boundary{false};
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <array>
+#include <map>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -32,6 +34,8 @@ constexpr uint32_t reader_q_addr = 0;
 constexpr uint32_t reader_k_addr = 1;
 constexpr uint32_t reader_w_addr = 2;
 constexpr uint32_t compute_chunk_start_tiles = 7;  // after 6 sched scalars + kv_len[6]
+constexpr uint32_t compute_straddle_q_tile = 8;    // mid-slab boundary-chip diagonal jump (q-tile-row)
+constexpr uint32_t compute_straddle_jump_tiles = 9;
 constexpr uint32_t writer_out_addr = 0;
 // Persistent-cache args, appended after each kernel's schedule/mcast args (hash-excluded, re-patched on a hit).
 constexpr uint32_t reader_num_scalars = 3 + 6;  // q/k/w addrs + schedule {row_group0..max_bands}
@@ -39,15 +43,49 @@ constexpr uint32_t mcast_args_per_dir = 8;      // role, rect (xs,ys,xe,ye), sen
 constexpr uint32_t reader_num_mcast_dirs = 2;   // K column, then Q/W row
 constexpr uint32_t reader_k_batch_offset = reader_num_scalars + reader_num_mcast_dirs * mcast_args_per_dir;  // 25
 constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;                                          // 26
+constexpr uint32_t reader_kv_len_partial = reader_kv_len_tiles + 1;  // 27: sub-tile remainder (mask-tile fill)
 constexpr uint32_t compute_kv_len_tiles = 6;     // after the 6 schedule scalars {row_group0..max_bands}
+constexpr uint32_t compute_kv_len_partial = 10;  // after straddle_jump[9]; sub-tile boundary-tile partial mask
 constexpr uint32_t writer_kv_len_tiles = 1 + 6;  // out_addr + the 6 schedule scalars {row_group0..max_bands}
 constexpr uint32_t writer_chunk_start_tiles = 1 + 7;  // after out_addr + 6 sched scalars + kv_len[7]; match writer
+constexpr uint32_t writer_straddle_q_tile = 1 + 8;    // mid-slab forced-local block jump (block-pool only)
+constexpr uint32_t writer_straddle_jump_tiles = 1 + 9;
 }  // namespace rt_arg
 
-// Per-device chunk_start (tiles): (base + rank*Sq) / TILE_WIDTH. Shared by create_at (device_index from
-// the coordinate) and override (stored device_index).
-inline uint32_t chunk_start_tiles_for(const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
-    return (args.chunk_start_idx + device_index * Sq) / tt::constants::TILE_WIDTH;
+// Per-device causal geometry for the slab layout, all in tiles. Each device scores Sq queries; on a mesh
+// device r's q-row 0 sits at chunk_start_idx + r*Sq (this op's own SP split, stride Sq -- decoupled from the
+// cache's slab SP). When those Sq queries cross a CACHE slab boundary (a multiple of cl = the cache's
+// per-shard width = slab_chunk_size / slab_sp), the post-boundary q-rows live in the next slab, so the causal
+// diagonal JUMPS by (slab_chunk_size - cl) tiles at q-row (cl - offset). offset == 0, or Sq fitting inside one
+// slab (offset + Sq <= cl), leaves the diagonal linear -- which is the common chunk-aligned case and any
+// re-split where Sq divides cl. Reduces to plain linear when there is no slab. (validate_slab guarantees
+// Sq <= cl, so a device crosses at most one boundary.)
+struct DeviceCausalGeometry {
+    uint32_t chunk_start_tiles;    // global position of this device's q-row 0 (tiles)
+    uint32_t straddle_q_tile;      // q-tile-row at/after which the diagonal jumps (only when this device straddles)
+    uint32_t straddle_jump_tiles;  // diagonal jump in tiles (0 unless this device straddles)
+};
+inline DeviceCausalGeometry device_causal_geometry(
+    const operation_attributes_t& args, uint32_t device_index, uint32_t Sq, bool single_chip) {
+    const uint32_t TW = tt::constants::TILE_WIDTH;
+    // This device's q-row-0 global position. SINGLE CHIP: chunk_start_idx IS this (simulated) device's position
+    // (device_index is always 0). MESH: rank 0's chunk_start_idx + this rank's Sq stride.
+    const uint32_t chunk_start = single_chip ? args.chunk_start_idx : args.chunk_start_idx + device_index * Sq;
+    if (!args.slab.has_value()) {
+        return {chunk_start / TW, 0u, 0u};  // contiguous K -> linear diagonal, never straddles
+    }
+    const uint32_t cl = args.slab->chunk_size / args.slab->ring_size;  // cache per-shard slab width (elements)
+    const uint32_t chunk_global = args.slab->chunk_size;
+    // On one chip the straddle is opt-in (chunk_start alone can't tell a boundary-chip's block-cyclic queries
+    // from a contiguous-natural-query device); on a mesh it is always evaluated from the per-device position.
+    const bool allow_straddle = single_chip ? args.mid_slab_boundary : true;
+    const uint32_t offset = chunk_start % cl;  // position within the cache slab
+    uint32_t straddle_q_tile = 0, straddle_jump_tiles = 0;
+    if (allow_straddle && offset != 0 && offset + Sq > cl) {
+        straddle_q_tile = (cl - offset) / TW;
+        straddle_jump_tiles = (chunk_global - cl) / TW;
+    }
+    return {chunk_start / TW, straddle_q_tile, straddle_jump_tiles};
 }
 
 // This device's linearized SP-ring index; 0 on a single device (no coordinate lookup needed).
@@ -69,15 +107,21 @@ inline void patch_arg(tt::tt_metal::RuntimeArgsData& args, uint32_t index, uint3
 // (bakes at miss) and override_runtime_arguments() (re-patches on a hit).
 struct PersistentCacheArgs {
     uint32_t k_batch_page_offset;  // cache_batch_idx * Tt * Dt; 0 when not indexed
-    uint32_t kv_len_tiles;         // valid key prefix in tiles; full Tt when kv_len unset
+    uint32_t kv_len_tiles;         // valid key prefix in tiles (CEIL, so a sub-tile boundary tile is included)
+    uint32_t kv_len_partial;       // kv_len % TILE_WIDTH: sub-tile remainder, 0 = tile-aligned (no partial mask)
 };
 inline PersistentCacheArgs persistent_cache_args(const operation_attributes_t& attrs, const Tensor& k) {
     const auto& shape = k.logical_shape();
-    const uint32_t Tt = shape[2] / tt::constants::TILE_WIDTH;
-    const uint32_t Dt = shape[3] / tt::constants::TILE_WIDTH;
+    const uint32_t TW = tt::constants::TILE_WIDTH;
+    const uint32_t Tt = shape[2] / TW;
+    const uint32_t Dt = shape[3] / TW;
+    const uint32_t kv_len = attrs.kv_len.value_or(shape[2]);
+    // CEIL: a sub-tile kv_len keeps its last (partial) tile in the valid range; that tile's pad columns
+    // [kv_len%TW, TW) are masked per-column in compute (kv_len_partial != 0). Tile-aligned -> partial 0.
     return {
         .k_batch_page_offset = attrs.cache_batch_idx.value_or(0) * Tt * Dt,
-        .kv_len_tiles = attrs.kv_len.value_or(shape[2]) / tt::constants::TILE_WIDTH};
+        .kv_len_tiles = (kv_len + TW - 1) / TW,
+        .kv_len_partial = kv_len % TW};
 }
 
 // Banded-product schedule: the work space (group_count q-row-groups x band_count k-bands) tiles onto a
@@ -103,8 +147,10 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
 
     // This device's SP-ring index and chunk_start (tiles), from the coordinate. chunk_t is a compute RUNTIME
     // arg, so the binary is identical across coords and steps.
+    const bool single_chip = q.device_storage().get_coords().size() <= 1;
     const uint32_t device_index = device_index_for(args, coord, q);
-    const uint32_t chunk_t = chunk_start_tiles_for(args, device_index, Sq);
+    const auto geom = device_causal_geometry(args, device_index, Sq, single_chip);
+    const uint32_t chunk_t = geom.chunk_start_tiles;
 
     const uint32_t Sqt = Sq / tt::constants::TILE_HEIGHT;
     const uint32_t Tt = T / tt::constants::TILE_WIDTH;
@@ -327,6 +373,22 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     reader_ct.push_back(args.synthesize_gate ? 1u : 0u);  // fill cb_w with gate_scale in L1 vs read DRAM
     reader_ct.push_back(gate_scale_bits);                 // bf16 pair, the in-kernel gate fill value
 
+    // Slab (per-SP-shard) K: bake invP's divisors as reader defines (only when a slab layout is present, so
+    // the contiguous path emits no defines -> byte-identical reader binary). cl_t = (chunk/ring)/TILE_WIDTH
+    // per-shard slab in tiles; the kernel maps logical tile L -> L + c*SLAB_DELTA_T - shard*SLAB_K_T.
+    // ring_size/chunk/T are all hashed, so SLAB_DELTA_T is a pure compile-time constant (no per-dispatch arg).
+    std::map<std::string, std::string> reader_defines;
+    if (args.has_slab()) {
+        const uint32_t ring = args.slab->ring_size;
+        const uint32_t chunk_t = args.slab->chunk_size / tt::constants::TILE_WIDTH;
+        const uint32_t cl_t = chunk_t / ring;  // per-shard slab width in tiles
+        reader_defines["SLAB_ENABLE"] = "1";
+        reader_defines["SLAB_RING"] = std::to_string(ring);
+        reader_defines["SLAB_CHUNK_LOCAL_T"] = std::to_string(cl_t);
+        reader_defines["SLAB_K_T"] = std::to_string(cl_t * (ring - 1));
+        reader_defines["SLAB_DELTA_T"] = std::to_string((Tt - chunk_t) / ring);
+    }
+
     std::vector<uint32_t> writer_ct = common_ct;
     const uint32_t out_elem_bytes = out.element_size();  // bf16 today
     // row-major page = one output row: T scores, or nblocks block-scores when pooling.
@@ -346,7 +408,10 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     auto reader_id = tt::tt_metal::CreateKernel(
-        program, kdir + "reader_indexer_score.cpp", core_ranges, tt::tt_metal::ReaderDataMovementConfig(reader_ct));
+        program,
+        kdir + "reader_indexer_score.cpp",
+        core_ranges,
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct, reader_defines));
     auto writer_id = tt::tt_metal::CreateKernel(
         program, kdir + "writer_indexer_score.cpp", core_ranges, tt::tt_metal::WriterDataMovementConfig(writer_ct));
     auto compute_id = tt::tt_metal::CreateKernel(
@@ -365,7 +430,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     // mcast rects are fixed per core; only the data changes per phase.
     const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
     // Indexed-cache k page offset + valid kv_len, baked at miss and re-applied each dispatch (both hash-excluded).
-    const auto [k_batch_page_offset, kv_len_tiles] = persistent_cache_args(args, k);
+    const auto [k_batch_page_offset, kv_len_tiles, kv_len_partial] = persistent_cache_args(args, k);
     std::vector<CoreCoord> cores;
     cores.reserve(num_cores);
     for (uint32_t row = 0; row < rows_used; ++row) {
@@ -430,19 +495,25 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
                 q_py,
                 q_sender,
                 cols_used - 1);
-            // Persistent-cache args last (slots reader[25,26]).
+            // Persistent-cache args last (slots reader[25,26,27]).
             reader_rt.push_back(k_batch_page_offset);
             reader_rt.push_back(kv_len_tiles);
+            reader_rt.push_back(kv_len_partial);  // slot [27], sub-tile remainder for the partial mask-tile fill
             tt::tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
-            // compute: schedule[0-5], then kv_len_tiles[6] + chunk_start_tiles[7] (both hash-excluded runtime).
+            // compute: schedule[0-5], kv_len_tiles[6], chunk_start[7], straddle[8,9], kv_len_partial[10].
             std::vector<uint32_t> compute_rt(sched.begin(), sched.end());
-            compute_rt.push_back(kv_len_tiles);  // slot [6]
-            compute_rt.push_back(chunk_t);       // slot [7]
+            compute_rt.push_back(kv_len_tiles);              // slot [6]
+            compute_rt.push_back(chunk_t);                   // slot [7]
+            compute_rt.push_back(geom.straddle_q_tile);      // slot [8], mid-slab boundary-chip diagonal jump
+            compute_rt.push_back(geom.straddle_jump_tiles);  // slot [9]
+            compute_rt.push_back(kv_len_partial);            // slot [10], sub-tile boundary-tile partial mask
             tt::tt_metal::SetRuntimeArgs(program, compute_id, core, compute_rt);
             std::vector<uint32_t> writer_rt = {out.buffer()->address()};
             writer_rt.insert(writer_rt.end(), sched.begin(), sched.end());
-            writer_rt.push_back(kv_len_tiles);  // slot [7], after out_addr + the 6 schedule scalars
-            writer_rt.push_back(chunk_t);       // slot [8], per-device chunk-start (tiles); block-pool forced-local
+            writer_rt.push_back(kv_len_tiles);              // slot [7], after out_addr + the 6 schedule scalars
+            writer_rt.push_back(chunk_t);                   // slot [8], per-device chunk-start (tiles); forced-local
+            writer_rt.push_back(geom.straddle_q_tile);      // slot [9], mid-slab forced-local block jump (pool only)
+            writer_rt.push_back(geom.straddle_jump_tiles);  // slot [10]
             tt::tt_metal::SetRuntimeArgs(program, writer_id, core, writer_rt);
         }
     }
@@ -484,13 +555,15 @@ void IndexerScoreProgramFactory::override_runtime_arguments(
     // Re-apply all hash-excluded runtime values on a hit: buffer addresses, cache_batch_idx / kv_len, and
     // chunk_start (per-coordinate, from the stored device_index).
     const uint32_t Sq = tensors.q.logical_shape()[2];
-    const auto [k_batch_page_offset, kv_len_tiles] = persistent_cache_args(args, tensors.k);
+    const bool single_chip = tensors.q.device_storage().get_coords().size() <= 1;
+    const auto [k_batch_page_offset, kv_len_tiles, kv_len_partial] = persistent_cache_args(args, tensors.k);
     for (auto& [range, shared] : cached.shared_variables) {
         auto& program = cached.workload.get_programs().at(range);
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, shared.reader_kernel);
         auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, shared.compute_kernel);
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, shared.writer_kernel);
-        const uint32_t chunk_t = chunk_start_tiles_for(args, shared.device_index, Sq);
+        const auto geom = device_causal_geometry(args, shared.device_index, Sq, single_chip);
+        const uint32_t chunk_t = geom.chunk_start_tiles;
         for (const auto& core : shared.worker_cores) {
             auto& reader_rt = reader_args[core.x][core.y];
             patch_arg(reader_rt, rt_arg::reader_q_addr, tensors.q.buffer()->address(), "reader.q_addr");
@@ -498,11 +571,34 @@ void IndexerScoreProgramFactory::override_runtime_arguments(
             patch_arg(reader_rt, rt_arg::reader_w_addr, tensors.weights.buffer()->address(), "reader.w_addr");
             patch_arg(reader_rt, rt_arg::reader_k_batch_offset, k_batch_page_offset, "reader.k_batch_offset");
             patch_arg(reader_rt, rt_arg::reader_kv_len_tiles, kv_len_tiles, "reader.kv_len_tiles");
+            patch_arg(reader_rt, rt_arg::reader_kv_len_partial, kv_len_partial, "reader.kv_len_partial");
             patch_arg(compute_args[core.x][core.y], rt_arg::compute_kv_len_tiles, kv_len_tiles, "compute.kv_len_tiles");
+            patch_arg(
+                compute_args[core.x][core.y], rt_arg::compute_kv_len_partial, kv_len_partial, "compute.kv_len_partial");
             patch_arg(compute_args[core.x][core.y], rt_arg::compute_chunk_start_tiles, chunk_t, "compute.chunk_start");
+            patch_arg(
+                compute_args[core.x][core.y],
+                rt_arg::compute_straddle_q_tile,
+                geom.straddle_q_tile,
+                "compute.straddle_q_tile");
+            patch_arg(
+                compute_args[core.x][core.y],
+                rt_arg::compute_straddle_jump_tiles,
+                geom.straddle_jump_tiles,
+                "compute.straddle_jump_tiles");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_out_addr, out.buffer()->address(), "writer.out_addr");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_kv_len_tiles, kv_len_tiles, "writer.kv_len_tiles");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_chunk_start_tiles, chunk_t, "writer.chunk_start");
+            patch_arg(
+                writer_args[core.x][core.y],
+                rt_arg::writer_straddle_q_tile,
+                geom.straddle_q_tile,
+                "writer.straddle_q_tile");
+            patch_arg(
+                writer_args[core.x][core.y],
+                rt_arg::writer_straddle_jump_tiles,
+                geom.straddle_jump_tiles,
+                "writer.straddle_jump_tiles");
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -395,19 +395,47 @@ inline void block_max_pool_batched(uint32_t unit_strip) {
     acc.pop_front(unit_strip);
 }
 
-/** Stamp the causal -inf mask onto row r's masked suffix [valid, KC) in place (empty when fully valid). */
+/** Stamp the causal -inf mask onto row r's masked suffix [valid, KC) in place (empty when fully valid).
+ *  straddle_* shift the diagonal on the mid-slab boundary chip (0 elsewhere); see causal_diag_tile. */
 inline void stamp_masked_suffix(
     const WorkUnitSpan& span,
     uint32_t q_row,
     uint32_t slot_base,
     uint32_t k_tiles_in_unit,
-    uint32_t chunk_start_tiles) {
+    uint32_t chunk_start_tiles,
+    uint32_t straddle_q_tile,
+    uint32_t straddle_jump_tiles) {
     const uint32_t k_tile0 = span.k_tile_start();
-    const uint32_t diag_tile = chunk_start_tiles + span.q_tile_start() + q_row;
-    const uint32_t valid = row_valid_prefix(span.q_tile_start() + q_row, k_tile0, k_tiles_in_unit, chunk_start_tiles);
+    const uint32_t q_row_abs = span.q_tile_start() + q_row;
+    const uint32_t diag_tile =
+        iscore::causal_diag_tile(q_row_abs, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
+    const uint32_t valid =
+        row_valid_prefix(q_row_abs, k_tile0, k_tiles_in_unit, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
     for (uint32_t k_col = valid; k_col < k_tiles_per_unit; ++k_col) {
         stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, k_tile0 + k_col, diag_tile);
     }
+}
+
+/** Sub-tile kv_len: when the valid prefix ends mid-tile, L1-accumulate the partial-column -inf mask
+ *  (cb_mask[2], cols [kv_len%32, 32) -> -inf) onto the boundary tile -- the band's last valid tile, local
+ *  index k_tiles_in_unit-1. Stacks with the causal/diagonal mask (both -inf), keeping the valid [0,
+ *  kv_len%32) scores. Only the band whose last valid tile IS the global boundary tile carries it; a no-op
+ *  when kv_len is tile-aligned (kv_len_partial == 0) or this band has no/interior tiles. */
+inline void stamp_partial_kv_len_tile(
+    const WorkUnitSpan& span, uint32_t slot_base, uint32_t k_tiles_in_unit, uint32_t kv_len_partial) {
+    if (kv_len_partial == 0 || k_tiles_in_unit == 0 ||
+        span.k_tile_start() + k_tiles_in_unit != span.valid_k_len_tiles) {
+        return;
+    }
+    copy_tile_to_dst_init_short(cb_mask);
+    pack_reconfig_l1_acc(1);  // accumulate -inf onto [kv_len%32, 32); the valid prefix columns keep their score
+    tile_regs_acquire();
+    copy_tile(cb_mask, 2, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile<true>(0, cb_acc_strip, slot_base + (k_tiles_in_unit - 1));
+    tile_regs_release();
+    pack_reconfig_l1_acc(0);
 }
 
 void kernel_main() {
@@ -425,6 +453,13 @@ void kernel_main() {
     const uint32_t kv_len_tiles = get_arg_val<uint32_t>(6);
     // Per-device chunk-start offset (tiles); runtime so distinct values reuse one program.
     const uint32_t chunk_start_tiles = get_arg_val<uint32_t>(7);
+    // Mid-slab boundary-chip diagonal straddle (tiles): q-rows >= straddle_q_tile jump by straddle_jump_tiles.
+    // Both 0 on every non-boundary device and in the chunk-aligned case, leaving the diagonal linear.
+    const uint32_t straddle_q_tile = get_arg_val<uint32_t>(8);
+    const uint32_t straddle_jump_tiles = get_arg_val<uint32_t>(9);
+    // Sub-tile kv_len remainder (kv_len % 32): when nonzero, the last valid k-tile's columns [remainder, 32)
+    // are pad and get the partial-column -inf mask (cb_mask[2]). 0 = tile-aligned (no partial mask).
+    const uint32_t kv_len_partial = get_arg_val<uint32_t>(10);
     if (num_groups == 0 || num_bands == 0) {
         return;
     }
@@ -508,7 +543,15 @@ void kernel_main() {
                     // Matmul left srcA in k's format; the mask copies a bf16 -inf tile -> reconfig srcA to bf16.
                     reconfig_data_format_srca(cb_k, cb_mask);
                     for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-                        stamp_masked_suffix(span, r, r * k_tiles_per_unit, k_tiles_in_unit, chunk_start_tiles);
+                        stamp_masked_suffix(
+                            span,
+                            r,
+                            r * k_tiles_per_unit,
+                            k_tiles_in_unit,
+                            chunk_start_tiles,
+                            straddle_q_tile,
+                            straddle_jump_tiles);
+                        stamp_partial_kv_len_tile(span, r * k_tiles_per_unit, k_tiles_in_unit, kv_len_partial);
                     }
                     acc.push_back(unit_strip);
                 } else {
@@ -536,7 +579,15 @@ void kernel_main() {
                             accumulate_row_streaming(q_row, slot_base);
                         }
 
-                        stamp_masked_suffix(span, q_row, slot_base, k_tiles_in_unit, chunk_start_tiles);
+                        stamp_masked_suffix(
+                            span,
+                            q_row,
+                            slot_base,
+                            k_tiles_in_unit,
+                            chunk_start_tiles,
+                            straddle_q_tile,
+                            straddle_jump_tiles);
+                        stamp_partial_kv_len_tile(span, slot_base, k_tiles_in_unit, kv_len_partial);
                     }
                     acc.push_back(unit_strip);
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
@@ -27,8 +27,9 @@ enum CbArg : uint32_t {
     num_cb_args
 };
 
-// Two mask tiles in cb_mask: index 0 = diagonal strict-upper -inf, index 1 = full -inf.
-constexpr uint32_t num_mask_tiles = 2;
+// Three mask tiles in cb_mask: index 0 = diagonal strict-upper -inf, index 1 = full -inf, index 2 = sub-tile
+// kv_len partial-column -inf (cols [kv_len%32, 32) -> -inf; filled only when kv_len is not tile-aligned).
+constexpr uint32_t num_mask_tiles = 3;
 
 // Per-direction multicast role, written by the factory into the reader's runtime args. Single-sourced
 // here so host and device can't drift on the encoding.

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -70,10 +70,17 @@ constexpr uint32_t k_chunk_tiles = k_tiles_per_unit * head_dim_tiles;           
 
 // Thin wrapper binding the shared work-split formula to this kernel's CT dims: unmasked prefix
 // k-tiles of absolute q-tile-row q_row_abs in a unit. chunk_start_tiles is the per-device runtime
-// chunk-start offset (in tiles); the compute kernel reads it from a runtime arg.
+// chunk-start offset (in tiles); straddle_* carry the mid-slab boundary-chip diagonal jump (0 otherwise).
+// All three are compute-kernel runtime args.
 inline uint32_t row_valid_prefix(
-    uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit, uint32_t chunk_start_tiles) {
-    return iscore::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
+    uint32_t q_row_abs,
+    uint32_t k_tile_start,
+    uint32_t k_tiles_in_unit,
+    uint32_t chunk_start_tiles,
+    uint32_t straddle_q_tile,
+    uint32_t straddle_jump_tiles) {
+    return iscore::valid_prefix_tiles(
+        q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
 }
 
 /** (group, band) cell cursor. group = absolute q-row-group index; band = absolute k-band index; the

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
@@ -18,11 +18,25 @@ namespace ttnn::operations::experimental::indexer_score {
 // Future/diagonal tiles are computed and masked to -inf in-band (see valid_prefix_tiles); cost is
 // negligible at high sp_rank (~2x only near sp~0).
 
+/** This q-tile-row's causal diagonal tile (the k-tile holding key == query). Normally chunk_start_tiles +
+ *  q_row_abs, but on the mid-slab BOUNDARY chip the q-rows straddle a slab boundary: rows at/after
+ *  straddle_q_tile jump by straddle_jump_tiles (the global K gap between the two slabs the chip spans).
+ *  straddle_jump_tiles == 0 (every non-boundary device, and the chunk-aligned case) leaves it linear. */
+constexpr uint32_t causal_diag_tile(
+    uint32_t q_row_abs, uint32_t chunk_start_tiles, uint32_t straddle_q_tile, uint32_t straddle_jump_tiles) {
+    return chunk_start_tiles + q_row_abs + (q_row_abs >= straddle_q_tile ? straddle_jump_tiles : 0);
+}
+
 /** Unmasked prefix k-tiles of q-tile-row q_row_abs in a unit (start k_tile_start, k_tiles_in_unit
  *  valid). Tiles [0, this) are below the diagonal (no mask); diagonal and beyond are masked. */
 constexpr uint32_t valid_prefix_tiles(
-    uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit, uint32_t chunk_start_tiles) {
-    const uint32_t diag_tile = chunk_start_tiles + q_row_abs;
+    uint32_t q_row_abs,
+    uint32_t k_tile_start,
+    uint32_t k_tiles_in_unit,
+    uint32_t chunk_start_tiles,
+    uint32_t straddle_q_tile,
+    uint32_t straddle_jump_tiles) {
+    const uint32_t diag_tile = causal_diag_tile(q_row_abs, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
     const uint32_t v = diag_tile > k_tile_start ? diag_tile - k_tile_start : 0;
     return v < k_tiles_in_unit ? v : k_tiles_in_unit;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -49,6 +49,25 @@ constexpr uint32_t fused_stream_k = get_compile_time_arg_val(mc_ct_base + 9);
 constexpr uint32_t synthesize_gate = get_compile_time_arg_val(mc_ct_base + 10);
 constexpr uint32_t gate_scale_bits = get_compile_time_arg_val(mc_ct_base + 11);  // bf16 pair (two per word)
 
+// Slab (per-SP-shard) K layout: the gathered cache stores each SP shard's per-chunk slab back-to-back, so
+// logical token tile L physically lives at invP(L). invP, in tiles, is page = L + c*SLAB_DELTA_T - g*SLAB_K_T,
+// with q = L/SLAB_CHUNK_LOCAL_T (= g*ring + c), g = q/SLAB_RING, c = q%SLAB_RING. The factory bakes the
+// divisors as compile-time defines (SLAB_CHUNK_LOCAL_T / SLAB_RING / SLAB_K_T / SLAB_DELTA_T) only when a slab
+// layout is present (ring_size > 1), so the contiguous path emits no defines and SLAB_KTILE is the identity
+// -> byte-identical reader binary. Reading K in logical order keeps the causal mask + block-max-pool (both
+// keyed on the logical column) unchanged and yields score columns in natural token order.
+#ifdef SLAB_ENABLE
+inline uint32_t slab_logical_to_physical_ktile(uint32_t logical_ktile) {
+    const uint32_t q = logical_ktile / SLAB_CHUNK_LOCAL_T;
+    const uint32_t shard = q / SLAB_RING;
+    const uint32_t c = q - shard * SLAB_RING;
+    return logical_ktile + c * SLAB_DELTA_T - shard * SLAB_K_T;
+}
+#define SLAB_KTILE(L) slab_logical_to_physical_ktile(L)
+#else
+#define SLAB_KTILE(L) (L)
+#endif
+
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
 struct McastDir {
     uint32_t role;            // McastRole: none (DRAM read), sender (read + mcast), receiver (wait for mcast)
@@ -125,11 +144,18 @@ inline void read_block_or_mcast(Noc noc, uint32_t ntiles, uint32_t bytes, const 
     cb.push_back(ntiles);
 }
 
-inline void build_mask_tiles(Noc noc) {
+inline void build_mask_tiles(Noc noc, uint32_t kv_len_partial) {
     CircularBuffer cb(cb_mask);
     cb.reserve_back(num_mask_tiles);
     fill_causal_diagonal_tile_bf16<bf16_tile_bytes>(noc, cb_mask, /*tile_id=*/0);  // diagonal strict-upper -inf
     fill_neginf_tile<bf16_tile_bytes>(cb_mask, /*tile_id=*/1);                     // full -inf
+    // tile 2: sub-tile kv_len partial-column mask (cols [kv_len%32, 32) -> -inf). Tile-aligned (partial == 0)
+    // -> all-valid zeros (compute never stamps it then). kv_len is runtime, so this is filled per dispatch.
+    if (kv_len_partial != 0) {
+        fill_vertical_tile_bf16<bf16_tile_bytes>(noc, cb_mask, /*tile_id=*/2, /*unpad_col_in_tile=*/kv_len_partial);
+    } else {
+        fill_tile_zeros<bf16_tile_bytes>(noc, cb_mask, /*tile_id=*/2);
+    }
     cb.push_back(num_mask_tiles);
 }
 
@@ -243,12 +269,14 @@ inline void read_k_chunk(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
             for (uint32_t k_col = 0; k_col < k_tiles_in_unit; ++k_col) {
+                // SLAB_KTILE: identity for contiguous K; invP(logical seq tile) for the per-SP-shard slab layout.
+                const uint32_t seq_tile = SLAB_KTILE(k_tile_start + k_col);
                 for (uint32_t dim_tile = 0; dim_tile < head_dim_tiles; ++dim_tile) {
                     noc.async_read(
                         k_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         k_tile_bytes,
-                        {.page_id = k_batch_page_offset + (k_tile_start + k_col) * head_dim_tiles + dim_tile},
+                        {.page_id = k_batch_page_offset + seq_tile * head_dim_tiles + dim_tile},
                         {});
                     ptr += k_tile_bytes;
                 }
@@ -269,12 +297,13 @@ inline void read_k_chunk_streaming(Noc noc, const KAcc& k_acc, uint32_t k_tile_s
         uint32_t ptr = cb.get_write_ptr();
         for (uint32_t c = cbase; c < c_end; ++c) {
             if (c < k_tiles_in_unit) {
+                const uint32_t seq_tile = SLAB_KTILE(k_tile_start + c);  // identity unless slab layout
                 for (uint32_t d = 0; d < head_dim_tiles; ++d) {
                     noc.async_read(
                         k_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         k_tile_bytes,
-                        {.page_id = (k_tile_start + c) * head_dim_tiles + d},
+                        {.page_id = seq_tile * head_dim_tiles + d},
                         {});
                     ptr += k_tile_bytes;
                 }
@@ -301,6 +330,7 @@ void kernel_main() {
     // Persistent-cache args (hash-excluded, re-applied each dispatch), after the mcast tuples.
     const uint32_t k_batch_page_offset = get_arg_val<uint32_t>(25);  // indexed-cache page offset; 0 when not indexed
     const uint32_t kv_len_tiles = get_arg_val<uint32_t>(26);         // valid KV length in tiles (full when unset)
+    const uint32_t kv_len_partial = get_arg_val<uint32_t>(27);       // sub-tile remainder (kv_len%32); 0 = tile-aligned
 
     const auto q_acc = TensorAccessor(q_args, q_addr, q_tile_bytes);
     const auto k_acc = TensorAccessor(k_args, k_addr, k_tile_bytes);
@@ -308,7 +338,7 @@ void kernel_main() {
 
     Noc noc;
 
-    build_mask_tiles(noc);
+    build_mask_tiles(noc, kv_len_partial);
     if constexpr (block_pool) {
         // 1.0 reduce-MAX scaler for the block-max-pool (row-0 fill, the layout reduce_block_max_row expects).
         dataflow_kernel_lib::

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -66,7 +66,9 @@ inline void write_pooled_strip(
     uint32_t q_seq_row0,
     uint32_t col_off_blocks,
     uint32_t valid_blocks,
-    uint32_t chunk_start_keys) {
+    uint32_t chunk_start_keys,
+    uint32_t straddle_q_keys,
+    uint32_t straddle_jump_keys) {
     CircularBuffer cb(cb_out_strip);
     cb.wait_front(blocks_per_unit);
     volatile tt_l1_ptr uint16_t* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_read_ptr());
@@ -88,10 +90,13 @@ inline void write_pooled_strip(
     }
 
     // Forced-local block (sparse_local_block=1): force each query's own block to +inf so top-k always
-    // keeps it. Query (q_seq_row0 + rr)'s block = (chunk_start_keys + q_seq_row0 + rr) / POOL_BLOCK_KEYS;
-    // stamp only when it lands in this unit's [col_off_blocks, +valid).
+    // keeps it. Query (q_seq_row0 + rr)'s block = (q_pos) / POOL_BLOCK_KEYS, where q_pos =
+    // chunk_start_keys + q_seq_row0 + rr plus the mid-slab boundary-chip straddle jump (0 otherwise, so the
+    // common case is unchanged); stamp only when it lands in this unit's [col_off_blocks, +valid).
     for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
-        const uint32_t local_block = (chunk_start_keys + q_seq_row0 + rr) / POOL_BLOCK_KEYS;
+        const uint32_t q_seq = q_seq_row0 + rr;
+        const uint32_t q_pos = chunk_start_keys + q_seq + (q_seq >= straddle_q_keys ? straddle_jump_keys : 0);
+        const uint32_t local_block = q_pos / POOL_BLOCK_KEYS;
         if (local_block >= col_off_blocks && local_block < col_off_blocks + valid_blocks) {
             scratch[rr * valid_blocks + (local_block - col_off_blocks)] = POOL_POS_INF_BF16;
         }
@@ -124,6 +129,9 @@ void kernel_main() {
     // [8] per-device chunk-start (tiles); runtime so distinct values reuse one program. Only the block-pool
     // forced-local stamp uses it; always set.
     const uint32_t chunk_start_keys = get_arg_val<uint32_t>(8) * tt::constants::TILE_WIDTH;
+    // [9],[10] mid-slab boundary-chip forced-local block jump (keys); both 0 off the boundary chip.
+    const uint32_t straddle_q_keys = get_arg_val<uint32_t>(9) * tt::constants::TILE_WIDTH;
+    const uint32_t straddle_jump_keys = get_arg_val<uint32_t>(10) * tt::constants::TILE_WIDTH;
 
     constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 1>();
     const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
@@ -153,7 +161,15 @@ void kernel_main() {
                     const uint32_t page_row_start = plane_row0 + q_seq_row0;
                     if constexpr (block_pool) {
                         write_pooled_strip(
-                            noc, out_acc, page_row_start, q_seq_row0, col_off_blocks, valid_blocks, chunk_start_keys);
+                            noc,
+                            out_acc,
+                            page_row_start,
+                            q_seq_row0,
+                            col_off_blocks,
+                            valid_blocks,
+                            chunk_start_keys,
+                            straddle_q_keys,
+                            straddle_jump_keys);
                     } else {
                         write_strip(noc, out_acc, page_row_start, k_tile0, valid_w);
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -53,15 +53,37 @@ void bind_indexer_score(nb::module_& mod) {
                 [B, 1, T, D] k cache (which may then be ND-sharded across DRAM
                 banks). Re-applied each dispatch, so switching slots does not
                 recompile.
-            kv_len: optional int. Valid prefix of a k allocated at its full T;
-                the rest is masked out. Tile-aligned, in (0, T], with
-                chunk_start_idx + Sq <= kv_len. Re-applied each dispatch, so a
-                serving loop growing kv_len (<= T) reuses one program -- no
-                recompile. Only output columns [0, kv_len) are written.
+            kv_len: optional int. The valid key prefix (= the real ISL); keys at
+                positions >= kv_len are masked out. In (0, T]; need NOT be
+                tile-aligned -- a sub-tile kv_len masks the pad columns of its last
+                (partial) valid tile per-column. The causal window MAY extend past
+                kv_len -- with a padded chunk (real
+                ISL < the fixed chunk) the padded-query devices reach past the
+                valid keys, which is fine (those keys are masked, their output
+                discarded). Re-applied each dispatch, so a serving loop growing
+                kv_len (<= T) reuses one program -- no recompile. Only output
+                columns [0, kv_len) are meaningful.
             cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis (Sq = q seq len). None = linear device order
                 (1 on a single device, so chunk_start_idx is used as-is).
+            slab_sp: optional int. The SP the K cache slab was gathered across --
+                i.e. the cache's OWN sequence-parallel degree, independent of how
+                this op splits Q. The gathered [B,1,T,D] k is then in per-SP-shard
+                slab (block-cyclic) physical order, and the reader reads it back in
+                natural token order (invP per tile) so scores come out token-ordered
+                and the causal mask/pool stay exact. Unset (or 1) = contiguous K (no
+                remap). Pair with slab_chunk_size. NOT derived from the mesh -- the
+                cache's slab is decoupled from this op's parallelization (e.g. an
+                SP=8 cache, slab_sp=8, scored by an SP=32 indexer with a smaller Sq).
+            slab_chunk_size: optional int, REQUIRED with slab_sp. The global prefill
+                chunk granularity in tokens (e.g. 5120); the cache's per-shard slab
+                width is slab_chunk_size / slab_sp. Must be divisible by slab_sp with
+                a tile-aligned per-shard width, divide T, and be >= Sq.
+            mid_slab_boundary: SINGLE-CHIP TESTING ONLY. Simulate this one device as
+                the boundary chip whose Sq queries straddle a cache-slab boundary
+                (the causal diagonal jumps mid-tensor). On a mesh the straddle is
+                derived from the per-device position, so this is ignored there.
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
@@ -75,7 +97,10 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cache_batch_idx") = std::nullopt,
         nb::arg("kv_len") = std::nullopt,
-        nb::arg("cluster_axis") = std::nullopt);
+        nb::arg("cluster_axis") = std::nullopt,
+        nb::arg("slab_sp") = std::nullopt,
+        nb::arg("slab_chunk_size") = std::nullopt,
+        nb::arg("mid_slab_boundary") = false);
 
     ttnn::bind_function<"indexer_score_msa", "ttnn.experimental.">(
         mod,
@@ -118,6 +143,14 @@ void bind_indexer_score(nb::module_& mod) {
             cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis. None = linear device order.
+            slab_sp / slab_chunk_size / mid_slab_boundary: same semantics as
+                indexer_score_dsa. slab_sp = the SP the K cache slab was gathered
+                across (the cache's own SP, decoupled from this op's split) and
+                slab_chunk_size = the global chunk granularity; the reader reads the
+                permuted cache back in natural token order so the per-group scores
+                (and the block-max-pool, which pools token-contiguous blocks) come
+                out correct. Unset = contiguous K. mid_slab_boundary is single-chip
+                testing only.
 
         Returns: score [B, num_groups, Sq, T_out] bf16 row-major (T_out = T, or
             T/block_size when block-max-pooling); future/pad columns/blocks -inf.
@@ -132,7 +165,10 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("block_size") = 0,
         nb::arg("program_config") = IndexerScoreProgramConfig{},
         nb::arg("compute_kernel_config") = std::nullopt,
-        nb::arg("cluster_axis") = std::nullopt);
+        nb::arg("cluster_axis") = std::nullopt,
+        nb::arg("slab_sp") = std::nullopt,
+        nb::arg("slab_chunk_size") = std::nullopt,
+        nb::arg("mid_slab_boundary") = false);
 }
 
 }  // namespace ttnn::operations::experimental::indexer_score::detail


### PR DESCRIPTION
### PR Category
Feature

> ✅ **Working version.** Full single-chip + multichip indexer suite passes (123 passed, 3 perf-skip). The slab-aware path is on by default in the functional tests, with dedicated contiguous-cache, partial-ISL, sub-tile `kv_len`, mid-slab-boundary, and multichip QB coverage.

### Summary

Makes `indexer_score_dsa` / `indexer_score_msa` correct on a chunked-prefill K cache and adds the controls a serving loop needs. Three things are supported here:

- **Slab-aware (block-cyclic) K cache** — chunked prefill splits each chunk across the SP ring and the all-gather concatenates device-major, so the gathered `[B,1,T,D]` k is in a per-SP-shard *slab* (block-cyclic) physical order, not natural token order. The reader remaps each logical k-tile to its physical tile in-kernel (`invP`), presenting K in natural token order, so the causal mask, banded multicast, and block-max-pool stay byte-identical and the emitted top-k indices are token-correct. The slab layout is **passed explicitly** (`slab_sp` = the SP the cache was gathered across, `slab_chunk_size` = the global chunk granularity); it is **decoupled from how this op splits Q** — e.g. an SP=8 cache scored by an SP=32 indexer. Both unset (or `slab_sp==1`) = contiguous K, byte-identical to before (no defines emitted).

- **Actual ISL (`kv_len`)** — the real valid key prefix for a partially-filled (padded) chunk. Keys at positions `>= kv_len` are masked; `kv_len` may be **sub-tile** (not a multiple of 32), in which case the last valid tile's pad columns get a per-column `-inf` mask synthesized by the reader at runtime. Re-applied each dispatch, so a serving loop growing `kv_len` reuses one program (no recompile).

- **KV history (`chunk_start_idx`)** — the absolute global position of rank 0's query row 0 (the history already in cache). Causality: key `t` visible to query `s` iff `t <= chunk_start + s`. On a mesh, device `r` uses `chunk_start = chunk_start_idx + r*Sq` along `cluster_axis` (omit to deduce `T - sp_ring*Sq`). When a device's `Sq` queries cross a cache-slab boundary the causal diagonal jumps by `(slab_chunk_size - cl)` tiles at the crossing row; on one chip this straddle is the opt-in `mid_slab_boundary` test flag.

Also plumbed: `cache_batch_idx` (hash-excluded — switching cache slots does not recompile).

### Notes for reviewers

- Reader `invP` (`slab_logical_to_physical_ktile`) is the heart of the change — it's the inverse of `update_padded_kv_cache`'s block-cyclic write; same concept as the `block_cyclic` remap in #48428, but the slab layout is passed explicitly (cache-SP independent of op-SP) rather than mesh-derived.
- `slab_sp` / `slab_chunk_size` are CT (hashed); `chunk_start_idx`, `kv_len`, `cache_batch_idx` are RT (no recompile).
- `validate_slab` enforces `Sq <= cl` (at most one slab crossing), `slab_chunk_size % slab_sp == 0`, tile-aligned per-shard width, and `slab_chunk_size | T`.
- Contiguous-cache path is exercised by dedicated sweeps to guarantee no regression when slab params are unset.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer-slab-aware)