### PR TITLE
fast quasar compile with runtime() deduplication

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -418,7 +418,7 @@ jobs:
          needs.find-changed-files.outputs.llk-sfpi-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
-    runs-on: tt-ubuntu-2204-large-stable
+    runs-on: tt-ubuntu-2204-xlarge-stable
     timeout-minutes: 80
     container:
       image: ${{ needs.resolve-docker-pull-refs.outputs.llk-ci-docker-image }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -418,7 +418,7 @@ jobs:
          needs.find-changed-files.outputs.llk-sfpi-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
-    runs-on: tt-ubuntu-2204-xlarge-stable
+    runs-on: tt-ubuntu-2204-large-stable
     timeout-minutes: 80
     container:
       image: ${{ needs.resolve-docker-pull-refs.outputs.llk-ci-docker-image }}

--- a/tt_metal/tt-llk/.github/workflows/on-pr.yml
+++ b/tt_metal/tt-llk/.github/workflows/on-pr.yml
@@ -186,7 +186,7 @@ jobs:
              needs.detect-changes.outputs.common == 'true') }}
     with:
       docker_image: ${{ needs.build-images.outputs.docker-image }}
-      runs_on: tt-ubuntu-2204-xlarge-stable
+      runs_on: tt-ubuntu-2204-large-stable
       test_splits: 1
       pytest_markers: "quasar"
 

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -432,11 +432,8 @@ def _collapse_runtime_only_variants(items):
         if marker is None:
             keep.append(item)
             continue
-        runtime_names = set(marker.args)
-        compile_params = {
-            k: v for k, v in item.callspec.params.items() if k not in runtime_names
-        }
-        key = (item.nodeid.split("[")[0], repr(sorted(compile_params.items())))
+        compile_key_fn = marker.kwargs["compile_key_fn"]
+        key = (item.nodeid.split("[")[0], repr(compile_key_fn(item.callspec.params)))
         if key not in seen:
             seen.add(key)
             keep.append(item)

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -437,12 +437,7 @@ def _collapse_runtime_only_variants(items):
         if key not in seen:
             seen.add(key)
             keep.append(item)
-    original = len(items)
     items[:] = keep
