### PR TITLE
Add flush for BH

### DIFF
--- a/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/coordinator_kernel.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/coordinator_kernel.cpp
@@ -56,6 +56,11 @@ void kernel_main() {
     uint64_t identity_tile_global_multicast_addr =
             get_noc_multicast_addr(start_x, start_y, end_x, end_y, tile_l1_addr);
     noc_async_write_multicast(tile_l1_addr, identity_tile_global_multicast_addr, single_tile_size, num_dests);
+#ifdef ARCH_BLACKHOLE
+    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
+    // sent in order they are issued
+    noc_async_writes_flushed();
+#endif
 
     ////////// MULTICAST 'VALID' STATE TO RECEIVERS //////////
     *(receiver_addr_ptr) = VALID;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This PR is to fix the issue #48480 . And flush is added for BH between `noc_async_write_multicast` and `noc_semaphore_set_multicast`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ronnie/48480-fix_BH_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ronnie/48480-fix_BH_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ronnie/48480-fix_BH_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ronnie/48480-fix_BH_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ronnie/48480-fix_BH_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ronnie/48480-fix_BH_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ronnie/48480-fix_BH_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ronnie/48480-fix_BH_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ronnie/48480-fix_BH_flush)