### PR TITLE
[ops] Trace-safety fatal for auto-config matmul, with opt-in TracePolicy

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3937,3 +3937,88 @@ def test_matmul_kt_not_divisible_by_in0_block_w_rejected(device, expect_error):
 
     with expect_error(RuntimeError, r"Kt \(4\) must be divisible by in0_block_w \(3\)"):
         ttnn.matmul(in0, in1, program_config=program_config)
+
+
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 10_000_000}], indirect=True)
+def test_matmul_without_program_config_fatals_under_require_stable_cache(device, expect_error):
+    """ttnn.matmul without a program_config must raise when REQUIRE_STABLE_CACHE is set.
+
+    Auto-config queries live device L1 space, making the program cache key
+    non-deterministic. A capture that opts into REQUIRE_STABLE_CACHE forbids such
+    ops so the trace is reproducible across replays.
+
+    Related issue: https://github.com/tenstorrent/tt-metal/issues/48275
+    """
+    a = ttnn.from_torch(torch.zeros(1, 1, 32, 64, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.zeros(1, 1, 64, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Sanity: works fine outside trace capture.
+    out = ttnn.matmul(a, b)
+    assert out.shape == (1, 1, 32, 32)
+
+    # Inside a REQUIRE_STABLE_CACHE capture it must fatal with a clear message.
+    tid = ttnn.begin_trace_capture(device, cq_id=0, policy=ttnn.TracePolicy.REQUIRE_STABLE_CACHE)
+    try:
+        with expect_error(RuntimeError, "not trace-safe"):
+            ttnn.matmul(a, b)
+    finally:
+        ttnn.end_trace_capture(device, tid, cq_id=0)
+
+
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 10_000_000}], indirect=True)
+def test_matmul_with_program_config_succeeds_during_trace(device):
+    """ttnn.matmul with an explicit program_config must work inside trace capture."""
+    a = ttnn.from_torch(torch.zeros(1, 1, 32, 64, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.zeros(1, 1, 64, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=2,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=1,
+        per_core_N=1,
+    )
+
+    ttnn.matmul(a, b, program_config=program_config)
+    ttnn.synchronize_device(device)
+
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    ttnn.matmul(a, b, program_config=program_config)
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+    ttnn.release_trace(device, tid)
+
+
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 10_000_000}], indirect=True)
+def test_matmul_without_program_config_allowed_by_default(device):
+    """ttnn.matmul without a program_config is permitted in a default (NONE) capture.
+
+    The default policy enforces no checks, so auto-config matmul is allowed inside
+    trace capture and the captured trace must replay successfully. A caller that needs
+    reproducibility opts into REQUIRE_STABLE_CACHE (see the fatal test above).
+    """
+    a = ttnn.from_torch(torch.zeros(1, 1, 32, 64, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.zeros(1, 1, 64, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Warm up the auto-config path / program cache outside capture first.
+    ttnn.matmul(a, b)
+    ttnn.synchronize_device(device)
+
+    # Default policy (NONE) — no program_config needed.
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    ttnn.matmul(a, b)
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+    ttnn.release_trace(device, tid)
+
+
+def test_trace_policy_is_a_flag():
+    """TracePolicy must behave like an enum.Flag: NONE is empty, bits compose with |."""
+    assert int(ttnn.TracePolicy.NONE.value) == 0
+    combined = ttnn.TracePolicy.NONE | ttnn.TracePolicy.REQUIRE_STABLE_CACHE
+    assert combined & ttnn.TracePolicy.REQUIRE_STABLE_CACHE
+    # NONE carries no policy bit.
+    assert not (ttnn.TracePolicy.NONE & ttnn.TracePolicy.REQUIRE_STABLE_CACHE)

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -24,6 +24,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/trace_policy.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/sub_device_types.hpp>
@@ -75,6 +76,8 @@ public:
     MeshDevice* device() const { return mesh_device_; }
     uint32_t id() const { return id_; }
     virtual std::optional<MeshTraceId> trace_id() const = 0;
+    // The trace policy active for the current capture region (NONE when not capturing).
+    virtual TracePolicy trace_policy() const = 0;
     virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
     virtual void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) = 0;
 
@@ -145,7 +148,10 @@ public:
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
     virtual void enqueue_wait_for_event(const MeshEvent& sync_event) = 0;
     virtual void finish(ttsl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
-    virtual void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) = 0;
+    virtual void record_begin(
+        const MeshTraceId& trace_id,
+        const std::shared_ptr<MeshTraceDescriptor>& ctx,
+        TracePolicy policy = TracePolicy::NONE) = 0;
     virtual void record_end() = 0;
     virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -30,6 +30,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/trace_policy.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 // UMD: re-exports tt::ARCH (used in MeshDevice::arch return type).
@@ -150,8 +151,8 @@ public:
 
     // MeshTrace Internal APIs - these should be used to deprecate the single device backed trace APIs
     // If cq_id is not provided, the current command queue is returned from the current thread
-    MeshTraceId begin_mesh_trace(uint8_t cq_id);
-    void begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
+    MeshTraceId begin_mesh_trace(uint8_t cq_id, TracePolicy policy = TracePolicy::NONE);
+    void begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, TracePolicy policy = TracePolicy::NONE);
     void end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
     void replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking);
     void release_mesh_trace(const MeshTraceId& trace_id);

