### PR TITLE
Fix MoEGate module

### DIFF
--- a/models/common/modules/moe/tt_moe_gate.py
+++ b/models/common/modules/moe/tt_moe_gate.py
@@ -412,27 +412,49 @@ class TTMoEGate:
           ``N_tiles = padded_experts/32`` (256 experts → 8, the 512-combine path → 16).
             • ``in0_block_w`` = largest divisor of ``K_tiles`` that is ≤ 32 (the widest K-block within the
               32-tile cap; a non-1024-multiple hidden gives e.g. 20 / 22 / 30 instead of 32).
+            • ``per_core_M`` = ``ceil(M_tiles / grid.y)`` — spread M over the grid's y-dim (mirrors ttnn's
+              ``create_matmul_program_config``). Decode (``M_tiles=1``) → 1 (one tile, nothing to split); a
+              large batch (``M_tiles > grid.y``) stacks > 1 M-tile per core instead of serializing all of M
+              onto one core-row.
             • ``per_core_N`` = smallest divisor ≥ 2 of ``N_tiles`` that fits the grid
               (``N_tiles / per_core_N ≤ grid.x``): 2 on an 8-wide grid, growing to 4 on a narrower one.
             • ``out_block_{h,w}`` = ``per_core_{M,N}``; ``out_subblock_{h,w}`` = largest factors with
