### PR TITLE
Ignore `quasar/` during collection on non-quasar arch

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -414,8 +414,11 @@ def pytest_configure(config):
 def pytest_ignore_collect(collection_path, config):
     # Skip collecting the quasar/ dir on non-quasar arch — those tests are
     # deselected there anyway, so there's no need to collect them.
-    if get_chip_architecture() != ChipArchitecture.QUASAR:
-        return "quasar" in collection_path.parts
+    if (
+        get_chip_architecture() != ChipArchitecture.QUASAR
+        and "quasar" in collection_path.parts
+    ):
+        return True
     return None
 
 

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -411,6 +411,14 @@ def pytest_configure(config):
             tt_exalens_init.init_ttexalens(use_4B_mode=False)
 
 
+def pytest_ignore_collect(collection_path, config):
+    # Skip collecting the quasar/ dir on non-quasar arch — those tests are
+    # deselected there anyway, so there's no need to collect them.
+    if get_chip_architecture() != ChipArchitecture.QUASAR:
+        return "quasar" in collection_path.parts
+    return None
+
+
 def pytest_collection_modifyitems(config, items):
     test_order_file = config.getoption("--test-order-file")
 


### PR DESCRIPTION
### PR Category
Performance

### Summary
On `wormhole` and `blackhole` runs, the quasar tests (`quasar/`, marked `@pytest.mark.quasar`) are deselected by `-m "not quasar"` — but pytest still collects all of them first, which makes collection slower and use a lot more memory on every worker. This adds a `pytest_ignore_collect` hook that skips the `quasar/` directory entirely when the target arch isn't `Quasar`, so those tests are never collected in the first place. The set of tests that actually run is unchanged.

### Notes for reviewers
- The whole change is one hook in `tests/python_tests/conftest.py`.
- The skip only applies when `CHIP_ARCH != quasar`. On a quasar build the hook returns `None` and quasar collection is untouched.
- `"quasar"` in `collection_path.parts` matches the `quasar/` directory, not files named `*_quasar.py` elsewhere (all quasar tests live under `quasar/`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/remove-quasar-collection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/remove-quasar-collection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jmacanovic/remove-quasar-collection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/remove-quasar-collection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/remove-quasar-collection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/remove-quasar-collection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/remove-quasar-collection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/remove-quasar-collection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/remove-quasar-collection)