### PR TITLE
Profiler L1 buffer accumulate mode

### DIFF
--- a/tests/pipeline_reorg/single_card_profiler_tests.yaml
+++ b/tests/pipeline_reorg/single_card_profiler_tests.yaml
@@ -66,3 +66,17 @@
       timeout: 15
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: ttnn
+
+- name: L1 accumulate profiler
+  cmd: run_accumulate_profiler_test
+  skus:
+    wh_n150_civ2:
+      timeout: 6
+    wh_n300_civ2:
+      timeout: 6
+    bh_p100a_civ2_viommu:
+      timeout: 6
+    bh_p150b_civ2_viommu:
+      timeout: 6
+  owner_id: U03BJ1L3LUQ # Mo Memarian
+  team: ttnn

--- a/tests/scripts/single_card/run_single_card_profiler_tests.sh
+++ b/tests/scripts/single_card/run_single_card_profiler_tests.sh
@@ -74,10 +74,7 @@ run_accumulate_profiler_test() {
     remove_default_log_locations
     echo "Sanity test: L1-accumulate device profiling coexists with dispatch-core profiling, accumulates worker zones, and skips the perf report"
     mkdir -p $PROFILER_ARTIFACTS_DIR
-    # Multi-invocation workload (1000 matmuls) exercises the full accumulate path
-    # (per-RISC L1 accumulation, BRISC aggregation, near-full flush + DRAM push) AND the
-    # accumulate<->dispatch-core coexistence: dispatch cores keep the classic
-    # guaranteed-slot path while worker cores accumulate, with no marker mismatch.
+    # 1000-matmul workload exercises the full accumulate path and accumulate<->dispatch-core coexistence (no marker mismatch).
     python -m tracy -p --enable-accumulate-profiling --profile-dispatch-cores -m pytest tests/ttnn/tracy/test_dispatch_profiler.py::test_with_ops -k WORKER
     python $PROFILER_TEST_SCRIPTS_ROOT/verify_accumulate_profiler.py
 }

--- a/tests/scripts/single_card/run_single_card_profiler_tests.sh
+++ b/tests/scripts/single_card/run_single_card_profiler_tests.sh
@@ -70,6 +70,16 @@ run_perf_op_report_test() {
     TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/tracy/test_perf_op_report.py --noconftest -k "not TestOpSupportCount"
 }
 
