### PR TITLE
Fix depthwise conv1d multi height block (in0_num_blocks_h > 1)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv1d.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+import torch
+import pytest
+from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
+import ttnn
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+@pytest.mark.parametrize(
+    "channels, path",
+    (
+        # 512*2*7 stays under the NoC burst limit -> coalesced read path.
+        (512, "coalesced"),
+        # 1280*2*7 exceeds the WH (8192B) and BH (16384B) burst limits -> non-coalesced read path.
+        (1280, "non-coalesced"),
+    ),
+)
+def test_conv1d_depthwise_multi_height_block(device, channels, path):
+    """Exercises depthwise conv1d with more than one output height block per core
+    (in0_num_blocks_h > 1) on both the coalesced and non-coalesced read paths."""
+    torch.manual_seed(0)
+    C, L, k, pad = channels, 512, 7, 3  # out_length == L
+    groups = C
+    x_ncl = torch.randn(1, C, L, dtype=torch.bfloat16).float()
+    w = torch.randn(C, 1, k, dtype=torch.bfloat16).float()
+    golden = torch.nn.functional.conv1d(x_ncl, w, bias=None, stride=1, padding=pad, groups=groups)
+
+    x_tt = ttnn.from_torch(x_ncl.permute(0, 2, 1), dtype=ttnn.bfloat16)
+    w_tt = ttnn.from_torch(w, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    conv_config = ttnn.Conv1dConfig(
+        weights_dtype=ttnn.bfloat16,
+        shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        deallocate_activation=False,
+    )
+    # Pin 8 cores in a row: 512 rows / 8 = 64 rows (2 tiles) per core.
+    conv_config.override_sharding_config = True
+    conv_config.core_grid = ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 0))})
+    # One tile-row per height block -> in0_num_blocks_h == 2 per core.
+    conv_config.act_block_h_override = 32
+
+    tt_out, out_length = ttnn.conv1d(
+        input_tensor=x_tt,
+        weight_tensor=w_tt,
+        device=device,
+        in_channels=C,
+        out_channels=C,
+        batch_size=1,
+        input_length=L,
+        kernel_size=k,
+        stride=1,
+        padding=pad,
+        groups=groups,
+        conv_config=conv_config,
+        dtype=ttnn.bfloat16,
+        return_output_dim=True,
+    )
+
+    out = ttnn.to_torch(tt_out).reshape(1, out_length, C).permute(0, 2, 1)
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(out, golden, pcc=0.998)
+    logger.info(f"[{path}] {pcc_msg}")
+    assert passing, pcc_msg

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -215,7 +215,7 @@ std::vector<CBInfo> get_cb_info(
     //    (0-page entry; allocate_cbs skips the device allocation).
     //  - Multiple height blocks, non-coalesced: out_cb is the persistent sharded output and cannot
     //    double as the dest-reuse scratch across blocks, so allocate a small double-buffered scratch
-    //    CB in the output data format (compute_depthwise_conv1d.cpp::mul_and_accumulate_block_scratch).
+    //    CB in the output data format (compute_depthwise_conv1d.cpp::mul_and_accumulate_block).
     const bool depthwise_dest_reuse_scratch = is_1d_depthwise_conv &&
                                               sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED &&
                                               !coalesce_1d_depthwise_kw_reads && num_blocks_act_h > 1;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -214,15 +214,15 @@ std::vector<CBInfo> get_cb_info(
     //  - Single height block: it reuses out_cb directly for the read-back, so no partials CB
     //    (0-page entry; allocate_cbs skips the device allocation).
     //  - Multiple height blocks, non-coalesced: out_cb is the persistent sharded output and cannot
-    //    double as the dest-reuse scratch across blocks, so allocate a small double-buffered scratch
-    //    CB in the output data format (compute_depthwise_conv1d.cpp::mul_and_accumulate_block).
+    //    double as the dest-reuse scratch across blocks, so allocate a dedicated scratch CB in the
+    //    output data format.
     const bool depthwise_dest_reuse_scratch = is_1d_depthwise_conv &&
                                               sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED &&
                                               !coalesce_1d_depthwise_kw_reads && num_blocks_act_h > 1;
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::MATMUL_PARTIALS,
         .num_pages =
-            depthwise_dest_reuse_scratch ? (2 * act_block_num_tiles) : (is_1d_depthwise_conv ? 0 : per_core_out_ntiles),
+            depthwise_dest_reuse_scratch ? act_block_num_tiles : (is_1d_depthwise_conv ? 0 : per_core_out_ntiles),
         .page_size = depthwise_dest_reuse_scratch ? output_tile_size : partial_tile_size,
         .is_globally_allocated = (!untilize_out && partial_dtype == output_datatype && !is_1d_depthwise_conv),
         .data_format = depthwise_dest_reuse_scratch ? output_df : partial_df});

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -190,7 +190,11 @@ std::vector<CBInfo> get_cb_info(
             if (!conv_config.enable_activation_reuse) {
                 const bool enable_fully_buffered_weights = num_blocks_act_h > 1;
                 if (enable_fully_buffered_weights) {
-                    weight_block_num_tiles *= kernel_size[0];
+                    // 1D depthwise (non-coalesced) streams num_blocks_act_w one-tap weight blocks per
+                    // height block. Buffer all of them so they stay resident and are reused across
+                    // height blocks (the writer reads weights once, on the first block) instead of
+                    // re-reading from DRAM each block. Normal conv buffers kernel_size[0] blocks.
+                    weight_block_num_tiles *= is_1d_depthwise_conv ? num_blocks_act_w : kernel_size[0];
                 } else if (conv_config.enable_weights_double_buffer) {
                     weight_block_num_tiles *= 2;
                 }
@@ -206,14 +210,22 @@ std::vector<CBInfo> get_cb_info(
             .data_format = weights_df});
     }
 
