### PR TITLE
Fix model_traced argmax sweep after use_multicore API removal

### DIFF
--- a/models/demos/gemma4/tests/unit/test_spec_decode.py
+++ b/models/demos/gemma4/tests/unit/test_spec_decode.py
@@ -2981,7 +2981,7 @@ def test_argmax_cost(mesh_device, reset_seeds):
     replicate = ttnn.ReplicateTensorToMesh(mesh_device)
 
     def _time_argmax(rows, width, mapper, mode="bare"):
-        """mode: 'bare' = argmax on TILE; 'mc' = argmax(use_multicore); 'untile_mc' = untilize+argmax(use_multicore)."""
+        """mode: 'bare' = argmax on TILE; 'mc' = argmax; 'untile_mc' = untilize+argmax."""
         t = ttnn.from_torch(
             torch.randn(1, 1, rows, width),
             device=mesh_device,
@@ -2994,7 +2994,7 @@ def test_argmax_cost(mesh_device, reset_seeds):
             if mode == "bare":
                 return ttnn.argmax(t, dim=-1, keepdim=False)
             tu = ttnn.untilize(t, use_multicore=True)
-            r = ttnn.argmax(tu, dim=-1, keepdim=False, use_multicore=True)
+            r = ttnn.argmax(tu, dim=-1, keepdim=False)
             tu.deallocate(True)
             return r
 
@@ -3040,7 +3040,7 @@ def test_argmax_cost(mesh_device, reset_seeds):
         )
         bare = ttnn.argmax(t, dim=-1, keepdim=False)
         tu = ttnn.untilize(t, use_multicore=True)
-        mc = ttnn.argmax(tu, dim=-1, keepdim=False, use_multicore=True)
+        mc = ttnn.argmax(tu, dim=-1, keepdim=False)
 
         def _to_list(x):
             h = ttnn.to_torch(ttnn.get_device_tensors(x)[0]) if tp > 1 else ttnn.to_torch(x)
@@ -3067,14 +3067,14 @@ def test_argmax_cost(mesh_device, reset_seeds):
             host, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=replicate
         )
         tu = ttnn.untilize(t, use_multicore=True)
-        mc = ttnn.argmax(tu, dim=-1, keepdim=False, use_multicore=True)
+        mc = ttnn.argmax(tu, dim=-1, keepdim=False)
         h = ttnn.to_torch(ttnn.get_device_tensors(mc)[0]) if tp > 1 else ttnn.to_torch(mc)
         got = [int(v) for v in h.reshape(-1)[:real_rows]]
         # time it (trace)
         ttnn.synchronize_device(mesh_device)
         tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         tu2 = ttnn.untilize(t, use_multicore=True)
-        mc2 = ttnn.argmax(tu2, dim=-1, keepdim=False, use_multicore=True)
+        mc2 = ttnn.argmax(tu2, dim=-1, keepdim=False)
         ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
         ttnn.synchronize_device(mesh_device)
         t0 = time.perf_counter()

--- a/tests/sweep_framework/sweeps/model_traced/argmax_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/argmax_model_traced.py
@@ -77,12 +77,7 @@ def run(
     is_mesh_device = hasattr(device, "get_num_devices")
     if dim is None:
         dim = -1
-    op_kwargs = build_op_kwargs(kwargs, output_memory_config=output_memory_config)
-    # The traced configs carry use_multicore=True, but the current ttnn.argmax
-    # API dropped that kwarg (multicore is automatic now; it exposes keepdim /
-    # sub_core_grids instead). Passing it raises "incompatible function
-    # arguments", so strip it — the default behavior is already multicore.
-    op_kwargs.pop("use_multicore", None)
+    op_kwargs = build_op_kwargs(kwargs, output_memory_config=output_memory_config, exclude={"use_multicore"})
 
     # Check if storage_type is HOST - if so, don't pass device to from_torch
     is_host = storage_type and "HOST" in str(storage_type)


### PR DESCRIPTION
### Ticket

- #48211

### Problem Description
After use_multicore was removed from ttnn.argmax #46340 , the daily model-traced argmax sweep still replays one old saved test config that calls ttnn.argmax(..., use_multicore=True). 
That keyword no longer exists in the API, so Python raises a TypeError before the test runs on device. Only 1 of 185 argmax sweep vectors fails; the rest pass. The fix is to stop forwarding use_multicore from old trace data in argmax_model_traced.py 

Additionally,
`test_argmax_cost` in **test_spec_decode.py** still passed use_multicore=True to ttnn.argmax, but that kwarg was removed from the argmax API. The probe would fail with an incompatible-arguments error if run manually with GEMMA4_RUN_ASSISTANT_PROBES=1, even though CI skips it by default

### What's Changed
1. **`tests/sweep_framework/sweeps/model_traced/argmax_model_traced.py`**

- Updated build_op_kwargs() to use `exclude={"use_multicore"}` so old model-traced vectors no longer pass the removed use_multicore kwarg to ttnn.argmax.

2. **`models/demos/gemma4/tests/unit/test_spec_decode.py`**
- Removed use_multicore=True from all four ttnn.argmax calls in test_argmax_cost.

### ttnn - run sweeps model traced CI status
- https://github.com/tenstorrent/tt-metal/actions/runs/28425966859
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/fix_argmax_model_traced_sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/fix_argmax_model_traced_sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/fix_argmax_model_traced_sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/fix_argmax_model_traced_sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/fix_argmax_model_traced_sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/fix_argmax_model_traced_sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/fix_argmax_model_traced_sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/fix_argmax_model_traced_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/fix_argmax_model_traced_sweep)