-    logger.info(
-        f"Compile-producer deselection: {original} -> {len(items)} tests "
-        f"({original - len(items)} runtime-only duplicates removed)"
-    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -423,6 +423,13 @@ def pytest_ignore_collect(collection_path, config):
 
 
 def _collapse_runtime_only_variants(items):
+    """Keep only one test per unique compile key, dropping runtime only duplicates.
+
+    Tests decorated with ``@parametrize`` that use ``runtime()`` markers carry a
+    ``compile_key_fn`` on their ``runtime_axes`` pytest mark.  That function extracts
+    the compile time subset of each item's params.  Items that share the same compile
+    key produce identical ELFs, so only the first is kept for the compile-producer pass.
+    """
     from helpers.param_config import RUNTIME_AXES_MARK
 
     seen = set()
@@ -441,7 +448,7 @@ def _collapse_runtime_only_variants(items):
 
 
 def pytest_collection_modifyitems(config, items):
-    if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
+    if TestConfig.BUILD_MODE == BuildMode.PRODUCE and not TestConfig.SPEED_OF_LIGHT:
         _collapse_runtime_only_variants(items)
 
     test_order_file = config.getoption("--test-order-file")

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -422,7 +422,36 @@ def pytest_ignore_collect(collection_path, config):
     return None
 
 
+def _collapse_runtime_only_variants(items):
+    from helpers.param_config import RUNTIME_AXES_MARK
+
+    seen = set()
+    keep = []
+    for item in items:
+        marker = item.get_closest_marker(RUNTIME_AXES_MARK)
+        if marker is None:
+            keep.append(item)
+            continue
+        runtime_names = set(marker.args)
+        compile_params = {
+            k: v for k, v in item.callspec.params.items() if k not in runtime_names
+        }
+        key = (item.nodeid.split("[")[0], repr(sorted(compile_params.items())))
+        if key not in seen:
+            seen.add(key)
+            keep.append(item)
+    original = len(items)
+    items[:] = keep
+    logger.info(
+        f"Compile-producer deselection: {original} -> {len(items)} tests "
+        f"({original - len(items)} runtime-only duplicates removed)"
+    )
+
+
 def pytest_collection_modifyitems(config, items):
+    if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
+        _collapse_runtime_only_variants(items)
+
     test_order_file = config.getoption("--test-order-file")
 
     if not test_order_file:

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -422,7 +422,7 @@ def pytest_ignore_collect(collection_path, config):
     return None
 
 
-def _collapse_runtime_only_variants(items):
+def _collapse_runtime_only_variants(config, items):
     """Keep only one test per unique compile key, dropping runtime only duplicates.
 
     Tests decorated with ``@parametrize`` that use ``runtime()`` markers carry a
@@ -434,6 +434,7 @@ def _collapse_runtime_only_variants(items):
 
     seen = set()
     keep = []
+    deselected = []
     for item in items:
         marker = item.get_closest_marker(RUNTIME_AXES_MARK)
         if marker is None:
@@ -444,12 +445,18 @@ def _collapse_runtime_only_variants(items):
         if key not in seen:
             seen.add(key)
             keep.append(item)
-    items[:] = keep
+        else:
+            deselected.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = keep
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     if TestConfig.BUILD_MODE == BuildMode.PRODUCE and not TestConfig.SPEED_OF_LIGHT:
-        _collapse_runtime_only_variants(items)
+        _collapse_runtime_only_variants(config, items)
 
     test_order_file = config.getoption("--test-order-file")
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -19,6 +19,34 @@ from .format_config import (
 from .golden_generators import TILE_DIMENSIONS
 from .llk_params import BlocksCalculationAlgorithm, DestAccumulation, DestSync
 
+RUNTIME_AXES_MARK = "runtime_axes"
+
+
+class _RuntimeMarker:
+    __slots__ = ("value",)
+
+    def __init__(self, value):
+        self.value = value
+
+
+def runtime(value):
+    return _RuntimeMarker(value)
+
+
+def split_combinations(combos, runtime_indices):
+    compile_keys = []
+    runtime_lookup = {}
+    for combo in combos:
+        key = tuple(v for i, v in enumerate(combo) if i not in runtime_indices)
+        rt = tuple(v for i, v in enumerate(combo) if i in runtime_indices)
+        key_repr = repr(key)
+        if key_repr not in runtime_lookup:
+            compile_keys.append(key)
+            runtime_lookup[key_repr] = []
+        runtime_lookup[key_repr].append(rt[0] if len(rt) == 1 else rt)
+    return compile_keys, runtime_lookup
+
+
 checked_formats_and_dest_acc = {}
 
 DEST_SYNC_TILE_LIMITS = {
@@ -291,9 +319,18 @@ def _params_solve_dependencies(**kwargs: any) -> List[Tuple]:
 
 
 def parametrize(**kwargs: any):
-    parameters = tuple(kwargs.keys())
+    runtime_axes = []
+    unwrapped = {}
+    for name, value in kwargs.items():
+        if isinstance(value, _RuntimeMarker):
+            runtime_axes.append(name)
+            unwrapped[name] = value.value
+        else:
+            unwrapped[name] = value
+
+    parameters = tuple(unwrapped.keys())
     parameters_string = ",".join(parameters)
-    parameter_values = _params_solve_dependencies(**kwargs)
+    parameter_values = _params_solve_dependencies(**unwrapped)
 
     def generate_id(value_tuple):
         """Generate readable test IDs from parameter values."""
@@ -313,6 +350,8 @@ def parametrize(**kwargs: any):
     ids = [generate_id(values) for values in parameter_values]
 
     def decorator(test_function):
+        if runtime_axes:
+            test_function = pytest.mark.runtime_axes(*runtime_axes)(test_function)
         return pytest.mark.parametrize(parameters_string, parameter_values, ids=ids)(
             test_function
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -306,12 +306,13 @@ def _params_solve_dependencies(**kwargs: any) -> List[Tuple]:
 
 def parametrize(**kwargs: any):
     compile_key_fn = None
-    runtime_axes = []
-    runtime_indices = None
+    _rt_names = set()
+    _combo_name = None
+    _combo_rt_indices = frozenset()
     unwrapped = {}
     for name, value in kwargs.items():
         if isinstance(value, _RuntimeMarker):
-            runtime_axes.append(name)
+            _rt_names.add(name)
             unwrapped[name] = value.value
         elif (
             isinstance(value, list)
@@ -319,10 +320,10 @@ def parametrize(**kwargs: any):
             and isinstance(value[0], tuple)
             and any(isinstance(v, _RuntimeMarker) for v in value[0])
         ):
-            runtime_indices = frozenset(
+            _combo_name = name
+            _combo_rt_indices = frozenset(
                 i for i, v in enumerate(value[0]) if isinstance(v, _RuntimeMarker)
             )
-            runtime_axes.append(name)
             unwrapped[name] = [
                 tuple(v.value if isinstance(v, _RuntimeMarker) else v for v in combo)
                 for combo in value
@@ -330,26 +331,21 @@ def parametrize(**kwargs: any):
         else:
             unwrapped[name] = value
 
-    if runtime_axes:
-        if runtime_indices is not None:
-            _combo_name = runtime_axes[0]
-            _ri = runtime_indices
+    if _rt_names or _combo_name:
 
-            def compile_key_fn(params):
-                combo = params[_combo_name]
-                if len(combo) == 1 and isinstance(combo[0], tuple):
-                    combo = combo[0]
-                filtered = tuple(v for i, v in enumerate(combo) if i not in _ri)
-                other = tuple(
-                    sorted((k, v) for k, v in params.items() if k != _combo_name)
-                )
-                return (filtered, other)
-
-        else:
-            _rt = frozenset(runtime_axes)
-
-            def compile_key_fn(params):
-                return tuple(sorted((k, v) for k, v in params.items() if k not in _rt))
+        def compile_key_fn(params):
+            parts = []
+            for k, v in sorted(params.items()):
+                if k in _rt_names:
+                    continue
+                if k == _combo_name:
+                    if len(v) == 1 and isinstance(v[0], tuple):
+                        v = v[0]
+                    v = tuple(
+                        el for i, el in enumerate(v) if i not in _combo_rt_indices
+                    )
+                parts.append((k, v))
+            return tuple(parts)
 
     parameters = tuple(unwrapped.keys())
     parameters_string = ",".join(parameters)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -314,8 +314,7 @@ def _params_solve_dependencies(**kwargs: any) -> List[Tuple]:
 def parametrize(**kwargs: any):
     compile_key_fn = None
     _rt_names = set()
-    _combo_name = None
-    _combo_rt_indices = frozenset()
+    _combo_rt_indices = {}
     unwrapped = {}
     for name, value in kwargs.items():
         if isinstance(value, _RuntimeMarker):
@@ -324,12 +323,14 @@ def parametrize(**kwargs: any):
         elif (
             isinstance(value, list)
             and value
-            and isinstance(value[0], tuple)
-            and any(isinstance(v, _RuntimeMarker) for v in value[0])
+            and all(isinstance(v, tuple) for v in value)
+            and any(isinstance(el, _RuntimeMarker) for combo in value for el in combo)
         ):
-            _combo_name = name
-            _combo_rt_indices = frozenset(
-                i for i, v in enumerate(value[0]) if isinstance(v, _RuntimeMarker)
+            _combo_rt_indices[name] = frozenset(
+                i
+                for combo in value
+                for i, el in enumerate(combo)
+                if isinstance(el, _RuntimeMarker)
             )
             unwrapped[name] = [
                 tuple(v.value if isinstance(v, _RuntimeMarker) else v for v in combo)
@@ -338,19 +339,18 @@ def parametrize(**kwargs: any):
         else:
             unwrapped[name] = value
 
-    if _rt_names or _combo_name:
+    if _rt_names or _combo_rt_indices:
 
         def compile_key_fn(params):
             parts = []
             for k, v in sorted(params.items()):
                 if k in _rt_names:
                     continue
-                if k == _combo_name:
+                if k in _combo_rt_indices:
                     if len(v) == 1 and isinstance(v[0], tuple):
                         v = v[0]
-                    v = tuple(
-                        el for i, el in enumerate(v) if i not in _combo_rt_indices
-                    )
+                    rt_indices = _combo_rt_indices[k]
+                    v = tuple(el for i, el in enumerate(v) if i not in rt_indices)
                 parts.append((k, v))
             return tuple(parts)
 
@@ -377,9 +377,9 @@ def parametrize(**kwargs: any):
 
     def decorator(test_function):
         if compile_key_fn is not None:
-            test_function = pytest.mark.runtime_axes(compile_key_fn=compile_key_fn)(
-                test_function
-            )
+            test_function = getattr(pytest.mark, RUNTIME_AXES_MARK)(
+                compile_key_fn=compile_key_fn
+            )(test_function)
         return pytest.mark.parametrize(parameters_string, parameter_values, ids=ids)(
             test_function
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -33,12 +33,15 @@ def runtime(value):
     return _RuntimeMarker(value)
 
 
-def split_combinations(combos, runtime_indices):
+def split_combinations(combos):
+    runtime_indices = {
+        i for i, v in enumerate(combos[0]) if isinstance(v, _RuntimeMarker)
+    }
     compile_keys = []
     runtime_lookup = {}
     for combo in combos:
         key = tuple(v for i, v in enumerate(combo) if i not in runtime_indices)
-        rt = tuple(v for i, v in enumerate(combo) if i in runtime_indices)
+        rt = tuple(v.value for i, v in enumerate(combo) if i in runtime_indices)
         key_repr = repr(key)
         if key_repr not in runtime_lookup:
             compile_keys.append(key)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -33,23 +33,6 @@ def runtime(value):
     return _RuntimeMarker(value)
 
 
-def split_combinations(combos):
-    runtime_indices = {
-        i for i, v in enumerate(combos[0]) if isinstance(v, _RuntimeMarker)
-    }
-    compile_keys = []
-    runtime_lookup = {}
-    for combo in combos:
-        key = tuple(v for i, v in enumerate(combo) if i not in runtime_indices)
-        rt = tuple(v.value for i, v in enumerate(combo) if i in runtime_indices)
-        key_repr = repr(key)
-        if key_repr not in runtime_lookup:
-            compile_keys.append(key)
-            runtime_lookup[key_repr] = []
-        runtime_lookup[key_repr].append(rt[0] if len(rt) == 1 else rt)
-    return compile_keys, runtime_lookup
-
-
 checked_formats_and_dest_acc = {}
 
 DEST_SYNC_TILE_LIMITS = {
@@ -322,14 +305,47 @@ def _params_solve_dependencies(**kwargs: any) -> List[Tuple]:
 
 
 def parametrize(**kwargs: any):
+    compile_key_fn = None
     runtime_axes = []
+    runtime_indices = None
     unwrapped = {}
     for name, value in kwargs.items():
         if isinstance(value, _RuntimeMarker):
             runtime_axes.append(name)
             unwrapped[name] = value.value
+        elif (
+            isinstance(value, list)
+            and value
+            and isinstance(value[0], tuple)
+            and any(isinstance(v, _RuntimeMarker) for v in value[0])
+        ):
+            runtime_indices = frozenset(
+                i for i, v in enumerate(value[0]) if isinstance(v, _RuntimeMarker)
+            )
+            runtime_axes.append(name)
+            unwrapped[name] = [
+                tuple(v.value if isinstance(v, _RuntimeMarker) else v for v in combo)
+                for combo in value
+            ]
         else:
             unwrapped[name] = value
+
+    if runtime_axes:
+        if runtime_indices is not None:
+            _name = runtime_axes[0]
+            _ri = runtime_indices
+
+            def compile_key_fn(params):
+                combo = params[_name]
+                if len(combo) == 1 and isinstance(combo[0], tuple):
+                    combo = combo[0]
+                return tuple(v for i, v in enumerate(combo) if i not in _ri)
+
+        else:
+            _rt = frozenset(runtime_axes)
+
+            def compile_key_fn(params):
+                return tuple(sorted((k, v) for k, v in params.items() if k not in _rt))
 
     parameters = tuple(unwrapped.keys())
     parameters_string = ",".join(parameters)
@@ -353,8 +369,10 @@ def parametrize(**kwargs: any):
     ids = [generate_id(values) for values in parameter_values]
 
     def decorator(test_function):
-        if runtime_axes:
-            test_function = pytest.mark.runtime_axes(*runtime_axes)(test_function)
+        if compile_key_fn is not None:
+            test_function = pytest.mark.runtime_axes(compile_key_fn=compile_key_fn)(
+                test_function
+            )
         return pytest.mark.parametrize(parameters_string, parameter_values, ids=ids)(
             test_function
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -332,14 +332,18 @@ def parametrize(**kwargs: any):
 
     if runtime_axes:
         if runtime_indices is not None:
-            _name = runtime_axes[0]
+            _combo_name = runtime_axes[0]
             _ri = runtime_indices
 
             def compile_key_fn(params):
-                combo = params[_name]
+                combo = params[_combo_name]
                 if len(combo) == 1 and isinstance(combo[0], tuple):
                     combo = combo[0]
-                return tuple(v for i, v in enumerate(combo) if i not in _ri)
+                filtered = tuple(v for i, v in enumerate(combo) if i not in _ri)
+                other = tuple(
+                    sorted((k, v) for k, v in params.items() if k != _combo_name)
+                )
+                return (filtered, other)
 
         else:
             _rt = frozenset(runtime_axes)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -23,6 +23,8 @@ RUNTIME_AXES_MARK = "runtime_axes"
 
 
 class _RuntimeMarker:
+    """Wrapper that tags a parameter value as runtime only."""
+
     __slots__ = ("value",)
 
     def __init__(self, value):
@@ -30,6 +32,11 @@ class _RuntimeMarker:
 
 
 def runtime(value):
+    """Mark a parametrize value as runtime only so compile producer can deduplicate it.
+
+    Wrapped values are excluded from the compile key: test variants that differ only in
+    ``runtime()`` parameters share an ELF and are collapsed to a single compilation.
+    """
     return _RuntimeMarker(value)
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -25,6 +25,7 @@ from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
@@ -80,8 +81,10 @@ FACE_ELEMS = 16 * 16
         else [ImpliedMathFormat.Yes]
     ),
     dest_sync_mode=[DestSync.Half, DestSync.Full],
-    input_dimensions=lambda dest_acc, dest_sync_mode: generate_unary_input_dimensions(
-        dest_acc, dest_sync_mode
+    input_dimensions=runtime(
+        lambda dest_acc, dest_sync_mode: generate_unary_input_dimensions(
+            dest_acc, dest_sync_mode
+        )
     ),
 )
 def test_eltwise_binary_broadcast_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -20,6 +20,7 @@ from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
@@ -40,12 +41,11 @@ from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 
 
-def eltwise_dimensions_dest_sync(dest_acc_modes):
+def _eltwise_dest_acc_sync(dest_acc_modes):
     return [
-        (dest_sync, dims, dest_acc)
+        (dest_sync, dest_acc)
         for dest_sync in (DestSync.Half, DestSync.Full)
         for dest_acc in dest_acc_modes
-        for dims in generate_unary_input_dimensions(dest_acc, dest_sync)
     ]
 
 
@@ -57,13 +57,12 @@ def get_num_tiles_per_accumulation(acc_to_dest: bool) -> int:
 _TILE_SHAPE = construct_tile_shape()
 
 
-def valid_acc_to_dest(dest_sync_dims_dest_acc) -> list:
+def valid_acc_to_dest(input_dimensions) -> list:
     """Pick the acc_to_dest modes worth running for a given input size.
 
     acc_to_dest=True accumulates `get_num_tiles_per_accumulation(True)` result tiles into
     dest, so it only makes sense when the tile count is a non-zero multiple of that.
     """
-    _, input_dimensions, _ = dest_sync_dims_dest_acc
     total_tiles = (
         input_dimensions[0] * input_dimensions[1]
     ) // _TILE_SHAPE.total_tile_size()
@@ -116,12 +115,17 @@ ELTWISE_FORMATS = input_output_formats(
         if not formats.input_format.is_mx_format()
         else [ImpliedMathFormat.Yes]
     ),
-    dest_sync_dims_dest_acc=lambda formats: (
-        eltwise_dimensions_dest_sync((DestAccumulation.Yes,))
+    dest_sync_dest_acc=lambda formats: (
+        _eltwise_dest_acc_sync((DestAccumulation.Yes,))
         if formats.input_format == DataFormat.Int8
-        else eltwise_dimensions_dest_sync((DestAccumulation.No,))
+        else _eltwise_dest_acc_sync((DestAccumulation.No,))
     ),
-    acc_to_dest=valid_acc_to_dest,
+    input_dimensions=runtime(
+        lambda dest_sync_dest_acc: generate_unary_input_dimensions(
+            dest_sync_dest_acc[1], dest_sync_dest_acc[0]
+        )
+    ),
+    acc_to_dest=runtime(valid_acc_to_dest),
     num_faces=[4],
 )
 def test_eltwise_binary(
@@ -129,12 +133,13 @@ def test_eltwise_binary(
     mathop,
     math_fidelity,
     implied_math_format,
-    dest_sync_dims_dest_acc,
+    dest_sync_dest_acc,
+    input_dimensions,
     acc_to_dest,
     num_faces,
     boot_mode=BootMode.DEFAULT,
 ):
-    dest_sync_mode, input_dimensions, dest_acc = dest_sync_dims_dest_acc
+    dest_sync_mode, dest_acc = dest_sync_dest_acc
 
     num_tiles_per_accumulation = get_num_tiles_per_accumulation(acc_to_dest)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -125,7 +125,7 @@ ELTWISE_FORMATS = input_output_formats(
             dest_sync_dest_acc[1], dest_sync_dest_acc[0]
         )
     ),
-    acc_to_dest=runtime(valid_acc_to_dest),
+    acc_to_dest=valid_acc_to_dest,
     num_faces=[4],
 )
 def test_eltwise_binary(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -24,6 +24,7 @@ from helpers.param_config import (
     get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -142,8 +143,8 @@ def valid_output_dimensions(formats, dest_sync_mode, input_dimensions) -> list:
         EltwiseBinaryReuseDestType.DEST_TO_SRCB,
     ],
     dest_sync_mode=[DestSync.Half, DestSync.Full],
-    input_dimensions=INPUT_DIMENSIONS,
-    output_dimensions=valid_output_dimensions,
+    input_dimensions=runtime(INPUT_DIMENSIONS),
+    output_dimensions=runtime(valid_output_dimensions),
 )
 def test_eltwise_binary_reuse_dest_quasar(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -306,13 +306,13 @@ def test_eltwise_binary_reuse_dest_quasar(
         formats,
         templates=[
             MATH_FIDELITY(math_fidelity),
-            generate_input_dim(input_dimensions, input_dimensions),
             MATH_OP(mathop=mathop),
             IMPLIED_MATH_FORMAT(implied_math_format),
             REUSE_DEST_TYPE(reuse_dest_type),
             DEST_SYNC(dest_sync_mode),
         ],
         runtimes=[
+            generate_input_dim(input_dimensions, input_dimensions),
             INPUT_TILE_CNT(tile_cnt_input),
             OUTPUT_TILE_CNT(tile_cnt_output),
             NUM_TILES_IN_BLOCK(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -25,6 +25,7 @@ from helpers.param_config import (
     input_output_formats,
     is_invalid_quasar_sfpu_format_combination,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
@@ -316,7 +317,7 @@ _FLOAT_OPS = [
     implied_math_format=lambda formats_dest_acc: _get_valid_implied_math_formats(
         formats_dest_acc[0]
     ),
-    tile_indices=_TILE_INDEX_VARIANTS,
+    tile_indices=runtime(_TILE_INDEX_VARIANTS),
 )
 def test_eltwise_binary_sfpu_float_quasar(
     formats_dest_acc, implied_math_format, tile_indices, binary_op, mathop
@@ -571,7 +572,7 @@ def _run_max_min(
             else (DestAccumulation.No,)
         ),
     ),
-    tile_indices=_TILE_INDEX_VARIANTS,
+    tile_indices=runtime(_TILE_INDEX_VARIANTS),
 )
 def test_eltwise_binary_sfpu_max_min_float_quasar(
     formats_dest_acc_implied_math_is_max_input_dims,
@@ -601,7 +602,7 @@ def test_eltwise_binary_sfpu_max_min_float_quasar(
         dest_acc_for_format=lambda fmt: (DestAccumulation.Yes,),
         implied_math_formats=(ImpliedMathFormat.No,),
     ),
-    tile_indices=_TILE_INDEX_VARIANTS,
+    tile_indices=runtime(_TILE_INDEX_VARIANTS),
 )
 def test_eltwise_binary_sfpu_max_min_int32_quasar(
     formats_dest_acc_implied_math_is_max_input_dims,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -23,6 +23,8 @@ from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -121,33 +123,27 @@ DATACOPY_FORMATS = input_output_formats(
 ALL_DATACOPY_COMBINATIONS = generate_eltwise_unary_datacopy_combinations(
     DATACOPY_FORMATS
 )
+_COMPILE, _RUNTIME = split_combinations(ALL_DATACOPY_COMBINATIONS, {3, 5, 6})
 
 
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices=ALL_DATACOPY_COMBINATIONS,
-    # don't generate the No variant for them. combo[0] is the InputOutputFormat (input/output pair).
-    implied_math_format=lambda formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices: (
+    compile_params=_COMPILE,
+    runtime_params=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    # don't generate the No variant for them. compile_params[0] is the InputOutputFormat (input/output pair).
+    implied_math_format=lambda compile_params: (
         [ImpliedMathFormat.Yes]
-        if formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices[
-            0
-        ].input_format.is_mx_format()
+        if compile_params[0].input_format.is_mx_format()
         else [ImpliedMathFormat.Yes, ImpliedMathFormat.No]
     ),
 )
 def test_eltwise_unary_datacopy_quasar(
-    formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices,
+    compile_params,
+    runtime_params,
     implied_math_format,
 ):
-    (
-        formats,
-        dest_acc,
-        data_copy_type,
-        input_dimensions,
-        dest_sync_mode,
-        dest_index,
-        tile_dimensions,
-    ) = formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices
+    (formats, dest_acc, data_copy_type, dest_sync_mode) = compile_params
+    input_dimensions, dest_index, tile_dimensions = runtime_params
 
     # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline)
     if (

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -100,10 +100,10 @@ def generate_eltwise_unary_datacopy_combinations(
                                         fmt,
                                         dest_acc,
                                         data_copy_type,
-                                        dimensions,
+                                        runtime(dimensions),
                                         dest_sync,
-                                        edgecase_dest_index,
-                                        tile_dims,
+                                        runtime(edgecase_dest_index),
+                                        runtime(tile_dims),
                                     )
                                 )
 
@@ -123,7 +123,7 @@ DATACOPY_FORMATS = input_output_formats(
 ALL_DATACOPY_COMBINATIONS = generate_eltwise_unary_datacopy_combinations(
     DATACOPY_FORMATS
 )
-_COMPILE, _RUNTIME = split_combinations(ALL_DATACOPY_COMBINATIONS, {3, 5, 6})
+_COMPILE, _RUNTIME = split_combinations(ALL_DATACOPY_COMBINATIONS)
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -24,7 +24,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -123,27 +122,33 @@ DATACOPY_FORMATS = input_output_formats(
 ALL_DATACOPY_COMBINATIONS = generate_eltwise_unary_datacopy_combinations(
     DATACOPY_FORMATS
 )
-_COMPILE, _RUNTIME = split_combinations(ALL_DATACOPY_COMBINATIONS)
 
 
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    runtime_params=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
-    # don't generate the No variant for them. compile_params[0] is the InputOutputFormat (input/output pair).
-    implied_math_format=lambda compile_params: (
+    formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices=ALL_DATACOPY_COMBINATIONS,
+    # don't generate the No variant for them. combo[0] is the InputOutputFormat (input/output pair).
+    implied_math_format=lambda formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices: (
         [ImpliedMathFormat.Yes]
-        if compile_params[0].input_format.is_mx_format()
+        if formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices[
+            0
+        ].input_format.is_mx_format()
         else [ImpliedMathFormat.Yes, ImpliedMathFormat.No]
     ),
 )
 def test_eltwise_unary_datacopy_quasar(
-    compile_params,
-    runtime_params,
+    formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices,
     implied_math_format,
 ):
-    (formats, dest_acc, data_copy_type, dest_sync_mode) = compile_params
-    input_dimensions, dest_index, tile_dimensions = runtime_params
+    (
+        formats,
+        dest_acc,
+        data_copy_type,
+        input_dimensions,
+        dest_sync_mode,
+        dest_index,
+        tile_dimensions,
+    ) = formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices
 
     # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline)
     if (

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -22,6 +22,8 @@ from helpers.param_config import (
     input_output_formats,
     is_invalid_quasar_sfpu_format_combination,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
@@ -692,12 +694,18 @@ def generate_sfpu_unary_combinations():
     return combinations
 
 
+_ALL_SFPU_UNARY_COMBINATIONS = generate_sfpu_unary_combinations()
+_COMPILE, _RUNTIME = split_combinations(_ALL_SFPU_UNARY_COMBINATIONS, {5})
+
+
 @pytest.mark.quasar
 @parametrize(
-    mathop_formats_dest_acc_sync_implied_math_input_dims=generate_sfpu_unary_combinations(),
+    compile_params=_COMPILE,
+    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
 )
 def test_eltwise_unary_sfpu_quasar(
-    mathop_formats_dest_acc_sync_implied_math_input_dims,
+    compile_params,
+    input_dimensions,
 ):
     """
     Consolidated unary-SFPU test on Quasar. One compile-time-selected op per
@@ -706,9 +714,7 @@ def test_eltwise_unary_sfpu_quasar(
     UnarySFPUGolden reference. Typecast sweeps explicit (src, dst) format pairs;
     every other op sweeps the shared format matrix.
     """
-    mathop, formats, dest_acc, dest_sync, implied_math_format, input_dimensions = (
-        mathop_formats_dest_acc_sync_implied_math_input_dims[0]
-    )
+    mathop, formats, dest_acc, dest_sync, implied_math_format = compile_params
 
     is_typecast = mathop == MathOperation.Typecast
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -687,15 +687,14 @@ def generate_sfpu_unary_combinations():
                                     dest_acc,
                                     dest_sync,
                                     implied_math_format,
-                                    input_dimensions,
+                                    runtime(input_dimensions),
                                 )
                             )
 
     return combinations
 
 
-_ALL_SFPU_UNARY_COMBINATIONS = generate_sfpu_unary_combinations()
-_COMPILE, _RUNTIME = split_combinations(_ALL_SFPU_UNARY_COMBINATIONS, {5})
+_COMPILE, _RUNTIME = split_combinations(generate_sfpu_unary_combinations())
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -23,7 +23,6 @@ from helpers.param_config import (
     is_invalid_quasar_sfpu_format_combination,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
@@ -694,17 +693,12 @@ def generate_sfpu_unary_combinations():
     return combinations
 
 
-_COMPILE, _RUNTIME = split_combinations(generate_sfpu_unary_combinations())
-
-
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    mathop_formats_dest_acc_sync_implied_math_input_dims=generate_sfpu_unary_combinations(),
 )
 def test_eltwise_unary_sfpu_quasar(
-    compile_params,
-    input_dimensions,
+    mathop_formats_dest_acc_sync_implied_math_input_dims,
 ):
     """
     Consolidated unary-SFPU test on Quasar. One compile-time-selected op per
@@ -713,7 +707,9 @@ def test_eltwise_unary_sfpu_quasar(
     UnarySFPUGolden reference. Typecast sweeps explicit (src, dst) format pairs;
     every other op sweeps the shared format matrix.
     """
-    mathop, formats, dest_acc, dest_sync, implied_math_format = compile_params
+    mathop, formats, dest_acc, dest_sync, implied_math_format, input_dimensions = (
+        mathop_formats_dest_acc_sync_implied_math_input_dims[0]
+    )
 
     is_typecast = mathop == MathOperation.Typecast
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_add_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_add_quasar.py
@@ -16,6 +16,8 @@ from helpers.param_config import (
     generate_sfpu_format_dest_acc_combinations,
     input_output_formats,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
@@ -56,17 +58,20 @@ SFPU_ADD_COMBINATIONS = [
     for input_dimensions in [[32, 32], [64, 64]]
 ]
 
+_COMPILE, _RUNTIME = split_combinations(SFPU_ADD_COMBINATIONS, {3})
+
 
 @pytest.mark.quasar
-@parametrize(formats_dest_acc_implied_math_input_dims=SFPU_ADD_COMBINATIONS)
-def test_isolate_sfpu_add_quasar(formats_dest_acc_implied_math_input_dims):
+@parametrize(
+    compile_params=_COMPILE,
+    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+)
+def test_isolate_sfpu_add_quasar(compile_params, input_dimensions):
     """
     Test isolated SFPU add (binary): UNPACK2 (UNP_S) x2 -> SrcS -> SFPU -> PACK1 -> L1.
     No MATH kernel (stub only). Two input operands unpacked to SrcS, added, packed.
     """
-    (formats, dest_acc, implied_math_format, input_dimensions) = (
-        formats_dest_acc_implied_math_input_dims[0]
-    )
+    (formats, dest_acc, implied_math_format) = compile_params
 
     torch.manual_seed(42)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_add_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_add_quasar.py
@@ -52,13 +52,13 @@ SFPU_ADD_FORMATS = input_output_formats(
 )
 
 SFPU_ADD_COMBINATIONS = [
-    (fmt, dest_acc, implied_math_format, input_dimensions)
+    (fmt, dest_acc, implied_math_format, runtime(input_dimensions))
     for fmt, dest_acc in generate_sfpu_format_dest_acc_combinations(SFPU_ADD_FORMATS)
     for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
     for input_dimensions in [[32, 32], [64, 64]]
 ]
 
-_COMPILE, _RUNTIME = split_combinations(SFPU_ADD_COMBINATIONS, {3})
+_COMPILE, _RUNTIME = split_combinations(SFPU_ADD_COMBINATIONS)
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_add_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_add_quasar.py
@@ -17,7 +17,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
@@ -58,20 +57,17 @@ SFPU_ADD_COMBINATIONS = [
     for input_dimensions in [[32, 32], [64, 64]]
 ]
 
-_COMPILE, _RUNTIME = split_combinations(SFPU_ADD_COMBINATIONS)
-
 
 @pytest.mark.quasar
-@parametrize(
-    compile_params=_COMPILE,
-    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
-)
-def test_isolate_sfpu_add_quasar(compile_params, input_dimensions):
+@parametrize(formats_dest_acc_implied_math_input_dims=SFPU_ADD_COMBINATIONS)
+def test_isolate_sfpu_add_quasar(formats_dest_acc_implied_math_input_dims):
     """
     Test isolated SFPU add (binary): UNPACK2 (UNP_S) x2 -> SrcS -> SFPU -> PACK1 -> L1.
     No MATH kernel (stub only). Two input operands unpacked to SrcS, added, packed.
     """
-    (formats, dest_acc, implied_math_format) = compile_params
+    (formats, dest_acc, implied_math_format, input_dimensions) = (
+        formats_dest_acc_implied_math_input_dims[0]
+    )
 
     torch.manual_seed(42)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
@@ -53,13 +53,13 @@ SFPU_SQUARE_FORMATS = input_output_formats(
 )
 
 SFPU_SQUARE_COMBINATIONS = [
-    (fmt, dest_acc, implied_math_format, input_dimensions)
+    (fmt, dest_acc, implied_math_format, runtime(input_dimensions))
     for fmt, dest_acc in generate_sfpu_format_dest_acc_combinations(SFPU_SQUARE_FORMATS)
     for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
     for input_dimensions in [[32, 32], [64, 64]]
 ]
 
-_COMPILE, _RUNTIME = split_combinations(SFPU_SQUARE_COMBINATIONS, {3})
+_COMPILE, _RUNTIME = split_combinations(SFPU_SQUARE_COMBINATIONS)
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
@@ -19,7 +19,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
@@ -59,20 +58,17 @@ SFPU_SQUARE_COMBINATIONS = [
     for input_dimensions in [[32, 32], [64, 64]]
 ]
 
-_COMPILE, _RUNTIME = split_combinations(SFPU_SQUARE_COMBINATIONS)
-
 
 @pytest.mark.quasar
-@parametrize(
-    compile_params=_COMPILE,
-    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
-)
-def test_isolate_sfpu_square_quasar(compile_params, input_dimensions):
+@parametrize(formats_dest_acc_implied_math_input_dims=SFPU_SQUARE_COMBINATIONS)
+def test_isolate_sfpu_square_quasar(formats_dest_acc_implied_math_input_dims):
     """
     Test isolated SFPU square: UNPACK2 (UNP_S) -> SrcS -> SFPU -> PACK1 -> L1.
     No MATH kernel (stub only).
     """
-    (formats, dest_acc, implied_math_format) = compile_params
+    (formats, dest_acc, implied_math_format, input_dimensions) = (
+        formats_dest_acc_implied_math_input_dims[0]
+    )
 
     torch.manual_seed(42)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_isolate_sfpu_square_quasar.py
@@ -18,6 +18,8 @@ from helpers.param_config import (
     generate_sfpu_format_dest_acc_combinations,
     input_output_formats,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
@@ -57,17 +59,20 @@ SFPU_SQUARE_COMBINATIONS = [
     for input_dimensions in [[32, 32], [64, 64]]
 ]
 
+_COMPILE, _RUNTIME = split_combinations(SFPU_SQUARE_COMBINATIONS, {3})
+
 
 @pytest.mark.quasar
-@parametrize(formats_dest_acc_implied_math_input_dims=SFPU_SQUARE_COMBINATIONS)
-def test_isolate_sfpu_square_quasar(formats_dest_acc_implied_math_input_dims):
+@parametrize(
+    compile_params=_COMPILE,
+    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+)
+def test_isolate_sfpu_square_quasar(compile_params, input_dimensions):
     """
     Test isolated SFPU square: UNPACK2 (UNP_S) -> SrcS -> SFPU -> PACK1 -> L1.
     No MATH kernel (stub only).
     """
-    (formats, dest_acc, implied_math_format, input_dimensions) = (
-        formats_dest_acc_implied_math_input_dims[0]
-    )
+    (formats, dest_acc, implied_math_format) = compile_params
 
     torch.manual_seed(42)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -255,11 +255,11 @@ def test_matmul(
             ENABLE_DIRECT_INDEXING(enable_direct_indexing),
             DEST_SYNC(dest_sync_mode),
             UNPACK_TRANS_FACES(transpose),
-            NUM_FACES(num_faces, num_faces, num_faces),
         ],
         runtimes=[
             CRK_TILE_DIMM(matmul_dims.ct_dim, matmul_dims.rt_dim, matmul_dims.kt_dim),
             TILE_COUNT(matmul_dims.output_tile_cnt),
+            NUM_FACES(num_faces, num_faces, num_faces),
         ],
         variant_stimuli=StimuliConfig(
             tilized_A.flatten(),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -27,6 +27,7 @@ from helpers.param_config import (
     DEST_SYNC_TILE_LIMITS,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
@@ -48,20 +49,20 @@ from helpers.utils import passed_test
 kt_dims = [1, 2, 4]
 
 
-def matmul_dimensions_dest_sync(dest_acc_modes):
+def _matmul_dest_acc_sync(dest_acc_modes):
     return [
-        (
-            [mt_dim * TILE_DIM, kt_dim * TILE_DIM],
-            [kt_dim * TILE_DIM, nt_dim * TILE_DIM],
-            dest_acc,
-            dest_sync,
-        )
+        (dest_acc, dest_sync)
         for dest_sync in (DestSync.Half, DestSync.Full)
         for dest_acc in dest_acc_modes
-        for max_tiles in (
-            DEST_SYNC_TILE_LIMITS[dest_sync]
-            // (2 if dest_acc == DestAccumulation.Yes else 1),
-        )
+    ]
+
+
+def _matmul_dimensions(dest_acc, dest_sync):
+    max_tiles = DEST_SYNC_TILE_LIMITS[dest_sync] // (
+        2 if dest_acc == DestAccumulation.Yes else 1
+    )
+    return [
+        ([mt_dim * TILE_DIM, kt_dim * TILE_DIM], [kt_dim * TILE_DIM, nt_dim * TILE_DIM])
         for mt_dim in range(1, max_tiles + 1)
         for nt_dim in range(1, max_tiles // mt_dim + 1)
         for kt_dim in kt_dims
@@ -101,10 +102,15 @@ _ARCH = get_chip_architecture()
             MathFidelity.HiFi4,
         ]
     ),
-    dimensions_dest_acc_dest_sync=lambda format: (
-        matmul_dimensions_dest_sync((DestAccumulation.Yes,))
+    dest_acc_dest_sync=lambda format: (
+        _matmul_dest_acc_sync((DestAccumulation.Yes,))
         if format.input_format == DataFormat.Int8
-        else matmul_dimensions_dest_sync((DestAccumulation.Yes, DestAccumulation.No))
+        else _matmul_dest_acc_sync((DestAccumulation.Yes, DestAccumulation.No))
+    ),
+    dimensions=runtime(
+        lambda dest_acc_dest_sync: _matmul_dimensions(
+            dest_acc_dest_sync[0], dest_acc_dest_sync[1]
+        )
     ),
     implied_math_format=lambda format: (
         [ImpliedMathFormat.Yes]
@@ -125,7 +131,8 @@ _ARCH = get_chip_architecture()
 # Note: this test is used to test boot modes, that is why it has them piped as default arguments to the test itself
 def test_matmul(
     math_fidelity,
-    dimensions_dest_acc_dest_sync,
+    dest_acc_dest_sync,
+    dimensions,
     format,
     implied_math_format,
     register_format_hint,
@@ -141,9 +148,8 @@ def test_matmul(
         register_format_hint=register_format_hint,
     )
 
-    input_A_dimensions, input_B_dimensions, dest_acc, dest_sync_mode = (
-        dimensions_dest_acc_dest_sync
-    )
+    dest_acc, dest_sync_mode = dest_acc_dest_sync
+    input_A_dimensions, input_B_dimensions = dimensions
 
     torch_format = format_dict[format.output_format]
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -23,6 +23,7 @@ from helpers.param_config import (
     get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -134,7 +135,7 @@ def generate_qsr_pack_l1_acc_combinations(
         else [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
     ),
     dest_sync_mode=[DestSync.Half, DestSync.Full],
-    input_dimensions=INPUT_DIMENSIONS,
+    input_dimensions=runtime(INPUT_DIMENSIONS),
 )
 def test_pack_l1_acc_quasar(
     formats_dest_acc,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -209,11 +209,11 @@ def test_pack_l1_acc_quasar(
         "sources/quasar/pack_l1_acc_quasar_test.cpp",
         formats,
         templates=[
-            generate_input_dim(input_dimensions, input_dimensions),
             IMPLIED_MATH_FORMAT(implied_math_format),
             DEST_SYNC(dest_sync_mode),
         ],
         runtimes=[
+            generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt),
             NUM_FACES(num_faces),
             NUM_TILES_IN_BLOCK(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -147,9 +147,9 @@ def generate_qsr_pack_combinations(
                                         fmt,
                                         dest_acc,
                                         dest_sync,
-                                        dimensions,
-                                        relu_type,
-                                        tile_dims,
+                                        runtime(dimensions),
+                                        runtime(relu_type),
+                                        runtime(tile_dims),
                                     )
                                 )
 
@@ -173,8 +173,7 @@ PACK_FORMATS = input_output_formats(
 )
 
 
-_PACK_COMBINATIONS = generate_qsr_pack_combinations(PACK_FORMATS)
-_COMPILE, _RUNTIME = split_combinations(_PACK_COMBINATIONS, {3, 4, 5})
+_COMPILE, _RUNTIME = split_combinations(generate_qsr_pack_combinations(PACK_FORMATS))
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -25,7 +25,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (  # generate_stimuli_w_tile_dimensions
@@ -173,17 +172,19 @@ PACK_FORMATS = input_output_formats(
 )
 
 
-_COMPILE, _RUNTIME = split_combinations(generate_qsr_pack_combinations(PACK_FORMATS))
-
-
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    runtime_params=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    formats_dest_acc_sync_dims_relu=generate_qsr_pack_combinations(PACK_FORMATS),
 )
-def test_pack_quasar(compile_params, runtime_params, boot_mode=BootMode.DEFAULT):
-    (formats, dest_acc, dest_sync_mode) = compile_params
-    input_dimensions, relu_type, tile_dimensions = runtime_params
+def test_pack_quasar(formats_dest_acc_sync_dims_relu, boot_mode=BootMode.DEFAULT):
+    (
+        formats,
+        dest_acc,
+        dest_sync_mode,
+        input_dimensions,
+        relu_type,
+        tile_dimensions,
+    ) = formats_dest_acc_sync_dims_relu[0]
 
     tile_shape = construct_tile_shape(tile_dimensions)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -24,6 +24,8 @@ from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (  # generate_stimuli_w_tile_dimensions
@@ -171,19 +173,18 @@ PACK_FORMATS = input_output_formats(
 )
 
 
+_PACK_COMBINATIONS = generate_qsr_pack_combinations(PACK_FORMATS)
+_COMPILE, _RUNTIME = split_combinations(_PACK_COMBINATIONS, {3, 4, 5})
+
+
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_dims_relu=generate_qsr_pack_combinations(PACK_FORMATS),
+    compile_params=_COMPILE,
+    runtime_params=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
 )
-def test_pack_quasar(formats_dest_acc_sync_dims_relu, boot_mode=BootMode.DEFAULT):
-    (
-        formats,
-        dest_acc,
-        dest_sync_mode,
-        input_dimensions,
-        relu_type,
-        tile_dimensions,
-    ) = formats_dest_acc_sync_dims_relu[0]
+def test_pack_quasar(compile_params, runtime_params, boot_mode=BootMode.DEFAULT):
+    (formats, dest_acc, dest_sync_mode) = compile_params
+    input_dimensions, relu_type, tile_dimensions = runtime_params
 
     tile_shape = construct_tile_shape(tile_dimensions)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -141,11 +141,12 @@ def test_pack_untilize_quasar(formats_dest_acc_sync_dimensions):
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.Yes),
             DEST_SYNC(dest_sync_mode),
             UNPACKER_ENGINE_SEL(),
+        ],
+        runtimes=[
             TEST_FACE_DIMS(),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
         ],
-        runtimes=[],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_dummy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_dummy_quasar.py
@@ -41,8 +41,12 @@ def test_sfpu_dummy_quasar():
     configuration = TestConfig(
         "sources/quasar/sfpu_dummy_test.cpp",
         formats,
-        templates=[generate_input_dim(input_dimensions, input_dimensions)],
-        runtimes=[TILE_COUNT(tile_cnt_A), NUM_FACES(4)],
+        templates=[],
+        runtimes=[
+            generate_input_dim(input_dimensions, input_dimensions),
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(4),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
@@ -231,10 +231,10 @@ def test_sfpu_exp_parallel_matmul_quasar(format_dest_acc_sync_implied_math):
             ENABLE_DIRECT_INDEXING(False),
             DEST_SYNC(dest_sync),
             UNPACK_TRANS_FACES(Transpose.No),
-            CRK_TILE_DIMM(matmul_dims.ct_dim, matmul_dims.rt_dim, matmul_dims.kt_dim),
-            NUM_FACES(num_faces, num_faces, num_faces),
         ],
         runtimes=[
+            CRK_TILE_DIMM(matmul_dims.ct_dim, matmul_dims.rt_dim, matmul_dims.kt_dim),
+            NUM_FACES(num_faces, num_faces, num_faces),
             TILE_COUNT(tile_cnt_exp),
         ],
         variant_stimuli=stimuli,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
@@ -103,9 +103,9 @@ def generate_parallel_matmul_exp_combinations(formats_list: list[FormatConfig]):
                             dest_acc,
                             dest_sync,
                             implied_math_format,
-                            exp_input_dimensions,
-                            input_A_dimensions,
-                            input_B_dimensions,
+                            runtime(exp_input_dimensions),
+                            runtime(input_A_dimensions),
+                            runtime(input_B_dimensions),
                         )
                     )
     return combinations
@@ -114,7 +114,7 @@ def generate_parallel_matmul_exp_combinations(formats_list: list[FormatConfig]):
 PARALLEL_MATMUL_EXP_COMBINATIONS = generate_parallel_matmul_exp_combinations(
     SFPU_UNARY_FORMATS
 )
-_COMPILE, _RUNTIME = split_combinations(PARALLEL_MATMUL_EXP_COMBINATIONS, {4, 5, 6})
+_COMPILE, _RUNTIME = split_combinations(PARALLEL_MATMUL_EXP_COMBINATIONS)
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
@@ -33,7 +33,6 @@ from helpers.param_config import (
     generate_sfpu_format_dest_acc_combinations,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
@@ -114,22 +113,22 @@ def generate_parallel_matmul_exp_combinations(formats_list: list[FormatConfig]):
 PARALLEL_MATMUL_EXP_COMBINATIONS = generate_parallel_matmul_exp_combinations(
     SFPU_UNARY_FORMATS
 )
-_COMPILE, _RUNTIME = split_combinations(PARALLEL_MATMUL_EXP_COMBINATIONS)
 
 
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    runtime_dims=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    format_dest_acc_sync_implied_math=PARALLEL_MATMUL_EXP_COMBINATIONS,
 )
-def test_sfpu_exp_parallel_matmul_quasar(compile_params, runtime_dims):
+def test_sfpu_exp_parallel_matmul_quasar(format_dest_acc_sync_implied_math):
     (
         formats,
         dest_acc,
         dest_sync,
         implied_math_format,
-    ) = compile_params
-    exp_input_dimensions, input_A_dimensions, input_B_dimensions = runtime_dims
+        exp_input_dimensions,
+        input_A_dimensions,
+        input_B_dimensions,
+    ) = format_dest_acc_sync_implied_math[0]
 
     matmul_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
@@ -32,6 +32,8 @@ from helpers.param_config import (
     DEST_SYNC_TILE_LIMITS,
     generate_sfpu_format_dest_acc_combinations,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
@@ -112,22 +114,22 @@ def generate_parallel_matmul_exp_combinations(formats_list: list[FormatConfig]):
 PARALLEL_MATMUL_EXP_COMBINATIONS = generate_parallel_matmul_exp_combinations(
     SFPU_UNARY_FORMATS
 )
+_COMPILE, _RUNTIME = split_combinations(PARALLEL_MATMUL_EXP_COMBINATIONS, {4, 5, 6})
 
 
 @pytest.mark.quasar
 @parametrize(
-    format_dest_acc_sync_implied_math=PARALLEL_MATMUL_EXP_COMBINATIONS,
+    compile_params=_COMPILE,
+    runtime_dims=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
 )
-def test_sfpu_exp_parallel_matmul_quasar(format_dest_acc_sync_implied_math):
+def test_sfpu_exp_parallel_matmul_quasar(compile_params, runtime_dims):
     (
         formats,
         dest_acc,
         dest_sync,
         implied_math_format,
-        exp_input_dimensions,
-        input_A_dimensions,
-        input_B_dimensions,
-    ) = format_dest_acc_sync_implied_math[0]
+    ) = compile_params
+    exp_input_dimensions, input_A_dimensions, input_B_dimensions = runtime_dims
 
     matmul_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
@@ -19,12 +19,7 @@ from helpers.llk_params import (
     UnpackerEngine,
     format_dict,
 )
-from helpers.param_config import (
-    input_output_formats,
-    parametrize,
-    runtime,
-    split_combinations,
-)
+from helpers.param_config import input_output_formats, parametrize, runtime
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -125,17 +120,13 @@ SFPU_FILL_INT_FORMATS = input_output_formats(
 )
 
 
-_COMPILE, _RUNTIME = split_combinations(
-    generate_sfpu_fill_combinations(SFPU_FILL_FLOAT_FORMATS, SFPU_FILL_INT_FORMATS)
-)
-
-
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    formats_dest_acc_implied_math_input_dims=generate_sfpu_fill_combinations(
+        SFPU_FILL_FLOAT_FORMATS, SFPU_FILL_INT_FORMATS
+    ),
 )
-def test_sfpu_fill_quasar(compile_params, input_dimensions):
+def test_sfpu_fill_quasar(formats_dest_acc_implied_math_input_dims):
     """
     Test fill operation on Quasar architecture.
 
@@ -154,7 +145,9 @@ def test_sfpu_fill_quasar(compile_params, input_dimensions):
     Since fill ignores input values, the input stimuli are arbitrary —
     typed stimuli are still generated so the unpack path sees a valid buffer.
     """
-    (formats, dest_acc, implied_math_format) = compile_params
+    (formats, dest_acc, implied_math_format, input_dimensions) = (
+        formats_dest_acc_implied_math_input_dims[0]
+    )
 
     is_int_fill = formats.input_format.is_integer()
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
@@ -19,7 +19,12 @@ from helpers.llk_params import (
     UnpackerEngine,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    input_output_formats,
+    parametrize,
+    runtime,
+    split_combinations,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -118,13 +123,18 @@ SFPU_FILL_INT_FORMATS = input_output_formats(
 )
 
 
+_FILL_COMBINATIONS = generate_sfpu_fill_combinations(
+    SFPU_FILL_FLOAT_FORMATS, SFPU_FILL_INT_FORMATS
+)
+_COMPILE, _RUNTIME = split_combinations(_FILL_COMBINATIONS, {3})
+
+
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_implied_math_input_dims=generate_sfpu_fill_combinations(
-        SFPU_FILL_FLOAT_FORMATS, SFPU_FILL_INT_FORMATS
-    ),
+    compile_params=_COMPILE,
+    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
 )
-def test_sfpu_fill_quasar(formats_dest_acc_implied_math_input_dims):
+def test_sfpu_fill_quasar(compile_params, input_dimensions):
     """
     Test fill operation on Quasar architecture.
 
@@ -143,9 +153,7 @@ def test_sfpu_fill_quasar(formats_dest_acc_implied_math_input_dims):
     Since fill ignores input values, the input stimuli are arbitrary —
     typed stimuli are still generated so the unpack path sees a valid buffer.
     """
-    (formats, dest_acc, implied_math_format, input_dimensions) = (
-        formats_dest_acc_implied_math_input_dims[0]
-    )
+    (formats, dest_acc, implied_math_format) = compile_params
 
     is_int_fill = formats.input_format.is_integer()
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
@@ -79,7 +79,7 @@ def generate_sfpu_fill_combinations(
         for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:
             for input_dimensions in [[32, 32], [64, 64]]:
                 combinations.append(
-                    (fmt, dest_acc, implied_math_format, input_dimensions)
+                    (fmt, dest_acc, implied_math_format, runtime(input_dimensions))
                 )
 
     # Int fill: _calculate_fill_int_ with FILL_INT_FORMAT-selected SFPMEM store mode.
@@ -89,7 +89,9 @@ def generate_sfpu_fill_combinations(
         in_fmt = fmt.input_format
         dest_acc = DestAccumulation.Yes if in_fmt.is_32_bit() else DestAccumulation.No
         for input_dimensions in [[32, 32], [64, 64]]:
-            combinations.append((fmt, dest_acc, ImpliedMathFormat.No, input_dimensions))
+            combinations.append(
+                (fmt, dest_acc, ImpliedMathFormat.No, runtime(input_dimensions))
+            )
 
     return combinations
 
@@ -123,10 +125,9 @@ SFPU_FILL_INT_FORMATS = input_output_formats(
 )
 
 
-_FILL_COMBINATIONS = generate_sfpu_fill_combinations(
-    SFPU_FILL_FLOAT_FORMATS, SFPU_FILL_INT_FORMATS
+_COMPILE, _RUNTIME = split_combinations(
+    generate_sfpu_fill_combinations(SFPU_FILL_FLOAT_FORMATS, SFPU_FILL_INT_FORMATS)
 )
-_COMPILE, _RUNTIME = split_combinations(_FILL_COMBINATIONS, {3})
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_trisc3_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_trisc3_quasar.py
@@ -23,7 +23,6 @@ from helpers.param_config import (
     is_invalid_quasar_sfpu_format_combination,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -86,26 +85,23 @@ def generate_sfpu_square_combinations(formats_list):
     return combinations
 
 
-_COMPILE, _RUNTIME = split_combinations(
-    generate_sfpu_square_combinations(SFPU_SQUARE_FORMATS)
-)
-
-
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    formats_dest_acc_sync_implied_math_dims=generate_sfpu_square_combinations(
+        SFPU_SQUARE_FORMATS
+    ),
 )
 def test_sfpu_square_trisc3_quasar(
-    compile_params,
-    input_dimensions,
+    formats_dest_acc_sync_implied_math_dims,
 ):
     """
     Test square operation on Quasar with SFPU on TRISC3.
 
     Same parameter coverage as test_sfpu_square_quasar.
     """
-    (formats, dest_acc, dest_sync_mode, implied_math_format) = compile_params
+    formats, dest_acc, dest_sync_mode, implied_math_format, input_dimensions = (
+        formats_dest_acc_sync_implied_math_dims[0]
+    )
 
     torch.manual_seed(42)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_trisc3_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_trisc3_quasar.py
@@ -80,14 +80,15 @@ def generate_sfpu_square_combinations(formats_list):
                                 dest_acc,
                                 dest_sync,
                                 implied_math_format,
-                                input_dimensions,
+                                runtime(input_dimensions),
                             )
                         )
     return combinations
 
 
-_TRISC3_COMBINATIONS = generate_sfpu_square_combinations(SFPU_SQUARE_FORMATS)
-_COMPILE, _RUNTIME = split_combinations(_TRISC3_COMBINATIONS, {4})
+_COMPILE, _RUNTIME = split_combinations(
+    generate_sfpu_square_combinations(SFPU_SQUARE_FORMATS)
+)
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_trisc3_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_trisc3_quasar.py
@@ -22,6 +22,8 @@ from helpers.llk_params import (
 from helpers.param_config import (
     is_invalid_quasar_sfpu_format_combination,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -84,23 +86,25 @@ def generate_sfpu_square_combinations(formats_list):
     return combinations
 
 
+_TRISC3_COMBINATIONS = generate_sfpu_square_combinations(SFPU_SQUARE_FORMATS)
+_COMPILE, _RUNTIME = split_combinations(_TRISC3_COMBINATIONS, {4})
+
+
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_implied_math_dims=generate_sfpu_square_combinations(
-        SFPU_SQUARE_FORMATS
-    ),
+    compile_params=_COMPILE,
+    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
 )
 def test_sfpu_square_trisc3_quasar(
-    formats_dest_acc_sync_implied_math_dims,
+    compile_params,
+    input_dimensions,
 ):
     """
     Test square operation on Quasar with SFPU on TRISC3.
 
     Same parameter coverage as test_sfpu_square_quasar.
     """
-    formats, dest_acc, dest_sync_mode, implied_math_format, input_dimensions = (
-        formats_dest_acc_sync_implied_math_dims[0]
-    )
+    (formats, dest_acc, dest_sync_mode, implied_math_format) = compile_params
 
     torch.manual_seed(42)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_swiglu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_swiglu_quasar.py
@@ -42,6 +42,7 @@ from helpers.param_config import (
     generate_sfpu_format_dest_acc_combinations,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -287,7 +288,7 @@ SFPU_SWIGLU_FORMATS = input_output_formats(
     formats_dest_acc_implied_math=_generate_sfpu_swiglu_combinations(
         SFPU_SWIGLU_FORMATS
     ),
-    distribution=list(_StimulusDistribution),
+    distribution=runtime(list(_StimulusDistribution)),
 )
 def test_sfpu_swiglu_quasar(formats_dest_acc_implied_math, distribution):
     """

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_where_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_where_quasar.py
@@ -18,6 +18,7 @@ from helpers.param_config import (
     generate_sfpu_format_dest_acc_combinations,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -104,7 +105,7 @@ def _is_unpack_to_dest(fmt: FormatConfig, dest_acc: DestAccumulation) -> bool:
     implied_math_format=lambda formats_dest_acc: _get_valid_implied_math_formats(
         formats_dest_acc[0]
     ),
-    test_case=["mixed", "all_ones", "all_zeros"],
+    test_case=runtime(["mixed", "all_ones", "all_zeros"]),
     vector_mode=[VectorMode.None_, VectorMode.R, VectorMode.C, VectorMode.RC],
 )
 def test_sfpu_where_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -26,7 +26,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -142,23 +141,21 @@ TRANSPOSE_DEST_FORMATS = input_output_formats(
     ],
 )
 
-_COMPILE, _RUNTIME = split_combinations(
-    generate_qsr_transpose_dest_combinations(TRANSPOSE_DEST_FORMATS)
-)
-
 
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    formats_dest_acc_sync_transpose_dims=generate_qsr_transpose_dest_combinations(
+        TRANSPOSE_DEST_FORMATS
+    ),
     implied_math_format=[ImpliedMathFormat.No, ImpliedMathFormat.Yes],
 )
 def test_transpose_dest_quasar(
-    compile_params,
-    input_dimensions,
+    formats_dest_acc_sync_transpose_dims,
     implied_math_format,
 ):
-    (formats, dest_acc, dest_sync, math_transpose_faces) = compile_params
+    (formats, dest_acc, dest_sync, math_transpose_faces, input_dimensions) = (
+        formats_dest_acc_sync_transpose_dims
+    )
 
     data_copy_type = DataCopyType.A2D
     num_faces = 4

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -25,6 +25,8 @@ from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -140,21 +142,24 @@ TRANSPOSE_DEST_FORMATS = input_output_formats(
     ],
 )
 
