### PR TITLE
[skip ci] Temporarily skip test_mlp1d_llama_demo on wormhole_b0 due to read-only tensor cache

### DIFF
--- a/models/common/demos/llama31_8B_demo.py
+++ b/models/common/demos/llama31_8B_demo.py
@@ -51,6 +51,7 @@ from models.tt_transformers.tt.common import (
 )
 from models.tt_transformers.tt.generator import Generator
 from models.tt_transformers.tt.model_config import DecodersPrecision
+from models.common.utility_functions import skip_for_wormhole_b0
 
 # =============================================================================
 # Constants and Expected Metrics
@@ -444,6 +445,7 @@ _collect_all_baselines()
 # =============================================================================
 
 
+@skip_for_wormhole_b0("Tensor cache directory mounted read-only on wh_llmbox T3K runners, refs #47720")
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 50000000, "num_command_queues": 1}],


### PR DESCRIPTION
The tensor cache directory `/mnt/MLPerf/huggingface/tt_cache/meta-llama--Llama-3.1-8B-Instruct/T3K/tensor_cache_instruct_bfp8/` is mounted read-only on the wh_llmbox T3K CI runners, causing `test_mlp1d_llama_demo` to fail with `errno=30` when attempting to write cached tensors. All four CI-relevant parametrizations (`token-accuracy` and `batch-32`, both `performance` and `accuracy` modes) are affected.

This PR temporarily skips the test on `wormhole_b0` hardware until the filesystem/infrastructure issue is resolved.

refs #47720

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47720)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47720)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47720)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47720)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47720)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47720)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47720)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47720)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47720)