### PR TITLE
[Feature] Bring up program dispatch on Quasar fast dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -1057,4 +1057,132 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCRTAUniqueL1Addresses) {
     unit_tests::runtime_args::verify_quasar_crtas(mesh_device, core, all_crtas, /*expect_shared_address*/ false);
 }
 
+TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
+    auto mesh_device = devices_[0];
+    const experimental::NodeCoord node{0, 0};
+    CoreRange core_range(CoreCoord{0, 0});
+    CoreRangeSet core_range_set(std::vector{core_range});
+
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+
+    const uint32_t address_1 = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t address_2 = address_1 + sizeof(uint32_t);
+    const uint32_t value_1 = 0xaaaabbbb;
+    const uint32_t value_2 = 0xccccdddd;
+
+    // Zero-init both output slots.
+    std::vector<uint32_t> zeros(2, 0);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, address_1, zeros);
+
+    // Two kernels, each using one DM thread, writing to distinct L1 addresses.
+    const experimental::KernelSpecName K1{"k1"}, K2{"k2"};
+    auto make_dm_spec = [&](const experimental::KernelSpecName& id) {
+        return experimental::KernelSpec{
+            .unique_id = id,
+            .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+            .num_threads = 1,
+            .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
+            .hw_config =
+                experimental::DataMovementHardwareConfig{
+                    .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+        };
+    };
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {K1, K2}, .target_nodes = core_range_set};
+    experimental::ProgramSpec spec{
+        .name = "merge_test", .kernels = {make_dm_spec(K1), make_dm_spec(K2)}, .work_units = {main_wu}};
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    // Build two partial ProgramRunArgs, one per kernel.
+    experimental::ProgramRunArgs part1;
+    part1.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = K1,
+        .runtime_arg_values = {{node, {{"address", address_1}}}},
+        .common_runtime_arg_values = {{"value", value_1}},
+    }};
+    experimental::ProgramRunArgs part2;
+    part2.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = K2,
+        .runtime_arg_values = {{node, {{"address", address_2}}}},
+        .common_runtime_arg_values = {{"value", value_2}},
+    }};
+
+    // Merge and set.
+    std::vector<experimental::ProgramRunArgs> rest = {part2};
+    experimental::ProgramRunArgs merged = experimental::MergeProgramRunArgs(std::move(part1), rest);
+    experimental::SetProgramRunArgs(program, merged);
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> out(2, 0);
+    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], node, address_1, 2 * sizeof(uint32_t), out);
+    ASSERT_EQ(out, std::vector<uint32_t>({value_1, value_2}));
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarUpdateProgramRunArgs) {
+    auto mesh_device = devices_[0];
+    const experimental::NodeCoord node{0, 0};
+    CoreRange core_range(CoreCoord{0, 0});
+    CoreRangeSet core_range_set(std::vector{core_range});
+
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+
+    const uint32_t address_1 = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t address_2 = address_1 + sizeof(uint32_t);
+    const uint32_t value_1 = 0x11223344;
+    const uint32_t value_2 = 0x99aabbcc;
+
+    const experimental::KernelSpecName DM_KERNEL{"dm_kernel"};
+    experimental::KernelSpec dm_kernel_spec{
+        .unique_id = DM_KERNEL,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+        .num_threads = unit_tests::runtime_args::kQuasarNumUserDms,
+        .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+    };
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = core_range_set};
+    experimental::ProgramSpec spec{
+        .name = "update_run_args_test", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, experimental::MakeProgramFromSpec(*mesh_device, spec));
+    Program& prog = workload.get_programs().at(device_range);
+
+    std::vector<uint32_t> zeros(2, 0);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, address_1, zeros);
+
+    // First enqueue: write value_1 to address_1.
+    experimental::ProgramRunArgs params1;
+    params1.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = DM_KERNEL,
+        .runtime_arg_values = {{node, {{"address", address_1}}}},
+        .common_runtime_arg_values = {{"value", value_1}},
+    }};
+    experimental::SetProgramRunArgs(prog, params1);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    // Second enqueue: update to value_2 and re-dispatch to address_2.
+    experimental::ProgramRunArgs params2;
+    params2.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = DM_KERNEL,
+        .runtime_arg_values = {{node, {{"address", address_2}}}},
+        .common_runtime_arg_values = {{"value", value_2}},
+    }};
+    experimental::UpdateProgramRunArgs(prog, params2);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> outputs(2, 0);
+    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], node, address_1, 2 * sizeof(uint32_t), outputs);
+    ASSERT_EQ(outputs, std::vector<uint32_t>({value_1, value_2}));
+}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -169,9 +169,6 @@ protected:
 class QuasarMeshDeviceSingleCardFixture : public MeshDeviceSingleCardFixture {
 protected:
     void SetUp() override {
-        // if (!this->validate_dispatch_mode()) {
-        //     GTEST_SKIP();
-        // }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         if (this->arch_ != tt::ARCH::QUASAR) {
             GTEST_SKIP() << "Not a Quasar device";

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -169,9 +169,9 @@ protected:
 class QuasarMeshDeviceSingleCardFixture : public MeshDeviceSingleCardFixture {
 protected:
     void SetUp() override {
-        if (!this->validate_dispatch_mode()) {
-            GTEST_SKIP();
-        }
+        // if (!this->validate_dispatch_mode()) {
+        //     GTEST_SKIP();
+        // }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         if (this->arch_ != tt::ARCH::QUASAR) {
             GTEST_SKIP() << "Not a Quasar device";

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -138,8 +138,11 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
 
         const auto detected_arch = tt::tt_metal::MetalContext::instance().get_cluster().arch();
+        // Watcher NOC sanitization currently only works on Quasar in slow dispatch.
+        // TODO: Remove the slow dispatch check once NOC sanitization is supported on Quasar in fast dispatch (#45878)
+        const bool slow_dispatch = !tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noc_sanitize_linked_transaction(
-            detected_arch == tt::ARCH::BLACKHOLE);
+            detected_arch == tt::ARCH::BLACKHOLE || (detected_arch == tt::ARCH::QUASAR && slow_dispatch));
 
         // Parent class initializes devices and any necessary flags
         DebugToolsMeshFixture::SetUp();

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -139,7 +139,7 @@ protected:
 
         const auto detected_arch = tt::tt_metal::MetalContext::instance().get_cluster().arch();
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noc_sanitize_linked_transaction(
-            detected_arch == tt::ARCH::BLACKHOLE || detected_arch == tt::ARCH::QUASAR);
+            detected_arch == tt::ARCH::BLACKHOLE);
 
         // Parent class initializes devices and any necessary flags
         DebugToolsMeshFixture::SetUp();

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -200,6 +200,17 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     // Dispatch non-blocking: kernels post waypoint then spin on sync flag
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
 
+    // Get processor counts from HAL and build expected waypoint strings.
+    uint32_t num_tensix = hal.get_num_risc_processors(HalProgrammableCoreType::TENSIX);
+    // On Quasar, DM0/DM1 are reserved for internal use and don't post a user waypoint,
+    // so the expected per-tensix waypoint count drops by 2.
+    if (is_quasar) {
+        num_tensix -= 2;
+    }
+    const uint32_t num_idle_eth = hal.get_num_risc_processors(HalProgrammableCoreType::IDLE_ETH);
+    std::string tensix_waypoints = build_waypoint_string(num_tensix);
+    std::string idle_eth_waypoints = build_waypoint_string(num_idle_eth);
+
     // Build poll patterns and wait for waypoints to appear.
     // On Quasar, slots 0/1 (reserved DM0/DM1) post a non-AAAA status (e.g. " NTW,  W1,") before
     // the first user AAAA. Glob between ": " and the waypoint absorbs that prefix; it matches
@@ -207,7 +218,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     std::vector<std::string> poll_strings;
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
-            poll_strings.push_back(fmt::format("worker core(x={:2},y={:2})*: *{}", x, y, waypoint));
+            poll_strings.push_back(fmt::format("worker core(x={:2},y={:2})*: *{}", x, y, tensix_waypoints));
         }
     }
     if (has_eth_cores) {
@@ -217,7 +228,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     }
     if (has_idle_eth_cores) {
         for (const auto& core : device->get_inactive_ethernet_cores()) {
-            poll_strings.push_back(fmt::format("idleth core(x={:2},y={:2})*: {}", core.x, core.y, waypoint));
+            poll_strings.push_back(fmt::format("idleth core(x={:2},y={:2})*: {}", core.x, core.y, idle_eth_waypoints));
         }
     }
 
