### PR TITLE
[Feature] Option to disable implicit sync for all DFBs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -827,6 +827,121 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
 // add a positive scope-disagreement test that exercises the
 // "must agree on DFBSelfLoopScope" TT_FATAL.
 
+// ----------------------------------------------------------------------------
+// DFB implicit-sync opt-out (Gen2)
+// ----------------------------------------------------------------------------
+// Implicit sync is ON by default for any DFB side that has a DM endpoint. A DM kernel can
+// opt out per-DFB (disable_implicit_sync_for) or for all the DFBs it binds at once
+// (disable_dfb_implicit_sync_for_all). These tests pin the per-kernel "all" hammer.
+
+TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllDisablesProducerSide) {
+    // Build the canonical DM-producer -> compute-consumer DFB, optionally hammering the
+    // producer's implicit sync off, and read back the lowered DataflowBufferConfig.
+    auto make_spec = [](bool disable_all) {
+        ProgramSpec spec;
+        spec.name = "test_program";
+
+        auto dm_kernel = MakeMinimalDMKernel("dm_kernel");
+        auto compute_kernel = MakeMinimalComputeKernel("compute_kernel");
+        std::get<DataMovementHardwareConfig>(dm_kernel.hw_config).gen2_config->disable_dfb_implicit_sync_for_all =
+            disable_all;
+
+        auto dfb = MakeMinimalDFB("dfb_0");
+        dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+        dm_kernel.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb_0"}, "out"));
+        compute_kernel.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_0"}, "in"));
+
+        spec.kernels = {dm_kernel, compute_kernel};
+        spec.dataflow_buffers = {dfb};
+        spec.work_units = {MakeMinimalWorkUnit("work_unit_0", NodeCoord{0, 0}, {"dm_kernel", "compute_kernel"})};
+        return spec;
+    };
+
+    // Default: the producer side has a DM kernel, so implicit sync is on.
+    {
+        auto program = MakeProgramFromSpec(*mesh_device_, make_spec(/*disable_all=*/false));
+        const uint32_t dfb_id = program.impl().get_dfb_handle("dfb_0");
+        EXPECT_TRUE(program.impl().get_dataflow_buffer(dfb_id)->config.enable_producer_implicit_sync);
+    }
+    // disable_dfb_implicit_sync_for_all turns it off for every DFB the kernel binds.
+    {
+        auto program = MakeProgramFromSpec(*mesh_device_, make_spec(/*disable_all=*/true));
+        const uint32_t dfb_id = program.impl().get_dfb_handle("dfb_0");
+        EXPECT_FALSE(program.impl().get_dataflow_buffer(dfb_id)->config.enable_producer_implicit_sync);
+    }
+}
+
+TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllDisagreementAcrossProducersFails) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto producer1 = MakeMinimalDMKernel("producer1");
+    auto producer2 = MakeMinimalDMKernel("producer2");
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    // producer1 hammers implicit sync off; producer2 leaves it on. Both bind the same DFB on
+    // the producer side, so the per-side opt-out disagrees and validation must reject.
+    std::get<DataMovementHardwareConfig>(producer1.hw_config).gen2_config->disable_dfb_implicit_sync_for_all = true;
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    producer1.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    producer2.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer1, producer2, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer1", "consumer"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer2", "consumer"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("disagreeing implicit-sync opt-out state")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllAgreesWithExplicitList) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto producer1 = MakeMinimalDMKernel("producer1");
+    auto producer2 = MakeMinimalDMKernel("producer2");
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    // producer1 opts out via the per-kernel hammer; producer2 opts the same DFB out by name.
+    // Both express the same per-side decision (disable), so they agree and the side lowers off.
+    std::get<DataMovementHardwareConfig>(producer1.hw_config).gen2_config->disable_dfb_implicit_sync_for_all = true;
+    std::get<DataMovementHardwareConfig>(producer2.hw_config)
+        .gen2_config->disable_implicit_sync_for.push_back(DFBSpecName{"dfb"});
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    producer1.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    producer2.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer1, producer2, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer1", "consumer"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer2", "consumer"}),
+    };
+
+    auto program = MakeProgramFromSpec(*mesh_device_, spec);
+    const uint32_t dfb_id = program.impl().get_dfb_handle("dfb");
+    EXPECT_FALSE(program.impl().get_dataflow_buffer(dfb_id)->config.enable_producer_implicit_sync);
+}
+
 // ============================================================================
 // SECTION 2: Semantic Validation Tests (ValidateProgramSpec)
 // ============================================================================

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -62,6 +62,11 @@ struct DataMovementHardwareConfig {
         //  - This feature is mainly for debug purposes, or for backwards-compatible code style.
         // Any bound DFB not listed here will use implicit sync by default.
         Group<DFBSpecName> disable_implicit_sync_for;
+        // TODO -- rename to disable_dfb_implicit_sync_for (need to update existing users)
+
+        // Opt out of DFB implicit sync for ALL the DFBs this kernel binds.
+        // (The per-kernel hammer; equivalent to listing every bound DFB above.)
+        bool disable_dfb_implicit_sync_for_all = false;
     };
     // For a Gen2 DM kernel, providing the Gen2Config is optional.
     std::optional<Gen2Config> gen2_config = std::nullopt;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -631,6 +631,20 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
     }
 }
 
