### PR TITLE
[Bugfix] Clean up Metal 2.0 API for self-loop DFBs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -295,19 +295,21 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopWithSharedLocalAccessorNameSucceeds) {
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, DMKernelSelfLoopFails) {
+TEST_F(ProgramSpecTestQuasar, DMKernelSelfLoopOnGen2Fails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.name = "test_program";
 
-    // A data-movement kernel may NOT self-loop a DFB (bind it as both PRODUCER and CONSUMER). A DFB
-    // synchronizes a producer and a consumer on DISTINCT cores via per-side credit masks, and a
-    // single DM kernel's producer and consumer masks are identical — the DFB backend would reject it
-    // with an opaque "producer_risc_mask and consumer_risc_mask must not overlap". Caught up front at
-    // validation with an actionable message instead. The legal alternatives are a private L1 scratch
-    // buffer, a LocalTensorAccessor tensor view, or a two-kernel cross-bind. (Compute self-loops stay
-    // legal — see SelfLoopWithSharedLocalAccessorNameSucceeds.)
+    // On Gen2, a data-movement kernel may NOT self-loop a DFB (bind it as both PRODUCER and CONSUMER).
+    // The DFB's tile-counter credit machinery synchronizes a producer and a consumer on DISTINCT RISCs
+    // via per-side masks, and a single DM kernel's producer and consumer masks are identical — the DFB
+    // backend would reject it with an opaque "producer_risc_mask and consumer_risc_mask must not
+    // overlap". Caught up front at validation with an actionable message instead. The legal Gen2
+    // alternatives are a private L1 scratch buffer, a LocalTensorAccessor tensor view, or a two-kernel
+    // cross-bind. (On Gen1 a DM self-loop IS legal — a DFB lowers to a plain circular buffer there; see
+    // DMKernelSelfLoopOnGen1Succeeds. Compute self-loops stay legal on both gens — see
+    // DFBSelfLoopOnComputeKernelSucceeds.)
     auto kernel = MakeMinimalDMKernel("kernel");
     auto dfb = MakeMinimalDFB("dfb");
     kernel.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "p"));
@@ -319,8 +321,9 @@ TEST_F(ProgramSpecTestQuasar, DMKernelSelfLoopFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("self-looped by data-movement kernel 'kernel'")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::AllOf(
+            ::testing::HasSubstr("self-looped by data-movement kernel 'kernel'"),
+            ::testing::HasSubstr("not supported for data-movement kernels on Gen2 architectures"))));
 }
 
 TEST_F(ProgramSpecTestQuasar, DFBBoundTwiceInSameRoleUnderDifferentNamesFails) {
@@ -792,9 +795,9 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
     // The sets are not equal — the self-loop multi-binding rule rejects this mix.
     //
     // All three kernels are COMPUTE so the self-loop participant (self_loop_1) is a legal compute
-    // self-loop — a DM self-loop would be rejected earlier (see DMKernelSelfLoopFails), masking the
-    // rule under test. With compute kernels the per-role kind-uniformity check passes and the
-    // self-loop set-equality refinement check is reached.
+    // self-loop — a DM self-loop would be rejected earlier on Gen2 (see DMKernelSelfLoopOnGen2Fails),
+    // masking the rule under test. With compute kernels the per-role kind-uniformity check passes and
+    // the self-loop set-equality refinement check is reached.
     auto self_loop_1 = MakeMinimalComputeKernel("self_loop_1");
     auto extra_producer = MakeMinimalComputeKernel("extra_producer");
     auto extra_consumer = MakeMinimalComputeKernel("extra_consumer");
@@ -820,12 +823,6 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
             ::testing::HasSubstr("DFB 'dfb' is self-looped (some kernel appears as both producer and consumer), but "
                                  "the set of producer KernelSpecs differs from the set of consumer KernelSpecs")));
 }
-
-// NOTE: A "scope-disagreement" test case is not currently expressible: the only valid scope
-// value today is INTRA (INTER is rejected upstream as not-yet-supported), so two
-// self-loop participants can't meaningfully disagree on scope. When INTER support lands,
-// add a positive scope-disagreement test that exercises the
-// "must agree on DFBSelfLoopScope" TT_FATAL.
 
 // ----------------------------------------------------------------------------
 // DFB implicit-sync opt-out (Gen2)