-    // Matmul partials CB. 1D depthwise compute uses dest-reuse accumulation, so the CB is unused
-    // for that path — emit a 0-page entry so allocate_cbs skips the device allocation.
+    // Matmul partials CB. 1D depthwise compute uses dest-reuse accumulation.
+    //  - Single height block: it reuses out_cb directly for the read-back, so no partials CB
+    //    (0-page entry; allocate_cbs skips the device allocation).
+    //  - Multiple height blocks, non-coalesced: out_cb is the persistent sharded output and cannot
+    //    double as the dest-reuse scratch across blocks, so allocate a small double-buffered scratch
+    //    CB in the output data format (compute_depthwise_conv1d.cpp::mul_and_accumulate_block_scratch).
+    const bool depthwise_dest_reuse_scratch = is_1d_depthwise_conv &&
+                                              sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED &&
+                                              !coalesce_1d_depthwise_kw_reads && num_blocks_act_h > 1;
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::MATMUL_PARTIALS,
-        .num_pages = is_1d_depthwise_conv ? 0 : per_core_out_ntiles,
-        .page_size = partial_tile_size,
+        .num_pages =
+            depthwise_dest_reuse_scratch ? (2 * act_block_num_tiles) : (is_1d_depthwise_conv ? 0 : per_core_out_ntiles),
+        .page_size = depthwise_dest_reuse_scratch ? output_tile_size : partial_tile_size,
         .is_globally_allocated = (!untilize_out && partial_dtype == output_datatype && !is_1d_depthwise_conv),
-        .data_format = partial_df});
+        .data_format = depthwise_dest_reuse_scratch ? output_df : partial_df});
 
     const bool overlap_im2col_cb =
         sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED && conv_input_df == output_df && !skip_act_cb_create;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1042,6 +1042,13 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         // compute_depthwise_conv1d.cpp uses a specialized dest-reuse accumulation path. The last
         // two args select the coalesced kernel-width activation layout when the reader can fetch
         // all kernel-width sticks as one NoC packet.