+// Whether a Gen2 DM kernel opts out of implicit sync for a particular DFB.
+// Two routes lead to the same opt-out:
+//   - disable_dfb_implicit_sync_for_all: the per-kernel hammer, covering every DFB the kernel binds.
+//   - disable_implicit_sync_for: an explicit per-DFB list.
+// Precondition: the caller has already established this is a DM kernel with a gen2_config.
+bool DmKernelDisablesImplicitSync(
+    const DataMovementHardwareConfig::Gen2Config& gen2_config, const DFBSpecName& dfb_name) {
+    if (gen2_config.disable_dfb_implicit_sync_for_all) {
+        return true;
+    }
+    const auto& vec = gen2_config.disable_implicit_sync_for;
+    return std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
+}
+
 // ValidateProgramSpec: Semantic validation
 // ----------------------------------------------------------------------------
 //
@@ -782,7 +796,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             // On Gen1 (WH/BH), the kernel must declare its placement: either a READER/WRITER role
             // hint (the runtime fills in processor/NOC/NOC-mode), or an explicit Gen1 config. There
             // is no safe default for reader-vs-writer — it is op-specific. Gen2 is fully optional:
-            // absence is treated as "use defaults" (empty disable_implicit_sync_for).
+            // absence is treated as "use defaults" (implicit sync left on for all bound DFBs).
             if (is_gen1_arch()) {
                 TT_FATAL(
                     data_movement_config.role != DataMovementRoleHint::UNSPECIFIED ||
@@ -926,15 +940,17 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate DM kernel disable_implicit_sync_for entries.
     //
     // Implicit sync is a Gen2-only, DM-only mechanism (ISR-based credit posting from NoC
-    // transaction completion). Each DM kernel can opt out per-DFB by listing the DFB's name
-    // in its Gen2Config::disable_implicit_sync_for vector. The opt-out applies to
-    // the side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
+    // transaction completion). A DM kernel can opt out per-DFB by listing the DFB's name in
+    // its Gen2Config::disable_implicit_sync_for vector, or opt out of all the DFBs it binds at
+    // once via Gen2Config::disable_dfb_implicit_sync_for_all. Either way the opt-out applies to the
+    // side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
     //
     // Per-kernel rule: every listed name references a DFB the kernel binds (typo guard).
     //
-    // Cross-kernel rule (per DFB): on each side independently, all DM kernels must agree —
-    // either all list the DFB, or none do. (Producer-side and consumer-side are checked
-    // separately; the underlying hardware mechanism is per-side, with one mask per side.)
+    // Cross-kernel rule (per DFB): on each side independently, all DM kernels must agree on the
+    // opt-out — either all disable it (by list or by _all), or none do. (Producer-side and
+    // consumer-side are checked separately; the underlying hardware mechanism is per-side, with
+    // one mask per side.)
     {
         // Per-kernel pass: typo guard.
         for (const auto& kernel : spec.kernels) {
@@ -967,7 +983,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 const DFBSpecName& dfb_name,
                 std::string_view side_label) {
                 const KernelSpec* canonical = nullptr;
-                bool canonical_lists_dfb = false;
+                bool canonical_disables = false;
                 for (const auto& ep : endpoints) {
                     if (!ep.kernel->is_data_movement_kernel()) {
                         continue;
@@ -977,16 +993,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                         // Gen1-only DM kernel — can't physically participate in Gen2 implicit sync; abstains.
                         continue;
                     }
-                    const auto& vec = dm_config.gen2_config->disable_implicit_sync_for;
-                    const bool lists_dfb = std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
+                    const bool disables = DmKernelDisablesImplicitSync(*dm_config.gen2_config, dfb_name);
                     if (canonical == nullptr) {
                         canonical = ep.kernel;
-                        canonical_lists_dfb = lists_dfb;
+                        canonical_disables = disables;
                         continue;
                     }
                     TT_FATAL(
-                        lists_dfb == canonical_lists_dfb,
-                        "DFB '{}' has disagreeing disable_implicit_sync_for state on the {} side",
+                        disables == canonical_disables,
+                        "DFB '{}' has disagreeing implicit-sync opt-out state on the {} side",
                         dfb_name,
                         side_label);
                 }
@@ -2377,8 +2392,7 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
             if (!dm_config.gen2_config.has_value()) {
                 continue;
             }
-            const auto& vec = dm_config.gen2_config->disable_implicit_sync_for;
-            if (std::find(vec.begin(), vec.end(), dfb_spec->unique_id) != vec.end()) {
+            if (DmKernelDisablesImplicitSync(*dm_config.gen2_config, dfb_spec->unique_id)) {
                 disabled = true;
             }
         }


### PR DESCRIPTION
### PR Category
Feature

### Summary
Add a single bool to disable implicit sync for all of a DM kernel's DFBs.

The original "disable implicit sync" feature was envisioned for very targeted performance fine-tuning. However, in practice the more common need is a bigger hammer.

Will follow up with a PR that moves existing users to the new API.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/disable-all-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/disable-all-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/disable-all-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/disable-all-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/disable-all-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/disable-all-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/disable-all-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/disable-all-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/disable-all-implicit-sync)