+_ALL_TRANSPOSE_DEST_COMBINATIONS = generate_qsr_transpose_dest_combinations(
+    TRANSPOSE_DEST_FORMATS
+)
+_COMPILE, _RUNTIME = split_combinations(_ALL_TRANSPOSE_DEST_COMBINATIONS, {4})
+
 
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_transpose_dims=generate_qsr_transpose_dest_combinations(
-        TRANSPOSE_DEST_FORMATS
-    ),
+    compile_params=_COMPILE,
+    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
     implied_math_format=[ImpliedMathFormat.No, ImpliedMathFormat.Yes],
 )
 def test_transpose_dest_quasar(
-    formats_dest_acc_sync_transpose_dims,
+    compile_params,
+    input_dimensions,
     implied_math_format,
 ):
-    (formats, dest_acc, dest_sync, math_transpose_faces, input_dimensions) = (
-        formats_dest_acc_sync_transpose_dims
-    )
+    (formats, dest_acc, dest_sync, math_transpose_faces) = compile_params
 
     data_copy_type = DataCopyType.A2D
     num_faces = 4

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -121,7 +121,7 @@ def generate_qsr_transpose_dest_combinations(
                                     dest_acc,
                                     dest_sync,
                                     math_transpose_faces,
-                                    dimensions,
+                                    runtime(dimensions),
                                 )
                             )
 