@@ -1844,117 +1841,6 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBConsumerOnNodeWithoutProducerFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("This node has a consumer but no producer")));
 }
 
-// ----------------------------------------------------------------------------
-// KernelSpec::dfb_self_loop_connectivities validation tests
-// ----------------------------------------------------------------------------
-// This advanced option only applies to compute kernels that self-loop a DFB (bind it
-// as both producer and consumer). All misapplications must fail loudly so authors
-// never silently get the wrong scope. INTER is recognized but not yet implemented.
-
-TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelInterScopeFails) {
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "self_loop_inter";
-
-    auto compute = MakeMinimalComputeKernel("compute");
-    compute.advanced_options =
-        KernelAdvancedOptions{.dfb_self_loop_connectivities = {{DFBSpecName{"dfb"}, DFBSelfLoopConnectivity::INTER}}};
-
-    auto dfb = MakeMinimalDFB("dfb");
-    dfb.data_format_metadata = tt::DataFormat::Float16_b;
-
-    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
-    compute.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
-
-    spec.kernels = {compute};
-    spec.dataflow_buffers = {dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("INTER scope is not yet supported by the runtime")));
-}
-
-TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnDMKernelFails) {
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "self_loop_on_dm";
-
-    auto producer = MakeMinimalDMKernel("producer");
-    // Misapplied: self-loop scope entries are valid only on compute kernels.
-    producer.advanced_options =
-        KernelAdvancedOptions{.dfb_self_loop_connectivities = {{DFBSpecName{"dfb"}, DFBSelfLoopConnectivity::INTRA}}};
-    auto consumer = MakeMinimalDMKernel("consumer");
-
-    auto dfb = MakeMinimalDFB("dfb");
-    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
-    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
-
-    spec.kernels = {producer, consumer};
-    spec.dataflow_buffers = {dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is not a compute kernel")));
-}
-
-TEST_F(ProgramSpecTestQuasar, SelfLoopScopeReferencingUnknownDFBFails) {
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "self_loop_unknown_dfb";
-
-    auto compute = MakeMinimalComputeKernel("compute");
-    // Misapplied: there is no DFB named "ghost" in the spec.
-    compute.advanced_options =
-        KernelAdvancedOptions{.dfb_self_loop_connectivities = {{DFBSpecName{"ghost"}, DFBSelfLoopConnectivity::INTRA}}};
-
-    auto dfb = MakeMinimalDFB("dfb");
-    dfb.data_format_metadata = tt::DataFormat::Float16_b;
-
-    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
-    compute.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
-
-    spec.kernels = {compute};
-    spec.dataflow_buffers = {dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("entry referencing unknown DFB 'ghost'")));
-}
-
-TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnNonSelfLoopedDFBFails) {
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "self_loop_not_self_looped";
-
-    auto compute = MakeMinimalComputeKernel("compute");
-    // Misapplied: the kernel only produces; it does not self-loop the DFB.
-    compute.advanced_options =
-        KernelAdvancedOptions{.dfb_self_loop_connectivities = {{DFBSpecName{"dfb"}, DFBSelfLoopConnectivity::INTRA}}};
-    auto dm_consumer = MakeMinimalDMKernel("dm_consumer");
-
-    auto dfb = MakeMinimalDFB("dfb");
-    dfb.data_format_metadata = tt::DataFormat::Float16_b;
-
-    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
-    dm_consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
-
-    spec.kernels = {compute, dm_consumer};
-    spec.dataflow_buffers = {dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute", "dm_consumer"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("does not self-loop this DFB")));
-}
-
 // ============================================================================
 // SECTION 4: Programs Creation Tests
 // ============================================================================
@@ -1970,15 +1856,14 @@ TEST_F(ProgramSpecTestQuasar, MinimalValidProgramSpecSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelImplicitIntraSucceeds) {
-    // The 99.5% case: a compute kernel that self-loops a DFB and does NOT explicitly declare a
-    // dfb_self_loop_connectivities entry. The implementation must default to INTRA so the
-    // lower-layer DFB layer (which requires an explicit scope for Tensix-to-Tensix DFBs) accepts
-    // the program.
+TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelSucceeds) {
+    // A compute kernel that self-loops a DFB (binds it as both producer and consumer) is legal: it
+    // lowers to the intra-Tensix packer->unpacker flow (TensixScope::INTRA), which the Metal 2.0
+    // layer applies automatically. There is no user-facing self-loop scope option.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.name = "self_loop_implicit_intra";
+    spec.name = "compute_self_loop";
 
     auto compute = MakeMinimalComputeKernel("compute");
 
@@ -1986,32 +1871,6 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelImplicitIntraSucceeds) {
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     // INTRA-tensix self-loop: no DM endpoint, so the spec-to-impl translation produces
     // enable_{producer,consumer}_implicit_sync=false at the lower DFB layer automatically.
-
-    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
-    compute.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
-
-    spec.kernels = {compute};
-    spec.dataflow_buffers = {dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute"})};
-
-    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
-}
-
-TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelExplicitIntraSucceeds) {
-    // Identical to the implicit case, but with an explicit INTRA entry on the kernel. The
-    // explicit declaration is redundant with the default but must be accepted (and produce
-    // the same program) so that authors can write self-documenting specs.
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "self_loop_explicit_intra";
-
-    auto compute = MakeMinimalComputeKernel("compute");
-    compute.advanced_options =
-        KernelAdvancedOptions{.dfb_self_loop_connectivities = {{DFBSpecName{"dfb"}, DFBSelfLoopConnectivity::INTRA}}};
-
-    auto dfb = MakeMinimalDFB("dfb");
-    dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
     compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
     compute.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
@@ -2917,6 +2776,29 @@ TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestGen1, DMKernelSelfLoopOnGen1Succeeds) {
+    // On Gen1 (WH/BH) a DFB lowers to a plain circular buffer, so a single DM kernel may bind it as
+    // both PRODUCER and CONSUMER (self-loop) — the classic scratch pattern of one DM engine filling
+    // and draining an L1 FIFO. There is no tile-counter credit machinery requiring disjoint
+    // producer/consumer masks, so the spec validator accepts it. (On Gen2 the same spec is rejected —
+    // see DMKernelSelfLoopOnGen2Fails.)
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "dm_self_loop";
+
+    auto kernel = MakeMinimalGen1DMKernel("kernel", DataMovementProcessor::RISCV_0);
+    auto dfb = MakeMinimalDFB("dfb");
+    kernel.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "p"));
+    kernel.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "c"));
+
+    spec.kernels = {kernel};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -99,37 +99,7 @@ struct KernelAdvancedOptions {
     //       existing uses are refactored to avoid it.
     [[deprecated("Per-node-vararg-count feature is deprecated and will be removed.")]]
     Table<Nodes, /* num_varargs */ uint32_t> num_runtime_varargs_per_node;
-
-    ////////////////////////////////////////////////////////////////////////////////
-    // Multi-threaded self-loop DFBs on compute kernels
-    ////////////////////////////////////////////////////////////////////////////////
-
-    // Self-loop DFBs on compute kernels (niche multi-threaded use case).
-    // This applies only to compute kernels that bind BOTH the producer and consumer
-    // endpoints of the same DFB (self-loop).
-    //
-    // This is ONLY pertinent to multi-threaded compute kernels on Gen2 architectures.
-    // These settings have absolutely no effect on single-threaded kernels.
-    // (A Gen1 compute kernel is always single-threaded.)
-    //
-    // A compute kernel's threads can communicate via the DFB in two topologies:
-    //
-    //   INTRA (intra-thread): Each kernel thread uses the DFB in its own self-loop.
-    //         (no cross-thread communication). This is the common case.
-    //   INTER (inter-thread): Within the kernel, some threads produce data for other
-    //          threads to consume.
-    //
-    // Only the INTRA case is currently supported. INTER will trigger a validation error.
-    // There are currently no known use cases for an INTER-thread self-loop. This option
-    // is present in the API for completeness, to surface any use cases that may arise.
-    enum class DFBSelfLoopConnectivity { INTRA, INTER };
-
-    // Self-loop DFBs on compute kernels: maps each self-looped DFB to its scope.
-    Table<DFBSpecName, DFBSelfLoopConnectivity> dfb_self_loop_connectivities;
 };
