### PR TITLE
Advance simulator device in D2H/H2D socket wait loops

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -44,6 +44,19 @@ namespace {
 // `_mm_clflush` invalidates one host cache line; 64 B is the line size on typical x86-64.
 constexpr uint32_t k_x86_clflush_line_bytes = 64;
 
+void advance_d2h_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
+    if (mesh_device == nullptr) {
+        return;
+    }
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
+        return;
+    }
+
+    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+}
+
 }  // namespace
 
 D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer(
@@ -419,6 +432,7 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     }
     uint32_t bytes_recv = bytes_sent_ - bytes_acked_;
     while (bytes_recv < num_bytes) {
+        advance_d2h_simulator_socket_device(mesh_device_, sender_core_.device_coord);
         if (using_hugepage_) {
             _mm_clflush(const_cast<void*>(reinterpret_cast<const volatile void*>(hugepage_bytes_sent_host_ptr_)));
             _mm_lfence();

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -25,6 +25,23 @@
 
 namespace tt::tt_metal::distributed {
 
+namespace {
+
+void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
+    if (mesh_device == nullptr) {
+        return;
+    }
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
+        return;
+    }
+
+    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+}
+
+}  // namespace
+
 H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const MeshCoordinateRangeSet& device_range,
@@ -459,6 +476,7 @@ H2DSocket::~H2DSocket() noexcept {
 void H2DSocket::reserve_bytes(uint32_t num_bytes) {
     uint32_t bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
     while (bytes_free < num_bytes) {
+        advance_h2d_simulator_socket_device(mesh_device_, recv_core_.device_coord);
         tt_driver_atomics::mfence();
         volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
         bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_value);
@@ -533,6 +551,7 @@ void H2DSocket::barrier(std::optional<uint32_t> timeout_ms) {
     auto start_time = std::chrono::high_resolution_clock::now();
     while (bytes_sent_ - bytes_acked_value != 0) {
         refresh_connector_write_state();
+        advance_h2d_simulator_socket_device(mesh_device_, recv_core_.device_coord);
         tt_driver_atomics::mfence();
         bytes_acked_value = bytes_acked_ptr_[0];
         if (timeout_ms.has_value()) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -234,7 +234,7 @@ Cluster::Cluster(llrt::RunTimeOptions& rtoptions) : rtoptions_(rtoptions) {
     this->initialize_ethernet_cores_router_mode();
 
     TT_FATAL(this->driver_, "UMD cluster object must be initialized and available");
-    auto & cluster_desc = (*(this->driver_->get_cluster_description()));
+    auto& cluster_desc = (*(this->driver_->get_cluster_description()));
     this->tunnels_from_mmio_device = llrt::discover_tunnels_from_mmio_device(cluster_desc);
 
     if (this->target_type_ != tt::TargetDevice::Mock && this->target_type_ != tt::TargetDevice::Emule) {
@@ -478,7 +478,8 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
     // May block waiting for other processes to release the device.
     this->driver_->start_device(device_params);
 
-    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator) && device_params.init_device) {
+    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator) &&
+        device_params.init_device) {
         // Configure TLBs on all MMIO devices in parallel
         std::vector<std::shared_future<void>> futures;
         const auto& mmio_device_ids = driver_->get_target_mmio_device_ids();
@@ -1080,7 +1081,7 @@ uint64_t Cluster::get_pcie_base_addr_from_device(ChipId chip_id) const {
 
 const std::unordered_set<ChipId>& Cluster::get_devices_controlled_by_mmio_device(ChipId mmio_device_id) const {
     TT_FATAL(driver_, "UMD cluster object must be initialized and available");
-    auto & cluster_desc = (*(driver_->get_cluster_description()));
+    auto& cluster_desc = (*(driver_->get_cluster_description()));
     return llrt::get_devices_controlled_by_mmio_device(cluster_desc, mmio_device_id);
 }
 

--- a/tt_metal/llrt/tunnels_from_mmio_device.cpp
+++ b/tt_metal/llrt/tunnels_from_mmio_device.cpp
@@ -52,7 +52,7 @@ std::map<ChipId, std::vector<std::vector<ChipId>>> discover_tunnels_from_mmio_de
                   device_ids.erase(other_chip_id);
                   std::vector<ChipId> first_stop = {other_chip_id};
                   auto it = std::find(tunnels_from_mmio.begin(), tunnels_from_mmio.end(), first_stop);
-                  TT_ASSERT(it == tunnels_from_mmio.end(), "Duplicate first tunnel stop found.");
+                  TT_FATAL(it == tunnels_from_mmio.end(), "Duplicate first tunnel stop found.");
                   tunnels_from_mmio.push_back(first_stop);
               }
           }
@@ -82,10 +82,10 @@ std::map<ChipId, std::vector<std::vector<ChipId>>> discover_tunnels_from_mmio_de
                   "Detected ethernet connections did not match expected device connectivity, try re-running tt-topology.");
           }
 
-          TT_ASSERT(!tunnels_from_mmio.empty(), "Must have at least 1 tunnel from MMIO Device.");
+          TT_FATAL(!tunnels_from_mmio.empty(), "Must have at least 1 tunnel from MMIO Device.");
           uint32_t tunnel_depth = tunnels_from_mmio[0].size();
           for (auto& dev_vec : tunnels_from_mmio) {
-              TT_ASSERT(dev_vec.size() == tunnel_depth, "All tunnels must have same depth.");
+              TT_FATAL(dev_vec.size() == tunnel_depth, "All tunnels must have same depth.");
               if (dev_vec.size() > MAX_TUNNEL_DEPTH) {
                   dev_vec.resize(MAX_TUNNEL_DEPTH);
               }


### PR DESCRIPTION
### Summary
In Simulator (ttsim) mode, socket wait loops (`wait_for_bytes`, `reserve_bytes`, `barrier`) spin on host memory without yielding to the simulated device, causing deadlocks when the device needs to progress before updating the shared FIFO pointers.

Adds `advance_*_simulator_socket_device()` helpers that call `cluster.advance_device_execution()` on the relevant device when the target is `Simulator`, inserted into each polling loop. On silicon/emu these are no-ops (early return on device-type check).

Also cleans up `TT_ASSERT` -> `TT_FATAL` in `tunnels_from_mmio_device.cpp` and fixes whitespace in `tt_cluster.cpp`.

### Notes for reviewers
The conflict resolution in `h2d_socket.cpp` `barrier()` keeps **both** the `refresh_connector_write_state()` call (recently added on main for connector SHM re-sync) and the new `advance_h2d_simulator_socket_device()` call — they serve different purposes and both are needed in the polling loop.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmalTT/sim-socket-advancement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmalTT/sim-socket-advancement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmalTT/sim-socket-advancement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmalTT/sim-socket-advancement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmalTT/sim-socket-advancement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmalTT/sim-socket-advancement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmalTT/sim-socket-advancement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmalTT/sim-socket-advancement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmalTT/sim-socket-advancement)