@@ -142,10 +142,9 @@ TRANSPOSE_DEST_FORMATS = input_output_formats(
     ],
 )
 
-_ALL_TRANSPOSE_DEST_COMBINATIONS = generate_qsr_transpose_dest_combinations(
-    TRANSPOSE_DEST_FORMATS
+_COMPILE, _RUNTIME = split_combinations(
+    generate_qsr_transpose_dest_combinations(TRANSPOSE_DEST_FORMATS)
 )
-_COMPILE, _RUNTIME = split_combinations(_ALL_TRANSPOSE_DEST_COMBINATIONS, {4})
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -139,12 +139,12 @@ def test_unary_broadcast_quasar(
         "sources/quasar/eltwise_unary_broadcast_quasar_test.cpp",
         formats,
         templates=[
-            generate_input_dim(input_dimensions, input_dimensions),
             IMPLIED_MATH_FORMAT(implied_math_format),
             BROADCAST_TYPE(broadcast_type),
             DEST_SYNC(dest_sync_mode),
         ],
         runtimes=[
+            generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt),
             NUM_FACES(num_faces),
             NUM_TILES_IN_BLOCK(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -21,6 +21,7 @@ from helpers.param_config import (
     get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_config import BootMode, TestConfig
@@ -81,7 +82,7 @@ def get_valid_dest_acc_unary_broadcast(formats):
         else [ImpliedMathFormat.Yes]
     ),
     dest_sync_mode=[DestSync.Half, DestSync.Full],
-    input_dimensions=INPUT_DIMENSIONS,
+    input_dimensions=runtime(INPUT_DIMENSIONS),
 )
 def test_unary_broadcast_quasar(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -29,6 +29,8 @@ from helpers.llk_params import (
 from helpers.param_config import (
     input_output_formats,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -142,19 +144,22 @@ ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS = (
         UNPACK_REDUCE_COL_TILIZEA_STRIDED_FORMATS
     )
 )
+_COMPILE, _RUNTIME = split_combinations(
+    ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS, {3}
+)
 
 
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims=ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS,
+    compile_params=_COMPILE,
+    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
 )
 def test_unpack_reduce_col_tilizeA_strided_quasar(
-    formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims,
+    compile_params,
+    input_dimensions,
     boot_mode=BootMode.DEFAULT,
 ):
-    (formats, dest_acc, dest_sync_mode, input_dimensions, pool_type) = (
-        formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims[0]
-    )
+    (formats, dest_acc, dest_sync_mode, pool_type) = compile_params
 
     num_faces = 4
     reduce_dim = ReduceDimension.Column

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -123,7 +123,7 @@ def generate_unpack_reduce_col_tilizeA_strided_combinations(
                         if pool_type == ReducePool.Average and in_fmt.is_integer():
                             continue
                         combinations.append(
-                            (fmt, acc, dest_sync, dimensions, pool_type)
+                            (fmt, acc, dest_sync, runtime(dimensions), pool_type)
                         )
 
     return combinations
@@ -145,7 +145,7 @@ ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS = (
     )
 )
 _COMPILE, _RUNTIME = split_combinations(
-    ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS, {3}
+    ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS
 )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -205,16 +205,17 @@ def test_unpack_reduce_col_tilizeA_strided_quasar(
         "sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp",
         formats,
         templates=[
-            generate_input_dim(input_dimensions, input_dimensions),
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
             MATH_OP(mathop=mathop, pool_type=pool_type),
             MATH_FIDELITY(math_fidelity),
             DEST_SYNC(dest_sync_mode),
+        ],
+        runtimes=[
+            generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt_A),
             TEST_FACE_DIMS(),
             NUM_FACES(),
         ],
-        runtimes=[],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -30,7 +30,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -144,22 +143,19 @@ ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS = (
         UNPACK_REDUCE_COL_TILIZEA_STRIDED_FORMATS
     )
 )
-_COMPILE, _RUNTIME = split_combinations(
-    ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS
-)
 
 
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    input_dimensions=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims=ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS,
 )
 def test_unpack_reduce_col_tilizeA_strided_quasar(
-    compile_params,
-    input_dimensions,
+    formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims,
     boot_mode=BootMode.DEFAULT,
 ):
-    (formats, dest_acc, dest_sync_mode, pool_type) = compile_params
+    (formats, dest_acc, dest_sync_mode, input_dimensions, pool_type) = (
+        formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims[0]
+    )
 
     num_faces = 4
     reduce_dim = ReduceDimension.Column

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
@@ -150,11 +150,12 @@ def test_unpack_tilize_quasar(
                 else DataCopyType.A2D
             ),
             DEST_SYNC(dest_sync_mode),
+        ],
+        runtimes=[
             TILE_COUNT(tile_cnt_A),
             TEST_FACE_DIMS(),
             NUM_FACES(),
         ],