-
-// (Convenience aliases for nested types)
-using DFBSelfLoopConnectivity = KernelAdvancedOptions::DFBSelfLoopConnectivity;
 
 struct DFBAdvancedOptions {
     ////////////////////////////////////////////////////////////////////////////////

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -207,11 +207,6 @@ const std::vector<DFBSpecName>& dfb_alias_with(const DataflowBufferSpec& dfb) {
     return dfb.advanced_options.alias_with;
 }
 
-// Helper: return a kernel's dfb-compute-self-loop-scopes map.
-const Table<DFBSpecName, DFBSelfLoopConnectivity>& kernel_self_loop_scopes(const KernelSpec& kernel) {
-    return kernel.advanced_options.dfb_self_loop_connectivities;
-}
-
 // Local accessor names for kernel resource bindings must be valid C++ identifiers
 // They are used verbatim in the generated kernel source code.
 // TODO: Move this to ttsl in a follow up PR
@@ -1230,14 +1225,18 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
 
         if (self_loop_kernel != nullptr) {
-            // DFB supports self-loop for compute kernels, but NOT for DM kernels.
-            // Catch this here (and emit a clear error message), rather than let it slip through and cause
-            // a much more confusing downstream error in the DFB backend code.
+            // A data-movement kernel may self-loop a DFB (bind it as both PRODUCER and CONSUMER) only
+            // on Gen1 (WH/BH), where a DFB lowers to a plain circular buffer that a single DM RISC can
+            // both fill and drain. On Gen2 the DFB's tile-counter credit machinery requires disjoint
+            // producer/consumer RISCs, so a DM self-loop cannot be lowered. Catch it here (with a clear
+            // message) rather than let it fall through to a confusing "producer_risc_mask and
+            // consumer_risc_mask must not overlap" error in the DFB backend. (Compute self-loops are
+            // always legal: they lower to the intra-Tensix packer->unpacker flow.)
             TT_FATAL(
-                !self_loop_kernel->is_data_movement_kernel(),
+                !(is_gen2_arch() && self_loop_kernel->is_data_movement_kernel()),
                 "DataflowBuffer '{}' is self-looped by data-movement kernel '{}' (bound as both PRODUCER "
-                "and CONSUMER). Self-loop DFBs are not supported for data-movement kernels. Consider using a "
-                "scratchpad or LocalTensorAccessor instead.",
+                "and CONSUMER). Self-loop DFBs are not supported for data-movement kernels on Gen2 "
+                "architectures. Consider using a scratchpad or LocalTensorAccessor instead.",
                 dfb.unique_id,
                 self_loop_kernel->unique_id);
 
@@ -1245,7 +1244,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             // as sets of KernelSpec*. This permits the natural pattern of multiple same-source
             // KernelSpecs each self-looping the DFB on their disjoint node ranges, while rejecting
             // the case where a self-looping kernel shares the DFB with an unrelated kernel (which
-            // would make per-instance tensix-scope semantics ambiguous).
+            // would make the producer/consumer mask and lowering semantics ambiguous).
             std::unordered_set<const KernelSpec*> producer_kernels;
             std::unordered_set<const KernelSpec*> consumer_kernels;
             for (const auto& p : endpoints.producers) {
@@ -1261,33 +1260,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 "When a DFB is self-looped, every same-side binding must come from a self-loop "
                 "participant (i.e. a kernel that appears on both sides).",
                 dfb.unique_id);
-
-            // All self-loop participants must agree on the tensix-scope for this DFB —
-            // MakeDataflowBufferConfig writes a single tensix_scope into the DFB config, and the
-            // self-loop participants alternate per node, so a disagreement is unresolvable.
-            // Iterate endpoints.producers (a vector) rather than producer_kernels (an
-            // unordered_set), so iteration order — and any resulting error message — is
-            // deterministic across runs.
-            auto scope_for_kernel = [&](const KernelSpec* k) {
-                auto conn = kernel_self_loop_scopes(*k).get(dfb.unique_id);
-                return conn ? *conn : DFBSelfLoopConnectivity::INTRA;
-            };
-            const KernelSpec* first_kernel = endpoints.producers.front().kernel;
-            const auto first_scope = scope_for_kernel(first_kernel);
-            std::unordered_set<const KernelSpec*> seen;
-            for (const auto& rec : endpoints.producers) {
-                if (!seen.insert(rec.kernel).second) {
-                    continue;
-                }
-                TT_FATAL(
-                    scope_for_kernel(rec.kernel) == first_scope,
-                    "DFB '{}' is self-looped; all self-loop participants must agree on "
-                    "DFBSelfLoopConnectivity, but kernel '{}' specifies a different scope "
-                    "than kernel '{}'.",
-                    dfb.unique_id,
-                    rec.kernel->unique_id,
-                    first_kernel->unique_id);
-            }
         }
     }
 