+
+        // Dest-reuse read-back scratch CB. A single height block accumulates in place (alias OUT);
+        // multiple blocks use the dedicated MATMUL_PARTIALS scratch (out_cb can't double as it).
+        const bool use_partials_scratch = !coalesce_1d_depthwise_kw_reads && num_blocks_act_h_per_core > 1;
+        const uint32_t dest_reuse_scratch_cb_id =
+            get_cb_info_by_name(cb_info, use_partials_scratch ? Conv2dCb::MATMUL_PARTIALS : Conv2dCb::OUT).index;
+
         compute_kernel_args = {
             act_block_w_ntiles,                                         // 0: in0_block_w
             act_num_subblocks,                                          // 1: in0_num_subblocks
@@ -1054,6 +1061,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
             get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,          // 8: out_cb_id
             filter_w,                                                   // 9: kernel_width
             coalesce_1d_depthwise_kw_reads,                             // 10: coalesced activation block
+            dest_reuse_scratch_cb_id,                                   // 11: dest-reuse read-back scratch
         };
     } else {
         compute_kernel_args = {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -14,24 +14,39 @@
 //
 // Per output tile:
 //   dst[0]  = in0 * in1                                                 (FPU mul)
-//   if idx > 0: dst[0] += prior partial loaded from out_cb              (FPU add via DST reuse)
-//   pack dst[0] -> out_cb
+//   if idx > 0: dst[0] += prior partial loaded from scratch_cb          (FPU add via DST reuse)
+//   pack dst[0] -> out_cb on the last tap, else scratch_cb
 //
-// `idx` is the kernel-tap block index (0 .. filter_h*filter_w-1). The very first call (idx == 0)
-// initializes out_cb with the tap-0 product; subsequent calls accumulate via the DST_TO_SRCB
-// dest-reuse pattern, which keeps the running partial in DST and only pulls the prior partial
-// from L1. This gives a single pack per output tile (to out_cb) and avoids the pack-format flips
+// `idx` is the kernel-tap block index (0 .. num_taps-1, num_taps == filter_h*filter_w). The very
+// first call (idx == 0) initializes the partial with the tap-0 product; subsequent calls accumulate
+// via the DST_TO_SRCB dest-reuse pattern, which keeps the running partial in DST and only pulls the
+// prior partial from L1. This gives a single pack per output tile and avoids the pack-format flips
 // that corrupt block-float (BFLOAT8_B/BFLOAT4_B) outputs in the round-tripped variant — while
 // still using FPU (not SFPU) for the add.
+//
+// The partial lives in scratch_cb; only the last tap (idx == num_taps-1) packs into out_cb. The host
+// aliases scratch_cb to out_cb for a single height block (in-place), but uses a separate buffer when
+// in0_num_blocks_h > 1, where out_cb (the persistent sharded output) cannot double as the read-back
+// scratch — block N would otherwise read back block N-1's already-written output.
 //
 // srcB (cfg92) tile descriptor: must match in1 for the mul, and is repopulated from DST for the
 // dest-reuse add. We force srcB back to in1's format every iteration so block-float weights are
 // decoded correctly.
 inline void mul_and_accumulate_block(
-    experimental::CB in0_cb, experimental::CB in1_cb, experimental::CB out_cb, uint32_t block_num_tiles, uint32_t idx) {
+    experimental::CB in0_cb,
+    experimental::CB in1_cb,
+    experimental::CB scratch_cb,
+    experimental::CB out_cb,
+    uint32_t block_num_tiles,
+    uint32_t idx,
+    uint32_t num_taps) {
     const uint32_t in0_cb_id = in0_cb.get_cb_id();
     const uint32_t in1_cb_id = in1_cb.get_cb_id();
-    const uint32_t out_cb_id = out_cb.get_cb_id();
+    const uint32_t scratch_cb_id = scratch_cb.get_cb_id();
+    // The last tap writes the finished output to out_cb; earlier taps write the partial to scratch_cb.
+    const bool is_last_tap = (idx + 1 == num_taps);
+    experimental::CB dst_cb = is_last_tap ? out_cb : scratch_cb;
+    const uint32_t dst_cb_id = dst_cb.get_cb_id();
 
     for (uint32_t i = 0; i < block_num_tiles; i++) {
         in1_cb.wait_front(1);
@@ -44,25 +59,27 @@ inline void mul_and_accumulate_block(
         mul_tiles(in0_cb_id, in1_cb_id, 0, 0, 0);
 
         if (idx != 0) {
-            // dest-reuse add: dst[0] += out_cb. srcA gets out_cb (cfg52 must match out_cb fmt);
-            // srcB is filled from dst[0] by the dest-reuse path.
-            reconfig_data_format_srca(out_cb_id);
+            // dest-reuse add: dst[0] += scratch_cb (the prior tap's partial). srcA gets scratch_cb
+            // (cfg52 must match its format); srcB is filled from dst[0] by the dest-reuse path.
+            reconfig_data_format_srca(scratch_cb_id);
             binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                out_cb_id);
-            out_cb.wait_front(1);
+                scratch_cb_id);
+            scratch_cb.wait_front(1);
             binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                out_cb_id, 0, 0);
-            out_cb.pop_front(1);
+                scratch_cb_id, 0, 0);
+            scratch_cb.pop_front(1);
 
             // Restore srcA to in0's format for the next iteration's mul unpack.
             reconfig_data_format_srca(in0_cb_id);
         }
         tile_regs_commit();
 
-        out_cb.reserve_back(1);
+        // scratch_cb and out_cb share the output data format, so packing to either target needs no
+        // pack reconfig.
+        dst_cb.reserve_back(1);
         tile_regs_wait();
-        pack_tile(0, out_cb_id);
-        out_cb.push_back(1);
+        pack_tile(0, dst_cb_id);
+        dst_cb.push_back(1);
         tile_regs_release();
 
         in0_cb.pop_front(1);
@@ -126,10 +143,14 @@ void kernel_main() {
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(8);
     constexpr uint32_t kernel_width = get_compile_time_arg_val(9);
     constexpr bool coalesce_kw_reads = get_compile_time_arg_val(10) == 1;
+    // Read-back scratch for the dest-reuse accumulation. The host points this at out_cb for a single
+    // height block (in-place) or at a dedicated scratch CB for multiple blocks.
+    constexpr uint32_t partials_cb_id = get_compile_time_arg_val(11);
 
     experimental::CB cb_tilized_in0(tilized_in0_cb_id);
     experimental::CB cb_in1(in1_cb_id);
     experimental::CB cb_out(out_cb_id);
+    experimental::CB cb_partials(partials_cb_id);
 
     // binary_op_init_common configures pack for out_cb, math for in0/in1, and unpack for in0/in1.
     // The pack target never changes (we only ever pack to out_cb), so no further pack reconfig is
@@ -148,8 +169,11 @@ void kernel_main() {
                 mul_and_accumulate_coalesced_block<in0_block_w, kernel_width, in0_block_num_tiles>(
                     cb_tilized_in0, cb_in1, cb_out);
             } else {
-                const uint32_t idx = in0_block_h_i * in0_num_blocks_w + in0_block_w_i;
-                mul_and_accumulate_block(cb_tilized_in0, cb_in1, cb_out, in0_block_num_tiles, idx);
+                // Accumulate kernel-tap in0_block_w_i of in0_num_blocks_w through cb_partials, writing
+                // the final tap to cb_out. The host points cb_partials at cb_out for a single height
+                // block (in-place, no extra buffer) or at a dedicated scratch CB for multiple blocks.
+                mul_and_accumulate_block(
+                    cb_tilized_in0, cb_in1, cb_partials, cb_out, in0_block_num_tiles, in0_block_w_i, in0_num_blocks_w);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -120,6 +120,8 @@ void kernel_main() {
         }
         reader_offset_idx = 0;
 
-        start_reader_idx = reader_idx;
+        // +1: advance past the last segment word to the next block's count word (the inline loop
+        // above stops on the last segment; the shared read_sticks() helper does this increment).
+        start_reader_idx = reader_idx + 1;
     }
 }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/48261

### Problem
When `act_block_h` is forced below the per-core output height, depthwise conv1d processes the output in multiple height blocks (`in0_num_blocks_h > 1`). The default makes `act_block_h` the full per-core height (one block), so this path was latent and broken.

### Fixes
- **Compute (non-coalesced):** used a global accumulation index instead of the per-height-block tap index → blocks after the first never re-initialised.
- **Reader (both paths):** `start_reader_idx` was off by one between height blocks → every block after the first re-read block 0's activations.
- **Dest-reuse scratch (non-coalesced):** `out_cb` (the persistent sharded output) was aliased as the read-back scratch, so block N read back block N-1's output. Now uses a dedicated double-buffered scratch CB for multi-block; a single block still accumulates in place.
- **Weights CB (non-coalesced):** wasn't fully buffered for multi-block. It must hold all `num_blocks_act_w` per-tap weight blocks so they stay resident and are reused across height blocks (the writer reads them once, on the first block). Was previously sized like normal conv (`kernel_size[0]`).

### Test
Adds a nightly regression (coalesced + non-coalesced) at `tests/ttnn/nightly/unit_tests/operations/conv/test_conv1d.py`, picked up automatically by the nightly conv suite. Both params pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjovic/conv1d-depthwise-multi-height-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjovic/conv1d-depthwise-multi-height-block)