--- a/tt_metal/api/tt-metalium/trace_policy.hpp
+++ b/tt_metal/api/tt-metalium/trace_policy.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tt::tt_metal {
+
+// Bit-flag set of policies applied to a trace-capture region.
+//
+// NONE (0) is the default: no policies are enforced. Each named bit opts into one specific
+// behavior for the duration of a capture region. The type is named generically (not "safety")
+// so future trace policies of any kind can be added as additional bits without renaming.
+enum class TracePolicy : uint32_t {
+    NONE = 0,
+    // Opt into a fatal on ops whose program-cache key depends on live device state (e.g. matmul
+    // auto-config, which queries free L1 to pick blocking parameters). Such ops are non-deterministic
+    // across captures; set this bit when the capture must be reproducible and you want it enforced.
+    REQUIRE_STABLE_CACHE = 1u << 0,
+    // FUTURE_POLICY     = 1u << 1,
+};
+
+inline TracePolicy operator|(TracePolicy a, TracePolicy b) {
+    return static_cast<TracePolicy>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+
+// Returns true if `bit` is set within `value`.
+inline bool is_trace_policy_set(TracePolicy value, TracePolicy bit) {
+    return (static_cast<uint32_t>(value) & static_cast<uint32_t>(bit)) != 0;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/dummy_mesh_command_queue.cpp
+++ b/tt_metal/distributed/dummy_mesh_command_queue.cpp
@@ -107,7 +107,7 @@ void DummyMeshCommandQueue::reset_worker_state(
 }
 
 void DummyMeshCommandQueue::record_begin(
-    const MeshTraceId& /*trace_id*/, const std::shared_ptr<MeshTraceDescriptor>& /*ctx*/) {
+    const MeshTraceId& /*trace_id*/, const std::shared_ptr<MeshTraceDescriptor>& /*ctx*/, TracePolicy /*policy*/) {
     TT_THROW("Trace operations not supported for DummyMeshCommandQueue (inactive rank)");
 }
 

--- a/tt_metal/distributed/dummy_mesh_command_queue.hpp
+++ b/tt_metal/distributed/dummy_mesh_command_queue.hpp
@@ -41,6 +41,7 @@ public:
     ~DummyMeshCommandQueue() override = default;
 
     std::optional<MeshTraceId> trace_id() const override;
+    TracePolicy trace_policy() const override { return TracePolicy::NONE; }
 
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override;
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) override;
@@ -64,7 +65,10 @@ public:
         const vector_aligned<uint32_t>& go_signal_noc_data,
         const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping,
         tt::stl::Span<const uint32_t> workers_per_sub_device) override;
-    void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) override;
+    void record_begin(
+        const MeshTraceId& trace_id,
+        const std::shared_ptr<MeshTraceDescriptor>& ctx,
+        TracePolicy policy = TracePolicy::NONE) override;
     void record_end() override;
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;
 };

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1154,7 +1154,8 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
     }
 }
 