-        runtimes=[],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -25,6 +25,8 @@ from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
+    runtime,
+    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (  # generate_stimuli_w_tile_dimensions
@@ -146,25 +148,21 @@ UNPACK_FORMATS = input_output_formats(
 ALL_UNPACK_UNARY_OPERAND_COMBINATIONS = generate_unpack_unary_operand_combinations(
     UNPACK_FORMATS
 )
+_COMPILE, _RUNTIME = split_combinations(ALL_UNPACK_UNARY_OPERAND_COMBINATIONS, {5, 6})
 
 
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_transpose_unpack_sel_dims=ALL_UNPACK_UNARY_OPERAND_COMBINATIONS,
+    compile_params=_COMPILE,
+    runtime_params=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
 )
 def test_unpack_unary_operand_quasar(
-    formats_dest_acc_sync_transpose_unpack_sel_dims,
+    compile_params,
+    runtime_params,
     boot_mode=BootMode.DEFAULT,
 ):
-    (
-        formats,
-        dest_acc,
-        dest_sync_mode,
-        transpose_en,
-        unpacker_sel,
-        input_dimensions,
-        tile_dimensions,
-    ) = formats_dest_acc_sync_transpose_unpack_sel_dims[0]
+    (formats, dest_acc, dest_sync_mode, transpose_en, unpacker_sel) = compile_params
+    input_dimensions, tile_dimensions = runtime_params
 
     tile_shape = construct_tile_shape(tile_dimensions)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -126,8 +126,8 @@ def generate_unpack_unary_operand_combinations(
                                         dest_sync,
                                         transpose_en,
                                         unpacker_sel,
-                                        dimensions,
-                                        tile_dims,
+                                        runtime(dimensions),
+                                        runtime(tile_dims),
                                     )
                                 )
 
