### PR TITLE
tt_dit: add model-agnostic DeviceClass primitive

### DIFF
--- a/models/tt_dit/tests/unit/test_device_class.py
+++ b/models/tt_dit/tests/unit/test_device_class.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.tt_dit.utils.device_class import GALAXY_BOARDS, DeviceClass, is_galaxy
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("p300", DeviceClass.P300),
+        ("P300", DeviceClass.P300),
+        ("p300x2", DeviceClass.P300X2),
+        ("P300X2", DeviceClass.P300X2),
+        ("t3k", DeviceClass.T3K),
+        ("n150", DeviceClass.N150),
+        ("p150x8", DeviceClass.P150X8),
+    ],
+)
+def test_from_string_is_case_insensitive(name, expected):
+    assert DeviceClass.from_string(name) is expected
+
+
+def test_from_string_rejects_unknown(expect_error):
+    # The error lists the valid names so the message is actionable.
+    with expect_error(ValueError, "p300"):
+        DeviceClass.from_string("does_not_exist")
+
+
+def test_from_string_roundtrips_every_member():
+    for member in DeviceClass:
+        assert DeviceClass.from_string(member.name.lower()) is member
+        assert DeviceClass.from_string(member.name) is member
+
+
+def test_is_galaxy_matches_membership_set():
+    for member in DeviceClass:
+        assert is_galaxy(member) == (member in GALAXY_BOARDS)
+
+
+def test_galaxy_boards_are_exactly_the_galaxy_members():
+    expected = {
+        DeviceClass.GALAXY,
+        DeviceClass.GALAXY_T3K,
+        DeviceClass.DUAL_GALAXY,
+        DeviceClass.QUAD_GALAXY,
+    }
+    assert set(GALAXY_BOARDS) == expected
+
+
+def test_non_galaxy_boards_are_not_galaxy():
+    for member in (DeviceClass.N150, DeviceClass.N300, DeviceClass.T3K, DeviceClass.P150, DeviceClass.P300):
+        assert not is_galaxy(member)

--- a/models/tt_dit/utils/device_class.py
+++ b/models/tt_dit/utils/device_class.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Model-agnostic Tenstorrent board / device-class taxonomy.
+
+`DeviceClass` is a shared primitive: it names the boards and clusters tt_dit
+runs on, with no knowledge of which models are supported on which board. That
+model-support matrix (e.g. BOARD_SPECS / per-model deployment shapes) belongs
+next to the model or the serving layer that consumes this enum, not here.
+
+The taxonomy mirrors tt-inference-server/workflows/workflow_types.py:DeviceTypes
+so that `DeviceClass.from_string("p300")` resolves the same names a user would
+pass on the inference-server CLI.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum, auto
+from typing import FrozenSet
+
+
+class DeviceClass(IntEnum):
+    """Tenstorrent board / cluster identity.
+
+    Mirrors tt-inference-server/workflows/workflow_types.py:DeviceTypes so
+    `DeviceClass.from_string("p300")` resolves the same names a user would
+    pass on the inference-server CLI.
+    """
+
+    # Wormhole_B0
+    N150 = auto()
+    N300 = auto()
+    T3K = auto()
+    GALAXY_T3K = auto()
+    GALAXY = auto()
+    DUAL_GALAXY = auto()
+    QUAD_GALAXY = auto()
+
+    # Blackhole
+    P100 = auto()
+    P150 = auto()
+    P150X2 = auto()
+    P150X4 = auto()
+    P150X8 = auto()
+    P300 = auto()
+    P300X2 = auto()
+
+    @classmethod
+    def from_string(cls, name: str) -> "DeviceClass":
+        """Parse 'p300', 'P300', 'p300x2', 'P300X2' etc."""
+        try:
+            return cls[name.upper()]
+        except KeyError:
+            valid = ", ".join(m.name.lower() for m in cls)
+            raise ValueError(f"Unknown device class '{name}'. Valid: {valid}")
+
+
+GALAXY_BOARDS: FrozenSet[DeviceClass] = frozenset(
+    {DeviceClass.GALAXY, DeviceClass.GALAXY_T3K, DeviceClass.DUAL_GALAXY, DeviceClass.QUAD_GALAXY}
+)
+
+
+def is_galaxy(board: DeviceClass) -> bool:
+    """True if `board` is a Galaxy-class cluster."""
+    return board in GALAXY_BOARDS


### PR DESCRIPTION
## What

Carves the model-agnostic board/cluster taxonomy into a shared `tt_dit` primitive: `models/tt_dit/utils/device_class.py`, containing the `DeviceClass` enum, its `from_string` parser, `GALAXY_BOARDS`, and `is_galaxy`.

`DeviceClass` names the systems `tt_dit` runs on, with **no knowledge of which models a board supports**. The taxonomy mirrors `tt-inference-server/workflows/workflow_types.py:DeviceTypes`, so `DeviceClass.from_string("p300")` resolves the same names a user passes on the inference-server CLI.

## Why

This is the model-agnostic half of the split requested by @cglagovichTT on #47510 ([discussion_r3452406483](https://github.com/tenstorrent/tt-metal/pull/47510#discussion_r3452406483)), and approved by @sadesoyeTT in the same thread:

> This could be a useful enum to have in general in the tt-dit folder. I believe it could be split out into two — a model-agnostic file containing `DeviceClass`, and this model-support matrix `BOARD_SPECS`.

The model-support matrix (`BOARD_SPECS` / per-model deployment shapes) intentionally **stays with the consuming serving layer** and can later evolve toward each model declaring its own supported systems, as discussed. This PR lands only the shared primitive so it's available to tests, model serving, and the media server independently.

## Tests

`models/tt_dit/tests/unit/test_device_class.py` (pure-Python, no device):
- case-insensitive `from_string` parsing
- round-trip over every enum member
- unknown-name rejection (via the `expect_error` fixture)
- `is_galaxy` membership matches `GALAXY_BOARDS`

```
12 passed in 1.69s
```

Net-new, import-only — no edits to existing files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:samt/pr-a-device-class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:samt/pr-a-device-class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:samt/pr-a-device-class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:samt/pr-a-device-class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:samt/pr-a-device-class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:samt/pr-a-device-class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:samt/pr-a-device-class)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=samt/pr-a-device-class)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:samt/pr-a-device-class)