-void FDMeshCommandQueue::record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) {
+void FDMeshCommandQueue::record_begin(
+    const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx, TracePolicy policy) {
     auto lock = lock_api_function_();
     trace_dispatch::reset_host_dispatch_state_for_trace(
         mesh_device_->num_sub_devices(),
@@ -1166,6 +1167,7 @@ void FDMeshCommandQueue::record_begin(const MeshTraceId& trace_id, const std::sh
         config_buffer_mgr_reset_);
 
     trace_id_ = trace_id;
+    trace_policy_ = policy;
     trace_ctx_ = ctx;
     for (auto* device : mesh_device_->get_devices()) {
         device->sysmem_manager().set_bypass_mode(/*enable*/ true, /*clear*/ true);
@@ -1498,6 +1500,7 @@ void FDMeshCommandQueue::record_end() {
     trace_nodes_.clear();
 
     trace_id_ = std::nullopt;
+    trace_policy_ = TracePolicy::NONE;
     trace_ctx_ = nullptr;
 
     trace_dispatch::load_host_dispatch_state(

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -104,6 +104,8 @@ private:
     // The following data structures are only popiulated when the MeshCQ is being used to trace workloads
     // i.e. between record_begin() and record_end() being called
     std::optional<MeshTraceId> trace_id_;
+    // Trace policy supplied at record_begin(); reset to NONE at record_end().
+    TracePolicy trace_policy_ = TracePolicy::NONE;
     std::shared_ptr<MeshTraceDescriptor> trace_ctx_;
     std::vector<MeshTraceNode> trace_nodes_;
 
@@ -214,6 +216,8 @@ public:
 
     std::optional<MeshTraceId> trace_id() const override { return this->trace_id_; }
 
+    TracePolicy trace_policy() const override { return this->trace_policy_; }
+
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override { return config_buffer_mgr_[index]; };
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) override;
 
@@ -253,7 +257,10 @@ public:
         const vector_aligned<uint32_t>& go_signal_noc_data,
         const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping,
         tt::stl::Span<const uint32_t> workers_per_sub_device) override;
-    void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) override;
+    void record_begin(
+        const MeshTraceId& trace_id,
+        const std::shared_ptr<MeshTraceDescriptor>& ctx,
+        TracePolicy policy = TracePolicy::NONE) override;
     void record_end() override;
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;
     // Main function (event loop) for the Completion Queue Reader

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1282,13 +1282,13 @@ std::shared_ptr<MeshTraceBuffer> MeshDeviceImpl::get_mesh_trace(const MeshTraceI
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_trace(trace_id);
 }
 
-MeshTraceId MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id) {
+MeshTraceId MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, TracePolicy policy) {
     auto trace_id = MeshTrace::next_id();
-    this->begin_mesh_trace(cq_id, trace_id);
+    this->begin_mesh_trace(cq_id, trace_id, policy);
     return trace_id;
 }
 
-void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
+void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, TracePolicy policy) {
     TracyTTMetalBeginMeshTrace(this->get_device_ids(), *trace_id);
     TT_FATAL(
         !this->mesh_command_queues_[cq_id]->trace_id().has_value(),
@@ -1312,7 +1312,7 @@ void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id
         this->mesh_id_,
         active_sub_device_manager->id());
     auto& trace_buffer = active_sub_device_manager->create_trace(trace_id);
-    this->mesh_command_queues_[cq_id]->record_begin(trace_id, trace_buffer->desc);
+    this->mesh_command_queues_[cq_id]->record_begin(trace_id, trace_buffer->desc, policy);
 }
 
 void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
@@ -1787,9 +1787,11 @@ uint32_t MeshDevice::get_noc_multicast_encoding(uint8_t noc_index, const CoreRan
     return pimpl_->get_noc_multicast_encoding(noc_index, cores);
 }
 SystemMemoryManager& MeshDevice::sysmem_manager() { return pimpl_->sysmem_manager(); }
-MeshTraceId MeshDevice::begin_mesh_trace(uint8_t cq_id) { return pimpl_->begin_mesh_trace(cq_id); }
-void MeshDevice::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
-    pimpl_->begin_mesh_trace(cq_id, trace_id);
+MeshTraceId MeshDevice::begin_mesh_trace(uint8_t cq_id, TracePolicy policy) {
+    return pimpl_->begin_mesh_trace(cq_id, policy);
+}
+void MeshDevice::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, TracePolicy policy) {
+    pimpl_->begin_mesh_trace(cq_id, trace_id, policy);
 }
 void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) { pimpl_->end_mesh_trace(cq_id, trace_id); }
 void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -32,6 +32,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/trace_policy.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <umd/device/types/arch.hpp>