@@ -148,7 +148,7 @@ UNPACK_FORMATS = input_output_formats(
 ALL_UNPACK_UNARY_OPERAND_COMBINATIONS = generate_unpack_unary_operand_combinations(
     UNPACK_FORMATS
 )
-_COMPILE, _RUNTIME = split_combinations(ALL_UNPACK_UNARY_OPERAND_COMBINATIONS, {5, 6})
+_COMPILE, _RUNTIME = split_combinations(ALL_UNPACK_UNARY_OPERAND_COMBINATIONS)
 
 
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -26,7 +26,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    split_combinations,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (  # generate_stimuli_w_tile_dimensions
@@ -148,21 +147,25 @@ UNPACK_FORMATS = input_output_formats(
 ALL_UNPACK_UNARY_OPERAND_COMBINATIONS = generate_unpack_unary_operand_combinations(
     UNPACK_FORMATS
 )
-_COMPILE, _RUNTIME = split_combinations(ALL_UNPACK_UNARY_OPERAND_COMBINATIONS)
 
 
 @pytest.mark.quasar
 @parametrize(
-    compile_params=_COMPILE,
-    runtime_params=runtime(lambda compile_params: _RUNTIME[repr(compile_params)]),
+    formats_dest_acc_sync_transpose_unpack_sel_dims=ALL_UNPACK_UNARY_OPERAND_COMBINATIONS,
 )
 def test_unpack_unary_operand_quasar(
-    compile_params,
-    runtime_params,
+    formats_dest_acc_sync_transpose_unpack_sel_dims,
     boot_mode=BootMode.DEFAULT,
 ):
-    (formats, dest_acc, dest_sync_mode, transpose_en, unpacker_sel) = compile_params
-    input_dimensions, tile_dimensions = runtime_params
+    (
+        formats,
+        dest_acc,
+        dest_sync_mode,
+        transpose_en,
+        unpacker_sel,
+        input_dimensions,
+        tile_dimensions,
+    ) = formats_dest_acc_sync_transpose_unpack_sel_dims[0]
 
     tile_shape = construct_tile_shape(tile_dimensions)
 

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -42,7 +42,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_desc_src_a.buf_desc.f.lmt_addr_16B = 0;
     tdma_desc_src_a.buf_desc.f.x_dim        = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
     tdma_desc_src_a.buf_desc.f.y_dim        = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-    tdma_desc_src_a.buf_desc.f.z_dim        = num_faces_A; // Number of faces = 4, tiny tiles not supported for quasar
+    tdma_desc_src_a.buf_desc.f.z_dim        = params.num_faces_A; // Number of faces = 4, tiny tiles not supported for quasar
     tdma_desc_src_a.buf_desc_id             = buf_desc_id_src_a;
     tdma_desc_src_a.reg_data_format         = static_cast<std::uint32_t>(formats.unpack_A_dst);
 
@@ -53,7 +53,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_desc_src_b.buf_desc.f.lmt_addr_16B = 0;
     tdma_desc_src_b.buf_desc.f.x_dim        = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
     tdma_desc_src_b.buf_desc.f.y_dim        = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-    tdma_desc_src_b.buf_desc.f.z_dim        = num_faces_B; // Number of faces = 4, tiny tiles not supported for quasar
+    tdma_desc_src_b.buf_desc.f.z_dim        = params.num_faces_B; // Number of faces = 4, tiny tiles not supported for quasar
     tdma_desc_src_b.buf_desc_id             = buf_desc_id_src_b;
     tdma_desc_src_b.reg_data_format         = static_cast<std::uint32_t>(formats.unpack_B_dst);
 
@@ -132,7 +132,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_desc_dst.buf_desc.f.format       = static_cast<std::uint8_t>(formats.pack_dst);
     tdma_desc_dst.buf_desc.f.x_dim        = FACE_C_DIM;
     tdma_desc_dst.buf_desc.f.y_dim        = FACE_R_DIM;
-    tdma_desc_dst.buf_desc.f.z_dim        = num_faces;
+    tdma_desc_dst.buf_desc.f.z_dim        = params.num_faces;
     tdma_desc_dst.buf_desc_id             = buf_desc_id_dst;
     tdma_desc_dst.reg_data_format         = static_cast<std::uint8_t>(formats.pack_src);
 

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -26,7 +26,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
     tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id          = 0;
-    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
 
     // Setup data valid scheme
     if constexpr (unpack_to_dest)
@@ -56,9 +56,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = params.buffer_A[0] / 16;
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = num_faces;
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = params.num_faces;
 
     td_val.buf_desc        = bd_val;
     td_val.buf_desc_id     = buf_desc_id;
@@ -130,12 +130,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
         }
 
-        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
+            params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
         for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
         {
             for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
             {
-                _llk_math_eltwise_unary_datacopy_(num_faces * TEST_FACE_R_DIM /*num_rows_per_tile*/, block_ct);
+                _llk_math_eltwise_unary_datacopy_(params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_tile*/, block_ct);
             }
             _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
         }
@@ -171,9 +172,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = params.buffer_Res[0] / 16;
     bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = num_faces;
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = params.num_faces;
 
     tdma_desc.buf_desc        = bd_val;
     tdma_desc.buf_desc_id     = buf_desc_id;

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
@@ -40,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_desc_src_a.buf_desc.f.lmt_addr_16B = 0;
     tdma_desc_src_a.buf_desc.f.x_dim        = FACE_C_DIM;
     tdma_desc_src_a.buf_desc.f.y_dim        = FACE_R_DIM;
-    tdma_desc_src_a.buf_desc.f.z_dim        = num_faces_A;
+    tdma_desc_src_a.buf_desc.f.z_dim        = params.num_faces_A;
     tdma_desc_src_a.buf_desc_id             = buf_desc_id_src_a;
     tdma_desc_src_a.reg_data_format         = static_cast<std::uint32_t>(formats.unpack_A_dst);
 
@@ -50,7 +50,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_desc_src_b.buf_desc.f.lmt_addr_16B = 0;
     tdma_desc_src_b.buf_desc.f.x_dim        = FACE_C_DIM;
     tdma_desc_src_b.buf_desc.f.y_dim        = FACE_R_DIM;
-    tdma_desc_src_b.buf_desc.f.z_dim        = num_faces_B;
+    tdma_desc_src_b.buf_desc.f.z_dim        = params.num_faces_B;
     tdma_desc_src_b.buf_desc_id             = buf_desc_id_src_b;
     tdma_desc_src_b.reg_data_format         = static_cast<std::uint32_t>(formats.unpack_B_dst);
 
@@ -58,11 +58,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _configure_buf_desc_table_(tdma_desc_src_b.buf_desc_id, tdma_desc_src_b.buf_desc);
     _llk_unpack_configure_binary_<p_unpacr::UNP_B, p_unpacr::UNP_A>(tdma_desc_src_a, tdma_desc_src_b);
 
-    _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(buf_desc_id_src_a, buf_desc_id_src_b, CT_DIM, RT_DIM, KT_DIM);
+    _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(buf_desc_id_src_a, buf_desc_id_src_b, params.CT_DIM, params.RT_DIM, params.KT_DIM);
 
-    for (std::uint32_t j = 0; j < KT_DIM; j++)
+    for (std::uint32_t j = 0; j < params.KT_DIM; j++)
     {
-        _llk_unpack_matmul_(CT_DIM, RT_DIM, KT_DIM, j, j * CT_DIM);
+        _llk_unpack_matmul_(params.CT_DIM, params.RT_DIM, params.KT_DIM, j, j * params.CT_DIM);
     }
 }
 
@@ -83,11 +83,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false>(
         static_cast<DataFormat>(formats.math), static_cast<DataFormat>(formats.math));
-    _llk_math_matmul_init_<(ckernel::MathFidelity)MATH_FIDELITY, ENABLE_DIRECT_INDEXING, ENABLE_2X_FORMAT>(CT_DIM, RT_DIM);
+    _llk_math_matmul_init_<(ckernel::MathFidelity)MATH_FIDELITY, ENABLE_DIRECT_INDEXING, ENABLE_2X_FORMAT>(params.CT_DIM, params.RT_DIM);
 
-    for (std::uint32_t i = 0; i < KT_DIM; i++)
+    for (std::uint32_t i = 0; i < params.KT_DIM; i++)
     {
-        _llk_math_matmul_block_(CT_DIM, RT_DIM);
+        _llk_math_matmul_block_(params.CT_DIM, params.RT_DIM);
     }
     _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
 }
