### PR TITLE
Default cache for unary operation - to review comments

### DIFF
--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -143,12 +143,14 @@ void test_operation_infrastructure() {
         .sub_core_grids = std::nullopt,
     };
     Op::tensor_args_t tensor_args{.input = input_tensor, .output_tensor = std::nullopt};
-    auto program_hash = Op::compute_program_hash(op_args, tensor_args);
-    auto program_hash_repeat = Op::compute_program_hash(op_args, tensor_args);
-    TT_FATAL(program_hash != 0, "compute_program_hash returned 0 — likely a bug");
+    auto program_hash =
+        tt::stl::hash::hash_objects_with_default_seed(tt::stl::hash::type_hash<Op>, op_args, tensor_args);
+    auto program_hash_repeat =
+        tt::stl::hash::hash_objects_with_default_seed(tt::stl::hash::type_hash<Op>, op_args, tensor_args);
+    TT_FATAL(program_hash != 0, "default program hash returned 0 — likely a bug");
     TT_FATAL(
         program_hash == program_hash_repeat,
-        "UnaryDeviceOperation::compute_program_hash must be deterministic ({} vs {})",
+        "UnaryDeviceOperation default program hash must be deterministic ({} vs {})",
         program_hash,
         program_hash_repeat);
 }

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
@@ -5,25 +5,16 @@
 """
 Unit tests for eltwise unary program cache behavior.
 
-Tests target potential caching issues.
-The unary operation uses 3 ProgramFactory variants:
-  - UnaryProgramFactory (interleaved)
-  - UnarySubCoreGridProgramFactory (explicit sub_core_grids)
-  - UnaryShardedProgramFactory (sharded input)
+UnaryDeviceOperation rides the default program-cache hash path.The input tensor is
+included in the key via its TensorSpec (logical shape, layout, dtype,
+memory_config), so the full tensor — including its shape — participates in the key.
 
-compute_program_hash() hashes:
-  TILE layout:  args, sub_core_grids, factory_index, input_dtype, input_memory_config, volume, layout
-  ROW_MAJOR:    args, sub_core_grids, factory_index, input_dtype, input_memory_config, padded_shape, layout
-
-Where args = entire UnaryParams (op_chain, output_dtype, output_memory_config,
-fp32_dest_acc_en, preserve_fp32_precision, bfp8_pack_precise, sub_core_grids).
-
-override_runtime_arguments() only updates buffer addresses — shape/work
-distribution changes require separate cache entries.
-
-For TILE layout, only volume is hashed. Same volume = same num_pages = same
-work distribution, so different shapes with same volume correctly share a
-cache entry.
+Consequences:
+  - Same op + same tensor spec -> 1 cache entry (reuse).
+  - Different shapes (even with the same volume) -> separate cache entries, since
+    the logical shape is part of the hashed TensorSpec.
+  - Different op_chain / output_dtype / memory_config / sub_core_grids / worker_grid
+    -> separate cache entries (they are operation_attributes / tensor fields).
 """
 
 import pytest
@@ -73,10 +64,9 @@ def test_unary_cache_reuse_same_config(device):
     assert not torch.equal(tt_out1, tt_out2)
 
 
-def test_unary_cache_reuse_same_volume_different_shapes(device):
-    """TILE layout: same volume, different shapes -> 1 cache entry.
-    unary doesn't hash volume or shape; tile counts are runtime args,
-    so any shape with the same op/dtype/memory_config shares one entry."""
+def test_unary_cache_same_volume_different_shapes_separate_entries(device):
+    """Default cache path: the input TensorSpec (including logical shape) is part of
+    the key, so two different shapes -> 2 cache entries, even with the same volume."""
     device.cache_entries_counter.reset()
 
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, [1, 1, 32, 64], dtype=ttnn.float32)
@@ -85,14 +75,12 @@ def test_unary_cache_reuse_same_volume_different_shapes(device):
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.relu, [1, 1, 64, 32], dtype=ttnn.float32)
     assert_equal(torch_ref2, tt_out2)
 
-    assert device.cache_entries_counter.total == 1
+    assert device.cache_entries_counter.total == 2
 
 
-def test_unary_cache_reuse_different_volumes(device):
-    """TILE layout: different volumes -> still 1 cache entry.
-    unary uses runtime tile counts (not compile-time), so different volumes
-    share the same compiled program. override_runtime_arguments handles the
-    different per-core tile distributions on cache hit."""
+def test_unary_cache_different_volumes_separate_entries(device):
+    """Default cache path: different shapes (different volumes) -> 2 cache entries,
+    since the input TensorSpec is hashed into the program-cache key."""
     device.cache_entries_counter.reset()
 
     torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, [1, 1, 32, 32], dtype=ttnn.float32)
