### PR TITLE
emule: multichip fiber engine + fabric/CCL teleport (8-chip loudbox)

### DIFF
--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -93,4 +93,10 @@ if(TT_UMD_BUILD_SIMULATION)
     target_compile_definitions(distributed PRIVATE TT_UMD_BUILD_SIMULATION)
 endif()
 
+if(TT_METAL_USE_EMULE)
+    # The slow-dispatch mesh command queue routes per-device dispatch through the emule
+    # register/run split (emulated_program_runner.hpp) — gated on this define.
+    target_compile_definitions(distributed PRIVATE TT_METAL_USE_EMULE=1)
+endif()
+
 target_include_directories(distributed SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -14,11 +14,17 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/graph_tracking.hpp>
+#ifdef TT_METAL_USE_EMULE
+#include "tt_metal/impl/emulation/emulated_program_runner.hpp"  // emule mesh register/run split
+#endif
 #include <utility>
 #include <unordered_set>
 #include <llrt/tt_cluster.hpp>
 #include <llrt/llrt.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#ifdef TT_METAL_USE_EMULE
+#include <thread>
+#endif
 
 namespace {
 
@@ -202,6 +208,11 @@ void SDMeshCommandQueue::dispatch_program(const MeshCoordinateRange& coord_range
         return;
     }
 
+    // Emule note: the register/run split is bracketed by enqueue_mesh_workload around the whole
+    // workload, not here per-program, so cross-chip sender/receiver programs co-run in one scheduler
+    // generation. LaunchProgram / DispatchCompiledProgramToDevice below only register (defer flag set
+    // by the outer begin_mesh_dispatch). See tt-emule docs/fiber-engine.md.
+
     // First device: full LaunchProgram (compiles, finalizes, allocates CBs, dispatches)
     tt_metal::detail::LaunchProgram(local_devices[0], program, false);
 
@@ -255,6 +266,27 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     }
 
     auto& range_program_map = mesh_workload.get_programs();
+
+#ifdef TT_METAL_USE_EMULE
+    if (this->get_target_device_type() == tt::TargetDevice::Emule) {
+        // Co-schedule every program in this workload in one fiber run so cross-chip sender/receiver
+        // programs co-run in one scheduler generation and the teleport's fiber wake reaches the
+        // parked receiver. Register all (deferred) sequentially (not the thread pool, to avoid a
+        // fiber-registration race), then run once. See tt-emule docs/fiber-engine.md.
+        tt::tt_metal::emule::begin_mesh_dispatch();
+        for (auto& [coord_range, program] : range_program_map) {
+            dispatch_program(coord_range, program, /*blocking=*/false);  // register only (defer)
+        }
+        tt::tt_metal::emule::run_mesh_dispatch();  // one concurrent run across all programs/chips
+        // run_until_idle completed every program synchronously, so all cores are idle now; keep the
+        // "previous workload cores" map empty (the emule invariant wait_for_cores_idle relies on).
+        {
+            std::lock_guard<std::mutex> guard(logical_cores_mutex_);
+            logical_cores_for_previous_workload_.clear();
+        }
+        return;
+    }
+#endif
 
     if (launch_thread_pool_) {
         // Dispatch programs in parallel

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -3,6 +3,13 @@ include(sources.cmake)
 add_library(fabric OBJECT)
 add_library(TT::Metalium::Fabric ALIAS fabric)
 
+# emule: append_fabric_connection_rt_args records each worker's fwd/bwd connection->neighbor for the
+# software-emulation teleport's 1D dst resolution (the firmware connection table emule skips). The define
+# is PRIVATE on the tt_metal target, which doesn't reach this OBJECT lib, so set it here too.
+if(TT_METAL_USE_EMULE)
+    target_compile_definitions(fabric PRIVATE TT_METAL_USE_EMULE=1)
+endif()
+
 # Enable unity builds for faster compilation
 TT_ENABLE_UNITY_BUILD(fabric)
 

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -93,6 +93,13 @@ std::unordered_map<MeshId, MeshShape> get_physical_mesh_shapes() {
     return mesh_shapes;
 }
 
+#if defined(TT_METAL_USE_EMULE)
+// emule has no fabric router, so the device-L1 connection table is never populated. Record the
+// fwd/bwd-to-neighbor binding host-side for the teleport's 1D dst resolution. Defined in the emule runner.
+// See tt-emule docs/fabric-ccl-emulation.md.
+extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t wy, uint32_t dir, uint32_t neighbor);
+#endif
+
 template <typename ProgramOrDescriptor>
 void append_fabric_connection_rt_args(
     const FabricNodeId& src_fabric_node_id,
@@ -205,6 +212,16 @@ void append_fabric_connection_rt_args(
     if (core_type == CoreType::WORKER) {
         append_worker_to_fabric_edm_sender_rt_args(
             fabric_router_channel, worker_teardown_semaphore_id, worker_buffer_index_semaphore_id, worker_args);
+#if defined(TT_METAL_USE_EMULE)
+        // Record (src_chip, worker_core, forwarding_direction, neighbor_chip) for the emule teleport's 1D
+        // dst resolution. Called per connection in fwd-then-bwd order (matches the kernel's read order).
+        __emule_fabric_record_conn(
+            static_cast<uint32_t>(control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id)),
+            static_cast<uint32_t>(worker_core.x),
+            static_cast<uint32_t>(worker_core.y),
+            static_cast<uint32_t>(forwarding_direction.value()),
+            static_cast<uint32_t>(control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id)));
+#endif
     } else {
         // TODO: will be deprecated. currently for ethernet dispatch case
         //       ethernet core need to have same memory mapping as worker

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -17,6 +17,7 @@
 #include "device/device_impl.hpp"
 #include "common/executor.hpp"
 #include "impl/context/context_descriptor.hpp"
+#include "context/metal_context.hpp"
 
 #include <experimental/fabric/control_plane.hpp>
 #include <experimental/fabric/fabric_types.hpp>
@@ -31,6 +32,13 @@ namespace {
 
 using tt::tt_fabric::chan_id_t;
 using tt::tt_fabric::EDMStatus;
+
+// Emule teleports cross-chip traffic at the fabric client-API shim and never runs the ERISC router,
+// so its launch/sync handshake would never complete — skip it (as for Mock). See tt-emule
+// docs/fabric-ccl-emulation.md.
+bool skip_fabric_fw_for_emule() {
+    return MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Emule;
+}
 
 static_assert(static_cast<uint32_t>(EDMStatus::STARTED) != 0);
 static_assert(static_cast<uint32_t>(EDMStatus::REMOTE_HANDSHAKE_COMPLETE) != 0);
@@ -279,8 +287,8 @@ void FabricFirmwareInitializer::init(
         return;
     }
 
-    if (descriptor_->is_mock_device()) {
-        log_info(tt::LogMetal, "Skipping fabric initialization for mock devices");
+    if (descriptor_->is_mock_device() || skip_fabric_fw_for_emule()) {
+        log_info(tt::LogMetal, "Skipping fabric initialization for mock/emule devices");
         return;
     }
 
@@ -314,9 +322,10 @@ void FabricFirmwareInitializer::init(
 }
 
 void FabricFirmwareInitializer::configure() {
-    // Mock: skip router sync (init() skips fabric; sync would fatal on uninitialized builder state).
-    if (descriptor_->is_mock_device()) {
-        log_info(tt::LogMetal, "Skipping fabric configure (router sync) for mock devices");
+    // Mock/Emule: skip router sync (init() skips fabric; sync would fatal/timeout — emule never
+    // runs the ERISC router, so the handshake status stays NOT_STARTED).
+    if (descriptor_->is_mock_device() || skip_fabric_fw_for_emule()) {
+        log_info(tt::LogMetal, "Skipping fabric configure (router sync) for mock/emule devices");
         initialized_.test_and_set();
         return;
     }
@@ -330,8 +339,8 @@ void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& ini
     TT_FATAL(
         !init_done.contains(InitializerKey::Dispatch),
         "FabricFirmwareInitializer must be torn down after DispatchKernelInitializer");
-    if (descriptor_->is_mock_device()) {
-        log_info(tt::LogMetal, "Skipping fabric teardown for mock devices");
+    if (descriptor_->is_mock_device() || skip_fabric_fw_for_emule()) {
+        log_info(tt::LogMetal, "Skipping fabric teardown for mock/emule devices");
         init_done.erase(key);
         return;
     }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -26,6 +26,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -60,10 +61,15 @@
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include "umd/device/chip/sw_emule_chip.hpp"
+#include <tt-metalium/experimental/fabric/control_plane.hpp>  // fabric route table (multi-chip dst resolve)
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>   // FabricNodeId, MeshId, FabricConfig
+#include <tt-metalium/experimental/fabric/fabric.hpp>         // is_2d_fabric_config
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>     // RoutingDirection
 #include "tt_emule/device.hpp"
 #include "tt_emule/dfb_sync_state.hpp"
 #include "tt_emule/tile_counter.hpp"
-
+#include "jit_hw/internal/emule_thread_ctx.h"
+#include "emule_fiber_scheduler.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 
 #include <tt-logger/tt-logger.hpp>
@@ -85,64 +91,38 @@
 // We use the real type directly here.
 using __emule_cb_state = tt_emule::CBSyncState;
 
-// Point into this core's L1 at kernel_config_base + rta_offset[proc_idx],
-// where WriteRuntimeArgsToDevice already wrote the bytes. nullptr = sentinel
-// (kernel declared no rt-args for this RISC).
-thread_local uint32_t* __rt_args = nullptr;
-thread_local uint32_t* __common_rt_args = nullptr;
+// The per-RISC identity / handles — rt_args, common_rt_args, core_obj, device,
+// bridge_l1/dram, cbs, dfbs, tc_array, processor_id, neo_id, trisc_id,
+// num_threads, my_thread_id, core_map — are now fields of the per-thread
+// ThreadCommonCtx, reached via __emule_self (defined just below; see
+// emule_thread_ctx.h). The runner sets them in the launch lambda; the JIT kernel
+// and the extern-C resolvers above read them through __emule_self->X. (The
+// mhartid regex now emits `__emule_self->processor_id`; CSR/get_num_threads/
+// get_arg shims read the corresponding ctx fields.)
 
-thread_local tt_emule::Core* __core = nullptr;
+// Per-thread execution context — the single source of truth for an emulated
+// RISC's thread-local state, specialized by RISC type (see emule_thread_ctx.h).
+// Defined here, exported via -rdynamic so the JIT .so resolves it at dlopen; set
+// per kernel thread in the launch lambda below.
+thread_local ThreadCommonCtx* __emule_self = nullptr;
 
-// Memory bridge pointers — now non-static for -rdynamic export.
-thread_local uint8_t* __emule_bridge_l1 = nullptr;
-thread_local uint8_t* __emule_bridge_dram = nullptr;
-
-// Per-core CB state array, shared between threads on the same core.
-thread_local __emule_cb_state* __emule_cbs = nullptr;
-
-// Per-thread DFB interface array (one entry per DFB on the core).
-thread_local tt_emule::EmuleDFBInterface* __emule_dfbs = nullptr;
-
-// Per-core tile counter array, shared between threads on the same core.
-thread_local tt_emule::TileCounterArray* __emule_tc_array = nullptr;
-
-// Quasar-specific per-thread identity, written by the runner at thread start
-// (see launch_cores below) and read inside the JIT'd kernel .so. Each variable
-// stands in for a different hardware signal; they are NOT interchangeable.
+// Core execution state (bridge_l1/dram, cbs, dfbs, tc_array, num_threads, my_thread_id, core_map)
+// now lives in ThreadCommonCtx, reached via __emule_self and set per-fiber in launch_cores.
 //
-// __processor_id  — RISC-V mhartid analogue. DM threads: DM index 0..7.
-//                   Compute threads: Neo engine index 0..3. Consumed by the
-//                   JIT regex that rewrites `asm volatile("csrr %0, mhartid" ...)`
-//                   into `VAR = __processor_id;` (x86 can't execute the CSR).
-//
-// __emule_neo_id  — Quasar NEO_ID CSR (0xBC2). Which of the 4 compute engines
-//                   in a Neo is executing. Set to processor_id for compute
-//                   threads, 0 for DM. Read by ckernel::csr_read<CSR::NEO_ID>().
-//
-// __emule_trisc_id — Quasar TRISC_ID CSR (0xBC3). Which TRISC sub-engine
-//                    (0=UNPACK, 1=MATH, 2=PACK, 3=ISOLATE_SFPU) is running.
-//                    Starts at 0; for Quasar compute kernels the launcher
-//                    iterates it 0..3 across ki.variants (see the variant
-//                    loop in launch_cores). Read by
-//                    ckernel::csr_read<CSR::TRISC_ID>().
-//
-// __emule_num_threads  — backs get_num_threads(). Total threads this kernel
-//                        runs on (DM count for DM kernels, active-engine count
-//                        for compute).
-//
-// __emule_my_thread_id — backs get_my_thread_id(). Index of this processor within
-//                        the kernel's processor list (0-based), matching the Quasar
-//                        firmware's my_thread_id semantics. NOT the same as
-//                        __processor_id: e.g. a consumer on RISCV_1 has
-//                        __processor_id=1 but __emule_my_thread_id=0 (first consumer).
+// These three Quasar identity signals are ALSO kept as -rdynamic globals: the JIT kernel reads them
+// from the ctx (__emule_self->{processor_id,neo_id,trisc_id}), but the ASAN sanitizer
+// (emule_sanitizers.cpp) reads the globals, so the launch lambda sets both.
+//   __processor_id   — RISC-V mhartid analogue (DM index / Neo engine index).
+//   __emule_neo_id   — Quasar NEO_ID CSR (0xBC2).
+//   __emule_trisc_id — Quasar TRISC_ID CSR (0xBC3); iterated 0..3 across ki.variants for compute.
 thread_local uint8_t __processor_id = 0;
 thread_local uint8_t __emule_neo_id = 0;
 thread_local uint8_t __emule_trisc_id = 0;
-thread_local uint32_t __emule_num_threads = 1;
-thread_local uint32_t __emule_my_thread_id = 0;
 
-// Mirrored from tt-emule/src/kernel_runner.cpp — the two libs are never linked
-// into the same binary, so the duplicate definitions are benign.
+// Sanitizer thread-local state (ASAN feature). Exported via -rdynamic so the jit_hw ASAN headers
+// resolve them; all null/zero and inert when TT_METAL_EMULE_ASAN is off. Mirrored from
+// tt-emule/src/kernel_runner.cpp — the two libs are never linked into the same binary, so the
+// duplicate definitions are benign.
 thread_local uint32_t __emule_sem_l1_range_start = 0;
 thread_local uint32_t __emule_sem_l1_range_end = 0;
 thread_local const char* __emule_kernel_name = nullptr;
@@ -173,9 +153,6 @@ thread_local bool __emule_cb_boundary_strict = false;
 thread_local uint32_t __emule_dram_unreserved_base = 0;
 thread_local const uint64_t* __emule_dram_tensor_ranges = nullptr;
 thread_local uint32_t __emule_dram_tensor_ranges_count = 0;
-
-// Core map for cross-core NOC address resolution (shared across all threads).
-thread_local std::unordered_map<uint64_t, tt_emule::Core*>* __emule_core_map = nullptr;
 
 // ---------------------------------------------------------------------------
 // Bank mapping arrays — populated from SoC descriptor before kernel launch.
@@ -212,14 +189,18 @@ static constexpr uint32_t NOC_NODE_MASK = (1 << NOC_NODE_ID_BITS) - 1;
 // checks below and the JIT kernel .so files resolve it at link/dlopen.
 extern "C" [[noreturn]] void __emule_asan_panic(const char* fmt, ...);
 
-// C-linkage bridge functions for JIT kernels.
+// C-linkage bridge/fabric hooks for JIT kernels. Every one runs inside a kernel fiber, so
+// __emule_self is always set; a null means the hook ran outside a fiber — a contract violation,
+// not a recoverable state. Fail loudly (uniform across the whole bridge surface).
+static inline void emule_require_self(const char* fn) {
+    TT_FATAL(__emule_self != nullptr, "{}: emule bridge call outside a kernel fiber context", fn);
+}
+
 extern "C" uint8_t* __emule_dram_ptr(uint64_t offset) {
-    // Range-test in 32 bits to match the live-range registry, whose addresses are
-    // uint32_t (LiveDramRanges stores uint32_t start/end). The full 64-bit offset
-    // is used only for the backing-store address (returned below). This assumes
-    // DRAM addresses fit in 32 bits — true for every emulated WH/BH config today;
-    // a Blackhole >4 GB per-bank view would need the registry + this test widened
-    // to 64 bit to avoid 4 GB-boundary aliasing.
+    emule_require_self(__func__);
+    // ASAN out-of-bounds DRAM check (inert when TT_METAL_EMULE_ASAN off — ranges stay null). Range-test
+    // in 32 bits to match the live-range registry (uint32_t start/end); the 64-bit offset is used only
+    // for the backing-store address. Assumes DRAM addresses fit in 32 bits (true for every WH/BH config).
     if (__emule_dram_tensor_ranges != nullptr &&
         static_cast<uint32_t>(offset) >= __emule_dram_unreserved_base) {
         uint32_t addr = static_cast<uint32_t>(offset);
@@ -240,10 +221,12 @@ extern "C" uint8_t* __emule_dram_ptr(uint64_t offset) {
                 addr);
         }
     }
-    return __emule_bridge_dram ? __emule_bridge_dram + offset : nullptr;
+    return __emule_self->bridge_dram ? __emule_self->bridge_dram + offset : nullptr;
 }
 
 extern "C" uint8_t* __emule_local_l1_ptr(uint32_t offset) {
+    emule_require_self(__func__);
+    // ASAN illegal-semaphore-region check (inert when ASAN off — range end stays 0).
     if (__emule_sem_l1_range_end > 0 &&
         offset >= __emule_sem_l1_range_start && offset < __emule_sem_l1_range_end) {
         __emule_asan_panic(
@@ -252,19 +235,42 @@ extern "C" uint8_t* __emule_local_l1_ptr(uint32_t offset) {
             __emule_sem_l1_range_start,
             __emule_sem_l1_range_end);
     }
-    return __emule_bridge_l1 ? __emule_bridge_l1 + offset : nullptr;
+    return __emule_self->bridge_l1 ? __emule_self->bridge_l1 + offset : nullptr;
 }
 
 extern "C" uint8_t* __emule_noc_resolve(uint32_t x, uint32_t y, uint64_t addr) {
-    if (__emule_core_map) {
+    emule_require_self(__func__);
+    if (__emule_self->core_map) {
         uint64_t key = (uint64_t(x) << 32) | y;
-        auto it = __emule_core_map->find(key);
-        if (it != __emule_core_map->end()) {
+        auto it = __emule_self->core_map->find(key);
+        if (it != __emule_self->core_map->end()) {
             return it->second->l1_ptr(static_cast<uint32_t>(addr));
         }
     }
     return nullptr;
 }
+
+// Fiber-scheduler bridge — the dlopen'd kernel .so calls these (declared in
+// include/jit_hw/internal/emule_fiber_bridge.h) to park/wake/yield on the one
+// scheduler instance. Resolved at dlopen via -rdynamic, like the resolvers above.
+namespace efib = tt::tt_metal::emule_fiber;
+extern "C" void __emule_fiber_lock(void) { efib::FiberScheduler::instance().lock(); }
+extern "C" void __emule_fiber_unlock(void) { efib::FiberScheduler::instance().unlock(); }
+extern "C" void __emule_fiber_park_locked(const void* key) {
+    efib::FiberScheduler::instance().park_locked(key);
+}
+extern "C" void __emule_fiber_wake(const void* key) { efib::FiberScheduler::instance().wake(key); }
+extern "C" void __emule_fiber_yield(void) { efib::FiberScheduler::instance().yield(); }
+extern "C" void __emule_fiber_read_latency(void) { efib::FiberScheduler::instance().latency_park(); }
+extern "C" void __emule_fiber_note_publish(unsigned pages) {
+    efib::FiberScheduler::instance().note_publish(pages);
+}
+
+// Worker L1 slot size + mask: a worker's L1 offset is a 2 MB-aligned truncated host pointer, so the masked
+// low bits recover the in-slot offset. Applied ONLY for WORKER cores (DRAM banks are GB-scale — see the
+// per-resolver comments). Used by every NOC-address resolver.
+static constexpr uint32_t L1_SLOT_SIZE = 2u * 1024 * 1024;  // 2 MB per worker L1 slot
+static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
 
 // Resolve a NOC address (encoded 64-bit) to a host pointer.
 // Real firmware encoding: y in bits [47:42], x in bits [41:36], addr in bits [35:0]
@@ -284,13 +290,11 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
     uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint64_t local_addr = noc_addr & NOC_LOCAL_MASK;  // 36 bits, raw
 
-    static constexpr uint32_t L1_SLOT_SIZE = 2u * 1024 * 1024;  // 2 MB per worker L1 slot
-    static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
-
-    if (__emule_core_map) {
+    emule_require_self(__func__);
+    if (__emule_self->core_map) {
         uint64_t key = (uint64_t(noc_x) << 32) | noc_y;
-        auto it = __emule_core_map->find(key);
-        if (it != __emule_core_map->end()) {
+        auto it = __emule_self->core_map->find(key);
+        if (it != __emule_self->core_map->end()) {
             uint32_t offset = (it->second->role() == tt_emule::CoreRole::WORKER)
                                   ? (static_cast<uint32_t>(local_addr) & L1_SLOT_MASK)
                                   : static_cast<uint32_t>(local_addr);
@@ -301,14 +305,15 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
 }
 
 extern "C" bool __emule_noc_addr_is_dram(uint64_t noc_addr) {
-    if (!__emule_core_map) {
+    emule_require_self(__func__);
+    if (!__emule_self->core_map) {
         return false;
     }
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
     uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint64_t key = (uint64_t(noc_x) << 32) | noc_y;
-    auto it = __emule_core_map->find(key);
-    if (it != __emule_core_map->end()) {
+    auto it = __emule_self->core_map->find(key);
+    if (it != __emule_self->core_map->end()) {
         return it->second->role() == tt_emule::CoreRole::DRAM;
     }
     return false;
@@ -337,11 +342,10 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
     // firmware-style offsets (< 2 MB) this is a no-op.
     // Multicast targets only WORKER cores (DRAM cores are skipped by the role
     // check in the delivery loop below), so the mask is L1-correct here.
-    static constexpr uint32_t L1_SLOT_SIZE = 2u * 1024 * 1024;  // 2 MB per worker L1 slot
-    static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
     l1_offset &= L1_SLOT_MASK;
 
-    if (!__emule_core_map) {
+    emule_require_self(__func__);
+    if (!__emule_self->core_map) {
         return;
     }
 
@@ -357,8 +361,8 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
                 continue;
             }
             uint64_t key = (uint64_t(x) << 32) | y;
-            auto it = __emule_core_map->find(key);
-            if (it != __emule_core_map->end() && it->second->role() == tt_emule::CoreRole::WORKER) {
+            auto it = __emule_self->core_map->find(key);
+            if (it != __emule_self->core_map->end() && it->second->role() == tt_emule::CoreRole::WORKER) {
                 uint8_t* dst = it->second->l1_ptr(static_cast<uint32_t>(l1_offset));
                 if (size == sizeof(uint32_t)) {
                     TT_FATAL(
@@ -369,6 +373,7 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
                     uint32_t val;
                     std::memcpy(&val, src, sizeof(uint32_t));
                     reinterpret_cast<std::atomic<uint32_t>*>(dst)->store(val, std::memory_order_release);
+                    efib::FiberScheduler::instance().wake(dst);  // wake the target core's sem waiter
                 } else {
                     std::memcpy(dst, src, size);
                     std::atomic_thread_fence(std::memory_order_release);
@@ -377,7 +382,8 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
             }
         }
     }
-    if (delivered == 0) {
+    static const bool mdbg = std::getenv("EMULE_DEBUG") != nullptr;
+    if (delivered == 0 && mdbg) {
         fprintf(
             stderr,
             "EMULE WARN: multicast (%u,%u)->(%u,%u) offset=0x%lx size=%u: "
@@ -698,7 +704,7 @@ static std::string emule_line_preserving_replace(
 static void apply_x86_rewrites(std::string& src) {
     static const std::regex mhartid_re(
         R"(asm\s+volatile\s*\(\s*"csrr\s+%0\s*,\s*mhartid"\s*:\s*"=r"\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*\)\s*;)");
-    src = emule_line_preserving_replace(src, mhartid_re, "$1 = __processor_id;");
+    src = emule_line_preserving_replace(src, mhartid_re, "$1 = __emule_self->processor_id;");
 
     static const std::regex fence_re(R"(asm\s+volatile\s*\(\s*"fence"\s*(:::\s*"memory"\s*)?\)\s*;)");
     src = emule_line_preserving_replace(src, fence_re, "__sync_synchronize();");
@@ -740,6 +746,11 @@ static void apply_x86_rewrites(std::string& src) {
     static const std::regex zero_len_noc_coords_re(
         R"((using\s+RemoteNocCoords\s*=\s*RemoteNocCoord\s*\[)\s*N\s*(\]))");
     src = std::regex_replace(src, zero_len_noc_coords_re, "$1(N) == 0 ? 1 : (N)$2");
+
+    // Note: C-style `(uint32_t)ptr` truncation casts (common in fabric/CCL kernels, e.g.
+    // `(uint32_t)sem_header_ptr`) are handled globally by the -fms-extensions JIT flag, which
+    // downgrades pointer→smaller-int casts from a hard error to a warning. The MAP_32BIT window keeps
+    // those addresses in the low 2 GB so the truncation is value-preserving.
 }
 
 // Patch `src_path` into `out_path`, then recurse into the quoted project headers
@@ -773,7 +784,9 @@ static void preprocess_tu_recursive(
         std::error_code ec;
         const std::filesystem::path candidate = src_dir / inc_name;
         if (!std::filesystem::exists(candidate, ec)) {
-            // Resolved via a -I path (emule api/, system headers) — not ours to patch.
+            // Resolved via a -I path (emule api/, system headers, repo-rooted kernel-common). Not ours
+            // to patch — pointer-truncation idioms there are handled by -fms-extensions (see the JIT
+            // compile flags), which downgrades pointer→uint32 casts to warnings.
             continue;
         }
         const std::string canon = std::filesystem::weakly_canonical(candidate, ec).string();
@@ -955,7 +968,26 @@ static std::function<void()> jit_compile_kernel(
     // (mhartid, fence) and raw L1 arg-val pointer casts. -I kernel_dir (below)
     // keeps relative includes in the patched file resolvable.
     std::string patched_kernel_path = dir + "/patched_kernel.cpp";
-    preprocess_kernel_source_for_x86(abs_kernel, patched_kernel_path);
+    // WORKAROUND: see tt-emule/.claude/skills/workarounds (WA-2).
+    // The fabric mux (tt_fabric_mux.cpp) is a transport-layer aggregation kernel: workers write packets
+    // into its L1 channels and it forwards them over ethernet. emule has no ethernet — WorkerToFabricMux
+    // Sender teleports each packet straight to its final destination (same as the no-mux direct path),
+    // so the mux has nothing to do. The real kernel is also persistent (loops until an external
+    // termination signal) and pulls in erisc firmware emule doesn't model, which would both fail to
+    // compile and hang emule's run-to-completion join. Substitute a no-op kernel: it compiles, exits
+    // immediately, and the teleporting mux sender carries the data. (Mirrors how emule collapses the eth
+    // router/switch into the teleport — the mux is the worker-side half of that same transport.)
+    if (std::filesystem::path(abs_kernel).filename() == "tt_fabric_mux.cpp") {
+        std::ofstream f(patched_kernel_path);
+        if (!f) {
+            throw std::runtime_error("jit_compile_kernel: cannot write mux stub " + patched_kernel_path);
+        }
+        f << "// emule no-op stub for tt_fabric_mux.cpp (the teleporting mux sender carries the data).\n"
+          << "#include \"api/dataflow/dataflow_api.h\"\n"
+          << "void kernel_main() {}\n";
+    } else {
+        preprocess_kernel_source_for_x86(abs_kernel, patched_kernel_path);
+    }
 
     // 3. Write wrapper.cpp
     // Kernel defines are written as #define directives in the wrapper to avoid
@@ -1028,8 +1060,12 @@ static std::function<void()> jit_compile_kernel(
         opt_flags += " -g -fno-omit-frame-pointer -funwind-tables";
     }
     std::ostringstream cmd;
+    // -fms-extensions: fabric/CCL kernels collapse 32-bit-device L1 pointers to uint32_t (e.g.
+    // `(uint32_t)pkt_hdr`); on the 64-bit host clang treats pointer→smaller-int as a hard error, but
+    // -fms-extensions downgrades it to a warning. emule's MAP_32BIT window keeps those addresses in the
+    // low 2 GB, so the truncation is value-preserving. (opt_flags = -O2, + ASAN debug info when enabled.)
     cmd << TT_EMULE_CXX_COMPILER << " -std=c++" << TT_EMULE_CXX_STANDARD << " -fPIC -shared" << opt_flags
-        << " -Wno-c++11-narrowing"
+        << " -Wno-c++11-narrowing -fms-extensions"
         << " -I\"" << jit_inc << "\""
         << " -I\"" << parent_inc << "\""
         << " -I\"" << kernel_dir << "\"";
@@ -1398,6 +1434,13 @@ static std::map<std::string, std::string> build_kernel_defines(
         }
     }
     defines["NUM_NOCS"] = std::to_string(NUM_NOCS);
+    // Fabric routing mode for the emule packet-header stamping shims. The real
+    // fabric_set_line_unicast_route dispatches 1D-vs-2D on the header TYPE, but emule aliases
+    // LowLatencyPacketHeader == HybridMeshPacketHeader (one 64B layout), so the shim cannot tell
+    // them apart by type — it disambiguates on this build-mode define instead.
+    if (tt::tt_fabric::is_2d_fabric_config(MetalContext::instance().get_fabric_config())) {
+        defines["EMULE_FABRIC_2D"] = "1";
+    }
     // Upstream tensor/dspec.h gates `get_common_arg_addr` as a forward-decl
     // under KERNEL_BUILD; emule's jit_kernel_stubs.hpp provides the definition.
     // Without KERNEL_BUILD, dspec.h emits a stub that collides with emule's.
@@ -1765,6 +1808,14 @@ static void collect_kernels(
 // ---------------------------------------------------------------------------
 // jit_compile_pending: Compile cache misses in parallel, resolve all fns.
 // ---------------------------------------------------------------------------
+// Global compile-once registry: dedups kernel compilation across jit_compile_pending's parallel compile
+// tasks. The first task to need a key publishes a shared_future the rest reuse, so each kernel compiles
+// exactly once to a unique tmp with an atomic rename (racing clang on one `.so.tmp` would corrupt it).
+// Shared across programs, hence the mutex. See tt-emule docs/metal-integration.md.
+static std::mutex g_compile_inflight_mutex;
+static std::unordered_map<std::string, std::shared_future<std::function<void()>>> g_compile_inflight;
+static std::atomic<uint64_t> g_compile_tmp_seq{0};
+
 static void jit_compile_pending(
     std::map<std::string, DeferredCompile>& deferred_compiles,
     std::unordered_map<std::string, std::function<void()>>& resolved_fns,
@@ -1772,27 +1823,53 @@ static void jit_compile_pending(
     if (!deferred_compiles.empty()) {
         log_info(tt::LogMetal, "JIT parallel compile: {} unique kernels to compile", deferred_compiles.size());
 
-        std::vector<std::pair<std::string, std::future<std::function<void()>>>> futures;
+        std::vector<std::pair<std::string, std::shared_future<std::function<void()>>>> futures;
         futures.reserve(deferred_compiles.size());
 
         for (auto& [key, dc] : deferred_compiles) {
-            std::string cache_path = disk_cache_so_path(key);
-            std::string tmp_path = cache_path + ".tmp." + std::to_string(::getpid());
-            futures.emplace_back(
-                key, std::async(std::launch::async, [&dc, cache_path, tmp_path]() {
-                    auto fn = jit_compile_kernel(
-                        dc.src_path, dc.compile_args, dc.named_compile_args, dc.defines, dc.extra_inc,
-                        dc.bindings, tmp_path);
-                    std::filesystem::rename(tmp_path, cache_path);
-                    return fn;
-                }));
+            std::shared_future<std::function<void()>> fut;
+            {
+                std::lock_guard<std::mutex> lock(g_compile_inflight_mutex);
+                // Another thread may have already finished this key (published to g_jit_cache) or be
+                // mid-compile (published an inflight future) since we built deferred_compiles.
+                {
+                    std::lock_guard<std::mutex> clock(g_jit_cache_mutex);
+                    auto cit = g_jit_cache.find(key);
+                    if (cit != g_jit_cache.end()) {
+                        resolved_fns[key] = cit->second;
+                        continue;
+                    }
+                }
+                auto iit = g_compile_inflight.find(key);
+                if (iit != g_compile_inflight.end()) {
+                    fut = iit->second;  // reuse the in-progress compile launched by another thread
+                } else {
+                    std::string cache_path = disk_cache_so_path(key);
+                    DeferredCompile dc_copy = dc;  // own a copy: the future may outlive this call's map
+                    fut = std::async(std::launch::async, [dc_copy, cache_path]() {
+                              std::string tmp_path = cache_path + ".tmp." + std::to_string(::getpid()) + "." +
+                                                     std::to_string(g_compile_tmp_seq.fetch_add(1));
+                              auto fn = jit_compile_kernel(
+                                  dc_copy.src_path, dc_copy.compile_args, dc_copy.named_compile_args,
+                                  dc_copy.defines, dc_copy.extra_inc, dc_copy.bindings, tmp_path);
+                              std::filesystem::rename(tmp_path, cache_path);
+                              return fn;
+                          }).share();
+                    g_compile_inflight[key] = fut;
+                }
+            }
+            futures.emplace_back(key, fut);
         }
 
         for (auto& [key, fut] : futures) {
             auto fn = fut.get();
             resolved_fns[key] = fn;
-            std::lock_guard<std::mutex> lock(g_jit_cache_mutex);
-            g_jit_cache[key] = fn;
+            {
+                std::lock_guard<std::mutex> lock(g_jit_cache_mutex);
+                g_jit_cache[key] = fn;
+            }
+            std::lock_guard<std::mutex> lock(g_compile_inflight_mutex);
+            g_compile_inflight.erase(key);
         }
     }
 
@@ -1812,12 +1889,14 @@ static void jit_compile_pending(
 // build_core_map: Build physical {x,y} → tt_emule::Core* for NOC resolution.
 // Cached per device_id since chip topology doesn't change between calls.
 // ---------------------------------------------------------------------------
+// Per-device physical {x,y}->Core* maps, at file scope so the fabric teleport hooks below can resolve a
+// remote chip's core (its map is built by that device's own concurrent run). See tt-emule docs/fabric-ccl-emulation.md.
+static std::mutex g_core_map_mutex;
+static std::unordered_map<uint32_t, std::shared_ptr<std::unordered_map<uint64_t, tt_emule::Core*>>>
+    g_core_map_cache;
+
 static std::unordered_map<uint64_t, tt_emule::Core*>* build_core_map(
     tt::umd::SWEmuleChip* sw_emu, IDevice* device, ChipId device_id) {
-    static std::mutex g_core_map_mutex;
-    static std::unordered_map<uint32_t, std::shared_ptr<std::unordered_map<uint64_t, tt_emule::Core*>>>
-        g_core_map_cache;
-
     std::lock_guard<std::mutex> lock(g_core_map_mutex);
     auto& core_map = g_core_map_cache[device_id];
     if (!core_map && sw_emu) {
@@ -1871,6 +1950,561 @@ static std::unordered_map<uint64_t, tt_emule::Core*>* build_core_map(
         core_map = std::make_shared<std::unordered_map<uint64_t, tt_emule::Core*>>();
     }
     return core_map.get();
+}
+
+// ---------------------------------------------------------------------------
+// Fabric route table: resolve a send's FINAL destination chip by a static walk of the
+// control-plane mesh graph (no multi-hop router sim). 1D dst = (src, dir, distance);
+// 2D dst = explicit FabricNodeId. See tt-emule docs/fabric-ccl-emulation.md.
+// ---------------------------------------------------------------------------
+static std::mutex g_fabric_route_mutex;
+// (src_chip << 3 | dir) -> ordered chips at distance 1,2,... in that direction (cached; topology is static).
+static std::unordered_map<uint32_t, std::vector<uint32_t>> g_fabric_walk_cache;
+
+// Immediate same-mesh neighbor physical chip of `chip` in `dir`, or -1 if none.
+static int __emule_fabric_dir_neighbor(
+    tt::tt_fabric::ControlPlane& cp, uint32_t chip, tt::tt_fabric::RoutingDirection dir) {
+    try {
+        auto node = cp.get_fabric_node_id_from_physical_chip_id(static_cast<ChipId>(chip));
+        auto neighbors = cp.get_chip_neighbors(node, dir);
+        for (auto& [mesh, chips] : neighbors) {
+            if (!chips.empty()) {
+                return static_cast<int>(cp.get_physical_chip_id_from_fabric_node_id(
+                    tt::tt_fabric::FabricNodeId(mesh, static_cast<std::uint32_t>(chips.front()))));
+            }
+        }
+    } catch (...) {
+        // control plane unavailable / chip not in graph — caller falls back to the neighbor table
+    }
+    return -1;
+}
+
+// Ordered chips reachable from `src` at distance 1,2,... in `dir` (line or ring), cached.
+static const std::vector<uint32_t>& __emule_fabric_walk(uint32_t src, tt::tt_fabric::RoutingDirection dir) {
+    std::lock_guard<std::mutex> lock(g_fabric_route_mutex);
+    uint32_t key = (src << 3) | static_cast<uint32_t>(dir);
+    auto it = g_fabric_walk_cache.find(key);
+    if (it != g_fabric_walk_cache.end()) {
+        return it->second;
+    }
+    std::vector<uint32_t> walk;
+    auto& cp = MetalContext::instance().get_control_plane();
+    uint32_t cur = src;
+    for (int hop = 0; hop < 64; ++hop) {  // 64 = chip-count backstop (loudbox = 8)
+        int nxt = __emule_fabric_dir_neighbor(cp, cur, dir);
+        if (nxt < 0 || static_cast<uint32_t>(nxt) == src) {
+            break;  // line end, or ring wrapped back to the source
+        }
+        walk.push_back(static_cast<uint32_t>(nxt));
+        cur = static_cast<uint32_t>(nxt);
+    }
+    return g_fabric_walk_cache.emplace(key, std::move(walk)).first->second;
+}
+
+// ===========================================================================
+// Fabric teleport hooks (multi-chip CCL): decode the real-layout packet header,
+// resolve the destination chip, and apply the terminal NOC command directly into
+// that chip's L1. Delivery is synchronous; the peer-chip consumer observes it via
+// its semaphore wait. See tt-emule docs/fabric-ccl-emulation.md.
+// ---------------------------------------------------------------------------
+
+// Resolve (noc_addr) -> host pointer on an arbitrary chip, mirroring __emule_resolve_noc_addr but
+// against the destination chip's cached core map (already built by that chip's launch).
+extern "C" uint8_t* __emule_fabric_resolve_remote(uint32_t dst_chip, uint64_t noc_addr) {
+    emule_require_self(__func__);
+    std::lock_guard<std::mutex> lock(g_core_map_mutex);
+    static const bool rdbg = std::getenv("EMULE_FABRIC_DEBUG") != nullptr;
+    auto it = g_core_map_cache.find(dst_chip);
+    if (it == g_core_map_cache.end() || !it->second) {
+        if (rdbg) {
+            fprintf(stderr, "[EMULE_FABRIC]   resolve_remote: NO CORE MAP for dst_chip=%u (cache has %zu chips)\n",
+                    dst_chip, g_core_map_cache.size());
+        }
+        return nullptr;
+    }
+    auto& m = *it->second;
+    uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
+    uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
+    uint64_t local_addr = noc_addr & NOC_LOCAL_MASK;
+
+    auto find_core = [&](uint32_t x, uint32_t y) {
+        return m.find((uint64_t(x) << 32) | y);
+    };
+
+    // (noc_x,noc_y) are the SOURCE chip's coords (get_noc_addr packs the caller core's); resolve against
+    // the destination chip's map. Cross-chip src->logical->dst translation applies ONLY to WORKER cores
+    // (harvesting can shift them per chip); DRAM/ETH coords are chip-invariant, so translating them would
+    // alias distinct banks. Try verbatim first; translate only if verbatim is a WORKER or missed.
+    // See tt-emule docs/fabric-ccl-emulation.md.
+    auto cit = find_core(noc_x, noc_y);
+    const uint32_t src_chip = __emule_self->chip_id;
+    const bool verbatim_is_worker =
+        (cit != m.end() && cit->second->role() == tt_emule::CoreRole::WORKER);
+    if (src_chip != dst_chip && (verbatim_is_worker || cit == m.end())) {
+        auto* src_obj = get_sw_emulated_chip(src_chip);
+        auto* dst_obj = get_sw_emulated_chip(dst_chip);
+        if (src_obj != nullptr && dst_obj != nullptr) {
+            try {
+                auto logical = src_obj->get_soc_descriptor().translate_coord_to(
+                    tt_xy_pair(noc_x, noc_y), CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
+                auto dst_xy = dst_obj->get_soc_descriptor().translate_coord_to(
+                    tt_xy_pair(logical.x, logical.y), CoordSystem::LOGICAL, CoordSystem::TRANSLATED);
+                auto t = find_core(static_cast<uint32_t>(dst_xy.x), static_cast<uint32_t>(dst_xy.y));
+                if (t != m.end() && t->second->role() == tt_emule::CoreRole::WORKER) {
+                    cit = t;  // harvesting-correct worker on the dest chip
+                }
+            } catch (...) {
+                // translation unavailable — keep the verbatim result
+            }
+        }
+    }
+    if (cit == m.end()) {
+        if (rdbg) {
+            fprintf(stderr, "[EMULE_FABRIC]   resolve_remote: dst_chip=%u has map (%zu cores) but core (%u,%u) NOT FOUND\n",
+                    dst_chip, m.size(), noc_x, noc_y);
+        }
+        return nullptr;
+    }
+    uint32_t offset = (cit->second->role() == tt_emule::CoreRole::WORKER)
+                          ? (static_cast<uint32_t>(local_addr) & L1_SLOT_MASK)
+                          : static_cast<uint32_t>(local_addr);
+    return cit->second->l1_ptr(offset);
+}
+
+// Destination chip for a fabric send from src_chip: the single ethernet-connected neighbor of a
+// directly-connected 2-chip system, from the cluster descriptor. See tt-emule docs/fabric-ccl-emulation.md.
+extern "C" uint32_t __emule_fabric_neighbor(uint32_t src_chip) {
+    auto ids = MetalContext::instance().get_cluster().get_ethernet_connected_device_ids(src_chip);
+    if (!ids.empty()) {
+        return *ids.begin();
+    }
+    return src_chip;
+}
+
+// emule route metadata, keyed by packet-header L1-alias address: the fabric_set_*_route shims record the
+// kernel's semantic dst (2D FabricNodeId, 1D hop distance, or line-multicast extent) here; the teleport
+// resolves it to physical chip(s). KIND constants KEEP IN SYNC with the shim. See tt-emule docs/fabric-ccl-emulation.md.
+namespace emule_route_kind {
+constexpr uint32_t UNSET = 0, UNICAST_1D = 1, UNICAST_2D = 2, MCAST_1D = 3, MCAST_2D = 4;
+}
+struct EmuleRoute {
+    uint32_t kind = 0, a = 0, b = 0, c = 0, d = 0, e = 0, f = 0;
+    uint32_t dir_index = 0;  // 1D: which of the worker's connections (fwd=0/bwd=1), set at send time
+    // Mux-path direction hint (preferred over the range-match heuristic), set at send time:
+    uint32_t mux_x = 0xFFFF, mux_y = 0xFFFF;   // worker's mux NOC (TRANSLATED) coords (fabric MUX path)
+};
+static std::mutex g_route_meta_mu;
+static std::unordered_map<uint32_t, EmuleRoute> g_route_meta;
+
+extern "C" void __emule_fabric_set_route(
+    uint32_t hdr, uint32_t kind, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f) {
+    std::lock_guard<std::mutex> lk(g_route_meta_mu);
+    auto& r = g_route_meta[hdr];
+    r.kind = kind; r.a = a; r.b = b; r.c = c; r.d = d; r.e = e; r.f = f;  // dir_index set separately at send
+}
+
+// Record a 1D send's per-connection direction signals: the fwd/bwd conn_index (direct path) and the
+// worker's mux NOC coords (MUX path); 0xFFFF means unset. See tt-emule docs/fabric-ccl-emulation.md.
+extern "C" void __emule_fabric_set_route_dir(
+    uint32_t hdr, uint32_t conn_index, uint32_t mux_x, uint32_t mux_y) {
+    std::lock_guard<std::mutex> lk(g_route_meta_mu);
+    auto& r = g_route_meta[hdr];
+    r.dir_index = conn_index;
+    r.mux_x = mux_x;
+    r.mux_y = mux_y;
+}
+
+// Fabric connection routes recorded host-side by append_fabric_connection_rt_args: for 1D the dst chip is
+// bound to the connection, not the header, so the host records each connection's direction + immediate
+// neighbor here. See tt-emule docs/fabric-ccl-emulation.md.
+struct ConnRoute {
+    uint32_t dir;       // RoutingDirection (N/E/S/W)
+    uint32_t neighbor;  // immediate neighbor physical chip
+};
+static std::mutex g_conn_route_mu;
+// Keyed by SRC CHIP only (line direction is a per-chip property; the connection-owner core can differ from
+// the sender, so a per-core key would miss). Deduped by direction; append order makes index 0=fwd, 1=bwd.
+// See tt-emule docs/fabric-ccl-emulation.md.
+static std::unordered_map<uint32_t, std::vector<ConnRoute>> g_conn_route;
+// Per-op reset flag: cleared at each new op's first connection-record so a later op's different line
+// orientation can't corrupt the src-keyed, direction-deduped table. See tt-emule docs/fabric-ccl-emulation.md.
+static std::atomic<bool> g_conn_route_dirty{true};
+// Per-worker resolved line direction, keyed (src<<32 | wx<<16 | wy): on the MUX path the sender carries no
+// direction, so infer it once from a multicast's range and reuse for that worker's unicasts. Reset per op.
+// See tt-emule docs/fabric-ccl-emulation.md.
+static std::unordered_map<uint64_t, uint32_t> g_worker_dir;
+// Per-mux-core line direction, keyed (src<<32 | logical_x<<16 | logical_y): the mux→EDM append records the
+// mux's forwarding_direction; the teleport recovers it from the worker's carried mux NOC coords. Reset per
+// op. See tt-emule docs/fabric-ccl-emulation.md.
+static std::unordered_map<uint64_t, uint32_t> g_mux_dir;
+static inline uint64_t __emule_worker_key(uint32_t src, uint32_t wx, uint32_t wy) {
+    return (static_cast<uint64_t>(src) << 32) | (static_cast<uint64_t>(wx & 0xFFFF) << 16) | (wy & 0xFFFF);
+}
+extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t wy, uint32_t dir, uint32_t neighbor) {
+    std::lock_guard<std::mutex> lk(g_conn_route_mu);
+    if (g_conn_route_dirty.exchange(false)) {
+        g_conn_route.clear();
+        g_worker_dir.clear();
+        g_mux_dir.clear();
+    }
+    // Record the connection-owner core's (the mux core, on the MUX path) direction, keyed by its LOGICAL
+    // coords — before the per-direction dedup below, which is for the src-keyed g_conn_route only.
+    g_mux_dir[__emule_worker_key(src, wx, wy)] = dir;
+    auto& v = g_conn_route[src];
+    for (const auto& c : v) {
+        if (c.dir == dir) {
+            return;  // already recorded this direction for src
+        }
+    }
+    v.push_back(ConnRoute{dir, neighbor});
+}
+
+// Ordered ring members at distance 1,2,... from `src` starting in `start_dir`, by chaining the per-chip
+// recorded ring neighbors (g_conn_route) — at each hop taking the neighbor that is NOT where we came from,
+// so it follows the turning Hamiltonian cycle the compass walk can't. Returns empty if the chain is
+// incomplete (caller falls back to the compass walk). See tt-emule docs/fabric-ccl-emulation.md.
+static std::vector<uint32_t> __emule_fabric_walk_ring(uint32_t src, uint32_t start_dir) {
+    std::vector<uint32_t> walk;
+    std::lock_guard<std::mutex> lk(g_conn_route_mu);
+    auto sit = g_conn_route.find(src);
+    if (sit == g_conn_route.end()) {
+        return walk;
+    }
+    int first = -1;
+    for (const auto& c : sit->second) {
+        if (c.dir == start_dir) {
+            first = static_cast<int>(c.neighbor);
+            break;
+        }
+    }
+    if (first < 0) {
+        return walk;  // start direction not recorded — caller falls back
+    }
+    walk.push_back(static_cast<uint32_t>(first));
+    uint32_t prev = src, cur = static_cast<uint32_t>(first);
+    for (int hop = 0; hop < 64; ++hop) {  // 64 = chip-count backstop
+        auto cit = g_conn_route.find(cur);
+        if (cit == g_conn_route.end()) {
+            break;
+        }
+        int next = -1;
+        for (const auto& c : cit->second) {
+            if (c.neighbor != prev) {  // the ring edge that continues forward (not the one back to prev)
+                next = static_cast<int>(c.neighbor);
+                break;
+            }
+        }
+        if (next < 0 || static_cast<uint32_t>(next) == src) {
+            break;  // dead end, or the cycle closed back at the source
+        }
+        walk.push_back(static_cast<uint32_t>(next));
+        prev = cur;
+        cur = static_cast<uint32_t>(next);
+    }
+    return walk;
+}
+
+// Resolve the FINAL destination chip(s) for a send: one chip for unicast, the line members for a multicast.
+// Gated by EMULE_FABRIC8 (off → legacy single neighbor). See tt-emule docs/fabric-ccl-emulation.md.
+static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, uint32_t src_chip) {
+    static const bool fabric8 = std::getenv("EMULE_FABRIC8") != nullptr;
+    if (!fabric8) {
+        return {__emule_fabric_neighbor(src_chip)};
+    }
+    EmuleRoute r;
+    {
+        std::lock_guard<std::mutex> lk(g_route_meta_mu);
+        auto it = g_route_meta.find(static_cast<uint32_t>(reinterpret_cast<uintptr_t>(h)));
+        if (it == g_route_meta.end()) {
+            return {__emule_fabric_neighbor(src_chip)};  // unstamped (e.g. 1D direct, not yet wired)
+        }
+        r = it->second;
+    }
+    static const bool rdbg = std::getenv("EMULE_FABRIC_DEBUG") != nullptr;
+    if (rdbg) {
+        std::lock_guard<std::mutex> lk(g_conn_route_mu);
+        auto cit = g_conn_route.find(src_chip);
+        fprintf(stderr, "[EMULE_FABRIC]   resolve src=%u kind=%u a=%u b=%u ewns=%u/%u/%u/%u dir_idx=%u conns=%zu mux=(%u,%u)\n",
+                src_chip, r.kind, r.a, r.b, r.c, r.d, r.e, r.f, r.dir_index,
+                cit == g_conn_route.end() ? (size_t)0 : cit->second.size(), r.mux_x, r.mux_y);
+    }
+    auto& cp = MetalContext::instance().get_control_plane();
+    if (r.kind == emule_route_kind::UNICAST_2D) {  // a=dst_dev, b=dst_mesh
+        try {
+            return {static_cast<uint32_t>(cp.get_physical_chip_id_from_fabric_node_id(
+                tt::tt_fabric::FabricNodeId(tt::tt_fabric::MeshId{r.b}, r.a)))};
+        } catch (...) {
+        }
+    } else if (r.kind == emule_route_kind::MCAST_2D) {
+        // 2D line multicast: {c,d,e,f}={E,W,N,S} per-direction hop counts; walk each non-zero direction.
+        using RD = tt::tt_fabric::RoutingDirection;
+        const std::pair<RD, uint32_t> dirs[4] = {{RD::E, r.c}, {RD::W, r.d}, {RD::N, r.e}, {RD::S, r.f}};
+        std::vector<uint32_t> tgts;
+        for (const auto& [dir, hops] : dirs) {
+            if (hops == 0) {
+                continue;
+            }
+            const auto& walk = __emule_fabric_walk(src_chip, dir);
+            for (uint32_t k = 0; k < hops && k < walk.size(); ++k) {
+                tgts.push_back(walk[k]);
+            }
+        }
+        if (!tgts.empty()) {
+            return tgts;
+        }
+    } else if (r.kind == emule_route_kind::MCAST_1D || r.kind == emule_route_kind::UNICAST_1D) {
+        // 1D MUX path carries no direction tag: infer the worker's direction from a multicast's range and
+        // cache it per (src, worker_core) for that worker's unicasts. See tt-emule docs/fabric-ccl-emulation.md.
+        emule_require_self(__func__);
+        TT_FATAL(__emule_self->core != nullptr, "{}: fiber has no core context", __func__);
+        const uint32_t wx = __emule_self->core->logical_x;
+        const uint32_t wy = __emule_self->core->logical_y;
+        const uint64_t wkey = __emule_worker_key(src_chip, wx, wy);
+        std::vector<ConnRoute> conns;
+        {
+            std::lock_guard<std::mutex> lk(g_conn_route_mu);
+            auto it = g_conn_route.find(src_chip);
+            if (it != g_conn_route.end()) {
+                conns = it->second;
+            }
+        }
+        int dir = -1;
+        // (1) Mux-core direction: translate the worker's mux NOC coords to the mux's LOGICAL core and look up
+        // the direction the mux→EDM append recorded. Resolves ring, where the range-match below cannot.
+        if (dir < 0 && r.mux_x != 0xFFFF) {
+            auto* src_obj = get_sw_emulated_chip(src_chip);
+            if (src_obj != nullptr) {
+                try {
+                    auto lg = src_obj->get_soc_descriptor().translate_coord_to(
+                        tt_xy_pair(r.mux_x, r.mux_y), CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
+                    std::lock_guard<std::mutex> lk(g_conn_route_mu);
+                    auto mit = g_mux_dir.find(__emule_worker_key(
+                        src_chip, static_cast<uint32_t>(lg.x), static_cast<uint32_t>(lg.y)));
+                    if (mit != g_mux_dir.end()) {
+                        dir = static_cast<int>(mit->second);
+                    }
+                } catch (...) {
+                }
+            }
+        }
+        // (2) Fallback — range-match heuristic (and its cached g_worker_dir / conn-index), used only when the
+        // mux signal above is absent. See tt-emule docs/fabric-ccl-emulation.md.
+        if (dir < 0 && r.kind == emule_route_kind::MCAST_1D) {
+            const uint32_t range = r.b ? r.b : 1;
+            for (const auto& cr : conns) {
+                if (__emule_fabric_walk(src_chip, static_cast<tt::tt_fabric::RoutingDirection>(cr.dir)).size() == range) {
+                    dir = static_cast<int>(cr.dir);
+                    break;
+                }
+            }
+            if (dir < 0 && !conns.empty()) {
+                dir = static_cast<int>(conns[r.dir_index < conns.size() ? r.dir_index : 0].dir);
+            }
+            if (dir >= 0) {
+                std::lock_guard<std::mutex> lk(g_conn_route_mu);
+                g_worker_dir[wkey] = static_cast<uint32_t>(dir);
+            }
+        } else if (dir < 0) {  // UNICAST_1D — reuse this worker's multicast-inferred direction; else the conn index
+            std::lock_guard<std::mutex> lk(g_conn_route_mu);
+            auto wit = g_worker_dir.find(wkey);
+            if (wit != g_worker_dir.end()) {
+                dir = static_cast<int>(wit->second);
+            } else if (!conns.empty()) {
+                dir = static_cast<int>(conns[r.dir_index < conns.size() ? r.dir_index : 0].dir);
+            }
+        }
+        if (dir >= 0) {
+            // Follow the real 1D ring via the recorded per-chip neighbors; fall back to the compass walk if
+            // the chain is incomplete (walk[0] equals the compass neighbor). See tt-emule docs/fabric-ccl-emulation.md.
+            std::vector<uint32_t> walk = __emule_fabric_walk_ring(src_chip, static_cast<uint32_t>(dir));
+            if (walk.empty()) {
+                walk = __emule_fabric_walk(src_chip, static_cast<tt::tt_fabric::RoutingDirection>(dir));
+            }
+            std::vector<uint32_t> tgts;
+            if (r.kind == emule_route_kind::MCAST_1D) {
+                const uint32_t start = r.a ? r.a : 1, range = r.b ? r.b : 1;
+                for (uint32_t hop = start; hop < start + range && hop - 1 < walk.size(); ++hop) {
+                    tgts.push_back(walk[hop - 1]);
+                }
+            } else {
+                const uint32_t dist = r.a ? r.a : 1;
+                if (dist - 1 < walk.size()) {
+                    tgts.push_back(walk[dist - 1]);
+                }
+            }
+            if (!tgts.empty()) {
+                return tgts;
+            }
+        }
+    }
+    // Fallthrough (unstamped / no recorded connection) → neighbor.
+    return {__emule_fabric_neighbor(src_chip)};
+}
+
+// Apply the terminal NOC command of a fabric send to ONE destination chip's L1 (the per-target delivery,
+// looped over by the teleport for multicast).
+static void __emule_fabric_deliver(
+    uint32_t dst_chip, const uint8_t* h, const void* payload, uint32_t size, uint8_t noc_send_type, bool dbg) {
+    const uint64_t noc_address = *reinterpret_cast<const uint64_t*>(h + 0);
+    switch (noc_send_type) {
+        case 0: {  // NOC_UNICAST_WRITE
+            uint8_t* d = __emule_fabric_resolve_remote(dst_chip, noc_address);
+            if (d != nullptr && payload != nullptr && size > 0) {
+                std::memcpy(d, payload, size);
+                std::atomic_thread_fence(std::memory_order_release);
+                __emule_fiber_wake(d);
+            }
+            break;
+        }
+        case 1: {  // NOC_UNICAST_INLINE_WRITE: {noc_address; value@8}
+            uint32_t value = *reinterpret_cast<const uint32_t*>(h + 8);
+            uint8_t* d = __emule_fabric_resolve_remote(dst_chip, noc_address);
+            if (d != nullptr) {
+                reinterpret_cast<std::atomic<uint32_t>*>(d)->store(value, std::memory_order_release);
+                __emule_fiber_wake(d);
+            }
+            break;
+        }
+        case 2: {  // NOC_UNICAST_ATOMIC_INC: {noc_address; val@8}
+            uint32_t val = *reinterpret_cast<const uint32_t*>(h + 8);
+            uint8_t* d = __emule_fabric_resolve_remote(dst_chip, noc_address);
+            if (d != nullptr) {
+                uint32_t old = reinterpret_cast<std::atomic<uint32_t>*>(d)->fetch_add(val, std::memory_order_release);
+                if (dbg) {
+                    fprintf(stderr, "[EMULE_FABRIC]   atomic_inc chip=%u dst=%p %u->%u (val=%u)\n",
+                            dst_chip, (void*)d, old, old + val, val);
+                }
+                __emule_fiber_wake(d);
+            }
+            break;
+        }
+        case 3: {  // NOC_FUSED_UNICAST_ATOMIC_INC: {noc_address; semaphore_noc_address@8; val@16}
+            uint64_t sem_addr = *reinterpret_cast<const uint64_t*>(h + 8);
+            uint32_t val = *reinterpret_cast<const uint32_t*>(h + 16);
+            uint8_t* d = __emule_fabric_resolve_remote(dst_chip, noc_address);
+            if (d != nullptr && payload != nullptr && size > 0) {
+                std::memcpy(d, payload, size);
+                std::atomic_thread_fence(std::memory_order_release);
+                __emule_fiber_wake(d);
+            }
+            uint8_t* s = __emule_fabric_resolve_remote(dst_chip, sem_addr);
+            if (s != nullptr) {
+                reinterpret_cast<std::atomic<uint32_t>*>(s)->fetch_add(val, std::memory_order_release);
+                __emule_fiber_wake(s);
+            }
+            break;
+        }
+        case 4: {  // NOC_UNICAST_SCATTER_WRITE: noc_address[4]@0, chunk_size[3]@32, chunk_count@38
+            const uint64_t* na = reinterpret_cast<const uint64_t*>(h + 0);
+            const uint16_t* cs = reinterpret_cast<const uint16_t*>(h + 32);
+            uint8_t chunk_count = *(h + 38);
+            uint32_t off = 0;
+            for (uint8_t i = 0; i < chunk_count && payload != nullptr; ++i) {
+                uint32_t csz = (i + 1 < chunk_count) ? cs[i] : (size - off);
+                uint8_t* d = __emule_fabric_resolve_remote(dst_chip, na[i]);
+                if (d != nullptr && csz > 0) {
+                    std::memcpy(d, static_cast<const uint8_t*>(payload) + off, csz);
+                    __emule_fiber_wake(d);
+                }
+                off += csz;
+            }
+            std::atomic_thread_fence(std::memory_order_release);
+            break;
+        }
+        default:
+            break;  // 5/6 native multicast send-types: emule expresses multicast via the target list above
+    }
+}
+
+// Top-level teleport: decode the real-layout packet header (NocCommandFields @0, payload_size @40,
+// noc_send_type @42), resolve the destination chip(s), and apply the terminal NOC command. payload may be
+// null for header-only commands (e.g. a bare atomic-inc). See tt-emule docs/fabric-ccl-emulation.md.
+extern "C" void __emule_fabric_teleport(const void* packet_header, const void* payload, uint32_t payload_size) {
+    emule_require_self(__func__);
+    const uint8_t* h = static_cast<const uint8_t*>(packet_header);
+    if (h == nullptr) {
+        return;
+    }
+    const uint16_t hdr_payload_size = *reinterpret_cast<const uint16_t*>(h + 40);
+    const uint8_t noc_send_type = *(h + 42);
+    const uint32_t size = payload_size ? payload_size : hdr_payload_size;
+    const uint32_t src_chip = __emule_self->chip_id;
+    const std::vector<uint32_t> targets = __emule_fabric_resolve_targets(h, src_chip);
+    static const bool dbg = std::getenv("EMULE_FABRIC_DEBUG") != nullptr;
+    if (dbg) {
+        const uint64_t noc_address = *reinterpret_cast<const uint64_t*>(h + 0);
+        std::string ts;
+        for (auto t : targets) {
+            ts += " " + std::to_string(t);
+        }
+        fprintf(stderr,
+                "[EMULE_FABRIC] teleport src=%u targets=[%s ] (neighbor=%u) send_type=%u noc_addr=0x%llx "
+                "payload_size=%u\n",
+                src_chip, ts.c_str(), __emule_fabric_neighbor(src_chip), noc_send_type,
+                (unsigned long long)noc_address, size);
+        // Route-table self-consistency: dump this src chip's per-direction distance walk (once per src).
+        static std::mutex dump_mu;
+        static std::unordered_map<uint32_t, bool> dumped;
+        std::lock_guard<std::mutex> lk(dump_mu);
+        if (!dumped[src_chip]) {
+            dumped[src_chip] = true;
+            const char* dn[4] = {"N", "E", "S", "W"};
+            for (int d = 0; d < 4; ++d) {
+                const auto& w = __emule_fabric_walk(src_chip, static_cast<tt::tt_fabric::RoutingDirection>(d));
+                std::string s;
+                for (auto c : w) {
+                    s += " " + std::to_string(c);
+                }
+                fprintf(stderr, "[EMULE_FABRIC]   route src=%u dir=%s walk=[%s ]\n", src_chip, dn[d], s.c_str());
+            }
+        }
+    }
+    // One target for unicast; the line members for a multicast. Replay the terminal NOC op to each.
+    for (uint32_t dst_chip : targets) {
+        __emule_fabric_deliver(dst_chip, h, payload, size, noc_send_type, dbg);
+    }
+}
+
+// DESIGN DIVERGENCE: see tt-emule/.claude/skills/workarounds (DM-1). Faithful mechanism, not a hack.
+// Remap a local-L1 host pointer (a cross-chip-shared object's absolute pointer, valid for only one chip's
+// MAP_32BIT mmap) to the CURRENT chip's copy of the same (core, offset). Single-chip runs short-circuit.
+// See tt-emule docs/fabric-ccl-emulation.md.
+extern "C" uint8_t* __emule_chip_relative_l1(uint8_t* p) {
+    emule_require_self(__func__);
+    std::lock_guard<std::mutex> lock(g_core_map_mutex);
+    if (g_core_map_cache.size() <= 1) {
+        return p;  // single chip: the pointer is already this chip's
+    }
+    const uint32_t cur = __emule_self->chip_id;
+    auto cur_it = g_core_map_cache.find(cur);
+    for (auto& [chip, mapp] : g_core_map_cache) {
+        if (!mapp) {
+            continue;
+        }
+        for (auto& [key, core] : *mapp) {
+            uint8_t* base = core->l1_data();
+            if (base != nullptr && p >= base && p < base + core->l1_size()) {
+                if (chip == cur) {
+                    return p;  // already on the current chip
+                }
+                uint64_t off = static_cast<uint64_t>(p - base);
+                if (cur_it != g_core_map_cache.end() && cur_it->second) {
+                    auto cc = cur_it->second->find(key);
+                    if (cc != cur_it->second->end()) {
+                        uint8_t* rp = cc->second->l1_ptr(off);
+                        if (std::getenv("EMULE_FABRIC_DEBUG") != nullptr) {
+                            fprintf(stderr,
+                                "[EMULE_FABRIC]   chip_relative cur=%u: %p (chip%u core[0x%llx]+0x%llx) -> %p\n",
+                                cur, (void*)p, chip, (unsigned long long)key, (unsigned long long)off, (void*)rp);
+                        }
+                        return rp;  // same core+offset on the current chip
+                    }
+                }
+                return p;
+            }
+        }
+    }
+    return p;  // not a known L1 pointer (firmware offset etc.) — leave unchanged
 }
 
 // ---------------------------------------------------------------------------
@@ -2225,25 +2859,10 @@ static std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>> build_per_thr
 // launch_cores: Spawn concurrent threads per core, each runs its kernels.
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
-// RISC-V-faithful integer divide/modulo fault recovery on x86 hosts.
-//
-// The real Tensix cores are RISC-V, where integer div/rem faults are DEFINED and
-// non-trapping (RISC-V ISA M-extension):
-//   - divide by zero: `divu x,0 -> all-ones`, `div x,0 -> -1`, `rem(u) x,0 -> x`
-//   - signed overflow (`div INT_MIN,-1`): quotient = INT_MIN, remainder = 0
-// emule JIT-compiles each kernel to x86, where `div`/`idiv` raises #DE -> SIGFPE
-// (si_code FPE_INTDIV for /0, FPE_INTOVF for INT_MIN/-1) and aborts. Kernels
-// legitimately hit /0 on idle/degenerate cores: e.g. binary_ng's no_bcast reader
-// computes `start_tile_id % (D*N*C*Ht*Wt)` and the host hands idle cores all-zero
-// dims, so the divisor is 0 and the (dead) result is never used. To match silicon we
-// trap the SIGFPE, write RISC-V's defined result into the saved register image, and
-// step the saved RIP past the faulting instruction.
-//
-// Scope/caveats: (1) the handler is process-global for the lifetime of launch_cores,
-// so any host thread that faults in that window is also "recovered" — acceptable
-// because only kernel threads run div-heavy code then; (2) a *genuine* kernel div bug
-// becomes silent-wrong-output rather than a crash, but that is exactly what silicon
-// would do (no trap). See docs/riscv-intdiv-by-zero.md in the tt-emule repo.
+// RISC-V-faithful integer divide/modulo fault recovery on x86 hosts. RISC-V div/rem faults are DEFINED
+// and non-trapping, but the JIT-compiled x86 `div`/`idiv` raises #DE -> SIGFPE; trap it, write RISC-V's
+// defined result into the saved register image, and step RIP past the faulting instruction. The handler
+// is process-global for launch_cores' lifetime. See docs/riscv-intdiv-by-zero.md in the tt-emule repo.
 #if defined(__x86_64__) && defined(__linux__)
 namespace {
 
@@ -2367,277 +2986,217 @@ struct EmuleSigfpeGuard {
 }  // namespace
 #endif  // __x86_64__ && __linux__
 
+// [MESH] Register/run split for concurrent multi-device dispatch: in defer mode each
+// execute_program_emulated REGISTERS its fibers (spawn, no run); run_mesh_dispatch then drives ONE
+// run_until_idle so all chips' fibers run concurrently. See tt-emule docs/fiber-engine.md.
+static bool g_emule_mesh_defer = false;
+static std::vector<std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>>>>
+    g_mesh_dfb_keep;
+
+// Resolved-program cache — emule's analogue of silicon's is_compiled(): collect + JIT compile + resolve
+// run ONCE per program (keyed by ProgramId); every device dispatches against the shared read-only result.
+// LRU-bounded as a safety net. See tt-emule docs/fiber-engine.md.
+//
+// Lock-free by invariant: written only from prepare_program on the sequential mesh-register path — single
+// writer, never a fiber. prepare_program asserts this.
+struct ResolvedProgram {
+    std::map<CoreCoord, std::vector<KernelInfo>> core_kernels;
+    uint32_t emule_sem_base = 0;
+};
+static std::unordered_map<ProgramId, ResolvedProgram> g_resolved_programs;
+static std::deque<ProgramId> g_resolved_lru;
+static constexpr size_t kMaxResolvedPrograms = 256;
+
 static void launch_cores(
     std::vector<CoreSetup>& core_setups,
     uint8_t* dram_data,
     std::unordered_map<uint64_t, tt_emule::Core*>* core_map_ptr,
+    ChipId device_id,
+    bool defer_run,
     const EmuleOobTensorState& oob_state) {
 #if defined(__x86_64__) && defined(__linux__)
     EmuleSigfpeGuard sigfpe_guard;
 #endif
-    std::vector<std::thread> core_threads;
-    std::vector<std::exception_ptr> core_exceptions(core_setups.size());
+    // Fiber engine: one cooperatively-scheduled fiber per (core, RISC), multiplexed
+    // onto a runtime-sized worker pool (TT_EMULE_FIBER_WORKERS). A blocked fiber parks
+    // (yields its worker) instead of blocking an OS thread — no thread ceiling, no spin.
+    // See docs/fiber-engine.md.
+    auto& sched = tt::tt_metal::emule_fiber::FiberScheduler::instance();
 
-    // Startup barrier modeling silicon's simultaneous multi-core dispatch. emule
-    // spawns kernel threads sequentially, so without it an early thread can run its
-    // whole kernel (including cross-core semaphore increments) before a later peer
-    // has executed its prologue — e.g. racing ahead of an argmax reducer's k=0
-    // done_sem reset. Releasing all threads from one barrier restores "all cores
-    // start together".
-    size_t total_kernel_threads = 0;
-    for (const auto& cs : core_setups) {
-        total_kernel_threads += cs.ki_list->size();
-    }
-    std::atomic<uint32_t> kernel_start_barrier{0};
+    // The fibers borrow the per-core DFB interface arrays; own them here so they
+    // outlive run_until_idle.
+    std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>>> dfb_keepalive;
+    dfb_keepalive.reserve(core_setups.size());
 
     for (size_t core_idx = 0; core_idx < core_setups.size(); ++core_idx) {
-        core_threads.emplace_back(
-            [&cs = core_setups[core_idx], dram_data, core_map_ptr, oob_state, &core_ep = core_exceptions[core_idx],
-             &kernel_start_barrier, total_kernel_threads]() {
-                try {
-                    auto* core = cs.core;
-                    uint8_t* l1_data = core->l1_data();
-                    tt_emule::CBSyncState* cb_array = core->cb_sync_array();
-                    tt_emule::TileCounterArray* tc_array = cs.has_dfbs ? core->tile_counters() : nullptr;
-                    uint8_t px = cs.phys_x;
-                    uint8_t py = cs.phys_y;
+        auto& cs = core_setups[core_idx];
+        auto* core = cs.core;
+        uint8_t* l1_data = core->l1_data();
+        tt_emule::CBSyncState* cb_array = core->cb_sync_array();
+        tt_emule::TileCounterArray* tc_array = cs.has_dfbs ? core->tile_counters() : nullptr;
+        const uint8_t px = cs.phys_x;
+        const uint8_t py = cs.phys_y;
+        const uint32_t lx = cs.logical_core.x;
+        const uint32_t ly = cs.logical_core.y;
 
-                    std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>> per_thread_dfbs;
-                    if (cs.has_dfbs) {
-                        per_thread_dfbs = build_per_thread_dfb_interfaces(*cs.ki_list, cs.dfb_allocs);
-                    }
+        // Per-core logical coords (shared by all RISC fibers on this core).
+        auto& cstate = core->core_state();
+        cstate.logical_x = lx;
+        cstate.logical_y = ly;
 
-                    ObjectIntentTracker intent_tracker;
-                    const auto& kil_for_oi = *cs.ki_list;
-                    static const std::vector<uint32_t> kEmptyRtArgs;
-                    intent_tracker.pre_launch_snapshot(
-                        oob_state,
-                        kil_for_oi.size(),
-                        kil_for_oi.size() == 1 ? kil_for_oi[0].rt_arg_values : kEmptyRtArgs,
-                        l1_data,
-                        cs.persistent_cb_ranges,
-                        static_cast<uint32_t>(cs.logical_core.x),
-                        static_cast<uint32_t>(cs.logical_core.y));
-
-                    std::vector<std::thread> threads;
-                    std::vector<std::exception_ptr> kernel_exceptions(cs.ki_list->size());
-                    uint32_t lx = cs.logical_core.x;
-                    uint32_t ly = cs.logical_core.y;
-                    uint32_t sem_base = cs.sem_base;
-                    uint32_t sem_size = cs.sem_size;
-                    for (size_t kidx = 0; kidx < cs.ki_list->size(); ++kidx) {
-                        KernelInfo* ki_ptr = &(*cs.ki_list)[kidx];
-                        tt_emule::EmuleDFBInterface* dfb_array =
-                            cs.has_dfbs ? per_thread_dfbs[kidx].get() : nullptr;
-                        threads.emplace_back([ki_ptr,
-                                              core,
-                                              l1_data,
-                                              dram_data,
-                                              cb_array,
-                                              dfb_array,
-                                              tc_array,
-                                              core_map_ptr,
-                                              px,
-                                              py,
-                                              lx,
-                                              ly,
-                                              sem_base,
-                                              sem_size,
-                                              kidx,
-                                              oob_state,
-                                              &intent_tracker,
-                                              &kernel_start_barrier,
-                                              total_kernel_threads,
-                                              &kep = kernel_exceptions[kidx]]() {
-                            (void)kidx;
-                            auto& ki = *ki_ptr;
-                            __rt_args = (ki.rta_offset_in_kc != kRtaCrtaNoArgsSentinel)
-                                            ? reinterpret_cast<uint32_t*>(
-                                                  core->l1_ptr(ki.kernel_config_base + ki.rta_offset_in_kc))
-                                            : nullptr;
-                            __common_rt_args = (ki.crta_offset_in_kc != kRtaCrtaNoArgsSentinel)
-                                                   ? reinterpret_cast<uint32_t*>(
-                                                         core->l1_ptr(ki.kernel_config_base + ki.crta_offset_in_kc))
-                                                   : nullptr;
-                            __emule_bridge_l1 = l1_data;
-                            __emule_bridge_dram = dram_data;
-                            __emule_cbs = cb_array;
-                            __emule_dfbs = dfb_array;
-                            __emule_tc_array = tc_array;
-                            __processor_id = ki.processor_id;
-                            __core = core;
-                            __emule_core_map = core_map_ptr;
-                            my_x[0] = px;
-                            my_x[1] = px;
-                            my_y[0] = py;
-                            my_y[1] = py;
-                            __emule_logical_x = lx;
-                            __emule_logical_y = ly;
-                            __emule_kernel_name = ki.kernel_name.empty() ? nullptr : ki.kernel_name.c_str();
-                            __emule_pending_noc_reads = 0;
-
-                            // Overflow drops excess (biases toward false positives, never false negatives).
-                            constexpr uint32_t kResolvedCap = 64;
-                            uint64_t local_resolved[kResolvedCap] = {};
-                            uint32_t local_resolved_count = 0;
-                            set_sanitizer_thread_locals(oob_state, sem_base, sem_size);
-                            intent_tracker.setup_kernel_tls(
-                                oob_state, local_resolved, kResolvedCap, &local_resolved_count);
-
-                            __emule_neo_id = ki.is_tensix ? ki.processor_id : 0;
-                            __emule_trisc_id = 0;
-                            __emule_num_threads = ki.num_threads;
-                            __emule_my_thread_id = ki.thread_idx;
-
-                            // Startup barrier (declared in launch_cores): all
-                            // kernel threads start together.
-                            kernel_start_barrier.fetch_add(1, std::memory_order_acq_rel);
-                            while (kernel_start_barrier.load(std::memory_order_acquire) < total_kernel_threads) {
-                                std::this_thread::yield();
-                            }
-
-                            log_debug(
-                                tt::LogMetal,
-                                "  Launching kernel[{}] on logical ({},{}) phys ({},{}) rta_off=0x{:x} crta_off=0x{:x}",
-                                kidx,
-                                lx,
-                                ly,
-                                px,
-                                py,
-                                ki.rta_offset_in_kc,
-                                ki.crta_offset_in_kc);
-
-                            try {
-                                for (size_t t = 0; t < ki.variants.size(); ++t) {
-                                    if (ki.run_all_variants) {
-                                        __emule_trisc_id = static_cast<uint8_t>(t);
-                                    }
-                                    ki.variants[t]();
-                                }
-                                sweep_per_kernel_dirty_cbs(oob_state, cb_array, ki.processor_id, lx, ly);
-                            } catch (...) {
-                                kep = std::current_exception();
-                            }
-
-                            __core = nullptr;
-                            __rt_args = nullptr;
-                            __common_rt_args = nullptr;
-                            __emule_bridge_l1 = nullptr;
-                            __emule_bridge_dram = nullptr;
-                            __emule_cbs = nullptr;
-                            __emule_dfbs = nullptr;
-                            __emule_tc_array = nullptr;
-                            __emule_core_map = nullptr;
-                            __emule_kernel_name = nullptr;
-                            __emule_pending_noc_reads = 0;
-                            intent_tracker.teardown_kernel_tls(
-                                oob_state, local_resolved, local_resolved_count);
-                            clear_sanitizer_thread_locals();
-                        });
-                    }
-
-                    for (auto& t : threads) {
-                        t.join();
-                    }
-
-                    const char* oi_kernel_name = (cs.ki_list->size() == 1 && !cs.ki_list->front().kernel_name.empty())
-                                                     ? cs.ki_list->front().kernel_name.c_str()
-                                                     : nullptr;
-                    intent_tracker.verify_post_launch(l1_data, lx, ly, oi_kernel_name);
-
-                    // Rethrow first kernel exception
-                    for (size_t i = 0; i < kernel_exceptions.size(); ++i) {
-                        if (kernel_exceptions[i]) {
-                            try {
-                                std::rethrow_exception(kernel_exceptions[i]);
-                            } catch (const std::exception& e) {
-                                std::throw_with_nested(std::runtime_error(
-                                    "EMULE: kernel[" + std::to_string(i) + "] on core (" + std::to_string(lx) + "," +
-                                    std::to_string(ly) + ") failed"));
-                            } catch (...) {
-                                throw std::runtime_error(
-                                    "EMULE: kernel[" + std::to_string(i) + "] on core (" + std::to_string(lx) + "," +
-                                    std::to_string(ly) + ") threw unknown exception");
-                            }
-                        }
-                    }
-                } catch (...) {
-                    core_ep = std::current_exception();
-                }
-            });
-    }
-
-    for (auto& t : core_threads) {
-        t.join();
-    }
-
-    // Rethrow first core exception
-    for (size_t i = 0; i < core_exceptions.size(); ++i) {
-        if (core_exceptions[i]) {
-            std::rethrow_exception(core_exceptions[i]);
+        std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>> per_thread_dfbs;
+        if (cs.has_dfbs) {
+            per_thread_dfbs = build_per_thread_dfb_interfaces(*cs.ki_list, cs.dfb_allocs);
         }
+
+        for (size_t kidx = 0; kidx < cs.ki_list->size(); ++kidx) {
+            KernelInfo* ki_ptr = &(*cs.ki_list)[kidx];
+            auto& ki = *ki_ptr;
+            tt_emule::EmuleDFBInterface* dfb_array = cs.has_dfbs ? per_thread_dfbs[kidx].get() : nullptr;
+
+            // Build + populate the fiber-owned ctx (set-once identity). The scheduler
+            // repoints __emule_self to this ctx on swap-in; my_x/my_y are restored from
+            // the FiberIdentity (they cannot move into the ctx — silicon-named globals).
+            std::unique_ptr<ThreadCommonCtx> ctx =
+                ki.is_tensix ? std::unique_ptr<ThreadCommonCtx>(new ComputeThreadCtx())
+                             : std::unique_ptr<ThreadCommonCtx>(new DatamovementThreadCtx());
+            ctx->rt_args = (ki.rta_offset_in_kc != kRtaCrtaNoArgsSentinel)
+                ? reinterpret_cast<uint32_t*>(core->l1_ptr(ki.kernel_config_base + ki.rta_offset_in_kc))
+                : nullptr;
+            ctx->common_rt_args = (ki.crta_offset_in_kc != kRtaCrtaNoArgsSentinel)
+                ? reinterpret_cast<uint32_t*>(core->l1_ptr(ki.kernel_config_base + ki.crta_offset_in_kc))
+                : nullptr;
+            ctx->bridge_l1 = l1_data;
+            ctx->bridge_dram = dram_data;
+            ctx->cbs = cb_array;
+            ctx->dfbs = dfb_array;
+            ctx->tc_array = tc_array;
+            ctx->processor_id = ki.processor_id;
+            ctx->core_obj = core;
+            ctx->device = nullptr;
+            ctx->chip_id = static_cast<uint32_t>(device_id);
+            ctx->core_map = core_map_ptr;
+            ctx->neo_id = ki.is_tensix ? ki.processor_id : 0;
+            ctx->trisc_id = 0;
+            ctx->num_threads = ki.num_threads;
+            ctx->my_thread_id = ki.thread_idx;
+            ctx->core = &cstate;
+
+            tt::tt_metal::emule_fiber::FiberIdentity id;
+            id.phys_x = px;
+            id.phys_y = py;
+            id.logical_x = lx;
+            id.logical_y = ly;
+            id.proc_id = ki.processor_id;
+            id.kernel_src = nullptr;
+
+            // The fiber entry is the kernel body. __emule_self is set by the scheduler
+            // on swap-in; the no-op start-barrier of the OS-thread model is gone (a
+            // blocked fiber parks rather than spins, so start order is irrelevant).
+            //
+            // ASAN sanitizer (#44848) is armed per-kernel here: set_sanitizer_thread_locals /
+            // sweep_per_kernel_dirty_cbs / clear (+ the identity globals the sanitizer .cpp reads,
+            // mirroring the ctx). All inert when TT_METAL_EMULE_ASAN is off — set_sanitizer_thread_locals
+            // early-returns, so the by-value oob_state view (owned by dispatch_to_device's OobStateOwner)
+            // is never dereferenced. Under the fiber engine these worker-thread-locals are best-effort
+            // (shared across parked fibers on a worker); per-fiber ASAN state + the per-core ObjectIntent
+            // snapshot/verify are a follow-up, so ASAN is aimed at single-device runs.
+            sched.spawn(
+                [ki_ptr, lx, ly, cb_array, oob_state, sem_base = cs.sem_base, sem_size = cs.sem_size]() {
+                    auto& ki = *ki_ptr;
+                    __processor_id = ki.processor_id;
+                    __emule_neo_id = ki.is_tensix ? ki.processor_id : 0;
+                    __emule_trisc_id = 0;
+                    __emule_kernel_name = ki.kernel_name.empty() ? nullptr : ki.kernel_name.c_str();
+                    __emule_pending_noc_reads = 0;
+                    set_sanitizer_thread_locals(oob_state, sem_base, sem_size);
+                    try {
+                        for (size_t t = 0; t < ki.variants.size(); ++t) {
+                            if (ki.run_all_variants) {
+                                __emule_self->trisc_id = static_cast<uint8_t>(t);
+                                __emule_trisc_id = static_cast<uint8_t>(t);
+                            }
+                            ki.variants[t]();
+                        }
+                        sweep_per_kernel_dirty_cbs(oob_state, cb_array, ki.processor_id, lx, ly);
+                    } catch (...) {
+                        clear_sanitizer_thread_locals();
+                        std::throw_with_nested(std::runtime_error(
+                            "EMULE: kernel on core (" + std::to_string(lx) + "," + std::to_string(ly) +
+                            ") failed"));
+                    }
+                    __emule_kernel_name = nullptr;
+                    __emule_pending_noc_reads = 0;
+                    clear_sanitizer_thread_locals();
+                },
+                std::move(ctx),
+                id);
+        }
+
+        dfb_keepalive.push_back(std::move(per_thread_dfbs));
     }
+
+    if (defer_run) {
+        // Mesh register phase: fibers are spawned but not run yet. Keep the DFB arrays they
+        // borrow alive until run_mesh_dispatch (the spawned ctx is already owned by the
+        // scheduler; core_kernels is kept by execute_program_emulated). The SIGFPE guard
+        // above is a no-op here since no kernel runs; run_mesh_dispatch installs its own.
+        g_mesh_dfb_keep.push_back(std::move(dfb_keepalive));
+        return;
+    }
+
+    // Run all registered fibers to completion; rethrows the first kernel exception,
+    // throws on a quiescent deadlock, aborts with a dump on livelock/hang.
+    sched.run_until_idle();
 }
 
 // ---------------------------------------------------------------------------
-// execute_program_emulated: Main entry point.
+// prepare_program: resolve a program's kernels ONCE (collect + JIT-compile + resolve), memoized by
+// ProgramId — emule's analogue of silicon's CompileProgram. The first mesh device resolves; the rest
+// reuse, taking its (homogeneous-chip-identical) compile defines. See tt-emule docs/metal-integration.md.
 // ---------------------------------------------------------------------------
-void execute_program_emulated(IDevice* device, Program& program) {
+static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
+    // Single-writer invariant for g_resolved_programs/g_resolved_lru: this runs only on the
+    // sequential dispatch thread (register phase), never inside a fiber. __emule_self is the
+    // running fiber (set on worker threads, null on the dispatch thread), so off-fiber == null.
+    TT_FATAL(__emule_self == nullptr, "prepare_program must run on the dispatch path, not a fiber");
     auto& impl = program.impl();
-    auto device_id = device->id();
-    log_debug(tt::LogMetal, "execute_program_emulated: device {} starting", device_id);
+    const ProgramId pid = impl.get_id();
+    if (auto it = g_resolved_programs.find(pid); it != g_resolved_programs.end()) {
+        return it->second;  // already resolved (peer mesh device or repeated invocation)
+    }
 
+    auto device_id = device->id();
     auto* sw_emu = get_sw_emulated_chip(device_id);
 
-    // Phase 0: Populate bank mapping arrays
     tt_emule::Core* dram_core = nullptr;
     uint32_t num_dram_channels = 0;
     uint32_t num_l1_banks = 0;
     populate_bank_mapping(sw_emu, device, device_id, dram_core, num_dram_channels, num_l1_banks);
 
-    // Build worker coordinate mapping strings
     std::string worker_col_map_str, worker_row_map_str;
     build_worker_coord_maps(device, worker_col_map_str, worker_row_map_str);
 
     std::string extra_inc = get_extra_include_flags();
 
-    // Compute semaphore base from HAL kernel config layout
     const auto& hal = MetalContext::instance().hal();
     uint32_t tensix_pct_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     uint32_t kernel_config_base =
         static_cast<uint32_t>(hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG));
     const auto& prog_config = impl.get_program_config(tensix_pct_index);
     uint32_t emule_sem_base = kernel_config_base + prog_config.sem_offset;
-    log_debug(
-        tt::LogMetal,
-        "  EMULE_SEM_BASE: 0x{:x} (kernel_config_base=0x{:x}, sem_offset=0x{:x})",
-        emule_sem_base,
-        kernel_config_base,
-        prog_config.sem_offset);
 
-    // Phase 1: Collect kernels and resolve/compile
     std::map<CoreCoord, std::vector<PendingKernelInfo>> pending_core_kernels;
     std::map<std::string, DeferredCompile> deferred_compiles;
     std::unordered_map<std::string, std::function<void()>> resolved_fns;
     std::vector<std::string> inline_src_temps;
-
     collect_kernels(
-        impl,
-        num_dram_channels,
-        num_l1_banks,
-        worker_col_map_str,
-        worker_row_map_str,
-        emule_sem_base,
-        extra_inc,
-        pending_core_kernels,
-        deferred_compiles,
-        resolved_fns,
-        inline_src_temps);
-
+        impl, num_dram_channels, num_l1_banks, worker_col_map_str, worker_row_map_str,
+        emule_sem_base, extra_inc, pending_core_kernels, deferred_compiles, resolved_fns, inline_src_temps);
     jit_compile_pending(deferred_compiles, resolved_fns, inline_src_temps);
 
-    // Resolve pending kernels to function pointers
-    std::map<CoreCoord, std::vector<KernelInfo>> core_kernels;
+    ResolvedProgram resolved;
+    resolved.emule_sem_base = emule_sem_base;
     for (auto& [logical_core, pending_list] : pending_core_kernels) {
         for (auto& pk : pending_list) {
             KernelInfo ki{
@@ -2656,25 +3215,98 @@ void execute_program_emulated(IDevice* device, Program& program) {
             }
             ki.rt_arg_values = std::move(pk.rt_arg_values);
             ki.kernel_name = std::move(pk.kernel_name);
-            core_kernels[logical_core].push_back(std::move(ki));
+            resolved.core_kernels[logical_core].push_back(std::move(ki));
         }
     }
+    log_info(
+        tt::LogMetal,
+        "execute_program_emulated: program {} resolved ({} logical cores)",
+        pid,
+        resolved.core_kernels.size());
 
-    log_info(tt::LogMetal, "execute_program_emulated: {} logical cores", core_kernels.size());
+    // LRU-bound the cache (safety net; entries are otherwise valid for the program's life).
+    if (g_resolved_programs.size() >= kMaxResolvedPrograms && !g_resolved_lru.empty()) {
+        g_resolved_programs.erase(g_resolved_lru.front());
+        g_resolved_lru.pop_front();
+    }
+    g_resolved_lru.push_back(pid);
+    return g_resolved_programs.emplace(pid, std::move(resolved)).first->second;
+}
 
-    // Phase 2: Build core map and set up per-core state
+// ---------------------------------------------------------------------------
+// dispatch_to_device: per-device setup + launch, reusing the program's resolved kernels.
+// emule's analogue of dispatching the already-compiled program to one chip. dram_core (the
+// chip's DRAM backing) and the bank-table globals are per device.
+// ---------------------------------------------------------------------------
+static void dispatch_to_device(
+    IDevice* device, Program& program, ResolvedProgram& resolved, bool defer_run) {
+    auto& impl = program.impl();
+    auto device_id = device->id();
+    auto* sw_emu = get_sw_emulated_chip(device_id);
+
+    tt_emule::Core* dram_core = nullptr;
+    uint32_t num_dram_channels = 0;
+    uint32_t num_l1_banks = 0;
+    populate_bank_mapping(sw_emu, device, device_id, dram_core, num_dram_channels, num_l1_banks);
+
     auto* core_map_ptr = build_core_map(sw_emu, device, device_id);
-
     std::vector<CoreSetup> core_setups;
-    setup_core_state(impl, device, sw_emu, core_kernels, emule_sem_base, core_setups);
+    setup_core_state(impl, device, sw_emu, resolved.core_kernels, resolved.emule_sem_base, core_setups);
 
-    // Phase 3: Launch all cores concurrently
     uint8_t* dram_data = dram_core ? dram_core->l1_data() : nullptr;
 
     OobStateOwner oob = build_oob_tensor_state(device, device_id);
-    launch_cores(core_setups, dram_data, core_map_ptr, oob.state);
+    launch_cores(core_setups, dram_data, core_map_ptr, device_id, defer_run, oob.state);
+}
 
+// ---------------------------------------------------------------------------
+// execute_program_emulated: Main entry point. Mirrors silicon's compile-once / dispatch-
+// reuse: prepare_program resolves once (memoized by program id), dispatch_to_device runs
+// per device against the shared resolved kernels.
+// ---------------------------------------------------------------------------
+void execute_program_emulated(IDevice* device, Program& program) {
+    auto device_id = device->id();
+    log_debug(tt::LogMetal, "execute_program_emulated: device {} starting", device_id);
+    // Mark the fabric connection-route table stale: the next op's first connection record clears it, so
+    // routes stay scoped to the current op (this op's builds already recorded before this launch).
+    g_conn_route_dirty.store(true, std::memory_order_relaxed);
+
+    ResolvedProgram& resolved = prepare_program(device, program);  // compile-once (memoized)
+
+    const bool defer = g_emule_mesh_defer;  // mesh register phase (the run is deferred)
+    dispatch_to_device(device, program, resolved, defer);
+
+    if (defer) {
+        log_debug(tt::LogMetal, "execute_program_emulated: device {} registered (deferred mesh run)", device_id);
+        return;
+    }
     log_debug(tt::LogMetal, "execute_program_emulated: device {} done", device_id);
+}
+
+// ---------------------------------------------------------------------------
+// Mesh register/run split (see header). begin_mesh_dispatch puts execute_program_emulated
+// into defer mode; run_mesh_dispatch drives the single concurrent run + frees kept state.
+// ---------------------------------------------------------------------------
+void begin_mesh_dispatch() {
+    g_emule_mesh_defer = true;
+    g_mesh_dfb_keep.clear();
+}
+
+void run_mesh_dispatch() {
+#if defined(__x86_64__) && defined(__linux__)
+    EmuleSigfpeGuard sigfpe_guard;  // the actual kernel run happens here, across all chips
+#endif
+    // Reset defer + free the kept per-device state even if the run throws.
+    struct Cleanup {
+        ~Cleanup() {
+            g_emule_mesh_defer = false;
+            g_mesh_dfb_keep.clear();
+        }
+    } cleanup;
+    // All devices' fibers were registered (spawned) during the per-device register phase;
+    // run them concurrently on the worker pool in one pass. Each fiber's ctx carries its
+    // device's core_map/bridge_dram, so cross-chip NOC resolution stays correct.
+    tt::tt_metal::emule_fiber::FiberScheduler::instance().run_until_idle();
 }
 
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emulated_program_runner.hpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.hpp
@@ -11,18 +11,17 @@ class Program;
 
 namespace tt::tt_metal::emule {
 
-/// Execute all kernels in a Program on the emulated device.
-///
-/// For each kernel in the program:
-///   1. Resolve source path from KernelSource
-///   2. JIT compile to x86 shared library (cached by kernel hash)
-///   3. For each core in the kernel's CoreRangeSet, spawn a thread that:
-///      - Sets thread-local context (__rt_args, __core_coord, __device_ptr)
-///      - Invokes the JIT'd entry point
-///   4. Join all threads
-///
-/// Memory I/O from kernels goes through the SWEmuleChip's backing store
-/// via UMD Cluster::write_core / Cluster::read_core.
+/// Execute all kernels in a Program on the emulated device: resolve + JIT-compile each kernel
+/// (cached), then run one cooperatively-scheduled fiber per (core, RISC) to completion. Kernel
+/// memory I/O reaches the SWEmuleChip backing store through extern "C" bridge hooks.
+/// See tt-emule docs/metal-integration.md and docs/fiber-engine.md.
 void execute_program_emulated(IDevice* device, Program& program);
+
+/// Multi-device (mesh) register/run split: begin_mesh_dispatch() puts the runner in "defer" mode
+/// so each execute_program_emulated registers its fibers without running; run_mesh_dispatch() then
+/// drives one run_until_idle so all devices' fibers run concurrently — required for inter-chip CCL,
+/// where chips co-run. Single-device (begin_mesh_dispatch not called) runs synchronously.
+void begin_mesh_dispatch();
+void run_mesh_dispatch();
 
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -1,0 +1,549 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "emule_fiber_scheduler.hpp"
+
+#include "tt_emule/cb_sync_state.hpp"  // tt_emule::CBSyncState (sizeof, for the dump)
+
+#include <ucontext.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+// Silicon-named per-RISC globals (read by unmodified upstream); defined in
+// emulated_program_runner.cpp. The scheduler restores them on every swap-in
+// since one worker hosts many fibers. See tt-emule docs/fiber-engine.md.
+extern thread_local uint8_t my_x[2];
+extern thread_local uint8_t my_y[2];
+
+namespace tt::tt_metal::emule_fiber {
+
+namespace {
+
+enum class FiberState : uint8_t { Ready, Running, Parked, LatencyParked, Done };
+
+struct Fiber {
+    ucontext_t ctx{};
+    void* map_base = nullptr;   // mmap'd region (guard page + stack); munmap on destroy
+    size_t map_bytes = 0;
+    std::unique_ptr<ThreadCommonCtx> owned_ctx;
+    std::function<void()> entry;
+    FiberIdentity id{};
+    FiberState state = FiberState::Ready;
+    const void* park_key = nullptr;
+    Fiber* park_link = nullptr;     // intrusive parked-list
+    std::exception_ptr eptr;
+    unsigned home = 0;              // pinned worker — a fiber NEVER migrates (the JIT kernel
+                                    // caches the thread_local __emule_self address)
+
+    ~Fiber() {
+        if (map_base) {
+            ::munmap(map_base, map_bytes);
+        }
+    }
+};
+
+// Per-worker state. Fibers are pinned (Fiber::home), so a fiber always runs on the
+// same worker — these are read/written only by that worker.
+thread_local ucontext_t t_sched;          // the worker loop's context (swap target)
+thread_local Fiber*     t_current = nullptr;
+thread_local struct FiberSchedulerImpl* t_impl = nullptr;
+thread_local unsigned   t_worker = 0;      // this worker's index (== home of its fibers)
+
+size_t env_size(const char* name, size_t dflt) {
+    if (const char* s = std::getenv(name)) {
+        char* end = nullptr;
+        unsigned long long v = std::strtoull(s, &end, 10);
+        if (end != s && v > 0) return static_cast<size_t>(v);
+    }
+    return dflt;
+}
+
+}  // namespace
+
+struct FiberSchedulerImpl {
+    std::mutex mu_;
+    std::condition_variable cv_;                       // workers wait here for ready fibers
+    std::mutex wd_mu_;                                 // guards the watchdog's shutdown wait
+    std::condition_variable wd_cv_;                    // wakes the watchdog promptly on teardown
+    std::vector<std::deque<Fiber*>> ready_;            // per-worker ready queues (fibers are
+                                                       // pinned: ready_[w] holds only home==w)
+    std::unordered_map<const void*, Fiber*> parked_;   // key -> intrusive list head
+    std::vector<Fiber*> latency_parked_;               // fibers modeling NOC read latency:
+                                                       // released only at quiescence (below)
+    std::vector<std::unique_ptr<Fiber>> all_;          // ownership of every spawned fiber
+
+    unsigned K_ = 1;           // persistent pool size (read once at pool creation)
+    unsigned W_ = 0;           // workers ACTIVE this program = min(K_, fiber count); only
+                               // ready_[0..W_) is used, fibers home to [0..W_), surplus
+                               // workers stay parked on start_cv_ (no per-fiber wakeups)
+    unsigned workers_done_ = 0;// active workers that finished the current run (under mu_)
+    unsigned idle_ = 0;        // workers waiting on cv_ (under mu_)
+    unsigned running_ = 0;     // fibers currently executing on a worker (under mu_)
+    unsigned active_ = 0;      // fibers not yet Done (under mu_)
+    bool deadlock_ = false;
+    bool abort_flag_ = false;
+    std::exception_ptr first_eptr_;
+
+    std::atomic<uint64_t> progress_{0};      // fiber completions + published pages (tier 2)
+    std::atomic<uint64_t> resumptions_{0};   // swap-ins (tier 2 livelock signal)
+
+    size_t stack_bytes_ = 1u << 20;          // 1 MB default
+
+    // Persistent worker pool, created once and reused: threads block on start_cv_
+    // between programs; run_until_idle bumps generation_ + notify_all to launch and
+    // waits on done_cv_ for workers_done_ == W_. See tt-emule docs/fiber-engine.md.
+    std::vector<std::thread> pool_;
+    std::condition_variable start_cv_;       // pool waits here between programs
+    std::condition_variable done_cv_;        // run_until_idle waits here for run completion
+    uint64_t generation_ = 0;                // bumped per program (under mu_); workers detect a new run
+    bool shutdown_ = false;                  // set by ~FiberScheduler to drain the pool
+
+    void worker_main(unsigned w);            // persistent outer loop (one per pool thread)
+    void inner_loop(unsigned w);             // per-program body; runs until active_==0 / abort
+    void install_fiber(Fiber* f);
+    bool any_ready() const {                 // any runnable fiber in any worker's queue?
+        for (const auto& q : ready_) {
+            if (!q.empty()) return true;
+        }
+        return false;
+    }
+    std::string dump_parked();               // single-threaded (post-join)
+    void watchdog();                         // tier-2
+    std::atomic<bool> run_active_{false};
+};
+
+// ---- the makecontext trampoline (first entry of a fiber) ----
+static void fiber_trampoline() {
+    Fiber* f = t_current;                    // set by the worker before swap-in
+    FiberSchedulerImpl* impl = t_impl;
+    try {
+        f->entry();
+    } catch (...) {
+        f->eptr = std::current_exception();
+    }
+    impl->mu_.lock();                        // re-lock so the worker loop resumes mu_-held
+    f->state = FiberState::Done;
+    swapcontext(&f->ctx, &t_sched);          // -> worker loop (never returns here)
+}
+
+void FiberSchedulerImpl::install_fiber(Fiber* f) {
+    __emule_self = f->owned_ctx.get();       // the single thread_local repoint
+    my_x[0] = my_x[1] = f->id.phys_x;        // restore the silicon-named coords
+    my_y[0] = my_y[1] = f->id.phys_y;
+}
+
+void FiberSchedulerImpl::worker_main(unsigned w) {
+    // Persistent worker: parks on start_cv_ between programs, participates only when
+    // this program activated it (w < W_). Reuse is safe because all per-RISC state is
+    // per-fiber or restored per swap-in. See tt-emule docs/fiber-engine.md.
+    t_impl = this;
+    t_worker = w;
+    uint64_t seen = 0;
+    mu_.lock();
+    for (;;) {
+        {
+            std::unique_lock<std::mutex> wl(mu_, std::adopt_lock);
+            start_cv_.wait(wl, [&] { return shutdown_ || generation_ != seen; });
+            wl.release();                        // mu_ stays locked
+        }
+        if (shutdown_) {
+            mu_.unlock();
+            return;
+        }
+        seen = generation_;
+        if (w < W_) {
+            inner_loop(w);                       // enters + returns with mu_ held
+            ++workers_done_;
+            if (workers_done_ == W_) {
+                done_cv_.notify_one();           // last active worker wakes run_until_idle
+            }
+        }
+        // surplus workers (w >= W_) loop back to wait for the next generation
+    }
+}
+
+// Per-program scheduling loop. Pre: mu_ held. Post: mu_ held. Runs this program's fibers to
+// completion (active_ == 0) or to an abort (deadlock / kernel exception).
+void FiberSchedulerImpl::inner_loop(unsigned w) {
+    for (;;) {
+        if (abort_flag_) break;
+        if (ready_[w].empty()) {
+            if (active_ == 0) break;
+            ++idle_;
+            // Quiescence: nothing executing, nothing runnable in any queue. The
+            // `!any_ready()` term is essential — `idle_ == W_` alone is a false positive
+            // at W>1 (a worker counts itself idle before re-observing a just-enqueued
+            // fiber). See tt-emule docs/fiber-engine.md.
+            if (idle_ == W_ && running_ == 0 && !any_ready()) {
+                // Read-latency model: a latency-parked fiber is an in-flight read. At
+                // quiescence the read "completes" — release them all (lowest priority),
+                // reproducing the silicon ordering some kernels lean on.
+                // See tt-emule docs/fiber-engine.md.
+                if (!latency_parked_.empty()) {
+                    for (Fiber* f : latency_parked_) {
+                        f->state = FiberState::Ready;
+                        ready_[f->home].push_back(f);
+                    }
+                    latency_parked_.clear();
+                    cv_.notify_all();
+                    --idle_;
+                    continue;
+                }
+                // Tier-1 quiescent deadlock: nothing to release and fibers still sync-parked.
+                if (!parked_.empty()) {
+                    deadlock_ = true;
+                    abort_flag_ = true;
+                    --idle_;
+                    break;
+                }
+            }
+            {
+                std::unique_lock<std::mutex> wl(mu_, std::adopt_lock);
+                cv_.wait(wl, [&] { return !ready_[w].empty() || active_ == 0 || abort_flag_; });
+                wl.release();                // mu_ stays locked, back to manual management
+            }
+            --idle_;
+            continue;
+        }
+        Fiber* f = ready_[w].front();
+        ready_[w].pop_front();
+        f->state = FiberState::Running;
+        ++running_;
+        t_current = f;
+        install_fiber(f);
+        resumptions_.fetch_add(1, std::memory_order_relaxed);
+        mu_.unlock();
+        swapcontext(&t_sched, &f->ctx);      // run/resume f; returns with mu_ LOCKED
+        --running_;
+        if (f->state == FiberState::Done) {
+            if (f->eptr && !first_eptr_) {
+                first_eptr_ = f->eptr;
+            }
+            progress_.fetch_add(1, std::memory_order_relaxed);
+            --active_;
+        }
+        // Parked/Ready already placed by park_locked/yield under mu_.
+        t_current = nullptr;
+        __emule_self = nullptr;
+    }
+    cv_.notify_all();                        // wake active peers to observe active_==0 / abort
+    // returns with mu_ held — worker_main increments workers_done_ under it
+}
+
+// ---- bridge ops (called from a running fiber via the runner's extern-C thunks) ----
+
+void FiberScheduler::lock() { p_->mu_.lock(); }
+void FiberScheduler::unlock() { p_->mu_.unlock(); }
+
+void FiberScheduler::park_locked(const void* key) {
+    // pre: mu_ held by this thread (the .so's __emule_fiber_lock). Register parked and
+    // hand the lock to the worker loop across the switch.
+    Fiber* f = t_current;
+    f->state = FiberState::Parked;
+    f->park_key = key;
+    Fiber*& head = p_->parked_[key];         // inserts nullptr if absent
+    f->park_link = head;
+    head = f;
+    swapcontext(&f->ctx, &t_sched);          // -> worker loop (mu_ held); resumes mu_-UNLOCKED
+}
+
+void FiberScheduler::latency_park() {
+    // Model NOC read latency: defer the current fiber as lowest-priority "in-flight" work,
+    // released only at quiescence (see worker_loop). No key, no predicate; takes mu_ itself
+    // and hands it to the worker loop across the switch (mirrors park_locked).
+    Fiber* f = t_current;
+    if (!f) {
+        return;  // read barriers only run inside a fiber; insurance against a host-side call
+    }
+    p_->mu_.lock();
+    f->state = FiberState::LatencyParked;
+    p_->latency_parked_.push_back(f);
+    swapcontext(&f->ctx, &t_sched);          // -> worker loop (mu_ held); resumes mu_-UNLOCKED
+}
+
+void FiberScheduler::wake(const void* key) {
+    std::lock_guard<std::mutex> g(p_->mu_);
+    auto it = p_->parked_.find(key);
+    if (it == p_->parked_.end()) {
+        return;
+    }
+    Fiber* f = it->second;
+    while (f) {
+        Fiber* nx = f->park_link;
+        f->park_link = nullptr;
+        f->park_key = nullptr;
+        f->state = FiberState::Ready;
+        p_->ready_[f->home].push_back(f);    // back to its pinned worker
+        f = nx;
+    }
+    p_->parked_.erase(it);
+    p_->cv_.notify_all();
+}
+
+void FiberScheduler::yield() {
+    Fiber* f = t_current;
+    p_->mu_.lock();
+    f->state = FiberState::Ready;
+    p_->ready_[f->home].push_back(f);        // back to its pinned worker (== this worker)
+    p_->cv_.notify_all();
+    swapcontext(&f->ctx, &t_sched);          // mu_ held -> worker loop; resumes mu_-UNLOCKED
+}
+
+void FiberScheduler::note_publish(unsigned pages) {
+    p_->progress_.fetch_add(pages ? pages : 1, std::memory_order_relaxed);
+}
+
+// ---- register / run ----
+
+void FiberScheduler::spawn(std::function<void()> entry, std::unique_ptr<ThreadCommonCtx> ctx,
+                           const FiberIdentity& id) {
+    auto f = std::make_unique<Fiber>();
+    const size_t pg = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t usable = p_->stack_bytes_;
+    const size_t total = usable + pg;
+    void* base = mmap(nullptr, total, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (base == MAP_FAILED) {
+        throw std::runtime_error("EMULE fiber: stack mmap failed");
+    }
+    if (mprotect(base, pg, PROT_NONE) != 0) {  // guard page at the low (overflow) end
+        munmap(base, total);
+        throw std::runtime_error("EMULE fiber: stack guard-page mprotect failed");
+    }
+    getcontext(&f->ctx);
+    f->ctx.uc_stack.ss_sp = static_cast<char*>(base) + pg;
+    f->ctx.uc_stack.ss_size = usable;
+    f->ctx.uc_link = nullptr;                // we switch explicitly (trampoline swaps out)
+    makecontext(&f->ctx, fiber_trampoline, 0);
+    f->map_base = base;
+    f->map_bytes = total;
+    f->entry = std::move(entry);
+    f->owned_ctx = std::move(ctx);
+    f->id = id;
+    f->state = FiberState::Ready;
+
+    std::lock_guard<std::mutex> g(p_->mu_);
+    p_->all_.push_back(std::move(f));   // home + ready-queue placement happens in run_until_idle
+}
+
+std::string FiberSchedulerImpl::dump_parked() {
+    std::ostringstream os;
+    os << "  " << parked_.size() << " distinct wait-key(s); parked fibers:\n";
+    for (auto& [key, head] : parked_) {
+        for (Fiber* f = head; f; f = f->park_link) {
+            os << "    core(log " << f->id.logical_x << "," << f->id.logical_y
+               << " phys " << int(f->id.phys_x) << "," << int(f->id.phys_y) << ")"
+               << " risc/proc " << int(f->id.proc_id);
+            if (f->id.kernel_src) {
+                os << " kernel " << f->id.kernel_src;
+            }
+            // Best-effort key naming: a CB if the key lands in this fiber's cbs[] array.
+            const auto* ctx = f->owned_ctx.get();
+            const char* name = nullptr;
+            char buf[64];
+            if (ctx && ctx->cbs) {
+                auto base = reinterpret_cast<uintptr_t>(ctx->cbs);
+                auto k = reinterpret_cast<uintptr_t>(key);
+                if (k >= base && k < base + sizeof(tt_emule::CBSyncState) * 32) {
+                    std::snprintf(buf, sizeof(buf), "CB %zu",
+                                  (k - base) / sizeof(tt_emule::CBSyncState));
+                    name = buf;
+                }
+            }
+            if (!name && ctx && ctx->bridge_l1) {
+                auto base = reinterpret_cast<uintptr_t>(ctx->bridge_l1);
+                auto k = reinterpret_cast<uintptr_t>(key);
+                if (k >= base) {
+                    std::snprintf(buf, sizeof(buf), "L1 sem @ 0x%lx (cur=%u)",
+                                  (unsigned long)(k - base),
+                                  *reinterpret_cast<const volatile uint32_t*>(key));
+                    name = buf;
+                }
+            }
+            os << " waiting on " << (name ? name : "sync object") << " (key " << key << ")\n";
+        }
+    }
+    if (!latency_parked_.empty()) {
+        os << "  " << latency_parked_.size() << " fiber(s) in read-latency flight\n";
+    }
+    return os.str();
+}
+
+void FiberSchedulerImpl::watchdog() {
+    const auto interval = std::chrono::milliseconds(250);
+    const uint64_t window = env_size("TT_EMULE_FIBER_PROGRESS_WINDOW", 200000);
+    const auto backstop = std::chrono::seconds(env_size("TT_EMULE_FIBER_WATCHDOG_SEC", 120));
+    uint64_t last_progress = progress_.load();
+    uint64_t last_resump = resumptions_.load();
+    auto last_advance = std::chrono::steady_clock::now();
+    while (run_active_.load(std::memory_order_acquire)) {
+        {
+            // Interruptible sleep: wake immediately when run_until_idle clears run_active_
+            // (set under wd_mu_, so the notify can't be lost), else time out after `interval`
+            // to do the progress check. Avoids a ~`interval` join stall at every program end.
+            std::unique_lock<std::mutex> lk(wd_mu_);
+            if (wd_cv_.wait_for(lk, interval,
+                                [this] { return !run_active_.load(std::memory_order_acquire); })) {
+                break;
+            }
+        }
+        uint64_t p = progress_.load();
+        uint64_t r = resumptions_.load();
+        if (p != last_progress) {
+            last_progress = p;
+            last_resump = r;
+            last_advance = std::chrono::steady_clock::now();
+            continue;
+        }
+        // progress stalled. Fast livelock trip: many resumptions, zero progress.
+        bool livelock = (r - last_resump) > window;
+        bool wall = (std::chrono::steady_clock::now() - last_advance) > backstop;
+        if (livelock || wall) {
+            std::fprintf(stderr,
+                "[EMULE] fiber engine: no global progress (%s) — suspected %s.\n%s",
+                livelock ? "resumption window" : "wall-clock backstop",
+                livelock ? "livelock / wake-cycle" : "lost wakeup / hang",
+                [this] { std::lock_guard<std::mutex> g(mu_); return dump_parked(); }().c_str());
+            std::abort();
+        }
+        last_resump = r;
+    }
+}
+
+void FiberScheduler::run_until_idle() {
+    // Lazily create the persistent worker pool on the first run (K is process-constant);
+    // threads live until ~FiberScheduler. See tt-emule docs/fiber-engine.md.
+    if (p_->pool_.empty()) {
+        p_->K_ = static_cast<unsigned>(env_size("TT_EMULE_FIBER_WORKERS", 64));
+        p_->pool_.reserve(p_->K_);
+        for (unsigned i = 0; i < p_->K_; ++i) {
+            p_->pool_.emplace_back([this, i] { p_->worker_main(i); });
+        }
+    }
+
+    unsigned W;
+    {
+        std::lock_guard<std::mutex> g(p_->mu_);
+        p_->active_ = static_cast<unsigned>(p_->all_.size());
+        if (p_->active_ == 0) {
+            return;   // nothing to run; the pool stays parked
+        }
+        p_->idle_ = 0;
+        p_->running_ = 0;
+        p_->workers_done_ = 0;
+        p_->deadlock_ = false;
+        p_->abort_flag_ = false;
+        p_->first_eptr_ = nullptr;
+        p_->latency_parked_.clear();
+        // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
+        // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
+        // See tt-emule docs/fiber-engine.md.
+        W = std::min<unsigned>(p_->K_, p_->active_);
+        p_->W_ = W;
+        p_->ready_.assign(W, {});
+        for (size_t i = 0; i < p_->all_.size(); ++i) {
+            Fiber* f = p_->all_[i].get();
+            f->home = static_cast<unsigned>(i % W);
+            p_->ready_[f->home].push_back(f);
+        }
+    }
+    p_->progress_.store(0);
+    p_->resumptions_.store(0);
+    if (std::getenv("TT_EMULE_FIBER_LOG_N")) {
+        std::fprintf(stderr, "[EMULE FIBER] program: %u fibers on W=%u of K=%u workers\n",
+                     p_->active_, W, p_->K_);
+    }
+
+    p_->run_active_.store(true, std::memory_order_release);
+    std::thread wd([this] { p_->watchdog(); });
+
+    // Launch: bump the generation under mu_ (after the watchdog is up), then wake the pool.
+    {
+        std::lock_guard<std::mutex> g(p_->mu_);
+        ++p_->generation_;
+    }
+    p_->start_cv_.notify_all();
+    {   // Block the dispatch thread until every active worker has finished this run.
+        std::unique_lock<std::mutex> lk(p_->mu_);
+        p_->done_cv_.wait(lk, [&] { return p_->workers_done_ == W; });
+    }
+
+    {   // Clear under wd_mu_ + notify so the watchdog wakes at once (no lost wakeup).
+        std::lock_guard<std::mutex> lk(p_->wd_mu_);
+        p_->run_active_.store(false, std::memory_order_release);
+    }
+    p_->wd_cv_.notify_all();
+    wd.join();
+
+    std::exception_ptr eptr;
+    bool deadlock;
+    std::string dump;
+    {   // Collect results + clear the registry for the next program / mesh (workers are parked
+        // on start_cv_ now, but take mu_ anyway for clean ordering).
+        std::lock_guard<std::mutex> g(p_->mu_);
+        eptr = p_->first_eptr_;
+        deadlock = p_->deadlock_;
+        if (deadlock) {
+            dump = p_->dump_parked();
+        }
+        p_->ready_.clear();
+        p_->parked_.clear();
+        p_->latency_parked_.clear();
+        p_->all_.clear();   // frees Fiber stacks via ~Fiber
+    }
+
+    // A real kernel exception is the root cause; report it before any deadlock symptom.
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+    if (deadlock) {
+        throw std::runtime_error("EMULE fiber engine: quiescent deadlock — all workers idle, "
+                                 "fibers parked, none runnable.\n" + dump);
+    }
+}
+
+FiberScheduler::FiberScheduler() : p_(std::make_unique<FiberSchedulerImpl>()) {
+    // Read the fiber stack size once, at construction: spawn() consumes stack_bytes_ to size each
+    // fiber's mmap'd stack, and spawn() always runs before run_until_idle (single-device launch spawns
+    // then runs; the mesh path spawns all devices in the defer phase, then runs once). Reading it in
+    // run_until_idle would miss the first program. See tt-emule docs/fiber-engine.md.
+    p_->stack_bytes_ = env_size("TT_EMULE_FIBER_STACK_BYTES", 1u << 20);
+}
+
+FiberScheduler::~FiberScheduler() {
+    if (p_ && !p_->pool_.empty()) {
+        {
+            std::lock_guard<std::mutex> g(p_->mu_);
+            p_->shutdown_ = true;
+        }
+        p_->start_cv_.notify_all();
+        for (auto& t : p_->pool_) {
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    }
+}
+
+FiberScheduler& FiberScheduler::instance() {
+    static FiberScheduler s;
+    return s;
+}
+
+}  // namespace tt::tt_metal::emule_fiber

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+// Cooperative stackful-fiber scheduler for the emule program runner: each
+// (core, RISC) kernel runs on a ucontext fiber multiplexed onto a persistent
+// pool of K worker threads; a fiber that blocks at a sync point parks and is
+// woken on its predicate. Process-global singleton reached from jit_hw sync
+// primitives via the extern-C bridge.
+// See tt-emule docs/fiber-engine.md.
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "jit_hw/internal/emule_thread_ctx.h"  // ThreadCommonCtx (the fiber-owned ctx)
+
+namespace tt::tt_metal::emule_fiber {
+
+struct FiberSchedulerImpl;  // defined in the .cpp (namespace-scope so the ucontext
+                            // trampoline + per-worker thread_locals can access it)
+
+// Per-fiber identity — used to restore the silicon-named my_x/my_y globals on
+// swap-in (they cannot move into the ctx) and for the hang-detection dump.
+struct FiberIdentity {
+    uint8_t  phys_x = 0;
+    uint8_t  phys_y = 0;
+    uint32_t logical_x = 0;
+    uint32_t logical_y = 0;
+    uint8_t  proc_id = 0;
+    const char* kernel_src = nullptr;  // static string (kernel source path), for diagnostics
+};
+
+class FiberScheduler {
+public:
+    static FiberScheduler& instance();
+
+    // ---- Runner-facing C++ API (register/run split) ----
+    // Register a fiber; does NOT run it. The fiber takes ownership of `ctx`
+    // (the per-RISC ThreadCommonCtx). `entry` is the kernel body.
+    void spawn(std::function<void()> entry, std::unique_ptr<ThreadCommonCtx> ctx, const FiberIdentity& id);
+
+    // Run all registered fibers to completion on K workers, then clear the
+    // registry. Rethrows the first fiber exception; throws on a quiescent
+    // deadlock (tier 1); aborts with a diagnostic dump on livelock/hang (tier 2).
+    void run_until_idle();
+
+    // ---- Bridge ops (called by the runner's extern-C thunks from a running fiber) ----
+    void lock();
+    void unlock();
+    void park_locked(const void* key);  // pre: lock held; post: lock released
+    void latency_park();                 // model NOC read latency; released at quiescence
+    void wake(const void* key);
+    void yield();
+    void note_publish(unsigned pages);
+
+    FiberScheduler(const FiberScheduler&) = delete;
+    FiberScheduler& operator=(const FiberScheduler&) = delete;
+
+private:
+    FiberScheduler();
+    ~FiberScheduler();
+    std::unique_ptr<FiberSchedulerImpl> p_;
+};
+
+}  // namespace tt::tt_metal::emule_fiber

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -441,12 +441,27 @@ void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
 
     auto device_id = device->id();
 
+#ifdef TT_METAL_USE_EMULE
+    if (MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Emule) {
+        // Emule lazily JIT-compiles inside execute_program_emulated, so is_finalized()/is_compiled()
+        // are never set — skip both asserts (HW-only) and run synchronously, mirroring LaunchProgram.
+        // Configure before writing runtime args: ConfigureDeviceWithProgram allocates the ephemeral
+        // scratchpad buffers whose addresses are passed as common runtime args, so the write must see
+        // them (matches LaunchProgram and the non-emule path below).
+        detail::ConfigureDeviceWithProgram(device, program, /*force_slow_dispatch=*/false);
+        detail::WriteRuntimeArgsToDevice(device, program, /*force_slow_dispatch=*/false);
+        emule::execute_program_emulated(device, program);
+        return;
+    }
+#endif
+
     // Verify program was prepared by prior LaunchProgram call
     TT_FATAL(
         program.impl().is_finalized(),
         "Program must be finalized before calling DispatchCompiledProgramToDevice (target device {}). "
         "Call LaunchProgram on another device first.",
         device_id);
+
     TT_FATAL(
         program.impl().is_compiled(),
         "Program must be compiled on at least one device before calling DispatchCompiledProgramToDevice (target device "

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -154,6 +154,7 @@ if(TT_METAL_USE_EMULE)
         APPEND
         IMPL_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/emulation/emulated_program_runner.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/emulation/emule_fiber_scheduler.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/emulation/host_sanitizers.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/emulation/emule_asan_panic.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/emulation/emule_sanitizers.cpp


### PR DESCRIPTION
### PR Category
Feature — software-emulator (tt-emule) only. All changes are behind `#ifdef TT_METAL_USE_EMULE` / the `Emule` target; silicon and simulation paths are untouched.

### Summary
The tt-metal-side runtime for tt-emule **multichip / fabric-CCL**: it lets the software emulator run real ttnn CCL collectives (`all_gather`, `reduce_scatter`, `point_to_point`, …) across an emulated multi-chip mesh — n300/p300 and the 8-chip Blackhole loudbox. Two pieces:

- **Cooperative fiber engine** (`tt_metal/impl/emulation/emule_fiber_scheduler.{hpp,cpp}`) — replaces the OS-thread-per-RISC model with an M:N stackful-fiber scheduler (pinned fibers, persistent worker pool, park/wake), so all chips' per-core kernels co-run.
- **Fabric "teleport" + CCL** (`emulated_program_runner.cpp` + host hooks in `fabric.cpp` / `fabric_firmware_initializer.cpp` / `tt_metal.cpp` / `sd_mesh_command_queue.cpp`) — intercepts a fabric send at the worker→fabric-client API, resolves the *final* destination chip(s) from the control plane, and applies the terminal NOC command directly into that chip's L1 (no ERISC router / multi-hop).

### Device kernels unchanged
Emule runs the same kernels silicon runs — zero `__EMULE_JIT_MODE` guards in device kernels (verify: `grep -rn __EMULE_JIT_MODE tt_metal/ ttnn/`). All emule behavior is in the host runtime here or in tt-emule's `jit_hw` shadow headers.

### Design docs
Kept out of the source comments; they live in the tt-emule repo: `docs/fabric-ccl-emulation.md`, `docs/fiber-engine.md`, `docs/metal-integration.md`.

### Not in this PR
- **No umd bump.** The emule multi-chip path needs umd's `sw_emule_chip` worker-L1 right-sizing (tt-umd #2950, merged), which reaches metal through the normal umd-bump process — not manually here. The `tt_metal/third_party/umd` gitlink is unchanged from `main`.
- **No test changes.** emule's own tests live in the tt-emule repo; existing n300/p300/loudbox CCL tests run unchanged.

### Test
Validated via the tt-emule regression (build + env: `tt-emule/BUILD_GUIDE.md`): WH/BH C++ gtest, n300 2-chip CCL, and the 8-chip loudbox CCL suites — green except the tracked emule-side gaps (tt-emule #221 sub-tile `all_gather` PCC, #222 `all_to_all_dispatch`), both green on real HW.

### Merge
Rebased on current `main`; squash-merge.

### Licensing
By submitting this PR I agree my contribution is licensed under the Apache License 2.0.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-multichip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-multichip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arminale/emule-multichip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-multichip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-multichip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-multichip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-multichip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-multichip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-multichip)