@@ -206,13 +206,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_desc_dst.buf_desc.f.format       = static_cast<std::uint8_t>(formats.pack_dst);
     tdma_desc_dst.buf_desc.f.x_dim        = FACE_C_DIM;
     tdma_desc_dst.buf_desc.f.y_dim        = FACE_R_DIM;
-    tdma_desc_dst.buf_desc.f.z_dim        = num_faces;
+    tdma_desc_dst.buf_desc.f.z_dim        = params.num_faces;
     tdma_desc_dst.buf_desc_id             = buf_desc_id_dst;
     tdma_desc_dst.reg_data_format         = static_cast<std::uint8_t>(formats.pack_src);
 
     _configure_buf_desc_table_(tdma_desc_dst.buf_desc_id, tdma_desc_dst.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc_dst);
-    _llk_pack_matmul_init_(buf_desc_id_dst, RT_DIM, CT_DIM, 1);
+    _llk_pack_matmul_init_(buf_desc_id_dst, params.RT_DIM, params.CT_DIM, 1);
 
     _llk_pack_matmul_(0, 0);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -29,7 +29,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     buffer_descriptor_u bd_val_A {};
     bd_val_A.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
     bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val_A.f.x_dim       = TEST_FACE_C_DIM;
+    bd_val_A.f.x_dim       = params.TEST_FACE_C_DIM;
     bd_val_A.f.y_dim       = 1;
     bd_val_A.f.z_dim       = 1;
 
