### PR TITLE
#48509: fix GPT-OSS host OOM/hang during prefill (bf16 weight load + free HF model)

### DIFF
--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -6,6 +6,7 @@
 GPT-OSS ModelArgs class that's compatible with tt_transformers interface
 """
 
+import gc
 import os
 from pathlib import Path
 
@@ -259,22 +260,35 @@ class ModelArgs:
             # Return dummy state dict for testing
             return {}
         else:
-            # Load actual GPT-OSS weights directly from safetensors files
-            # Check if we have a cached torch_state_dict.pt file
+            # Load actual GPT-OSS weights directly from safetensors files.
+            #
+            # GPT-OSS ships MXFP4-quantized weights (see configs/*/config.json). On a CPU host
+            # (CI loads weights on host before pushing them to the Tenstorrent device) transformers
+            # dequantizes the MXFP4 experts during from_pretrained. With torch_dtype="auto" that
+            # dequant intermediate lands in fp32, ~doubling the resident host footprint AND forcing
+            # the bf16 conversion pass below to allocate a second full copy of the state dict --
+            # enough to OOM / hang the host for the 20B & 120B demos (#48509, #48508). Loading
+            # straight to bf16 makes dequant target bf16 and turns that pass into a no-op (the dict
+            # comprehension then rebinds references rather than copying tensors).
             model = AutoModelForCausalLM.from_pretrained(
                 weights_path,
-                torch_dtype="auto"
-                # Note that the default setting is torch.dtype.float32, but model weights are
-                # may come in any dtype. If the model weights are in torch.dtype.bfloat16, this would result in 2x memory usage from an
-                # unnecessary cast.
+                torch_dtype=torch.bfloat16,
+                low_cpu_mem_usage=True,
             )
+            head_dim = model.config.head_dim
             state_dict = model.state_dict()
+            # Drop the HF module graph/buffers now that we hold the weight tensors. state_dict shares
+            # storage with the params, so after this the peak host footprint is bounded by the bf16
+            # weights themselves rather than weights + a live HF model object.
+            del model
+            gc.collect()
             # Convert HF QKV weights to Meta format for RoPE compatibility (if requested)
             if convert_to_meta_format:
                 logger.info("Converting QKV weights from HuggingFace to Meta format for RoPE")
-                state_dict = convert_hf_qkv_to_meta_format(state_dict, model.config.head_dim)
+                state_dict = convert_hf_qkv_to_meta_format(state_dict, head_dim)
+            # Safety net: ensure bf16. With the bf16 load above this is a no-op for every tensor
+            # (references are reused); it only casts genuine fp32 stragglers.
             if state_dict["model.norm.weight"].dtype != torch.bfloat16:
-                # Convert to bfloat16 if needed
                 state_dict = {
                     k: v.to(torch.bfloat16) if v.dtype == torch.float32 else v
                     for k, v in tqdm(state_dict.items(), desc="Converting to bfloat16")


### PR DESCRIPTION
## What

Fixes the GPT-OSS 20B e2e demo host resource exhaustion during prefill across all three platforms. Fixes #48509 (and the same-root-cause sibling #48508 / #48354 / #48355 / #48307).

## Root cause

GPT-OSS 20B/120B ship **MXFP4-quantized** weights (`configs/*/config.json`: `quant_method: mxfp4`). The demo loads the full HF model on host at setup via `GptOssModelArgs.load_state_dict`:

```python
model = AutoModelForCausalLM.from_pretrained(weights_path, torch_dtype="auto")
state_dict = model.state_dict()
```

On a CPU host (CI loads weights on host before pushing them to the Tenstorrent device) transformers **dequantizes** the MXFP4 experts during `from_pretrained`. The `transformers 4.57.0 → 5.10.2` bump (#47671, `d65929317ab`) changed this enough to tip CI hosts over:

- with `torch_dtype="auto"` the dequant intermediate lands in **fp32**, ~doubling the resident host footprint, and
- the subsequent bf16-conversion pass then allocates a **second full copy** of the state dict, and
- the HF `model` object is **never freed**, so the bloated weights stay resident into the prefill phase.

Prefill's own host allocations then trip the OOM killer / swap-hang:
- **bh_p150:** OOM-kill (exit 137) — #48354
- **wh_llmbox_perf:** swap-hang → job timeout — #48355
- **bh_quietbox_2:** runner resource starvation → crash — #48307

`#47671` was validated only on unit tests (single decoder layer / small configs), so the full-model e2e blowup slipped through. (120B normally runs with `--skip-model-load`, which is why its regression surfaced as a unit test, #48508.)

## Fix

`models/demos/gpt_oss/tt/model_config.py::load_state_dict`:
- Load straight to **bf16** (`torch_dtype=torch.bfloat16, low_cpu_mem_usage=True`) so MXFP4 dequant targets bf16 and the bf16-conversion pass becomes a no-op (rebinds references instead of copying).
- `del model; gc.collect()` after extracting `state_dict`, bounding peak host memory to the bf16 weights alone.

## Test plan

Tier-2 Models E2E on the branch ([run 28389512443](https://github.com/tenstorrent/tt-metal/actions/runs/28389512443)), `model=gpt-oss-20b`, all SKUs:

- ✅ `GPT-OSS 20B e2e [bh_p150]` — **pass** (was OOM-kill 137)
- ✅ `GPT-OSS 20B e2e [wh_llmbox_perf]` — **pass** (was hang/timeout)
- ⏳ `GPT-OSS 20B e2e [bh_quietbox_2]` — queued (awaiting QB2 runner); same root cause, will update

Draft until the QB2 leg lands.

## Follow-ups (not in this PR)
- Implement the `torch_state_dict.pt` cache the code comment already references, so the full `from_pretrained` runs once rather than every CI run.
- Free the host `state_dict` after TT tensors are materialized in `tt/common.py` (data-parallel=1 case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gpt-oss-host-oom-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gpt-oss-host-oom-prefill)