### PR TITLE
[LLK] Fix SETDMAREG→WRCFG ordering on Blackhole; drop redundant THCON stall on Wormhole

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -1009,6 +1009,7 @@ inline void set_dst_write_addr(const std::uint32_t &context_id, const std::uint3
     // Set unpacker Z-stride to the canonical baseline for unpack_dst_format. Paired with
     // unpack_to_dest_tile_done's canonical restore; no GPR snapshot of the prior value.
     TT_SETDMAREG(0, LOWER_HALFWORD(canonical_unpA_z_stride(unpack_dst_format) << UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT), 0, LO_16(p_gpr_unpack::TMP_LO));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON); // Wait for ThCon to land the SETDMAREG GPR write before WRCFG reads it (BH)
     TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32);
     if (context_id == 0)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -90,6 +90,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape
 
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, LO_16(p_gpr_unpack::TMP0));
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON); // Wait for ThCon to land the SETDMAREG GPR write before WRCFG reads it (BH)
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     // y_dim = number of faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile). Hardcoding 4 makes the
     // unpacker stride a full 32x32 tile between block tiles, over-reading the next tile (out-of-bounds
@@ -100,6 +101,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape
         TTI_SETDMAREG(0, 4 /* y_dim: 4 faces (32x32 tile) */, 0, LO_16(p_gpr_unpack::TMP0));
     }
     TTI_SETDMAREG(0, 1 /* z_dim */, 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON); // Wait for ThCon to land the SETDMAREG GPR write before WRCFG reads it (BH)
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
 
     _llk_unpack_AB_reduce_block_max_row_mop_config_<block_ct_dim, respect_trigger>(); // Unpack operand and scaler

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -87,6 +87,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
 
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, LO_16(p_gpr_unpack::TMP0));
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON); // Wait for ThCon to land the SETDMAREG GPR write before WRCFG reads it (BH)
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     // y_dim = number of faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile). Hardcoding 4 makes the
     // unpacker stride a full 32x32 tile between block tiles, over-reading the next tile (out-of-bounds
@@ -97,6 +98,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
         TTI_SETDMAREG(0, 4 /* y_dim: 4 faces (32x32 tile) */, 0, LO_16(p_gpr_unpack::TMP0));
     }
     TTI_SETDMAREG(0, 1 /* z_dim */, 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON); // Wait for ThCon to land the SETDMAREG GPR write before WRCFG reads it (BH)
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
 
     _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(block_ct_dim, respect_trigger); // Unpack operand and scaler

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_tilize.h
@@ -81,10 +81,12 @@ inline void _llk_unpack_fast_tilize_init_(const std::uint32_t unpack_dst_format,
     // Tile_x_dim = 32, Tile_y_dim = ct_dim, Tile_z_dim = 16
     TT_SETDMAREG(0, TILE_C_DIM, 0, LO_16(p_gpr_unpack::TMP0));
     TT_SETDMAREG(0, TILE_C_DIM, 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON); // Wait for ThCon to land the SETDMAREG GPR write before WRCFG reads it (BH)
     TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
 
     TT_SETDMAREG(0, ct_dim, 0, LO_16(p_gpr_unpack::TMP0));
     TT_SETDMAREG(0, FACE_R_DIM, 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON); // Wait for ThCon to land the SETDMAREG GPR write before WRCFG reads it (BH)
     TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
 
     // BH HW bug: TileDescriptor words 1-3 (YDim, ZDim) are not tracked as unpacker

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -250,8 +250,9 @@ inline void _llk_pack_reduce_mask_config_(const std::uint32_t face_r_dim = FACE_
     TTI_SETDMAREG(0, LOWER_HALFWORD(row_set_mapping_1), 0, LO_16(p_gpr_pack::TMP1));
     TTI_SETDMAREG(0, UPPER_HALFWORD(row_set_mapping_1), 0, HI_16(p_gpr_pack::TMP1));
 
-    // Wait for packer to finish to avoid breaking its current configuration
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
+    // Wait for packer to finish to avoid breaking its current configuration (PACK), and for ThCon to land the
+    // SETDMAREG GPR writes above before the WRCFGs below consume them (THCON, required on Blackhole)
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
 
     cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(face_r_dim);
 
@@ -283,8 +284,9 @@ inline void _llk_pack_reduce_mask_clear_()
     TTI_SETDMAREG(0, LOWER_HALFWORD(pack_edge_offset.val), 0, LO_16(p_gpr_pack::TMP0));
     TTI_SETDMAREG(0, UPPER_HALFWORD(pack_edge_offset.val), 0, HI_16(p_gpr_pack::TMP0));
 
-    // Wait for packer to finish to avoid breaking its current configuration
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
+    // Wait for packer to finish to avoid breaking its current configuration (PACK), and for ThCon to land the
+    // SETDMAREG GPR writes above before the WRCFGs below consume them (THCON, required on Blackhole)
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
 
     cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(1);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -217,9 +217,6 @@ inline void unpack_tilize_to_dest_impl(
         TT_SETDMAREG(0, UPPER_HALFWORD(address), 0, HI_16(p_gpr_unpack::TMP0));
         TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG3_Base_address_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::TMP0);
 
-        // Stall unpacker until pending CFG writes from Trisc have completed
-        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::THCON);
-
         // Unpack bottom faces
         ckernel::ckernel_template::run();
     }


### PR DESCRIPTION
## Problem

On **Blackhole**, a GPR written by a ThCon `SETDMAREG` is not guaranteed to be committed by the time a subsequent `WRCFG` (Configuration Unit) reads that GPR. Without an explicit `TTI_STALLWAIT(STALL_CFG, THCON)` between them, the `WRCFG` can latch a stale GPR value. On **Wormhole** the path latency makes this ordering automatic, so the same guard is unnecessary.

The BH tree already uses `STALLWAIT(STALL_CFG, THCON)` for this in ~26 places, but a handful of `SETDMAREG → WRCFG` sequences were missing it. Conversely, WH carried one stall that waits on `THCON` which it does not need.

Closes / refs: https://github.com/tenstorrent/tt-llk/issues/1661

## Blackhole — add the missing `STALL_CFG / THCON` guard

| File | Function |
|---|---|
| `cunpack_common.h` | `set_dst_write_addr` (UNP0 ZW stride) |
| `experimental/llk_unpack_AB_reduce_custom.h` | block-max-row init (Tile_x_dim, TileDescriptor) |
| `experimental/llk_unpack_AB_reduce_custom_runtime.h` | block-max-row init runtime |
| `experimental/llk_unpack_fast_tilize.h` | tile-descriptor setup |
| `llk_pack_common.h` | `_llk_pack_reduce_mask_config_` / `_clear_` — folded `THCON` into the existing `STALL_CFG, PACK` drain (`PACK \| THCON`), matching the sibling `_llk_pack_relu_config_` |

## Wormhole — remove the redundant guard

- `llk_unpack_tilize.h` (bottom-face `REG2FLOP` path): removed `TTI_STALLWAIT(STALL_UNPACK, THCON)`. WH orders the ThCon write ahead of the consumer without it. The top-face path's `STALL_UNPACK, TRISC_CFG` (a RISC MMIO store ordering — different mechanism) is left intact.

## Verification

Header-only device LLK changes; the added/removed lines mirror existing validated `TTI_STALLWAIT` idioms. Recommend running the reduce/tilize compile + on-device tests on a Blackhole part to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-setdmareg-wrcfg-thcon-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-setdmareg-wrcfg-thcon-stall)