### PR TITLE
tt-dit: fused-QKV LoRA test coverage (TP=4 + alpha-scaling), follow-up to #46519

### DIFF
--- a/models/tt_dit/experimental/tests/test_adapter_loader.py
+++ b/models/tt_dit/experimental/tests/test_adapter_loader.py
@@ -42,9 +42,12 @@ def _save_synthetic_adapter(
     dim: int = 128,
     ffn_dim: int = 256,
     rank: int = 8,
+    alpha: float | None = None,
 ) -> None:
     """Write a fake LoRA safetensors that covers all 6 LoRA-targeted Linears
-    per block, using the lightx2v naming convention."""
+    per block, using the lightx2v naming convention. When ``alpha`` is given,
+    a matching ``.alpha`` scalar is written for every pair (block-prefixed,
+    exactly as real lightx2v/Seko adapters ship them)."""
     from safetensors.torch import save_file
 
     state: dict[str, torch.Tensor] = {}
@@ -53,6 +56,8 @@ def _save_synthetic_adapter(
     def add_pair(base: str, in_dim: int, out_dim: int):
         state[f"{base}.lora_A.weight"] = torch.randn(rank, in_dim, dtype=dtype) * 0.02
         state[f"{base}.lora_B.weight"] = torch.randn(out_dim, rank, dtype=dtype) * 0.02
+        if alpha is not None:
+            state[f"{base}.alpha"] = torch.tensor(float(alpha), dtype=torch.float32)
 
     for i in range(num_blocks):
         # self-attn Q, K, V, O
@@ -222,3 +227,68 @@ def test_pipeline_bind_unbind_walks_all_modules(mesh_device: ttnn.MeshDevice) ->
             cur = cur[int(part)] if part.isdigit() else getattr(cur, part)
         assert not cur.is_lora_active
         assert cur.active_idx is None
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_fused_qkv_alpha_scaling_matches_singletons(mesh_device: ttnn.MeshDevice) -> None:
+    """Regression: fused-QKV targets must honor the adapter's per-key ``alpha``
+    just like singletons. The alpha lookup is block-prefixed
+    (``blocks.N.self_attn.q``); a key built without the block index silently
+    misses and falls back to ``rank`` → the delta is applied (rank/alpha)x too
+    strong (8x for the Seko V2 lightning LoRAs: alpha=8, rank=64), which wrecks
+    the high-noise expert. See _lightx2v_qkv_key / _register_fused_qkv.
+    """
+    num_heads = 4
+    head_dim = 32
+    dim = num_heads * head_dim
+    ffn_dim = 2 * dim
+    rank = 8
+    alpha = 2.0  # alpha != rank so a missed lookup (→ eff_scale=scale) is detectable
+    scale = 1.0
+    expected_eff = scale * (alpha / rank)  # 0.25
+
+    parallel_config = DiTParallelConfig(
+        cfg_parallel=ParallelFactor(factor=1, mesh_axis=0),
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
+        sequence_parallel=ParallelFactor(factor=1, mesh_axis=0),
+    )
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    transformer = WanTransformer3DModel(
+        patch_size=(1, 2, 2),
+        num_heads=num_heads,
+        dim=dim,
+        in_channels=16,
+        out_channels=16,
+        text_dim=128,
+        freq_dim=64,
+        ffn_dim=ffn_dim,
+        num_layers=1,
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=False,
+        lora_enabled=True,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        adapter_path = Path(tmp) / "synthetic.safetensors"
+        _save_synthetic_adapter(adapter_path, num_blocks=1, dim=dim, ffn_dim=ffn_dim, rank=rank, alpha=alpha)
+        load_adapter_into(transformer, str(adapter_path), scale=scale, name="synthetic")
+
+    block0 = transformer.blocks[0]
+    fused_targets = {
+        "attn1.to_qkv": block0.attn1.to_qkv,  # self-attn fused QKV
+        "attn2.to_kv": block0.attn2.to_kv,  # cross-attn fused KV
+    }
+    singleton_targets = {
+        "attn2.to_q": block0.attn2.to_q,
+        "attn1.to_out": block0.attn1.to_out,
+        "ffn.ff1": block0.ffn.ff1,
+    }
+    for label, mod in {**fused_targets, **singleton_targets}.items():
+        got = mod.lora_bank[0].scale
+        assert got == pytest.approx(expected_eff), (
+            f"{label}: eff_scale={got}, expected {expected_eff} "
+            f"(alpha={alpha}/rank={rank}); a value of {scale} means the alpha "
+            "lookup missed and fell back to rank"
+        )

--- a/models/tt_dit/experimental/tests/test_fused_qkv_lora_device.py
+++ b/models/tt_dit/experimental/tests/test_fused_qkv_lora_device.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+On-device confirmation of the fused-QKV LoRA path across tensor-parallel shards.
+
+The host test (``test_fused_qkv_lora_math.py``) proves the *unsharded*
+construction is correct. This test confirms the remaining device-only links:
+the head-interleaved fused weight + fused LoRA ``B`` are **column-sharded**
+across devices, the fuse-merge runs on-device (``_apply_delta``), and the
+matmul reconstructs the right output — at the production layout (TP=4).
+
+It exercises the exact production-critical module (``LoRAColParallelLinear`` —
+the class ``WanAttention.to_qkv`` is) loaded with a head-interleaved fused
+weight, rather than the full attention forward (which would need 8+ devices
+for the real 14B model). Parametrized over a 1x1 mesh (trivial) and a 1x4 mesh
+(TP=4, matching p300x2's n_dev).
+
+Run (needs hardware; the tt-metal server must NOT be holding the devices):
+    ./python_env/bin/python3 -m pytest -xvs \
+        models/tt_dit/experimental/tests/test_fused_qkv_lora_device.py
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.tt_dit.experimental.lora.adapter_loader import _head_interleave_lora_B
+from models.tt_dit.layers.linear import LoRAColParallelLinear
+from models.tt_dit.utils.check import assert_quality
+from models.tt_dit.utils.tensor import bf16_tensor
+
+HEAD_DIM = 32
+NUM_HEADS = 8
+IN_DIM = 256
+RANK = 8
+SCALE = 0.125
+
+
+def _interleave_heads(tensors, *, n_dev, n_local_heads, head_dim, num_heads):
+    """Verbatim transcription of WanAttention._interleave_heads
+    (attention_wan.py:186-206) — authoritative fused out-dim layout."""
+    tensors = [t.T for t in tensors]
+    tensors = [t.reshape(t.shape[0], n_dev, n_local_heads, head_dim) for t in tensors]
+    merged = torch.cat(tensors, dim=2)
+    merged = merged.reshape(merged.shape[0], len(tensors) * num_heads * head_dim)
+    return merged.T
+
+
+def _build_fused_ab(A_per, B_per, *, n_dev, n_local_heads, head_dim):
+    """Mirror adapter_loader._register_fused_qkv's A_fused / B_fused build."""
+    n = len(A_per)
+    r = A_per[0].shape[0]
+    out_per = n_dev * n_local_heads * head_dim
+    A_fused = torch.cat(A_per, dim=0)
+    B_per_padded = []
+    for i, B in enumerate(B_per):
+        pad = torch.zeros(out_per, n * r, dtype=B.dtype)
+        pad[:, i * r : (i + 1) * r] = B
+        B_per_padded.append(pad)
+    B_fused = _head_interleave_lora_B(B_per_padded, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim)
+    return A_fused, B_fused
+
+
+def _readback(out, mesh_device, tp_axis):
+    """Concat the column-sharded output back to a full torch tensor."""
+    concat_dims = [None, None]
+    concat_dims[tp_axis] = -1
+    concat_dims[1 - tp_axis] = 0  # other axis has size 1 in these configs
+    return ttnn.to_torch(
+        out,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=concat_dims, mesh_shape=tuple(mesh_device.shape)),
+    )
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [pytest.param((1, 1), id="1x1_tp1"), pytest.param((1, 4), id="1x4_tp4")],
+    indirect=True,
+)
+@pytest.mark.parametrize("case", ["self_attn_qkv", "cross_attn_kv"])
+def test_fused_qkv_lora_device(mesh_device: ttnn.MeshDevice, case: str) -> None:
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    tp_axis = 1
+    n_dev = tuple(mesh_device.shape)[tp_axis]
+    n_local_heads = NUM_HEADS // n_dev
+    assert NUM_HEADS % n_dev == 0
+
+    n = 3 if case == "self_attn_qkv" else 2
+    dim = NUM_HEADS * HEAD_DIM
+    out_dim = n * dim
+    seq_len = 128
+
+    # Separate per-source base weights → interleaved fused weight (the real layout).
+    W_per = [torch.randn(dim, IN_DIM, dtype=dtype) * 0.02 for _ in range(n)]
+    W_fused = _interleave_heads(W_per, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=HEAD_DIM, num_heads=NUM_HEADS)
+    torch_lin = torch.nn.Linear(IN_DIM, out_dim, bias=False).to(dtype=dtype)
+    with torch.no_grad():
+        torch_lin.weight.copy_(W_fused)
+
+    # Per-source LoRA pairs and the fused A/B the loader would build.
+    A_per = [torch.randn(RANK, IN_DIM, dtype=dtype) * 0.05 for _ in range(n)]
+    B_per = [torch.randn(dim, RANK, dtype=dtype) * 0.05 for _ in range(n)]
+    A_fused, B_fused = _build_fused_ab(A_per, B_per, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=HEAD_DIM)
+
+    # Reference (float32): base, and base + interleaved per-source deltas.
+    x_t = torch.randn(1, 1, seq_len, IN_DIM, dtype=dtype)
+    per_src_delta = [SCALE * (B.float() @ A.float()) for A, B in zip(A_per, B_per)]
+    delta_ref = _interleave_heads(
+        per_src_delta, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=HEAD_DIM, num_heads=NUM_HEADS
+    )
+    with torch.no_grad():
+        y_base_ref = torch.nn.functional.linear(x_t.float(), W_fused.float())
+        y_lora_ref = torch.nn.functional.linear(x_t.float(), W_fused.float() + delta_ref)
+
+    # Device module: the production fused-projection class.
+    tt = LoRAColParallelLinear(
+        IN_DIM, out_dim, bias=False, mesh_device=mesh_device, mesh_axis=tp_axis, lora_mode="fuse"
+    )
+    tt.load_torch_state_dict(torch_lin.state_dict())
+    idx = tt.register_lora(A_fused, B_fused, scale=SCALE)
+    x_tt = bf16_tensor(x_t, device=mesh_device)
+
+    # 1) base (no LoRA bound)
+    assert_quality(y_base_ref, _readback(tt(x_tt), mesh_device, tp_axis), pcc=0.999)
+
+    # 2) bound → fused LoRA delta merged on-device and column-sharded
+    tt.bind_active(idx, scale=SCALE)
+    assert_quality(y_lora_ref, _readback(tt(x_tt), mesh_device, tp_axis), pcc=0.99)
+
+    # 3) unbind restores base
+    tt.unbind_active()
+    assert_quality(y_base_ref, _readback(tt(x_tt), mesh_device, tp_axis), pcc=0.999)
+
+    tt.deallocate_lora()