@@ -277,8 +278,8 @@ public:
 
     // MeshTrace Internal APIs - these should be used to deprecate the single device backed trace APIs
     // If cq_id is not provided, the current command queue is returned from the current thread
-    MeshTraceId begin_mesh_trace(uint8_t cq_id);
-    void begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
+    MeshTraceId begin_mesh_trace(uint8_t cq_id, TracePolicy policy = TracePolicy::NONE);
+    void begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, TracePolicy policy = TracePolicy::NONE);
     void end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
     void replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking);
     void release_mesh_trace(const MeshTraceId& trace_id);

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -366,7 +366,7 @@ void SDMeshCommandQueue::reset_worker_state(
     const std::vector<std::pair<CoreRangeSet, uint32_t>>&,
     tt::stl::Span<const uint32_t>) {}
 
-void SDMeshCommandQueue::record_begin(const MeshTraceId&, const std::shared_ptr<MeshTraceDescriptor>&) {
+void SDMeshCommandQueue::record_begin(const MeshTraceId&, const std::shared_ptr<MeshTraceDescriptor>&, TracePolicy) {
     TT_THROW("Not supported for slow dispatch");
 }
 

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -48,6 +48,7 @@ public:
     ~SDMeshCommandQueue() override = default;
 
     std::optional<MeshTraceId> trace_id() const override;
+    TracePolicy trace_policy() const override { return TracePolicy::NONE; }
 
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override;
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) override;
@@ -71,7 +72,10 @@ public:
         const vector_aligned<uint32_t>& go_signal_noc_data,
         const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping,
         tt::stl::Span<const uint32_t> workers_per_sub_device) override;
-    void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) override;
+    void record_begin(
+        const MeshTraceId& trace_id,
+        const std::shared_ptr<MeshTraceDescriptor>& ctx,
+        TracePolicy policy = TracePolicy::NONE) override;
     void record_end() override;
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;
 

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -147,6 +147,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/tensor_accessor_args.hpp
     api/tt-metalium/tile.hpp
     api/tt-metalium/tilize_utils.hpp
+    api/tt-metalium/trace_policy.hpp
     api/tt-metalium/tt_align.hpp
     api/tt-metalium/tt_backend_api_types.hpp
     api/tt-metalium/tt_metal.hpp

--- a/ttnn/cpp/ttnn-nanobind/operations/trace.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/trace.cpp
@@ -26,17 +26,30 @@ void py_module_types(nb::module_& mod) {
                 return "MeshTraceId(" + std::to_string(static_cast<int>(*self)) + ")";
             })
         .def(nb::self == nb::self);