@@ -246,17 +257,6 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
         }
     }
     distributed::Finish(mesh_device->mesh_command_queue());
-
-    // Get processor counts from HAL and build expected waypoint strings.
-    // On Quasar, DM0/DM1 are reserved for internal use and don't post a user waypoint,
-    // so the expected per-tensix waypoint count drops by 2.
-    uint32_t num_tensix = hal.get_num_risc_processors(HalProgrammableCoreType::TENSIX);
-    if (is_quasar) {
-        num_tensix -= 2;
-    }
-    uint32_t num_idle_eth = hal.get_num_risc_processors(HalProgrammableCoreType::IDLE_ETH);
-    std::string tensix_waypoints = build_waypoint_string(num_tensix);
-    std::string idle_eth_waypoints = build_waypoint_string(num_idle_eth);
 
     log_info(tt::LogTest, "Verifying: {} waypoints/TENSIX, 1/active ETH, {}/idle ETH", num_tensix, num_idle_eth);
 

--- a/tests/tt_metal/tt_metal/sources.cmake
+++ b/tests/tt_metal/tt_metal/sources.cmake
@@ -26,6 +26,9 @@ set(UNIT_TESTS_LEGACY_SRC
     test_multiple_programs.cpp
     test_pack_relu.cpp
     test_quasar_compute_kernels.cpp
+    test_quasar_events.cpp
+    test_quasar_mesh_buffers.cpp
+    test_quasar_mesh_workloads.cpp
     test_quasar_semaphores.cpp
     test_sdpa_reduce_c.cpp
     test_single_dm_l1_write.cpp

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -275,6 +275,10 @@ TEST_F(MeshDeviceSingleCardFixture, Bmm) {
 // when running a multi-neo emu/sim build. Otherwise its the same test with batch split across nodes.
 TEST_F(QuasarMeshDeviceSingleCardFixture, BmmMultinode) {
     auto& mesh_device = *devices_[0];
+    if (mesh_device.compute_with_storage_grid_size().x < 2) {
+        GTEST_SKIP() << "This test requires at least 2 worker nodes.";
+    }
+
     IDevice* dev = mesh_device.get_devices()[0];
 
     BmmParams p;

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -38,9 +38,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 
-    // These addresses have been randomly chosen
-    uint32_t l1_address = 1000 * 1024;
-    uint32_t dram_address = 30000 * 1024;
+    uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    uint32_t dram_address = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
     std::vector<uint32_t> value = {0x12345678};
 
     tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_address, value);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
@@ -30,9 +30,10 @@ extern uint32_t crta_count;
 // Helper: Signal completion to dispatcher before assert hangs the kernel
 static FORCE_INLINE void signal_completion_before_assert() {
 #if defined(ARCH_QUASAR)
-    // Quasar SD: signal via go_message
     volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
     go_message_in->signal = RUN_MSG_DONE;
+    uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
+    notify_dispatch_core_done(dispatch_addr, noc_index);
 #else  // Else WH/BH
 #ifdef COMPILE_FOR_TRISC
     // signal via subordinate sync

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts_2_0.cpp
@@ -41,13 +41,9 @@ void kernel_main() {
         // Signal completion to dispatcher before the assert hangs the kernel so the
         // dispatcher (and Device::close) can still make progress.
         volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-#if defined(COMPILE_FOR_DM)
-        // TODO: Remove the SD path once FD is enabled on Quasar.
         go_message_in->signal = RUN_MSG_DONE;
-#else
         uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
         notify_dispatch_core_done(dispatch_addr, noc_index);
-#endif
     }
 #else
 #if defined(COMPILE_FOR_TRISC)

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -27,6 +27,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
         GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
+    auto mesh_device = devices_[0];
+    if (mesh_device->compute_with_storage_grid_size().x < 2) {
+        GTEST_SKIP() << "This test requires at least 2 worker nodes.";
+    }
     if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         log_error(
             tt::LogTest,
@@ -35,8 +39,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
         log_error(tt::LogTest, "For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)");
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
-    auto mesh_device = devices_[0];
+    IDevice* dev = mesh_device->get_devices()[0];
 
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -43,7 +43,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
-    constexpr uint32_t l1_address = 1000 * 1024;
+    const uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     std::vector<uint32_t> init_values(16, 0);
     tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, l1_address, init_values);
 
@@ -119,7 +120,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
-    constexpr uint32_t l1_address = 1000 * 1024;
+    const uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     std::vector<uint32_t> init_values(4, 0);
     tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, l1_address, init_values);
 

--- a/tests/tt_metal/tt_metal/test_quasar_events.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_events.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/device_fixture.hpp"
+#include "context/metal_context.hpp"
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_event.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, EventSynchronize) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    auto mesh_device = devices_[0];
+    IDevice* dev = mesh_device->get_devices()[0];
+    const experimental::NodeCoord node{0, 0};
+
+    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t value = 0x12abcd34;
+
+    std::vector<uint32_t> zeros(1, 0);
+    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    const experimental::KernelSpecName DM_KERNEL{"dm_kernel"};
+    experimental::KernelSpec dm_kernel_spec{
+        .unique_id = DM_KERNEL,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+        .num_threads = 1,
+        .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+    };
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
+    experimental::ProgramSpec spec{.name = "event_test", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = DM_KERNEL,
+        .runtime_arg_values = {{node, {{"address", address}}}},
+        .common_runtime_arg_values = {{"value", value}},
+    }};
+    experimental::SetProgramRunArgs(program, params);
+
+    workload.add_program(device_range, std::move(program));
+
+    // Dispatch non-blocking and record a host-visible event immediately after.
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::MeshEvent event = cq.enqueue_record_event_to_host();
+
+    // Block the host until the CQ has processed past the event point.
+    distributed::EventSynchronize(event);
+
+    std::vector<uint32_t> outputs(1, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), outputs);
+    ASSERT_EQ(outputs[0], value);
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, EventQuery) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    auto mesh_device = devices_[0];
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+
+    distributed::MeshEvent event = cq.enqueue_record_event_to_host();
+
+    while (!distributed::EventQuery(event)) {
+    };
+
+    ASSERT_TRUE(distributed::EventQuery(event));
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, EventBetweenWorkloads) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    auto mesh_device = devices_[0];
+    IDevice* dev = mesh_device->get_devices()[0];
+    const experimental::NodeCoord node{0, 0};
+
+    const uint32_t address_1 = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t address_2 = address_1 + sizeof(uint32_t);
+    const uint32_t value_1 = 0xaabb1122;
+    const uint32_t value_2 = 0xccdd3344;
+
+    std::vector<uint32_t> zeros(2, 0);
+    tt_metal::detail::WriteToDeviceL1(dev, node, address_1, zeros);
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    auto make_workload = [&](uint32_t address, uint32_t value, const char* kernel_id) {
+        distributed::MeshWorkload wl;
+        const experimental::KernelSpecName DM_KERNEL{kernel_id};
+        experimental::KernelSpec spec{
+            .unique_id = DM_KERNEL,
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+            .num_threads = 1,
+            .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
+            .hw_config =
+                experimental::DataMovementHardwareConfig{
+                    .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+        };
+        experimental::WorkUnitSpec wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
+        experimental::ProgramSpec pspec{
+            .name = std::string("event_between_") + kernel_id, .kernels = {spec}, .work_units = {wu}};
+        Program program = experimental::MakeProgramFromSpec(*mesh_device, pspec);
+        experimental::ProgramRunArgs params;
+        params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+            .kernel = DM_KERNEL,
+            .runtime_arg_values = {{node, {{"address", address}}}},
+            .common_runtime_arg_values = {{"value", value}},
+        }};
+        experimental::SetProgramRunArgs(program, params);
+        wl.add_program(device_range, std::move(program));
+        return wl;
+    };
+
+    auto wl1 = make_workload(address_1, value_1, "dm_kernel_1");
+    auto wl2 = make_workload(address_2, value_2, "dm_kernel_2");
+
+    // Enqueue both non-blocking; record event after first to observe ordering.
+    distributed::EnqueueMeshWorkload(cq, wl1, false);
+    distributed::MeshEvent event_after_wl1 = cq.enqueue_record_event_to_host();
+    distributed::EnqueueMeshWorkload(cq, wl2, false);
+
+    // Synchronize on event_after_wl1 and verify wl1's result is present.
+    distributed::EventSynchronize(event_after_wl1);
+
+    std::vector<uint32_t> out_1(1, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, node, address_1, sizeof(uint32_t), out_1);
+    ASSERT_EQ(out_1[0], value_1);
+
+    // Drain the remaining wl2.
+    distributed::Finish(cq);
+
+    std::vector<uint32_t> out_2(1, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, node, address_2, sizeof(uint32_t), out_2);
+    ASSERT_EQ(out_2[0], value_2);
+}