@@ -1452,56 +1424,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 dfb_spec->data_format_metadata.has_value(),
                 "DFB '{}' is used by a compute kernel, but no data_format_metadata is specified",
                 dfb_name);
-        }
-    }
-
-    // Validate KernelSpec::dfb_self_loop_connectivities entries.
-    // This is a niche advanced option that only applies to compute kernels that self-loop a DFB
-    // (bind it as both producer and consumer).
-    // All misapplications fail loudly here for the benefit of users (especially AI users).
-    for (const KernelSpec& kernel : spec.kernels) {
-        if (kernel_self_loop_scopes(kernel).empty()) {
-            continue;
-        }
-        TT_FATAL(
-            kernel.is_compute_kernel(),
-            "KernelSpec '{}' specifies dfb_self_loop_connectivities, but is not a compute kernel. "
-            "This option applies only to compute kernels.",
-            kernel.unique_id);
-
-        for (const auto& [dfb_spec_name, scope] : kernel_self_loop_scopes(kernel)) {
-            TT_FATAL(
-                collected.dfb_by_name.contains(dfb_spec_name),
-                "KernelSpec '{}' has a dfb_self_loop_connectivities entry referencing unknown DFB '{}'.",
-                kernel.unique_id,
-                dfb_spec_name);
-
-            bool has_producer_binding = false;
-            bool has_consumer_binding = false;
-            for (const auto& binding : kernel.dfb_bindings) {
-                if (binding.dfb_spec_name != dfb_spec_name) {
-                    continue;
-                }
-                if (binding.endpoint_type == DFBEndpointType::PRODUCER) {
-                    has_producer_binding = true;
-                } else if (binding.endpoint_type == DFBEndpointType::CONSUMER) {
-                    has_consumer_binding = true;
-                }
-            }
-            TT_FATAL(
-                has_producer_binding && has_consumer_binding,
-                "KernelSpec '{}' has a dfb_self_loop_connectivities entry for DFB '{}', but the "
-                "kernel does not self-loop this DFB (does not bind it as BOTH producer and "
-                "consumer). This option applies only to self-looped DFBs.",
-                kernel.unique_id,
-                dfb_spec_name);
-
-            TT_FATAL(
-                scope != DFBSelfLoopConnectivity::INTER,
-                "KernelSpec '{}' specifies INTER scope for self-looped DFB '{}'. INTER scope is "
-                "not yet supported by the runtime.",
-                kernel.unique_id,
-                dfb_spec_name);
         }
     }
 
