### PR TITLE
[skip ci] #48510: rebaseline Qwen2.5-VL-32B wh_llmbox_perf decode gate

### DIFF
--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -1052,10 +1052,18 @@ targets:
               # gross regressions without flaking on the swing.
               prefill_time_to_first_token: 351
               prefill_time_to_first_token_tolerance: 0.4
-              # decode raised 19.9 -> 23.8: 4/4 recent scheduled runs measured
-              # 23.1-24.4 t/s/u on wh_llmbox_perf (consistently above old target).
-              decode_t/s/u: 23.8
-              decode_t/s: 23.8
+              # decode_t/s/u is run-to-run unstable (observed 14.4-21.1 across runs,
+              # see #48510). The earlier 23.8 target was set pre-#48037; the on-device
+              # gibberish fix (#48037) traded decode throughput for correctness
+              # (per-step decode-input re-staging + eager, un-traced sampling), so
+              # sustained perf now centers ~18. This is a Tier 3 model (minimum
+              # coverage, not perf-optimized), so center on the post-fix mean with a
+              # wide 0.2 tolerance ([14.4, 21.6]) to gate gross regressions without
+              # flaking on the swing.
+              decode_t/s/u: 18.0
+              decode_t_s_u_tolerance: 0.2
+              decode_t/s: 18.0
+              decode_t_s_tolerance: 0.2
             accuracy: {}
             owner_id: U07RY6B5FLJ # Gongyu Wang
             team: models


### PR DESCRIPTION
## What

Re-baselines the `decode_t/s` / `decode_t/s/u` perf gate for **Qwen2.5-VL-32B** on `wh_llmbox_perf` (b1/s128). Fixes #48510.

| | Before | After |
|---|---|---|
| `decode_t/s/u` | 23.8 | **18.0** |
| `decode_t/s` | 23.8 | **18.0** |
| tolerance | default 0.15 | **0.2** (both metrics) |
| Lower bound | 20.23 | **14.4** |
| Upper bound | 27.4 | **21.6** |

## Why

The failing gate is the combination of two things, neither of which is a regression worth bisecting on a Tier 3 model:

1. **The 23.8 target is stale.** It was set in #47028 based on 4 pre-#48037 runs (23.1–24.4 t/s/u), when on-device greedy decode ran fully traced.
2. **#48037 traded decode throughput for correctness.** The on-device decode gibberish fix sets `_tt_disable_sampling_trace` + `_tt_vllm_always_refresh_decode_trace_inputs` unconditionally (`models/demos/qwen25_vl/tt/model.py`), adding per-step host work (decode-input re-staging + eager, un-traced sampling) — applied to batch-1 too. Sustained perf now centers ~18, with a wide run-to-run swing (observed 14.38–21.11, consistent with the host-side overhead + thermal/board sensitivity noted in the issue).

**Qwen2.5-VL-32B is Tier 3** (`models/model_ci_tiers.md`) — minimum coverage, explicitly *not* performance-optimized. The gate should catch gross regressions, not flake on the swing. So this re-centers on the post-fix mean (18.0) with a wide 0.2 tolerance (`[14.4, 21.6]`) that absorbs the full observed range — the same wide-band approach already used for the equally-unstable `qwen2.5-coder-32b` entry.

If/when the `#48404` heavy-path fix lands and the `#48037` workarounds can be scoped to batch>1 (restoring traced batch-1 decode), this target can be raised again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/qwen25-vl-32b-perf-gate-rebaseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/qwen25-vl-32b-perf-gate-rebaseline)