### PR TITLE
gpt_oss: auto-skip HF weight load when ttnn cache is warm

### DIFF
--- a/models/demos/gpt_oss/conftest.py
+++ b/models/demos/gpt_oss/conftest.py
@@ -7,8 +7,6 @@ import os
 
 import pytest
 
-from models.demos.gpt_oss.tt.model_config import ModelArgs
-
 
 def pytest_addoption(parser):
     parser.addoption("--skip-model-load", action="store_true", default=False, help="Skip loading the model state dict")
@@ -19,9 +17,12 @@ def state_dict(request):
     load_model = not request.config.getoption("--skip-model-load")
     model_path = os.getenv("HF_MODEL", None)
     if model_path is None or not load_model:
+        # Explicit skip: build weights purely from the ttnn cache.
         return {}
-    else:
-        return ModelArgs.load_state_dict(model_path, dummy_weights=False)
+    # Defer the (expensive) HF weight load to create_tt_model, which knows the mesh shape +
+    # dtype and can skip it when a warm ttnn cache is already on disk (see
+    # ModelArgs.weight_cache_is_complete). Returning None signals "load if needed".
+    return None
 
 
 @pytest.fixture

--- a/models/demos/gpt_oss/tt/common.py
+++ b/models/demos/gpt_oss/tt/common.py
@@ -6,6 +6,8 @@
 GPT-OSS specific implementation of create_tt_model that's compatible with tt_transformers
 """
 
+from loguru import logger
+
 import ttnn
 from models.tt_transformers.tt.common import PagedAttentionConfig
 
@@ -50,14 +52,27 @@ def create_tt_model(
         gpt_oss_model_args.hf_config.num_hidden_layers = num_layers
         gpt_oss_model_args.n_layers = num_layers
 
-    # Avoid loading state_dict for every DP model. An empty dict is intentional
-    # when --skip-model-load is used.
+    # Decide whether the HF weights are still needed on host. When the ttnn weight cache for
+    # this (model, dtype, mesh shape) was already fully built on a previous run, ttnn.as_tensor
+    # loads every weight from disk and the state_dict is never read -- so skip the expensive
+    # from_pretrained host load entirely. This is what spares the e2e demo the prefill host-OOM
+    # (#48509) on warm-cache runs, without relying on the manual --skip-model-load flag.
+    #
+    # state_dict is None  -> decide here (warm cache => {} skip, else cold load).
+    # state_dict == {}     -> explicit skip (--skip-model-load) or a prior DP model already skipped.
+    # state_dict populated -> reuse across DP models (avoid reloading for every submesh).
+    loaded_real_weights = False
     if state_dict is None:
-        state_dict = gpt_oss_model_args.load_state_dict(
-            weights_path=gpt_oss_model_args.model_path,
-            dummy_weights=gpt_oss_model_args.dummy_weights,
-            convert_to_meta_format=True,
-        )
+        if not gpt_oss_model_args.dummy_weights and gpt_oss_model_args.weight_cache_is_complete(dtype):
+            logger.info("Warm ttnn weight cache detected -- skipping HF state_dict load.")
+            state_dict = {}
+        else:
+            state_dict = gpt_oss_model_args.load_state_dict(
+                weights_path=gpt_oss_model_args.model_path,
+                dummy_weights=gpt_oss_model_args.dummy_weights,
+                convert_to_meta_format=True,
+            )
+            loaded_real_weights = bool(state_dict) and not gpt_oss_model_args.dummy_weights
 
     # Create GPT-OSS model using transformer-compatible constructor
     model = Model.create_transformer_compatible(
@@ -72,6 +87,12 @@ def create_tt_model(
         users_row_sharded=users_row_sharded,
         use_throughput_experts=use_throughput_experts,
     )
+
+    # If this run populated the cache from a cold host load, record completion so future runs
+    # can skip the load. Only for full-model builds (a num_layers override produces a partial
+    # cache that must not satisfy the completeness check).
+    if loaded_real_weights and num_layers is None:
+        gpt_oss_model_args.mark_weight_cache_complete(dtype)
 
     # Extract tt_kv_cache like tt_transformers does
     tt_kv_cache = []

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -7,6 +7,7 @@ GPT-OSS ModelArgs class that's compatible with tt_transformers interface
 """
 
 import gc
+import json
 import os
 from pathlib import Path
 
@@ -308,6 +309,67 @@ class ModelArgs:
 
         cache_path.mkdir(parents=True, exist_ok=True)
         return cache_path