+
+    nb::enum_<ttnn::TracePolicy>(mod, "TracePolicy", nb::is_flag(), R"doc(
+        Trace-capture policy. Pass to begin_trace_capture(..., policy=...) to enforce
+        additional checks over a capture region. Flags compose with ``|``.
+
+        - NONE (default): no policies enforced.
+        - REQUIRE_STABLE_CACHE: fatal on ops whose program-cache key depends on live device
+          state (e.g. matmul without an explicit program_config, which queries free L1 to pick
+          blocking parameters). Set this when the capture must be reproducible across replays.
+    )doc")
+        .value("NONE", ttnn::TracePolicy::NONE)
+        .value("REQUIRE_STABLE_CACHE", ttnn::TracePolicy::REQUIRE_STABLE_CACHE);
 }
 
 void py_module(nb::module_& mod) {
     mod.def(
         "begin_trace_capture",
-        [](MeshDevice* device, std::optional<ttnn::QueueId> cq_id) {
-            return ttnn::operations::trace::begin_trace_capture(device, cq_id);
+        [](MeshDevice* device, std::optional<ttnn::QueueId> cq_id, ttnn::TracePolicy policy) {
+            return ttnn::operations::trace::begin_trace_capture(device, cq_id, policy);
         },
         nb::arg("mesh_device"),
         nb::kw_only(),
         nb::arg("cq_id") = nb::none(),
+        nb::arg("policy") = ttnn::TracePolicy::NONE,
         nb::call_guard<nb::gil_scoped_release>());
 
     mod.def(

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -6,6 +6,8 @@
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "ttnn/types.hpp"
 #include <ranges>
+#include <tt-metalium/mesh_command_queue.hpp>
+#include <tt-metalium/trace_policy.hpp>
 
 namespace ttnn::operations::matmul {
 
@@ -992,6 +994,16 @@ MatmulProgramConfig get_program_config(
     if (attributes.program_config.has_value()) {
         return attributes.program_config.value();
     }
+    const auto& mesh_cq = input_tensor_a.device()->mesh_command_queue();
+    const bool capturing_trace = mesh_cq.trace_id().has_value();
+    const bool stable_cache_required =
+        tt::tt_metal::is_trace_policy_set(mesh_cq.trace_policy(), tt::tt_metal::TracePolicy::REQUIRE_STABLE_CACHE);
+    TT_FATAL(
+        !capturing_trace || !stable_cache_required,
+        "ttnn.matmul without a program_config is not trace-safe: it queries live device L1 space to auto-select "
+        "blocking parameters, which can cause non-deterministic program cache misses during trace capture. This "
+        "capture was started with policy=TracePolicy.REQUIRE_STABLE_CACHE, which forbids such ops. Pass a "
+        "MatmulProgramConfig (e.g. MatmulMultiCoreReuseProgramConfig) for this matmul.");
     auto config = generate_matmul_program_config(
         input_tensor_a,
         input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/trace.cpp
+++ b/ttnn/cpp/ttnn/operations/trace.cpp
@@ -13,10 +13,10 @@
 
 namespace ttnn::operations::trace {
 
-MeshTraceId begin_trace_capture(MeshDevice* device, std::optional<QueueId> cq_id) {
+MeshTraceId begin_trace_capture(MeshDevice* device, std::optional<QueueId> cq_id, TracePolicy policy) {
     ZoneScoped;
     QueueId cq_id_value = cq_id.value_or(get_current_command_queue_id_for_thread());
-    return device->begin_mesh_trace(cq_id_value.get());
+    return device->begin_mesh_trace(cq_id_value.get(), policy);
 }
 void end_trace_capture(MeshDevice* device, MeshTraceId trace_id, std::optional<QueueId> cq_id) {
     ZoneScoped;

--- a/ttnn/cpp/ttnn/operations/trace.hpp
+++ b/ttnn/cpp/ttnn/operations/trace.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/trace_policy.hpp>
 
 #include <optional>
 
@@ -14,10 +15,12 @@
 namespace ttnn {
 
 using MeshTraceId = tt::tt_metal::distributed::MeshTraceId;
+using TracePolicy = tt::tt_metal::TracePolicy;
 
 namespace operations::trace {
 
-MeshTraceId begin_trace_capture(MeshDevice* device, std::optional<QueueId> cq_id);
+MeshTraceId begin_trace_capture(
+    MeshDevice* device, std::optional<QueueId> cq_id, TracePolicy policy = TracePolicy::NONE);
 void end_trace_capture(MeshDevice* device, MeshTraceId trace_id, std::optional<QueueId> cq_id);
 void execute_trace(MeshDevice* device, MeshTraceId trace_id, std::optional<QueueId> cq_id, bool blocking);
 void release_trace(MeshDevice* device, MeshTraceId trace_id);

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -149,6 +149,7 @@ from ttnn._ttnn.events import (
 
 from ttnn._ttnn.operations.trace import (
     MeshTraceId,
+    TracePolicy,
     begin_trace_capture,
     end_trace_capture,
     execute_trace,


### PR DESCRIPTION
## Summary

`ttnn.matmul` without a `program_config` auto-selects blocking parameters by querying **live device L1** (`get_max_l1_space`). Inside trace capture that makes the program-cache key non-deterministic, causing spurious cache misses and a cryptic `Writes are not supported during trace capture` crash.

This PR adds a `TT_FATAL` at the auto-config gateway (`get_program_config`) that fires when matmul is called without a `program_config` during trace capture — and a **region-level opt-in** to relax it for callers who have verified their capture is stable.

Fixes #48275.

## Approach

Rather than thread an explicit `program_config` into every model call site (large blast radius), the relaxation is opt-in **once per capture region**:

```python
tid = ttnn.begin_trace_capture(device, cq_id=0, policy=ttnn.TracePolicy.ALLOW_UNSTABLE_CACHE)
... # ops that rely on auto-config are allowed here
ttnn.end_trace_capture(device, tid, cq_id=0)
```

- **`TracePolicy`** (`tt_metal/api/tt-metalium/trace_policy.hpp`): a bit-flag enum. `STRICT = 0` (default, no relaxations); each escape hatch is its own bit (`ALLOW_UNSTABLE_CACHE`). Named generically so future non-safety trace policies can be added as bits. Bound to Python via `nb::is_flag` as a real `enum.Flag`.
- The policy is supplied at `begin_trace_capture` and stored on the command queue for the capture scope (set in `record_begin`, cleared in `record_end`) — the same state the fatal already reads via `trace_id()`.
- The matmul guard fatals only when **capturing AND** `ALLOW_UNSTABLE_CACHE` is not set.

Default behavior is unchanged: auto-config matmul under capture still fatals unless the caller explicitly opts out. **No model files are modified** — models adopt the kwarg individually.

## Test plan

`tests/ttnn/unit_tests/operations/matmul/test_matmul.py` (all pass locally on P150):
- `test_matmul_without_program_config_fatals_during_trace` — default STRICT still fatals
- `test_matmul_with_program_config_succeeds_during_trace` — explicit config path works
- `test_matmul_without_program_config_allowed_with_policy` — opt-out captures + replays clean
- `test_trace_policy_is_a_flag` — Flag semantics (STRICT==0, bits compose with `|`)

Existing tracy trace tests (`test_trace_runs.py`, `test_*_device_trace.py`) updated to pass explicit configs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/matmul-trace-policy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/matmul-trace-policy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/matmul-trace-policy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/matmul-trace-policy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/matmul-trace-policy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/matmul-trace-policy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/matmul-trace-policy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/matmul-trace-policy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/matmul-trace-policy)