@@ -41,9 +41,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     buffer_descriptor_u bd_val_B {};
     bd_val_B.f.l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
     bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
-    bd_val_B.f.x_dim       = TEST_FACE_C_DIM;
-    bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
-    bd_val_B.f.z_dim       = num_faces;
+    bd_val_B.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val_B.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val_B.f.z_dim       = params.num_faces;
 
     tdma_descriptor_t td_val_B;
     td_val_B.buf_desc        = bd_val_B;
@@ -55,13 +55,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
 
     constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
-    _llk_unpack_reduce_col_tilizeA_strided_init_(buf_desc_id_a, buf_desc_id_b, FULL_CT_DIM, tensor_shape);
+    _llk_unpack_reduce_col_tilizeA_strided_init_(buf_desc_id_a, buf_desc_id_b, params.FULL_CT_DIM, tensor_shape);
 
-    std::uint32_t y_stride_external = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
-    for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
+    std::uint32_t y_stride_external = params.FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
+    for (std::uint32_t block_rt = 0; block_rt < params.BLOCK_RT_DIM; block_rt++)
     {
         std::uint32_t offset = block_rt * y_stride_external;
-        for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
+        for (std::uint32_t block_ct = 0; block_ct < params.BLOCK_CT_DIM; block_ct++)
         {
             const std::uint32_t l1_unpack_tilize_idx = offset + block_ct;
             _llk_unpack_reduce_col_tilizeA_strided_(tensor_shape, l1_unpack_tilize_idx, 0);
@@ -100,7 +100,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE);
 
-    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         _llk_math_reduce_(i);
     }
@@ -122,16 +122,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     std::uint32_t const buf_desc_id        = 8;
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
+    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
     buffer_descriptor_u bd_val = {0};
     bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
     bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = num_faces;
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
 
     tdma_descriptor_t tdma_desc;
     tdma_desc.buf_desc        = bd_val;

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -61,9 +61,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     bd_val.f.l1_addr_16B = l1_addr_16B;
     bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = num_faces;
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = params.num_faces;
 
     td_val.buf_desc        = bd_val;
     td_val.buf_desc_id     = buf_desc_id;
@@ -133,10 +133,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         DataFormat src_format = static_cast<DataFormat>(formats.math);
         _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
 
-        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-        for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
+            params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
         {
-            _llk_math_eltwise_unary_datacopy_(num_faces * TEST_FACE_R_DIM /*num_rows_per_tile*/, i);
+            _llk_math_eltwise_unary_datacopy_(params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_tile*/, i);
         }
         _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
     }
@@ -156,7 +157,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     std::uint32_t const buf_desc_id        = 8;
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
+    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     constexpr auto dest_producer = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_producer, dest_dvalid_client::PACK});
@@ -164,9 +165,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     buffer_descriptor_u bd_val = {0};
     bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
     bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = num_faces;
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
 
     tdma_descriptor_t tdma_desc;
     tdma_desc.buf_desc        = bd_val;


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Performance

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Reduce quasar `--compile-producer` from ~413k to ~20k test variants by tagging runtime only parameters with runtime() markers so tests that share the same compiled ELF are deduplicated during collection.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fast-qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:markoradosavljevic/fast-qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:markoradosavljevic/fast-qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fast-qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:markoradosavljevic/fast-qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fast-qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fast-qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/fast-qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fast-qsr)