--- a/tests/tt_metal/tt_metal/test_quasar_mesh_buffers.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_mesh_buffers.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/device_fixture.hpp"
+#include "context/metal_context.hpp"
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/host_api.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+constexpr uint32_t num_elems = 1024;
+constexpr uint32_t buf_size = num_elems * sizeof(uint32_t);
+constexpr uint32_t page_size = buf_size / 8;
+
+std::shared_ptr<distributed::MeshBuffer> make_mesh_buffer(
+    BufferType buffer_type, distributed::MeshDevice* mesh_device) {
+    distributed::DeviceLocalBufferConfig local_cfg{
+        .page_size = page_size,
+        .buffer_type = buffer_type,
+    };
+    distributed::ReplicatedBufferConfig global_cfg{.size = buf_size};
+    return distributed::MeshBuffer::create(global_cfg, local_cfg, mesh_device);
+}
+
+}  // namespace
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferWriteReadDRAM) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    distributed::MeshCommandQueue& cq = devices_[0]->mesh_command_queue();
+    std::shared_ptr<distributed::MeshBuffer> buf = make_mesh_buffer(BufferType::DRAM, devices_[0].get());
+
+    std::vector<uint32_t> src(num_elems);
+    std::iota(src.begin(), src.end(), 0xabcd0000u);
+
+    distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+
+    std::vector<uint32_t> dst;
+    distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+
+    ASSERT_EQ(dst.size(), src.size());
+    ASSERT_EQ(dst, src);
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferMultipleWriteReadRoundsDRAM) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    distributed::MeshCommandQueue& cq = devices_[0]->mesh_command_queue();
+    std::shared_ptr<distributed::MeshBuffer> buf = make_mesh_buffer(BufferType::DRAM, devices_[0].get());
+
+    for (uint32_t round = 0; round < 10; round++) {
+        std::vector<uint32_t> src(num_elems);
+        std::iota(src.begin(), src.end(), round * 1000u);
+
+        distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+
+        std::vector<uint32_t> dst;
+        distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+
+        ASSERT_EQ(dst, src);
+    }
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferWriteReadL1) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    distributed::MeshCommandQueue& cq = devices_[0]->mesh_command_queue();
+    std::shared_ptr<distributed::MeshBuffer> buf = make_mesh_buffer(BufferType::L1, devices_[0].get());
+
+    std::vector<uint32_t> src(num_elems);
+    std::iota(src.begin(), src.end(), 0xabcd0000u);
+
+    distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+
+    std::vector<uint32_t> dst;
+    distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+
+    ASSERT_EQ(dst.size(), src.size());
+    ASSERT_EQ(dst, src);
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferMultipleWriteReadRoundsL1) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    distributed::MeshCommandQueue& cq = devices_[0]->mesh_command_queue();
+    std::shared_ptr<distributed::MeshBuffer> buf = make_mesh_buffer(BufferType::L1, devices_[0].get());
+
+    for (uint32_t round = 0; round < 10; round++) {
+        std::vector<uint32_t> src(num_elems);
+        std::iota(src.begin(), src.end(), round * 1000u);
+
+        distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+
+        std::vector<uint32_t> dst;
+        distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+
+        ASSERT_EQ(dst, src);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/device_fixture.hpp"
+#include "context/metal_context.hpp"
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+constexpr uint32_t kNumUserDMThreads = 6;
+constexpr uint32_t kNumComputeNEOs = 4;
+constexpr uint32_t kNumTRISCsPerNEO = 4;
+constexpr uint32_t kL1CacheLineBytes = 64;
+
+// L1 slots consumed by one workload: kNumUserDMThreads (DM) + kNumComputeNEOs*kNumTRISCsPerNEO (compute)
+constexpr uint32_t kWorkloadOutputCount = kNumUserDMThreads + kNumComputeNEOs * kNumTRISCsPerNEO;
+
+// Expected output of risc_math.cpp kernel with kNumComputeNEOs=4 (4 NEOs × 4 TRISCs = 16 writes).
+const std::vector<uint32_t> kExpectedComputeValues = {4, 6, 5, 9, 8, 10, 9, 13, 12, 14, 13, 17, 16, 18, 17, 21};
+
+// Builds a MeshWorkload with kNumUserDMThreads DM kernels and one 4-NEO compute kernel.
+//
+// DM kernel layout: each of the kNumUserDMThreads kernel specs uses num_threads=1, allowing
+// each DM processor to receive its own address arg.  DM processor i writes
+//   dm_base_value + i  →  dm_base_address + i * sizeof(uint32_t)
+//
+// Compute kernel layout: risc_math.cpp with num_threads=kNumComputeNEOs writes 16 uint32_t
+// values starting at compute_address (outputs match kExpectedComputeValues).
+//
+// workload_id_str must be unique per call (used to derive kernel names).
+distributed::MeshWorkload create_workload(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const experimental::NodeCoord& node,
+    uint32_t dm_base_address,
+    uint32_t dm_base_value,
+    uint32_t compute_address,
+    const std::string& workload_id_str) {
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    std::vector<experimental::KernelSpec> kernel_specs;
+    std::vector<experimental::KernelSpecName> wu_kernel_names;
+
+    for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
+        experimental::KernelSpecName kernel_id{std::string("dm_") + workload_id_str + "_" + std::to_string(i)};
+        kernel_specs.push_back(experimental::KernelSpec{
+            .unique_id = kernel_id,
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+            .num_threads = 1,
+            .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
+            .hw_config =
+                experimental::DataMovementHardwareConfig{
+                    .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+        });
+        wu_kernel_names.push_back(std::move(kernel_id));
+    }
+
+    const experimental::KernelSpecName COMPUTE_KERNEL{std::string("compute_") + workload_id_str};
+    kernel_specs.push_back(experimental::KernelSpec{
+        .unique_id = COMPUTE_KERNEL,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
+        .num_threads = kNumComputeNEOs,
+        .runtime_arg_schema = {.runtime_arg_names = {"l1_address"}},
+        .hw_config = experimental::ComputeHardwareConfig{},
+    });
+    wu_kernel_names.push_back(COMPUTE_KERNEL);
+
+    experimental::WorkUnitSpec main_wu{
+        .name = "main",
+        .kernels = wu_kernel_names,
+        .target_nodes = node,
+    };
+    experimental::ProgramSpec spec{
+        .name = std::string("l1_write_") + workload_id_str,
+        .kernels = kernel_specs,
+        .work_units = {main_wu},
+    };
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::ProgramRunArgs params;
+    for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
+        params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
+            .kernel = experimental::KernelSpecName{std::string("dm_") + workload_id_str + "_" + std::to_string(i)},
+            .runtime_arg_values = {{node, {{"address", dm_base_address + i * sizeof(uint32_t)}}}},
+            .common_runtime_arg_values = {{"value", dm_base_value + i}},
+        });
+    }
+    params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = COMPUTE_KERNEL,
+        .runtime_arg_values = {{node, {{"l1_address", compute_address}}}},
+    });
+    experimental::SetProgramRunArgs(program, params);
+
+    workload.add_program(device_range, std::move(program));
+    return workload;
+}
+
+}  // namespace
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, TestSingleWorkloadNonBlockingEnqueueFinish) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    auto mesh_device = devices_[0];
+    IDevice* dev = mesh_device->get_devices()[0];
+    const experimental::NodeCoord node{0, 0};
+
+    const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t dm_base_address = base_address;
+    const uint32_t compute_address = base_address + kNumUserDMThreads * sizeof(uint32_t);
+    const uint32_t dm_base_value = 0xdead0000;
+
+    std::vector<uint32_t> zeros(kWorkloadOutputCount, 0);
+    tt_metal::detail::WriteToDeviceL1(dev, node, base_address, zeros);
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload =
+        create_workload(mesh_device, node, dm_base_address, dm_base_value, compute_address, "k0");
+
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    std::vector<uint32_t> dm_output(kNumUserDMThreads, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, node, dm_base_address, kNumUserDMThreads * sizeof(uint32_t), dm_output);
+    for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
+        ASSERT_EQ(dm_output[i], dm_base_value + i);
+    }
+
+    std::vector<uint32_t> compute_output(kNumComputeNEOs * kNumTRISCsPerNEO, 0);
+    tt_metal::detail::ReadFromDeviceL1(
+        dev, node, compute_address, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
+    ASSERT_EQ(compute_output, kExpectedComputeValues);
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, TestMultipleWorkloadsNonBlockingEnqueueFinish) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    auto mesh_device = devices_[0];
+    IDevice* dev = mesh_device->get_devices()[0];
+    const experimental::NodeCoord node{0, 0};
+
+    const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+
+    constexpr uint32_t kNumWorkloads = 4;
+    const std::array<uint32_t, kNumWorkloads> dm_base_values = {0x11110000, 0x22220000, 0x33330000, 0x44440000};
+
+    // Put each workload's DM and compute outputs on separate 64-byte cache lines so the DM cache flush can't clobber
+    // the compute kernel's uncached writes.
+    auto dm_base_addr_for = [&](uint32_t w) { return base_address + w * 2 * kL1CacheLineBytes; };
+    auto compute_addr_for = [&](uint32_t w) { return dm_base_addr_for(w) + kL1CacheLineBytes; };
+
+    std::vector<uint32_t> zeros(kNumWorkloads * 2 * kL1CacheLineBytes / sizeof(uint32_t), 0);
+    tt_metal::detail::WriteToDeviceL1(dev, node, base_address, zeros);
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    std::vector<distributed::MeshWorkload> workloads;
+    workloads.reserve(kNumWorkloads);
+    for (uint32_t w = 0; w < kNumWorkloads; w++) {
+        const std::string kernel_id = "k" + std::to_string(w + 1);
+        workloads.push_back(
+            create_workload(mesh_device, node, dm_base_addr_for(w), dm_base_values[w], compute_addr_for(w), kernel_id));
+    }
+
+    for (uint32_t w = 0; w < kNumWorkloads; w++) {
+        distributed::EnqueueMeshWorkload(cq, workloads[w], false);
+    }
+    distributed::Finish(cq);
+
+    for (uint32_t w = 0; w < kNumWorkloads; w++) {
+        const uint32_t dm_base_addr = dm_base_addr_for(w);
+        const uint32_t compute_addr = compute_addr_for(w);
+
+        std::vector<uint32_t> dm_output(kNumUserDMThreads, 0);
+        tt_metal::detail::ReadFromDeviceL1(dev, node, dm_base_addr, kNumUserDMThreads * sizeof(uint32_t), dm_output);
+        for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
+            EXPECT_EQ(dm_output[i], dm_base_values[w] + i);
+        }
+
+        std::vector<uint32_t> compute_output(kNumComputeNEOs * kNumTRISCsPerNEO, 0);
+        tt_metal::detail::ReadFromDeviceL1(
+            dev, node, compute_addr, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
+        EXPECT_EQ(compute_output, kExpectedComputeValues);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "hal.hpp"
 #include "llrt/rtoptions.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -37,10 +38,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
     constexpr uint32_t num_elements = 10;
-    constexpr uint32_t buf_a_addr = 1000 * 1024;
-    constexpr uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
-    constexpr uint32_t dram_src_addr = 29000 * 1024;
-    constexpr uint32_t dram_dst_addr = 30000 * 1024;
+    const uint32_t buf_a_addr = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
+    const uint32_t dram_src_addr = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
+    const uint32_t dram_dst_addr = dram_src_addr + (1000 * 1024);
 
     std::vector<uint32_t> initial_data(num_elements, 0);
     for (uint32_t i = 0; i < num_elements; i++) {
@@ -185,10 +187,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
     constexpr uint32_t num_elements = 10;
-    constexpr uint32_t buf_a_addr = 1000 * 1024;
-    constexpr uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
-    const uint32_t dram_mid_addr = 31000 * 1024;
-    const uint32_t dram_dst_addr = 32000 * 1024;
+    const uint32_t buf_a_addr = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
+    const uint32_t dram_mid_addr = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
+    const uint32_t dram_dst_addr = dram_mid_addr + (1000 * 1024);
 
     std::vector<uint32_t> initial_data(num_elements, 0);
     for (uint32_t i = 0; i < num_elements; i++) {

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -178,6 +178,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
 
     auto mesh_device = devices_[0];
 
+    if (mesh_device->compute_with_storage_grid_size().x < 2) {
+        GTEST_SKIP() << "This test requires at least 2 worker nodes.";
+    }
+
     const experimental::NodeCoord node_0{0, 0};
     const experimental::NodeCoord node_1{1, 0};
 

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "common/device_fixture.hpp"
+#include "context/metal_context.hpp"
 
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
@@ -28,7 +29,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
     IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
 
-    const uint32_t address = 100 * 1024;
+    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     const uint32_t value = 0x12345678;
     std::vector<uint32_t> outputs(1);
     outputs[0] = 0;

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -208,15 +208,6 @@ void wait_for_go_message() {
 FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) {
     go_msg_t go_message;
     go_message.all = go_message_in->all;
-    DPRINT(
-        "calculate_dispatch_addr: go_message.master_x: {}, go_message.master_y: {}, "
-        "go_message.dispatch_message_offset: {}\n",
-        go_message.master_x,
-        go_message.master_y,
-        go_message.dispatch_message_offset);
-    DPRINT("NOC_X: {:#x}\n", NOC_X(go_message.master_x));
-    DPRINT("NOC_Y: {:#x}\n", NOC_Y(go_message.master_y));
-    DPRINT("DISPATCH_MESSAGE_ADDR: {:#x}\n", DISPATCH_MESSAGE_ADDR);
 #ifdef ARCH_QUASAR
     constexpr uint32_t dispatch_message_stride = L1_ALIGNMENT;
 #else
@@ -226,12 +217,10 @@ FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) 
         NOC_X(go_message.master_x),
         NOC_Y(go_message.master_y),
         DISPATCH_MESSAGE_ADDR + dispatch_message_stride * go_message.dispatch_message_offset);
-    DPRINT("addr: {:#x}\n", addr);
     return addr;
 }
 
 FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_index) {
-    DPRINT("notify_dispatch_core_done: dispatch_addr: {:#x}, noc_index: {}\n", dispatch_addr, noc_index);
 #ifdef ARCH_QUASAR
     // Quasar has no stream registers; dispatch_addr points to an L1 worker completion counter address.
     noc_fast_atomic_increment<DM_DEDICATED_NOC>(

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -208,14 +208,42 @@ void wait_for_go_message() {
 FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) {
     go_msg_t go_message;
     go_message.all = go_message_in->all;
+    DPRINT(
+        "calculate_dispatch_addr: go_message.master_x: {}, go_message.master_y: {}, "
+        "go_message.dispatch_message_offset: {}\n",
+        go_message.master_x,
+        go_message.master_y,
+        go_message.dispatch_message_offset);
+    DPRINT("NOC_X: {:#x}\n", NOC_X(go_message.master_x));
+    DPRINT("NOC_Y: {:#x}\n", NOC_Y(go_message.master_y));
+    DPRINT("DISPATCH_MESSAGE_ADDR: {:#x}\n", DISPATCH_MESSAGE_ADDR);
+#ifdef ARCH_QUASAR
+    constexpr uint32_t dispatch_message_stride = L1_ALIGNMENT;
+#else
+    constexpr uint32_t dispatch_message_stride = NOC_STREAM_REG_SPACE_SIZE;
+#endif
     uint64_t addr = NOC_XY_ADDR(
         NOC_X(go_message.master_x),
         NOC_Y(go_message.master_y),
-        DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * go_message.dispatch_message_offset);
+        DISPATCH_MESSAGE_ADDR + dispatch_message_stride * go_message.dispatch_message_offset);
+    DPRINT("addr: {:#x}\n", addr);
     return addr;
 }
 
 FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_index) {
+    DPRINT("notify_dispatch_core_done: dispatch_addr: {:#x}, noc_index: {}\n", dispatch_addr, noc_index);
+#ifdef ARCH_QUASAR
+    // Quasar has no stream registers; dispatch_addr points to an L1 worker completion counter address.
+    noc_fast_atomic_increment<DM_DEDICATED_NOC>(
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        dispatch_addr,
+        NOC_UNICAST_WRITE_VC,
+        1,     // increment
+        31,    // wrap bits
+        false  // linked
+    );
+#else
     // Workaround for BH inline writes does not apply here because this writes to a stream register.
     // See comment in `noc_get_interim_inline_value_addr` for more details.
     noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
@@ -228,6 +256,7 @@ FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_
         false,  // mcast
         true    // posted
     );
