### PR TITLE
Bug fix: pgm_dispatch load_prefetcher trace-region overflow on wormhole_b0 (#46983)

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.py
@@ -38,11 +38,17 @@ def add_benchmark_iterations(input):
     out = {}
     for benchmark in input["benchmarks"]:
         name = benchmark["name"]
+        # A benchmark that aborted (e.g. a TT_FATAL) has no timing fields. Preserve the error entry so
+        # the comparison below reports it explicitly instead of crashing with a KeyError on IterationTime.
+        if benchmark.get("error_occurred") or "IterationTime" not in benchmark:
+            if "error_occurred" not in out.get(name, {}):
+                out[name] = benchmark
+            continue
         if benchmark["repetitions"] == 1:
             out[name] = benchmark
         elif benchmark["repetitions"] == 2:
             if benchmark["run_type"] == "iteration":
-                if name in out:
+                if name in out and "IterationTime" in out[name]:
                     # Use the minimum time to reduce the impact of flakes. Flakes are unlikely to improve performance,
                     # but may hurt performance due to some other process using CPU. Avoid using the median in the 2
                     # repetition case, because it reverts to the mean and is more sensitive to flakes.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -689,7 +689,10 @@ static int pgm_dispatch(T& state, TestInfo info) {
         const ChipId device_id = 0;
         const std::size_t cq_id = 0;
         DispatchCoreType dispatch_core_type = info.dispatch_from_eth ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
-        size_t trace_region_size = 1'000'000'000;
+        // load_prefetcher_test captures hundreds of programs in a single trace to overflow the
+        // prefetcher cache; the captured trace is ~1.03 GB on wormhole_b0 (refs #46983), so the
+        // region must comfortably exceed 1 GB.
+        size_t trace_region_size = 1'500'000'000;
         std::string arch_name = tt::tt_metal::hal::get_arch_name();
         if (arch_name == std::string("blackhole")) {
             // Blackhole has more cores, so we need more room to store RTAs.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`BM_pgm_dispatch/load_prefetcher_test/512` fails on `wh_n300_civ2` (Wormhole N300) in the (Runtime) Performance Tests workflow. The benchmark captures hundreds of programs in a single trace to overflow the prefetcher cache. After #46526 added `kernel_text_size[]` to `kernel_config_msg_t`, the per-program trace footprint grew just enough to push the `/512` case to ~1.03 GB, exceeding the hardcoded 1 GB trace region on `wormhole_b0`. This tripped a `TT_FATAL` in `tt_metal/distributed/mesh_trace.cpp`, and the resulting errored benchmark JSON (no `IterationTime`) then crashed `compare_pgm_dispatch_perf_ci.py` with `KeyError: 'IterationTime'`, masking the real failure.

This change:
- Bumps the `wormhole_b0` trace region `1.0 GB -> 1.5 GB` in `test_pgm_dispatch.cpp`, comfortably above the ~1.03 GB the test captures (blackhole already uses 2.5 GB).
- Hardens `add_benchmark_iterations()` in `compare_pgm_dispatch_perf_ci.py` to preserve error entries instead of dereferencing a missing `IterationTime`, so a benchmark abort is reported explicitly rather than masked by a `KeyError`.

The benchmark itself is enabled as-is on `main` — the lifecycle disable PR #46983's #47713 was never merged — so no re-enable is needed. This is the real fix in place of that disable.

Relates to #46983

### Notes for reviewers
- The trace size is data-dependent: the test self-sizes program count to 1.5x the prefetcher ringbuffer, so the region just needs comfortable headroom over 1 GB rather than an exact value.
- Verified the compare script locally: an errored result now prints `Error: Benchmark ... gave unexpected error` and exits 1 (no traceback); golden-vs-self still reports `Test successful` (exit 0).
- The C++ change is a single integer-literal bump in an existing valid expression; not yet run on-device in this branch.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-pgm-dispatch-trace-region-46983)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-pgm-dispatch-trace-region-46983)