### PR TITLE
[skip ci] Disable test_mlp_1d tests on wh_llmbox due to read-only filesystem

### DIFF
--- a/models/common/tests/modules/mlp/test_mlp_1d.py
+++ b/models/common/tests/modules/mlp/test_mlp_1d.py
@@ -32,8 +32,9 @@ from models.common.auto_compose import to_torch_auto_compose
 from models.common.modules.lazy_weight import LazyWeight
 from models.common.modules.mlp.mlp_1d import MLP1D, MLP1DConfig, _matmul_config
 from models.common.tensor_utils import TILE_SIZE
-from models.common.utility_functions import comp_allclose, comp_pcc
+from models.common.utility_functions import comp_allclose, comp_pcc, skip_for_wormhole_b0
 from models.tt_transformers.tt.common import Mode
+from models.common.utility_functions import is_galaxy
 
 
 def get_mlp_weights_from_ref_model(reference_mlp) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -146,6 +147,7 @@ def _get_or_init_mlp_weights(model_name: str, reference_mlp) -> None:
 # (test_mlp_1d_vs_reference) since it requires real LazyWeight instances.
 
 
+@skip_for_wormhole_b0("Read-only filesystem on wh_llmbox prevents cache writes, refs #47718")
 def test_mlp_1d_config_creation():
     """Test that MLP1DConfig dataclass can be created with explicit values."""
     from unittest.mock import MagicMock
@@ -183,6 +185,7 @@ def test_mlp_1d_config_creation():
     assert config.topology == ttnn.Topology.Ring
 
 
+@skip_for_wormhole_b0("Read-only filesystem on wh_llmbox prevents cache writes, refs #47718")
 def test_mlp_1d_config_defaults():
     """Test that MLP1DConfig has sensible defaults."""
     from unittest.mock import MagicMock
@@ -203,6 +206,7 @@ def test_mlp_1d_config_defaults():
     assert config.hidden_dim is None
 
 
+@skip_for_wormhole_b0("Read-only filesystem on wh_llmbox prevents cache writes, refs #47718")
 def test_mlp_1d_config_power_user_overrides():
     """Test that MLP1DConfig accepts power-user overrides for program configs."""
     from unittest.mock import MagicMock
@@ -513,6 +517,7 @@ def _list_non_glx_test_cases() -> list[pytest.param]:
 
 # [INFO] generate random tensor for every test case is too expensive; cache weights and reuse them across test cases
 # [INFO] separate out ttnn_mesh_device parameter allows for sharing the same mesh device across test cases
+@skip_for_wormhole_b0("Read-only filesystem on wh_llmbox prevents cache writes, refs #47718")
 @pytest.mark.parametrize(
     "ttnn_mesh_device",
     [(1, 1), (1, 2), (1, 8)],
@@ -607,6 +612,7 @@ def test_mlp_1d_vs_reference(
     logger.info(f"MLP1D (direct API) vs HF reference: PASSED for mode={mode}, seq_len={seq_len}")
 
 
+@skip_for_wormhole_b0("Read-only filesystem on wh_llmbox prevents cache writes, refs #47718")
 @pytest.mark.parametrize(
     "ttnn_mesh_device",
     [(1, 8)],
@@ -702,6 +708,7 @@ def test_mlp_1d_config_prefill_override(ttnn_mesh_device: ttnn.MeshDevice):
 
 
 # [INFO] this test will retire once models/tt_transformers/tt/model_config.py retires
+@skip_for_wormhole_b0("Read-only filesystem on wh_llmbox prevents cache writes, refs #47718")
 @pytest.mark.parametrize(
     "ttnn_mesh_device",
     [


### PR DESCRIPTION
All tests in `models/common/tests/modules/mlp/test_mlp_1d.py` are failing on the `wh_llmbox` (T3000 unit tests / t3k_tttv2_fast_unit_tests) CI job because the `/mnt/MLPerf/huggingface/tt_cache/tttv2/mlp_1d/` path is read-only on that machine, causing a fatal error when the test tries to write weight cache files.

Error: `TT_FATAL: Cannot open ".../w1_srcshape_4096_14336_dtype_BFLOAT4_B_layout_TILE_memcfg_..._device_5.tensorbin" for writing: errno=30 "Read-only file system"`

This PR temporarily skips all tests in the file on Wormhole B0 hardware until the filesystem issue is resolved.

refs #47718

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47718)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47718)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lifecycle/disable-issue-47718)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47718)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47718)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47718)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47718)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47718)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47718)