@@ -2346,17 +2268,14 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     auto producer_access_pattern = to_hw_access_pattern(producer_binding->access_pattern);
     auto consumer_access_pattern = to_hw_access_pattern(consumer_binding->access_pattern);
 
-    // For a compute kernel that self-loops a DFB (binds it as both producer and consumer), the
-    // lower-layer DFB API requires an explicit scope. Self-loop is detected as any overlap
-    // between the producer and consumer kernel sets — under the multi-binding regime, the
-    // first-record pointers may differ even when the kernel sets are identical (the overlap is
-    // what matters, not vector ordering). Upstream validation guarantees producer set ==
-    // consumer set whenever any overlap exists, and that all self-loop participants agree on
-    // the tensix scope; reading from the first producer is therefore safe and representative.
-    // The user can declare scope via KernelSpec::dfb_self_loop_connectivities:
-    //  - absence of an entry means we infer INTRA (the common case)
-    //  - user-specified INTRA is also fine
-    //  - user-specified INTER is not currently supported. This will have already failed validation.
+    // A compute kernel that self-loops a DFB (binds it as both producer and consumer) lowers to the
+    // intra-Tensix packer->unpacker flow, so the lower-layer DFB API needs TensixScope::INTRA. The
+    // Metal 2.0 surface does not expose a scope option — INTRA is the only supported topology, applied
+    // automatically here. Self-loop is detected as any overlap between the producer and consumer kernel
+    // sets — under the multi-binding regime the first-record pointers may differ even when the kernel
+    // sets are identical (the overlap is what matters, not vector ordering). Upstream validation
+    // guarantees producer set == consumer set whenever any overlap exists, so reading from the first
+    // producer is safe and representative. A DM self-loop (Gen1-only) needs no tensix_scope.
     const bool is_self_loop = [&] {
         for (const auto& p : dfb_endpoint_info.producers) {
             for (const auto& c : dfb_endpoint_info.consumers) {
@@ -2369,11 +2288,7 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     }();
     std::optional<experimental::dfb::TensixScope> tensix_scope;
     if (is_self_loop && producer->is_compute_kernel()) {
-        auto user_conn = kernel_self_loop_scopes(*producer).get(dfb_spec->unique_id);
-        const auto user_scope = user_conn ? *user_conn : DFBSelfLoopConnectivity::INTRA;
-        tensix_scope = (user_scope == DFBSelfLoopConnectivity::INTRA)
-                           ? experimental::dfb::TensixScope::INTRA
-                           : experimental::dfb::TensixScope::INTER;  // currently blocked in validation
+        tensix_scope = experimental::dfb::TensixScope::INTRA;
     }
 
     // Compute the per-side implicit-sync value by polling the bound DM kernels' Gen2 votes.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1537,11 +1537,6 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
             {"kernel_width", filter_w},
             {"coalesce_kw_reads", (uint32_t)coalesce_1d_depthwise_kw_reads},
         };
-        // OUT self-loop (dest-reuse accumulate) + ACT_TILIZED self-loop.
-        compute_kernel_spec.advanced_options.dfb_self_loop_connectivities.insert(
-            {DFB_OUT, m2::DFBSelfLoopConnectivity::INTRA});
-        compute_kernel_spec.advanced_options.dfb_self_loop_connectivities.insert(
-            {DFB_ACT_TILIZED, m2::DFBSelfLoopConnectivity::INTRA});
     } else {
         compute_kernel_spec.compile_time_args = {
             {"in0_block_w", act_block_w_ntiles},
@@ -1589,17 +1584,6 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
             compute_kernel_spec.compile_time_args.insert({"tilized_cb_second_reader_offset", 0u});
         }
         compute_kernel_spec.compile_time_args.insert({"split_reader_cb_shared", 0u});
-
-        // MATMUL_PARTIALS self-loop (resolution #2) and OUT degenerate self-loop (resolution #1).
-        compute_kernel_spec.advanced_options.dfb_self_loop_connectivities.insert(
-            {DFB_MATMUL_PARTIALS, m2::DFBSelfLoopConnectivity::INTRA});
-        compute_kernel_spec.advanced_options.dfb_self_loop_connectivities.insert(
-            {DFB_OUT, m2::DFBSelfLoopConnectivity::INTRA});
-        if (!block_sharded) {
-            // Height-sharded: ACT_TILIZED is a compute-internal tilize->matmul self-loop.
-            compute_kernel_spec.advanced_options.dfb_self_loop_connectivities.insert(
-                {DFB_ACT_TILIZED, m2::DFBSelfLoopConnectivity::INTRA});
-        }
 
         if (has_bias) {
             compute_kernel_spec.compiler_options.defines.insert({"FUSE_BIAS", "1"});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -618,10 +618,6 @@ ttnn::device_operation::ProgramArtifacts Conv2dWidthShardedProgramFactory::creat
                 .math_approx_mode = math_approx_mode,
             },
     };
