### PR TITLE
[Metal] CoreRangeSet(Span<CoreCoord>): O(N) solid-rectangle fast path

### DIFF
--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_construct.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_construct.cpp
@@ -25,4 +25,46 @@ TEST_F(CoreCoordFixture, TestCoreRangeSetInvalidConstruct) {
     EXPECT_ANY_THROW(::CoreRangeSet(std::vector{this->sc1, this->cr1}));
 }
 
+// Construction from a list of CoreCoords (CoreRangeSet(Span<const CoreCoord>)) — exercises the
+// solid-rectangle fast path and its fall-back to merge_ranges.
+TEST_F(CoreCoordFixture, TestCoreRangeSetFromCoreCoordsSolidRectangle) {
+    // A filled 3-wide x 2-tall block of coords collapses to a single CoreRange.
+    std::vector<CoreCoord> coords;
+    for (size_t y = 1; y <= 2; y++) {
+        for (size_t x = 3; x <= 5; x++) {
+            coords.push_back(CoreCoord(x, y));
+        }
+    }
+    ::CoreRangeSet crs(coords);
+    EXPECT_EQ(crs.size(), 1u);
+    EXPECT_EQ(*crs.ranges().begin(), ::CoreRange(CoreCoord(3, 1), CoreCoord(5, 2)));
+}
+
+TEST_F(CoreCoordFixture, TestCoreRangeSetFromCoreCoordsSingle) {
+    std::vector<CoreCoord> coords = {CoreCoord(4, 2)};
+    ::CoreRangeSet crs(coords);
+    EXPECT_EQ(crs.size(), 1u);
+    EXPECT_EQ(*crs.ranges().begin(), ::CoreRange(CoreCoord(4, 2), CoreCoord(4, 2)));
+}
+
+TEST_F(CoreCoordFixture, TestCoreRangeSetFromCoreCoordsLShapeNotCollapsed) {
+    // 3 coords forming an L (a 2x2 with one corner missing): NOT a solid rectangle, must keep the hole.
+    std::vector<CoreCoord> coords = {CoreCoord(0, 0), CoreCoord(1, 0), CoreCoord(0, 1)};
+    ::CoreRangeSet crs(coords);
+    EXPECT_TRUE(crs.contains(CoreCoord(0, 0)));
+    EXPECT_TRUE(crs.contains(CoreCoord(1, 0)));
+    EXPECT_TRUE(crs.contains(CoreCoord(0, 1)));
+    EXPECT_FALSE(crs.contains(CoreCoord(1, 1)));  // the missing corner stays missing
+}
+
+TEST_F(CoreCoordFixture, TestCoreRangeSetFromCoreCoordsDuplicateThrows) {
+    // Duplicate coords are rejected by validate_no_overlap (pre-existing behavior: the per-coord ranges
+    // overlap). The fast path must NOT mask this. Here bbox area (2x2=4) == coord count (4), but (0,0)
+    // is duplicated and (0,1) absent — a naive count==area check would wrongly accept this as a solid
+    // 2x2 rectangle (no throw). The dup-detecting bitset forces the merge_ranges fall-back, which throws
+    // exactly as the original code did.
+    std::vector<CoreCoord> coords = {CoreCoord(0, 0), CoreCoord(0, 0), CoreCoord(1, 0), CoreCoord(1, 1)};
+    EXPECT_ANY_THROW(::CoreRangeSet{coords});
+}
+
 }  // namespace basic_tests::CoreRangeSet

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -167,6 +167,38 @@ CoreRangeSet::CoreRangeSet(const std::set<CoreRange>& core_ranges) : ranges_(cor
 CoreRangeSet::CoreRangeSet(const CoreRange& core_range) : ranges_{core_range} {}
 
 CoreRangeSet::CoreRangeSet(tt::stl::Span<const CoreCoord> core_coords) {
+    // Fast path: a list of cores that fills a single solid rectangle (the common case — a full worker
+    // grid) merges to exactly one CoreRange. Detect that in O(N) and emit the range directly, skipping
+    // merge_ranges (which allocates a 2D grid and churns std::sets) that otherwise runs every dispatch.
+    if (!core_coords.empty()) {
+        size_t min_x = std::numeric_limits<size_t>::max(), min_y = std::numeric_limits<size_t>::max();
+        size_t max_x = 0, max_y = 0;
+        for (const auto& c : core_coords) {
+            min_x = std::min(min_x, c.x);
+            max_x = std::max(max_x, c.x);
+            min_y = std::min(min_y, c.y);
+            max_y = std::max(max_y, c.y);
+        }
+        const size_t w = max_x - min_x + 1, h = max_y - min_y + 1;
+        if (w * h == core_coords.size()) {
+            // count == bounding-box area; confirm no duplicates (a dup would mean a hole, not a solid
+            // rect) with a flat bitset over the bbox. If solid, the merge result is a single range.
+            std::vector<bool> seen(core_coords.size(), false);
+            bool solid = true;
+            for (const auto& c : core_coords) {
+                const size_t idx = (c.y - min_y) * w + (c.x - min_x);
+                if (seen[idx]) {
+                    solid = false;
+                    break;
+                }
+                seen[idx] = true;
+            }
+            if (solid) {
+                this->ranges_ = {CoreRange(CoreCoord(min_x, min_y), CoreCoord(max_x, max_y))};
+                return;
+            }
+        }
+    }
     std::vector<CoreRange> core_ranges;
     core_ranges.reserve(core_coords.size());
     for (const auto& core_coord : core_coords) {


### PR DESCRIPTION
## What

Adds an O(N) **solid-rectangle fast path** to `CoreRangeSet(tt::stl::Span<const CoreCoord>)`. When the
input cores fill a single solid rectangle — the common case, a full worker grid — it computes the
bounding box, confirms there are no holes via a flat bitset (O(N)), and emits a **single `CoreRange`**
directly. Non-rectangular sets fall back to the existing `merge_ranges()`.

## Why

The `Span<const CoreCoord>` constructor calls `merge_ranges()`, which allocates a 2D grid and churns
`std::set`s. For sharded ops this runs on **every dispatch** (the per-core list is rebuilt each time),
so it's pure host-dispatch overhead. The solid-rectangle case — by far the most common — doesn't need
any of that.

This is a shared metal primitive, so it helps **both the legacy and Metal 2.0 paths** and every op that
builds a `CoreRangeSet` from a core list.

## Performance (host dispatch, µs/op)

Measured apples-to-apples (both with/without this change under identical conditions) on the sharded
ops that build a `CoreRangeSet` from coords:

| op | without | with | Δ host |
|----|----:|----:|----:|
| i2s | 99.1 | 93.7 | −5.4µs |
| reshard | 102.2 | 97.8 | −4.4µs |

Non-coord-built ops (transpose, etc.) are unchanged (within ±1µs noise).

## Validation

- `CoreRangeSet` construction unit tests extended: solid rectangle, single core, L-shape-with-hole
  (falls back to `merge_ranges`), and a duplicate-coords case (still throws via `validate_no_overlap`).
- Behavior-preserving: the fast path produces the identical `CoreRangeSet` as `merge_ranges` for the
  solid-rectangle case, and defers to `merge_ranges` for everything else.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/corerangeset-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/corerangeset-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/corerangeset-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/corerangeset-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/corerangeset-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/corerangeset-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/corerangeset-fast-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/corerangeset-fast-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/corerangeset-fast-path)