### PR TITLE
Revert "[chore] Bump pytorch to 2.12.1"

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -47,9 +47,9 @@ jsbeautifier==1.14.7
 datasets>=2.20,<3
 
 pyarrow>=21.0.0,<22
-torch==2.12.1 ; platform_machine == 'aarch64'
+torch==2.11.0 ; platform_machine == 'aarch64'
 networkx==3.1
-torchvision==0.27.1 ; platform_machine == 'aarch64'
+torchvision==0.26.0 ; platform_machine == 'aarch64'
 torchmetrics==1.9.0
 torch-fidelity==0.3.0
 xlsxwriter==3.0.8
@@ -103,5 +103,5 @@ efficientnet-pytorch==0.7.1
 
 # CPU-only torch for x86_64 to avoid installing CUDA dependencies on dev machines
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.12.1 ; platform_machine == 'x86_64'
-torchvision==0.27.1 ; platform_machine == 'x86_64'
+torch==2.11.0 ; platform_machine == 'x86_64'
+torchvision==0.26.0 ; platform_machine == 'x86_64'

--- a/tt_metal/tt-llk/tests/requirements.txt
+++ b/tt_metal/tt-llk/tests/requirements.txt
@@ -45,5 +45,5 @@ pyyaml==6.0.3
 sympy==1.14.0
 termcolor==3.2.0
 tomli==2.2.1
-torch==2.12.1
+torch==2.9.1
 typing-extensions==4.15.0

--- a/ttnn/tutorials/basic_python/tutorials-dev.txt
+++ b/ttnn/tutorials/basic_python/tutorials-dev.txt
@@ -6,12 +6,12 @@
 numpy>=1.24.4,<2
 
 # Torch packages
-torch==2.12.1 ; platform_machine == 'aarch64'
-torchvision==0.27.1 ; platform_machine == 'aarch64'
+torch==2.11.0 ; platform_machine == 'aarch64'
+torchvision==0.26.0 ; platform_machine == 'aarch64'
 torchmetrics==1.9.0
 torch-fidelity==0.3.0
 
 # CPU-only torch for x86_64 to avoid installing CUDA dependencies on dev machines
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.12.1 ; platform_machine == 'x86_64'
-torchvision==0.27.1 ; platform_machine == 'x86_64'
+torch==2.11.0 ; platform_machine == 'x86_64'
+torchvision==0.26.0 ; platform_machine == 'x86_64'


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#47800, which drops accuracy in many tests. As an example ttnn fused group 2:

```
FAILED tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py::test_pre_allgather_layernorm[fuse_residual=False-max_atol_ex2=0.04-min_pcc_ex2=0.982-min_pcc_residual_add=0.997-min_pcc_ex=0.9997-max_atol_ex=0.01-core_grid=(8, 4)-mean=0-std=1-input_df=DataType.BFLOAT16-num_devices=4-input_width=2048-seed=1234-is_rmsnorm=True] - AssertionError: Numeric metrics comparison failed: 2/3 checks passed
﻿2026-06-29T21:49:01.5721678Z [ALLCLOSE PASSED] Max ATOL Delta: 0.0234375, Max RTOL Delta: 0.02294921875
[FROBENIUS PASSED] Relative Frobenius norm 1.147461e-02 <= threshold 0.15
[PCC FAILED] PCC=0.981753 < threshold 0.982
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
= 1 failed, 887 passed, 262 skipped, 2302 deselected, 409 xfailed in 146.69s (0:02:26) =
```

https://github.com/tenstorrent/tt-metal/actions/runs/28399172565

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:revert-47800-vlad/bump-pytorch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:revert-47800-vlad/bump-pytorch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:revert-47800-vlad/bump-pytorch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:revert-47800-vlad/bump-pytorch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:revert-47800-vlad/bump-pytorch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:revert-47800-vlad/bump-pytorch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:revert-47800-vlad/bump-pytorch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=revert-47800-vlad/bump-pytorch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:revert-47800-vlad/bump-pytorch)