-    // Intra-thread self-loop scope for the two compute self-loop DFBs (single-threaded on Gen1).
-    compute_kernel.advanced_options.dfb_self_loop_connectivities.insert(
-        {DFB_MATMUL_PARTIALS, m2::DFBSelfLoopConnectivity::INTRA});
-    compute_kernel.advanced_options.dfb_self_loop_connectivities.insert({DFB_OUT, m2::DFBSelfLoopConnectivity::INTRA});
 
     // ---- Activation reader kernel ----
     // DFB bindings: produces ACT_ROW_MAJOR + ACT (mcast), consumes ACT_TILIZED (mcast source);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -1196,13 +1196,6 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         .hw_config = compute_hw,
     };
     compute.compiler_options.defines = std::move(compute_defines);
-    if (return_indices) {
-        compute.advanced_options.dfb_self_loop_connectivities.insert(
-            {DFB_COMPUTE_TMP_IDX, DFBSelfLoopConnectivity::INTRA});
-    } else if (cb_sizes.has_pre_tilize) {
-        compute.advanced_options.dfb_self_loop_connectivities.insert({DFB_PRE_TILIZE, DFBSelfLoopConnectivity::INTRA});
-        compute.advanced_options.dfb_self_loop_connectivities.insert({DFB_FAST_TILIZE, DFBSelfLoopConnectivity::INTRA});
-    }
 
     spec.kernels = {reader0};
     if (reader1.has_value()) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -192,10 +192,6 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
         .compile_time_args = {{"Ht", Ht}, {"Wt", Wt}, {"NC", NC}, {"post_mul_scaler_bits", post_mul_scaler_bits}},
         .hw_config = ComputeHardwareConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en},
     };