-              ``h * w ≤ 8`` (the DEST half-register tile cap).
+              ``h * w ≤ dst_subblock_cap`` — the DEST subblock budget = HALF of the DEST tile capacity
+              (MATH/PACK double-buffer): 8 tiles for bf16 accumulation, but **4 for fp32 accumulation**
+              (an fp32 tile takes 2× the DEST space, so half as many fit). This matches ttnn's own
+              ``get_subblock_sizes`` rule (``h*w ≤ 4`` iff ``fp32_dest_acc_en``). The gate DEFAULTS to fp32
+              accumulation (see ``_matmul_compute_config``), so the cap is normally 4.
         """
+        # DEST subblock tile budget: fp32 accumulation halves the usable DEST (8->4 tiles). Read the flag off
+        # the already-built compute config (None = ttnn default = bf16 accumulate). Must match the cap ttnn's
+        # own auto-derivation enforces, else a hand-built subblock could exceed the fp32 DEST budget.
+        fp32_dest_acc_en = bool(getattr(self.compute_kernel_config, "fp32_dest_acc_en", False))
+        dst_subblock_cap = 4 if fp32_dest_acc_en else 8
         batch = self.config.batch_per_device or 32
         m_tiles = (batch + 31) // 32
         k_tiles = self.hidden_size // 32
         n_tiles = self._padded_experts // 32
         grid_x = self._grid.x
+        grid_y = self._grid.y
         in0_block_w = max(d for d in range(1, 33) if k_tiles % d == 0)
         per_core_n = next((d for d in range(2, n_tiles + 1) if n_tiles % d == 0 and n_tiles // d <= grid_x), n_tiles)
-        out_subblock_w = next((w for w in range(min(per_core_n, 8), 0, -1) if per_core_n % w == 0), 1)
-        out_subblock_h = next((h for h in range(m_tiles, 0, -1) if m_tiles % h == 0 and h * out_subblock_w <= 8), 1)
+        # per_core_M: spread M over the grid's y-dim (ceil), mirroring ttnn's create_matmul_program_config.
+        # Decode (m_tiles=1) -> 1 with nothing to split; a large batch (m_tiles > grid_y) stacks >1 M-tile/core.
+        per_core_m = (m_tiles + grid_y - 1) // grid_y
+        # out_subblock_w capped at dst_subblock_cap too: out_subblock_h can be 1, so w alone can equal the
+        # h*w budget — without the cap a wide per_core_n (e.g. 8) would pick w=8,h=1 = 8 tiles, busting fp32's 4.
+        out_subblock_w = next((w for w in range(min(per_core_n, dst_subblock_cap), 0, -1) if per_core_n % w == 0), 1)
+        out_subblock_h = next(
+            (h for h in range(per_core_m, 0, -1) if per_core_m % h == 0 and h * out_subblock_w <= dst_subblock_cap),
+            1,
+        )
         return {
             "in0_block_w": in0_block_w,
             "out_subblock_h": out_subblock_h,
             "out_subblock_w": out_subblock_w,
-            "out_block_h": m_tiles,
+            "out_block_h": per_core_m,
             "out_block_w": per_core_n,
-            "per_core_M": m_tiles,
+            "per_core_M": per_core_m,
             "per_core_N": per_core_n,
             "transpose_mcast": False,
             "fused_activation": None,

--- a/models/common/modules/moe/tt_moe_gate.py
+++ b/models/common/modules/moe/tt_moe_gate.py
@@ -412,10 +412,6 @@ class TTMoEGate:
           ``N_tiles = padded_experts/32`` (256 experts → 8, the 512-combine path → 16).
             • ``in0_block_w`` = largest divisor of ``K_tiles`` that is ≤ 32 (the widest K-block within the
               32-tile cap; a non-1024-multiple hidden gives e.g. 20 / 22 / 30 instead of 32).
-            • ``per_core_M`` = ``ceil(M_tiles / grid.y)`` — spread M over the grid's y-dim (mirrors ttnn's
-              ``create_matmul_program_config``). Decode (``M_tiles=1``) → 1 (one tile, nothing to split); a
-              large batch (``M_tiles > grid.y``) stacks > 1 M-tile per core instead of serializing all of M
-              onto one core-row.
             • ``per_core_N`` = smallest divisor ≥ 2 of ``N_tiles`` that fits the grid
               (``N_tiles / per_core_N ≤ grid.x``): 2 on an 8-wide grid, growing to 4 on a narrower one.
             • ``out_block_{h,w}`` = ``per_core_{M,N}``; ``out_subblock_{h,w}`` = largest factors with
@@ -435,26 +431,21 @@ class TTMoEGate:
         k_tiles = self.hidden_size // 32
         n_tiles = self._padded_experts // 32
         grid_x = self._grid.x
-        grid_y = self._grid.y
         in0_block_w = max(d for d in range(1, 33) if k_tiles % d == 0)
         per_core_n = next((d for d in range(2, n_tiles + 1) if n_tiles % d == 0 and n_tiles // d <= grid_x), n_tiles)
-        # per_core_M: spread M over the grid's y-dim (ceil), mirroring ttnn's create_matmul_program_config.
-        # Decode (m_tiles=1) -> 1 with nothing to split; a large batch (m_tiles > grid_y) stacks >1 M-tile/core.
-        per_core_m = (m_tiles + grid_y - 1) // grid_y
         # out_subblock_w capped at dst_subblock_cap too: out_subblock_h can be 1, so w alone can equal the
         # h*w budget — without the cap a wide per_core_n (e.g. 8) would pick w=8,h=1 = 8 tiles, busting fp32's 4.
         out_subblock_w = next((w for w in range(min(per_core_n, dst_subblock_cap), 0, -1) if per_core_n % w == 0), 1)
         out_subblock_h = next(
-            (h for h in range(per_core_m, 0, -1) if per_core_m % h == 0 and h * out_subblock_w <= dst_subblock_cap),
-            1,
+            (h for h in range(m_tiles, 0, -1) if m_tiles % h == 0 and h * out_subblock_w <= dst_subblock_cap), 1
         )
         return {
             "in0_block_w": in0_block_w,
             "out_subblock_h": out_subblock_h,
             "out_subblock_w": out_subblock_w,
-            "out_block_h": per_core_m,
+            "out_block_h": m_tiles,
             "out_block_w": per_core_n,
-            "per_core_M": per_core_m,
+            "per_core_M": m_tiles,
             "per_core_N": per_core_n,
             "transpose_mcast": False,
             "fused_activation": None,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This PR resolves a potential bug in the generalized MoEGate module by updating the DEST subblock budget for matrix multiplication (matmul). Specifically, the budget is now set to 4 when `fp32_dest_acc_en` is enabled, and 8 when it is disabled.

### Test to run
All the test cases in `test_tt_moe_gate.py` have passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ronnie/generalize_moegate_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ronnie/generalize_moegate_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ronnie/generalize_moegate_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ronnie/generalize_moegate_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ronnie/generalize_moegate_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ronnie/generalize_moegate_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ronnie/generalize_moegate_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ronnie/generalize_moegate_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ronnie/generalize_moegate_fix)