+#endif
 }
 #endif
 

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -32,7 +32,9 @@ enum class CommandQueueDeviceAddrType : uint8_t {
     REALTIME_PROFILER_MSG = 10,
     DISPATCH_TELEMETRY = 11,
     DISPATCH_TELEMETRY_CONTROL = 12,
-    UNRESERVED = 13,
+    // Completion counters for worker-done signalling on Quasar. Not used on WH/BH.
+    WORKER_COMPLETION_SEMAPHORES = 13,
+    UNRESERVED = 14,
 };
 
 // likely only used in impl

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -7,10 +7,10 @@
 #include <cstring>
 
 #include <random>
-#include <chrono>
 
 #include <tt_stl/aligned_allocator.hpp>
 #include <tt_stl/assert.hpp>
+#include "dispatch/dispatch_mem_map.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch/memcpy.hpp"
 #include "dispatch_settings.hpp"
@@ -109,6 +109,21 @@ vector_aligned<uint32_t> DeviceCommand<hugepage_write>::cmd_vector() const {
 template <bool hugepage_write>
 void DeviceCommand<hugepage_write>::add_dispatch_wait(
     uint32_t flags, uint32_t address, uint32_t stream, uint32_t count, uint8_t dispatcher_type) {
+    // If there are no stream registers (Quasar), translate stream flags to memory flags and calculate the L1 worker
+    // completion counter address from the stream index.
+    if (!MetalContext::instance().hal().has_stream_registers() &&
+        (flags & (CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM))) {
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
+        const uint32_t first_stream = mem_map.get_dispatch_stream_index(0);
+        address = mem_map.get_dispatch_message_addr_start() + mem_map.get_sync_offset(stream - first_stream);
+        uint32_t new_flags = flags & ~(CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM);
+        new_flags |= CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
+        if (flags & CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM) {
+            new_flags |= CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_MEMORY;
+        }
+        flags = new_flags;
+        stream = 0;
+    }
     auto initialize_wait_cmds = [&](CQPrefetchCmd* relay_wait, CQDispatchCmd* wait_cmd) {
         relay_wait->base.cmd_id = CQ_PREFETCH_CMD_RELAY_INLINE;
         relay_wait->relay_inline.dispatcher_type = dispatcher_type;

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -45,7 +45,8 @@ DispatchMemMap::DispatchMemMap(
     noc_overlay_start_addr_(hal.get_noc_overlay_start_addr()),
     noc_stream_reg_space_size_(hal.get_noc_stream_reg_space_size()),
     noc_stream_remote_dest_buf_space_available_update_reg_index_(
-        hal.get_noc_stream_remote_dest_buf_space_available_update_reg_index()) {
+        hal.get_noc_stream_remote_dest_buf_space_available_update_reg_index()),
+    has_stream_registers_(hal.has_stream_registers()) {
     uint32_t l1_base;
     uint32_t l1_size;
     if (core_type == CoreType::WORKER) {
@@ -96,6 +97,9 @@ DispatchMemMap::DispatchMemMap(
             device_cq_addr_sizes_[dev_addr_idx] = DISPATCH_TELEMETRY_SIZE;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_TELEMETRY_CONTROL) {
             device_cq_addr_sizes_[dev_addr_idx] = sizeof(DispatchTelemetryControl);
+        } else if (dev_addr_type == CommandQueueDeviceAddrType::WORKER_COMPLETION_SEMAPHORES) {
+            device_cq_addr_sizes_[dev_addr_idx] =
+                has_stream_registers_ ? 0 : DispatchSettings::DISPATCH_MESSAGE_ENTRIES * l1_alignment;
         } else if (
             dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS ||
             dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_PROGRESS) {
@@ -118,7 +122,8 @@ DispatchMemMap::DispatchMemMap(
             dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS ||
             dev_addr_type == CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG ||
             dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_TELEMETRY ||
-            dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_TELEMETRY_CONTROL) {
+            dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_TELEMETRY_CONTROL ||
+            dev_addr_type == CommandQueueDeviceAddrType::WORKER_COMPLETION_SEMAPHORES) {
             device_cq_addrs_[dev_addr_idx] = align(device_cq_addrs_[dev_addr_idx], l1_alignment);
         }
     }
@@ -231,8 +236,11 @@ uint32_t DispatchMemMap::device_print_dispatch_noc_locations_addr() const { retu
 uint32_t DispatchMemMap::device_print_dispatch_l1_cache_addr() const { return dispatch_s_buffer_end_; }
 
 uint32_t DispatchMemMap::get_device_command_queue_addr(const CommandQueueDeviceAddrType& device_addr_type) const {
-    uint32_t index = ttsl::as_underlying_type<CommandQueueDeviceAddrType>(device_addr_type);
+    const uint32_t index = ttsl::as_underlying_type<CommandQueueDeviceAddrType>(device_addr_type);
     TT_ASSERT(index < this->device_cq_addrs_.size());
+    if (device_addr_type == CommandQueueDeviceAddrType::WORKER_COMPLETION_SEMAPHORES) {
+        TT_FATAL(!this->has_stream_registers_, "Attempting to read address of unallocated memory region");
+    }
     return device_cq_addrs_[index];
 }
 
@@ -246,8 +254,10 @@ uint32_t DispatchMemMap::get_sync_offset(uint32_t index) const {
 }
 
 uint32_t DispatchMemMap::get_dispatch_message_addr_start() const {
-    // Address of the first dispatch message entry. Remaining entries are each offset by
-    // noc_stream_reg_space_size bytes.
+    if (!has_stream_registers_) {
+        // On arches without stream registers (Quasar), use the dedicated L1 worker completion counters region.
+        return get_device_command_queue_addr(CommandQueueDeviceAddrType::WORKER_COMPLETION_SEMAPHORES);
+    }
     return noc_overlay_start_addr_ + (noc_stream_reg_space_size_ * get_dispatch_stream_index(0)) +
            (noc_stream_remote_dest_buf_space_available_update_reg_index_ * sizeof(uint32_t));
 }

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -124,6 +124,7 @@ private:
     uint32_t noc_stream_reg_space_size_ = 0;
     uint32_t noc_stream_remote_dest_buf_space_available_update_reg_index_ = 0;
     uint32_t dispatch_stream_base_ = 0;
+    bool has_stream_registers_ = false;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -358,10 +358,12 @@ constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER = 0x01;
 constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH = 0x02;
 // Wait for a count value on memory.
 constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY = 0x04;
-// Wait for a count value on a stream
-constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM = 0x08;
+// Clear a count value in memory.
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_MEMORY = 0x08;
+// Wait for a count value on a stream.
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM = 0x10;
 // Clear a count value on a stream.
-constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM = 0x10;
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM = 0x20;
 
 struct CQDispatchWaitCmd {
     uint8_t flags;    // see above

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -312,7 +312,7 @@ get_packed_write_max_multicast_sub_cmds(uint32_t packed_write_max_unicast_sub_cm
     uint32_t packed_write_max_multicast_sub_cmds = packed_write_max_unicast_sub_cmds *
                                                    sizeof(CQDispatchWritePackedUnicastSubCmd) /
                                                    sizeof(CQDispatchWritePackedMulticastSubCmd);
-    return packed_write_max_multicast_sub_cmds;
+    return packed_write_max_multicast_sub_cmds < 1 ? 1 : packed_write_max_multicast_sub_cmds;
 }
 
 // Current implementation limit is based on size of the l1_cache which stores the sub_cmds

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1054,12 +1054,9 @@ static void process_wait() {
         last_wait_stream = stream;
         volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
             static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
-        DPRINT("DISPATCH WAIT STREAM 0x{:08x} count {}\n", stream, count);
-        DPRINT("stream reg addr value before do loop: {:#x}\n", *sem_addr);
         do {
             IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
         } while (!stream_wrap_ge(*sem_addr, count));
-        DPRINT("stream reg addr value after do loop: {:#x}\n", *sem_addr);
     }
     WAYPOINT("PWD");
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -998,6 +998,24 @@ uint32_t stream_wrap_ge(uint32_t a, uint32_t b) {
     return (diff << shift) >= 0;
 }
 
+#ifdef ARCH_QUASAR
+// Returns a pointer to the L1 worker completion counter address
+FORCE_INLINE volatile uint32_t* worker_completion_sem_addr(uint32_t stream) {
+    return reinterpret_cast<volatile uint32_t*>(
+        l1_uncached_addr(DISPATCH_MESSAGE_ADDR + L1_ALIGNMENT * (stream - first_stream_used)));
+}
+#endif
+
+FORCE_INLINE void wait_worker_completion(uint32_t stream, uint32_t wait_count) {
+#ifdef ARCH_QUASAR
+    while (!wrap_ge(*worker_completion_sem_addr(stream), wait_count)) {
+    }
+#else
+    while (!stream_wrap_ge(NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), wait_count)) {
+    }
+#endif
+}
+
 static void process_wait() {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
@@ -1006,6 +1024,7 @@ static void process_wait() {
     uint32_t barrier = flags & CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER;
     uint32_t notify_prefetch = flags & CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH;
     uint32_t clear_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM;
+    uint32_t clear_memory = flags & CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_MEMORY;
     uint32_t wait_memory = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
     uint32_t wait_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM;
     uint32_t count = cmd->wait.count;
@@ -1035,10 +1054,12 @@ static void process_wait() {
         last_wait_stream = stream;
         volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
             static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
-        // DPRINT("DISPATCH WAIT STREAM 0x{:08x} count {}\n", stream, count);
+        DPRINT("DISPATCH WAIT STREAM 0x{:08x} count {}\n", stream, count);
+        DPRINT("stream reg addr value before do loop: {:#x}\n", *sem_addr);
         do {
             IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
         } while (!stream_wrap_ge(*sem_addr, count));
+        DPRINT("stream reg addr value after do loop: {:#x}\n", *sem_addr);
     }
     WAYPOINT("PWD");
 
@@ -1055,6 +1076,10 @@ static void process_wait() {
         if constexpr (telemetry_enabled) {
             dispatch_telemetry_control->worker_stream_reset_update = ++local_worker_stream_reset_update;
         }
+    }
+    if (clear_memory) {
+        uintptr_t addr = cmd->wait.addr;
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr)) = 0;
     }
     if (notify_prefetch) {
 #ifdef ARCH_QUASAR
@@ -1116,17 +1141,13 @@ void process_go_signal_mcast_cmd() {
         noc_nonposted_writes_acked[noc_index] += num_dests;
 
         WAYPOINT("WCW");
-        while (!stream_wrap_ge(
-            NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), wait_count)) {
-        }
+        wait_worker_completion(stream, wait_count);
         WAYPOINT("WCD");
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
         noc_nonposted_writes_num_issued[noc_index] += 1;
     } else {
         WAYPOINT("WCW");
-        while (!stream_wrap_ge(
-            NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), wait_count)) {
-        }
+        wait_worker_completion(stream, wait_count);
         WAYPOINT("WCD");
     }
 
@@ -1143,10 +1164,14 @@ void process_go_signal_mcast_cmd() {
             // the number of cores specified inside cmd->mcast.num_unicast_txns. If this is
             // greater than the number of cores actually on the chip, we must account for acks
             // from non-existent cores here.
+#ifdef ARCH_QUASAR
+            *worker_completion_sem_addr(stream) += (num_virtual_unicast_cores - num_physical_unicast_cores);
+#else
             NOC_STREAM_WRITE_REG(
                 stream,
                 STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
                 (num_virtual_unicast_cores - num_physical_unicast_cores) << REMOTE_DEST_BUF_WORDS_FREE_INC);
+#endif
         }
     }
 
@@ -1517,13 +1542,16 @@ void kernel_main() {
     }
 
     for (size_t i = 0; i < max_num_worker_sems; i++) {
-        uint32_t index = i + first_stream_used;
-
+        const uint32_t index = i + first_stream_used;
+#ifdef ARCH_QUASAR
+        *worker_completion_sem_addr(index) = 0;
+#else
         NOC_STREAM_WRITE_REG(
             index,
             STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
             -NOC_STREAM_READ_REG(index, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)
                 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+#endif
     }
 
     uint32_t l1_cache[l1_cache_elements_rounded];

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -83,6 +83,8 @@ void issue_trace_commands(
     uint8_t cq_id,
     const DispatchArray<uint32_t>& expected_num_workers_completed,
     CoreCoord dispatch_core) {
+    TT_FATAL(device->arch() != tt::ARCH::QUASAR, "Trace commands are currently not supported on Quasar");
+
     void* cmd_region = sysmem_manager.issue_queue_reserve(dispatch_md.cmd_sequence_sizeB, cq_id);
 
     HugepageDeviceCommand command_sequence(cmd_region, dispatch_md.cmd_sequence_sizeB);


### PR DESCRIPTION
### PR Category
Feature

### Summary
This branch extends Quasar fast dispatch to handle worker-completion signalling and dispatch-wait commands correctly on Quasar, which has no NOC stream registers.

The key host-side changes are:
 - `command_queue_common.hpp` / `dispatch_mem_map.cpp` add a new `WORKER_COMPLETION_SEMAPHORES` entry in `CommandQueueDeviceAddrType`. On arches without stream registers (Quasar), this region is allocated as `DISPATCH_MESSAGE_ENTRIES * L1_ALIGNMENT` bytes in the dispatch L1 map; on WH/BH the size is zero so the region consumes no L1.
 - `dispatch_mem_map.cpp` / `dispatch_mem_map.hpp`: `get_dispatch_message_addr_start()` returns the `WORKER_COMPLETION_SEMAPHORES` base address on Quasar instead of computing an offset into the NOC overlay.
 - `device_command.cpp`: `add_dispatch_wait()` translates stream-based wait/clear flags (`CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM` / `..._CLEAR_STREAM`) into memory-based equivalents (`..._WAIT_MEMORY` / `..._CLEAR_MEMORY`) when the arch has no stream registers, so the dispatcher kernel reads from L1 instead of a stream register.
 - `cq_commands.hpp` adds `CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_MEMORY` and renumbers the existing stream flags to make room.
 - `trace/dispatch.cpp` adds a `TT_FATAL` to prevent trace commands from being issued on Quasar, since trace replay is not yet supported.

The key device-side changes are:
 - `firmware_common.h`: `calculate_dispatch_addr` uses `L1_ALIGNMENT` as the dispatch-message stride on Quasar (replacing `NOC_STREAM_REG_SPACE_SIZE`), and `notify_dispatch_core_done` performs an atomic L1 increment via NOC instead of an inline stream-register write.
 - `cq_dispatch.cpp`: `wait_worker_completion()` branches between a stream-register poll (WH/BH) and an L1 counter poll (Quasar), and `process_wait()` handles the new `CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_MEMORY` flag by zeroing the L1 counter.

For testing, `device_fixture.hpp` drops the slow dispatch check from `QuasarMeshDeviceSingleCardFixture::SetUp()` so Quasar tests can run under fast dispatch. `test_runtime_args.cpp` adds `QuasarMergeProgramRunArgs` and `QuasarUpdateProgramRunArgs`, and new suites `test_quasar_events.cpp`, `test_quasar_mesh_buffers.cpp`, and `test_quasar_mesh_workloads.cpp` cover event synchronization, mesh buffer read/write, and multi-workload dispatch. Several existing Quasar tests were updated to query unreserved L1/DRAM addresses from HAL and to skip when fewer than two worker nodes are available.

Remaining work:
 - adding support for trace replay on Quasar in fast dispatch
 - enabling support for DFBs to run in fast dispatch on Quasar
 - moving the FD kernels from a regular core to a Dispatch Engine
 - using host hugepages instead of DRAM for the command queue on Quasar
 - supporting 2-CQ fast dispatch on Quasar

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_fd_programs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_fd_programs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_fd_programs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_fd_programs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_fd_programs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_fd_programs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_fd_programs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_fd_programs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_fd_programs)