### PR TITLE
Pass parent environment to generate_rank_bindings in tt-run Phase 1

### DIFF
--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -777,9 +777,25 @@ def build_generate_rank_bindings_mpi_cmd(
     # Always enable tagged output for easier debugging (prefixes output with rank info)
     cmd.extend(["--tag-output"])
 
-    # Pass LD_LIBRARY_PATH so generate_rank_bindings can find libtt_metal.so when spawned by mpirun
-    ld_path = os.environ.get("LD_LIBRARY_PATH", DEFAULT_LD_LIBRARY_PATH.format(home=str(ORIGINAL_CWD)))
-    cmd.extend(["-x", f"LD_LIBRARY_PATH={ld_path}"])
+    parent_env_prefix = _parent_env_prefix_from_environ()
+
+    if mock_rank_to_desc:
+        ranks = sorted(mock_rank_to_desc.keys())
+        phase1_config = TTRunConfig(
+            rank_bindings=[RankBinding(rank=r, mesh_id=0) for r in ranks],
+            mesh_graph_desc_path=mgd_path,
+            mock_cluster_rank_binding=dict(mock_rank_to_desc),
+        )
+    else:
+        phase1_config = TTRunConfig(
+            rank_bindings=[RankBinding(rank=0, mesh_id=0)],
+            mesh_graph_desc_path=mgd_path,
+        )
+        cmd.extend(
+            build_rank_environment_args(
+                phase1_config.rank_bindings[0], phase1_config, parent_env_prefix=parent_env_prefix
+            )
+        )
 
     # Add user-provided MPI args (e.g., --allow-run-as-root for Docker containers)
     if mpi_args:
@@ -797,9 +813,9 @@ def build_generate_rank_bindings_mpi_cmd(
         for i, rank in enumerate(sorted(mock_rank_to_desc.keys())):
             if i > 0:
                 cmd.append(":")
-            desc_path = mock_rank_to_desc[rank]
+            binding = phase1_config.rank_bindings[i]
             cmd.extend(["-np", "1"])
-            cmd.extend(["-x", f"TT_METAL_MOCK_CLUSTER_DESC_PATH={desc_path.resolve()}"])
+            cmd.extend(build_rank_environment_args(binding, phase1_config, parent_env_prefix=parent_env_prefix))
             cmd.append(str(executable.resolve()))
             cmd.extend(["--mesh-graph-descriptor", str(mgd_path.resolve())])
             cmd.extend(["--output-dir", str(output_dir.resolve())])


### PR DESCRIPTION
### Summary
Phase 1 (`generate_rank_bindings`) now passes parent shell env vars to `mpirun` via `-x`, matching Phase 2 behavior. Previously Phase 1 only forwarded `LD_LIBRARY_PATH`, which caused failures when other env vars (e.g. `TT_METAL_RUNTIME_ROOT`) were needed by remote ranks.

This is especially relevant for monorepo layouts where the runtime root is set by a top-level `env.sh` rather than a standard tt-metal install layout.

### Notes for reviewers
Single-file change to `ttnn/ttnn/distributed/ttrun.py`. The `build_generate_rank_bindings_mpi_cmd` function now uses `build_rank_environment_args()` (same as Phase 2) instead of hardcoding only `LD_LIBRARY_PATH`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmalTT/ttrun-phase1-env-propagate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmalTT/ttrun-phase1-env-propagate)