+run_accumulate_profiler_test() {
+    remove_default_log_locations
+    echo "Sanity test: L1-accumulate device profiling runs, accumulates worker zones, and skips the perf report"
+    mkdir -p $PROFILER_ARTIFACTS_DIR
+    # Multi-invocation workload (1000 matmuls) exercises the full accumulate path:
+    # per-RISC L1 accumulation, BRISC aggregation, near-full flush + DRAM push.
+    python -m tracy -p --enable-accumulate-profiling -m pytest tests/ttnn/tracy/test_dispatch_profiler.py::test_with_ops -k WORKER
+    python $PROFILER_TEST_SCRIPTS_ROOT/verify_accumulate_profiler.py
+}
+
 run_realtime_profiler_test() {
     remove_default_log_locations
     # Consolidated real-time profiler test suite: callback smoke test, short-zone
@@ -89,6 +99,7 @@ run_profiling_test() {
     run_device_profiler_test
     run_perf_op_report_test
     run_realtime_profiler_test
+    run_accumulate_profiler_test
 }
 
 main() {

--- a/tests/scripts/single_card/run_single_card_profiler_tests.sh
+++ b/tests/scripts/single_card/run_single_card_profiler_tests.sh
@@ -72,11 +72,13 @@ run_perf_op_report_test() {
 
 run_accumulate_profiler_test() {
     remove_default_log_locations
-    echo "Sanity test: L1-accumulate device profiling runs, accumulates worker zones, and skips the perf report"
+    echo "Sanity test: L1-accumulate device profiling coexists with dispatch-core profiling, accumulates worker zones, and skips the perf report"
     mkdir -p $PROFILER_ARTIFACTS_DIR
-    # Multi-invocation workload (1000 matmuls) exercises the full accumulate path:
-    # per-RISC L1 accumulation, BRISC aggregation, near-full flush + DRAM push.
-    python -m tracy -p --enable-accumulate-profiling -m pytest tests/ttnn/tracy/test_dispatch_profiler.py::test_with_ops -k WORKER
+    # Multi-invocation workload (1000 matmuls) exercises the full accumulate path
+    # (per-RISC L1 accumulation, BRISC aggregation, near-full flush + DRAM push) AND the
+    # accumulate<->dispatch-core coexistence: dispatch cores keep the classic
+    # guaranteed-slot path while worker cores accumulate, with no marker mismatch.
+    python -m tracy -p --enable-accumulate-profiling --profile-dispatch-cores -m pytest tests/ttnn/tracy/test_dispatch_profiler.py::test_with_ops -k WORKER
     python $PROFILER_TEST_SCRIPTS_ROOT/verify_accumulate_profiler.py
 }
 

--- a/tests/tt_metal/tools/profiler/verify_accumulate_profiler.py
+++ b/tests/tt_metal/tools/profiler/verify_accumulate_profiler.py
@@ -3,21 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Sanity check for L1-accumulate device profiling alongside dispatch-core profiling.
-
-Run AFTER a multi-invocation workload has executed under
-``python -m tracy -p --enable-accumulate-profiling --profile-dispatch-cores ...``.
-Verifies that:
-  1. the device log was produced and contains worker-core zones,
-  2. zones from many invocations were accumulated (not just one program's worth),
-  3. the accumulate flush path ran (PROFILER-DRAM-PUSH zones present),
-  4. dispatch-core profiling coexisted (CQ-DISPATCH zones present; the run completing at
-     all means no start/end marker mismatch between the accumulating workers and the
-     classic-path dispatch cores),
-  5. the per-op perf report was skipped (meaningless without per-op IDs in accumulate).
-
-Exits non-zero with a clear message on any failure.
-"""
+"""Sanity check that L1-accumulate device profiling accumulates worker zones, runs the DRAM-push flush, coexists with dispatch-core profiling, and skips the per-op perf report."""
 
 import sys
 from pathlib import Path
@@ -28,9 +14,7 @@ from tracy.common import (
     PROFILER_CPP_DEVICE_PERF_REPORT,
 )
 
-# Single uninstrumented program across a worker grid produces at most a few thousand
-# marker rows; accumulating ~1000 invocations produces far more. Use a lower bound well
-# above one program but well below what accumulation yields.
+# Lower bound well above one program's marker rows but below what ~1000 accumulated invocations yield.
 MIN_ACCUMULATED_WORKER_ROWS = 20000
 
 

--- a/tests/tt_metal/tools/profiler/verify_accumulate_profiler.py
+++ b/tests/tt_metal/tools/profiler/verify_accumulate_profiler.py
@@ -3,14 +3,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Sanity check for L1-accumulate device profiling.
+"""Sanity check for L1-accumulate device profiling alongside dispatch-core profiling.
 
 Run AFTER a multi-invocation workload has executed under
-``python -m tracy -p --enable-accumulate-profiling ...``. Verifies that:
+``python -m tracy -p --enable-accumulate-profiling --profile-dispatch-cores ...``.
+Verifies that:
   1. the device log was produced and contains worker-core zones,
   2. zones from many invocations were accumulated (not just one program's worth),
   3. the accumulate flush path ran (PROFILER-DRAM-PUSH zones present),
-  4. the per-op perf report was skipped (meaningless without per-op IDs in accumulate).
+  4. dispatch-core profiling coexisted (CQ-DISPATCH zones present; the run completing at
+     all means no start/end marker mismatch between the accumulating workers and the
+     classic-path dispatch cores),
+  5. the per-op perf report was skipped (meaningless without per-op IDs in accumulate).
 
 Exits non-zero with a clear message on any failure.
 """
@@ -47,13 +51,19 @@ def main():
     if "PROFILER-DRAM-PUSH" not in text:
         sys.exit("FAIL: no PROFILER-DRAM-PUSH zone in device log -- accumulate flush path did not run")
 
+    if "CQ-DISPATCH" not in text:
+        sys.exit(
+            "FAIL: no CQ-DISPATCH zone in device log -- dispatch-core profiling did not run alongside "
+            "accumulate (coexistence broken or --profile-dispatch-cores not honored)"
+        )
+
     perf_report = Path(PROFILER_LOGS_DIR) / PROFILER_CPP_DEVICE_PERF_REPORT
     if perf_report.exists():
         sys.exit(f"FAIL: per-op perf report must be skipped in accumulate mode but exists: {perf_report}")
 
     print(
         f"PASS: accumulate sanity OK -- {len(worker_rows)} accumulated worker rows, "
-        f"PROFILER-DRAM-PUSH present, perf report correctly skipped"
+        f"PROFILER-DRAM-PUSH present, CQ-DISPATCH present (dispatch coexistence), perf report correctly skipped"
     )
 
 

--- a/tests/tt_metal/tools/profiler/verify_accumulate_profiler.py
+++ b/tests/tt_metal/tools/profiler/verify_accumulate_profiler.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sanity check for L1-accumulate device profiling.
+
+Run AFTER a multi-invocation workload has executed under
+``python -m tracy -p --enable-accumulate-profiling ...``. Verifies that:
+  1. the device log was produced and contains worker-core zones,
+  2. zones from many invocations were accumulated (not just one program's worth),
+  3. the accumulate flush path ran (PROFILER-DRAM-PUSH zones present),
+  4. the per-op perf report was skipped (meaningless without per-op IDs in accumulate).
+
+Exits non-zero with a clear message on any failure.
+"""
+
+import sys
+from pathlib import Path
+
+from tracy.common import (
+    PROFILER_LOGS_DIR,
+    PROFILER_DEVICE_SIDE_LOG,
+    PROFILER_CPP_DEVICE_PERF_REPORT,
+)
+
+# Single uninstrumented program across a worker grid produces at most a few thousand
+# marker rows; accumulating ~1000 invocations produces far more. Use a lower bound well
+# above one program but well below what accumulation yields.
+MIN_ACCUMULATED_WORKER_ROWS = 20000
+
+
+def main():
+    device_log = Path(PROFILER_LOGS_DIR) / PROFILER_DEVICE_SIDE_LOG
+    if not device_log.exists():
+        sys.exit(f"FAIL: device log was not produced: {device_log}")
+
+    text = device_log.read_text()
+    worker_rows = [line for line in text.splitlines() if ("BRISC" in line or "NCRISC" in line or "TRISC" in line)]
+
+    if len(worker_rows) < MIN_ACCUMULATED_WORKER_ROWS:
+        sys.exit(
+            f"FAIL: expected accumulated worker zones (>= {MIN_ACCUMULATED_WORKER_ROWS} rows), "
+            f"got {len(worker_rows)} -- accumulation did not occur"
+        )
+
+    if "PROFILER-DRAM-PUSH" not in text:
+        sys.exit("FAIL: no PROFILER-DRAM-PUSH zone in device log -- accumulate flush path did not run")
+
+    perf_report = Path(PROFILER_LOGS_DIR) / PROFILER_CPP_DEVICE_PERF_REPORT
+    if perf_report.exists():
+        sys.exit(f"FAIL: per-op perf report must be skipped in accumulate mode but exists: {perf_report}")
+
+    print(
+        f"PASS: accumulate sanity OK -- {len(worker_rows)} accumulated worker rows, "
+        f"PROFILER-DRAM-PUSH present, perf report correctly skipped"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -190,6 +190,15 @@ def main():
     (options, args) = parser.parse_args()
     sys.argv[:] = args
 
+    # Accumulate mode interleaves zones from many program invocations and does not store
+    # per-program op IDs, so an ops perf report cannot be attributed and would be
+    # meaningless. Disallow -r together with --enable-accumulate-profiling.
+    if options.report and options.do_accumulate:
+        parser.error(
+            "-r (ops report) cannot be used with --enable-accumulate-profiling: "
+            "accumulate mode does not store per-op IDs, so no ops report can be generated"
+        )
+
     outputFolderEnvStr = "TT_METAL_PROFILER_DIR"
     outputFolder = PROFILER_ARTIFACTS_DIR
     if options.output_folder:

--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -190,9 +190,7 @@ def main():
     (options, args) = parser.parse_args()
     sys.argv[:] = args
 
-    # Accumulate mode interleaves zones from many program invocations and does not store
-    # per-program op IDs, so an ops perf report cannot be attributed and would be
-    # meaningless. Disallow -r together with --enable-accumulate-profiling.
+    # Accumulate mode stores no per-op IDs, so an ops report is meaningless: disallow -r with --enable-accumulate-profiling.
     if options.report and options.do_accumulate:
         parser.error(
             "-r (ops report) cannot be used with --enable-accumulate-profiling: "

--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -89,6 +89,13 @@ def main():
         default=False,
     )
     parser.add_option(
+        "--enable-accumulate-profiling",
+        dest="do_accumulate",
+        action="store_true",
+        help="Accumulate multiple kernel invocations in the L1 profiler buffer and only push to DRAM when full (worker cores only)",
+        default=False,
+    )
+    parser.add_option(
         "--no-runtime-analysis",
         dest="no_runtime_analysis",
         action="store_true",
@@ -228,6 +235,9 @@ def main():
 
     if options.do_sum:
         os.environ["TT_METAL_PROFILER_SUM"] = "1"
+
+    if options.do_accumulate:
+        os.environ["TT_METAL_PROFILER_ACCUMULATE"] = "1"
 
     if options.mid_run_device_data:
         os.environ["TT_METAL_PROFILER_MID_RUN_DUMP"] = "1"

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -64,9 +64,7 @@ namespace {
 // between finish-path sync checks, per physical chip. Matches the finish-path throttle.
 constexpr auto kRtProfilerMinSyncInterval = std::chrono::seconds(60);
 
-// Last time we completed a full init sync (run_sync success) for a chip, process-wide
-// (across MeshDevice open/close). Used to avoid repeating ~0.5s+ run_sync on every mesh
-// open when the same host chips are frequently reconstructed.
+// Last full init sync per chip, process-wide, to avoid repeating ~0.5s run_sync on every mesh open.
 std::mutex g_rt_profiler_init_sync_mu;
 std::unordered_map<uint32_t, std::chrono::steady_clock::time_point> g_rt_profiler_last_init_sync_by_chip;
 
@@ -81,9 +79,8 @@ struct RealtimeProfilerRuntimeSizes {
     static constexpr uint32_t core_l1_size = sizeof(RealtimeProfilerCoreL1);
 };
 
-// Compute the RT-profiler tensix L1 carve-out addresses for a given RealtimeProfilerCoreL1
-// base, anchored past dispatch_mem_map's UNRESERVED so the layout sits outside the
-// user-space allocator.
+// Compute the RT-profiler L1 carve-out addresses from a base anchored past UNRESERVED (outside the user-space
+// allocator).
 inline RealtimeProfilerCoreL1Addrs compute_rt_profiler_core_l1_addrs(uint32_t base) {
     return {
         .base = base,
@@ -98,26 +95,10 @@ struct RealtimeProfilerEligibility {
     CoreCoord core;  // Only meaningful when enabled == true.
 };
 
-// Consolidated eligibility check; logs the reason for disabling and returns
-// {enabled=false} on failure.
-//
-// Evaluates against the device's owning context (passed in as `context_id`) rather than
-// bare MetalContext::instance(): the latter would route through the inline non-default
-// fallback in instance() and pick whichever context happens to populate the global
-// lookup first. In silicon-first coexistence (#38445), that fallback returns the silicon
-// DEFAULT_CONTEXT_ID even when `device` is a mock device, falsely enabling the profiler
-// on mock and SEGV'ing in LaunchProgram. See #39849.
-//
-// Checks (in order):
-//   0. Target is not mock or emulated (extends #43968's Mock-only short-circuit to also
-//      cover Emule; D2HSocket requires a real PCIe hugepage in either case).
-//   1. Device is MMIO-capable (D2H sockets need a PCIe-connected sender core).
-//   2. D2H socket memory-allocation path is supported (64-bit PCIe addressing requires IOMMU).
-//   3. Fabric tensix datamover (MUX / UDM) is disabled (it competes for the same dispatch pool).
-//   4. A tensix core was reserved for the RT profiler at dispatch_core_manager construction.
-//   5. Reserved coordinate lives inside the logical TENSIX grid.
-//   6. Kernels are not nullified (DEBUG_NULL_KERNELS / TT_METAL_NULL_KERNELS).
-//   7. Reserved profiler core's L1 bank fits the ring + socket-config layout.
+// Consolidated eligibility check; logs the disable reason. Evaluates against the device's owning context_id (not bare
+// instance()) so a mock device isn't falsely enabled via the silicon DEFAULT_CONTEXT_ID fallback (#38445/#39849).
+// Checks: not mock/emulated, MMIO-capable, IOMMU if 64-bit PCIe, fabric tensix datamover off, a tensix reserved and
+// in-grid, kernels not nullified, L1 bank fits the layout.
 RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* device, ContextId context_id) {
     auto device_id = device->id();
     auto& metal = MetalContext::instance(context_id);
@@ -125,11 +106,7 @@ RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* devi
     const auto& cluster = metal.get_cluster();
     auto& dispatch_core_manager = metal.get_dispatch_core_manager();
 
-    // Subsumes the Mock-only short-circuit added in #43968: is_mock_or_emulated() also
-    // catches Emule, and is the canonical accessor used throughout metal_context.cpp /
-    // device.cpp. D2HSocket::init_host_buffer_hugepage dereferences a real PCIe hugepage
-    // and faults on either target, so gate here before any per-device profiler state is
-    // constructed.
+    // Gate mock/emulated targets: D2HSocket::init_host_buffer_hugepage dereferences a real PCIe hugepage absent there.
     if (cluster.is_mock_or_emulated()) {
         log_debug(
             tt::LogMetal,
@@ -139,13 +116,8 @@ RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* devi
         return {};
     }
 
-    // ttsim: the simulator's D2H socket exists but its device kernels run many orders of
-    // magnitude slower than real silicon, so the 2 s WriteToDeviceL1/sync poll deadline
-    // in run_sync() always trips before the profiler core can respond. That burns ~30 s
-    // per chip during MeshDevice bring-up, and on WH (where the 64-bit-PCIe gate below
-    // does NOT fire) it deadlocks downstream waiters that depend on first_unthrottled
-    // finish_sync. Skip the profiler entirely on Simulator targets; performance traces
-    // are not interesting on the sim anyway.
+    // Skip Simulator: ttsim kernels are too slow to meet run_sync's 2s poll deadline, burning ~30s/chip and deadlocking
+    // finish_sync waiters on WH.
     if (cluster.get_target_device_type() == tt::TargetDevice::Simulator) {
         log_debug(
             tt::LogMetal,
@@ -252,9 +224,8 @@ RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* devi
     return {.enabled = true, .core = core};
 }
 
-// Host clock wrapper for the RT profiler sync handshake. Tracy stubs TracyGetCpuTime() /
-// TracyGetTimerMul() to 0 when disabled, which would write sync_host_timestamp = 0 to L1
-// and stall the device handshake. Fall back to steady_clock in that case.
+// Host clock for the sync handshake; falls back to steady_clock since Tracy stubs TracyGetCpuTime to 0 when disabled
+// (which would stall the device).
 inline int64_t rt_profiler_host_ticks() {
 #ifdef TRACY_ENABLE
     return TracyGetCpuTime();
@@ -337,15 +308,13 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
     // HAL offsets are the same for all devices (same arch).
     const auto& hal = MetalContext::instance(context_id_).hal();
     const auto& factory = hal.get_realtime_profiler_msgs_factory(HalProgrammableCoreType::TENSIX);
-    // realtime_profiler_msg_t lives in a dispatch-core-local L1 region assigned by
-    // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG (only reachable on dispatch cores
-    // and the reserved RT-profiler tensix).
+    // realtime_profiler_msg_t lives in the REALTIME_PROFILER_MSG dispatch-core-local L1 region (reachable on dispatch
+    // cores and the reserved RT tensix).
     const auto& dispatch_mem_map = MetalContext::instance(context_id_).dispatch_mem_map();
     const uint32_t realtime_profiler_base_addr =
         dispatch_mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG);
-    // RealtimeProfilerCoreL1 (ring + D2H socket sender config) sits past the dispatch
-    // carve-outs on the reserved profiler tensix; the core is excluded from the L1 bank
-    // table so the user-space allocator can never land here.
+    // RealtimeProfilerCoreL1 (ring + D2H sender config) sits past the dispatch carve-outs; the core is off the L1 bank
+    // table so the allocator never lands here.
     const uint32_t rt_profiler_core_l1_base =
         dispatch_mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
     const auto rt_profiler_core_l1_addrs = compute_rt_profiler_core_l1_addrs(rt_profiler_core_l1_base);
@@ -399,8 +368,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
         dev_state.chip_id = device_id;
         dev_state.mesh_coord = coord;
         dev_state.realtime_profiler_core = realtime_profiler_core;
-        // Single base anchored past dispatch_mem_map's UNRESERVED, with all sub-addresses
-        // derived via offsetof — bypasses the user-space allocator entirely.
+        // Single base past UNRESERVED, sub-addresses via offsetof, bypassing the allocator.
         dev_state.core_l1 = rt_profiler_core_l1_addrs;
 
         auto sender_core = MeshCoreCoord{coord, realtime_profiler_core};
@@ -411,14 +379,11 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             device_id,
             mesh_device->id());
 
-        // Defensive: the eligibility gate above filters known-bad configurations, but D2H
-        // socket construction (host pinning / hugepage / UMD interaction) has been
-        // historically fragile, so we catch and skip this device on failure rather than
+        // D2H socket construction (host pinning / hugepage / UMD) is fragile, so catch and skip this device rather than
         // abort the run.
         try {
-            // Pass the L1 sender-config address from the dispatch carve-out so D2HSocket
-            // does not allocate via MeshBuffer::create on a reserved dispatch core (which
-            // would crash get_buffer_pages on cores not in the L1 bank table).
+            // Pass the carve-out L1 sender-config address so D2HSocket doesn't MeshBuffer::create on a core absent from
+            // the L1 bank table.
             dev_state.socket = std::make_unique<D2HSocket>(
                 mesh_device,
                 sender_core,
@@ -492,9 +457,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 dispatch_s_core.y);
         }
 
-        // Ring buffer (BRISC->NCRISC handoff) sits at a fixed offset inside the carve-out;
-        // not allocated via Buffer::create because the profiler core is excluded from the
-        // L1 bank table.
+        // Ring buffer (BRISC->NCRISC handoff) at a fixed carve-out offset; not Buffer::create'd since the core is off
+        // the L1 bank table.
         const uint32_t ring_buffer_addr = dev_state.core_l1.ring_buffer;
 
         // Get PCIe core NOC-0 coordinates for WH (NCRISC kernel translates to NOC 1).
@@ -524,12 +488,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 device, realtime_profiler_core, ring_buffer_addr, zero_header, CoreType::WORKER);
         }
 
-        // Zero the realtime_profiler_msg_t region before launching the kernels — L1 is not
-        // guaranteed zero between runs and stale values misbehave at BRISC/NCRISC boot:
-        //   * config_buffer_addr != 0  -> NCRISC reads garbage socket config.
-        //   * sync_request != 0        -> BRISC enters sync before the host is ready.
-        //   * sync_host_timestamp != 0 -> phantom sync marker pushed on first boot.
-        //   * realtime_profiler_state / program_id_fifo_{start,end} corrupt state machine.
+        // Zero realtime_profiler_msg_t before launch: stale L1 values misbehave at BRISC/NCRISC boot (garbage socket
+        // config, premature sync, phantom marker, corrupt state machine).
         {
             const uint32_t profiler_msg_size = factory.size_of<realtime_profiler_msgs::realtime_profiler_msg_t>();
             const uint32_t profiler_msg_words = profiler_msg_size / sizeof(uint32_t);
@@ -538,9 +498,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 device, realtime_profiler_core, realtime_profiler_base_addr, zero_msg, CoreType::WORKER);
         }
 
-        // Compile and launch real-time profiler kernels (BRISC reader + NCRISC pusher).
-        // The Program is owned by dev_state so it (and its kernel metadata) outlives this
-        // scope; otherwise tt-inspector loses track of the running RT-profiler kernels.
+        // Compile and launch RT-profiler kernels (BRISC reader + NCRISC pusher); Program owned by dev_state so its
+        // kernel metadata outlives this scope for tt-inspector.
         {
             dev_state.realtime_profiler_program = std::make_unique<Program>();
             auto& realtime_profiler_program = *dev_state.realtime_profiler_program;
@@ -633,9 +592,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
     std::vector<size_t> init_run_sync_indices;
     init_run_sync_indices.reserve(devices_.size());
 
-    // Run our own host-device sync; the device profiler's SyncInfo masks the high word to
-    // 12 bits and would shift RT zones by hours in Tracy. Skip full calibration for chips
-    // that were init-synced recently (same window as finish-path trigger_sync_check).
+    // Run our own host-device sync (device profiler's SyncInfo masks the high word to 12 bits, shifting RT zones by
+    // hours); skip recently init-synced chips.
     for (size_t di = 0; di < devices_.size(); ++di) {
         auto& dev_state = devices_[di];
         bool throttle_skip = false;
@@ -707,9 +665,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             dev_state.realtime_profiler_core.str());
     }
 
-    // Emit sync verification markers: take one independent device measurement per device
-    // and push paired host + device events. In Tracy, the horizontal distance between the
-    // host "SYNC_CHECK" zone and the device "SYNC_CHECK" zone is the sync error.
+    // Emit paired host+device SYNC_CHECK markers; their horizontal distance in Tracy is the sync error.
     std::vector<size_t> init_sync_check_indices;
     init_sync_check_indices.reserve(devices_.size());
     for (size_t di = 0; di < devices_.size(); ++di) {
@@ -729,9 +685,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
-        // Same anchor convention as trigger_sync_check: capture host TSC, emit Tracy
-        // message, then PCIe write; CalibrateDevice must run before PushSyncCheckMarker
-        // or extrapolation skew can exceed the ±10µs test bound.
+        // Capture host TSC, emit Tracy message, then PCIe write; CalibrateDevice must precede PushSyncCheckMarker or
+        // skew exceeds the ±10µs test bound.
         int64_t sync_check_host_anchor = rt_profiler_host_ticks();
         uint32_t host_time_id = 0x5C5C5C5C;
         std::vector<uint32_t> host_time_data = {host_time_id};
@@ -944,8 +899,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
 RealtimeProfilerManager::~RealtimeProfilerManager() { shutdown(); }
 
 void RealtimeProfilerManager::shutdown() {
-    // Re-write ring_buffer->terminate as a safety net (dispatch_s already set it via the
-    // profiler core's TERMINATE), then give the push kernel time to deliver the last PCIe page.
+    // Re-write ring_buffer->terminate as a safety net, then let the push kernel deliver the last PCIe page.
     for (auto& dev_state : devices_) {
         if (dev_state.core_l1.ring_buffer != 0 && dev_state.device) {
             const uint32_t terminate_addr = dev_state.core_l1.ring_buffer + offsetof(RtProfilerRingBuffer, terminate);
@@ -994,10 +948,8 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
     };
     std::vector<SyncSample> samples;
 
-    // Discard pre-existing pages before entering sync mode without reading the data
-    // region (its PCIe-mapped bytes can be undefined on the first sync of a fresh
-    // MeshDevice). discard_pending_pages() rebases bytes_acked -> bytes_sent and
-    // notifies the device.
+    // Discard pre-existing pages before sync (their PCIe-mapped bytes can be undefined on a fresh MeshDevice);
+    // discard_pending_pages rebases bytes_acked and notifies the device.
     constexpr uint32_t kSyncPageWords = 64 / sizeof(uint32_t);
     uint32_t stale_pages = dev_state.socket->discard_pending_pages();
     if (stale_pages > 0) {
@@ -1097,9 +1049,8 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
         sync_req_data,
         CoreType::WORKER);
 
-    // Centered linear regression for slope = frequency * tracy_ratio (device cycles per
-    // TSC tick). Centering on the mean avoids catastrophic cancellation in the normal
-    // equations at the ~10^25 operand magnitudes seen for absolute timestamps.
+    // Mean-centered linear regression for slope (device cycles per TSC tick); centering avoids catastrophic
+    // cancellation at absolute-timestamp magnitudes.
     if (samples.size() >= 2) {
         const double n = static_cast<double>(samples.size());
         const double tracy_ratio = rt_profiler_ns_per_tick();
@@ -1145,8 +1096,7 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
             samples.size(),
             dev_state.sync_frequency,
             dev_state.first_timestamp);
-        // The device (Tracy) profiler's sync anchor is published in lockstep with the rt
-        // context's own calibration (AddDevice / CalibrateDevice sites), not here -- see
+        // Device-profiler sync anchor is published in lockstep with the rt calibration sites, not here -- see
         // publish_device_profiler_sync_anchor().
     } else {
         dev_state.sync_frequency = cluster.get_device_aiclk(dev_state.chip_id) / 1000.0;
@@ -1161,19 +1111,13 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
 
 void RealtimeProfilerManager::publish_device_profiler_sync_anchor(
     uint32_t chip_id, double host_anchor, double device_anchor, double frequency, const std::string& core_label) {
-    // Accumulate-only for now: in accumulate mode the device profiler skips its own
-    // syncDeviceHost handshake, so it borrows the rt profiler's host<->device fit. In
-    // non-accumulate mode the device profiler runs its own sync, so don't publish --
-    // leave realtime_sync_line unset and let updateTracyContext use that sync instead.
+    // Accumulate-only: there the device profiler skips its own sync and borrows the rt fit; otherwise it runs its own
+    // sync so leave realtime_sync_line unset.
     if (!MetalContext::instance(context_id_).rtoptions().get_profiler_accumulate()) {
         return;
     }
-    // Mirror the rt context's calibration point onto the device (Tracy) profiler so its
-    // worker zones host-align to the same line as the rt records. We pass the raw anchor
-    // (host TSC, device cycle, frequency) -- NOT a finished SyncInfo -- because the device
-    // profiler keeps its OWN worker-marker device anchor and only adopts our host<->device
-    // mapping (updateTracyContext does the conversion). Worker and rt/dispatch cores share
-    // one device wall clock, so the anchor is valid for worker-marker cycles.
+    // Pass the raw anchor (host TSC, device cycle, frequency), not a SyncInfo: the device profiler keeps its own worker
+    // anchor and only adopts our host<->device mapping. Valid because all cores share one wall clock.
     auto& psm = MetalContext::instance(context_id_).profiler_state_manager();
     if (!psm || !psm->device_profiler_map.contains(chip_id)) {
         return;
@@ -1217,9 +1161,8 @@ void RealtimeProfilerManager::trigger_sync_check() {
         return;
     }
 
-    // 1. Pause the receiver thread for exclusive socket access. This breaks a potential
-    //    GIL deadlock: the receiver may be waiting on the GIL for a Python callback while
-    //    the caller (holding the GIL) blocks here. Skip the check if pause times out.
+    // 1. Pause the receiver for exclusive socket access (breaks a GIL deadlock vs Python callbacks); skip if pause
+    // times out.
     pause_requested_.store(true, std::memory_order_release);
     {
         auto pause_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kPauseTimeoutMs);
@@ -1234,8 +1177,7 @@ void RealtimeProfilerManager::trigger_sync_check() {
         }
     }
 
-    // Only devices in device_indices_to_sync enter sync mode and emit FINISH_SYNC; others
-    // keep receiving via the receiver thread once it resumes (no device-side sync_request).
+    // Only these devices enter sync mode and emit FINISH_SYNC; others keep receiving once the thread resumes.
     parallel_for_each_device_index(device_indices_to_sync, [&](size_t dev_index) {
         auto& dev_state = devices_[dev_index];
         std::vector<uint32_t> page_buf(kPageWords);

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -53,6 +53,8 @@
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/kernels/realtime_profiler_ring_buffer.hpp"
 #include "tt_metal/impl/dispatch/realtime_profiler_tracy_handler.hpp"
+#include "tt_metal/impl/profiler/profiler.hpp"                // tt::tt_metal::SyncInfo, DeviceProfiler
+#include "tt_metal/impl/profiler/profiler_state_manager.hpp"  // ProfilerStateManager
 
 namespace tt::tt_metal::distributed {
 
@@ -697,6 +699,12 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             dev_state.sync_host_start,
             static_cast<double>(dev_state.first_timestamp),
             dev_state.sync_frequency);
+        publish_device_profiler_sync_anchor(
+            dev_state.chip_id,
+            static_cast<double>(dev_state.sync_host_start),
+            static_cast<double>(dev_state.first_timestamp),
+            dev_state.sync_frequency,
+            dev_state.realtime_profiler_core.str());
     }
 
     // Emit sync verification markers: take one independent device measurement per device
@@ -762,6 +770,12 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             tracy_handler_->CalibrateDevice(
                 dev_state.chip_id, sync_check_host_anchor, device_time, dev_state.sync_frequency);
             tracy_handler_->PushSyncCheckMarker(dev_state.chip_id, device_time, dev_state.sync_frequency);
+            publish_device_profiler_sync_anchor(
+                dev_state.chip_id,
+                static_cast<double>(sync_check_host_anchor),
+                static_cast<double>(device_time),
+                dev_state.sync_frequency,
+                dev_state.realtime_profiler_core.str());
 
             dev_state.last_finish_sync_at = std::chrono::steady_clock::now();
 
@@ -811,6 +825,12 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 tracy_handler_->CalibrateDevice(
                     dev_state.chip_id, dev_state.sync_host_time_before, device_time, dev_state.sync_frequency);
                 tracy_handler_->PushSyncCheckMarker(dev_state.chip_id, device_time, dev_state.sync_frequency);
+                publish_device_profiler_sync_anchor(
+                    dev_state.chip_id,
+                    static_cast<double>(dev_state.sync_host_time_before),
+                    static_cast<double>(device_time),
+                    dev_state.sync_frequency,
+                    dev_state.realtime_profiler_core.str());
                 pages_received++;
                 dev_state.sync_response_received.store(true);
                 return true;
@@ -1125,6 +1145,9 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
             samples.size(),
             dev_state.sync_frequency,
             dev_state.first_timestamp);
+        // The device (Tracy) profiler's sync anchor is published in lockstep with the rt
+        // context's own calibration (AddDevice / CalibrateDevice sites), not here -- see
+        // publish_device_profiler_sync_anchor().
     } else {
         dev_state.sync_frequency = cluster.get_device_aiclk(dev_state.chip_id) / 1000.0;
         dev_state.first_timestamp = 0;
@@ -1134,6 +1157,32 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
             "[Real-time profiler] Device {} sync failed - not enough samples, using default frequency",
             dev_state.chip_id);
     }
+}
+
+void RealtimeProfilerManager::publish_device_profiler_sync_anchor(
+    uint32_t chip_id, double host_anchor, double device_anchor, double frequency, const std::string& core_label) {
+    // Mirror the rt context's calibration point onto the device (Tracy) profiler so its
+    // worker zones host-align to the same line as the rt records. We pass the raw anchor
+    // (host TSC, device cycle, frequency) -- NOT a finished SyncInfo -- because the device
+    // profiler keeps its OWN worker-marker device anchor and only adopts our host<->device
+    // mapping (updateTracyContext does the conversion). Worker and rt/dispatch cores share
+    // one device wall clock, so the anchor is valid for worker-marker cycles.
+    auto& psm = MetalContext::instance(context_id_).profiler_state_manager();
+    if (!psm || !psm->device_profiler_map.contains(chip_id)) {
+        return;
+    }
+    std::scoped_lock map_lock(psm->device_profiler_map_mutex);
+    psm->device_profiler_map.at(chip_id).realtime_sync_line =
+        tt::tt_metal::DeviceProfiler::RealtimeSyncLine{host_anchor, device_anchor, frequency};
+    log_debug(
+        tt::LogMetal,
+        "[Real-time profiler] Device-profiler clock anchor for device {} core {}: "
+        "host_anchor={:.0f}, device_anchor={:.0f}, freq={:.6f} GHz",
+        chip_id,
+        core_label,
+        host_anchor,
+        device_anchor,
+        frequency);
 }
 
 void RealtimeProfilerManager::trigger_sync_check() {
@@ -1254,6 +1303,12 @@ void RealtimeProfilerManager::trigger_sync_check() {
                 tracy_handler_->CalibrateDevice(
                     dev_state.chip_id, dev_state.sync_host_time_before, device_time, dev_state.sync_frequency);
                 tracy_handler_->PushSyncCheckMarker(dev_state.chip_id, device_time, dev_state.sync_frequency);
+                publish_device_profiler_sync_anchor(
+                    dev_state.chip_id,
+                    static_cast<double>(dev_state.sync_host_time_before),
+                    static_cast<double>(device_time),
+                    dev_state.sync_frequency,
+                    dev_state.realtime_profiler_core.str());
                 dev_state.last_finish_sync_at = std::chrono::steady_clock::now();
                 dev_state.pending_first_unthrottled_finish_sync = false;
                 got_sync = true;

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -1161,6 +1161,13 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
 
 void RealtimeProfilerManager::publish_device_profiler_sync_anchor(
     uint32_t chip_id, double host_anchor, double device_anchor, double frequency, const std::string& core_label) {
+    // Accumulate-only for now: in accumulate mode the device profiler skips its own
+    // syncDeviceHost handshake, so it borrows the rt profiler's host<->device fit. In
+    // non-accumulate mode the device profiler runs its own sync, so don't publish --
+    // leave realtime_sync_line unset and let updateTracyContext use that sync instead.
+    if (!MetalContext::instance(context_id_).rtoptions().get_profiler_accumulate()) {
+        return;
+    }
     // Mirror the rt context's calibration point onto the device (Tracy) profiler so its
     // worker zones host-align to the same line as the rt records. We pass the raw anchor
     // (host TSC, device cycle, frequency) -- NOT a finished SyncInfo -- because the device

--- a/tt_metal/distributed/realtime_profiler_manager.hpp
+++ b/tt_metal/distributed/realtime_profiler_manager.hpp
@@ -119,6 +119,12 @@ private:
 
     void run_sync(DeviceState& dev_state, uint32_t num_samples);
 
+    // Mirror the rt-profiler Tracy context calibration onto the device (Tracy) profiler's
+    // sync anchor, so its worker zones host-align to the same line as the rt records.
+    // Called wherever we (re)calibrate the rt context (AddDevice / CalibrateDevice).
+    void publish_device_profiler_sync_anchor(
+        uint32_t chip_id, double host_anchor, double device_anchor, double frequency, const std::string& core_label);
+
     // ContextId of the owning MeshDevice, captured in the constructor. All MetalContext
     // accesses inside this manager must go through MetalContext::instance(context_id_)
     // so a non-default (mock / coexistence) context routes through its own HAL, cluster

--- a/tt_metal/distributed/realtime_profiler_manager.hpp
+++ b/tt_metal/distributed/realtime_profiler_manager.hpp
@@ -29,35 +29,16 @@ namespace distributed {
 class D2HSocket;
 class MeshDevice;
 
-// L1 carve-out addresses for the reserved RT-profiler tensix core. The ring buffer
-// (BRISC->NCRISC handoff) and the D2H socket sender config sit in a single carve-out
-// anchored past dispatch_mem_map's UNRESERVED, bypassing the user-space allocator.
+// L1 carve-out addresses (ring buffer + D2H socket config) for the reserved RT-profiler tensix, anchored past
+// UNRESERVED to bypass the user-space allocator.
 struct RealtimeProfilerCoreL1Addrs {
     uint32_t base = 0;
     uint32_t ring_buffer = 0;
     uint32_t socket_config = 0;
 };
 
-// Owns the full RT-profiler subsystem for a single MeshDevice: per-device state, the
-// background receiver thread, the host-side Tracy handler, and the host-device sync
-// handshake.
-//
-// Lifecycle:
-//   * Constructor runs the eligibility gate, brings up D2H sockets and BRISC/NCRISC
-//     kernels on each eligible device, and starts the receiver thread.
-//   * shutdown() (or destruction) signals receiver termination, joins the thread, and
-//     drops the Tracy handler. Idempotent.
-//   * trigger_sync_check() pauses the receiver, runs a sync handshake only on devices
-//     whose last finish/init sync was at least 60s ago (each device tracked separately),
-//     or on the first finish-path attempt after init (so short runs still get FINISH_SYNC),
-//     then resumes the receiver. Called from the FD command queue's finish path.
-//     Constructor init uses the same interval process-wide per chip_id to throttle full
-//     run_sync + SYNC_CHECK when reopening meshes on the same chips.
-//
-//     Init host-device sync (run_sync + constructor SYNC_CHECK) and finish-path
-//     trigger_sync_check shard work across devices using a small worker pool (up to
-//     hardware_concurrency). ProgramRealtimeProfilerCallbacks invoked from parallel
-//     finish-path workers are serialized — callbacks run outside DataCollector's mutex.
+// Owns the RT-profiler subsystem for one MeshDevice: per-device state, the receiver thread, the Tracy handler, and the
+// host-device sync handshake (sharded across a small worker pool, with a 60s per-chip throttle).
 class RealtimeProfilerManager {
 public:
     explicit RealtimeProfilerManager(const std::shared_ptr<MeshDevice>& mesh_device);
@@ -72,10 +53,8 @@ public:
     // and notifies deactivation. Safe to call multiple times.
     void shutdown();
 
-    // Pauses receiver if at least one device needs a sync, then performs the handshake
-    // only on those devices (others are unchanged). No-op when no devices are active,
-    // the Tracy handler has been released, or every device was synced within the last
-    // 60 seconds (except the first finish-path sync after init, which always runs).
+    // Runs the sync handshake only on devices due for one (last sync >60s ago, or first finish-path sync after init);
+    // pauses the receiver while doing so.
     void trigger_sync_check();
 
     // First active device's D2H socket, or nullptr if no device is active.
@@ -88,9 +67,8 @@ private:
         MeshCoordinate mesh_coord = MeshCoordinate(0);
         CoreCoord realtime_profiler_core;
         std::unique_ptr<D2HSocket> socket;
-        // Owns the BRISC+NCRISC realtime-profiler program so its kernels remain alive for
-        // the lifetime of the manager. If this goes out of scope while the kernels are
-        // still running, downstream tooling (e.g. tt-inspector) loses the kernel metadata.
+        // Owns the BRISC+NCRISC program to keep its kernels (and their metadata for tt-inspector) alive for the
+        // manager's lifetime.
         std::unique_ptr<Program> realtime_profiler_program;
         RealtimeProfilerCoreL1Addrs core_l1;
         uint64_t first_timestamp = 0;
@@ -104,9 +82,8 @@ private:
         // Updated after a successful finish-path or init SYNC_CHECK handshake; used to
         // throttle redundant finish syncs (minimum 60s between attempts per device).
         std::optional<std::chrono::steady_clock::time_point> last_finish_sync_at;
-        // After init, the first finish-path sync bypasses the throttle so short runs still
-        // get a FINISH_SYNC pair even when finish runs within the minimum interval of init.
-        // Cleared after the first successful finish-path handshake for this device.
+        // First finish-path sync bypasses the throttle so short runs still get a FINISH_SYNC pair; cleared after that
+        // handshake.
         bool pending_first_unthrottled_finish_sync = false;
 
         DeviceState();
@@ -119,17 +96,13 @@ private:
 
     void run_sync(DeviceState& dev_state, uint32_t num_samples);
 
-    // Mirror the rt-profiler Tracy context calibration onto the device (Tracy) profiler's
-    // sync anchor, so its worker zones host-align to the same line as the rt records.
-    // Called wherever we (re)calibrate the rt context (AddDevice / CalibrateDevice).
+    // Mirror the rt-profiler Tracy calibration onto the device profiler's sync anchor so worker zones host-align to the
+    // same line as rt records.
     void publish_device_profiler_sync_anchor(
         uint32_t chip_id, double host_anchor, double device_anchor, double frequency, const std::string& core_label);
 
-    // ContextId of the owning MeshDevice, captured in the constructor. All MetalContext
-    // accesses inside this manager must go through MetalContext::instance(context_id_)
-    // so a non-default (mock / coexistence) context routes through its own HAL, cluster
-    // and dispatch_mem_map instead of leaking to the silicon DEFAULT_CONTEXT_ID via the
-    // bare instance() inline fallback. See #38445 / #39849 for the broader migration.
+    // Owning MeshDevice's ContextId; all MetalContext access must go through instance(context_id_) so a non-default
+    // context doesn't leak to silicon DEFAULT_CONTEXT_ID. See #38445 / #39849.
     ContextId context_id_;
     std::vector<DeviceState> devices_;
     std::thread receiver_thread_;

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -9,12 +9,8 @@
 #define PROFILER_OPT_DO_DISPATCH_CORES (1 << 1)
 #define PROFILER_OPT_DO_TRACE_ONLY (1 << 2)
 #define PROFILER_OPT_DO_SUM (1 << 3)
-// Accumulate multiple kernel invocations into the L1 buffer before pushing to
-// DRAM. The "main"/"main child" zones use the growing wIndex (like a normal
-// DeviceZoneScopedN) instead of the fixed guaranteed slots, so successive
-// program iterations append rather than overwrite. The L1 buffer is only
-// flushed to DRAM once it is nearly full; the un-pushed residual is read back
-// directly from L1 (host ProfilerDataBufferSource::DRAM_AND_L1).
+// Accumulate many invocations in L1 (main zones use growing wIndex, not fixed slots), flushing to DRAM only when nearly
+// full; residual read via DRAM_AND_L1.
 #define PROFILER_OPT_DO_ACCUMULATE (1 << 4)
 
 namespace kernel_profiler {
@@ -65,10 +61,8 @@ enum ControlBuffer {
     DROPPED_ZONES,
     PROFILER_DONE,
     TRACE_REPLAY_STATUS,
-    // Per-core runtime flag set by the host: non-zero on dispatch cores. In
-    // accumulate mode the firmware main scope reads this to keep the classic
-    // guaranteed-slot layout + finish on dispatch cores (so their realtime
-    // quick_push feed is not corrupted), while worker cores accumulate.
+    // Host-set flag, non-zero on dispatch cores: in accumulate mode keeps the classic guaranteed-slot layout there so
+    // their quick_push feed isn't corrupted.
     PROFILER_DISPATCH_CORE,
     // Used for device debug dump mode. Needs to come last in the control buffer
     // because we first update the host buffer end index and then the DRAM buffer address

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -65,6 +65,11 @@ enum ControlBuffer {
     DROPPED_ZONES,
     PROFILER_DONE,
     TRACE_REPLAY_STATUS,
+    // Per-core runtime flag set by the host: non-zero on dispatch cores. In
+    // accumulate mode the firmware main scope reads this to keep the classic
+    // guaranteed-slot layout + finish on dispatch cores (so their realtime
+    // quick_push feed is not corrupted), while worker cores accumulate.
+    PROFILER_DISPATCH_CORE,
     // Used for device debug dump mode. Needs to come last in the control buffer
     // because we first update the host buffer end index and then the DRAM buffer address
     DRAM_PROFILER_ADDRESS_BR_ER_0,

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -9,6 +9,13 @@
 #define PROFILER_OPT_DO_DISPATCH_CORES (1 << 1)
 #define PROFILER_OPT_DO_TRACE_ONLY (1 << 2)
 #define PROFILER_OPT_DO_SUM (1 << 3)
+// Accumulate multiple kernel invocations into the L1 buffer before pushing to
+// DRAM. The "main"/"main child" zones use the growing wIndex (like a normal
+// DeviceZoneScopedN) instead of the fixed guaranteed slots, so successive
+// program iterations append rather than overwrite. The L1 buffer is only
+// flushed to DRAM once it is nearly full; the un-pushed residual is read back
+// directly from L1 (host ProfilerDataBufferSource::DRAM_AND_L1).
+#define PROFILER_OPT_DO_ACCUMULATE (1 << 4)
 
 namespace kernel_profiler {
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2711,7 +2711,33 @@ void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& devi
         double device_time = device_sync_info.device_time;
         double frequency = device_sync_info.frequency;
 
-        if (frequency == 0) {
+        if (realtime_sync_line.has_value() && smallest_timestamp != (1lu << 63)) {
+            // Realtime-profiler clock fit is available: anchor this worker context to that
+            // line so its zones align with the rt-profiler records (shared device wall
+            // clock). Keep device_time at the smallest WORKER marker (in-range, correct
+            // clock reference -- do NOT use the rt anchor's dispatch-core cycle here), but
+            // derive cpu_time as the host TSC at which the shared device clock reads that
+            // marker per the fit:
+            //   cpu_time = host_start + (device_time - first_timestamp) / (freq * ratio)
+            // ratio = TracyGetTimerMul(), the same TSC->ns factor the fit was built with.
+            const double ratio = TracyGetTimerMul();
+            device_time = static_cast<double>(smallest_timestamp);
+            cpu_time = realtime_sync_line->host_anchor +
+                       (device_time - realtime_sync_line->device_anchor) / (realtime_sync_line->frequency * ratio);
+            frequency = realtime_sync_line->frequency;
+            device_sync_info = SyncInfo(cpu_time, device_time, frequency);
+            log_debug(
+                tt::LogMetal,
+                "Device {}, core {},{} anchored to realtime-profiler clock fit: smallest_ts={}, "
+                "device_anchor={:.0f}, cpu_time={:.0f}, freq={} GHz",
+                device_id,
+                worker_core.x,
+                worker_core.y,
+                smallest_timestamp,
+                realtime_sync_line->device_anchor,
+                cpu_time,
+                frequency);
+        } else if (frequency == 0) {
             cpu_time = TracyGetCpuTime();
             device_time = smallest_timestamp;
             frequency = device_core_frequency / 1000.0;

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2333,6 +2333,13 @@ void DeviceProfiler::generateAnalysesForDeviceMarkers(
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
+    // Accumulate mode interleaves zones from many program invocations in one L1 buffer
+    // and does not store per-program op IDs, so the markers cannot be attributed to ops.
+    // A per-program perf report would be meaningless, so skip report generation entirely.
+    if (MetalContext::instance(context_id).rtoptions().get_profiler_accumulate()) {
+        return;
+    }
+
     const std::filesystem::path analysis_configs_path =
         std::filesystem::path(MetalContext::instance(context_id).rtoptions().get_root_dir()) /
         "tt_metal/tools/profiler/cpp_device_analyses.json";

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1498,9 +1498,8 @@ void DeviceProfiler::readRiscProfilerResults(
 
     const auto& rtoptions = MetalContext::instance(context_id).rtoptions();
 
-    // This early-out checks HOST_BUFFER_END_INDEX (the DRAM flush count). In trace-only and
-    // accumulate modes the data lives in L1 and may never be flushed to DRAM (HOST_BUFFER_END_INDEX
-    // stays 0), so skipping this guard is required or the L1 residual would never be read.
+    // Skip the HOST_BUFFER_END_INDEX (DRAM flush count) early-out in trace-only/accumulate modes, where data stays in
+    // L1 and the index may never advance.
     if (!rtoptions.get_profiler_trace_only() && !rtoptions.get_profiler_accumulate()) {
         if ((control_buffer[kernel_profiler::HOST_BUFFER_END_INDEX_BR_ER] == 0) &&
             (control_buffer[kernel_profiler::HOST_BUFFER_END_INDEX_NC] == 0)) {
@@ -2333,9 +2332,8 @@ void DeviceProfiler::generateAnalysesForDeviceMarkers(
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    // Accumulate mode interleaves zones from many program invocations in one L1 buffer
-    // and does not store per-program op IDs, so the markers cannot be attributed to ops.
-    // A per-program perf report would be meaningless, so skip report generation entirely.
+    // Accumulate mode lacks per-program op IDs (zones from many invocations are interleaved), so a per-op perf report
+    // is meaningless -- skip it.
     if (MetalContext::instance(context_id).rtoptions().get_profiler_accumulate()) {
         return;
     }
@@ -2692,12 +2690,8 @@ void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& devi
     const ChipId device_id = device_core.first;
     const CoreCoord worker_core = device_core.second;
 
-    // Accumulate mode uses the same device-context calibration fallback as the default profiler
-    // (device_time anchored to the smallest WORKER marker timestamp). Do NOT override with the
-    // realtime profiler's calibration here: its anchor is the dispatch core's raw device cycle,
-    // which is a different clock reference and bit-width than the worker zones' 44-bit marker
-    // timestamps, so feeding it to the worker contexts produced out-of-range sync values and the
-    // timelines failed to render (zones placed off-screen).
+    // Accumulate uses the default calibration (device_time = smallest WORKER marker); don't use the rt anchor's
+    // dispatch-core cycle here -- different clock/bit-width yields out-of-range, off-screen zones.
 
     if (!core_sync_info.contains(worker_core)) {
         const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
@@ -2719,14 +2713,8 @@ void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& devi
         double frequency = device_sync_info.frequency;
 
         if (realtime_sync_line.has_value() && smallest_timestamp != (1lu << 63)) {
-            // Realtime-profiler clock fit is available: anchor this worker context to that
-            // line so its zones align with the rt-profiler records (shared device wall
-            // clock). Keep device_time at the smallest WORKER marker (in-range, correct
-            // clock reference -- do NOT use the rt anchor's dispatch-core cycle here), but
-            // derive cpu_time as the host TSC at which the shared device clock reads that
-            // marker per the fit:
-            //   cpu_time = host_start + (device_time - first_timestamp) / (freq * ratio)
-            // ratio = TracyGetTimerMul(), the same TSC->ns factor the fit was built with.
+            // Anchor to the rt-profiler clock fit: keep device_time = smallest WORKER marker, but derive cpu_time from
+            // the fit (ratio = TracyGetTimerMul, the TSC->ns factor the fit used).
             const double ratio = TracyGetTimerMul();
             device_time = static_cast<double>(smallest_timestamp);
             cpu_time = realtime_sync_line->host_anchor +

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1430,6 +1430,10 @@ void DeviceProfiler::resetControlBuffers(
         core_control_buffer_reset[kernel_profiler::FLAT_ID] = control_buffer[kernel_profiler::FLAT_ID];
         core_control_buffer_reset[kernel_profiler::CORE_COUNT_PER_DRAM] =
             control_buffer[kernel_profiler::CORE_COUNT_PER_DRAM];
+        // Preserve the dispatch-core tag across resets (set once in setControlBuffer);
+        // accumulate mode relies on it to keep dispatch cores on the classic path.
+        core_control_buffer_reset[kernel_profiler::PROFILER_DISPATCH_CORE] =
+            control_buffer[kernel_profiler::PROFILER_DISPATCH_CORE];
         core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_BR_ER_0] = buffer_0_address;
         core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_NC_0] = buffer_0_address;
         core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_T0_0] = buffer_0_address;

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/fmt.hpp>
+#include <optional>
 #include "context/metal_env_accessor.hpp"
 #include "core_coord.hpp"
 #include <common/TracyTTDeviceData.hpp>
@@ -1493,7 +1494,10 @@ void DeviceProfiler::readRiscProfilerResults(
 
     const auto& rtoptions = MetalContext::instance(context_id).rtoptions();
 
-    if (!rtoptions.get_profiler_trace_only()) {
+    // This early-out checks HOST_BUFFER_END_INDEX (the DRAM flush count). In trace-only and
+    // accumulate modes the data lives in L1 and may never be flushed to DRAM (HOST_BUFFER_END_INDEX
+    // stays 0), so skipping this guard is required or the L1 residual would never be read.
+    if (!rtoptions.get_profiler_trace_only() && !rtoptions.get_profiler_accumulate()) {
         if ((control_buffer[kernel_profiler::HOST_BUFFER_END_INDEX_BR_ER] == 0) &&
             (control_buffer[kernel_profiler::HOST_BUFFER_END_INDEX_NC] == 0)) {
             return;
@@ -2676,6 +2680,13 @@ void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& devi
     }
     const ChipId device_id = device_core.first;
     const CoreCoord worker_core = device_core.second;
+
+    // Accumulate mode uses the same device-context calibration fallback as the default profiler
+    // (device_time anchored to the smallest WORKER marker timestamp). Do NOT override with the
+    // realtime profiler's calibration here: its anchor is the dispatch core's raw device cycle,
+    // which is a different clock reference and bit-width than the worker zones' 44-bit marker
+    // timestamps, so feeding it to the worker contexts produced out-of-range sync values and the
+    // timelines failed to render (zones placed off-screen).
 
     if (!core_sync_info.contains(worker_core)) {
         const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -271,6 +271,21 @@ public:
     // Device-core Syncdata
     std::map<CoreCoord, SyncInfo> device_core_sync_info;
 
+    // Optional realtime-profiler clock anchor: host_anchor (TSC), device_anchor (device
+    // cycle at host_anchor on the shared wall clock), frequency (GHz). Set by
+    // RealtimeProfilerManager and kept in lockstep with the rt-profiler's OWN Tracy
+    // context calibration (its AddDevice/CalibrateDevice points), so the rt records and
+    // these worker zones render against the same anchor. When present, updateTracyContext
+    // anchors the worker Tracy context to this line (keeping device_time = smallest worker
+    // marker, but deriving cpu_time from the line) instead of the read-time fallback.
+    // Valid only because worker and rt/dispatch cores share one device wall clock.
+    struct RealtimeSyncLine {
+        double host_anchor = 0.0;
+        double device_anchor = 0.0;
+        double frequency = 0.0;
+    };
+    std::optional<RealtimeSyncLine> realtime_sync_line;
+
     // DRAM Vector
     std::vector<uint32_t> profile_buffer;
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -271,14 +271,9 @@ public:
     // Device-core Syncdata
     std::map<CoreCoord, SyncInfo> device_core_sync_info;
 
-    // Optional realtime-profiler clock anchor: host_anchor (TSC), device_anchor (device
-    // cycle at host_anchor on the shared wall clock), frequency (GHz). Set by
-    // RealtimeProfilerManager and kept in lockstep with the rt-profiler's OWN Tracy
-    // context calibration (its AddDevice/CalibrateDevice points), so the rt records and
-    // these worker zones render against the same anchor. When present, updateTracyContext
-    // anchors the worker Tracy context to this line (keeping device_time = smallest worker
-    // marker, but deriving cpu_time from the line) instead of the read-time fallback.
-    // Valid only because worker and rt/dispatch cores share one device wall clock.
+    // Optional rt-profiler clock anchor (host_anchor TSC, device_anchor cycle, frequency GHz) set by
+    // RealtimeProfilerManager, kept in lockstep with the rt Tracy calibration so worker zones render against the same
+    // anchor. Valid because all cores share one device wall clock.
     struct RealtimeSyncLine {
         double host_anchor = 0.0;
         double device_anchor = 0.0;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -740,6 +740,27 @@ void InitDeviceProfiler(IDevice* device) {
         return;
     }
 
+    // L1-accumulate is an internal runtime-team mode, not a general profiling mode.
+    // Warn loudly, once per process, at the start of any accumulate run.
+    if (MetalContext::instance().rtoptions().get_profiler_accumulate()) {
+        static std::atomic<bool> accumulate_warned = false;
+        if (!accumulate_warned.exchange(true)) {
+            log_warning(
+                tt::LogAlways,
+                "===================================== L1-ACCUMULATE PROFILING "
+                "=====================================");
+            log_warning(
+                tt::LogAlways,
+                "Accumulate mode is for INTERNAL RUNTIME-TEAM use only and must NOT be used for general "
+                "profiling: key information such as program / op IDs is not recorded, and the per-op perf "
+                "report is disabled. Results are raw accumulated device zones only.");
+            log_warning(
+                tt::LogAlways,
+                "=================================================================================="
+                "=================");
+        }
+    }
+
     TracySetCpuTime(TracyGetCpuTime());
 
     static std::atomic<bool> firstInit = true;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -590,6 +590,15 @@ void ProfilerSync(ProfilerSyncState state) {
     if (!MetalContext::instance().rtoptions().get_profiler_sync_enabled()) {
         return;
     }
+    // In accumulate mode, skip the dedicated device-host sync. Its kernel runs on
+    // SYNC_CORE (0,0) and overwrites that core's accumulated L1 profiler buffer
+    // (which is only flushed to DRAM when full), destroying its zones. The
+    // realtime (dispatch-core) profiler already provides device-host sync across
+    // all reporting cores, so the dedicated pass is redundant here. This is
+    // equivalent to running with sync disabled, which is a supported path.
+    if (MetalContext::instance().rtoptions().get_profiler_accumulate()) {
+        return;
+    }
     if (!getDeviceProfilerState(DEFAULT_CONTEXT_ID)) {
         return;
     }
@@ -856,7 +865,10 @@ static void ReadDeviceProfilerResultsImpl(
     TT_FATAL(
         !MetalContext::instance().dprint_server(), "Debug print server is running, cannot read device profiler data");
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_trace_only()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_trace_only() ||
+        tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_accumulate()) {
+        // Accumulate mode keeps the un-pushed residual in L1 (only flushing to DRAM when the
+        // buffer is nearly full), so the L1 buffers must be read alongside DRAM.
         profiler.readResults(
             mesh_device, device, virtual_cores, state, ProfilerDataBufferSource::DRAM_AND_L1, metadata);
     } else {
@@ -906,7 +918,8 @@ void ReadDeviceProfilerResultsInternal(
         !MetalContext::instance(context_id).dprint_server(),
         "Debug print server is running, cannot read device profiler data");
 
-    if (include_l1 || MetalContext::instance(context_id).rtoptions().get_profiler_trace_only()) {
+    if (include_l1 || MetalContext::instance(context_id).rtoptions().get_profiler_trace_only() ||
+        MetalContext::instance(context_id).rtoptions().get_profiler_accumulate()) {
         profiler.readResults(
             mesh_device, device, virtual_cores, state, ProfilerDataBufferSource::DRAM_AND_L1, metadata);
     } else {
@@ -961,7 +974,8 @@ void ProcessDeviceProfilerResults(
         return;
     }
 
-    if (MetalContext::instance().rtoptions().get_profiler_trace_only()) {
+    if (MetalContext::instance().rtoptions().get_profiler_trace_only() ||
+        MetalContext::instance().rtoptions().get_profiler_accumulate()) {
         profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM_AND_L1, metadata);
     } else {
         profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -88,11 +88,34 @@ void setControlBuffer(
     const metal_SocDescriptor& soc_d = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
 
     control_buffer[kernel_profiler::CORE_COUNT_PER_DRAM] = soc_d.profiler_ceiled_core_count_perf_dram_bank;
+
+    // In accumulate mode, tag dispatch cores so their firmware main scope keeps the
+    // classic guaranteed-slot layout + finish (accumulate is worker-core-only).
+    // Computed once here; otherwise the flag stays zero and behavior is unchanged.
+    std::vector<CoreCoord> dispatch_virtual_cores;
+    const bool tag_dispatch_cores = MetalContext::instance(context_id).rtoptions().get_profiler_accumulate();
+    if (tag_dispatch_cores) {
+        const auto& dispatch_core_config = get_dispatch_core_config();
+        for (const CoreCoord& core : tt::get_logical_dispatch_cores(
+                 MetalEnvAccessor(MetalContext::instance(context_id).get_env()).impl(),
+                 device_id,
+                 device->num_hw_cqs(),
+                 dispatch_core_config)) {
+            dispatch_virtual_cores.push_back(
+                device->virtual_core_from_logical_core(core, get_core_type_from_config(dispatch_core_config)));
+        }
+    }
+
     for (auto core :
          MetalContext::instance(context_id).get_cluster().get_virtual_routing_to_profiler_flat_id(device_id)) {
         const CoreCoord curr_core = core.first;
 
         control_buffer[kernel_profiler::FLAT_ID] = core.second;
+        control_buffer[kernel_profiler::PROFILER_DISPATCH_CORE] =
+            (std::find(dispatch_virtual_cores.begin(), dispatch_virtual_cores.end(), curr_core) !=
+             dispatch_virtual_cores.end())
+                ? 1
+                : 0;
 
         writeToCoreControlBuffer(mesh_device, device, curr_core, control_buffer, force_slow_dispatch, context_id);
     }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -180,6 +180,9 @@ void JitBuildEnv::init(
         if (rtoptions.get_profiler_sum()) {
             profiler_options |= PROFILER_OPT_DO_SUM;
         }
+        if (rtoptions.get_profiler_accumulate()) {
+            profiler_options |= PROFILER_OPT_DO_ACCUMULATE;
+        }
         this->defines_ += "-DPROFILE_KERNEL=" + std::to_string(profiler_options) + " ";
 
         this->defines_ += "-DPROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC=" +

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -955,11 +955,8 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         }
 
         // TT_METAL_PROFILER_ACCUMULATE
-        // Accumulate multiple kernel invocations in the per-RISC L1 buffer and only push to DRAM
-        // once it is nearly full. The "main"/"main child" zones use the growing index instead of
-        // the fixed guaranteed slots. Read the residual back via DRAM_AND_L1.
-        // Default: false
-        // Usage: export TT_METAL_PROFILER_ACCUMULATE=1
+        // Accumulate kernel invocations in per-RISC L1 (main zones use the growing index), flush to DRAM when nearly
+        // full, read residual via DRAM_AND_L1. Default: false Usage: export TT_METAL_PROFILER_ACCUMULATE=1
         case EnvVarID::TT_METAL_PROFILER_ACCUMULATE: {
             if (this->profiler_enabled && is_env_enabled(value)) {
                 this->profiler_accumulate = true;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -132,6 +132,7 @@ enum class EnvVarID {
     TT_METAL_PROFILER_MID_RUN_DUMP,                // Force mid-run profiler dumps
     TT_METAL_PROFILER_CPP_POST_PROCESS,            // Enable C++ post-processing for profiler
     TT_METAL_PROFILER_SUM,                         // Enable sum profiling
+    TT_METAL_PROFILER_ACCUMULATE,                  // Accumulate multiple kernels in L1 before DRAM push
     TT_METAL_PROFILER_PROGRAM_SUPPORT_COUNT,       // Maximum number of programs supported by the profiler
     TT_METAL_TRACY_MID_RUN_PUSH,                   // Force Tracy mid-run pushes
     TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES,       // Disable dumping collected device data to files
@@ -949,6 +950,19 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_PROFILER_SUM: {
             if (this->profiler_enabled && is_env_enabled(value)) {
                 this->profiler_sum = true;
+            }
+            break;
+        }
+
+        // TT_METAL_PROFILER_ACCUMULATE
+        // Accumulate multiple kernel invocations in the per-RISC L1 buffer and only push to DRAM
+        // once it is nearly full. The "main"/"main child" zones use the growing index instead of
+        // the fixed guaranteed slots. Read the residual back via DRAM_AND_L1.
+        // Default: false
+        // Usage: export TT_METAL_PROFILER_ACCUMULATE=1
+        case EnvVarID::TT_METAL_PROFILER_ACCUMULATE: {
+            if (this->profiler_enabled && is_env_enabled(value)) {
+                this->profiler_accumulate = true;
             }
             break;
         }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -214,6 +214,7 @@ class RunTimeOptions {
     bool profiler_trace_tracking = false;
     bool profiler_cpp_post_process = false;
     bool profiler_sum = false;
+    bool profiler_accumulate = false;
     bool profiler_buffer_usage_enabled = false;
     bool profiler_noc_events_enabled = false;
     uint32_t profiler_perf_counter_mode = 0;
@@ -622,6 +623,7 @@ public:
     bool get_profiler_mid_run_dump() const { return profiler_mid_run_dump; }
     bool get_profiler_cpp_post_process() const { return profiler_cpp_post_process; }
     bool get_profiler_sum() const { return profiler_sum; }
+    bool get_profiler_accumulate() const { return profiler_accumulate; }
     std::optional<uint32_t> get_profiler_program_support_count() const { return profiler_program_support_count; }
     void set_profiler_program_support_count(uint32_t profiler_program_support_count) {
         this->profiler_program_support_count = profiler_program_support_count;

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -63,19 +63,14 @@ constexpr bool DO_SUM = true;
 #else
 constexpr bool DO_SUM = false;
 #endif
-// Accumulate mode records main/main-child zones at the growing wIndex on ALL worker
-// RISCs (BRISC/NCRISC/TRISC). erisc is excluded (never a worker; tight firmware). The
-// aggregating push (finish) and the dispatch-core coexistence path are BRISC-only,
-// gated separately below, so NCRISC/TRISC carry only the lightweight recording.
+// Accumulate mode: all worker RISCs (BRISC/NCRISC/TRISC) record main zones at the growing wIndex; erisc excluded.
 #if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL) && !defined(COMPILE_FOR_ERISC) && \
     !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_AERISC)
 constexpr bool DO_ACCUMULATE = true;
 #else
 constexpr bool DO_ACCUMULATE = false;
 #endif
-// In accumulate mode, flush the L1 buffer to DRAM once fewer than this many
-// uint32 slots remain, leaving room for the next iteration's main + child
-// start/end markers so they are not dropped mid-iteration.
+// Accumulate mode: headroom to flush before the buffer can't fit the next iteration's main+child markers.
 constexpr uint32_t ACCUMULATE_FLUSH_HEADROOM = PROFILER_L1_GUARANTEED_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE;
 constexpr uint32_t TRACE_MARK_FW_START = (1 << 31);
 constexpr uint32_t TRACE_MARK_KERNEL_START = (1 << 30);
@@ -196,10 +191,7 @@ inline __attribute__((always_inline)) void mark_time_at_index_inlined(uint32_t i
     profiler_data_buffer[myRiscID].data[index + 1] = p_reg[WALL_CLOCK_LOW_INDEX];
 }
 
-// Like mark_time_at_index_inlined but writes a timestamp that was captured
-// earlier (time_h = upper bits of wall clock, time_l = lower 32 bits) instead of
-// sampling the clock now. Used to record an event whose start/end were measured
-// across a span of code (e.g. the finish() DRAM push) into fixed buffer slots.
+// Like mark_time_at_index_inlined but writes a pre-captured timestamp (time_h/time_l) instead of sampling now.
 inline __attribute__((always_inline)) void mark_time_at_index_with_stamp(
     uint32_t index, uint32_t timer_id, uint32_t time_h, uint32_t time_l) {
     profiler_data_buffer[myRiscID].data[index] = 0x80000000 | ((timer_id & 0x7FFFF) << 12) | (time_h & 0xFFF);
@@ -318,17 +310,12 @@ __attribute__((noinline)) void signal_host_buffer_full(uint32_t control_buffer_i
     } while (profiler_control_buffer[control_buffer_index_for_dram] == DRAM_PROFILER_ADDRESS_STALLED);
 }
 
-// do_accumulate is a runtime parameter (not a template): on a dispatch core the
-// accumulate main scope calls finish with do_accumulate=false (classic finish that
-// cooperates with the dispatch kernel's quick_push), while worker cores call it
-// with true. A single runtime branch keeps BRISC firmware under its text limit.
+// do_accumulate is runtime (not template) so dispatch cores (false=classic finish) and workers (true) share one fn,
+// keeping BRISC text small.
 __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULATE) {
     if (do_accumulate) {
-        // Accumulate mode: do NOT reset wIndex or push every iteration. Each RISC
-        // pads its own buffer to NOC alignment and publishes its current fill
-        // level; the aggregating RISC then flushes ALL RISCs to DRAM only when at
-        // least one RISC is full. After a flush, each published end index is
-        // zeroed as a sentinel so that RISC restarts accumulation on next entry.
+        // Accumulate: don't reset wIndex/push each iteration. Each RISC publishes its fill level; aggregating RISC
+        // flushes ALL only when one is full, then zeros end indices as restart sentinels.
         for (uint32_t i = 0; i < (wIndex % NOC_ALIGNMENT_FACTOR); i++) {
             mark_padding();
         }
@@ -352,11 +339,8 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
             uint32_t pageSize =
                 PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MaxProcessorsPerCoreType * profiler_core_count_per_dram;
 
-            // Time the DRAM push: the guaranteed-marker slots are free in accumulate
-            // mode (main/main-child append at the growing wIndex), so the total push
-            // (slots 1/2) and the nested NOC flush/drain (slots 3/4) are timed there.
-            // They ride out on the next flush; the final pair stays in L1 and is read
-            // back via DRAM_AND_L1.
+            // Guaranteed-marker slots are free in accumulate mode, so time the push (slots 1/2) and nested NOC flush
+            // (slots 3/4) there.
             volatile tt_reg_ptr uint32_t* push_clk =
                 reinterpret_cast<volatile tt_reg_ptr uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L);
             uint32_t push_start_h = push_clk[WALL_CLOCK_HIGH_INDEX];
@@ -384,11 +368,8 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
                                            hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
                                            profiler_control_buffer[hostIndex] * sizeof(uint32_t);
 
-                    // If the per-RISC DRAM region is exhausted: only ask the host for a fresh one
-                    // in NON_DROPPING (debug-dump) mode, where a host thread services the request.
-                    // In normal profiling NOTHING services signal_host_buffer_full, so calling it
-                    // would spin the RISC forever and deadlock the program (host Finish() never
-                    // returns). In that case fall through to the drop path below instead.
+                    // Only request a fresh DRAM region in NON_DROPPING (debug-dump) mode; in normal profiling nothing
+                    // services signal_host_buffer_full so it would deadlock -- drop instead.
                     if constexpr (NON_DROPPING) {
                         if (currEndIndexAll > PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
                             signal_host_buffer_full(dramProfilerAddressIndex);
@@ -421,8 +402,7 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
                             send_size);
                     }
                 }
-                // Reset sentinel: a zeroed end index tells this RISC to restart
-                // accumulation (reset its wIndex) on its next main-scope entry.
+                // Zeroed end index = sentinel telling this RISC to restart accumulation on next main-scope entry.
                 profiler_control_buffer[deviceIndex] = 0;
             }
 
@@ -431,12 +411,8 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
             profiler_noc_async_flush_posted_write();
             uint32_t flush_end_h = push_clk[WALL_CLOCK_HIGH_INDEX];
             uint32_t flush_end_l = push_clk[WALL_CLOCK_LOW_INDEX];
-            // Total DRAM push -> guaranteed slots 1/2 (outer); nested NOC flush/drain
-            // -> 3/4 (inner). The host pairs guaranteed markers by timestamp, so the
-            // inner zone's end MUST be strictly before the outer's -- a shared end lets
-            // the pairing pop them in the wrong order (NOC-FLUSH start vs DRAM-PUSH end).
-            // Emit the inner NOC-FLUSH at flush_end first, then sample push_end AFTER so
-            // the outer DRAM-PUSH ends strictly later (by the cost of these stores).
+            // Host pairs guaranteed markers by timestamp, so inner NOC-FLUSH end must be strictly before outer
+            // DRAM-PUSH end: emit flush first, sample push_end after.
             {
                 SrcLocNameToHash("PROFILER-NOC-FLUSH");
                 mark_time_at_index_with_stamp(
@@ -728,28 +704,15 @@ struct profileScopeGuaranteed {
     }
 };
 
-// Out-of-line helpers for the accumulate main / main-child scope. `index` is the
-// only template parameter and timer_id is passed at runtime (get_id is identical
-// to get_const_id), so ALL main zones share one begin/end pair per index instead
-// of inlining the dispatch + accumulate branches at every site -- BRISC hosts
-// several main zones and inlining overflows its small firmware text region.
-//
-// Worker cores accumulate: main / main-child timestamps append at the growing
-// wIndex (like a regular profileScope) so successive iterations accumulate in the
-// per-RISC L1 buffer, flushed to DRAM only when nearly full; residual is read back
-// via ProfilerDataBufferSource::DRAM_AND_L1. Dispatch cores (tagged by the host in
-// PROFILER_DISPATCH_CORE) instead keep the classic guaranteed-slot layout + finish:
-// their realtime quick_push feed drains the optional region mid-run, so a marker at
-// wIndex would be split across pushes and cross-pair with a dispatch (cq_dispatch)
-// zone on the host. The fixed guaranteed slots are never touched by quick_push.
-//   index == 0 -> main / FW scope: owns one-time init and the full-buffer flush.
-//   index == 1 -> main-child / KERNEL scope: just brackets the kernel.
+// Out-of-line accumulate main/main-child helpers: timer_id is runtime so all main zones share one begin/end per index,
+// keeping BRISC text small. Workers append markers at growing wIndex (flushed when full, residual read via
+// DRAM_AND_L1); dispatch cores keep the classic guaranteed-slot layout so their quick_push feed isn't split. index 0 =
+// main/FW (owns init + flush), index 1 = main-child/KERNEL.
 template <uint32_t index>
 __attribute__((noinline)) bool main_accumulate_begin(uint32_t timer_id) {
 #if defined(COMPILE_FOR_BRISC)
-    // Dispatch-core coexistence is BRISC-only (only BRISC runs cq_dispatch + quick_push):
-    // on a dispatch core, keep the classic guaranteed-slot layout so the realtime feed
-    // isn't split. NCRISC/TRISC are never dispatch cores, so this is BRISC-only.
+    // Dispatch-core coexistence is BRISC-only: keep the classic guaranteed-slot layout so the realtime quick_push feed
+    // isn't split.
     if (profiler_control_buffer[PROFILER_DISPATCH_CORE] != 0) {
         constexpr uint32_t start_index = (2 * index * PROFILER_L1_MARKER_UINT32_SIZE) + GUARANTEED_MARKER_1_H;
         static_assert(start_index < CUSTOM_MARKERS);
@@ -761,16 +724,13 @@ __attribute__((noinline)) bool main_accumulate_begin(uint32_t timer_id) {
     }
 #endif
     if constexpr (index == 0) {
-        // wIndex is a per-RISC global, zero-initialized in BSS and left at
-        // CUSTOM_MARKERS by init_profiler(), so it is only ever 0 before this RISC
-        // has initialized. (RUN_COUNTER cannot guard here: it is shared by all
-        // RISCs on the core, which would let later RISCs skip their own init.)
+        // wIndex is per-RISC (BSS-zeroed, set to CUSTOM_MARKERS by init), so 0 only before this RISC inits. RUN_COUNTER
+        // can't guard: it's shared across RISCs.
         if (wIndex == 0) {
             init_profiler();
         } else if (profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] == 0) {
-            // The aggregating RISC flushed this RISC's buffer and zeroed its
-            // published end index as a reset sentinel; restart accumulation from
-            // the optional region (headers stay intact).
+            // Aggregating RISC flushed us and zeroed our end index (reset sentinel); restart accumulation from the
+            // optional region.
             wIndex = CUSTOM_MARKERS;
             stackSize = 0;
         }
@@ -803,15 +763,13 @@ __attribute__((noinline)) void main_accumulate_end(uint32_t timer_id, bool start
         stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
     }
     if constexpr (index == 0) {
-        // Publish this RISC's fill level and let the aggregating RISC (BRISC /
-        // idle-ERISC) flush ALL RISCs to DRAM iff any one of them is full. No
-        // quick_push: the only DRAM push path in worker accumulate mode is finish.
+        // Publish fill level; aggregating RISC flushes ALL to DRAM iff any is full. finish is the only DRAM push path
+        // in worker accumulate mode.
         finish_profiler(/*do_accumulate=*/true);
     }
 }
 
-// Thin always-inline wrapper: the heavy logic lives once in the helpers above, so
-// each zone site only emits two calls.
+// Thin always-inline wrapper: heavy logic lives once in the helpers, so each site emits only two calls.
 template <uint32_t timer_id, uint32_t index>
 struct profileScopeMainAccumulate {
     bool start_marked = false;
@@ -966,10 +924,8 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceValidateProfiler(condition) kernel_profiler::set_profiler_zone_valid(condition);
 
-// Select between the fixed-slot guaranteed scope (default) and the accumulating
-// scope for the main / main-child zones. Same gate as DO_ACCUMULATE above, so all
-// worker RISCs (BRISC/NCRISC/TRISC) accumulate; erisc and dispatch kernels get the
-// small guaranteed scope.
+// Pick accumulating scope (workers) vs fixed-slot guaranteed scope (erisc/dispatch) for main/main-child zones; same
+// gate as DO_ACCUMULATE.
 #if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL) && !defined(COMPILE_FOR_ERISC) && \
     !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_AERISC)
 #define PROFILER_MAIN_SCOPE kernel_profiler::profileScopeMainAccumulate
@@ -1019,11 +975,8 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceIncrementTraceCount() kernel_profiler::increment_trace_count();
 
-// Accumulate mode keeps only the zone-scope family (DeviceZoneScoped*N) and
-// DeviceRecordEvent. The other profiler features pull device code into the
-// size-constrained accumulate firmware, so compile them out -- their device
-// functions then go unreferenced and drop. Sync is unaffected: its kernels use
-// DeviceZoneScopedN + raw control-buffer access, neither touched here.
+// Accumulate mode keeps only the zone-scope family + DeviceRecordEvent; compile out the rest to fit the
+// size-constrained accumulate firmware.
 #if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL)
 #undef DeviceTimestampedData
 #define DeviceTimestampedData(data_id, data) (void(sizeof(data_id) + sizeof(data)))

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -63,8 +63,10 @@ constexpr bool DO_SUM = true;
 #else
 constexpr bool DO_SUM = false;
 #endif
-// Accumulate mode is worker-core-only. Excluded for DISPATCH_KERNEL builds and all
-// erisc variants (never worker cores; keeps their size-constrained firmware lean).
+// Accumulate mode records main/main-child zones at the growing wIndex on ALL worker
+// RISCs (BRISC/NCRISC/TRISC). erisc is excluded (never a worker; tight firmware). The
+// aggregating push (finish) and the dispatch-core coexistence path are BRISC-only,
+// gated separately below, so NCRISC/TRISC carry only the lightweight recording.
 #if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL) && !defined(COMPILE_FOR_ERISC) && \
     !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_AERISC)
 constexpr bool DO_ACCUMULATE = true;
@@ -198,6 +200,12 @@ inline __attribute__((always_inline)) void mark_time_at_index_inlined(uint32_t i
 // earlier (time_h = upper bits of wall clock, time_l = lower 32 bits) instead of
 // sampling the clock now. Used to record an event whose start/end were measured
 // across a span of code (e.g. the finish() DRAM push) into fixed buffer slots.
+inline __attribute__((always_inline)) void mark_time_at_index_with_stamp(
+    uint32_t index, uint32_t timer_id, uint32_t time_h, uint32_t time_l) {
+    profiler_data_buffer[myRiscID].data[index] = 0x80000000 | ((timer_id & 0x7FFFF) << 12) | (time_h & 0xFFF);
+    profiler_data_buffer[myRiscID].data[index + 1] = time_l;
+}
+
 inline __attribute__((always_inline)) void mark_padding() {
     if (wIndex < PROFILER_L1_VECTOR_SIZE) {
         profiler_data_buffer[myRiscID].data[wIndex] = 0x80000000;
@@ -344,6 +352,16 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
             uint32_t pageSize =
                 PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MaxProcessorsPerCoreType * profiler_core_count_per_dram;
 
+            // Time the DRAM push: the guaranteed-marker slots are free in accumulate
+            // mode (main/main-child append at the growing wIndex), so the total push
+            // (slots 1/2) and the nested NOC flush/drain (slots 3/4) are timed there.
+            // They ride out on the next flush; the final pair stays in L1 and is read
+            // back via DRAM_AND_L1.
+            volatile tt_reg_ptr uint32_t* push_clk =
+                reinterpret_cast<volatile tt_reg_ptr uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L);
+            uint32_t push_start_h = push_clk[WALL_CLOCK_HIGH_INDEX];
+            uint32_t push_start_l = push_clk[WALL_CLOCK_LOW_INDEX];
+
             NocRegisterStateSave noc_state;
             for (uint32_t riscID = 0; riscID < PROCESSOR_COUNT; riscID++) {
                 bool do_noc = true;
@@ -408,7 +426,33 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
                 profiler_control_buffer[deviceIndex] = 0;
             }
 
+            uint32_t flush_start_h = push_clk[WALL_CLOCK_HIGH_INDEX];
+            uint32_t flush_start_l = push_clk[WALL_CLOCK_LOW_INDEX];
             profiler_noc_async_flush_posted_write();
+            uint32_t flush_end_h = push_clk[WALL_CLOCK_HIGH_INDEX];
+            uint32_t flush_end_l = push_clk[WALL_CLOCK_LOW_INDEX];
+            // Total DRAM push -> guaranteed slots 1/2 (outer); nested NOC flush/drain
+            // -> 3/4 (inner). The host pairs guaranteed markers by timestamp, so the
+            // inner zone's end MUST be strictly before the outer's -- a shared end lets
+            // the pairing pop them in the wrong order (NOC-FLUSH start vs DRAM-PUSH end).
+            // Emit the inner NOC-FLUSH at flush_end first, then sample push_end AFTER so
+            // the outer DRAM-PUSH ends strictly later (by the cost of these stores).
+            {
+                SrcLocNameToHash("PROFILER-NOC-FLUSH");
+                mark_time_at_index_with_stamp(
+                    GUARANTEED_MARKER_3_H, get_const_id(hash, ZONE_START), flush_start_h, flush_start_l);
+                mark_time_at_index_with_stamp(
+                    GUARANTEED_MARKER_4_H, get_const_id(hash, ZONE_END), flush_end_h, flush_end_l);
+            }
+            uint32_t push_end_h = push_clk[WALL_CLOCK_HIGH_INDEX];
+            uint32_t push_end_l = push_clk[WALL_CLOCK_LOW_INDEX];
+            {
+                SrcLocNameToHash("PROFILER-DRAM-PUSH");
+                mark_time_at_index_with_stamp(
+                    GUARANTEED_MARKER_1_H, get_const_id(hash, ZONE_START), push_start_h, push_start_l);
+                mark_time_at_index_with_stamp(
+                    GUARANTEED_MARKER_2_H, get_const_id(hash, ZONE_END), push_end_h, push_end_l);
+            }
             profiler_control_buffer[RUN_COUNTER]++;
         }
         profiler_control_buffer[PROFILER_DONE] = 1;
@@ -702,6 +746,10 @@ struct profileScopeGuaranteed {
 //   index == 1 -> main-child / KERNEL scope: just brackets the kernel.
 template <uint32_t index>
 __attribute__((noinline)) bool main_accumulate_begin(uint32_t timer_id) {
+#if defined(COMPILE_FOR_BRISC)
+    // Dispatch-core coexistence is BRISC-only (only BRISC runs cq_dispatch + quick_push):
+    // on a dispatch core, keep the classic guaranteed-slot layout so the realtime feed
+    // isn't split. NCRISC/TRISC are never dispatch cores, so this is BRISC-only.
     if (profiler_control_buffer[PROFILER_DISPATCH_CORE] != 0) {
         constexpr uint32_t start_index = (2 * index * PROFILER_L1_MARKER_UINT32_SIZE) + GUARANTEED_MARKER_1_H;
         static_assert(start_index < CUSTOM_MARKERS);
@@ -711,6 +759,7 @@ __attribute__((noinline)) bool main_accumulate_begin(uint32_t timer_id) {
         mark_time_at_index_inlined(start_index, get_id(timer_id, ZONE_START));
         return false;
     }
+#endif
     if constexpr (index == 0) {
         // wIndex is a per-RISC global, zero-initialized in BSS and left at
         // CUSTOM_MARKERS by init_profiler(), so it is only ever 0 before this RISC
@@ -737,6 +786,7 @@ __attribute__((noinline)) bool main_accumulate_begin(uint32_t timer_id) {
 
 template <uint32_t index>
 __attribute__((noinline)) void main_accumulate_end(uint32_t timer_id, bool start_marked) {
+#if defined(COMPILE_FOR_BRISC)
     if (profiler_control_buffer[PROFILER_DISPATCH_CORE] != 0) {
         constexpr uint32_t end_index = (2 * index * PROFILER_L1_MARKER_UINT32_SIZE) + GUARANTEED_MARKER_2_H;
         static_assert(end_index < CUSTOM_MARKERS);
@@ -746,6 +796,7 @@ __attribute__((noinline)) void main_accumulate_end(uint32_t timer_id, bool start
         }
         return;
     }
+#endif
     if (start_marked) {
         mark_time_at_index_inlined(wIndex, get_id(timer_id, ZONE_END));
         wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
@@ -916,8 +967,9 @@ __attribute__((noinline)) void trace_only_init() {
 #define DeviceValidateProfiler(condition) kernel_profiler::set_profiler_zone_valid(condition);
 
 // Select between the fixed-slot guaranteed scope (default) and the accumulating
-// scope for the main / main-child zones. Same gate as DO_ACCUMULATE above, so
-// dispatch kernels and erisc variants get the small guaranteed scope.
+// scope for the main / main-child zones. Same gate as DO_ACCUMULATE above, so all
+// worker RISCs (BRISC/NCRISC/TRISC) accumulate; erisc and dispatch kernels get the
+// small guaranteed scope.
 #if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL) && !defined(COMPILE_FOR_ERISC) && \
     !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_AERISC)
 #define PROFILER_MAIN_SCOPE kernel_profiler::profileScopeMainAccumulate

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -1019,6 +1019,24 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceIncrementTraceCount() kernel_profiler::increment_trace_count();
 
+// Accumulate mode keeps only the zone-scope family (DeviceZoneScoped*N) and
+// DeviceRecordEvent. The other profiler features pull device code into the
+// size-constrained accumulate firmware, so compile them out -- their device
+// functions then go unreferenced and drop. Sync is unaffected: its kernels use
+// DeviceZoneScopedN + raw control-buffer access, neither touched here.
+#if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL)
+#undef DeviceTimestampedData
+#define DeviceTimestampedData(data_id, data) (void(sizeof(data_id) + sizeof(data)))
+#undef DeviceZoneScopedSumN1
+#define DeviceZoneScopedSumN1(name) (void(name))
+#undef DeviceZoneScopedSumN2
+#define DeviceZoneScopedSumN2(name) (void(name))
+#undef DeviceZoneSetCounter
+#define DeviceZoneSetCounter(counter) (void(sizeof(counter)))
+#undef DeviceValidateProfiler
+#define DeviceValidateProfiler(condition) (void(sizeof(condition)))
+#endif
+
 #else
 
 // The void(sizeof(FOO)) idiom (a) ensures FOO is syntactically and

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -310,8 +310,12 @@ __attribute__((noinline)) void signal_host_buffer_full(uint32_t control_buffer_i
     } while (profiler_control_buffer[control_buffer_index_for_dram] == DRAM_PROFILER_ADDRESS_STALLED);
 }
 
-__attribute__((noinline)) void finish_profiler() {
-    if constexpr (DO_ACCUMULATE) {
+// do_accumulate is a runtime parameter (not a template): on a dispatch core the
+// accumulate main scope calls finish with do_accumulate=false (classic finish that
+// cooperates with the dispatch kernel's quick_push), while worker cores call it
+// with true. A single runtime branch keeps BRISC firmware under its text limit.
+__attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULATE) {
+    if (do_accumulate) {
         // Accumulate mode: do NOT reset wIndex or push every iteration. Each RISC
         // pads its own buffer to NOC alignment and publishes its current fill
         // level; the aggregating RISC then flushes ALL RISCs to DRAM only when at
@@ -680,56 +684,91 @@ struct profileScopeGuaranteed {
     }
 };
 
-// Variant of profileScopeGuaranteed used when PROFILER_OPT_DO_ACCUMULATE is set.
-// Instead of writing the main/main-child timestamps into the fixed guaranteed
-// slots (which would overwrite the previous iteration), it appends them at the
-// growing wIndex like a regular profileScope. This lets several program
-// iterations accumulate in the per-RISC L1 buffer; the buffer is only pushed to
-// DRAM once it is nearly full. The un-pushed residual is left in L1 and read
-// back by the host via ProfilerDataBufferSource::DRAM_AND_L1.
-//   index == 0 -> the main / FW scope: owns one-time init and the full-buffer flush.
-//   index == 1 -> the main-child / KERNEL scope: just brackets the kernel.
+// Out-of-line helpers for the accumulate main / main-child scope. `index` is the
+// only template parameter and timer_id is passed at runtime (get_id is identical
+// to get_const_id), so ALL main zones share one begin/end pair per index instead
+// of inlining the dispatch + accumulate branches at every site -- BRISC hosts
+// several main zones and inlining overflows its small firmware text region.
+//
+// Worker cores accumulate: main / main-child timestamps append at the growing
+// wIndex (like a regular profileScope) so successive iterations accumulate in the
+// per-RISC L1 buffer, flushed to DRAM only when nearly full; residual is read back
+// via ProfilerDataBufferSource::DRAM_AND_L1. Dispatch cores (tagged by the host in
+// PROFILER_DISPATCH_CORE) instead keep the classic guaranteed-slot layout + finish:
+// their realtime quick_push feed drains the optional region mid-run, so a marker at
+// wIndex would be split across pushes and cross-pair with a dispatch (cq_dispatch)
+// zone on the host. The fixed guaranteed slots are never touched by quick_push.
+//   index == 0 -> main / FW scope: owns one-time init and the full-buffer flush.
+//   index == 1 -> main-child / KERNEL scope: just brackets the kernel.
+template <uint32_t index>
+__attribute__((noinline)) bool main_accumulate_begin(uint32_t timer_id) {
+    if (profiler_control_buffer[PROFILER_DISPATCH_CORE] != 0) {
+        constexpr uint32_t start_index = (2 * index * PROFILER_L1_MARKER_UINT32_SIZE) + GUARANTEED_MARKER_1_H;
+        static_assert(start_index < CUSTOM_MARKERS);
+        if constexpr (index == 0) {
+            init_profiler();
+        }
+        mark_time_at_index_inlined(start_index, get_id(timer_id, ZONE_START));
+        return false;
+    }
+    if constexpr (index == 0) {
+        // wIndex is a per-RISC global, zero-initialized in BSS and left at
+        // CUSTOM_MARKERS by init_profiler(), so it is only ever 0 before this RISC
+        // has initialized. (RUN_COUNTER cannot guard here: it is shared by all
+        // RISCs on the core, which would let later RISCs skip their own init.)
+        if (wIndex == 0) {
+            init_profiler();
+        } else if (profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] == 0) {
+            // The aggregating RISC flushed this RISC's buffer and zeroed its
+            // published end index as a reset sentinel; restart accumulation from
+            // the optional region (headers stay intact).
+            wIndex = CUSTOM_MARKERS;
+            stackSize = 0;
+        }
+    }
+    if (bufferHasRoom()) {
+        stackSize += PROFILER_L1_MARKER_UINT32_SIZE;
+        mark_time_at_index_inlined(wIndex, get_id(timer_id, ZONE_START));
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+        return true;
+    }
+    return false;
+}
+
+template <uint32_t index>
+__attribute__((noinline)) void main_accumulate_end(uint32_t timer_id, bool start_marked) {
+    if (profiler_control_buffer[PROFILER_DISPATCH_CORE] != 0) {
+        constexpr uint32_t end_index = (2 * index * PROFILER_L1_MARKER_UINT32_SIZE) + GUARANTEED_MARKER_2_H;
+        static_assert(end_index < CUSTOM_MARKERS);
+        mark_time_at_index_inlined(end_index, get_id(timer_id, ZONE_END));
+        if constexpr (index == 0) {
+            finish_profiler(/*do_accumulate=*/false);
+        }
+        return;
+    }
+    if (start_marked) {
+        mark_time_at_index_inlined(wIndex, get_id(timer_id, ZONE_END));
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+        stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
+    }
+    if constexpr (index == 0) {
+        // Publish this RISC's fill level and let the aggregating RISC (BRISC /
+        // idle-ERISC) flush ALL RISCs to DRAM iff any one of them is full. No
+        // quick_push: the only DRAM push path in worker accumulate mode is finish.
+        finish_profiler(/*do_accumulate=*/true);
+    }
+}
+
+// Thin always-inline wrapper: the heavy logic lives once in the helpers above, so
+// each zone site only emits two calls.
 template <uint32_t timer_id, uint32_t index>
 struct profileScopeMainAccumulate {
     bool start_marked = false;
     inline __attribute__((always_inline)) profileScopeMainAccumulate() {
-        if constexpr (index == 0) {
-            // wIndex is a per-RISC global, zero-initialized in BSS and left at
-            // CUSTOM_MARKERS by init_profiler(), so it is only ever 0 before this
-            // RISC has initialized. (RUN_COUNTER cannot be the guard here: it is
-            // shared by all RISCs on the core, which would let later RISCs skip
-            // their own init.)
-            if (wIndex == 0) {
-                // First entry on this RISC: full init (sets wIndex = CUSTOM_MARKERS).
-                init_profiler();
-            } else if (profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] == 0) {
-                // The aggregating RISC flushed this RISC's buffer to DRAM and
-                // zeroed its published end index as a reset sentinel; restart
-                // accumulation from the optional region (headers stay intact).
-                wIndex = CUSTOM_MARKERS;
-                stackSize = 0;
-            }
-        }
-        if (bufferHasRoom()) {
-            stackSize += PROFILER_L1_MARKER_UINT32_SIZE;
-            start_marked = true;
-            mark_time_at_index_inlined(wIndex, get_const_id(timer_id, ZONE_START));
-            wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
-        }
+        start_marked = main_accumulate_begin<index>(timer_id);
     }
     inline __attribute__((always_inline)) ~profileScopeMainAccumulate() {
-        if (start_marked) {
-            mark_time_at_index_inlined(wIndex, get_const_id(timer_id, ZONE_END));
-            wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
-            start_marked = false;
-            stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
-        }
-        if constexpr (index == 0) {
-            // Publish this RISC's fill level and let the aggregating RISC (BRISC /
-            // idle-ERISC) flush ALL RISCs to DRAM iff any one of them is full.
-            // No quick_push: the only DRAM push path in this mode is finish.
-            finish_profiler();
-        }
+        main_accumulate_end<index>(timer_id, start_marked);
     }
 };
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -63,6 +63,18 @@ constexpr bool DO_SUM = true;
 #else
 constexpr bool DO_SUM = false;
 #endif
+// Accumulate mode is worker-core-only. Excluded for DISPATCH_KERNEL builds and all
+// erisc variants (never worker cores; keeps their size-constrained firmware lean).
+#if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL) && !defined(COMPILE_FOR_ERISC) && \
+    !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_AERISC)
+constexpr bool DO_ACCUMULATE = true;
+#else
+constexpr bool DO_ACCUMULATE = false;
+#endif
+// In accumulate mode, flush the L1 buffer to DRAM once fewer than this many
+// uint32 slots remain, leaving room for the next iteration's main + child
+// start/end markers so they are not dropped mid-iteration.
+constexpr uint32_t ACCUMULATE_FLUSH_HEADROOM = PROFILER_L1_GUARANTEED_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE;
 constexpr uint32_t TRACE_MARK_FW_START = (1 << 31);
 constexpr uint32_t TRACE_MARK_KERNEL_START = (1 << 30);
 constexpr uint32_t TRACE_MARK_ALL_ENDS = (1 << 29);
@@ -182,6 +194,10 @@ inline __attribute__((always_inline)) void mark_time_at_index_inlined(uint32_t i
     profiler_data_buffer[myRiscID].data[index + 1] = p_reg[WALL_CLOCK_LOW_INDEX];
 }
 
+// Like mark_time_at_index_inlined but writes a timestamp that was captured
+// earlier (time_h = upper bits of wall clock, time_l = lower 32 bits) instead of
+// sampling the clock now. Used to record an event whose start/end were measured
+// across a span of code (e.g. the finish() DRAM push) into fixed buffer slots.
 inline __attribute__((always_inline)) void mark_padding() {
     if (wIndex < PROFILER_L1_VECTOR_SIZE) {
         profiler_data_buffer[myRiscID].data[wIndex] = 0x80000000;
@@ -295,6 +311,106 @@ __attribute__((noinline)) void signal_host_buffer_full(uint32_t control_buffer_i
 }
 
 __attribute__((noinline)) void finish_profiler() {
+    if constexpr (DO_ACCUMULATE) {
+        // Accumulate mode: do NOT reset wIndex or push every iteration. Each RISC
+        // pads its own buffer to NOC alignment and publishes its current fill
+        // level; the aggregating RISC then flushes ALL RISCs to DRAM only when at
+        // least one RISC is full. After a flush, each published end index is
+        // zeroed as a sentinel so that RISC restarts accumulation on next entry.
+        for (uint32_t i = 0; i < (wIndex % NOC_ALIGNMENT_FACTOR); i++) {
+            mark_padding();
+        }
+        profiler_control_buffer[kernel_profiler::DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] = wIndex;
+#if defined(COMPILE_FOR_IDLE_ERISC) || (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)) || \
+    defined(COMPILE_FOR_BRISC)
+        constexpr uint32_t ACCUMULATE_FULL_THRESHOLD = PROFILER_L1_VECTOR_SIZE - ACCUMULATE_FLUSH_HEADROOM;
+        bool any_full = false;
+        for (uint32_t riscID = 0; riscID < PROCESSOR_COUNT; riscID++) {
+            if (profiler_control_buffer[kernel_profiler::DEVICE_BUFFER_END_INDEX_BR_ER + riscID] >=
+                ACCUMULATE_FULL_THRESHOLD) {
+                any_full = true;
+                break;
+            }
+        }
+        if (any_full) {
+            uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
+            uint32_t profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
+            bool is_dram_set = profiler_control_buffer[DRAM_PROFILER_ADDRESS] != 0;
+            int dramProfilerAddressIndex = DRAM_PROFILER_ADDRESS;
+            uint32_t pageSize =
+                PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MaxProcessorsPerCoreType * profiler_core_count_per_dram;
+
+            NocRegisterStateSave noc_state;
+            for (uint32_t riscID = 0; riscID < PROCESSOR_COUNT; riscID++) {
+                bool do_noc = true;
+                if constexpr (NON_DROPPING) {
+                    dramProfilerAddressIndex = kernel_profiler::DRAM_PROFILER_ADDRESS_BR_ER_0 + riscID;
+                    is_dram_set = profiler_control_buffer[dramProfilerAddressIndex] != 0;
+                }
+                // Preserve the upper (trace ID) bits of ID_LH; stamp core + risc id.
+                profiler_data_buffer[riscID].data[ID_LH] =
+                    (profiler_data_buffer[riscID].data[ID_LH] & 0x7FFF800) | (((core_flat_id & 0xFF) << 3) | riscID);
+
+                int hostIndex = kernel_profiler::HOST_BUFFER_END_INDEX_BR_ER + riscID;
+                int deviceIndex = kernel_profiler::DEVICE_BUFFER_END_INDEX_BR_ER + riscID;
+                if (profiler_control_buffer[deviceIndex]) {
+                    uint32_t currEndIndexAll =
+                        profiler_control_buffer[deviceIndex] + profiler_control_buffer[hostIndex];
+                    uint32_t send_size = 0;
+                    uint32_t dram_offset = (core_flat_id % profiler_core_count_per_dram) * MaxProcessorsPerCoreType *
+                                               PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                                           hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                                           profiler_control_buffer[hostIndex] * sizeof(uint32_t);
+
+                    // If the per-RISC DRAM region is exhausted: only ask the host for a fresh one
+                    // in NON_DROPPING (debug-dump) mode, where a host thread services the request.
+                    // In normal profiling NOTHING services signal_host_buffer_full, so calling it
+                    // would spin the RISC forever and deadlock the program (host Finish() never
+                    // returns). In that case fall through to the drop path below instead.
+                    if constexpr (NON_DROPPING) {
+                        if (currEndIndexAll > PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
+                            signal_host_buffer_full(dramProfilerAddressIndex);
+                            profiler_control_buffer[hostIndex] = 0;
+                            currEndIndexAll = profiler_control_buffer[deviceIndex];
+                            dram_offset = (core_flat_id % profiler_core_count_per_dram) * MaxProcessorsPerCoreType *
+                                              PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                                          hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC;
+                        }
+                    }
+
+                    if (currEndIndexAll <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
+                        send_size = profiler_control_buffer[deviceIndex] * sizeof(uint32_t);
+                        profiler_control_buffer[hostIndex] = currEndIndexAll;
+                    } else {
+                        do_noc = false;
+                        mark_dropped_timestamps(hostIndex);
+                    }
+
+                    if (do_noc && is_dram_set) {
+                        const auto s = TensorAccessor(
+                            tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(),
+                            profiler_control_buffer[dramProfilerAddressIndex],
+                            pageSize);
+                        uint64_t dram_bank_dst_noc_addr =
+                            s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
+                        profiler_noc_async_write_posted(
+                            reinterpret_cast<uint32_t>(profiler_data_buffer[riscID].data),
+                            dram_bank_dst_noc_addr,
+                            send_size);
+                    }
+                }
+                // Reset sentinel: a zeroed end index tells this RISC to restart
+                // accumulation (reset its wIndex) on its next main-scope entry.
+                profiler_control_buffer[deviceIndex] = 0;
+            }
+
+            profiler_noc_async_flush_posted_write();
+            profiler_control_buffer[RUN_COUNTER]++;
+        }
+        profiler_control_buffer[PROFILER_DONE] = 1;
+#endif
+        return;
+    }
     risc_finished_profiling();
 #if defined(COMPILE_FOR_IDLE_ERISC) || (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)) || \
     defined(COMPILE_FOR_BRISC)
@@ -564,6 +680,59 @@ struct profileScopeGuaranteed {
     }
 };
 
+// Variant of profileScopeGuaranteed used when PROFILER_OPT_DO_ACCUMULATE is set.
+// Instead of writing the main/main-child timestamps into the fixed guaranteed
+// slots (which would overwrite the previous iteration), it appends them at the
+// growing wIndex like a regular profileScope. This lets several program
+// iterations accumulate in the per-RISC L1 buffer; the buffer is only pushed to
+// DRAM once it is nearly full. The un-pushed residual is left in L1 and read
+// back by the host via ProfilerDataBufferSource::DRAM_AND_L1.
+//   index == 0 -> the main / FW scope: owns one-time init and the full-buffer flush.
+//   index == 1 -> the main-child / KERNEL scope: just brackets the kernel.
+template <uint32_t timer_id, uint32_t index>
+struct profileScopeMainAccumulate {
+    bool start_marked = false;
+    inline __attribute__((always_inline)) profileScopeMainAccumulate() {
+        if constexpr (index == 0) {
+            // wIndex is a per-RISC global, zero-initialized in BSS and left at
+            // CUSTOM_MARKERS by init_profiler(), so it is only ever 0 before this
+            // RISC has initialized. (RUN_COUNTER cannot be the guard here: it is
+            // shared by all RISCs on the core, which would let later RISCs skip
+            // their own init.)
+            if (wIndex == 0) {
+                // First entry on this RISC: full init (sets wIndex = CUSTOM_MARKERS).
+                init_profiler();
+            } else if (profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] == 0) {
+                // The aggregating RISC flushed this RISC's buffer to DRAM and
+                // zeroed its published end index as a reset sentinel; restart
+                // accumulation from the optional region (headers stay intact).
+                wIndex = CUSTOM_MARKERS;
+                stackSize = 0;
+            }
+        }
+        if (bufferHasRoom()) {
+            stackSize += PROFILER_L1_MARKER_UINT32_SIZE;
+            start_marked = true;
+            mark_time_at_index_inlined(wIndex, get_const_id(timer_id, ZONE_START));
+            wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+        }
+    }
+    inline __attribute__((always_inline)) ~profileScopeMainAccumulate() {
+        if (start_marked) {
+            mark_time_at_index_inlined(wIndex, get_const_id(timer_id, ZONE_END));
+            wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+            start_marked = false;
+            stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
+        }
+        if constexpr (index == 0) {
+            // Publish this RISC's fill level and let the aggregating RISC (BRISC /
+            // idle-ERISC) flush ALL RISCs to DRAM iff any one of them is full.
+            // No quick_push: the only DRAM push path in this mode is finish.
+            finish_profiler();
+        }
+    }
+};
+
 template <uint32_t timer_id, uint32_t index>
 struct profileScopeAccumulate {
     uint64_t start_time = 0;
@@ -707,15 +876,25 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceValidateProfiler(condition) kernel_profiler::set_profiler_zone_valid(condition);
 
+// Select between the fixed-slot guaranteed scope (default) and the accumulating
+// scope for the main / main-child zones. Same gate as DO_ACCUMULATE above, so
+// dispatch kernels and erisc variants get the small guaranteed scope.
+#if (PROFILE_KERNEL & PROFILER_OPT_DO_ACCUMULATE) && !defined(DISPATCH_KERNEL) && !defined(COMPILE_FOR_ERISC) && \
+    !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_AERISC)
+#define PROFILER_MAIN_SCOPE kernel_profiler::profileScopeMainAccumulate
+#else
+#define PROFILER_MAIN_SCOPE kernel_profiler::profileScopeGuaranteed
+#endif
+
 #define DeviceZoneScopedMainN(name)                                            \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
-    kernel_profiler::profileScopeGuaranteed<hash, 0> zone = kernel_profiler::profileScopeGuaranteed<hash, 0>();
+    PROFILER_MAIN_SCOPE<hash, 0> zone = PROFILER_MAIN_SCOPE<hash, 0>();
 
 #define DeviceZoneScopedMainChildN(name)                                       \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
-    kernel_profiler::profileScopeGuaranteed<hash, 1> zone = kernel_profiler::profileScopeGuaranteed<hash, 1>();
+    PROFILER_MAIN_SCOPE<hash, 1> zone = PROFILER_MAIN_SCOPE<hash, 1>();
 
 #define DeviceZoneScopedSumN1(name)                                            \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \


### PR DESCRIPTION
### PR Category
Feature

### Summary
In this mode profiler L1 buffer accumulates data until it is full it will then drop markers until L1 is flushed to DRAM. The flush can only take place during finish in brisc FW.

`--enable-accumulate-profiling` on tracy python module enables it.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mo/L1_accum_min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mo/L1_accum_min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mo/L1_accum_min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mo/L1_accum_min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mo/L1_accum_min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mo/L1_accum_min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mo/L1_accum_min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mo/L1_accum_min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mo/L1_accum_min)