-    if (operation_attributes.negate) {
-        compute.advanced_options.dfb_self_loop_connectivities.insert({ACC, DFBSelfLoopConnectivity::INTRA});
-        compute.advanced_options.dfb_self_loop_connectivities.insert({INEG, DFBSelfLoopConnectivity::INTRA});
-    }
 
     Group<KernelSpec> kernels = {reader, writer, compute};
     Group<WorkUnitSpec> work_units = {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -207,12 +207,6 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
              {"pack_num_pages_last_row_col", pack_num_pages_last_row_col}},
         .hw_config = compute_cfg,
     };
-    // Compute self-loops are permitted as INTRA (per-thread). cb_tilize (tilize->transpose staging) is
-    // always self-looped; cb_out0 (borrowed output shard) is self-looped only on the ht<=8 in-place path.
-    compute_spec.advanced_options.dfb_self_loop_connectivities.insert({CB_TILIZE, DFBSelfLoopConnectivity::INTRA});
-    if (!ht_gt_8) {
-        compute_spec.advanced_options.dfb_self_loop_connectivities.insert({CB_OUT0, DFBSelfLoopConnectivity::INTRA});
-    }
 
     std::vector<KernelSpec> kernels;
     std::vector<KernelSpecName> wu_kernels;


### PR DESCRIPTION
### PR Category
Bugfix

### Summary
Two related cleanups to the Metal 2.0 self-loop DFB surface.

1. Remove the INTRA/INTER `DFBSelfLoopConnectivity` pseudo-option from the API. 
      - INTER is unsupported and has no known use cases; INTRA is the only valid selection for a compute self-loop.
      - Exposing the choice was confusing to AI users. It also adds unnecessary (and confusing) boilerplate to user host code. 
      - Even if INTER support were to be added, the existing API was incomplete (you'd need some extra knobs to indicate thread mapping). So, the existing placeholder API was doubly confusing.
      - INTRA (the only valid option) is now applied by default.

2. Make the DM-kernel DFB self-loop legality check gen-aware. [PR 48012](https://github.com/tenstorrent/tt-metal/pull/48012) disallowed all DM self-loop DFBs, but this is only forbidden on Gen 2.

### Notes for reviewers
The DM self-loop difference is a small hazard for ops porting to Quasar, but it will be managed by an update to the porting recipe rather than by an unnecessary restriction in the API.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/tidy-self-loop-dfbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/tidy-self-loop-dfbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/tidy-self-loop-dfbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/tidy-self-loop-dfbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/tidy-self-loop-dfbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/tidy-self-loop-dfbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/tidy-self-loop-dfbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/tidy-self-loop-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/tidy-self-loop-dfbs)