### PR TITLE
Bind get_physical_mesh_shapes to Python

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -5,7 +5,9 @@
 #include "fabric.hpp"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 
 #include <tt-metalium/core_coord.hpp>
@@ -228,6 +230,25 @@ void bind_fabric_api(nb::module_& mod) {
         &tt::tt_fabric::get_tt_fabric_max_payload_size_bytes,
         R"(
             Returns the maximum fabric packet payload size in bytes.
+        )");
+
+    mod.def(
+        "get_physical_mesh_shapes",
+        []() {
+            // Return plain ints ({mesh_id: (rows, cols)}) to avoid MeshId/MeshShape
+            // Python-type friction -- callers just need the open shape per local mesh.
+            std::unordered_map<uint32_t, std::array<uint32_t, 2>> out;
+            for (const auto& [mid, shape] : tt::tt_fabric::get_physical_mesh_shapes()) {
+                out[*mid] = {shape[0], shape[1]};
+            }
+            return out;
+        },
+        R"(
+            Physical shape of each mesh local to this rank, read from the active mesh graph descriptor.
+
+            Returns a {mesh_id: (rows, cols)} map scoped to get_user_physical_mesh_ids() -- i.e. only
+            this rank's local mesh(es). This is exactly the shape to pass to open_mesh_device, so it is
+            safe to call before the device is opened (the control plane lazily inits from the MGD).
         )");
 }
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -174,6 +174,7 @@ from ttnn._ttnn.fabric import (
     get_fabric_config,
     get_tt_fabric_packet_header_size_bytes,
     get_tt_fabric_max_payload_size_bytes,
+    get_physical_mesh_shapes,
     MeshId,
     FabricNodeId,
     setup_fabric_connection,


### PR DESCRIPTION
### PR Category
Feature

### Summary
Exposes `tt::tt_fabric::get_physical_mesh_shapes()` to Python via nanobind. Returns a `{mesh_id: (rows, cols)}` dict of the physical shape of each mesh local to this rank, read from the active mesh graph descriptor.

This is exactly the shape to pass to `open_mesh_device`, so it is safe to call before the device is opened (the control plane lazily inits from the MGD).

The binding converts `MeshId`/`MeshShape` to plain ints to avoid Python-type friction — callers just need the open shape per local mesh.

### Notes for reviewers
The underlying C++ function already exists on main (`tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp:121`). This PR only adds the nanobind binding and the Python import. Adds `#include <nanobind/stl/unordered_map.h>` to `fabric.cpp` for the return type.

Part of tt-blaze #1831 — upstreaming generic tt-metal fixes that are not Blaze-specific.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmalTT/bind-get-physical-mesh-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmalTT/bind-get-physical-mesh-shapes)