+
+    # Name of the marker file dropped into a weight-cache directory once every weight
+    # for that (model, dtype, mesh shape) has been materialized to disk.
+    WEIGHT_CACHE_MARKER = ".weights_complete"
+    # Cache-format version embedded in the marker. Bump this whenever the set/naming/layout of
+    # cached weight tensors changes in a way that an existing cache would not satisfy (e.g. a
+    # weight tensor is added or renamed without changing the layer count). A marker written by an
+    # older format is then rejected -> the run cold-loads and regenerates the cache, rather than
+    # skipping the load and hard-failing in ttnn.as_tensor(None, ...) on a missing .tensorbin.
+    # (Mirrors DeepSeek's WEIGHT_CACHE_FORMAT_VERSION in deepseek_v3/utils/weight_config.py.)
+    WEIGHT_CACHE_FORMAT_VERSION = 1
+
+    def weight_cache_is_complete(self, dtype):
+        """True when the on-disk ttnn weight cache for this (model, dtype, mesh shape) was
+        fully built by a previous run.
+
+        When True, ttnn.as_tensor loads every weight from its cached .tensorbin and the HF
+        state_dict is never read, so the caller can skip the expensive from_pretrained host
+        load entirely (the load that OOMs/hangs during prefill, #48509) without needing the
+        manual --skip-model-load flag. Set GPT_OSS_FORCE_MODEL_LOAD=1 to force a fresh load
+        (e.g. to regenerate the cache)."""
+        if os.getenv("GPT_OSS_FORCE_MODEL_LOAD") == "1":
+            return False
+        cache_path = self.weight_cache_path(dtype)
+        marker = cache_path / self.WEIGHT_CACHE_MARKER
+        if not marker.is_file():
+            return False
+        try:
+            meta = json.loads(marker.read_text())
+        except (ValueError, OSError):
+            return False
+        # Reject a stale marker: an older cache format, a different model, or a partial
+        # (num_layers-limited) build whose cache does not cover the full model we are about to
+        # construct. A rejected marker falls back to a cold load (which regenerates the cache)
+        # rather than skipping the load and crashing on a missing/renamed .tensorbin.
+        if meta.get("format_version") != self.WEIGHT_CACHE_FORMAT_VERSION:
+            return False
+        if meta.get("model_name") != self.model_name or meta.get("n_layers") != self.n_layers:
+            return False
+        # Belt-and-suspenders: the cache dir must still actually hold tensor files.
+        return any(cache_path.glob("*.tensorbin"))
+
+    def mark_weight_cache_complete(self, dtype):
+        """Record that the ttnn weight cache for this (model, dtype, mesh shape) was fully
+        built, so subsequent runs can skip the HF state_dict load (see weight_cache_is_complete)."""
+        cache_path = self.weight_cache_path(dtype)
+        marker = cache_path / self.WEIGHT_CACHE_MARKER
+        try:
+            marker.write_text(
+                json.dumps(
+                    {
+                        "format_version": self.WEIGHT_CACHE_FORMAT_VERSION,
+                        "model_name": self.model_name,
+                        "n_layers": self.n_layers,
+                        "dtype": str(dtype),
+                    }
+                )
+            )
+            logger.info(f"Marked ttnn weight cache complete: {marker}")
+        except OSError as e:
+            logger.warning(f"Could not write weight-cache completion marker {marker}: {e}")
 
     def get_model_config(self):
         """Return model configuration dict"""


### PR DESCRIPTION
## What

Follow-up to #48509 / #48524 (merged). Adds a **warm ttnn-cache detector** so GPT-OSS skips the HF `from_pretrained` host weight load automatically when the weight cache is already built — instead of relying on the manual `--skip-model-load` flag.

> Rebased onto `main` now that #48524 has merged; this PR is just the incremental warm-cache change (3 files).

## Why

The expensive host load only matters on a **cold** ttnn cache. When the per-`(model, dtype, mesh shape)` cache exists, `ttnn.as_tensor(cache_file_name=...)` loads every weight from its `.tensorbin` and the HF `state_dict` is **never read** — yet today the demo still loads the full HF model into host RAM and throws it away.

Until now the only way to skip that was `--skip-model-load`, which the **120B** e2e passes but the **20B** e2e does **not** — which is exactly why the 20B e2e took the host-OOM path (#48509) and the 120B e2e didn't. Auto-skipping on a warm cache removes that footgun for every caller.

## How

- **`ModelArgs.weight_cache_is_complete(dtype)` / `mark_weight_cache_complete(dtype)`** — a `.weights_complete` marker is dropped into the cache dir after a successful full (cold) build, and validated on read (`model_name` + `n_layers` match, cache dir non-empty) to reject stale/partial caches. `GPT_OSS_FORCE_MODEL_LOAD=1` forces a fresh load (e.g. to regenerate the cache).
- **`create_tt_model`** — when `state_dict is None` and the cache is complete, build from cache with an empty `state_dict`; otherwise cold-load and, for full-model builds (`num_layers is None`), mark the cache complete afterwards. DP-reuse across submeshes is preserved (the resolved `state_dict` is returned and threaded into later submeshes).
- **`conftest` `state_dict` fixture** — defers to `create_tt_model` (returns `None`) instead of eager-loading, so the mesh/dtype-aware skip can apply. Explicit `--skip-model-load` still returns `{}`. Only two consumers (the demo + `test_full_model_accuracy`), both pass the value straight to `create_tt_model`; the accuracy test loads its reference weights separately, so deferring is safe.

## Rollout note
The marker is self-populating: the **first** run against an existing markerless cache still cold-loads (safe since #48524) and writes the marker; every subsequent run skips the load. A `mlperf-write-access` cache-regen run populates markers for the shared NAS caches.

## Test plan (validated)
- [x] **Cold path / no regression** — 20B e2e default (read-only) green on all 3 SKUs ([run 28398366426](https://github.com/tenstorrent/tt-metal/actions/runs/28398366426)); cold-loads as before, marker write warns gracefully on the read-only NAS.
- [x] **Skip path** — a write-access run populated the `.weights_complete` markers ([run 28431821784](https://github.com/tenstorrent/tt-metal/actions/runs/28431821784): `wh_llmbox_perf`, `bh_p150` green), then default read-only runs on those SKUs **logged the skip and passed**:
  - `wh_llmbox_perf` ([run 28439947821](https://github.com/tenstorrent/tt-metal/actions/runs/28439947821)) — `create_tt_model:67 - Warm ttnn weight cache detected -- skipping HF state_dict load.`
  - `bh_p150` ([run 28439949693](https://github.com/tenstorrent/tt-metal/actions/runs/28439949693)) — same.
- [x] `--skip-model-load` path unchanged (still returns `{}`).
- [x] `GPT_OSS_FORCE_MODEL_LOAD=1` cold-load + marker-write path exercised by the write-access run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gpt-oss-warm-cache-skip-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gpt-oss-warm-cache-skip-load)