### PR TITLE
Cleanup: Add -Wno-volatile/-Wno-template-body warning suppression

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -320,6 +320,8 @@ set(GPP_FLAGS_common
     -Wno-error=unused-but-set-variable
     -Wno-unused-variable
     -Wno-unused-function
+    -Wno-volatile
+    -Wno-template-body
     -Os
     -fno-tree-loop-distribute-patterns
 )

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -143,7 +143,8 @@ void JitBuildEnv::init(
     string common_flags =
         "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -ftt-no-dyninit "
         "-flto=auto -ffast-math "
-        "-fno-exceptions -fno-rtti -fno-use-cxa-atexit ";
+        "-fno-exceptions -fno-rtti -fno-use-cxa-atexit "
+        "-Wno-volatile -Wno-template-body ";
 
     if (rtoptions.get_jit_analytics_enabled()) {
         common_flags += "-fdump-rtl-all -fdump-tree-original ";


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Suppresses two warnings emitted by the tt toolchain (clang-based) that fire on kernel and JIT-compiled C++ code:
- `-Wno-volatile`: suppresses warnings on volatile-qualified accesses in kernel code that intentionally uses volatile for MMIO/sync.
- `-Wno-template-body`: suppresses warnings on template-body constructs expanded during JIT build.

Added to both the kernel hardware flags (`tt_metal/hw/CMakeLists.txt`) and the JIT build common flags (`tt_metal/jit_build/build.cpp`).

### Notes for reviewers
Minimal change — two flag additions only. No functional behavior change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmalTT/wno-volatile-template-body)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmalTT/wno-volatile-template-body)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmalTT/wno-volatile-template-body)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmalTT/wno-volatile-template-body)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmalTT/wno-volatile-template-body)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmalTT/wno-volatile-template-body)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmalTT/wno-volatile-template-body)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmalTT/wno-volatile-template-body)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmalTT/wno-volatile-template-body)