--- a/models/tt_dit/experimental/tests/test_fused_qkv_lora_math.py
+++ b/models/tt_dit/experimental/tests/test_fused_qkv_lora_math.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Host-only numerical correctness test for the fused-QKV LoRA reconstruction.
+
+Wan attention fuses the separate Q/K/V (self-attn) and K/V (cross-attn)
+projections into a single ``to_qkv`` / ``to_kv`` Linear whose output dim is
+**head-interleaved** across tensor-parallel devices (see
+``WanAttention._interleave_heads`` in
+``models/tt_dit/models/transformers/wan2_2/attention_wan.py``). LoRA adapters
+ship separate q/k/v pairs, so ``adapter_loader._register_fused_qkv`` hand-builds
+a combined adapter (``A_fused`` stacked on rank, zero-padded block-diagonal
+``B_fused`` head-interleaved via ``_head_interleave_lora_B``).
+
+The fused LoRA delta added to the fused base weight MUST equal the per-source
+deltas interleaved with the SAME permutation the base weight uses:
+
+    scale·(B_fused @ A_fused)  ==  interleave([ scale·B_q@A_q, scale·B_k@A_k, scale·B_v@A_v ])
+
+This is pure linear algebra — no device needed. Crucially we sweep ``n_dev`` so
+the multi-device interleave path (production runs at TP=4) is exercised; the
+existing structural test only runs at TP=1 where the interleave is near-trivial.
+
+Run:
+    ./python_env/bin/python3 -m pytest -xvs \
+        models/tt_dit/experimental/tests/test_fused_qkv_lora_math.py
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from models.tt_dit.experimental.lora.adapter_loader import _head_interleave_lora_B
+
+
+def ref_interleave_heads(
+    tensors: list[torch.Tensor],
+    *,
+    n_dev: int,
+    n_local_heads: int,
+    head_dim: int,
+    num_heads: int,
+) -> torch.Tensor:
+    """Verbatim transcription of WanAttention._interleave_heads
+    (attention_wan.py:186-206) — the authoritative base-weight out-dim layout.
+
+    Inputs are [out=num_heads*head_dim, in] (PyTorch [out, in]). Returns the
+    merged [len(tensors)*num_heads*head_dim, in] tensor.
+    """
+    # Transpose to [in, out]
+    tensors = [t.T for t in tensors]
+    # Reshape out dim to [in, n_dev, n_local_heads, head_dim]
+    tensors = [t.reshape(t.shape[0], n_dev, n_local_heads, head_dim) for t in tensors]
+    # Concatenate on the heads dim so each device shard gets its own heads from every tensor
+    merged = torch.cat(tensors, dim=2)  # [in, n_dev, len(tensors)*n_local_heads, head_dim]
+    merged = merged.reshape(merged.shape[0], len(tensors) * num_heads * head_dim)
+    # Transpose back to [out, in] PyTorch convention
+    return merged.T
+
+
+def _loader_fused_delta(
+    A_per: list[torch.Tensor],
+    B_per: list[torch.Tensor],
+    *,
+    scale: float,
+    n_dev: int,
+    n_local_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Reproduce adapter_loader._register_fused_qkv's fused A/B construction and
+    return the resulting weight delta in PyTorch [out, in] convention.
+
+    Mirrors lines 300-339 of adapter_loader.py. The device adds
+    ``scale·(B_fused @ A_fused)`` (in [out, in]) into the fused base weight
+    (see lora.py:_apply_delta / _upload_ab_for_w_sharding).
+    """
+    n = len(A_per)
+    r = A_per[0].shape[0]
+    out_per = n_dev * n_local_heads * head_dim
+
+    # A stacked on rank dim → [n*r, in]
+    A_fused = torch.cat(A_per, dim=0)
+
+    # B: embed each per-source [out_per, r] into a [out_per, n*r] block-diagonal tile
+    B_per_padded: list[torch.Tensor] = []
+    for i, B in enumerate(B_per):
+        pad = torch.zeros(out_per, n * r, dtype=B.dtype)
+        pad[:, i * r : (i + 1) * r] = B
+        B_per_padded.append(pad)
+
+    B_fused = _head_interleave_lora_B(B_per_padded, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim)
+
+    # Device computes delta in [out, in] = scale * (B_fused @ A_fused)
+    return scale * (B_fused @ A_fused)
+
+
+# Wan2.2-T2V-A14B geometry: dim=5120, num_heads=40, head_dim=128. Use the real
+# head_dim/num_heads so per-head reshapes match production; in_dim shrunk for speed.
+HEAD_DIM = 128
+NUM_HEADS = 40
+IN_DIM = 256
+RANK = 64
+SCALE = 0.125  # alpha(8)/rank(64)
+
+
+@pytest.mark.parametrize("n_dev", [1, 2, 4])
+@pytest.mark.parametrize("case", ["self_attn_qkv", "cross_attn_kv"])
+def test_fused_qkv_lora_delta_matches_interleaved_reference(n_dev: int, case: str) -> None:
+    torch.manual_seed(0)
+    dtype = torch.float32  # exact math; bf16 rounding is covered by the device test
+
+    n = 3 if case == "self_attn_qkv" else 2
+    dim = NUM_HEADS * HEAD_DIM
+    n_local_heads = NUM_HEADS // n_dev
+    assert NUM_HEADS % n_dev == 0
+
+    # Per-source LoRA pairs: A_i [rank, in], B_i [out=dim, rank]
+    A_per = [torch.randn(RANK, IN_DIM, dtype=dtype) for _ in range(n)]
+    B_per = [torch.randn(dim, RANK, dtype=dtype) for _ in range(n)]
+
+    # Loader path (the code under test)
+    delta_fused = _loader_fused_delta(
+        A_per, B_per, scale=SCALE, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=HEAD_DIM
+    )
+
+    # Reference: per-source deltas interleaved exactly like the base weight
+    per_source_delta = [SCALE * (B @ A) for A, B in zip(A_per, B_per)]  # each [dim, in]
+    delta_ref = ref_interleave_heads(
+        per_source_delta,
+        n_dev=n_dev,
+        n_local_heads=n_local_heads,
+        head_dim=HEAD_DIM,
+        num_heads=NUM_HEADS,
+    )
+
+    assert delta_fused.shape == delta_ref.shape == (n * dim, IN_DIM)
+
+    # Localize any mismatch to specific output heads to make a failure actionable.
+    if not torch.allclose(delta_fused, delta_ref, atol=1e-4, rtol=1e-4):
+        out_rows = delta_fused.shape[0]
+        bad = []
+        # Compare in head_dim-sized row chunks; report first few mismatching chunks.
+        for h in range(out_rows // HEAD_DIM):
+            sl = slice(h * HEAD_DIM, (h + 1) * HEAD_DIM)
+            if not torch.allclose(delta_fused[sl], delta_ref[sl], atol=1e-4, rtol=1e-4):
+                bad.append(h)
+        pytest.fail(
+            f"[{case} n_dev={n_dev}] fused LoRA delta != interleaved reference. "
+            f"{len(bad)}/{out_rows // HEAD_DIM} head-rows differ (first 10: {bad[:10]}). "
+            f"max abs err={ (delta_fused - delta_ref).abs().max().item():.3e }"
+        )


### PR DESCRIPTION
Test-only follow-up to #46519 (Wan2.2 LoRA, @pshahTT). No production code changes.

The merged LoRA tests all run at TP=1 and check adapter ranks but never the effective alpha/rank scale. This adds three things that cover those gaps:

- **`test_fused_qkv_alpha_scaling_matches_singletons`** — checks fused-QKV targets honor the adapter's per-key `alpha` like singletons do. Correct in `main` today, but otherwise untested: an adapter with `alpha != rank` (e.g. Seko lightning, `alpha=8`/`rank=64`) would silently mis-scale if it regressed.
- **`test_fused_qkv_lora_math.py`** — host-only (no device) check that the fused Q/K/V delta matches the per-source deltas interleaved the same way as the base weight, swept across `n_dev = 1/2/4`. The existing tests only cover TP=1; production runs at TP=4.
- **`test_fused_qkv_lora_device.py`** — on-device fused-QKV forward parity at TP=1 and the production TP=4 (p300x2) layout.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stisi/lora-fused-qkv-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stisi/lora-fused-qkv-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stisi/lora-fused-qkv-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stisi/lora-fused-qkv-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stisi/lora-fused-qkv-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stisi/lora-fused-qkv-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stisi/lora-fused-qkv-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stisi/lora-fused-qkv-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stisi/lora-fused-qkv-tests)