@@ -101,7 +89,7 @@ def test_unary_cache_reuse_different_volumes(device):
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.relu, [1, 1, 64, 64], dtype=ttnn.float32)
     assert_equal(torch_ref2, tt_out2)
 
-    assert device.cache_entries_counter.total == 1
+    assert device.cache_entries_counter.total == 2
 
 
 # =============================================================================
@@ -221,13 +209,14 @@ def test_unary_cache_correctness_repeated_runs(device):
 
 
 def test_unary_cache_correctness_same_volume_different_shapes(device):
-    """Same volume, different shapes all produce correct results via cache reuse."""
+    """Same volume, different shapes all produce correct results; each distinct shape
+    gets its own cache entry under the default cache path (TensorSpec is hashed)."""
     device.cache_entries_counter.reset()
     for shape in [[1, 1, 32, 64], [1, 1, 64, 32]]:
         torch_ref, tt_out = run_unary_op(device, ttnn.sqrt, shape, dtype=ttnn.float32)
         assert_with_ulp(torch_ref, tt_out, 1)
 
-    assert device.cache_entries_counter.total == 1
+    assert device.cache_entries_counter.total == 2
 
 
 # =============================================================================

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -13,18 +13,6 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::unary {
 
-tt::stl::hash::hash_t UnaryDeviceOperation::operation_attributes_t::to_hash() const {
-    return tt::stl::hash::hash_objects_with_default_seed(
-        op_chain,
-        output_dtype,
-        memory_config,
-        fp32_dest_acc_en,
-        preserve_fp32_precision,
-        bfp8_pack_precise,
-        sub_core_grids,
-        worker_grid);
-}
-
 void UnaryDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
@@ -141,48 +129,6 @@ Tensor UnaryDeviceOperation::create_output_tensors(
         return *tensor_args.output_tensor;
     }
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
-}
-
-tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    TT_FATAL(
-        tt::tt_metal::is_device_tensor(input_tensor), "Unary: Unexpected tensor type {}", input_tensor.storage_type());
-
-    const auto output_spec = compute_output_specs(attributes, tensor_args);
-    const auto shard_specs = get_shard_specs(input_tensor.tensor_spec(), output_spec);
-    std::optional<uint32_t> src_shard_vol = std::nullopt;
-    std::optional<uint32_t> dst_shard_vol = std::nullopt;
-    if (shard_specs.has_value()) {
-        const auto tile_hw = input_tensor.tensor_spec().tile().get_tile_hw();
-        if (input_tensor.is_sharded()) {
-            src_shard_vol = shard_specs->input_shard_spec.numel() / tile_hw;
-        }
-        const auto out_tile_hw = output_spec.tile().get_tile_hw();
-        dst_shard_vol = shard_specs->output_shard_spec.numel() / out_tile_hw;
-    }
-
-    // TODO: For ROW_MAJOR, page size depends on width. Hashing padded_shape ensures
-    // different widths get separate cache entries. Consider hashing only the last
-    // dimension to allow cache reuse when only height differs
-    if (input_tensor.layout() == Layout::ROW_MAJOR) {
-        return operation::hash_operation<UnaryDeviceOperation>(
-            attributes,
-            input_tensor.dtype(),
-            input_tensor.layout(),
-            input_tensor.memory_config(),
-            input_tensor.padded_shape(),
-            src_shard_vol,
-            dst_shard_vol);
-    }
-
-    return operation::hash_operation<UnaryDeviceOperation>(
-        attributes,
-        input_tensor.dtype(),
-        input_tensor.layout(),
-        input_tensor.memory_config(),
-        src_shard_vol,
-        dst_shard_vol);
 }
 
 bool UnaryDeviceOperation::skip_launch(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -30,7 +30,26 @@ struct UnaryDeviceOperation {
         const CoreRangeSet worker_grid;
         std::optional<CoreRangeSet> sub_core_grids;
 
-        tt::stl::hash::hash_t to_hash() const;
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "op_chain",
+            "output_dtype",
+            "memory_config",
+            "fp32_dest_acc_en",
+            "preserve_fp32_precision",
+            "bfp8_pack_precise",
+            "worker_grid",
+            "sub_core_grids");
+        auto attribute_values() const {
+            return std::forward_as_tuple(
+                op_chain,
+                output_dtype,
+                memory_config,
+                fp32_dest_acc_en,
+                preserve_fp32_precision,
+                bfp8_pack_precise,
+                worker_grid,
+                sub_core_grids);
+        }
     };
 
     struct tensor_args_t {
@@ -50,7 +69,6 @@ struct UnaryDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_u_UnaryDeviceOperation)