### PR TITLE
ttnn/argmax (multicore): remove timing-dependent k==0 done_sem reset

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -350,13 +350,21 @@ void kernel_main() {
     uint32_t max_idx = 0;
     auto max_val = get_default_value<src_cb_addr_data_format>();
 
-    done_sem.set(0);
-
     // -------------------------------------------------------------------------
     // Main loop - run by all cores
     for (uint32_t k = 0; k < outer_dim_units; ++k) {
         if (is_reduce_core) {
-            done_sem.set(0);
+            // done_sem is zero-initialized by the dispatcher before the kernel
+            // launches, so the k == 0 iteration needs no reset. Resetting it here
+            // at k == 0 would race the worker cores' done_sem.up() increments:
+            // those increments are ungated at k == 0 (the start_sem handshake
+            // below only orders k > 0), so a reset could clobber an increment that
+            // already landed and stall the done_sem.wait(num_cores) below forever.
+            // For k > 0 the reset clears the previous iteration's count and is
+            // ordered ahead of the increments by the start_sem multicast/wait.
+            if (k > 0) {
+                done_sem.set(0);
+            }
             start_sem.set(k + 1);
 
             if constexpr (num_cores > 1) {


### PR DESCRIPTION
# argmax (multicore): remove timing-dependent `k == 0` `done_sem` reset

## Summary

The multi-core argmax reader kernel
(`reader_argmax_interleaved_multicore.cpp`) has a missing happens-before at the
`k == 0` iteration of its main loop. The reducer core resets the `done_sem`
counter that worker cores remotely increment, but at `k == 0` nothing orders
that reset against the workers' increments. When an increment lands before the
reset, the reset clobbers it and the reducer's `done_sem.wait(num_cores)` blocks
forever — the op hangs.

This is a genuine kernel race, not a hardware-specific quirk. The fix is to drop
the redundant `k == 0` reset (the semaphore is already zero-initialized by the
dispatcher) and keep the `k > 0` reset, which is already correctly ordered by the
`start_sem` handshake. The change is **behavior-preserving on silicon** — it only
removes a write that re-asserts a value the dispatcher already wrote.

## The bug

All cores run the same `kernel_main`. `done_sem` lives on the reducer core;
every core (workers and reducer) increments it once per output via
`done_sem.up(reducer)`, and the reducer waits for `done_sem == num_cores` before
collating.

Per-iteration ordering is provided by `start_sem`:

```cpp
if (is_reduce_core) {
    done_sem.set(0);                 // reset for this iteration
    start_sem.set(k + 1);
    if (num_cores > 1) {
        if (k > 0) {                 // <-- multicast gated on k > 0
            start_sem.set_multicast(... group0 ...);
        }
        if (num_cores1 > 0) { start_sem.set_multicast(... group1 ...); }
        noc.async_write_barrier();
    }
}

if (k > 0) {                         // <-- workers wait, gated on k > 0
    start_sem.wait(k + 1);
}

find_argmax_for_core(...);           // workers' input read + compute
... write partial results to reducer ...
done_sem.up(reducer);                // <-- worker increment
```

For `k >= 1` this is race-free: the reducer resets `done_sem`, **then**
multicasts `start_sem`, and workers block on `start_sem.wait(k+1)` before they
increment. Reset → release → increment is an explicit happens-before.

At `k == 0` both the `start_sem` multicast and the `start_sem.wait` are gated out
(`if (k > 0)`). So the reducer's `done_sem.set(0)` and the workers'
`done_sem.up(reducer)` are unordered. A worker that reaches its increment before
the reducer executes its reset has that increment silently erased, and the
reducer's exact-match `done_sem.wait(num_cores)` never completes.

The same applies to the pre-loop `done_sem.set(0)` immediately before the loop —
it is a second unordered reset of the same counter at startup.

## Why this is real, not an emulation artifact

On silicon the race is masked by a large timing margin, not by any ordering
guarantee: every worker performs a NOC/DRAM input read inside
`find_argmax_for_core` before it can reach `done_sem.up`, while the reducer's
reset is a local L1 write at the top of the loop. Hundreds of cycles of read
latency vs. a one-cycle local write means the reset almost always wins — but
"almost always" is a timing assumption, not a happens-before. Anything that
narrows that margin (dispatch/scheduling changes, a configuration where the
reducer's prologue is delayed, a workload where workers' first read is cheap)
can surface it.

The reset itself is **provably redundant**: `done_sem` is created with
`initial_value = 0` and the dispatcher writes semaphore init values into L1
before the kernel launches, so the counter is already `0` at `k == 0`. The kernel
re-zeroing it adds nothing except the race window.

We found this while bringing argmax up on a functional emulator that executes
NOC reads with zero latency. With the timing margin removed, the latent race
becomes observable: on a 64-core configuration the op hangs ~**56% of runs**
(14/25 on `[1, 1024]`, dim=-1). The emulator did not introduce the bug — it
removed the latency that was hiding it, which is exactly the kind of fragility we
want surfaced rather than masked.

## The fix

```cpp
// before the loop: drop the redundant pre-loop reset (dispatcher zero-inits)
// in the loop:
if (is_reduce_core) {
    if (k > 0) {            // only reset when clearing the previous iteration
        done_sem.set(0);
    }
    start_sem.set(k + 1);
    ...
}
```

- `k == 0`: no reset; the dispatcher's zero-init is the happens-before.
- `k > 0`: reset stays, ordered ahead of the increments by the existing
  `start_sem` multicast/wait.

No change to results on any input — the removed writes only re-assert the
dispatcher's initial value. This covers both the per-dim (`reduce_all == false`)
and reduce-all paths, which share the loop and the same `done_sem` protocol.

## Test plan / CI

The change touches only `argmax_multi_core_program_factory`'s reader kernel
(the single-core and NC argmax paths use different kernels and are unaffected),
and `ttnn.argmax` is not called internally by other ops, so the blast radius is
the `ttnn.argmax` multi-core last-dim path.

- **`ttnn-post-commit`** → `ttnn reduce group`
  (`pytest tests/ttnn/unit_tests/operations/reduce`, incl. `test_argmax.py`) on
  **wh_n300** and **bh_p100** — the direct functional gate.
- **`ttnn-run-sweeps`** → `reduction.argmax.argmax`,
  `reduction.argmax.argmax_output`, `reduction.generality.argmax` — broad
  shape/dtype/keepdim coverage of the multi-core path (best blast-radius check).
- Optional: nightly reduction (`ttnn nightly reduction tests`) and the
  `model_traced/argmax_model_traced` sweep, since argmax is used for
  argmax-sampling in LLM decode.

### CI Status

_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholami/argmax-fix)
  - One failing test `test_conv1d ` on tt-sim: unrelated to these changes.
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholami/argmax-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sgholami/argmax-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholami/argmax-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholami/argmax-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholami/argmax-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholami/argmax-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholami/argmax-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholami/argmax-fix)