### PR TITLE
[Bug fix] Incorrect watcher check & usage around Quasar SRAM uncached memory addresses

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -64,9 +64,6 @@ uint32_t get_runtime_arg_addr(
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     uint32_t num_dm = hal.get_processor_types_count(
         HalProgrammableCoreType::TENSIX, ttsl::as_underlying_type(tt::tt_metal::HalProcessorClassType::DM));
-    const uint32_t uncached_l1_offset = (hal.get_arch() == tt::ARCH::QUASAR)
-                                            ? hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE)
-                                            : 0;
 
     switch (processor_class) {
         case tt::tt_metal::HalProcessorClassType::DM:
@@ -86,7 +83,9 @@ uint32_t get_runtime_arg_addr(
     // Common args go after all unique arg slots
     uint32_t total_processors = hal.get_num_risc_processors(HalProgrammableCoreType::TENSIX);
     uint32_t offset = is_common ? total_processors * runtime_args_space : 0;
-    return (result_base + offset + uncached_l1_offset);
+    // Always return the cached L1 address. Host reads/writes go over the NOC (no cache) and must use
+    // the cached address; only DM cores access the uncached alias, which they add device-side.
+    return (result_base + offset);
 };
 
 distributed::MeshWorkload initialize_program_data_movement_rta(

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp
@@ -14,6 +14,7 @@
 #include "api/core_local_mem.h"
 #include "api/debug/dprint.h"
 #include "experimental/kernel_args.h"
+#include "dev_mem_map.h"
 // TODO FIXME: this build system is ridiculously stupid
 #ifdef COMPILE_FOR_TRISC
 #include "api/compute/tile_move_copy.h"
@@ -22,7 +23,14 @@
 #endif
 
 void kernel_main() {
+    // RESULTS_ADDR is the cached L1 address shared with the host (which reads/writes over the NOC and
+    // must use the cached address). DM cores must reach that same physical memory through the uncached
+    // alias, so add MEM_L1_UNCACHED_BASE here.
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    CoreLocalMem<uint32_t> results(RESULTS_ADDR + MEM_L1_UNCACHED_BASE);
+#else
     CoreLocalMem<uint32_t> results(RESULTS_ADDR);
+#endif
     constexpr uint32_t kCommonRTASeparation = 1024;
     uint64_t hartid = 0;
 #ifdef COMPILE_FOR_DM

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -55,6 +55,8 @@ inline uint64_t debug_normalize_l1_addr(uint64_t addr) {
     }
     return addr;
 }
+#else
+inline uint64_t debug_normalize_l1_addr(uint64_t addr) { return addr; }
 #endif
 
 // Helper function to get the core type from noc coords.
@@ -182,9 +184,7 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write)
     if (addr + len <= addr) {
         return DebugSanitizeNocAddrZeroLength;
     }
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     addr = debug_normalize_l1_addr(addr);
-#endif
     if (addr < MEM_L1_BASE) {
         return DebugSanitizeNocAddrUnderflow;
     }
@@ -278,9 +278,7 @@ inline uint16_t debug_valid_drisc_addr(uint64_t addr, uint64_t len, bool write) 
 // BRISC/NCRISC where cb_addr_shift == 0 (addresses are in bytes).
 // Relies on unused CBs having fifo_size == 0 (cleared at kernel startup).
 inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     l1_addr = static_cast<uint32_t>(debug_normalize_l1_addr(l1_addr));
-#endif
     for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
         LocalCBInterface& cb = get_local_cb_interface(i);
         if (cb.fifo_size == 0) {
@@ -631,9 +629,7 @@ void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
 #else
     constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
 #endif
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     addr = debug_normalize_l1_addr(addr);
-#endif
     if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(
             0,  // unused (not a noc transaction)

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -46,6 +46,17 @@ using debug_sanitize_noc_cast_t = bool;
 #define DEBUG_SANITIZE_NOC_LOCAL false
 using debug_sanitize_noc_which_core_t = bool;
 
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+// Quasar DM cores access L1 through an uncached alias at MEM_L1_UNCACHED_BASE. Normalize
+// uncached addresses to their physical (cached) offset for bounds checks.
+inline uint64_t debug_normalize_l1_addr(uint64_t addr) {
+    if (addr >= MEM_L1_UNCACHED_BASE) {
+        return addr - MEM_L1_UNCACHED_BASE;
+    }
+    return addr;
+}
+#endif
+
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y, bool& is_virtual_coord) {
     core_info_msg_t tt_l1_ptr* core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
@@ -171,6 +182,9 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write)
     if (addr + len <= addr) {
         return DebugSanitizeNocAddrZeroLength;
     }
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    addr = debug_normalize_l1_addr(addr);
+#endif
     if (addr < MEM_L1_BASE) {
         return DebugSanitizeNocAddrUnderflow;
     }
@@ -264,6 +278,9 @@ inline uint16_t debug_valid_drisc_addr(uint64_t addr, uint64_t len, bool write) 
 // BRISC/NCRISC where cb_addr_shift == 0 (addresses are in bytes).
 // Relies on unused CBs having fifo_size == 0 (cleared at kernel startup).
 inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    l1_addr = static_cast<uint32_t>(debug_normalize_l1_addr(l1_addr));
+#endif
     for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
         LocalCBInterface& cb = get_local_cb_interface(i);
         if (cb.fifo_size == 0) {
@@ -613,6 +630,9 @@ void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
     constexpr uint64_t l1_overflow_addr = MEM_DRISC_L1_SIZE;
 #else
     constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
+#endif
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    addr = debug_normalize_l1_addr(addr);
 #endif
     if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -140,9 +140,10 @@ uint32_t firmware_config_init(
         sem_l1_base[index] =
             (uint32_t tt_l1_ptr*)(kernel_config_base[index] + launch_msg_address->kernel_config.sem_offset[index]);
     }
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when cache invalidating
     // functionality is ready for Quasar
+    // Note that the uncached address range is only valid for Quasar DM cores.
     rta_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base[core_type_index] +
                                         launch_msg_address->kernel_config.rta_offset[processor_index].rta_offset +
                                         MEM_L1_UNCACHED_BASE);

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -11,8 +11,6 @@
 namespace tt {
 
 // Host MMIO reads/writes don't have alignment restrictions, so no need to check alignment here.
-// TODO: For Quasar, this range would need to be expanded if we need to write into uncached L1
-// (>= MEM_L1_UNCACHED_BASE) from host, probably by baking the existence of uncached memory into HAL.
 #define DEBUG_VALID_L1_ADDR(a, l) (((a) >= HAL_MEM_L1_BASE) && ((a) + (l) <= HAL_MEM_L1_BASE + HAL_MEM_L1_SIZE))
 
 #define DEBUG_VALID_REG_ADDR(a) tt::tt_metal::MetalContext::instance().hal().valid_reg_addr(a)


### PR DESCRIPTION
### PR Category
Bug fix #48617 

### Summary
This PR addresses 2 issues around the usage of the uncached memory address:

1. Watcher is not currently allowing DMs to use the uncached memory range. Watcher should allow addresses from DM cores in L1 range + MEM_L1_UNCACHED_BASE. 
2. In some cases, the host is using the uncached address for RTAs. All addresses over the NOC should be using the regular memory range, not the uncached memory range, as NOC transactions don't go through the cache. This bug appears to work on the aether emulator, but may not work on future, more accurate emulators or silicon. This corresponds to the changes in the other 3 files.

### Notes for reviewers
The watcher check corresponds to the changes to `sanitize.h` and `sanitize_noc_host.hpp`.
The RTA using cached address in the right locations (i.e. only use uncached address in DMs) corresponds to the other 3 files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_48617)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_48617)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kstevens/issue_48617)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_48617)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_48617)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_48617)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_48617)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_48617)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_48617)