### PR TITLE
[Feature] group_norm: synthesize per-group masks in the kernel

### DIFF
--- a/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_attention.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_attention.py
@@ -21,7 +21,6 @@ class Attention:
         self.norm_num_blocks = 1
         self.norm_grid_core = ttnn.CoreGrid(y=4, x=8) if in_channels == 128 else ttnn.CoreGrid(y=8, x=8)
         (
-            self.norm_input_mask,
             self.norm_weights,
             self.norm_bias,
         ) = prepare_group_norm(
@@ -110,7 +109,6 @@ class Attention:
         hidden_states = ttnn.group_norm(
             hidden_states,
             num_groups=GROUPNORM_GROUPS,
-            input_mask=self.norm_input_mask,
             weight=self.norm_weights,
             bias=self.norm_bias,
             epsilon=GROUPNORM_EPSILON,

--- a/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_decoder.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_decoder.py
@@ -77,7 +77,6 @@ class VaeDecoder:
         self.norm_num_blocks = norm_num_blocks
         self.norm_grid_core = ttnn.CoreGrid(y=4, x=8)
         (
-            self.norm_input_mask,
             self.norm_weights,
             self.norm_bias,
         ) = prepare_group_norm(
@@ -114,7 +113,6 @@ class VaeDecoder:
         hidden_states = ttnn.group_norm(
             hidden_states,
             num_groups=GROUPNORM_GROUPS,
-            input_mask=self.norm_input_mask,
             weight=self.norm_weights,
             bias=self.norm_bias,
             core_grid=self.norm_grid_core,

--- a/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_resnet.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_resnet.py
@@ -32,7 +32,6 @@ class ResnetBlock:
         self.norm1_num_blocks = norm1_num_blocks
         self.norm1_grid_core = ttnn.CoreGrid(y=4, x=8) if in_channels == 128 else ttnn.CoreGrid(y=8, x=8)
         (
-            self.norm1_input_mask,
             self.norm1_weights,
             self.norm1_bias,
         ) = prepare_group_norm(
@@ -57,7 +56,6 @@ class ResnetBlock:
         self.norm2_num_blocks = norm2_num_blocks
         self.norm2_grid_core = ttnn.CoreGrid(y=4, x=8) if out_channels == 128 else ttnn.CoreGrid(y=8, x=8)
         (
-            self.norm2_input_mask,
             self.norm2_weights,
             self.norm2_bias,
         ) = prepare_group_norm(
@@ -105,7 +103,6 @@ class ResnetBlock:
         hidden_states = ttnn.group_norm(
             hidden_states,
             num_groups=GROUPNORM_GROUPS,
-            input_mask=self.norm1_input_mask,
             weight=self.norm1_weights,
             bias=self.norm1_bias,
             epsilon=GROUPNORM_EPSILON,
@@ -123,7 +120,6 @@ class ResnetBlock:
         hidden_states = ttnn.group_norm(
             hidden_states,
             num_groups=GROUPNORM_GROUPS,
-            input_mask=self.norm2_input_mask,
             weight=self.norm2_weights,
             bias=self.norm2_bias,
             epsilon=GROUPNORM_EPSILON,

--- a/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_utils.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tt/vae/ttnn_vae_utils.py
@@ -7,8 +7,6 @@ import ttnn
 
 def prepare_group_norm(device, in_channels, core_grid, torch_weights, torch_bias, num_groups=32):
     num_cores_across_channel = core_grid.y
-    input_mask = ttnn.create_group_norm_input_mask(in_channels, num_groups, num_cores_across_channel, ttnn.bfloat16)
-    input_mask = ttnn.to_device(input_mask, device)
     weights = ttnn.from_torch(
         ttnn.create_group_norm_weight_bias_rm(torch_weights, in_channels, num_cores_across_channel),
         device=device,
@@ -22,4 +20,4 @@ def prepare_group_norm(device, in_channels, core_grid, torch_weights, torch_bias
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    return input_mask, weights, bias
+    return weights, bias

--- a/models/experimental/retinanet/tt/tt_classification_head.py
+++ b/models/experimental/retinanet/tt/tt_classification_head.py
@@ -133,9 +133,6 @@ def ttnn_retinanet_classification_head(
 
     grid_size = ttnn.CoreGrid(y=8, x=8)
 
-    input_mask_tensor = ttnn.create_group_norm_input_mask(in_channels, 32, grid_size.y)
-    input_mask_tensor = input_mask_tensor.to(device, ttnn.DRAM_MEMORY_CONFIG)
-
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=model_config.get("MATH_FIDELITY", ttnn.MathFidelity.HiFi4),
@@ -165,7 +162,6 @@ def ttnn_retinanet_classification_head(
                 padding=(1, 1),
                 num_groups=32,
                 grid_size=grid_size,
-                input_mask=input_mask_tensor,
                 model_config=model_config,
                 compute_config=compute_config,
                 conv_config=fpn_conv_config,

--- a/models/experimental/retinanet/tt/tt_regression_head.py
+++ b/models/experimental/retinanet/tt/tt_regression_head.py
@@ -310,8 +310,6 @@ def ttnn_retinanet_regression_head(
     all_bbox_regression = []
 
     grid_size = ttnn.CoreGrid(y=8, x=8)
-    input_mask_tensor = ttnn.create_group_norm_input_mask(in_channels, 32, grid_size.y)
-    input_mask_tensor = input_mask_tensor.to(device, ttnn.DRAM_MEMORY_CONFIG)
 
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -344,7 +342,6 @@ def ttnn_retinanet_regression_head(
                 padding=(1, 1),
                 num_groups=32,
                 grid_size=grid_size,
-                input_mask=input_mask_tensor,
                 model_config=model_config,
                 compute_config=compute_config,
                 conv_config=conv_config,

--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -479,11 +479,6 @@ class GroupNorm(Module):
             math.ceil(self.num_channels // self.num_virtual_cols / 32) * self.num_virtual_cols,
             32,
         ]
-        block_wt = ttnn.operations.normalization.find_max_tile_span(
-            self.num_channels, self.num_channels // self.num_groups, 32
-        )
-        mask_shape = [1, self.num_groups, 32, 32 * block_wt]
-
         self.weight = Parameter(
             total_shape=weight_shape,
             layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -496,7 +491,6 @@ class GroupNorm(Module):
             mesh_axes=[mesh_axis, None, None, None],
             device=self.mesh_device,
         )
-        self.mask = Parameter(total_shape=mask_shape, device=self.mesh_device)
 
     @classmethod
     def from_torch(
@@ -525,9 +519,6 @@ class GroupNorm(Module):
         if "bias" in state:
             state["bias"] = self._prepare_param(state["bias"])
 
-        input_mask = ttnn.create_group_norm_input_mask(self.num_channels, self.num_groups, self.num_virtual_cols)
-        state["mask"] = ttnn.to_torch(input_mask)
-
     def _prepare_param(self, param: torch.Tensor) -> torch.Tensor:
         expected_shape = (self.num_channels * self.num_devices,)
         assert param.shape == expected_shape, f"expected shape {expected_shape}, got {param.shape}"
@@ -544,7 +535,6 @@ class GroupNorm(Module):
         kwargs = dict(
             weight=self.weight.data,
             bias=self.bias.data,
-            input_mask=self.mask.data,
             num_groups=self.num_groups,
             epsilon=self.eps,
             core_grid=self.core_grid,
@@ -567,7 +557,7 @@ class GroupNorm3D(Module):
     Routes through the DRAM-interleaved ``ttnn.group_norm``. The grid is pinned at
     construction from ``input_nhw``/``num_batches`` via
     ``determine_expected_group_norm_dram_grid_size`` (uniform multicast groups; avoids
-    the mcast deadlock at small spatial sizes), so gamma/beta/mask are static
+    the mcast deadlock at small spatial sizes), so gamma/beta are static
     ``Parameter``s and round-trip through ``Module.save``/``load``.
     """
 
@@ -609,12 +599,9 @@ class GroupNorm3D(Module):
         )
 
         weight_shape = [1, 1, math.ceil(num_channels // self.num_virtual_cols / 32) * self.num_virtual_cols, 32]
-        block_wt = ttnn.operations.normalization.find_max_tile_span(num_channels, num_channels // num_groups, 32)
-        mask_shape = [1, num_groups, 32, 32 * block_wt]
 
         self.weight = Parameter(total_shape=weight_shape, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=dtype, device=mesh_device)
         self.bias = Parameter(total_shape=weight_shape, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=dtype, device=mesh_device)
-        self.mask = Parameter(total_shape=mask_shape, dtype=dtype, device=mesh_device)
 
     @classmethod
     def from_torch(
@@ -647,8 +634,6 @@ class GroupNorm3D(Module):
             state["bias"] = ttnn.create_group_norm_weight_bias_rm(
                 state["bias"], self.num_channels, self.num_virtual_cols
             )
-        mask = ttnn.create_group_norm_input_mask(self.num_channels, self.num_groups, self.num_virtual_cols)
-        state["mask"] = ttnn.to_torch(mask)
 
     def forward(self, x_BTHWC: ttnn.Tensor) -> ttnn.Tensor:
         B, T, H, W, C = x_BTHWC.shape
@@ -669,7 +654,6 @@ class GroupNorm3D(Module):
             # -1 = built-in chunk heuristic. Default 1 (with pinned core_grid) overflows L1
             # at large gathered spatial.
             num_out_blocks=-1,
-            input_mask=self.mask.data,
             weight=self.weight.data,
             bias=self.bias.data,
             epsilon=self.eps,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -295,8 +295,9 @@ def test_group_norm_oft(device, N, C, H, W, num_groups, shard, eps, use_negative
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
 @pytest.mark.parametrize("N, C, H, W, num_groups", base.NO_INPUT_MASK_SHAPES)
 @pytest.mark.parametrize("specify_grid", [False])
-def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, specify_grid):
-    base.test_group_norm_no_input_mask(device, N, C, H, W, num_groups, specify_grid)
+@pytest.mark.parametrize("use_welford", base.welford_flavors, ids=base.welford_ids)
+def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, use_welford, specify_grid):
+    base.test_group_norm_no_input_mask(device, N, C, H, W, num_groups, use_welford, specify_grid)
 
 
 @pytest.mark.parametrize("N, C, H, W, num_groups", base.DRAM_GRID_SIZE_SHAPES)

--- a/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
@@ -21,11 +21,6 @@ from ttnn._ttnn.operations.normalization import (
 )
 
 
-# ===========================================================================
-#  Pure CPU-only tests (no device fixture required)
-# ===========================================================================
-
-
 # ---------------------------------------------------------------------------
 # groupnorm_input_mask.cpp  create_group_norm_input_mask_impl():
 #   TT_FATAL — num_cores_across_channel must be > 0
@@ -73,14 +68,9 @@ def test_find_expected_dram_grid_no_valid_grid(expect_error):
 # normalization.py  dram_group_norm_virtual_columns():
 #   AssertionError — no valid num_virtual_cols (wraps compute_num_virtual_cols)
 #
-# This covers the num_virtual_cols == 0 scenario that used to be asserted via
-# groupnorm.cpp get_mask_tensor() (removed along with the host-side mask build).
-# The surviving C++ guard in groupnorm_device_operation.cpp select_program_factory()
-# is unreachable from ttnn.group_norm: it sits behind the non-sharded branch, and
-# every non-sharded input is forced to TILE layout, so padded W is always tile
-# aligned and num_virtual_cols is always >= 1.  dram_group_norm_virtual_columns()
-# is the guard DRAM group-norm callers actually hit, and it is exercised here with
-# the same (grid_x=1, num_channels=48, num_groups=16) configuration.
+# No num_virtual_cols can satisfy (num_channels / nvc) % 32 == 0 and
+# num_groups % nvc == 0 for grid_x=1, num_channels=48, num_groups=16, so the
+# helper must raise instead of returning 0.
 # ---------------------------------------------------------------------------
 def test_dram_group_norm_virtual_columns_none_valid(expect_error):
     with expect_error(AssertionError, "could not find a valid num_virtual_cols for"):
@@ -89,11 +79,6 @@ def test_dram_group_norm_virtual_columns_none_valid(expect_error):
             num_channels=48,
             num_groups=16,
         )
-
-
-# ===========================================================================
-#  Device-dependent tests (use TT-Sim simulated device)
-# ===========================================================================
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
@@ -69,34 +69,31 @@ def test_find_expected_dram_grid_no_valid_grid(expect_error):
         )
 
 
+# ---------------------------------------------------------------------------
+# normalization.py  dram_group_norm_virtual_columns():
+#   AssertionError — no valid num_virtual_cols (wraps compute_num_virtual_cols)
+#
+# This covers the num_virtual_cols == 0 scenario that used to be asserted via
+# groupnorm.cpp get_mask_tensor() (removed along with the host-side mask build).
+# The surviving C++ guard in groupnorm_device_operation.cpp select_program_factory()
+# is unreachable from ttnn.group_norm: it sits behind the non-sharded branch, and
+# every non-sharded input is forced to TILE layout, so padded W is always tile
+# aligned and num_virtual_cols is always >= 1.  dram_group_norm_virtual_columns()
+# is the guard DRAM group-norm callers actually hit, and it is exercised here with
+# the same (grid_x=1, num_channels=48, num_groups=16) configuration.
+# ---------------------------------------------------------------------------
+def test_dram_group_norm_virtual_columns_none_valid(expect_error):
+    with expect_error(AssertionError, "could not find a valid num_virtual_cols for"):
+        ttnn.operations.normalization.dram_group_norm_virtual_columns(
+            core_grid=ttnn.CoreGrid(x=1, y=1),
+            num_channels=48,
+            num_groups=16,
+        )
+
+
 # ===========================================================================
 #  Device-dependent tests (use TT-Sim simulated device)
 # ===========================================================================
-
-
-# ---------------------------------------------------------------------------
-# groupnorm.cpp  get_mask_tensor():
-#   TT_FATAL — num_virtual_cols == 0 (non-L1 buffer path; DRAM height-sharded skips validate_dram_grid)
-# ---------------------------------------------------------------------------
-def test_get_mask_tensor_num_virtual_cols_zero(device, expect_error):
-    torch_x = torch.randn(1, 1, 32, 48, dtype=torch.bfloat16)
-    shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-        (32, 48),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    dram_height_sharded = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttnn.BufferType.DRAM,
-        shard_spec,
-    )
-    x = ttnn.interleaved_to_sharded(
-        ttnn.from_torch(torch_x, dtype=ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT),
-        dram_height_sharded,
-    )
-
-    with expect_error(RuntimeError, "Cannot determine num_virtual_cols"):
-        ttnn.group_norm(x, num_groups=16, core_grid=ttnn.CoreGrid(x=1, y=1), inplace=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1584,14 +1584,12 @@ def test_group_norm_bf16_negative_mask(device, N, C, H, W, num_groups):
 
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE_SDXL_BG_N_MASK, indirect=True)
 @pytest.mark.parametrize("N, C, H, W, num_groups", [(1, 640, 128, 128, 32)])
-def test_group_norm_synthesize_negative_mask(device, N, C, H, W, num_groups):
+def test_group_norm_auto_negative_mask_synthesis(device, N, C, H, W, num_groups):
     """
-    Exercises NEGATIVE_MASK_SYNTHESIZE on the sharded factory. No mask tensors
-    are passed; instead, synthesize_negative_mask=True opts into the writer-
-    kernel negative-mask synthesis path, and the positive mask is synthesized
-    automatically because input_mask is omitted. Compares against the same
-    computation with a caller-supplied bf16 negative_mask to confirm bit-
-    equivalence.
+    Exercises NEGATIVE_MASK_SYNTHESIZE with no mask tensors passed at all. The L1 ballast
+    below leaves the overlap as the only layout that fits, so the call completing is the
+    proof that the op enabled it by itself. Compared against the caller-supplied bf16
+    mask path for bit-equivalence.
     """
     torch.manual_seed(0)
     grid_size = ttnn.CoreGrid(y=8, x=8)
@@ -1641,6 +1639,24 @@ def test_group_norm_synthesize_negative_mask(device, N, C, H, W, num_groups):
     # second run already-normalized data.
     tt_input_synth = ttnn.to_device(tt_input_tensor, device, memory_config=sharded_mem_config)
 
+    # 64 KB/core: more than the margin by which the non-overlapping layout fits, less
+    # than the ~385 KB the overlap frees. Held live across the call below.
+    ballast_rows_per_core, ballast_cols_per_core = 64, 512
+    ballast_shard = ttnn.ShardSpec(
+        shard_grid, (ballast_rows_per_core, ballast_cols_per_core), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    ballast = ttnn.from_torch(
+        torch.zeros(
+            (1, 1, ballast_rows_per_core * grid_size.y, ballast_cols_per_core * grid_size.x), dtype=torch.bfloat16
+        ),
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, ballast_shard
+        ),
+    )
+
     tt_output_tensor = ttnn.group_norm(
         tt_input_synth,
         num_groups=num_groups,
@@ -1648,9 +1664,9 @@ def test_group_norm_synthesize_negative_mask(device, N, C, H, W, num_groups):
         core_grid=grid_size,
         weight=gamma_t,
         bias=beta_t,
-        synthesize_negative_mask=True,
     )
     ttnn.synchronize_device(device)
+    ttnn.deallocate(ballast)
 
     tt_output_tensor = ttnn.from_device(tt_output_tensor)
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
@@ -1857,11 +1873,14 @@ def test_group_norm_rejects_host_negative_mask(device, expect_error):
         )
 
 
-def _block_sharded_320ch_input(device, grid_size, layout):
-    torch_input_tensor = torch.rand((1, 320, 32, 32), dtype=torch.bfloat16)
-    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(1, 1, 32 * 32, 320)
+def _block_sharded_320ch_input(device, grid_size, layout, spatial=32):
+    # Single core, so `spatial` sets how much L1 the program needs. The default is too big
+    # to fit; pass a smaller one when the op is expected to run to completion.
+    hw = spatial * spatial
+    torch_input_tensor = torch.rand((1, 320, spatial, spatial), dtype=torch.bfloat16)
+    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(1, 1, hw, 320)
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
-    shard_spec = ttnn.ShardSpec(shard_grid, (32 * 32, 320), ttnn.ShardOrientation.ROW_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, (hw, 320), ttnn.ShardOrientation.ROW_MAJOR)
     sharded_mem_config = ttnn.MemoryConfig(
         ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
     )
@@ -1872,22 +1891,14 @@ def _block_sharded_320ch_input(device, grid_size, layout):
         device=device,
         memory_config=sharded_mem_config,
     )
-    return input_tensor, sharded_mem_config
+    return torch_input_tensor, input_tensor, sharded_mem_config
 
 
 def test_group_norm_rejects_negative_mask_with_welford(device, expect_error):
+    # Only a caller-supplied negative mask can reach the Welford kernels; the op's own
+    # decision declines for use_welford=True.
     grid_size = ttnn.CoreGrid(y=1, x=1)
-    input_tensor, sharded_mem_config = _block_sharded_320ch_input(device, grid_size, ttnn.ROW_MAJOR_LAYOUT)
-
-    with expect_error(RuntimeError, "synthesize_negative_mask=True is not supported with use_welford=True"):
-        ttnn.group_norm(
-            input_tensor,
-            num_groups=32,
-            memory_config=sharded_mem_config,
-            core_grid=grid_size,
-            use_welford=True,
-            synthesize_negative_mask=True,
-        )
+    _, input_tensor, sharded_mem_config = _block_sharded_320ch_input(device, grid_size, ttnn.ROW_MAJOR_LAYOUT)
 
     input_mask = ttnn.to_device(ttnn.create_group_norm_input_mask(320, 32, grid_size.x, ttnn.DataType.BFLOAT16), device)
     negative_mask = ttnn.to_device(
@@ -1905,19 +1916,35 @@ def test_group_norm_rejects_negative_mask_with_welford(device, expect_error):
         )
 
 
-def test_group_norm_rejects_synthesize_negative_mask_with_tile_layout(device, expect_error):
+def test_group_norm_tile_layout_declines_negative_mask(device):
+    # A TILE input has no negative-mask code path, so the op must decline the overlap.
+    # Guards the layout check in needs_negative_mask_overlap.
     grid_size = ttnn.CoreGrid(y=1, x=1)
-    input_tensor, sharded_mem_config = _block_sharded_320ch_input(device, grid_size, ttnn.TILE_LAYOUT)
+    torch.manual_seed(0)
+    torch_input, input_tensor, sharded_mem_config = _block_sharded_320ch_input(
+        device, grid_size, ttnn.TILE_LAYOUT, spatial=8
+    )
 
-    with expect_error(RuntimeError, "synthesize_negative_mask=True requires a ROW_MAJOR input tensor"):
-        ttnn.group_norm(
-            input_tensor,
-            num_groups=32,
-            memory_config=sharded_mem_config,
-            core_grid=grid_size,
-            inplace=False,
-            synthesize_negative_mask=True,
-        )
+    output = ttnn.group_norm(
+        input_tensor,
+        num_groups=32,
+        memory_config=sharded_mem_config,
+        core_grid=grid_size,
+        inplace=False,
+    )
+    ttnn.synchronize_device(device)
+    assert output.layout == ttnn.TILE_LAYOUT
+
+    torch_output = torch.nn.functional.group_norm(torch_input, 32)
+    torch_output = torch_output.permute(0, 2, 3, 1).view(1, 1, 8 * 8, 320)
+    assert_numeric_metrics(
+        torch_output,
+        ttnn.to_torch(ttnn.from_device(output)),
+        pcc_threshold=0.9999,
+        rtol=0.065,
+        atol=0.065,
+        frobenius_threshold=0.016,
+    )
 
 
 @pytest.mark.parametrize("N, C, H, W, num_groups", DRAM_GRID_SIZE_SHAPES)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1399,9 +1399,7 @@ def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, use_welford, s
     """
     Test that a group norm without an input mask produces the same result as torch.
 
-    Exercises the writer-kernel mask-synthesis path on the sharded factory. Parametrized
-    over use_welford so we cover the Welford + sharded + synthesis combination, which
-    depends on the mask-multiply reorder in welford_groupnorm_sharded_v2.cpp.
+    Exercises the writer-kernel mask-synthesis path on the sharded factory.
     """
     torch.manual_seed(0)
     input_shape = (N, C, H, W)
@@ -2235,12 +2233,16 @@ def test_group_norm_sharded_all_config(
     [(2, 1), (2, 2), (2, 4), (4, 2)],
 )
 @pytest.mark.parametrize(
-    # prebuilt_mask=True is what real code should do (free); False makes group_norm derive the
-    # second set per call (~4x slower), covered so the fallback cannot rot.
-    "prebuilt_mask",
-    [True, False],
+    # How the {0,1} column selector reaches the kernel, for each way group_norm accepts it:
+    #   "doubled"     -- caller ships both mask sets (create_group_norm_input_mask with
+    #                    rows_in_last_tile).
+    #   "single_set"  -- caller ships the column selector only.
+    #   "synthesized" -- no mask at all; the writer builds one row-0-only selector set directly
+    #                    in L1, and compute composes the row-masked final row-tile on device.
+    "mask_mode",
+    ["doubled", "single_set", "synthesized"],
 )
-def test_group_norm_sharded_dirty_padding(device, grid_y, grid_x, padding_value, prebuilt_mask):
+def test_group_norm_sharded_dirty_padding(device, grid_y, grid_x, padding_value, mask_mode):
     # Mirror of test_group_norm_non_tile_aligned_garbage_padding_DRAM for the BLOCK-SHARDED path:
     # supply non-zero tile padding and require the result to be independent of it.
     #
@@ -2275,16 +2277,19 @@ def test_group_norm_sharded_dirty_padding(device, grid_y, grid_x, padding_value,
     )
     tt = ttnn.to_memory_config(tt, sharded_mem_config)
 
-    mask = ttnn.to_device(
-        ttnn.create_group_norm_input_mask(
-            C,
-            G,
-            grid_size.y,
-            ttnn.DataType.BFLOAT8_B,
-            rows_in_last_tile=(HW % 32) if prebuilt_mask else 0,
-        ),
-        device,
-    )
+    if mask_mode == "synthesized":
+        mask = None
+    else:
+        mask = ttnn.to_device(
+            ttnn.create_group_norm_input_mask(
+                C,
+                G,
+                grid_size.y,
+                ttnn.DataType.BFLOAT8_B,
+                rows_in_last_tile=(HW % 32) if mask_mode == "doubled" else 0,
+            ),
+            device,
+        )
     out = ttnn.group_norm(
         tt,
         num_groups=G,
@@ -2299,10 +2304,96 @@ def test_group_norm_sharded_dirty_padding(device, grid_y, grid_x, padding_value,
     pcc = torch.corrcoef(torch.stack([out.flatten(), ref.flatten()]))[0, 1].item()
     logger.info(
         f"block-sharded dirty padding grid={grid_x}x{grid_y} padding={padding_value} "
-        f"prebuilt_mask={prebuilt_mask}: max_abs_err={max_abs_err} pcc={pcc}"
+        f"mask_mode={mask_mode}: max_abs_err={max_abs_err} pcc={pcc}"
     )
     assert max_abs_err < 0.08, (
         f"max abs error {max_abs_err} with tile padding = {padding_value} on a {grid_x}x{grid_y} "
         f"block-sharded grid; group_norm must be independent of its padding (see #52685)"
     )
     assert pcc > 0.999, f"pcc {pcc} with tile padding = {padding_value} (see #52685)"
+
+
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+@pytest.mark.parametrize("padding_value", [7.0, -3.5])
+@pytest.mark.parametrize("grid_x", [1, 2, 4])
+@pytest.mark.parametrize(
+    # Group sizes that are a WHOLE number of tiles. On grid_y=8, C=1024 gives 128 channels
+    # (4 tiles) per core:
+    #   G=32 -> group 32 ch = 1 tile   (block_wt == 1)
+    #   G=16 -> group 64 ch = 2 tiles  (block_wt == 2)
+    #   G=64 -> group 16 ch, sub-tile  (control, matches the regime already covered)
+    "C, G, whole_tile_groups",
+    [(1024, 32, True), (1024, 16, True), (1024, 64, False)],
+    ids=["blockwt1", "blockwt2", "subtile_control"],
+)
+@pytest.mark.parametrize("mask_mode", ["doubled", "single_set", "synthesized"])
+def test_group_norm_sharded_dirty_padding_tile_aligned_groups(
+    device, grid_x, C, G, whole_tile_groups, padding_value, mask_mode
+):
+    # Same contract as test_group_norm_sharded_dirty_padding -- the result must not depend on what
+    # sits in the tile padding -- but at group sizes that are a whole number of tiles, where the
+    # per-group column selector is all-ones and only the composed row exclusion does any work.
+    grid_y = 8
+    if device.core_grid.x < grid_x or device.core_grid.y < grid_y:
+        pytest.skip(f"device grid too small for {grid_x}x{grid_y}")
+
+    torch.manual_seed(0)
+    N, HW, padded = 1, 100, 128
+    assert (padded // 32) % grid_x == 0, "padded H*W tiles must split evenly across the M cores"
+    grid_size = ttnn.CoreGrid(y=grid_y, x=grid_x)
+
+    real = torch.rand((N, 1, HW, C), dtype=torch.bfloat16)
+    ref = torch.nn.functional.group_norm(real.view(N, HW, C).permute(0, 2, 1).reshape(N, C, 1, HW).float(), G)
+    ref = ref.permute(0, 2, 3, 1).reshape(N, 1, HW, C)
+
+    buf = torch.zeros((N, 1, padded, C), dtype=torch.bfloat16)
+    buf[:, :, :HW, :] = real
+    buf[:, :, HW:, :] = padding_value
+
+    tt = ttnn.from_torch(
+        buf, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt = ttnn.reshape(tt, ttnn.Shape([N, 1, HW, C]), ttnn.Shape([N, 1, padded, C]))
+
+    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_spec = ttnn.ShardSpec(shard_grid, (padded // grid_size.x, C // grid_size.y), ttnn.ShardOrientation.COL_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    tt = ttnn.to_memory_config(tt, sharded_mem_config)
+
+    if mask_mode == "synthesized":
+        mask = None
+    else:
+        mask = ttnn.to_device(
+            ttnn.create_group_norm_input_mask(
+                C,
+                G,
+                grid_size.y,
+                ttnn.DataType.BFLOAT8_B,
+                rows_in_last_tile=(HW % 32) if mask_mode == "doubled" else 0,
+            ),
+            device,
+        )
+    out = ttnn.group_norm(
+        tt,
+        num_groups=G,
+        input_mask=mask,
+        memory_config=sharded_mem_config,
+        core_grid=grid_size,
+        inplace=False,
+    )
+    out = ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float()[:, :, :HW, :]
+
+    max_abs_err = (out - ref).abs().max().item()
+    pcc = torch.corrcoef(torch.stack([out.flatten(), ref.flatten()]))[0, 1].item()
+    logger.info(
+        f"whole-tile groups={whole_tile_groups} C={C} G={G} grid={grid_x}x{grid_y} "
+        f"padding={padding_value} mask_mode={mask_mode}: max_abs_err={max_abs_err} pcc={pcc}"
+    )
+    assert max_abs_err < 0.08, (
+        f"max abs error {max_abs_err} with tile padding = {padding_value} at C={C} G={G} "
+        f"(whole-tile groups={whole_tile_groups}); the composed row mask must still apply"
+    )
+    assert pcc > 0.999, f"pcc {pcc} at C={C} G={G} with tile padding = {padding_value}"

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1680,6 +1680,10 @@ def test_group_norm_auto_negative_mask_synthesis(device, N, C, H, W, num_groups)
         frobenius_threshold=0.016,
     )
 
+    # Holding tt_input_synth leaves two 320 KB/core shards across the second call,
+    # which does not fit on Wormhole's L1.
+    ttnn.deallocate(tt_input_synth)
+
     # The path this replaces: the same computation driven by caller-supplied bf16
     # positive and negative mask tensors read from DRAM. Run it from the identical
     # input and compare the two device outputs directly, since agreeing with torch

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1394,9 +1394,14 @@ def test_group_norm_oft(device, N, C, H, W, num_groups, shard, eps, use_negative
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
 @pytest.mark.parametrize("N, C, H, W, num_groups", NO_INPUT_MASK_SHAPES)
 @pytest.mark.parametrize("specify_grid", [True])
-def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, specify_grid):
+@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
+def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, use_welford, specify_grid):
     """
     Test that a group norm without an input mask produces the same result as torch.
+
+    Exercises the writer-kernel mask-synthesis path on the sharded factory. Parametrized
+    over use_welford so we cover the Welford + sharded + synthesis combination, which
+    depends on the mask-multiply reorder in welford_groupnorm_sharded_v2.cpp.
     """
     torch.manual_seed(0)
     input_shape = (N, C, H, W)
@@ -1433,6 +1438,7 @@ def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, specify_grid):
             memory_config=sharded_mem_config,
             core_grid=grid_size if specify_grid else None,
             compute_kernel_config=compute_config,
+            use_welford=use_welford,
         )
         tt_output_tensor_host = ttnn.from_device(tt_output_tensor)
         tt_output_tensor_host = ttnn.to_torch(tt_output_tensor_host)
@@ -1465,10 +1471,233 @@ def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, specify_grid):
     tt_output_high = do_group_norm_for_config(config_high)
     frobenius_high2 = (ref_f2 - tt_output_high.float()).norm() / (ref_f2.norm() + 1e-8)
 
+    assert_numeric_metrics(
+        torch_output_tensor,
+        tt_output_high,
+        pcc_threshold=0.9999,
+        rtol=0.065,
+        atol=0.075,
+        frobenius_threshold=0.015,
+    )
+
+    assert_numeric_metrics(
+        torch_output_tensor,
+        tt_output_low,
+        pcc_threshold=0.999,
+        rtol=0.15,
+        atol=0.30,
+        frobenius_threshold=0.12,
+    )
+
     # Verify that the higher-accuracy config is closer to torch
     assert (
         frobenius_high2 <= frobenius_low2
     ), "High-accuracy config should have lower Frobenius error than low-accuracy config"
+
+
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE_SDXL_BG_N_MASK, indirect=True)
+@pytest.mark.parametrize("N, C, H, W, num_groups", [(1, 640, 128, 128, 32)])
+def test_group_norm_bf16_negative_mask(device, N, C, H, W, num_groups):
+    """
+    Caller-supplied bf16 positive + negative masks on the sharded factory.
+    The existing SDXL negative-mask coverage passes BFP8 masks, so this is the
+    only exercise of the bf16 mask dtype through the writer's DRAM read path.
+    """
+    torch.manual_seed(0)
+    grid_size = ttnn.CoreGrid(y=8, x=8)
+
+    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_weight = torch.rand((C,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch.nn.functional.group_norm(
+        torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
+    )
+    torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    tt_input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    tt_input_tensor = ttnn.from_torch(
+        tt_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.x, ttnn.DataType.BFLOAT16)
+    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
+
+    input_negative_mask_tensor = ttnn.create_group_norm_input_negative_mask(
+        C, num_groups, grid_size.x, ttnn.DataType.BFLOAT16
+    )
+    input_negative_mask_tensor = ttnn.to_device(input_negative_mask_tensor, device)
+
+    gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.x)
+    beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.x)
+
+    gamma_t = ttnn.from_torch(
+        gamma,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    beta_t = ttnn.from_torch(
+        beta,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_shape = N * H * W // grid_size.y, C // grid_size.x
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    tt_input_tensor = ttnn.to_device(tt_input_tensor, device, memory_config=sharded_mem_config)
+
+    tt_output_tensor = ttnn.group_norm(
+        tt_input_tensor,
+        num_groups=num_groups,
+        input_mask=input_mask_tensor,
+        negative_mask=input_negative_mask_tensor,
+        memory_config=sharded_mem_config,
+        core_grid=grid_size,
+        weight=gamma_t,
+        bias=beta_t,
+    )
+    ttnn.synchronize_device(device)
+
+    tt_output_tensor = ttnn.from_device(tt_output_tensor)
+    tt_output_tensor = ttnn.to_torch(tt_output_tensor)
+
+    assert_numeric_metrics(
+        torch_output_tensor,
+        tt_output_tensor,
+        pcc_threshold=0.9999,
+        rtol=0.065,
+        atol=0.065,
+        frobenius_threshold=0.016,
+    )
+
+
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE_SDXL_BG_N_MASK, indirect=True)
+@pytest.mark.parametrize("N, C, H, W, num_groups", [(1, 640, 128, 128, 32)])
+def test_group_norm_synthesize_negative_mask(device, N, C, H, W, num_groups):
+    """
+    Exercises NEGATIVE_MASK_SYNTHESIZE on the sharded factory. No mask tensors
+    are passed; instead, synthesize_negative_mask=True opts into the writer-
+    kernel negative-mask synthesis path, and the positive mask is synthesized
+    automatically because input_mask is omitted. Compares against the same
+    computation with a caller-supplied bf16 negative_mask to confirm bit-
+    equivalence.
+    """
+    torch.manual_seed(0)
+    grid_size = ttnn.CoreGrid(y=8, x=8)
+
+    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_weight = torch.rand((C,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch.nn.functional.group_norm(
+        torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
+    )
+    torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    tt_input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    tt_input_tensor = ttnn.from_torch(
+        tt_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.x)
+    beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.x)
+    gamma_t = ttnn.from_torch(
+        gamma,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    beta_t = ttnn.from_torch(
+        beta,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_shape = N * H * W // grid_size.y, C // grid_size.x
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    # Each path gets its own freshly uploaded copy of the identical input: the op writes
+    # its output over the input's L1 shard, so reusing one device tensor would feed the
+    # second run already-normalized data.
+    tt_input_synth = ttnn.to_device(tt_input_tensor, device, memory_config=sharded_mem_config)
+
+    tt_output_tensor = ttnn.group_norm(
+        tt_input_synth,
+        num_groups=num_groups,
+        memory_config=sharded_mem_config,
+        core_grid=grid_size,
+        weight=gamma_t,
+        bias=beta_t,
+        synthesize_negative_mask=True,
+    )
+    ttnn.synchronize_device(device)
+
+    tt_output_tensor = ttnn.from_device(tt_output_tensor)
+    tt_output_tensor = ttnn.to_torch(tt_output_tensor)
+
+    assert_numeric_metrics(
+        torch_output_tensor,
+        tt_output_tensor,
+        pcc_threshold=0.9999,
+        rtol=0.065,
+        atol=0.065,
+        frobenius_threshold=0.016,
+    )
+
+    # The path this replaces: the same computation driven by caller-supplied bf16
+    # positive and negative mask tensors read from DRAM. Run it from the identical
+    # input and compare the two device outputs directly, since agreeing with torch
+    # to within a tolerance does not by itself establish that the two paths agree
+    # with each other.
+    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.x, ttnn.DataType.BFLOAT16)
+    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
+
+    input_negative_mask_tensor = ttnn.create_group_norm_input_negative_mask(
+        C, num_groups, grid_size.x, ttnn.DataType.BFLOAT16
+    )
+    input_negative_mask_tensor = ttnn.to_device(input_negative_mask_tensor, device)
+
+    tt_input_supplied = ttnn.to_device(tt_input_tensor, device, memory_config=sharded_mem_config)
+
+    tt_output_supplied_mask = ttnn.group_norm(
+        tt_input_supplied,
+        num_groups=num_groups,
+        input_mask=input_mask_tensor,
+        negative_mask=input_negative_mask_tensor,
+        memory_config=sharded_mem_config,
+        core_grid=grid_size,
+        weight=gamma_t,
+        bias=beta_t,
+    )
+    ttnn.synchronize_device(device)
+
+    tt_output_supplied_mask = ttnn.from_device(tt_output_supplied_mask)
+    tt_output_supplied_mask = ttnn.to_torch(tt_output_supplied_mask)
+
+    assert torch.equal(tt_output_tensor, tt_output_supplied_mask), (
+        "Synthesized masks must reproduce the caller-supplied bf16 mask path bit-exactly; "
+        f"max abs difference {(tt_output_tensor.float() - tt_output_supplied_mask.float()).abs().max()}"
+    )
 
 
 @pytest.mark.parametrize("input_shape, num_groups, msg_pattern", NEGATIVE_TESTS_PARAMS)
@@ -1625,6 +1854,69 @@ def test_group_norm_rejects_host_negative_mask(device, expect_error):
             negative_mask=negative_mask,
             memory_config=sharded_mem_config,
             core_grid=grid_size,
+        )
+
+
+def _block_sharded_320ch_input(device, grid_size, layout):
+    torch_input_tensor = torch.rand((1, 320, 32, 32), dtype=torch.bfloat16)
+    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(1, 1, 32 * 32, 320)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (32 * 32, 320), ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    input_tensor = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=layout,
+        device=device,
+        memory_config=sharded_mem_config,
+    )
+    return input_tensor, sharded_mem_config
+
+
+def test_group_norm_rejects_negative_mask_with_welford(device, expect_error):
+    grid_size = ttnn.CoreGrid(y=1, x=1)
+    input_tensor, sharded_mem_config = _block_sharded_320ch_input(device, grid_size, ttnn.ROW_MAJOR_LAYOUT)
+
+    with expect_error(RuntimeError, "synthesize_negative_mask=True is not supported with use_welford=True"):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=32,
+            memory_config=sharded_mem_config,
+            core_grid=grid_size,
+            use_welford=True,
+            synthesize_negative_mask=True,
+        )
+
+    input_mask = ttnn.to_device(ttnn.create_group_norm_input_mask(320, 32, grid_size.x, ttnn.DataType.BFLOAT16), device)
+    negative_mask = ttnn.to_device(
+        ttnn.create_group_norm_input_negative_mask(320, 32, grid_size.x, ttnn.DataType.BFLOAT16), device
+    )
+    with expect_error(RuntimeError, "Negative mask is not supported with use_welford=True"):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=32,
+            input_mask=input_mask,
+            negative_mask=negative_mask,
+            memory_config=sharded_mem_config,
+            core_grid=grid_size,
+            use_welford=True,
+        )
+
+
+def test_group_norm_rejects_synthesize_negative_mask_with_tile_layout(device, expect_error):
+    grid_size = ttnn.CoreGrid(y=1, x=1)
+    input_tensor, sharded_mem_config = _block_sharded_320ch_input(device, grid_size, ttnn.TILE_LAYOUT)
+
+    with expect_error(RuntimeError, "synthesize_negative_mask=True requires a ROW_MAJOR input tensor"):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=32,
+            memory_config=sharded_mem_config,
+            core_grid=grid_size,
+            inplace=False,
+            synthesize_negative_mask=True,
         )
 
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -250,6 +250,10 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             negative_mask.value().padded_shape()[3],
             tile_width);
         TT_FATAL(a.is_sharded(), "Negative mask support is only available for sharded input tensors.");
+        // The Welford compute kernels have no negative-mask path, and the sharded factory skips the
+        // untilize-output CB (c_30) whenever a negative mask is in play while the Welford kernel
+        // still reads it under UNTILIZE_OUT, so the combination hangs instead of being ignored.
+        TT_FATAL(!args.use_welford, "Negative mask is not supported with use_welford=True.");
         TT_FATAL(
             a.layout() == Layout::ROW_MAJOR,
             "If using negative mask, input tensor must be in ROW_MAJOR layout, but layout is {}",
@@ -259,6 +263,36 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             output_layout == Layout::ROW_MAJOR,
             "If using negative mask, output tensor must be in ROW_MAJOR layout, but layout is {}",
+            output_layout);
+    }
+
+    // synthesize_negative_mask=True makes the sharded writer kernel build the inverted per-group
+    // selector directly in L1 instead of reading a negative_mask tensor, so it inherits the same
+    // constraints as a caller-supplied negative mask. Checked here rather than only in the ttnn
+    // wrapper so that direct ttnn::prim::group_norm callers are covered too.
+    if (args.synthesize_negative_mask) {
+        TT_FATAL(
+            a.is_sharded(),
+            "group_norm: synthesize_negative_mask=True is only supported for sharded inputs (the interleaved factories "
+            "have no negative-mask code path).");
+        // The negative mask only exists so the legacy sharded kernel can accumulate output in place
+        // into the tilized-input CB. The Welford kernels never overlap those CBs, so they have no
+        // negative-mask path at all -- and the sharded factory skips allocating the untilize-output
+        // CB (c_30) whenever a negative mask is in play, which the Welford kernel still reads under
+        // UNTILIZE_OUT. Accepting the combination would hang rather than ignore the flag.
+        TT_FATAL(
+            !args.use_welford, "group_norm: synthesize_negative_mask=True is not supported with use_welford=True.");
+        // Mirrors the layout requirements enforced above for a caller-supplied negative_mask tensor.
+        // Without these the flag reaches kernels whose input or output CB is never written.
+        TT_FATAL(
+            a.layout() == Layout::ROW_MAJOR,
+            "group_norm: synthesize_negative_mask=True requires a ROW_MAJOR input tensor, but layout is {}",
+            a.layout());
+        Layout output_layout =
+            std::visit([](const auto& config) -> Layout { return config.output_layout; }, args.program_config);
+        TT_FATAL(
+            output_layout == Layout::ROW_MAJOR,
+            "group_norm: synthesize_negative_mask=True requires a ROW_MAJOR output layout, but layout is {}",
             output_layout);
     }
 
@@ -359,7 +393,8 @@ Tensor group_norm(
     std::optional<Tensor> beta,
     std::optional<Tensor> input_mask,
     std::optional<Tensor> negative_mask,
-    std::optional<Tensor> reciprocals) {
+    std::optional<Tensor> reciprocals,
+    bool synthesize_negative_mask) {
     if (negative_mask.has_value()) {
         TT_FATAL(
             negative_mask.value().storage_type() == StorageType::DEVICE,
@@ -369,6 +404,9 @@ Tensor group_norm(
             negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
         TT_FATAL(input.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
     }
+    TT_FATAL(
+        !(synthesize_negative_mask && negative_mask.has_value()),
+        "synthesize_negative_mask=True is mutually exclusive with a caller-supplied negative_mask tensor.");
     using OperationType = GroupNormDeviceOperation;
     auto operation_attributes = OperationType::operation_attributes_t{
         .eps = eps,
@@ -377,6 +415,7 @@ Tensor group_norm(
         .program_config = program_config,
         .compute_kernel_config = compute_kernel_config,
         .use_welford = use_welford,
+        .synthesize_negative_mask = synthesize_negative_mask,
     };
     auto tensor_args = OperationType::tensor_args_t{
         .input = input,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -250,9 +250,7 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             negative_mask.value().padded_shape()[3],
             tile_width);
         TT_FATAL(a.is_sharded(), "Negative mask support is only available for sharded input tensors.");
-        // The Welford compute kernels have no negative-mask path, and the sharded factory skips the
-        // untilize-output CB (c_30) whenever a negative mask is in play while the Welford kernel
-        // still reads it under UNTILIZE_OUT, so the combination hangs instead of being ignored.
+        // The Welford compute kernels have no negative-mask path.
         TT_FATAL(!args.use_welford, "Negative mask is not supported with use_welford=True.");
         TT_FATAL(
             a.layout() == Layout::ROW_MAJOR,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -266,33 +266,26 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             output_layout);
     }
 
-    // synthesize_negative_mask=True makes the sharded writer kernel build the inverted per-group
-    // selector directly in L1 instead of reading a negative_mask tensor, so it inherits the same
-    // constraints as a caller-supplied negative mask. Checked here rather than only in the ttnn
-    // wrapper so that direct ttnn::prim::group_norm callers are covered too.
+    // synthesize_negative_mask makes the sharded writer kernel build the per-group
+    // selector directly in L1 instead of reading a tensor.
+    // This attribute is determined by ttnn::group_norm itself (see needs_negative_mask_overlap)
     if (args.synthesize_negative_mask) {
         TT_FATAL(
             a.is_sharded(),
-            "group_norm: synthesize_negative_mask=True is only supported for sharded inputs (the interleaved factories "
+            "group_norm: synthesize_negative_mask is only supported for sharded inputs (the interleaved factories "
             "have no negative-mask code path).");
-        // The negative mask only exists so the legacy sharded kernel can accumulate output in place
-        // into the tilized-input CB. The Welford kernels never overlap those CBs, so they have no
-        // negative-mask path at all -- and the sharded factory skips allocating the untilize-output
-        // CB (c_30) whenever a negative mask is in play, which the Welford kernel still reads under
-        // UNTILIZE_OUT. Accepting the combination would hang rather than ignore the flag.
-        TT_FATAL(
-            !args.use_welford, "group_norm: synthesize_negative_mask=True is not supported with use_welford=True.");
+        // The Welford kernels have no negative-mask path at all.
+        TT_FATAL(!args.use_welford, "group_norm: synthesize_negative_mask is not supported with use_welford=True.");
         // Mirrors the layout requirements enforced above for a caller-supplied negative_mask tensor.
-        // Without these the flag reaches kernels whose input or output CB is never written.
         TT_FATAL(
             a.layout() == Layout::ROW_MAJOR,
-            "group_norm: synthesize_negative_mask=True requires a ROW_MAJOR input tensor, but layout is {}",
+            "group_norm: synthesize_negative_mask requires a ROW_MAJOR input tensor, but layout is {}",
             a.layout());
         Layout output_layout =
             std::visit([](const auto& config) -> Layout { return config.output_layout; }, args.program_config);
         TT_FATAL(
             output_layout == Layout::ROW_MAJOR,
-            "group_norm: synthesize_negative_mask=True requires a ROW_MAJOR output layout, but layout is {}",
+            "group_norm: synthesize_negative_mask requires a ROW_MAJOR output layout, but layout is {}",
             output_layout);
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
@@ -66,6 +66,7 @@ Tensor group_norm(
     std::optional<Tensor> beta,
     std::optional<Tensor> input_mask,
     std::optional<Tensor> negative_mask,
-    std::optional<Tensor> reciprocals);
+    std::optional<Tensor> reciprocals,
+    bool synthesize_negative_mask = false);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
@@ -46,6 +46,12 @@ struct GroupNormParams {
     GroupNormProgramConfig program_config;
     DeviceComputeKernelConfig compute_kernel_config;
     bool use_welford = false;
+    // When true (and negative_mask is not passed), the writer kernel synthesizes
+    // the per-group inverted {1.0, 0.0} negative-mask directly in L1 — same as
+    // the positive-mask synthesis path. Sharded only; the interleaved factories
+    // don't emit negative-mask code paths. Mutually exclusive with a caller-
+    // supplied negative_mask tensor.
+    bool synthesize_negative_mask = false;
 };
 
 struct GroupNormInputs {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -322,8 +322,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
-    // The row-masked set shares the CB with the normal one, on top of the double-buffering.
-    uint32_t in_mask_CB_size = use_welford ? input_mask.value().physical_volume() * input_mask.value().element_size()
+    // Welford writer reserves block_w * num_groups_per_core tiles up-front and the compute kernel
+    // waits on all of them; non-Welford double-buffers block_wt tiles. Sized from block_wt rather
+    // than from the caller's tensor because a synthesized mask has no tensor to size against.
+    // mask_sets == 2 when the row-masked set is present -- it shares the CB with the normal set on
+    // top of the double-buffering. pad.active is false whenever use_welford, so mask_sets is always
+    // 1 on the Welford arm and is not needed there.
+    uint32_t in_mask_CB_size = use_welford ? input_mask_num_tiles_per_core * in_mask_single_tile_size
                                            : block_wt * in_mask_single_tile_size * 2 * mask_sets;
     uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;
     uint32_t interm_block_tiles_group_1 = in0_block_tiles_group_1;
@@ -341,7 +346,10 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
 
     if (use_welford) {
         x_CB_size_group_1 = single_tile_size * 1;
-        xmm_CB_size_group_1 = single_tile_size * 3;
+        // cb_xmm double buffer. After the Welford mask-multiply reorder
+        // (`((x − μ) · rsqrt) · mask`), only one tile is live in cb_xmm at
+        // a time, so the allocation drops from 3 to 2.
+        xmm_CB_size_group_1 = single_tile_size * 2;
     }
 
     // c_17 holds the whole per-core group, tilized once and reused by all three passes.
@@ -570,6 +578,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"num_groups_per_core", num_groups_per_core},
         {"num_batches_per_core", num_batches_per_core_group_1},
         {"num_cols_per_group", num_channels_per_group_mod_tile_w},
+        {"num_channels_per_group", num_channels_per_group},
         {"num_tiles_per_batch", per_core_Mt_group_1 * Wt / num_batches_per_core_group_1},
         {"block_w_last", block_wt_last},
         {"GROUP_SIZE_IS_POWER_OF_2",
@@ -618,6 +627,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     std::map<std::string, std::string> writer_defines;
     if (untilize_out) {
         writer_defines["UNTILIZE_OUT"] = "1";
+    }
+    // See groupnorm_sharded_program_factory.cpp for the mask data path
+    // selection (synthesize / full read). Synthesis fires only when the
+    // caller did not pass an input_mask tensor.
+    const bool synth_mask = !input_mask.has_value();
+    if (synth_mask) {
+        writer_defines["MASK_SYNTHESIZE"] = "1";
     }
 
     KernelDescriptor writer_desc;
@@ -946,7 +962,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
             }}},
         });
     }
-    if (input_mask.has_value()) {
+    if (input_mask.has_value() || synth_mask) {
         constexpr uint32_t in_mask_cb_index = tt::CBIndex::c_28;
         desc.cbs.push_back(CBDescriptor{
             .total_size = in_mask_CB_size,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -322,12 +322,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
-    // Welford writer reserves block_w * num_groups_per_core tiles up-front and the compute kernel
-    // waits on all of them; non-Welford double-buffers block_wt tiles. Sized from block_wt rather
-    // than from the caller's tensor because a synthesized mask has no tensor to size against.
-    // mask_sets == 2 when the row-masked set is present -- it shares the CB with the normal set on
-    // top of the double-buffering. pad.active is false whenever use_welford, so mask_sets is always
-    // 1 on the Welford arm and is not needed there.
+    // Sized from block_wt (a synthesized mask has no tensor to size against). Welford holds all
+    // groups' tiles at once; non-Welford double-buffers block_wt tiles per set (mask_sets == 2
+    // when the row-masked set is present).
     uint32_t in_mask_CB_size = use_welford ? input_mask_num_tiles_per_core * in_mask_single_tile_size
                                            : block_wt * in_mask_single_tile_size * 2 * mask_sets;
     uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;
@@ -1309,12 +1306,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
-        // Where this core reads the row-masked set from. Only the core holding a batch's final
-        // row-tile needs it; the rest get the normal set again, making compute's switch a no-op
-        // there. Deciding it here keeps the compute kernel compile-time-only.
+        // Per-core: under synthesis the valid-row count, on the DRAM path where to read the
+        // row-masked set from. Cores that do not hold a batch's final row-tile get values that
+        // make the second set identical to the first.
+        const bool owns_pad_tile = pad.active && group_norm_core_owns_pad_tile(virtual_core.y, num_cores_per_batch);
         writer_mcast_sender_args.push_back(
-            input_mask_tile_start_id +
-            (pad.active && group_norm_core_owns_pad_tile(virtual_core.y, num_cores_per_batch) ? mask_set_tiles : 0));
+            synth_mask ? (owns_pad_tile ? pad.rows_in_last_tile : tile_height)
+                       : (input_mask_tile_start_id + (owns_pad_tile ? mask_set_tiles : 0)));
         writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -425,8 +425,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
-    // The row-masked set shares the CB with the normal one, on top of the double-buffering.
-    uint32_t in_mask_CB_size = use_welford ? input_mask.value().physical_volume() * input_mask.value().element_size()
+    // Welford writer reserves block_w * num_groups_per_core tiles up-front and the compute kernel
+    // waits on all of them; non-Welford double-buffers block_wt tiles. Sized from block_wt rather
+    // than from the caller's tensor because a synthesized mask has no tensor to size against.
+    // mask_sets == 2 when the row-masked set is present -- it shares the CB with the normal set on
+    // top of the double-buffering. pad.active is false whenever use_welford, so mask_sets is always
+    // 1 on the Welford arm and is not needed there.
+    uint32_t in_mask_CB_size = use_welford ? input_mask_num_tiles_per_core * in_mask_single_tile_size
                                            : block_wt * in_mask_single_tile_size * 2 * mask_sets;
     uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;
     uint32_t interm_block_tiles_group_1 = in0_block_tiles_group_1;
@@ -471,8 +476,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     if (use_welford) {
         x_CB_size_group_1 = single_tile_size * 1;
         x_CB_size_group_2 = single_tile_size * 1;
-        xmm_CB_size_group_1 = single_tile_size * 3;
-        xmm_CB_size_group_2 = single_tile_size * 3;
+        // cb_xmm double buffer. After the Welford mask-multiply reorder
+        // (`((x − μ) · rsqrt) · mask`), only one tile is live in cb_xmm at
+        // a time, so the allocation drops from 3 to 2.
+        xmm_CB_size_group_1 = single_tile_size * 2;
+        xmm_CB_size_group_2 = single_tile_size * 2;
     }
 
     // c_17 holds the whole per-core group, tilized once and reused by all three passes.
@@ -720,6 +728,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"num_groups_per_core", num_groups_per_core},
         {"num_batches_per_core", num_batches_per_core_group_1},
         {"num_cols_per_group", num_channels_per_group_mod_tile_w},
+        {"num_channels_per_group", num_channels_per_group},
         {"num_tiles_per_batch", per_core_Mt_group_1 * Wt / num_batches_per_core_group_1},
         {"block_w_last", block_wt_last},
         {"GROUP_SIZE_IS_POWER_OF_2",
@@ -753,6 +762,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"num_groups_per_core", num_groups_per_core},
         {"num_batches_per_core", num_batches_per_core_group_2},
         {"num_cols_per_group", num_channels_per_group_mod_tile_w},
+        {"num_channels_per_group", num_channels_per_group},
         {"num_tiles_per_batch", per_core_Mt_group_2 * Wt / num_batches_per_core_group_2},
         {"block_w_last", block_wt_last},
         {"GROUP_SIZE_IS_POWER_OF_2",
@@ -796,6 +806,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     std::map<std::string, std::string> writer_defines;
     if (untilize_out) {
         writer_defines["UNTILIZE_OUT"] = "1";
+    }
+    // See groupnorm_sharded_program_factory.cpp for the mask data path
+    // selection (synthesize / full read). Synthesis fires only when the
+    // caller did not pass an input_mask tensor.
+    const bool synth_mask = !input_mask.has_value();
+    if (synth_mask) {
+        writer_defines["MASK_SYNTHESIZE"] = "1";
     }
 
     KernelDescriptor writer_desc_g1;
@@ -1208,7 +1225,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             }}},
         });
     }
-    if (input_mask.has_value()) {
+    if (input_mask.has_value() || synth_mask) {
         constexpr uint32_t in_mask_cb_index = tt::CBIndex::c_28;
         desc.cbs.push_back(CBDescriptor{
             .total_size = in_mask_CB_size,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -425,12 +425,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
-    // Welford writer reserves block_w * num_groups_per_core tiles up-front and the compute kernel
-    // waits on all of them; non-Welford double-buffers block_wt tiles. Sized from block_wt rather
-    // than from the caller's tensor because a synthesized mask has no tensor to size against.
-    // mask_sets == 2 when the row-masked set is present -- it shares the CB with the normal set on
-    // top of the double-buffering. pad.active is false whenever use_welford, so mask_sets is always
-    // 1 on the Welford arm and is not needed there.
+    // Sized from block_wt (a synthesized mask has no tensor to size against). Welford holds all
+    // groups' tiles at once; non-Welford double-buffers block_wt tiles per set (mask_sets == 2
+    // when the row-masked set is present).
     uint32_t in_mask_CB_size = use_welford ? input_mask_num_tiles_per_core * in_mask_single_tile_size
                                            : block_wt * in_mask_single_tile_size * 2 * mask_sets;
     uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;
@@ -1607,11 +1604,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
-        // Where this core reads the row-masked set from. Only the core holding a batch's final
-        // row-tile needs it; the rest get the normal set again, making compute's switch a no-op.
+        // Per-core: under synthesis the valid-row count, on the DRAM path where to read the
+        // row-masked set from. Cores that do not hold a batch's final row-tile get values that
+        // make the second set identical to the first.
+        const bool owns_pad_tile = pad.active && group_norm_core_owns_pad_tile(virtual_core.y, num_cores_per_batch);
         writer_mcast_sender_args.push_back(
-            input_mask_tile_start_id +
-            (pad.active && group_norm_core_owns_pad_tile(virtual_core.y, num_cores_per_batch) ? mask_set_tiles : 0));
+            synth_mask ? (owns_pad_tile ? pad.rows_in_last_tile : tile_height)
+                       : (input_mask_tile_start_id + (owns_pad_tile ? mask_set_tiles : 0)));
         if (equal_batches_per_core || (virtual_core.y <= last_row_with_extra_batch)) {
             writer_desc_g1.emplace_runtime_args(core, writer_mcast_sender_args);
         } else {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -9,6 +9,9 @@
 #include <limits>
 #include <algorithm>
 
+#include <tt-metalium/tt_backend_api_types.hpp>  // tt::DataFormat, tt::tile_size
+#include <ttnn/tensor/types.hpp>                 // tt::tt_metal::datatype_to_dataformat_converter
+
 namespace ttnn::prim {
 
 uint32_t GroupNormPadCorrection::scaler_bits(uint32_t reduce_factor_w) const {
@@ -238,6 +241,135 @@ std::pair<uint32_t, uint32_t> find_max_tile_span(uint32_t W, uint32_t group_size
     }
 
     return {max_tile_span, num_groups_before_start_again_at_tile_beginning};
+}
+
+uint32_t GroupNormShardedStaticCbSizes::total(const GroupNormShardedCbFlags& flags) const {
+    uint32_t t = 0;
+    t += in_CB_size;  // c_1 tilized input
+    // The no-negative-mask path keeps a second full-shard copy for untilize-out (c_30); the
+    // negative-mask path accumulates in place into c_1 and replaces c_30 with the (much
+    // smaller) negative-mask CB (c_14). This one line is the whole L1 trade-off.
+    t += flags.with_negative_mask ? in_negative_mask_CB_size : (flags.untilize_out ? in_CB_size : 0u);
+    t += in2_CB_size;  // c_2 scaler
+    t += in3_CB_size;  // c_3 eps
+    if (!flags.use_welford) {
+        t += in2_CB_size;  // c_4 scaler-c
+    }
+    if (flags.has_gamma) {
+        t += in5_CB_size;  // c_5
+    }
+    if (flags.has_beta) {
+        t += in6_CB_size;  // c_6
+    }
+    // c_7 is unconditional: the factory allocates it whether the writer NOC-reads a
+    // caller-supplied mask or synthesizes one in L1, and one of those is always true.
+    t += in_mask_CB_size;
+    if (flags.reader_repack_output) {
+        t += repack_CB_size;  // c_11/c_12
+    }
+    t += x_CB_size;           // c_13
+    t += ex_partial_CB_size;  // c_8
+    if (!flags.use_welford) {
+        t += single_tile_size;  // c_10 ex_external
+    }
+    t += ex_global_CB_size;  // c_9/c_15
+    t += ex2pe_CB_size;      // c_17
+    t += scalar_tile_size;   // c_26 ones
+    if (flags.pad_correction_active) {
+        t += 3 * single_tile_size;  // c_18/c_19/c_20, see append_group_norm_pad_correction_cbs
+    }
+    return t;
+}
+
+GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
+    const ttnn::Tensor& input,
+    tt::tt_metal::DataType im_data_format,
+    std::optional<tt::tt_metal::DataType> gamma_dtype,
+    std::optional<tt::tt_metal::DataType> beta_dtype,
+    std::optional<tt::tt_metal::DataType> input_mask_dtype,
+    std::optional<tt::tt_metal::DataType> negative_mask_dtype,
+    bool use_welford,
+    uint32_t num_groups,
+    uint32_t mask_sets) {
+    using tt::tt_metal::datatype_to_dataformat_converter;
+
+    // Data formats, mirroring groupnorm_sharded_program_factory.cpp. Note beta overrides gamma
+    // when both are present -- they share one CB format there, so they must here too.
+    const tt::DataFormat in_data_format = datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(im_data_format);
+    tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
+    if (gamma_dtype.has_value()) {
+        gamma_beta_cb_data_format = datatype_to_dataformat_converter(gamma_dtype.value());
+    }
+    if (beta_dtype.has_value()) {
+        gamma_beta_cb_data_format = datatype_to_dataformat_converter(beta_dtype.value());
+    }
+    // Absent mask tensors mean the writer synthesizes them, which it does in bfloat16.
+    const tt::DataFormat in_mask_cb_data_format = input_mask_dtype.has_value()
+                                                      ? datatype_to_dataformat_converter(input_mask_dtype.value())
+                                                      : tt::DataFormat::Float16_b;
+    const tt::DataFormat in_negative_mask_cb_data_format =
+        negative_mask_dtype.has_value() ? datatype_to_dataformat_converter(negative_mask_dtype.value())
+                                        : tt::DataFormat::Float16_b;
+
+    const uint32_t in_single_tile_size = tt::tile_size(in_data_format);
+    const uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    const uint32_t gamma_beta_single_tile_size = tt::tile_size(gamma_beta_cb_data_format);
+    const uint32_t in_mask_single_tile_size = tt::tile_size(in_mask_cb_data_format);
+    const uint32_t in_negative_mask_single_tile_size = tt::tile_size(in_negative_mask_cb_data_format);
+
+    // Geometry, again mirroring the factory. Only the derivations the CB sizes depend on.
+    const uint32_t tile_height = input.tensor_spec().tile().get_height();
+    const uint32_t tile_width = input.tensor_spec().tile().get_width();
+    const auto& shard_spec = input.shard_spec().value();
+    const uint32_t per_core_M = shard_spec.shape[0];
+    const uint32_t per_core_N = shard_spec.shape[1];
+    const uint32_t per_core_Mt = per_core_M / tile_height;
+    const uint32_t per_core_Nt = (per_core_N + tile_width - 1) / tile_width;
+
+    const auto& padded_shape = input.padded_shape();
+    const uint32_t num_batches = padded_shape[0];
+    const uint32_t H = padded_shape[2] * num_batches;
+    const uint32_t W = padded_shape[3];
+    const uint32_t group_size = W / num_groups;
+    const uint32_t block_wt = find_max_tile_span(per_core_N, group_size).first;
+
+    const uint32_t num_shards_r = H / per_core_M;
+    const uint32_t num_shards_c = W / per_core_N;
+    const uint32_t num_batches_per_core = num_batches > num_shards_r ? num_batches / num_shards_r : 1;
+    const uint32_t num_groups_per_core = num_groups > num_shards_c ? num_groups / num_shards_c : 1;
+    const uint32_t block_ht = per_core_Mt / num_batches_per_core;
+
+    const uint32_t in0_block_tiles = per_core_Nt * per_core_Mt;
+    const uint32_t interm_block_tiles = block_ht * block_wt;
+
+    GroupNormShardedStaticCbSizes sizes;
+    sizes.in_CB_size = in0_block_tiles * in_single_tile_size;
+    // cb_xmm (c_2) double buffer. After the Welford mask-multiply reorder
+    // (`((x - mu) * rsqrt) * mask`), only one tile is live in cb_xmm at a time, so the
+    // Welford allocation is 2 rather than 3.
+    // Scalar CBs are written as bf16 bit patterns, so they stay bf16 even on the legacy fp32
+    // path where cb_data_format is Float32. Welford repurposes c_2 as the fp32 cb_xmm
+    // intermediate; legacy uses it as the bf16 scaler. Mirrors the factory.
+    const uint32_t scalar_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
+    const uint32_t in2_single_tile_size = use_welford ? single_tile_size : scalar_tile_size;
+    sizes.in2_CB_size = in2_single_tile_size * (use_welford ? 2 : 1);
+    sizes.in3_CB_size = scalar_tile_size;
+    sizes.in5_CB_size = per_core_Nt * gamma_beta_single_tile_size;
+    sizes.in6_CB_size = per_core_Nt * gamma_beta_single_tile_size;
+    // Non-Welford: double-buffered, doubled again for the row-masked set when present.
+    sizes.in_mask_CB_size =
+        block_wt * in_mask_single_tile_size * (use_welford ? num_groups_per_core : 2 * mask_sets);
+    sizes.in_negative_mask_CB_size = block_wt * in_negative_mask_single_tile_size * 2;
+    sizes.repack_CB_size = per_core_Nt * in_single_tile_size * 2;
+    sizes.x_CB_size = single_tile_size * (use_welford ? 1 : interm_block_tiles);
+    // In welford, mean and var are both stored here, so double the size.
+    sizes.ex_partial_CB_size = single_tile_size * (use_welford ? 2 : 1);
+    sizes.ex_global_CB_size = sizes.ex_partial_CB_size * (use_welford ? num_groups_per_core : 1);
+    sizes.ex2pe_CB_size = use_welford ? single_tile_size * num_groups_per_core : sizes.ex_partial_CB_size;
+    sizes.single_tile_size = single_tile_size;
+    sizes.scalar_tile_size = scalar_tile_size;
+    return sizes;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -276,7 +276,9 @@ uint32_t GroupNormShardedStaticCbSizes::total(const GroupNormShardedCbFlags& fla
     t += ex2pe_CB_size;      // c_17
     t += scalar_tile_size;   // c_26 ones
     if (flags.pad_correction_active) {
-        t += 3 * single_tile_size;  // c_18/c_19/c_20, see append_group_norm_pad_correction_cbs
+        // c_18 rowvalid + c_19 composed mask, created inline by the sharded factory (the
+        // append_group_norm_pad_correction_cbs helper this once referred to no longer exists).
+        t += rowvalid_CB_size + composed_mask_CB_size;
     }
     return t;
 }
@@ -289,8 +291,7 @@ GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
     std::optional<tt::tt_metal::DataType> input_mask_dtype,
     std::optional<tt::tt_metal::DataType> negative_mask_dtype,
     bool use_welford,
-    uint32_t num_groups,
-    uint32_t mask_sets) {
+    uint32_t num_groups) {
     using tt::tt_metal::datatype_to_dataformat_converter;
 
     // Data formats, mirroring groupnorm_sharded_program_factory.cpp. Note beta overrides gamma
@@ -357,9 +358,9 @@ GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
     sizes.in3_CB_size = scalar_tile_size;
     sizes.in5_CB_size = per_core_Nt * gamma_beta_single_tile_size;
     sizes.in6_CB_size = per_core_Nt * gamma_beta_single_tile_size;
-    // Non-Welford: double-buffered, doubled again for the row-masked set when present.
-    sizes.in_mask_CB_size =
-        block_wt * in_mask_single_tile_size * (use_welford ? num_groups_per_core : 2 * mask_sets);
+    // Non-Welford: double-buffered single set. Caller masks may carry a row-masked second set
+    // under the pad correction, but the sharded writer never streams it into c_7.
+    sizes.in_mask_CB_size = block_wt * in_mask_single_tile_size * (use_welford ? num_groups_per_core : 2);
     sizes.in_negative_mask_CB_size = block_wt * in_negative_mask_single_tile_size * 2;
     sizes.repack_CB_size = per_core_Nt * in_single_tile_size * 2;
     sizes.x_CB_size = single_tile_size * (use_welford ? 1 : interm_block_tiles);
@@ -369,6 +370,10 @@ GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
     sizes.ex2pe_CB_size = use_welford ? single_tile_size * num_groups_per_core : sizes.ex_partial_CB_size;
     sizes.single_tile_size = single_tile_size;
     sizes.scalar_tile_size = scalar_tile_size;
+    // Pad-correction CBs (c_18 rowvalid, c_19 composed mask), both bf16. Computed
+    // unconditionally; total() only counts them when the correction is active.
+    sizes.rowvalid_CB_size = scalar_tile_size;
+    sizes.composed_mask_CB_size = block_wt * scalar_tile_size;
     return sizes;
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -7,10 +7,12 @@
 #include <vector>
 #include <cstdint>
 #include <initializer_list>
+#include <optional>
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include "ttnn/tensor/tensor.hpp"  // ttnn::Tensor, tt::tt_metal::DataType
 
 namespace ttnn::prim {
 
@@ -102,5 +104,54 @@ bool groupnorm_legacy_rm_input_fits_l1(
 // Prefer composite (host tilize + TILE GN) over fused RM for small grids or uneven batch mapping.
 // num_cores = num_virtual_cols * num_virtual_rows.
 bool groupnorm_legacy_rm_prefer_composite_for_perf(uint32_t num_cores, uint32_t num_virtual_rows, uint32_t num_batches);
+
+// Which of the optional static CBs the sharded factory will emit.
+struct GroupNormShardedCbFlags {
+    // Selects the negative-mask CB (c_14) in place of the untilize-out copy (c_30) -- the
+    // overlap trick the negative mask exists for. True whenever the factory sees either a
+    // caller-supplied negative_mask or synthesize_negative_mask.
+    bool with_negative_mask = false;
+    bool untilize_out = false;
+    bool has_gamma = false;
+    bool has_beta = false;
+    bool reader_repack_output = false;
+    bool use_welford = false;
+    bool pad_correction_active = false;
+};
+
+// Per-core byte sizes of the statically-allocated circular buffers used by the sharded
+// group-norm program factory.
+struct GroupNormShardedStaticCbSizes {
+    uint32_t in_CB_size = 0;                // c_1  tilized input (and the c_30 untilize-out copy)
+    uint32_t in2_CB_size = 0;               // c_2  scaler (and c_4 scaler-c when !welford)
+    uint32_t in3_CB_size = 0;               // c_3  eps
+    uint32_t in5_CB_size = 0;               // c_5  gamma
+    uint32_t in6_CB_size = 0;               // c_6  beta
+    uint32_t in_mask_CB_size = 0;           // c_7  input mask
+    uint32_t in_negative_mask_CB_size = 0;  // c_14 negative mask
+    uint32_t repack_CB_size = 0;            // c_11/c_12 repack
+    uint32_t x_CB_size = 0;                 // c_13 x
+    uint32_t ex_partial_CB_size = 0;        // c_8  ex_partial
+    uint32_t ex_global_CB_size = 0;         // c_9/c_15 ex_global
+    uint32_t ex2pe_CB_size = 0;             // c_17 ex2pe
+    uint32_t single_tile_size = 0;          // c_10 ex_external, c_18..c_20 pad correction
+    uint32_t scalar_tile_size = 0;          // c_26 ones -- bf16 even on the legacy fp32 path
+
+    // Total per-core L1 occupied by the static CB region.
+    uint32_t total(const GroupNormShardedCbFlags& flags) const;
+};
+
+GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
+    const ttnn::Tensor& input,
+    tt::tt_metal::DataType im_data_format,
+    std::optional<tt::tt_metal::DataType> gamma_dtype,
+    std::optional<tt::tt_metal::DataType> beta_dtype,
+    std::optional<tt::tt_metal::DataType> input_mask_dtype,
+    std::optional<tt::tt_metal::DataType> negative_mask_dtype,
+    bool use_welford,
+    uint32_t num_groups,
+    // 2 when a row-masked second mask set is streamed for non-tile-aligned H*W (#52685), which
+    // doubles c_7. Must match the factory's `mask_sets`, or this estimate under-counts L1.
+    uint32_t mask_sets = 1);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -19,10 +19,12 @@ namespace ttnn::prim {
 enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
 
 // Non-tile-aligned H*W: the reduce scaler must divide by the real element count (`scaler_bits`),
-// and the padding rows must be excluded from both accumulation passes -- the kernels do that by
-// switching to a row-masked set of input-mask tiles on each batch's final row-tile, of which
-// `rows_in_last_tile` are real. Shared by all three two-pass factories. Kernels re-derive `active`
-// from (padded_hw != logical_hw), hence kernel_logical_hw reporting padded_hw when off.
+// and the padding rows must be excluded from both accumulation passes. The interleaved kernels do
+// that by switching to a row-masked set of input-mask tiles on each batch's final row-tile, of
+// which `rows_in_last_tile` are real; the sharded kernels compose that row mask on device from a
+// rowvalid tile (c_18) and the column selector. Shared by all three two-pass factories. Kernels
+// re-derive `active` from (padded_hw != logical_hw), hence kernel_logical_hw reporting padded_hw
+// when off.
 struct GroupNormPadCorrection {
     bool active = false;
     uint32_t logical_hw = 0;
@@ -134,8 +136,10 @@ struct GroupNormShardedStaticCbSizes {
     uint32_t ex_partial_CB_size = 0;        // c_8  ex_partial
     uint32_t ex_global_CB_size = 0;         // c_9/c_15 ex_global
     uint32_t ex2pe_CB_size = 0;             // c_17 ex2pe
-    uint32_t single_tile_size = 0;          // c_10 ex_external, c_18..c_20 pad correction
+    uint32_t single_tile_size = 0;          // c_10 ex_external
     uint32_t scalar_tile_size = 0;          // c_26 ones -- bf16 even on the legacy fp32 path
+    uint32_t rowvalid_CB_size = 0;          // c_18, bf16, 1 tile, pad correction only
+    uint32_t composed_mask_CB_size = 0;     // c_19, bf16, block_wt tiles, pad correction only
 
     // Total per-core L1 occupied by the static CB region.
     uint32_t total(const GroupNormShardedCbFlags& flags) const;
@@ -149,9 +153,6 @@ GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
     std::optional<tt::tt_metal::DataType> input_mask_dtype,
     std::optional<tt::tt_metal::DataType> negative_mask_dtype,
     bool use_welford,
-    uint32_t num_groups,
-    // 2 when a row-masked second mask set is streamed for non-tile-aligned H*W (#52685), which
-    // doubles c_7. Must match the factory's `mask_sets`, or this estimate under-counts L1.
-    uint32_t mask_sets = 1);
+    uint32_t num_groups);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -332,7 +332,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // block size for in0 (tensor a)
     uint32_t in0_block_tiles = per_core_Nt * per_core_Mt;
     uint32_t in0_CB_size = a.buffer()->aligned_size_per_bank();  // use buffer size to handle both RM and Tile
-    uint32_t in_CB_size = in0_block_tiles * in_single_tile_size;
     // Scalar CBs (scaler c_2, scaler-c c_4, eps c_3, ones c_26) are written as bf16 bit patterns, so
     // they stay bf16 even on the legacy fp32 path where cb_data_format is Float32.
     const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
@@ -341,43 +340,29 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // Welford repurposes c_2 as the fp32 cb_xmm intermediate; legacy uses it as the bf16 scaler.
     const tt::DataFormat in2_cb_data_format = use_welford ? cb_data_format : eps_cb_data_format;
     const uint32_t in2_single_tile_size = use_welford ? single_tile_size : scalar_single_tile_size;
-    // cb_xmm (c_2) double buffer. After the Welford mask-multiply reorder
-    // (`((x - mu) * rsqrt) * mask`), only one tile is live in cb_xmm at a
-    // time, so the Welford allocation drops from 3 to 2.
-    uint32_t in2_CB_size = in2_single_tile_size * (use_welford ? 2 : 1);
-    // in3 - eps.
-    uint32_t in3_CB_size = eps_single_tile_size;
-    // gamma
+
+    const GroupNormShardedStaticCbSizes static_cb = compute_sharded_gn_static_cb_sizes(
+        a,
+        im_data_format,
+        gamma.has_value() ? std::make_optional(gamma.value().dtype()) : std::nullopt,
+        beta.has_value() ? std::make_optional(beta.value().dtype()) : std::nullopt,
+        input_mask.has_value() ? std::make_optional(input_mask.value().dtype()) : std::nullopt,
+        negative_mask.has_value() ? std::make_optional(negative_mask.value().dtype()) : std::nullopt,
+        use_welford,
+        num_groups,
+        mask_sets);
+
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
-    uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
-    // beta
-    uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
-    // input mask
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
-    // Not welford: double-buffered, doubled again for the row-masked set.
-    uint32_t in_mask_CB_size =
-        block_wt * in_mask_single_tile_size * (use_welford ? num_groups_per_core : 2 * mask_sets);
-    // negative mask
-    uint32_t in_negative_mask_CB_size = block_wt * in_negative_mask_single_tile_size * 2;  // double buffer
-    // repack cb
-    uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;  // double buffer
-    // itermediate buffers
-    uint32_t interm_block_tiles = block_ht * block_wt;
-    uint32_t x_CB_size = single_tile_size * (use_welford ? 1 : interm_block_tiles);
-    // In welford, we both store mean and var here, so double the size
-    uint32_t ex_partial_CB_size = single_tile_size * (use_welford ? 2 : 1);
-    uint32_t ex_global_CB_size = ex_partial_CB_size * (use_welford ? num_groups_per_core : 1);  // the final result Ex
-    uint32_t ex2pe_CB_size = use_welford ? single_tile_size * num_groups_per_core : ex_partial_CB_size;
-    // output buffer size
     uint32_t out_CB_size = in0_block_tiles * out_single_tile_size;
 
     log_debug(tt::LogOp, "per_core_Nt: {}", per_core_Nt);
     log_debug(tt::LogOp, "per_core_Mt: {}", per_core_Mt);
     log_debug(tt::LogOp, "in0_CB_size: {}", in0_CB_size);
-    log_debug(tt::LogOp, "in_CB_size: {}", in_CB_size);
+    log_debug(tt::LogOp, "in_CB_size: {}", static_cb.in_CB_size);
     log_debug(tt::LogOp, "gamma_beta_num_cols_tile_per_core: {}", gamma_beta_num_cols_tile_per_core);
-    log_debug(tt::LogOp, "in5_CB_size: {}", in5_CB_size);
-    log_debug(tt::LogOp, "repack_CB_size: {}", repack_CB_size);
+    log_debug(tt::LogOp, "in5_CB_size: {}", static_cb.in5_CB_size);
+    log_debug(tt::LogOp, "repack_CB_size: {}", static_cb.repack_CB_size);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
@@ -985,11 +970,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     };
     if (!(negative_mask.has_value() || synth_neg_mask)) {
         // in - stores tilized input
-        desc.cbs.push_back(make_in_cb_desc(in_CB_size));
+        desc.cbs.push_back(make_in_cb_desc(static_cb.in_CB_size));
         if (untilize_out) {
             constexpr uint32_t out_cb_index = tt::CBIndex::c_30;
             desc.cbs.push_back(CBDescriptor{
-                .total_size = in_CB_size,
+                .total_size = static_cb.in_CB_size,
                 .core_ranges = all_cores,
                 .format_descriptors = {{CBFormatDescriptor{
                     .buffer_index = static_cast<uint8_t>(out_cb_index),
@@ -1001,12 +986,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     } else {
         // in - stores tilized input
         // tilized in is overlapped with it
-        desc.cbs.push_back(make_in_cb_desc(in_CB_size));
+        desc.cbs.push_back(make_in_cb_desc(static_cb.in_CB_size));
     }
     // in2 scaler - for partial Ex
     constexpr uint32_t in2_cb_index = tt::CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = in2_CB_size,
+        .total_size = static_cb.in2_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in2_cb_index),
@@ -1017,7 +1002,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // in3 eps
     constexpr uint32_t in3_cb_index = tt::CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = in3_CB_size,
+        .total_size = static_cb.in3_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
@@ -1029,7 +1014,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (!use_welford) {
         constexpr uint32_t in4_cb_index = tt::CBIndex::c_4;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in2_CB_size,
+            .total_size = static_cb.in2_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in4_cb_index),
@@ -1042,7 +1027,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (gamma.has_value()) {
         constexpr uint32_t in5_cb_index = tt::CBIndex::c_5;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in5_CB_size,
+            .total_size = static_cb.in5_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in5_cb_index),
@@ -1055,7 +1040,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (beta.has_value()) {
         constexpr uint32_t in6_cb_index = tt::CBIndex::c_6;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in6_CB_size,
+            .total_size = static_cb.in6_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in6_cb_index),
@@ -1069,7 +1054,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (input_mask.has_value() || synth_mask) {
         constexpr uint32_t in_mask_cb_index = tt::CBIndex::c_7;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in_mask_CB_size,
+            .total_size = static_cb.in_mask_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in_mask_cb_index),
@@ -1083,7 +1068,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (negative_mask.has_value() || synth_neg_mask) {
         constexpr uint32_t in_negative_mask_cb_index = tt::CBIndex::c_14;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in_negative_mask_CB_size,
+            .total_size = static_cb.in_negative_mask_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in_negative_mask_cb_index),
@@ -1096,7 +1081,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         constexpr uint32_t repack_cb_index = tt::CBIndex::c_11;
         constexpr uint32_t repack_out_cb_index = tt::CBIndex::c_12;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = repack_CB_size,
+            .total_size = static_cb.repack_CB_size,
             .core_ranges = all_cores,
             .format_descriptors =
                 {{CBFormatDescriptor{
@@ -1114,7 +1099,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // x
     constexpr uint32_t x_cb_index = tt::CBIndex::c_13;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = x_CB_size,
+        .total_size = static_cb.x_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(x_cb_index),
@@ -1126,7 +1111,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // ex_partial
     constexpr uint32_t ex_cb_partial_index = tt::CBIndex::c_8;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = ex_partial_CB_size,
+        .total_size = static_cb.ex_partial_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(ex_cb_partial_index),
@@ -1153,7 +1138,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     constexpr uint32_t ex_cb_index = tt::CBIndex::c_9;
     constexpr uint32_t ex_global_cb_index = tt::CBIndex::c_15;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = ex_global_CB_size,
+        .total_size = static_cb.ex_global_CB_size,
         .core_ranges = all_cores,
         .format_descriptors =
             {{CBFormatDescriptor{
@@ -1171,7 +1156,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // ex2pe
     constexpr uint32_t cb_ex2pe_index = tt::CBIndex::c_17;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = ex2pe_CB_size,
+        .total_size = static_cb.ex2pe_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(cb_ex2pe_index),

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -307,16 +307,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             block_wt * tile_width);
     }
 
-    // Non-tile-aligned H*W: corrected reduce scaler + the row-masked mask set. See
-    // compute/groupnorm.cpp and GroupNormPadCorrection. Unlike the interleaved paths the scaler and the
-    // row-masked set's start id ship as RUNTIME args (8, 9).
+    // Non-tile-aligned H*W: corrected reduce scaler + on-device row-mask composition (c_18/c_19).
+    // See compute/groupnorm.cpp and GroupNormPadCorrection. Unlike the interleaved paths the scaler
+    // and the core's valid-row count ship as RUNTIME args (8, 9).
     const auto pad = make_group_norm_pad_correction(
         static_cast<uint32_t>(a.logical_shape()[2]),
         static_cast<uint32_t>(a.padded_shape()[2]),
         use_welford,
         tile_height);
-    // The mask carries two sets when the correction is active; cores stride through the first, and
-    // the row-masked one sits mask_set_tiles beyond it.
+    // Caller-supplied masks still carry a row-masked second set when the correction is active
+    // (validation requires it), but the sharded writer never reads it -- the row mask is composed
+    // on device instead. mask_sets only scopes the per-core start-id wrap to the first set.
     const uint32_t mask_sets = pad.active ? 2 : 1;
     const uint32_t mask_set_tiles =
         input_mask.has_value() ? (input_mask.value().physical_volume() / tile_hw) / mask_sets : 0;
@@ -349,8 +350,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         input_mask.has_value() ? std::make_optional(input_mask.value().dtype()) : std::nullopt,
         negative_mask.has_value() ? std::make_optional(negative_mask.value().dtype()) : std::nullopt,
         use_welford,
-        num_groups,
-        mask_sets);
+        num_groups);
 
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
@@ -584,8 +584,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     std::map<std::string, std::string> writer_defines;
     writer_defines["TILE_HW_VAL"] = std::to_string(tile_hw);
     // FUSE_NEGATIVE_MASK enables the compute-side second multiply against a
-    // negative mask. Fires whenever the caller either passed a negative_mask
-    // OR opted into synthesizing one via synthesize_negative_mask=True.
+    // negative mask: either the caller passed one, or the op decided to
+    // synthesize one (the L1-fit heuristic in needs_negative_mask_overlap).
     const bool synth_neg_mask = operation_attributes.synthesize_negative_mask && !negative_mask.has_value();
     if (negative_mask.has_value() || synth_neg_mask) {
         writer_defines["FUSE_NEGATIVE_MASK"] = "1";
@@ -593,19 +593,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (pad.active) {
         writer_defines["PAD_CORRECTION"] = "1";
     }
-    // Mask data path selection. Two paths:
-    //   1. MASK_SYNTHESIZE: writer kernel writes row 0 of face 0 + face 1
-    //      directly into L1 from `num_cols_per_group` and the per-group
-    //      start_stride recurrence — no DRAM mask read at all. Fires only
-    //      when the caller did NOT pass an input_mask (the auto-built format
-    //      is always bf16 and always synth-safe).
-    //   2. fallthrough: writer NOC-reads the entire mask tile from DRAM.
-    // A user-supplied mask is always used (bytes NOC-read, not synthesized) —
-    // synthesis only substitutes for the DRAM-mask allocation the host used
-    // to build. The negative-mask synthesis path fires when the caller opts
-    // in via synthesize_negative_mask=True (and did not pass a tensor); the
-    // interleaved factories don't support negative masks so this gate is
-    // sharded-only.
+    // MASK_SYNTHESIZE: no caller mask, so the writer builds the selector directly in L1
+    // (always bf16) instead of NOC-reading a tensor. A caller-supplied mask is always
+    // NOC-read.
     const bool synth_mask = !input_mask.has_value();
     if (synth_mask) {
         writer_defines["MASK_SYNTHESIZE"] = "1";
@@ -715,7 +705,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         num_groups_per_reset,
         single_tile_size,
         per_core_Mt * per_core_Nt / num_batches_per_core,
-        num_groups_per_core * block_wt * mask_sets,
+        num_groups_per_core * block_wt,
         block_wt_last,
         static_cast<uint32_t>((num_datum_row_per_group_mod_tile_w & (num_datum_row_per_group_mod_tile_w - 1)) == 0),
         static_cast<uint32_t>(num_datum_row_per_group < tile_width),
@@ -754,7 +744,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         num_groups_per_reset,
         single_tile_size,
         per_core_Mt * per_core_Nt / num_batches_per_core,
-        num_groups_per_core * block_wt * mask_sets,
+        num_groups_per_core * block_wt,
         block_wt_last,
         static_cast<uint32_t>((num_datum_row_per_group_mod_tile_w & (num_datum_row_per_group_mod_tile_w - 1)) == 0),
         static_cast<uint32_t>(num_datum_row_per_group < tile_width),
@@ -1176,6 +1166,32 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         }}},
     });
 
+    // Pad correction: c_18 rowvalid (written once per core by the writer, never popped) and
+    // c_19 the composed per-(batch,group) mask -- rowvalid x column selector, produced and
+    // consumed by compute.
+    if (pad.active) {
+        constexpr uint32_t cb_rowvalid_index = tt::CBIndex::c_18;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = scalar_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_rowvalid_index),
+                .data_format = eps_cb_data_format,
+                .page_size = scalar_single_tile_size,
+            }}},
+        });
+        constexpr uint32_t cb_composed_mask_index = tt::CBIndex::c_19;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = block_wt * scalar_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_composed_mask_index),
+                .data_format = eps_cb_data_format,
+                .page_size = scalar_single_tile_size,
+            }}},
+        });
+    }
+
     // Runtime Args
     uint32_t eps_u = std::bit_cast<uint32_t>(eps);
 
@@ -1337,12 +1353,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         // args 8, 9: only read when PAD_CORRECTION.
         writer_mcast_sender_args.push_back(pad_scaler_bits);
-        // Where this core reads the row-masked set from. Only the core holding a batch's final
-        // row-tile needs it; the rest get the normal set again, making compute's switch a no-op
-        // there. Deciding it here keeps the compute kernel compile-time-only.
-        writer_mcast_sender_args.push_back(
-            input_mask_tile_start_id +
-            (pad.active && group_norm_core_owns_pad_tile(m_index, num_cores_per_batch) ? mask_set_tiles : 0));
+        // Arg 9: the core's valid-row count for the c_18 rowvalid tile. Only the core holding
+        // a batch's final row-tile gets a partial count; the rest get tile_height, making their
+        // rowvalid tile all-ones.
+        const bool owns_pad_tile = pad.active && group_norm_core_owns_pad_tile(m_index, num_cores_per_batch);
+        writer_mcast_sender_args.push_back(owns_pad_tile ? pad.rows_in_last_tile : tile_height);
         writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
 
         if (gamma.has_value()) {
@@ -1355,7 +1370,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         }
         if (input_mask.has_value()) {
             // Tile id for negative mask is same as input mask. Wrap on the set size, not the whole
-            // tensor: the row-masked set is an offset off this.
+            // tensor: under the pad correction the caller's mask carries a second (row-masked) set
+            // beyond the first that the sharded writer never reads.
             input_mask_tile_start_id =
                 (input_mask_tile_start_id + input_mask_num_tiles_per_core) % mask_set_tiles;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -338,10 +338,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
     uint32_t eps_single_tile_size = tt::tile_size(eps_cb_data_format);
     uint32_t scalar_single_tile_size = eps_single_tile_size;
-    // Welford repurposes c_2 as the fp32 cb_xmm intermediate (3 tile slots); legacy uses it as the bf16 scaler.
+    // Welford repurposes c_2 as the fp32 cb_xmm intermediate; legacy uses it as the bf16 scaler.
     const tt::DataFormat in2_cb_data_format = use_welford ? cb_data_format : eps_cb_data_format;
     const uint32_t in2_single_tile_size = use_welford ? single_tile_size : scalar_single_tile_size;
-    uint32_t in2_CB_size = in2_single_tile_size * (use_welford ? 3 : 1);
+    // cb_xmm (c_2) double buffer. After the Welford mask-multiply reorder
+    // (`((x - mu) * rsqrt) * mask`), only one tile is live in cb_xmm at a
+    // time, so the Welford allocation drops from 3 to 2.
+    uint32_t in2_CB_size = in2_single_tile_size * (use_welford ? 2 : 1);
     // in3 - eps.
     uint32_t in3_CB_size = eps_single_tile_size;
     // gamma
@@ -595,11 +598,35 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // writer defines
     std::map<std::string, std::string> writer_defines;
     writer_defines["TILE_HW_VAL"] = std::to_string(tile_hw);
-    if (negative_mask.has_value()) {
+    // FUSE_NEGATIVE_MASK enables the compute-side second multiply against a
+    // negative mask. Fires whenever the caller either passed a negative_mask
+    // OR opted into synthesizing one via synthesize_negative_mask=True.
+    const bool synth_neg_mask = operation_attributes.synthesize_negative_mask && !negative_mask.has_value();
+    if (negative_mask.has_value() || synth_neg_mask) {
         writer_defines["FUSE_NEGATIVE_MASK"] = "1";
     }
     if (pad.active) {
         writer_defines["PAD_CORRECTION"] = "1";
+    }
+    // Mask data path selection. Two paths:
+    //   1. MASK_SYNTHESIZE: writer kernel writes row 0 of face 0 + face 1
+    //      directly into L1 from `num_cols_per_group` and the per-group
+    //      start_stride recurrence — no DRAM mask read at all. Fires only
+    //      when the caller did NOT pass an input_mask (the auto-built format
+    //      is always bf16 and always synth-safe).
+    //   2. fallthrough: writer NOC-reads the entire mask tile from DRAM.
+    // A user-supplied mask is always used (bytes NOC-read, not synthesized) —
+    // synthesis only substitutes for the DRAM-mask allocation the host used
+    // to build. The negative-mask synthesis path fires when the caller opts
+    // in via synthesize_negative_mask=True (and did not pass a tensor); the
+    // interleaved factories don't support negative masks so this gate is
+    // sharded-only.
+    const bool synth_mask = !input_mask.has_value();
+    if (synth_mask) {
+        writer_defines["MASK_SYNTHESIZE"] = "1";
+    }
+    if (synth_neg_mask) {
+        writer_defines["NEGATIVE_MASK_SYNTHESIZE"] = "1";
     }
     // writer compile time args
     std::vector<uint32_t> writer_mcast_sender_compile_time_args = {
@@ -654,6 +681,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = writer_mcast_sender_compile_time_args;
+    // Read under MASK_SYNTHESIZE / NEGATIVE_MASK_SYNTHESIZE to drive the per-group
+    // start_stride recurrence. Passed unconditionally, as the interleaved factories do.
+    writer_desc.named_compile_time_args = {{"num_channels_per_group", num_datum_row_per_group}};
     writer_desc.defines = KernelDescriptor::Defines(writer_defines.begin(), writer_defines.end());
     writer_desc.config = DataMovementConfigDescriptor{
         .processor = DataMovementProcessor::RISCV_1,
@@ -671,7 +701,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (untilize_out) {
         eltwise_binary_defines["UNTILIZE_OUT"] = "1";
     }
-    if (negative_mask.has_value()) {
+    if (negative_mask.has_value() || synth_neg_mask) {
         eltwise_binary_defines["FUSE_NEGATIVE_MASK"] = "1";
     }
     // compute kernel compile time args
@@ -953,7 +983,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         }
         return in_desc;
     };
-    if (!negative_mask.has_value()) {
+    if (!(negative_mask.has_value() || synth_neg_mask)) {
         // in - stores tilized input
         desc.cbs.push_back(make_in_cb_desc(in_CB_size));
         if (untilize_out) {
@@ -1034,8 +1064,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             }}},
         });
     }
-    // input mask
-    if (input_mask.has_value()) {
+    // input mask: CB is needed whenever the writer kernel will populate it,
+    // either by reading from DRAM (has_value) or by synthesizing in-L1.
+    if (input_mask.has_value() || synth_mask) {
         constexpr uint32_t in_mask_cb_index = tt::CBIndex::c_7;
         desc.cbs.push_back(CBDescriptor{
             .total_size = in_mask_CB_size,
@@ -1047,8 +1078,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             }}},
         });
     }
-    // negative mask
-    if (negative_mask.has_value()) {
+    // negative mask: CB is needed whenever the writer will populate it,
+    // either by reading from DRAM (has_value) or by synthesizing in-L1.
+    if (negative_mask.has_value() || synth_neg_mask) {
         constexpr uint32_t in_negative_mask_cb_index = tt::CBIndex::c_14;
         desc.cbs.push_back(CBDescriptor{
             .total_size = in_negative_mask_CB_size,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -333,7 +333,14 @@ void kernel_main() {
                 uint32_t row_tile_base = out_block_index * out_block_h_normal;
                 reconfig_data_format_srcb(dfb_in0_id, dfb_input_mask_id);
                 // mask input
-                mul_init(dfb_input_id, dfb_input_mask_id);
+                // The row-masked set varies down the rows of a tile, so it can only be consumed by
+                // a full-tile multiply. Row-0-only synthesis and the row broadcast are therefore
+                // available exactly when there is no row mask, i.e. on tile-aligned H*W.
+                if constexpr (has_row_mask) {
+                    mul_init(dfb_input_id, dfb_input_mask_id);
+                } else {
+                    mul_bcast_rows_init(dfb_input_id, dfb_input_mask_id);
+                }
                 dfb_x.reserve_back(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; ++i) {
                     // Row-masked set on the batch's final row-tile, so the padding contributes
@@ -347,8 +354,17 @@ void kernel_main() {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset + index_h_offset + out_block_base;
-                            uint32_t index_mask = w + index_subblock_w_offset + mask_set_offset;
-                            mul_tiles(dfb_input_id, dfb_input_mask_id, index, index_mask, w);
+                            if constexpr (has_row_mask) {
+                                mul_tiles(
+                                    dfb_input_id,
+                                    dfb_input_mask_id,
+                                    index,
+                                    w + index_subblock_w_offset + mask_set_offset,
+                                    w);
+                            } else {
+                                mul_tiles_bcast_rows(
+                                    dfb_input_id, dfb_input_mask_id, index, w + index_subblock_w_offset, w);
+                            }
                         }
                         tile_regs_commit();
                         tile_regs_wait();
@@ -463,7 +479,11 @@ void kernel_main() {
 
                 // zero out the garbage values by mult mask again
                 reconfig_data_format_srcb(dfb_ex_global_id, dfb_input_mask_id);
-                mul_init(dfb_xmm_id, dfb_input_mask_id);
+                if constexpr (has_row_mask) {
+                    mul_init(dfb_xmm_id, dfb_input_mask_id);
+                } else {
+                    mul_bcast_rows_init(dfb_xmm_id, dfb_input_mask_id);
+                }
                 dfb_x.reserve_back(out_block_hw_normal);
                 dfb_xmm.wait_front(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
@@ -478,8 +498,11 @@ void kernel_main() {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset;
-                            uint32_t index_mask = index + mask_set_offset;
-                            mul_tiles(dfb_xmm_id, dfb_input_mask_id, index, index_mask, w);
+                            if constexpr (has_row_mask) {
+                                mul_tiles(dfb_xmm_id, dfb_input_mask_id, index, index + mask_set_offset, w);
+                            } else {
+                                mul_tiles_bcast_rows(dfb_xmm_id, dfb_input_mask_id, index, index, w);
+                            }
                         }
                         tile_regs_commit();
                         tile_regs_wait();
@@ -646,7 +669,7 @@ void kernel_main() {
 
                 // zero out the garbage values by mult mask again
                 reconfig_data_format_srcb(dfb_ex_global_id, dfb_input_mask_id);
-                mul_init(dfb_xmm_id, dfb_input_mask_id);
+                mul_bcast_rows_init(dfb_xmm_id, dfb_input_mask_id);
                 dfb_x.reserve_back(out_block_hw_normal);
                 dfb_xmm.wait_front(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
@@ -656,7 +679,7 @@ void kernel_main() {
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset;
                             uint32_t index_mask = index;
-                            mul_tiles(dfb_xmm_id, dfb_input_mask_id, index, index_mask, w);
+                            mul_tiles_bcast_rows(dfb_xmm_id, dfb_input_mask_id, index, index_mask, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -63,7 +63,10 @@ void kernel_main() {
     constexpr uint32_t logical_hw [[maybe_unused]] = get_compile_time_arg_val(25);
     constexpr uint32_t padded_hw [[maybe_unused]] = get_compile_time_arg_val(26);
     constexpr bool has_row_mask = get_compile_time_arg_val(27) == 1;
-    constexpr uint32_t mask_tiles_per_group = has_row_mask ? 2 * block_w : block_w;
+    // Composed-mask protocol: the writer ships ONE row-0-only column-selector set per (batch,
+    // group) unconditionally; under has_row_mask this kernel composes the batch's final
+    // row-tile's mask on device as rowvalid (c_18) x column selector -> c_19.
+    constexpr uint32_t mask_tiles_per_group = block_w;
 
     constexpr uint32_t block_w_minus_one = block_w - 1;
     constexpr uint32_t block_w_minus_two = block_w - 2;
@@ -82,6 +85,13 @@ void kernel_main() {
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
     constexpr uint32_t dfb_input_mask_id = tt::CBIndex::c_7;
+    // Pass-1 operand source: tilized-input CB when the reader tilizes, raw input CB otherwise.
+    // (The init calls keep using dfb_in0_id, as before -- only the ops switch.)
+#ifdef TILIZE_IN
+    constexpr uint32_t dfb_pass1_src_id = dfb_in_id;
+#else
+    constexpr uint32_t dfb_pass1_src_id = dfb_in0_id;
+#endif
 
     // interm cbs
     constexpr uint32_t dfb_repack_id = tt::CBIndex::c_11;
@@ -93,6 +103,10 @@ void kernel_main() {
     constexpr uint32_t dfb_ex_global_id = num_cores_per_mcast_group == 1 ? dfb_ex_partial_id : tt::CBIndex::c_15;
     constexpr uint32_t dfb_ex2pe_id = tt::CBIndex::c_17;
     constexpr uint32_t dfb_ones_id = tt::CBIndex::c_26;
+    // Composed-mask CBs, created only under pad correction (has_row_mask); aliased to
+    // always-present CBs otherwise.
+    constexpr uint32_t dfb_rowvalid_id = has_row_mask ? tt::CBIndex::c_18 : tt::CBIndex::c_26;
+    constexpr uint32_t dfb_mask_last_id = has_row_mask ? tt::CBIndex::c_19 : tt::CBIndex::c_7;
 
     // output cb
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
@@ -172,10 +186,12 @@ void kernel_main() {
     DataflowBuffer dfb_in_negative_mask(dfb_in_negative_mask_id);
     DataflowBuffer dfb_inbeta(dfb_inbeta_id);
     DataflowBuffer dfb_input_mask(dfb_input_mask_id);
+    DataflowBuffer dfb_mask_last(dfb_mask_last_id);
     DataflowBuffer dfb_ones(dfb_ones_id);
     DataflowBuffer dfb_out(dfb_out_id);
     DataflowBuffer dfb_outbeta(dfb_outbeta_id);
     DataflowBuffer dfb_outgamma(dfb_outgamma_id);
+    DataflowBuffer dfb_rowvalid(dfb_rowvalid_id);
     DataflowBuffer dfb_scaler(dfb_scaler_id);
     DataflowBuffer dfb_scaler_global(dfb_scaler_global_id);
     DataflowBuffer dfb_x(dfb_x_id);
@@ -208,6 +224,10 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_in0_id, dfb_input_mask_id, dfb_x_id);
 #endif
 
+    if constexpr (has_row_mask) {
+        dfb_rowvalid.wait_front(1);
+    }
+
     index_b_offset = 0;
     for (uint32_t b = 0; b < batch; ++b) {
         index_g_offset = 0;
@@ -215,23 +235,41 @@ void kernel_main() {
             // mask input
             index_h_offset = index_b_offset + index_g_offset;
             reconfig_data_format_srcb(dfb_in0_id, dfb_input_mask_id);
-            // The row-masked set varies down the rows of a tile, so it can only be consumed by a
-            // full-tile multiply. Row-0-only synthesis and the row broadcast are therefore
-            // available exactly when there is no row mask, i.e. on tile-aligned H*W.
+            dfb_input_mask.wait_front(mask_tiles_per_group);
+            // Compose the final row-tile's mask: rowvalid[r] * colsel[c] -> dfb_mask_last. The
+            // column selector's row 0 is broadcast down the rowvalid tile, so the product
+            // varies down the rows.
             if constexpr (has_row_mask) {
-                mul_init(dfb_in0_id, dfb_input_mask_id);
-            } else {
-                mul_bcast_rows_init(dfb_in0_id, dfb_input_mask_id);
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_rowvalid_id);
+                    pack_reconfig_data_format(dfb_mask_last_id);
+                }
+                mul_bcast_rows_init(dfb_rowvalid_id, dfb_input_mask_id);
+                dfb_mask_last.reserve_back(block_w);
+                index_subblock_w_offset = 0;
+                for (uint32_t j = 0; j < num_subblocks_w; ++j) {
+                    tile_regs_acquire();
+                    for (uint32_t w = 0; w < subblock_w; ++w) {
+                        mul_tiles_bcast_rows(dfb_rowvalid_id, dfb_input_mask_id, 0, w + index_subblock_w_offset, w);
+                    }
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    for (uint32_t w = 0; w < subblock_w; ++w) {
+                        pack_tile(w, dfb_mask_last_id);
+                    }
+                    tile_regs_release();
+                    index_subblock_w_offset += subblock_w;
+                }
+                dfb_mask_last.push_back(block_w);
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_in0_id);
+                    pack_reconfig_data_format(dfb_x_id);
+                }
             }
             dfb_x.reserve_back(block_hw);
-            dfb_input_mask.wait_front(mask_tiles_per_group);
-            for (uint32_t i = 0; i < block_h; ++i) {
-                // Row-masked set on the batch's final row-tile, so the padding contributes nothing
-                // to E[x]. if constexpr keeps tile-aligned codegen unchanged.
-                uint32_t mask_set_offset = 0;
-                if constexpr (has_row_mask) {
-                    mask_set_offset = (i == block_h - 1) ? block_w : 0;
-                }
+            const uint32_t bcast_row_tiles = has_row_mask ? block_h - 1 : block_h;
+            mul_bcast_rows_init(dfb_in0_id, dfb_input_mask_id);
+            for (uint32_t i = 0; i < bcast_row_tiles; ++i) {
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                     tile_regs_acquire();
@@ -243,21 +281,33 @@ void kernel_main() {
                         if (index >= per_core_MN) {
                             index = per_core_MN - 1;
                         }
-                        if constexpr (has_row_mask) {
-                            const uint32_t index_mask = w + index_subblock_w_offset + mask_set_offset;
-#ifdef TILIZE_IN
-                            mul_tiles(dfb_in_id, dfb_input_mask_id, index, index_mask, w);
-#else
-                            mul_tiles(dfb_in0_id, dfb_input_mask_id, index, index_mask, w);
-#endif
-                        } else {
-                            const uint32_t index_mask = w + index_subblock_w_offset;
-#ifdef TILIZE_IN
-                            mul_tiles_bcast_rows(dfb_in_id, dfb_input_mask_id, index, index_mask, w);
-#else
-                            mul_tiles_bcast_rows(dfb_in0_id, dfb_input_mask_id, index, index_mask, w);
-#endif
+                        mul_tiles_bcast_rows(
+                            dfb_pass1_src_id, dfb_input_mask_id, index, w + index_subblock_w_offset, w);
+                    }
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    for (uint32_t i = 0; i < subblock_w; ++i) {
+                        pack_tile(i, dfb_x_id);
+                    }
+                    tile_regs_release();
+                    index_subblock_w_offset += subblock_w;
+                }
+                index_h_offset += per_core_N;
+            }
+            // Peeled final row-tile: full-tile multiply with the composed mask.
+            if constexpr (has_row_mask) {
+                dfb_mask_last.wait_front(block_w);
+                reconfig_data_format_srcb(dfb_input_mask_id, dfb_mask_last_id);
+                mul_init(dfb_in0_id, dfb_mask_last_id);
+                index_subblock_w_offset = 0;
+                for (uint32_t j = 0; j < num_subblocks_w; ++j) {
+                    tile_regs_acquire();
+                    for (uint32_t w = 0; w < subblock_w; ++w) {
+                        uint32_t index = w + index_subblock_w_offset + index_h_offset;
+                        if (index >= per_core_MN) {
+                            index = per_core_MN - 1;
                         }
+                        mul_tiles(dfb_pass1_src_id, dfb_mask_last_id, index, w + index_subblock_w_offset, w);
                     }
                     tile_regs_commit();
                     tile_regs_wait();
@@ -270,7 +320,7 @@ void kernel_main() {
                 index_h_offset += per_core_N;
             }
             dfb_x.push_back(block_hw);
-            reconfig_data_format_srcb(dfb_input_mask_id, dfb_ones_id);
+            reconfig_data_format_srcb(has_row_mask ? dfb_mask_last_id : dfb_input_mask_id, dfb_ones_id);
 
             // Partial-E[x]
             index_h_offset = 0;
@@ -358,30 +408,42 @@ void kernel_main() {
             dfb_ex_global.pop_front(1);
 
             reconfig_data_format_srcb(dfb_ex_global_id, dfb_input_mask_id);
-            if constexpr (has_row_mask) {
-                mul_init(dfb_x_id, dfb_input_mask_id);
-            } else {
-                mul_bcast_rows_init(dfb_x_id, dfb_input_mask_id);
-            }
+            // Re-mask (x - E[x]); otherwise each padding row is centered to (garbage - E[x])
+            // and squared into the variance.
+            mul_bcast_rows_init(dfb_x_id, dfb_input_mask_id);
             dfb_x.wait_front(block_hw);
 
-            for (uint32_t i = 0; i < block_h; i++) {
-                // Same switch as pass 1; otherwise each padding row is centered to
-                // (garbage - E[x]) and squared into the variance.
-                uint32_t mask_set_offset = 0;
-                if constexpr (has_row_mask) {
-                    mask_set_offset = (i == block_h - 1) ? block_w : 0;
-                }
+            for (uint32_t i = 0; i < bcast_row_tiles; i++) {
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                     tile_regs_acquire();
                     for (uint32_t w = 0; w < subblock_w; ++w) {
                         uint32_t index = w + index_subblock_w_offset;
-                        if constexpr (has_row_mask) {
-                            mul_tiles(dfb_x_id, dfb_input_mask_id, index, index + mask_set_offset, w);
-                        } else {
-                            mul_tiles_bcast_rows(dfb_x_id, dfb_input_mask_id, index, index, w);
-                        }
+                        mul_tiles_bcast_rows(dfb_x_id, dfb_input_mask_id, index, index, w);
+                    }
+                    tile_regs_commit();
+
+                    dfb_x.pop_front(subblock_w);
+                    dfb_x.reserve_back(subblock_w);
+
+                    tile_regs_wait();
+                    for (uint32_t i = 0; i < subblock_w; ++i) {
+                        pack_tile(i, dfb_x_id);
+                    }
+                    dfb_x.push_back(subblock_w);
+                    tile_regs_release();
+                }
+            }
+            // Peeled final row-tile: full-tile multiply with the composed mask.
+            if constexpr (has_row_mask) {
+                reconfig_data_format_srcb(dfb_input_mask_id, dfb_mask_last_id);
+                mul_init(dfb_x_id, dfb_mask_last_id);
+                index_subblock_w_offset = 0;
+                for (uint32_t j = 0; j < num_subblocks_w; ++j) {
+                    tile_regs_acquire();
+                    for (uint32_t w = 0; w < subblock_w; ++w) {
+                        uint32_t index = w + index_subblock_w_offset;
+                        mul_tiles(dfb_x_id, dfb_mask_last_id, index, index, w);
                     }
                     tile_regs_commit();
 
@@ -397,7 +459,10 @@ void kernel_main() {
                 }
             }
             dfb_input_mask.pop_front(mask_tiles_per_group);
-            reconfig_data_format_srcb(dfb_input_mask_id, dfb_x_id);
+            if constexpr (has_row_mask) {
+                dfb_mask_last.pop_front(block_w);
+            }
+            reconfig_data_format_srcb(has_row_mask ? dfb_mask_last_id : dfb_input_mask_id, dfb_x_id);
 
             // (x - E[x])^2
             index_h_offset = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -215,7 +215,14 @@ void kernel_main() {
             // mask input
             index_h_offset = index_b_offset + index_g_offset;
             reconfig_data_format_srcb(dfb_in0_id, dfb_input_mask_id);
-            mul_init(dfb_in0_id, dfb_input_mask_id);
+            // The row-masked set varies down the rows of a tile, so it can only be consumed by a
+            // full-tile multiply. Row-0-only synthesis and the row broadcast are therefore
+            // available exactly when there is no row mask, i.e. on tile-aligned H*W.
+            if constexpr (has_row_mask) {
+                mul_init(dfb_in0_id, dfb_input_mask_id);
+            } else {
+                mul_bcast_rows_init(dfb_in0_id, dfb_input_mask_id);
+            }
             dfb_x.reserve_back(block_hw);
             dfb_input_mask.wait_front(mask_tiles_per_group);
             for (uint32_t i = 0; i < block_h; ++i) {
@@ -236,12 +243,21 @@ void kernel_main() {
                         if (index >= per_core_MN) {
                             index = per_core_MN - 1;
                         }
-                        uint32_t index_mask = w + index_subblock_w_offset + mask_set_offset;
+                        if constexpr (has_row_mask) {
+                            const uint32_t index_mask = w + index_subblock_w_offset + mask_set_offset;
 #ifdef TILIZE_IN
-                        mul_tiles(dfb_in_id, dfb_input_mask_id, index, index_mask, w);
+                            mul_tiles(dfb_in_id, dfb_input_mask_id, index, index_mask, w);
 #else
-                        mul_tiles(dfb_in0_id, dfb_input_mask_id, index, index_mask, w);
+                            mul_tiles(dfb_in0_id, dfb_input_mask_id, index, index_mask, w);
 #endif
+                        } else {
+                            const uint32_t index_mask = w + index_subblock_w_offset;
+#ifdef TILIZE_IN
+                            mul_tiles_bcast_rows(dfb_in_id, dfb_input_mask_id, index, index_mask, w);
+#else
+                            mul_tiles_bcast_rows(dfb_in0_id, dfb_input_mask_id, index, index_mask, w);
+#endif
+                        }
                     }
                     tile_regs_commit();
                     tile_regs_wait();
@@ -342,7 +358,11 @@ void kernel_main() {
             dfb_ex_global.pop_front(1);
 
             reconfig_data_format_srcb(dfb_ex_global_id, dfb_input_mask_id);
-            mul_init(dfb_x_id, dfb_input_mask_id);
+            if constexpr (has_row_mask) {
+                mul_init(dfb_x_id, dfb_input_mask_id);
+            } else {
+                mul_bcast_rows_init(dfb_x_id, dfb_input_mask_id);
+            }
             dfb_x.wait_front(block_hw);
 
             for (uint32_t i = 0; i < block_h; i++) {
@@ -357,8 +377,11 @@ void kernel_main() {
                     tile_regs_acquire();
                     for (uint32_t w = 0; w < subblock_w; ++w) {
                         uint32_t index = w + index_subblock_w_offset;
-                        uint32_t index_mask = index + mask_set_offset;
-                        mul_tiles(dfb_x_id, dfb_input_mask_id, index, index_mask, w);
+                        if constexpr (has_row_mask) {
+                            mul_tiles(dfb_x_id, dfb_input_mask_id, index, index + mask_set_offset, w);
+                        } else {
+                            mul_tiles_bcast_rows(dfb_x_id, dfb_input_mask_id, index, index, w);
+                        }
                     }
                     tile_regs_commit();
 
@@ -540,7 +563,7 @@ void kernel_main() {
                 // zero out values in cb_tilized_in input by multiplying with negative mask for the current group
                 dfb_in_negative_mask.wait_front(block_w);
                 reconfig_data_format_srcb(dfb_x_id, dfb_in_negative_mask_id);
-                mul_init(dfb_in_id, dfb_in_negative_mask_id);
+                mul_bcast_rows_init(dfb_in_id, dfb_in_negative_mask_id);
 
                 for (uint32_t w = 0; w < block_w_curr; w++) {
                     index_h_offset = index_b_offset + index_g_offset;
@@ -551,7 +574,7 @@ void kernel_main() {
                         uint32_t index_in = w + index_h_offset;
                         uint32_t index_mask = w;
 
-                        mul_tiles(dfb_in_id, dfb_in_negative_mask_id, index_in, index_mask, dst0);
+                        mul_tiles_bcast_rows(dfb_in_id, dfb_in_negative_mask_id, index_in, index_mask, dst0);
                         tile_regs_commit();
 
                         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -448,7 +448,7 @@ void kernel_main() {
 
                     uint32_t group_offset = 0;
                     for (uint32_t g = min_group; g < num_groups; ++g) {
-                        dfb_xmm.reserve_back(2);
+                        dfb_xmm.reserve_back(1);
 
                         // // Now let us do the actual computation for the current group here
                         // // a. x-u
@@ -469,69 +469,52 @@ void kernel_main() {
                         tile_regs_wait();
                         pack_tile(dst0, dfb_xmm_id);
                         tile_regs_release();
+                        dfb_xmm.push_back(1);
 
-                        // // b. 1/[sqrt(Var + eps)] * mask
-                        const uint32_t mask_offset = g * block_w;
-                        const uint32_t mask_index = mask_offset + block_w_index;
-
-                        // fp32: reset SrcA to the mask format before reading dfb_input_mask (prior step left it on fp32
-                        // dfb_in0).
-                        mul_bcast_scalar_init(dfb_input_mask_id, dfb_ex2pe_id);
+                        // // b. (x - u) * 1/[sqrt(Var + eps)]
+                        dfb_xmm.wait_front(1);
+                        mul_bcast_scalar_init(dfb_xmm_id, dfb_ex2pe_id);
+                        // fp32: step a left SrcA on dfb_in0; move it to dfb_xmm. Both are bf16 on the
+                        // default path, so this compiles out.
                         if constexpr (enable_fp32_reconfig) {
-                            reconfig_data_format_srca(dfb_in0_id, dfb_input_mask_id);
+                            reconfig_data_format_srca(dfb_in0_id, dfb_xmm_id);
                         }
                         reconfig_data_format_srcb(dfb_ex_global_id, dfb_ex2pe_id);
                         tile_regs_acquire();
-                        mul_tiles_bcast_scalar(dfb_input_mask_id, dfb_ex2pe_id, mask_index, g, dst0);
+                        mul_tiles_bcast_scalar(dfb_xmm_id, dfb_ex2pe_id, 0, g, dst0);
                         tile_regs_commit();
-                        tile_regs_wait();
-                        pack_tile(dst0, dfb_xmm_id);
-                        tile_regs_release();
-                        dfb_xmm.push_back(2);
-
-                        // // c. a * b
-                        dfb_xmm.wait_front(2);
-                        mul_init(dfb_xmm_id, dfb_xmm_id);
-                        // fp32: reset SrcA to dfb_xmm (fp32); step b above left SrcA on the bf16 input mask.
-                        if constexpr (enable_fp32_reconfig) {
-                            reconfig_data_format_srca(dfb_xmm_id);
-                        }
-                        reconfig_data_format_srcb(dfb_ex2pe_id, dfb_xmm_id);
-                        tile_regs_acquire();
-                        mul_tiles(dfb_xmm_id, dfb_xmm_id, 0, 1, dst0);
-                        tile_regs_commit();
-                        dfb_xmm.pop_front(2);
+                        dfb_xmm.pop_front(1);
                         dfb_xmm.reserve_back(1);
                         tile_regs_wait();
                         pack_tile(dst0, dfb_xmm_id);
                         tile_regs_release();
                         dfb_xmm.push_back(1);
 
-                        // // d. Add to cb_xmm_id (accumulate results)
-                        // // First we get the result in dst0
-                        if (group_offset == 0) {
-                            // When group_offset is 0, this is the first group for this tile,
-                            // so we can copy the results to cb_x_id without needing to add them
-                            copy_tile_init(dfb_xmm_id);
+                        // // c. [(x - u) * rsqrt] * mask
+                        const uint32_t mask_offset = g * block_w;
+                        const uint32_t mask_index = mask_offset + block_w_index;
 
-                            dfb_xmm.wait_front(1);
-                            tile_regs_acquire();
-                            copy_tile(dfb_xmm_id, 0, dst0);
-                            tile_regs_commit();
-                            dfb_xmm.pop_front(1);
-                        } else {
-                            // This is not the first group for this tile, so we need to add
-                            // the results over what is already in cb_x_id
-                            add_init(dfb_x_id, dfb_xmm_id);
+                        dfb_xmm.wait_front(1);
+                        mul_bcast_rows_init(dfb_xmm_id, dfb_input_mask_id);
+                        reconfig_data_format_srcb(dfb_ex2pe_id, dfb_input_mask_id);
+                        tile_regs_acquire();
+                        mul_tiles_bcast_rows(dfb_xmm_id, dfb_input_mask_id, 0, mask_index, dst0);
+                        dfb_xmm.pop_front(1);
 
-                            dfb_xmm.wait_front(1);
+                        // // d. Accumulate into cb_x_id.
+                        if (group_offset != 0) {
+                            // Not the first group for this tile: add what is already in cb_x.
+                            reconfig_data_format_srca(dfb_x_id);
+                            binary_dest_reuse_tiles_init<
+                                EltwiseBinaryType::ELWADD,
+                                EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb_x_id);
                             dfb_x.wait_front(1);
-                            tile_regs_acquire();
-                            add_tiles(dfb_x_id, dfb_xmm_id, 0, 0, dst0);
-                            tile_regs_commit();
-                            dfb_xmm.pop_front(1);
+                            binary_dest_reuse_tiles<
+                                EltwiseBinaryType::ELWADD,
+                                EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb_x_id, 0, dst0);
                             dfb_x.pop_front(1);
                         }
+                        tile_regs_commit();
 
                         // Then we pack the result into cb_x_id
                         dfb_x.reserve_back(1);
@@ -539,6 +522,9 @@ void kernel_main() {
                         pack_tile(dst0, dfb_x_id);
                         tile_regs_release();
                         dfb_x.push_back(1);
+
+                        // The blocks after this loop assume srcb still carries cb_xmm's format.
+                        reconfig_data_format_srcb(dfb_xmm_id);
 
                         uint32_t cols_available = tile_width - group_offset;
                         uint32_t cols_consumed = std::min(cols_available, channels_left);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -474,8 +474,6 @@ void kernel_main() {
                         // // b. (x - u) * 1/[sqrt(Var + eps)]
                         dfb_xmm.wait_front(1);
                         mul_bcast_scalar_init(dfb_xmm_id, dfb_ex2pe_id);
-                        // fp32: step a left SrcA on dfb_in0; move it to dfb_xmm. Both are bf16 on the
-                        // default path, so this compiles out.
                         if constexpr (enable_fp32_reconfig) {
                             reconfig_data_format_srca(dfb_in0_id, dfb_xmm_id);
                         }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -336,7 +336,7 @@ void kernel_main() {
             for (uint32_t nt = 0; nt < per_core_N; ++nt) {
                 uint32_t group_offset = 0;
                 for (uint32_t g = min_group; g < num_groups; ++g) {
-                    dfb_xmm.reserve_back(2);
+                    dfb_xmm.reserve_back(1);
 
                     // // Now let us do the actual computation for the current group here
                     // // a. x-u
@@ -353,61 +353,46 @@ void kernel_main() {
                     tile_regs_wait();
                     pack_tile(dst0, dfb_xmm_id);
                     tile_regs_release();
+                    dfb_xmm.push_back(1);
 
-                    // // b. 1/[sqrt(Var + eps)] * mask
-                    const uint32_t mask_offset = g * block_w;
-                    const uint32_t mask_index = mask_offset + block_w_index;
-
-                    reconfig_data_format(dfb_in0_id, dfb_input_mask_id, dfb_ex_global_id, dfb_ex2pe_id);
-                    mul_bcast_scalar_init(dfb_input_mask_id, dfb_ex2pe_id);
+                    // // b. (x - u) * 1/[sqrt(Var + eps)]
+                    dfb_xmm.wait_front(1);
+                    reconfig_data_format(dfb_in0_id, dfb_xmm_id, dfb_ex_global_id, dfb_ex2pe_id);
+                    mul_bcast_scalar_init(dfb_xmm_id, dfb_ex2pe_id);
                     tile_regs_acquire();
-                    mul_tiles_bcast_scalar(dfb_input_mask_id, dfb_ex2pe_id, mask_index, g, dst0);
+                    mul_tiles_bcast_scalar(dfb_xmm_id, dfb_ex2pe_id, 0, g, dst0);
                     tile_regs_commit();
-                    tile_regs_wait();
-                    pack_tile(dst0, dfb_xmm_id);
-                    tile_regs_release();
-                    dfb_xmm.push_back(2);
-
-                    // // c. a * b
-                    dfb_xmm.wait_front(2);
-                    reconfig_data_format(dfb_input_mask_id, dfb_xmm_id, dfb_ex2pe_id, dfb_xmm_id);
-                    mul_init(dfb_xmm_id, dfb_xmm_id);
-                    tile_regs_acquire();
-                    mul_tiles(dfb_xmm_id, dfb_xmm_id, 0, 1, dst0);
-                    tile_regs_commit();
-                    dfb_xmm.pop_front(2);
+                    dfb_xmm.pop_front(1);
                     dfb_xmm.reserve_back(1);
                     tile_regs_wait();
                     pack_tile(dst0, dfb_xmm_id);
                     tile_regs_release();
                     dfb_xmm.push_back(1);
 
-                    // // d. Add to cb_xmm_id (accumulate results)
-                    // // First we get the result in dst0
-                    if (group_offset == 0) {
-                        // When group_offset is 0, this is the first group for this tile,
-                        // so we can copy the results to cb_x_id without needing to add them
-                        copy_tile_init(dfb_xmm_id);
+                    // // c. [(x - u) * rsqrt] * mask
+                    const uint32_t mask_offset = g * block_w;
+                    const uint32_t mask_index = mask_offset + block_w_index;
 
-                        dfb_xmm.wait_front(1);
-                        tile_regs_acquire();
-                        copy_tile(dfb_xmm_id, 0, dst0);
-                        tile_regs_commit();
-                        dfb_xmm.pop_front(1);
-                    } else {
-                        // This is not the first group for this tile, so we need to add
-                        // the results over what is already in cb_x_id
-                        reconfig_data_format_srca(dfb_xmm_id, dfb_x_id);
-                        add_init(dfb_x_id, dfb_xmm_id);
+                    dfb_xmm.wait_front(1);
+                    reconfig_data_format(dfb_xmm_id, dfb_xmm_id, dfb_ex2pe_id, dfb_input_mask_id);
+                    mul_bcast_rows_init(dfb_xmm_id, dfb_input_mask_id);
+                    tile_regs_acquire();
+                    mul_tiles_bcast_rows(dfb_xmm_id, dfb_input_mask_id, 0, mask_index, dst0);
+                    dfb_xmm.pop_front(1);
 
-                        dfb_xmm.wait_front(1);
+                    // // d. Accumulate into cb_x_id.
+                    if (group_offset != 0) {
+                        // Not the first group for this tile: add what is already in cb_x.
+                        reconfig_data_format_srca(dfb_x_id);
+                        binary_dest_reuse_tiles_init<
+                            EltwiseBinaryType::ELWADD,
+                            EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb_x_id);
                         dfb_x.wait_front(1);
-                        tile_regs_acquire();
-                        add_tiles(dfb_x_id, dfb_xmm_id, 0, 0, dst0);
-                        tile_regs_commit();
-                        dfb_xmm.pop_front(1);
+                        binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                            dfb_x_id, 0, dst0);
                         dfb_x.pop_front(1);
                     }
+                    tile_regs_commit();
 
                     // Then we pack the result into cb_x_id
                     dfb_x.reserve_back(1);
@@ -415,6 +400,9 @@ void kernel_main() {
                     pack_tile(dst0, dfb_x_id);
                     tile_regs_release();
                     dfb_x.push_back(1);
+
+                    // The blocks after this loop assume srcb still carries cb_xmm's format.
+                    reconfig_data_format_srcb(dfb_xmm_id);
 
                     uint32_t cols_available = tile_width - group_offset;
                     uint32_t cols_consumed = std::min(cols_available, channels_left);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+#include "api/core_local_mem.h"
+
+// In-kernel synthesis of a single mask tile's row 0 (face 0 + face 1) for the
+// group_norm op.
+//
+// The mask data is bit-identical across all 32 rows of a tile — only the
+// per-column 0/1 selector pattern varies along the width. The
+// mul_tiles_bcast_rows unpacker reads only face 0 row 0 + face 1 row 0
+// (bytes [0, face_w_bytes) and [face_bytes, face_bytes + face_w_bytes) in the
+// TILE-layout L1 page). This helper writes exactly those bytes from a
+// {start_col, end_col, complement} description, avoiding the need for a
+// host-built DRAM mask tensor and the associated NOC read.
+//
+// The helper is bf16-only — it writes packed 16-bit values directly. Block-
+// float formats (Bfp*) have a shared-exponent + mantissa layout that would
+// need a different writer.
+//
+// Layout assumptions (Wormhole / Blackhole bf16 tile):
+//   - face 0 row 0 occupies tile bytes [0, 32) — 16 bf16 elements (cols 0-15)
+//   - face 1 row 0 occupies tile bytes [512, 544) — 16 bf16 elements (cols 16-31)
+//   - face 1 base offset == 512 bytes (= 256 elements * 2 bytes)
+
+namespace tt::tt_metal::groupnorm {
+
+// bf16(0.0) = 0x0000, bf16(1.0) = 0x3F80
+constexpr uint16_t BF16_ZERO = 0x0000u;
+constexpr uint16_t BF16_ONE = 0x3F80u;
+
+// Pack two bf16 values into a uint32_t for wide L1 stores. NCRISC is 32-bit
+// RISC-V so a single 32-bit store replaces two 16-bit stores. L1 is little-
+// endian: the low 16 bits land at the lower byte address (the even column).
+inline constexpr uint32_t pack_bf16_pair(uint16_t even, uint16_t odd) { return (uint32_t(odd) << 16) | uint32_t(even); }
+
+// Write face 0 row 0 + face 1 row 0 of one mask tile.
+//
+// l1_tile_base: L1 address of the start of the tile slot in the mask CB.
+// start_col_in_tile, end_col_in_tile: half-open [start, end) range of columns
+//   within this tile (both in [0, 32]) that should be set to value_inside.
+//   Columns outside [start, end) are set to value_outside.
+//
+// Typical usage:
+//   - positive mask: value_inside = BF16_ONE,  value_outside = BF16_ZERO
+//   - negative mask: value_inside = BF16_ZERO, value_outside = BF16_ONE
+inline void synthesize_mask_tile_row0_bf16(
+    uint32_t l1_tile_base,
+    uint32_t start_col_in_tile,
+    uint32_t end_col_in_tile,
+    uint16_t value_inside,
+    uint16_t value_outside) {
+    // Face 0 row 0: cols 0..15 at L1 byte offset 0..32.
+    // Face 1 row 0: cols 16..31 at L1 byte offset 512..544.
+    constexpr uint32_t FACE_W = 16;  // bf16 elements per face row
+    constexpr uint32_t FACE1_OFFSET = 512;
+    constexpr uint32_t PAIRS_PER_FACE = FACE_W / 2;  // 8 uint32_t stores per face
+
+    volatile tt_l1_ptr uint32_t* face0 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_tile_base);
+    volatile tt_l1_ptr uint32_t* face1 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_tile_base + FACE1_OFFSET);
+
+    // Column c=2*i lands in the low half of pair i, c=2*i+1 in the high half.
+    for (uint32_t i = 0; i < PAIRS_PER_FACE; ++i) {
+        uint32_t c_even = 2 * i;
+        uint32_t c_odd = c_even + 1;
+        uint16_t v_even = (c_even >= start_col_in_tile && c_even < end_col_in_tile) ? value_inside : value_outside;
+        uint16_t v_odd = (c_odd >= start_col_in_tile && c_odd < end_col_in_tile) ? value_inside : value_outside;
+        face0[i] = pack_bf16_pair(v_even, v_odd);
+    }
+    for (uint32_t i = 0; i < PAIRS_PER_FACE; ++i) {
+        uint32_t c_even = 2 * i + FACE_W;
+        uint32_t c_odd = c_even + 1;
+        uint16_t v_even = (c_even >= start_col_in_tile && c_even < end_col_in_tile) ? value_inside : value_outside;
+        uint16_t v_odd = (c_odd >= start_col_in_tile && c_odd < end_col_in_tile) ? value_inside : value_outside;
+        face1[i] = pack_bf16_pair(v_even, v_odd);
+    }
+}
+
+// Fast path: fill face 0 row 0 + face 1 row 0 of a tile with a single bf16
+// value. Used when a tile is entirely-outside or entirely-inside the group's
+// [start_stride, end_stride) span — skips the per-column classifier that
+// synthesize_mask_tile_row0_bf16 runs.
+inline void fill_mask_tile_row0_bf16(uint32_t l1_tile_base, uint16_t value) {
+    constexpr uint32_t FACE1_OFFSET = 512;
+    constexpr uint32_t PAIRS_PER_FACE = 8;  // 16 bf16 columns / 2
+
+    volatile tt_l1_ptr uint32_t* face0 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_tile_base);
+    volatile tt_l1_ptr uint32_t* face1 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_tile_base + FACE1_OFFSET);
+    const uint32_t packed = pack_bf16_pair(value, value);
+    for (uint32_t i = 0; i < PAIRS_PER_FACE; ++i) {
+        face0[i] = packed;
+        face1[i] = packed;
+    }
+}
+
+// Run the per-core start-stride recurrence from groupnorm_input_mask.cpp:60-72.
+// Stateful: caller passes in the current row_offset and updates it.
+//
+// Invariant: row_offset is always in [0, tile_width).
+inline uint32_t advance_row_offset(uint32_t row_offset, uint32_t group_size_mod_tile_w, uint32_t tile_w) {
+    uint32_t sum = row_offset + group_size_mod_tile_w;
+    if (sum == tile_w) {
+        return 0;
+    } else if (sum > tile_w) {
+        return sum - tile_w;
+    } else {
+        return sum;
+    }
+}
+
+// Synthesize all block_w mask tiles for a single group into a contiguous L1
+// region starting at l1_mask_base. `start_stride` is the per-group starting
+// column offset (in [0, tile_width)) computed by the row_offset recurrence;
+// `group_size` is num_channels / num_groups; `tile_size_bytes` is the L1
+// stride between consecutive mask tile slots in the CB.
+//
+// For each of the block_w mask tiles, computes the [start, end) sub-range
+// that falls inside this tile's [0, tile_width) span and writes row 0 of
+// face 0 + face 1.
+inline void synthesize_group_mask_tiles_bf16(
+    uint32_t l1_mask_base,
+    uint32_t start_stride,
+    uint32_t group_size,
+    uint32_t block_w,
+    uint32_t tile_size_bytes,
+    uint32_t tile_w,
+    uint16_t value_inside,
+    uint16_t value_outside) {
+    uint32_t end_stride = start_stride + group_size;
+    uint32_t l1_addr = l1_mask_base;
+    for (uint32_t t = 0; t < block_w; ++t) {
+        uint32_t tile_lo = t * tile_w;
+        uint32_t tile_hi = tile_lo + tile_w;
+        // At most one tile per group straddles the [start_stride, end_stride)
+        // boundary. Every other tile is either fully-outside (all `value_outside`)
+        // or fully-inside (all `value_inside`) — for those, skip the per-column
+        // classifier and just fill 32 slots with a constant.
+        if (start_stride >= tile_hi || end_stride <= tile_lo) {
+            // Whole tile is outside the group's span.
+            fill_mask_tile_row0_bf16(l1_addr, value_outside);
+        } else if (start_stride <= tile_lo && tile_hi <= end_stride) {
+            // Whole tile is inside the group's span.
+            fill_mask_tile_row0_bf16(l1_addr, value_inside);
+        } else {
+            // Boundary tile — a subset of columns is `value_inside`, rest are
+            // `value_outside`. Run the per-column classifier.
+            uint32_t s = (start_stride > tile_lo) ? (start_stride - tile_lo) : 0;
+            uint32_t e = (end_stride < tile_hi) ? (end_stride - tile_lo) : tile_w;
+            synthesize_mask_tile_row0_bf16(l1_addr, s, e, value_inside, value_outside);
+        }
+        l1_addr += tile_size_bytes;
+    }
+}
+
+}  // namespace tt::tt_metal::groupnorm

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp
@@ -156,4 +156,102 @@ inline void synthesize_group_mask_tiles_bf16(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Full-tile variants, for non-tile-aligned H*W.
+//
+// When the tile-padding rows must be excluded from the reductions, the mask
+// becomes row-VARIANT on the batch's final row-tile, so compute consumes it
+// with a full-tile mul_tiles rather than mul_tiles_bcast_rows. A row-0-only
+// tile is then not enough: all 32 rows must be written.
+//
+// Layout: 4 faces of 16x16, face stride 512 B. Faces 0/1 carry rows 0-15 and
+// faces 2/3 rows 16-31, so the face-pair index selects the row base; faces 1/3
+// carry columns 16-31. Within a face, row r is 8 uint32 at offset r*8.
+// ---------------------------------------------------------------------------
+
+// Write one full 32x32 bf16 mask tile. Columns in [start_col_in_tile, end_col_in_tile)
+// get `value_inside`, the rest `value_outside`; rows >= rows_valid are forced to 0.0
+// regardless of column.
+//
+// Note the asymmetry: invalid rows are 0.0, NOT `value_outside`. For a negative mask
+// `value_outside` is 1.0, and a row-masked set must still be zero in the padding rows.
+//
+// 512 uint32 stores, in address order. The per-column classifier runs 8 times per face
+// rather than once per row, since the column pattern is identical down the tile.
+inline void synthesize_mask_tile_full_bf16(
+    uint32_t l1_tile_base,
+    uint32_t start_col_in_tile,
+    uint32_t end_col_in_tile,
+    uint32_t rows_valid,
+    uint16_t value_inside,
+    uint16_t value_outside) {
+    constexpr uint32_t FACE_W = 16;                 // bf16 columns per face
+    constexpr uint32_t FACE_R = 16;                 // rows per face
+    constexpr uint32_t PAIRS_PER_ROW = FACE_W / 2;  // 8 uint32 per face row
+    constexpr uint32_t U32_PER_FACE = 128;          // 512 B / 4
+
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_tile_base);
+    for (uint32_t f = 0; f < 4U; ++f) {
+        const uint32_t row_base = (f >> 1) * FACE_R;  // faces 0,1 -> rows 0-15; faces 2,3 -> rows 16-31
+        const uint32_t col_base = (f & 1U) * FACE_W;  // faces 0,2 -> cols 0-15; faces 1,3 -> cols 16-31
+
+        uint32_t packed[PAIRS_PER_ROW];
+        for (uint32_t i = 0; i < PAIRS_PER_ROW; ++i) {
+            const uint32_t c_even = col_base + 2 * i;
+            const uint32_t c_odd = c_even + 1;
+            const uint16_t v_even =
+                (c_even >= start_col_in_tile && c_even < end_col_in_tile) ? value_inside : value_outside;
+            const uint16_t v_odd =
+                (c_odd >= start_col_in_tile && c_odd < end_col_in_tile) ? value_inside : value_outside;
+            packed[i] = pack_bf16_pair(v_even, v_odd);
+        }
+
+        uint32_t idx = f * U32_PER_FACE;
+        for (uint32_t r = 0; r < FACE_R; ++r) {
+            const bool row_valid = (row_base + r) < rows_valid;
+            for (uint32_t i = 0; i < PAIRS_PER_ROW; ++i) {
+                ptr[idx + i] = row_valid ? packed[i] : 0U;  // a bf16 0.0 pair is 0x00000000
+            }
+            idx += PAIRS_PER_ROW;
+        }
+    }
+}
+
+// Full-tile counterpart of synthesize_group_mask_tiles_bf16. `rows_valid` is the number
+// of leading rows carrying real data: tile_w for the normal set, and (logical_hw % 32)
+// for the row-masked set on the core that owns a batch's final row-tile. Cores that do
+// not own it pass tile_w, which makes their row-masked set identical to the normal one
+// and the compute-side switch a no-op there.
+inline void synthesize_group_mask_tiles_full_bf16(
+    uint32_t l1_mask_base,
+    uint32_t start_stride,
+    uint32_t group_size,
+    uint32_t block_w,
+    uint32_t tile_size_bytes,
+    uint32_t tile_w,
+    uint32_t rows_valid,
+    uint16_t value_inside,
+    uint16_t value_outside) {
+    const uint32_t end_stride = start_stride + group_size;
+    uint32_t l1_addr = l1_mask_base;
+    for (uint32_t t = 0; t < block_w; ++t) {
+        const uint32_t tile_lo = t * tile_w;
+        const uint32_t tile_hi = tile_lo + tile_w;
+        uint32_t s;
+        uint32_t e;
+        if (start_stride >= tile_hi || end_stride <= tile_lo) {
+            s = 0;  // whole tile outside the group's span
+            e = 0;
+        } else if (start_stride <= tile_lo && tile_hi <= end_stride) {
+            s = 0;  // whole tile inside
+            e = tile_w;
+        } else {
+            s = (start_stride > tile_lo) ? (start_stride - tile_lo) : 0;
+            e = (end_stride < tile_hi) ? (end_stride - tile_lo) : tile_w;
+        }
+        synthesize_mask_tile_full_bf16(l1_addr, s, e, rows_valid, value_inside, value_outside);
+        l1_addr += tile_size_bytes;
+    }
+}
+
 }  // namespace tt::tt_metal::groupnorm

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -13,6 +13,9 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+#if defined(MASK_SYNTHESIZE)
+#include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp"
+#endif
 
 // Queue the DRAM read of a gamma/beta row (TILE_WIDTH datums) into face 0; byte offsets scale with
 // datum size (2B bf16 / 4B fp32). Full row goes to face 0 (Blackhole DRAM reads need 64B granularity).
@@ -114,6 +117,14 @@ void kernel_main() {
 
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr);
 
+#if defined(MASK_SYNTHESIZE)
+    // Full group size, distinct from num_cols_per_group above, which is that value
+    // mod tile width. The row_offset recurrence mirrors groupnorm_input_mask.cpp:60-72.
+    constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
+    constexpr uint32_t MASK_TILE_W = tt::constants::TILE_WIDTH;
+    constexpr uint32_t MASK_GROUP_SIZE_MOD_TILE_W = num_channels_per_group % MASK_TILE_W;
+#endif
+
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
     uint32_t num_out_blocks_padded = num_out_blocks;
     uint32_t extra_out_block = false;
@@ -131,7 +142,28 @@ void kernel_main() {
     dfb_input_mask.reserve_back(block_w * num_groups_per_core);
     uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
     uint32_t input_mask_tile_id = input_mask_tile_start_id;
+#if defined(MASK_SYNTHESIZE)
+    // start_stride for the first group on this core is 0. Subsequent groups
+    // advance row_offset by group_size_mod_tile_w with wrapping.
+    uint32_t mask_row_offset = 0;
+#endif
     for (uint32_t i = 0; i < num_groups_per_core; ++i) {
+#if defined(MASK_SYNTHESIZE)
+        // Write face 0 row 0 + face 1 row 0 of each of the block_w mask tiles
+        // for this group directly — no DRAM read.
+        tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
+            l1_write_addr_input_mask,
+            mask_row_offset,
+            num_channels_per_group,
+            block_w,
+            input_mask_single_tile_size_bytes,
+            MASK_TILE_W,
+            tt::tt_metal::groupnorm::BF16_ONE,
+            tt::tt_metal::groupnorm::BF16_ZERO);
+        mask_row_offset =
+            tt::tt_metal::groupnorm::advance_row_offset(mask_row_offset, MASK_GROUP_SIZE_MOD_TILE_W, MASK_TILE_W);
+        l1_write_addr_input_mask += block_w * input_mask_single_tile_size_bytes;
+#else
         for (uint32_t j = 0; j < block_w; ++j) {
             noc.async_read(
                 mask,
@@ -143,6 +175,7 @@ void kernel_main() {
             noc.async_read_barrier();
             l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
         }
+#endif  // MASK_SYNTHESIZE
     }
     dfb_input_mask.push_back(block_w * num_groups_per_core);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -13,6 +13,9 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+#if defined(MASK_SYNTHESIZE)
+#include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp"
+#endif
 
 void kernel_main() {
     constexpr uint32_t TILE_HW = TILE_HW_VAL;
@@ -63,14 +66,42 @@ void kernel_main() {
 
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr);
 
+#if defined(MASK_SYNTHESIZE)
+    // Full group size (num_channels / num_groups). The row_offset wrapping
+    // recurrence mirrors groupnorm_input_mask.cpp:60-72.
+    constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
+    constexpr uint32_t MASK_TILE_W = tt::constants::TILE_WIDTH;
+    constexpr uint32_t MASK_GROUP_SIZE_MOD_TILE_W = num_channels_per_group % MASK_TILE_W;
+#endif
+
     constexpr uint32_t eps_dfb_id = tt::CBIndex::c_3;
     const uint32_t eps = get_arg_val<uint32_t>(0);
     generate_bcast_col_scalar(CircularBuffer(eps_dfb_id), eps);
 
     uint32_t input_mask_tile_id = input_mask_tile_start_id;
+#if defined(MASK_SYNTHESIZE)
+    // start_stride for the first group on this core is 0. Subsequent
+    // groups advance row_offset by group_size_mod_tile_w with wrapping.
+    uint32_t mask_row_offset = 0;
+#endif
     for (uint32_t i = 0; i < num_groups_per_core; ++i) {
         dfb_input_mask.reserve_back(block_w);
         uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
+#if defined(MASK_SYNTHESIZE)
+        // Write face 0 row 0 + face 1 row 0 of each of the block_w mask
+        // tiles directly, no DRAM read.
+        tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
+            l1_write_addr_input_mask,
+            mask_row_offset,
+            num_channels_per_group,
+            block_w,
+            input_mask_single_tile_size_bytes,
+            MASK_TILE_W,
+            tt::tt_metal::groupnorm::BF16_ONE,
+            tt::tt_metal::groupnorm::BF16_ZERO);
+        mask_row_offset =
+            tt::tt_metal::groupnorm::advance_row_offset(mask_row_offset, MASK_GROUP_SIZE_MOD_TILE_W, MASK_TILE_W);
+#else
         for (uint32_t j = 0; j < block_w; ++j) {
             noc.async_read(
                 mask,
@@ -82,6 +113,7 @@ void kernel_main() {
             input_mask_tile_id += 1;
         }
         noc.async_read_barrier();
+#endif  // MASK_SYNTHESIZE
         dfb_input_mask.push_back(block_w);
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -14,6 +14,9 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+#if defined(MASK_SYNTHESIZE)
+#include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp"
+#endif
 
 // Queue the DRAM read of a gamma/beta row (TILE_WIDTH datums) into face 0; byte offsets scale with
 // datum size (2B bf16 / 4B fp32). Full row goes to face 0 (Blackhole DRAM reads need 64B granularity).
@@ -76,6 +79,12 @@ void kernel_main() {
     constexpr uint32_t pad_scaler_bits = get_named_compile_time_arg_val("pad_scaler_bits");
     constexpr bool has_row_mask = get_named_compile_time_arg_val("has_row_mask") == 1;
     constexpr uint32_t mask_tiles_per_group = has_row_mask ? 2 * block_w : block_w;
+
+#if defined(MASK_SYNTHESIZE)
+    // The synthesized mask is row-invariant (row 0 only, consumed by mul_tiles_bcast_rows), so it
+    // cannot express the row-masked second set. The op must not enable both.
+    static_assert(!has_row_mask, "MASK_SYNTHESIZE is incompatible with a row mask (non-tile-aligned H*W)");
+#endif
 
     constexpr auto out_args = TensorAccessorArgs<0>();
     constexpr auto gamma_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
@@ -147,15 +156,43 @@ void kernel_main() {
     index_b_offset = 0;
     constexpr uint32_t row_tile_max_index = num_cols_tile_gamma_beta;
 
+#if defined(MASK_SYNTHESIZE)
+    // Group sizing for in-kernel mask synthesis — mirrors the host
+    // start_stride recurrence in groupnorm_input_mask.cpp:60-72.
+    //
+    // num_cols_per_group (above) is num_channels_per_group_mod_tile_w, used by
+    // the existing index_g_offset arithmetic. The mask synthesis path needs
+    // the FULL group size (num_channels_per_group) to compute end_stride
+    // correctly when block_wt > 1.
+    constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
+    constexpr uint32_t MASK_GROUP_SIZE_MOD_TILE_W = num_channels_per_group % tile_width;
+#endif
+
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
         uint32_t input_mask_tile_id = input_mask_tile_start_id;
         uint32_t input_mask_row_tile_id = input_mask_row_tile_start_id;
         index_g_offset = 0;
         row_offset = num_cols_per_group;
+#if defined(MASK_SYNTHESIZE)
+        uint32_t mask_row_offset = 0;
+#endif
 
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
             dfb_input_mask.reserve_back(mask_tiles_per_group);
             uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
+#if defined(MASK_SYNTHESIZE)
+            tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
+                l1_write_addr_input_mask,
+                mask_row_offset,
+                num_channels_per_group,
+                block_w,
+                input_mask_single_tile_size_bytes,
+                tile_width,
+                tt::tt_metal::groupnorm::BF16_ONE,
+                tt::tt_metal::groupnorm::BF16_ZERO);
+            mask_row_offset =
+                tt::tt_metal::groupnorm::advance_row_offset(mask_row_offset, MASK_GROUP_SIZE_MOD_TILE_W, tile_width);
+#else
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc.async_read(
                     mask,
@@ -180,6 +217,10 @@ void kernel_main() {
                 }
             }
             noc.async_read_barrier();
+#endif  // MASK_SYNTHESIZE
+            // Must match reserve_back(mask_tiles_per_group) above, or the compute kernel's
+            // wait_front(mask_tiles_per_group) starves. Equals block_w under MASK_SYNTHESIZE,
+            // which is mutually exclusive with the row mask (see static_assert above).
             dfb_input_mask.push_back(mask_tiles_per_group);
 
             if (i == 0 and b == 0) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -80,12 +80,6 @@ void kernel_main() {
     constexpr bool has_row_mask = get_named_compile_time_arg_val("has_row_mask") == 1;
     constexpr uint32_t mask_tiles_per_group = has_row_mask ? 2 * block_w : block_w;
 
-#if defined(MASK_SYNTHESIZE)
-    // The synthesized mask is row-invariant (row 0 only, consumed by mul_tiles_bcast_rows), so it
-    // cannot express the row-masked second set. The op must not enable both.
-    static_assert(!has_row_mask, "MASK_SYNTHESIZE is incompatible with a row mask (non-tile-aligned H*W)");
-#endif
-
     constexpr auto out_args = TensorAccessorArgs<0>();
     constexpr auto gamma_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto beta_args = TensorAccessorArgs<gamma_args.next_compile_time_args_offset()>();
@@ -108,9 +102,14 @@ void kernel_main() {
     const uint32_t beta_tile_start_id = get_arg_val<uint32_t>(7);
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(8);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(9);
-    // Only read when has_row_mask; equals input_mask_tile_start_id on cores that do not hold a
-    // batch's final row-tile.
+    // Only read when has_row_mask. Under synthesis it is the per-core valid-row count; on the
+    // DRAM-read path it is where to read the row-masked set from. Both encode "does this core hold
+    // a batch's final row-tile" -- cores that do not get data making compute's switch a no-op.
+#if defined(MASK_SYNTHESIZE)
+    const uint32_t mask_rows_valid = get_arg_val<uint32_t>(10);
+#else
     const uint32_t input_mask_row_tile_start_id = get_arg_val<uint32_t>(10);
+#endif
 
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
@@ -170,7 +169,9 @@ void kernel_main() {
 
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
         uint32_t input_mask_tile_id = input_mask_tile_start_id;
+#if !defined(MASK_SYNTHESIZE)
         uint32_t input_mask_row_tile_id = input_mask_row_tile_start_id;
+#endif
         index_g_offset = 0;
         row_offset = num_cols_per_group;
 #if defined(MASK_SYNTHESIZE)
@@ -181,15 +182,42 @@ void kernel_main() {
             dfb_input_mask.reserve_back(mask_tiles_per_group);
             uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
 #if defined(MASK_SYNTHESIZE)
-            tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
-                l1_write_addr_input_mask,
-                mask_row_offset,
-                num_channels_per_group,
-                block_w,
-                input_mask_single_tile_size_bytes,
-                tile_width,
-                tt::tt_metal::groupnorm::BF16_ONE,
-                tt::tt_metal::groupnorm::BF16_ZERO);
+            if constexpr (has_row_mask) {
+                // Compute consumes the mask with a full-tile mul_tiles here and selects a second,
+                // row-masked set on each batch's final row-tile, so both sets need all 32 rows.
+                // Set 1 zeroes rows >= mask_rows_valid, which is tile_width on cores that do not
+                // hold that row-tile -- making their second set identical to the first.
+                tt::tt_metal::groupnorm::synthesize_group_mask_tiles_full_bf16(
+                    l1_write_addr_input_mask,
+                    mask_row_offset,
+                    num_channels_per_group,
+                    block_w,
+                    input_mask_single_tile_size_bytes,
+                    tile_width,
+                    tile_width,  // set 0: every row valid
+                    tt::tt_metal::groupnorm::BF16_ONE,
+                    tt::tt_metal::groupnorm::BF16_ZERO);
+                tt::tt_metal::groupnorm::synthesize_group_mask_tiles_full_bf16(
+                    l1_write_addr_input_mask + block_w * input_mask_single_tile_size_bytes,
+                    mask_row_offset,
+                    num_channels_per_group,
+                    block_w,
+                    input_mask_single_tile_size_bytes,
+                    tile_width,
+                    mask_rows_valid,  // set 1: the row-masked set
+                    tt::tt_metal::groupnorm::BF16_ONE,
+                    tt::tt_metal::groupnorm::BF16_ZERO);
+            } else {
+                tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
+                    l1_write_addr_input_mask,
+                    mask_row_offset,
+                    num_channels_per_group,
+                    block_w,
+                    input_mask_single_tile_size_bytes,
+                    tile_width,
+                    tt::tt_metal::groupnorm::BF16_ONE,
+                    tt::tt_metal::groupnorm::BF16_ZERO);
+            }
             mask_row_offset =
                 tt::tt_metal::groupnorm::advance_row_offset(mask_row_offset, MASK_GROUP_SIZE_MOD_TILE_W, tile_width);
 #else
@@ -218,9 +246,6 @@ void kernel_main() {
             }
             noc.async_read_barrier();
 #endif  // MASK_SYNTHESIZE
-            // Must match reserve_back(mask_tiles_per_group) above, or the compute kernel's
-            // wait_front(mask_tiles_per_group) starves. Equals block_w under MASK_SYNTHESIZE,
-            // which is mutually exclusive with the row mask (see static_assert above).
             dfb_input_mask.push_back(mask_tiles_per_group);
 
             if (i == 0 and b == 0) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -14,6 +14,9 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+#if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE)
+#include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp"
+#endif
 
 void generate_tile_with_packed_bfloat16_values(uint32_t dfb_id, uint32_t packed_bf16_value) {
     DataflowBuffer dfb(dfb_id);
@@ -101,6 +104,12 @@ void kernel_main() {
     constexpr uint32_t mask_tiles_per_group = block_w;
 #endif
 
+#if defined(MASK_SYNTHESIZE) && defined(PAD_CORRECTION)
+// The synthesized mask is row-invariant (row 0 only, consumed by mul_tiles_bcast_rows), so it cannot
+// express the row-masked second set PAD_CORRECTION streams. The op must not enable both.
+#error "MASK_SYNTHESIZE is incompatible with PAD_CORRECTION (non-tile-aligned H*W)"
+#endif
+
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
@@ -125,7 +134,15 @@ void kernel_main() {
 
     constexpr auto negative_mask_args = TensorAccessorArgs<input_mask_args.next_compile_time_args_offset()>();
     const auto negative_mask_tensor_accessor = TensorAccessor(negative_mask_args, input_negative_mask_addr);
+#endif
 
+#if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE)
+    // Full group size (num_channels / num_groups, e.g. 10 for SDXL C=320,
+    // num_groups=32). The row_offset wrapping recurrence mirrors
+    // groupnorm_input_mask.cpp:60-72.
+    constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
+    constexpr uint32_t MASK_TILE_W = tt::constants::TILE_WIDTH;
+    constexpr uint32_t MASK_GROUP_SIZE_MOD_TILE_W = num_channels_per_group % MASK_TILE_W;
 #endif
 
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
@@ -136,9 +153,27 @@ void kernel_main() {
 #if defined(FUSE_NEGATIVE_MASK)
         uint32_t input_negative_mask_tile_id = input_mask_tile_start_id;
 #endif
+#if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE)
+        // start_stride for the first group on this core is 0. Subsequent
+        // groups advance row_offset by group_size_mod_tile_w with wrapping.
+        uint32_t mask_row_offset = 0;
+#endif
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
             dfb_input_mask.reserve_back(mask_tiles_per_group);
             uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
+#if defined(MASK_SYNTHESIZE)
+            // Write face 0 row 0 + face 1 row 0 of each of the block_w mask
+            // tiles directly, no DRAM read.
+            tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
+                l1_write_addr_input_mask,
+                mask_row_offset,
+                num_channels_per_group,
+                block_w,
+                input_mask_single_tile_size_bytes,
+                MASK_TILE_W,
+                tt::tt_metal::groupnorm::BF16_ONE,
+                tt::tt_metal::groupnorm::BF16_ZERO);
+#else
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc.async_read(
                     mask,
@@ -162,11 +197,28 @@ void kernel_main() {
             }
 #endif
             noc.async_read_barrier();
+#endif  // MASK_SYNTHESIZE
+            // Must match reserve_back(mask_tiles_per_group) above, or the compute kernel's
+            // wait_front(mask_tiles_per_group) starves. Equals block_w under MASK_SYNTHESIZE,
+            // which is mutually exclusive with the row mask (see static_assert above).
             dfb_input_mask.push_back(mask_tiles_per_group);
 
 #if defined(FUSE_NEGATIVE_MASK)
             dfb_input_negative_mask.reserve_back(block_w);
             uint32_t l1_write_addr_input_negative_mask = dfb_input_negative_mask.get_write_ptr();
+#if defined(NEGATIVE_MASK_SYNTHESIZE)
+            // Negative mask: same start_stride as positive mask but inverted
+            // fill values (1s outside the group, 0s inside).
+            tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
+                l1_write_addr_input_negative_mask,
+                mask_row_offset,
+                num_channels_per_group,
+                block_w,
+                input_negative_mask_single_tile_size_bytes,
+                MASK_TILE_W,
+                tt::tt_metal::groupnorm::BF16_ZERO,
+                tt::tt_metal::groupnorm::BF16_ONE);
+#else
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc.async_read(
                     negative_mask_tensor_accessor,
@@ -178,7 +230,15 @@ void kernel_main() {
                 input_negative_mask_tile_id += 1;
             }
             noc.async_read_barrier();
+#endif  // NEGATIVE_MASK_SYNTHESIZE
             dfb_input_negative_mask.push_back(block_w);
+#endif
+
+#if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE)
+            // Advance row_offset for the next group (same recurrence as
+            // groupnorm_input_mask.cpp:64-70).
+            mask_row_offset =
+                tt::tt_metal::groupnorm::advance_row_offset(mask_row_offset, MASK_GROUP_SIZE_MOD_TILE_W, MASK_TILE_W);
 #endif
 
             if (i == 0 and b == 0) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -14,7 +14,7 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
-#if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE)
+#if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE) || defined(PAD_CORRECTION)
 #include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_mask_synthesize.hpp"
 #endif
 
@@ -95,26 +95,24 @@ void kernel_main() {
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(7);
 
 #ifdef PAD_CORRECTION
-    // Non-tile-aligned H*W: a second, row-masked set of mask tiles is streamed behind the normal
-    // one, which compute selects with +block_w. Arg 9 equals input_mask_tile_start_id on cores that
-    // do not hold a batch's final row-tile, making their second set a copy of the first.
-    constexpr uint32_t mask_tiles_per_group = 2 * block_w;
-    const uint32_t input_mask_row_tile_start_id = get_arg_val<uint32_t>(9);
-#else
+    // Non-tile-aligned H*W: c_7 still carries only the row-0-only column selector; the row
+    // exclusion on each batch's final row-tile is applied by the compute kernel, which composes
+    // the selector with the once-per-core c_18 rowvalid tile synthesized below. Arg 9 carries the
+    // per-core valid-row count: rows_in_last_tile on the core holding a batch's final row-tile,
+    // and tile_height elsewhere (an all-ones rowvalid tile, making the composition a no-op there).
+    const uint32_t rows_valid_this_core = get_arg_val<uint32_t>(9);
+#endif
+    // c_7 ships one row-0-only column-selector set per (batch, group) in every build.
     constexpr uint32_t mask_tiles_per_group = block_w;
-#endif
-
-#if defined(MASK_SYNTHESIZE) && defined(PAD_CORRECTION)
-// The synthesized mask is row-invariant (row 0 only, consumed by mul_tiles_bcast_rows), so it cannot
-// express the row-masked second set PAD_CORRECTION streams. The op must not enable both.
-#error "MASK_SYNTHESIZE is incompatible with PAD_CORRECTION (non-tile-aligned H*W)"
-#endif
 
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
     constexpr uint32_t dfb_input_mask_id = tt::CBIndex::c_7;
     constexpr uint32_t dfb_ones_id = tt::CBIndex::c_26;
+#ifdef PAD_CORRECTION
+    constexpr uint32_t dfb_rowvalid_id = tt::CBIndex::c_18;
+#endif
 
     Noc noc;
     DataflowBuffer dfb_gamma(dfb_gamma_id);
@@ -136,20 +134,19 @@ void kernel_main() {
     const auto negative_mask_tensor_accessor = TensorAccessor(negative_mask_args, input_negative_mask_addr);
 #endif
 
+#if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE) || defined(PAD_CORRECTION)
+    constexpr uint32_t MASK_TILE_W = tt::constants::TILE_WIDTH;
+#endif
 #if defined(MASK_SYNTHESIZE) || defined(NEGATIVE_MASK_SYNTHESIZE)
     // Full group size (num_channels / num_groups, e.g. 10 for SDXL C=320,
     // num_groups=32). The row_offset wrapping recurrence mirrors
     // groupnorm_input_mask.cpp:60-72.
     constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
-    constexpr uint32_t MASK_TILE_W = tt::constants::TILE_WIDTH;
     constexpr uint32_t MASK_GROUP_SIZE_MOD_TILE_W = num_channels_per_group % MASK_TILE_W;
 #endif
 
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
         uint32_t input_mask_tile_id = input_mask_tile_start_id;
-#ifdef PAD_CORRECTION
-        uint32_t input_mask_row_tile_id = input_mask_row_tile_start_id;
-#endif
 #if defined(FUSE_NEGATIVE_MASK)
         uint32_t input_negative_mask_tile_id = input_mask_tile_start_id;
 #endif
@@ -159,11 +156,12 @@ void kernel_main() {
         uint32_t mask_row_offset = 0;
 #endif
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
+            // The matching push_back below must use the same count, or the compute kernel's
+            // wait_front(mask_tiles_per_group) starves. Every build ships exactly block_w
+            // row-0-only column-selector tiles per (batch, group).
             dfb_input_mask.reserve_back(mask_tiles_per_group);
             uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
 #if defined(MASK_SYNTHESIZE)
-            // Write face 0 row 0 + face 1 row 0 of each of the block_w mask
-            // tiles directly, no DRAM read.
             tt::tt_metal::groupnorm::synthesize_group_mask_tiles_bf16(
                 l1_write_addr_input_mask,
                 mask_row_offset,
@@ -174,6 +172,7 @@ void kernel_main() {
                 tt::tt_metal::groupnorm::BF16_ONE,
                 tt::tt_metal::groupnorm::BF16_ZERO);
 #else
+            // Only the first (row-0-only column selector) set of the caller's mask is read.
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc.async_read(
                     mask,
@@ -184,23 +183,8 @@ void kernel_main() {
                 l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
                 input_mask_tile_id += 1;
             }
-#ifdef PAD_CORRECTION
-            for (uint32_t j = 0; j < block_w; ++j) {
-                noc.async_read(
-                    mask,
-                    CoreLocalMem<uint32_t>(l1_write_addr_input_mask),
-                    input_mask_single_tile_size_bytes,
-                    {.page_id = input_mask_row_tile_id},
-                    {});
-                l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
-                input_mask_row_tile_id += 1;
-            }
-#endif
             noc.async_read_barrier();
 #endif  // MASK_SYNTHESIZE
-            // Must match reserve_back(mask_tiles_per_group) above, or the compute kernel's
-            // wait_front(mask_tiles_per_group) starves. Equals block_w under MASK_SYNTHESIZE,
-            // which is mutually exclusive with the row mask (see static_assert above).
             dfb_input_mask.push_back(mask_tiles_per_group);
 
 #if defined(FUSE_NEGATIVE_MASK)
@@ -261,6 +245,22 @@ void kernel_main() {
 
                 constexpr uint32_t ones = 0x3F803F80;  // 2 packed bfloat16 into 1 uint32_t of value 1.0
                 generate_tile_with_packed_bfloat16_values(dfb_ones_id, ones);
+
+#ifdef PAD_CORRECTION
+                // Once-per-core rowvalid tile (c_18): rows < rows_valid_this_core all-ones,
+                // the rest zero. Compute composes it with the c_7 column selectors to build
+                // each batch's final row-tile mask.
+                DataflowBuffer dfb_rowvalid(dfb_rowvalid_id);
+                dfb_rowvalid.reserve_back(1);
+                tt::tt_metal::groupnorm::synthesize_mask_tile_full_bf16(
+                    dfb_rowvalid.get_write_ptr(),
+                    0,            // start_col_in_tile: the whole width is "inside", ...
+                    MASK_TILE_W,  // ... so every valid row comes out all-ones
+                    rows_valid_this_core,
+                    tt::tt_metal::groupnorm::BF16_ONE,
+                    tt::tt_metal::groupnorm::BF16_ZERO);
+                dfb_rowvalid.push_back(1);
+#endif
 
                 if constexpr (is_mcast_sender) {
                     constexpr uint32_t dfb_in_4 = tt::CBIndex::c_4;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -6,6 +6,7 @@
 #include "device/groupnorm_device_operation.hpp"
 #include "device/groupnorm_program_utils.hpp"
 #include "groupnorm_grid_utils.hpp"
+#include "groupnorm_input_mask.hpp"
 
 #include <mutex>
 #include <optional>
@@ -154,10 +155,10 @@ bool needs_negative_mask_overlap(
         input_mask.has_value() ? std::make_optional(input_mask->dtype()) : std::nullopt,
         /*negative_mask_dtype=*/std::nullopt,  // synthesized, hence bfloat16
         use_welford,
-        num_groups,
-        // Must match the factory: a row-masked second mask set doubles c_7, and omitting it here
-        // would under-count L1 and let the op pick a layout that then fails to fit.
-        pad.active ? 2 : 1);
+        // c_7 sizing matches the factory by construction now: the sharded writer streams a single
+        // (double-buffered) mask set even under the pad correction -- the row mask is composed on
+        // device (c_18/c_19) -- so there is no second-set factor to keep in sync here.
+        num_groups);
     const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
     ttnn::prim::GroupNormShardedCbFlags flags{
         .with_negative_mask = false,
@@ -184,6 +185,24 @@ bool needs_negative_mask_overlap(
             tt::LogOp, "group_norm: no negative-mask overlap needed ({} B of CBs fit in {} B)", cb_total, available);
     }
     return needed;
+}
+
+int64_t get_group_norm_cores_across_channel(
+    tt::tt_metal::TensorMemoryLayout memory_layout,
+    const ttnn::CoreGrid& core_grid,
+    const std::optional<tt::tt_metal::ShardOrientation>& shard_orientation) {
+    using tt::tt_metal::ShardOrientation;
+    using tt::tt_metal::TensorMemoryLayout;
+    if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        if (shard_orientation == ShardOrientation::ROW_MAJOR) {
+            return static_cast<int64_t>(core_grid.x);
+        }
+        return static_cast<int64_t>(core_grid.y);
+    }
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        return 1;
+    }
+    return static_cast<int64_t>(core_grid.x * core_grid.y);
 }
 
 }  // namespace
@@ -493,42 +512,36 @@ Tensor group_norm(
         validate_dram_grid(core_grid.value(), W, Ht, num_groups, input_padded_shape[0]);
     }
 
-    // Tile-aligned H*W: the caller's optional passes straight through, and when it is empty the
-    // writer kernel synthesizes the per-group {0.0, 1.0} selector directly in L1 from a small
-    // recurrence (see groupnorm_mask_synthesize.hpp) -- no host build, no DRAM tensor. Every
-    // (sharded/DRAM x welford/legacy) writer + compute combination supports synthesis.
+    // Tile-aligned H*W: the caller's optional passes straight through; when it is empty the
+    // writer kernel synthesizes the per-group {0.0, 1.0} selector directly in L1 (see
+    // groupnorm_mask_synthesize.hpp).
     //
-    // Non-tile-aligned H*W: the tile-padding rows are not guaranteed to hold zeros (reshape, slice
-    // and exp all leave non-zero bytes there), so they must be excluded from both accumulation
-    // passes. That needs a second set of mask tiles with those rows zeroed, selected on each
-    // batch's final row-tile (#52685). Such a mask varies DOWN the rows of a tile, so it cannot be
-    // consumed by mul_tiles_bcast_rows and cannot be synthesized from row 0 alone -- a host-built
-    // mask tensor is required here. Welford is unaffected: non-tile-aligned H*W already fell back
-    // to the two-pass path above.
+    // Non-tile-aligned H*W: the tile-padding rows are not guaranteed to hold zeros (reshape,
+    // slice and exp all leave non-zero bytes there), so both accumulation passes must exclude
+    // them via a row-masked variant of the mask on each batch's final row-tile. An empty
+    // optional still means "synthesize". Welford is unaffected: non-tile-aligned H*W already
+    // fell back to the two-pass path above.
+    //
+    // A caller-supplied mask is honoured as the column selector (synthesis is bf16-only, while
+    // callers commonly supply BFLOAT8_B). A doubled mask built with rows_in_last_tile is
+    // accepted; a single-set mask is used for both sets.
     const uint32_t rows_in_last_tile =
         (input_padded_shape[2] != input_shape[2] && !use_welford) ? (input_shape[2] % tile_height_align) : 0;
 
     std::optional<ttnn::Tensor> effective_input_mask = input_mask;
-    if (rows_in_last_tile != 0) {
-        // auto generate mask tensor if both input_mask and negative_mask are not provided
-        ttnn::Tensor mask = operations::normalization::get_mask_tensor(
-            input_tensor, input_mask, negative_mask, core_grid.value(), num_groups, rows_in_last_tile);
-
-        // Fallback for a caller-supplied mask not built with rows_in_last_tile: derive the second
-        // set here. Costs a host build, an upload, a multiply and a concat per call, so prefer
-        // passing rows_in_last_tile to create_group_norm_input_mask instead.
-        if (input_mask.has_value() && mask.padded_shape()[1] == static_cast<uint32_t>(num_groups)) {
-            const auto row_mask = operations::normalization::create_group_norm_row_mask(
-                                      rows_in_last_tile,
-                                      mask.padded_shape()[1],
-                                      mask.padded_shape()[3],
-                                      mask.dtype(),
-                                      tile_height_align)
-                                      .to_device(mask.device());
-            const auto row_masked = ttnn::multiply(mask, row_mask, mask.dtype());
-            mask = ttnn::concat({mask, row_masked}, 1);
-        }
-        effective_input_mask = mask;
+    if (rows_in_last_tile != 0 && input_mask.has_value() &&
+        input_mask.value().padded_shape()[1] == static_cast<uint32_t>(num_groups)) {
+        // Caller supplied a single-set mask for a non-tile-aligned input. Derive the row-masked
+        // second set. Costs a host build, an upload, a multiply and a concat per call, so prefer
+        // passing rows_in_last_tile to create_group_norm_input_mask -- or omitting the mask
+        // entirely, which is now free on this path.
+        ttnn::Tensor mask = input_mask.value();
+        const auto row_mask =
+            operations::normalization::create_group_norm_row_mask(
+                rows_in_last_tile, mask.padded_shape()[1], mask.padded_shape()[3], mask.dtype(), tile_height_align)
+                .to_device(mask.device());
+        const auto row_masked = ttnn::multiply(mask, row_mask, mask.dtype());
+        effective_input_mask = ttnn::concat({mask, row_masked}, 1);
     }
 
     if (input_tensor.is_sharded()) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -6,7 +6,6 @@
 #include "device/groupnorm_device_operation.hpp"
 #include "device/groupnorm_program_utils.hpp"
 #include "groupnorm_grid_utils.hpp"
-#include "groupnorm_input_mask.hpp"
 
 #include <mutex>
 #include <tt-logger/tt-logger.hpp>
@@ -86,24 +85,6 @@ void validate_dram_grid(
     }
 }
 
-int64_t get_group_norm_cores_across_channel(
-    tt::tt_metal::TensorMemoryLayout memory_layout,
-    const ttnn::CoreGrid& core_grid,
-    const std::optional<tt::tt_metal::ShardOrientation>& shard_orientation) {
-    using tt::tt_metal::ShardOrientation;
-    using tt::tt_metal::TensorMemoryLayout;
-    if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        if (shard_orientation == ShardOrientation::ROW_MAJOR) {
-            return static_cast<int64_t>(core_grid.x);
-        }
-        return static_cast<int64_t>(core_grid.y);
-    }
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        return 1;
-    }
-    return static_cast<int64_t>(core_grid.x * core_grid.y);
-}
-
 }  // namespace
 
 namespace ttnn::operations::normalization {
@@ -176,7 +157,8 @@ Tensor group_norm(
     std::optional<int> num_out_blocks,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<Tensor>& negative_mask,
-    bool use_welford) {
+    bool use_welford,
+    bool synthesize_negative_mask) {
     if (input_tensor.layout() == Layout::TILE and inplace.has_value()) {
         TT_FATAL(
             !inplace.value(),
@@ -198,6 +180,13 @@ Tensor group_norm(
     TT_FATAL(
         input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
         "Unsupported memory layout: Input tensor cannot be width-sharded.");
+
+    TT_FATAL(
+        !(synthesize_negative_mask && negative_mask.has_value()),
+        "group_norm: synthesize_negative_mask=True is mutually exclusive with a caller-supplied negative_mask tensor.");
+    // The remaining synthesize_negative_mask constraints (sharded-only, no Welford, ROW_MAJOR
+    // input and output) live in GroupNormDeviceOperation::validate_on_program_cache_miss so that
+    // direct ttnn::prim::group_norm callers are covered as well.
 
     const auto& input_shape = input_tensor.logical_shape();
     TT_FATAL(
@@ -410,33 +399,42 @@ Tensor group_norm(
         validate_dram_grid(core_grid.value(), W, Ht, num_groups, input_padded_shape[0]);
     }
 
+    // Tile-aligned H*W: the caller's optional passes straight through, and when it is empty the
+    // writer kernel synthesizes the per-group {0.0, 1.0} selector directly in L1 from a small
+    // recurrence (see groupnorm_mask_synthesize.hpp) -- no host build, no DRAM tensor. Every
+    // (sharded/DRAM x welford/legacy) writer + compute combination supports synthesis.
+    //
     // Non-tile-aligned H*W: the tile-padding rows are not guaranteed to hold zeros (reshape, slice
     // and exp all leave non-zero bytes there), so they must be excluded from both accumulation
-    // passes. The input mask is already multiplied into both, so carry a second set of mask tiles
-    // with those rows zeroed; the kernels select it on the final row-tile of each batch. Nothing
-    // writes to the input tensor, which is what makes this work for sharded too. See #52685.
-    // Welford is unaffected: non-tile-aligned H*W already fell back to the two-pass path above.
+    // passes. That needs a second set of mask tiles with those rows zeroed, selected on each
+    // batch's final row-tile (#52685). Such a mask varies DOWN the rows of a tile, so it cannot be
+    // consumed by mul_tiles_bcast_rows and cannot be synthesized from row 0 alone -- a host-built
+    // mask tensor is required here. Welford is unaffected: non-tile-aligned H*W already fell back
+    // to the two-pass path above.
     const uint32_t rows_in_last_tile =
         (input_padded_shape[2] != input_shape[2] && !use_welford) ? (input_shape[2] % tile_height_align) : 0;
 
-    // auto generate mask tensor if both input_mask and negative_mask are not provided
-    ttnn::Tensor mask = operations::normalization::get_mask_tensor(
-        input_tensor, input_mask, negative_mask, core_grid.value(), num_groups, rows_in_last_tile);
+    std::optional<ttnn::Tensor> effective_input_mask = input_mask;
+    if (rows_in_last_tile != 0) {
+        // auto generate mask tensor if both input_mask and negative_mask are not provided
+        ttnn::Tensor mask = operations::normalization::get_mask_tensor(
+            input_tensor, input_mask, negative_mask, core_grid.value(), num_groups, rows_in_last_tile);
 
-    // Fallback for a caller-supplied mask not built with rows_in_last_tile: derive the second set
-    // here. Costs a host build, an upload, a multiply and a concat per call, so prefer passing
-    // rows_in_last_tile to create_group_norm_input_mask instead.
-    if (rows_in_last_tile != 0 && input_mask.has_value() &&
-        mask.padded_shape()[1] == static_cast<uint32_t>(num_groups)) {
-        const auto row_mask = operations::normalization::create_group_norm_row_mask(
-                                  rows_in_last_tile,
-                                  mask.padded_shape()[1],
-                                  mask.padded_shape()[3],
-                                  mask.dtype(),
-                                  tile_height_align)
-                                  .to_device(mask.device());
-        const auto row_masked = ttnn::multiply(mask, row_mask, mask.dtype());
-        mask = ttnn::concat({mask, row_masked}, 1);
+        // Fallback for a caller-supplied mask not built with rows_in_last_tile: derive the second
+        // set here. Costs a host build, an upload, a multiply and a concat per call, so prefer
+        // passing rows_in_last_tile to create_group_norm_input_mask instead.
+        if (input_mask.has_value() && mask.padded_shape()[1] == static_cast<uint32_t>(num_groups)) {
+            const auto row_mask = operations::normalization::create_group_norm_row_mask(
+                                      rows_in_last_tile,
+                                      mask.padded_shape()[1],
+                                      mask.padded_shape()[3],
+                                      mask.dtype(),
+                                      tile_height_align)
+                                      .to_device(mask.device());
+            const auto row_masked = ttnn::multiply(mask, row_mask, mask.dtype());
+            mask = ttnn::concat({mask, row_masked}, 1);
+        }
+        effective_input_mask = mask;
     }
 
     if (input_tensor.is_sharded()) {
@@ -456,9 +454,10 @@ Tensor group_norm(
             use_welford,
             gamma,
             beta,
-            mask,
+            effective_input_mask,
             negative_mask,
-            effective_reciprocals);
+            effective_reciprocals,
+            synthesize_negative_mask);
     }
 
     const uint32_t per_batch_hw = input_padded_shape[1] * input_padded_shape[2];
@@ -545,9 +544,12 @@ Tensor group_norm(
         use_welford,
         gamma,
         beta,
-        mask,
+        effective_input_mask,
         negative_mask,
-        effective_reciprocals);
+        effective_reciprocals,
+        // The interleaved factories have no negative-mask code path; forward the flag anyway so
+        // the device op rejects it instead of silently ignoring it.
+        synthesize_negative_mask);
     if (untilize_out_on_host) {
         output = ttnn::to_layout(output, Layout::ROW_MAJOR);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -8,7 +8,9 @@
 #include "groupnorm_grid_utils.hpp"
 
 #include <mutex>
+#include <optional>
 #include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/allocator.hpp>
 
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
@@ -85,6 +87,105 @@ void validate_dram_grid(
     }
 }
 
+// Decides whether the sharded program needs the negative-mask CB-overlap trick to fit in L1.
+bool needs_negative_mask_overlap(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::prim::GroupNormShardedMultiCoreProgramConfig& program_config,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const std::optional<ttnn::Tensor>& gamma,
+    const std::optional<ttnn::Tensor>& beta,
+    const std::optional<ttnn::Tensor>& input_mask,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    float eps,
+    bool use_welford,
+    uint32_t num_groups) {
+    using tt::tt_metal::BufferType;
+    using tt::tt_metal::HalMemType;
+    using tt::tt_metal::Layout;
+
+    // Only the ROW_MAJOR-in / ROW_MAJOR-out non-Welford sharded kernels have a negative-mask
+    // path.
+    if (use_welford || input_tensor.layout() != Layout::ROW_MAJOR ||
+        program_config.output_layout != Layout::ROW_MAJOR) {
+        return false;
+    }
+
+    auto* device = input_tensor.device();
+    const auto& allocator = device->allocator();
+    const uint32_t l1_base = allocator->get_base_allocator_addr(HalMemType::L1);
+    // L1 tensor buffers grow down from the top of L1 while circular buffers grow up from
+    // l1_base, so the gap between the two is what the CB region has to fit into. nullopt means
+    // no L1 tensor is placed at all, which cannot happen on this path.
+    const auto lowest_occupied = device->lowest_occupied_compute_l1_address();
+    if (!lowest_occupied.has_value() || lowest_occupied.value() <= l1_base) {
+        return false;
+    }
+    uint32_t available = lowest_occupied.value() - l1_base;
+
+    // The output buffer is allocated after this point, so account for it up front.
+    if (!program_config.inplace && output_mem_config.buffer_type() == BufferType::L1) {
+        const auto output_spec = ttnn::prim::GroupNormDeviceOperation::compute_output_specs(
+            ttnn::prim::GroupNormParams{
+                .eps = eps,
+                .num_groups = num_groups,
+                .output_mem_config = output_mem_config,
+                .program_config = program_config,
+                .compute_kernel_config = compute_kernel_config,
+                .use_welford = use_welford},
+            ttnn::prim::GroupNormInputs{.input = input_tensor});
+        const uint32_t output_per_bank = static_cast<uint32_t>(output_spec.compute_consumed_memory_bytes_per_bank(
+            allocator->get_alignment(BufferType::L1), allocator->get_num_banks(BufferType::L1)));
+        if (output_per_bank >= available) {
+            // Nothing left for CBs either way.
+            return false;
+        }
+        available -= output_per_bank;
+    }
+
+    const auto pad = ttnn::prim::make_group_norm_pad_correction(
+        static_cast<uint32_t>(input_tensor.logical_shape()[2]),
+        static_cast<uint32_t>(input_tensor.padded_shape()[2]),
+        use_welford);
+    const auto cb_sizes = ttnn::prim::compute_sharded_gn_static_cb_sizes(
+        input_tensor,
+        program_config.im_data_format,
+        gamma.has_value() ? std::make_optional(gamma->dtype()) : std::nullopt,
+        beta.has_value() ? std::make_optional(beta->dtype()) : std::nullopt,
+        input_mask.has_value() ? std::make_optional(input_mask->dtype()) : std::nullopt,
+        /*negative_mask_dtype=*/std::nullopt,  // synthesized, hence bfloat16
+        use_welford,
+        num_groups,
+        // Must match the factory: a row-masked second mask set doubles c_7, and omitting it here
+        // would under-count L1 and let the op pick a layout that then fails to fit.
+        pad.active ? 2 : 1);
+    const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
+    ttnn::prim::GroupNormShardedCbFlags flags{
+        .with_negative_mask = false,
+        .untilize_out = true,  // guaranteed by the ROW_MAJOR output check above
+        .has_gamma = gamma.has_value(),
+        .has_beta = beta.has_value(),
+        .reader_repack_output = (input_tensor.shard_spec().value().shape[1] % tile_width) != 0,
+        .use_welford = use_welford,
+        .pad_correction_active = pad.active};
+    const uint32_t cb_total = cb_sizes.total(flags);
+
+    const bool needed = cb_total > available;
+    if (needed) {
+        flags.with_negative_mask = true;
+        log_debug(
+            tt::LogOp,
+            "group_norm: enabling the negative-mask CB overlap -- {} B of CBs do not fit in {} B of L1, "
+            "the overlap needs {} B",
+            cb_total,
+            available,
+            cb_sizes.total(flags));
+    } else {
+        log_debug(
+            tt::LogOp, "group_norm: no negative-mask overlap needed ({} B of CBs fit in {} B)", cb_total, available);
+    }
+    return needed;
+}
+
 }  // namespace
 
 namespace ttnn::operations::normalization {
@@ -157,8 +258,7 @@ Tensor group_norm(
     std::optional<int> num_out_blocks,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<Tensor>& negative_mask,
-    bool use_welford,
-    bool synthesize_negative_mask) {
+    bool use_welford) {
     if (input_tensor.layout() == Layout::TILE and inplace.has_value()) {
         TT_FATAL(
             !inplace.value(),
@@ -181,12 +281,6 @@ Tensor group_norm(
         input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
         "Unsupported memory layout: Input tensor cannot be width-sharded.");
 
-    TT_FATAL(
-        !(synthesize_negative_mask && negative_mask.has_value()),
-        "group_norm: synthesize_negative_mask=True is mutually exclusive with a caller-supplied negative_mask tensor.");
-    // The remaining synthesize_negative_mask constraints (sharded-only, no Welford, ROW_MAJOR
-    // input and output) live in GroupNormDeviceOperation::validate_on_program_cache_miss so that
-    // direct ttnn::prim::group_norm callers are covered as well.
 
     const auto& input_shape = input_tensor.logical_shape();
     TT_FATAL(
@@ -444,6 +538,19 @@ Tensor group_norm(
             .out_data_format = out_dtype,
             .inplace = inplace.value_or(false),
             .output_layout = output_layout.value_or(input_tensor.layout())};
+        // A caller-supplied negative_mask always wins; otherwise the op decides for itself
+        // whether it needs it.
+        const bool synthesize_negative_mask = !negative_mask.has_value() && needs_negative_mask_overlap(
+                                                                                input_tensor,
+                                                                                program_config,
+                                                                                output_mem_config,
+                                                                                gamma,
+                                                                                beta,
+                                                                                input_mask,
+                                                                                kernel_config_val,
+                                                                                epsilon,
+                                                                                use_welford,
+                                                                                static_cast<uint32_t>(num_groups));
         return ttnn::prim::group_norm(
             input_tensor,
             epsilon,
@@ -547,9 +654,8 @@ Tensor group_norm(
         effective_input_mask,
         negative_mask,
         effective_reciprocals,
-        // The interleaved factories have no negative-mask code path; forward the flag anyway so
-        // the device op rejects it instead of silently ignoring it.
-        synthesize_negative_mask);
+        // The interleaved factories have no negative-mask code path at all.
+        /*synthesize_negative_mask=*/false);
     if (untilize_out_on_host) {
         output = ttnn::to_layout(output, Layout::ROW_MAJOR);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
@@ -27,6 +27,7 @@ Tensor group_norm(
     std::optional<int> num_out_blocks = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     const std::optional<Tensor>& negative_mask = std::nullopt,
-    bool use_welford = false);
+    bool use_welford = false,
+    bool synthesize_negative_mask = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
@@ -27,7 +27,6 @@ Tensor group_norm(
     std::optional<int> num_out_blocks = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     const std::optional<Tensor>& negative_mask = std::nullopt,
-    bool use_welford = false,
-    bool synthesize_negative_mask = false);
+    bool use_welford = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -66,6 +66,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration for the op. Defaults to `None`.
                 negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Used to reduce the number of CB's used in the sharded version of the kernel by overlapping the CB's used for tilized input and output. (The kernel is in fact row major variant, but is internally tilizing RM into tilized inputs).
                 use_welford (bool, optional): Defaults to `False`. If `True`, the Welford's algorithm is used to compute the mean and variance. Welford cannot exclude the tile-padding rows, so if the per-sample ``H*W`` is not a multiple of the tile height this silently falls back to the two-pass path -- which handles that case correctly -- and :attr:`reciprocals` is ignored. The fallback is warned once per process.
+                synthesize_negative_mask (bool, optional): Defaults to `False`. Sharded-only opt-in for the negative-mask L1 overlap trick without allocating a DRAM tensor: the writer kernel synthesizes the inverted per-group {1.0, 0.0} selector directly in L1 (same recurrence as the positive-mask synthesis path). Mutually exclusive with :attr:`negative_mask` — pass either a tensor OR this flag, not both.
                 reciprocals (ttnn.Tensor, optional): Defaults to `None`. FP32 tensor containing pre-computed reciprocal values. Only valid when ``use_welford`` is True. Must be sharded to L1 using the legacy ``ShardSpec`` representation, with the shard grid matching the compute :attr:`core_grid`. Interleaved tensors and ``NdShardSpec`` sharding are currently not supported for the :attr:`reciprocals` tensor.
 
             Returns:
@@ -144,7 +145,8 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         nb::arg("num_out_blocks") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("negative_mask") = nb::none(),
-        nb::arg("use_welford") = false);
+        nb::arg("use_welford") = false,
+        nb::arg("synthesize_negative_mask") = false);
     mod.def(
         "create_group_norm_input_mask",
         [](int64_t num_channel,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -64,9 +64,8 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 output_layout (ttnn.Layout, optional): Defaults to `None`.
                 num_out_blocks (int, optional): For non-sharded (interleaved) inputs, splits the per-core output height (``block_h``, in tiles) into ``num_out_blocks`` chunks so each iteration uses less SRAM, at the cost of performance. Ignored for sharded inputs. Should only be set if needed to relieve SRAM pressure. Accepted explicit values are ``-1`` (use the built-in auto-heuristic) or a chunk count in range ``[1, block_h]``. Defaults to `None`, whose meaning depends on :attr:`core_grid` (non-sharded inputs only): when :attr:`core_grid` is also `None` (auto-selected), ``num_out_blocks`` is determined automatically using the same auto-heuristic as ``-1``, and passing an explicit ``num_out_blocks`` in that case is rejected. When :attr:`core_grid` is provided and ``num_out_blocks`` is `None` (default), ``num_out_blocks`` defaults to ``1`` (no chunking).
                 compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration for the op. Defaults to `None`.
-                negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Used to reduce the number of CB's used in the sharded version of the kernel by overlapping the CB's used for tilized input and output. (The kernel is in fact row major variant, but is internally tilizing RM into tilized inputs).
+                negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Created with ttnn.create_group_norm_input_negative_mask. Used to reduce the number of CB's used in the sharded version of the kernel. When no tensor is passed the op synthesizes the mask in L1 if and only if the program would otherwise not fit in L1.
                 use_welford (bool, optional): Defaults to `False`. If `True`, the Welford's algorithm is used to compute the mean and variance. Welford cannot exclude the tile-padding rows, so if the per-sample ``H*W`` is not a multiple of the tile height this silently falls back to the two-pass path -- which handles that case correctly -- and :attr:`reciprocals` is ignored. The fallback is warned once per process.
-                synthesize_negative_mask (bool, optional): Defaults to `False`. Sharded-only opt-in for the negative-mask L1 overlap trick without allocating a DRAM tensor: the writer kernel synthesizes the inverted per-group {1.0, 0.0} selector directly in L1 (same recurrence as the positive-mask synthesis path). Mutually exclusive with :attr:`negative_mask` — pass either a tensor OR this flag, not both.
                 reciprocals (ttnn.Tensor, optional): Defaults to `None`. FP32 tensor containing pre-computed reciprocal values. Only valid when ``use_welford`` is True. Must be sharded to L1 using the legacy ``ShardSpec`` representation, with the shard grid matching the compute :attr:`core_grid`. Interleaved tensors and ``NdShardSpec`` sharding are currently not supported for the :attr:`reciprocals` tensor.
 
             Returns:
@@ -145,8 +144,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         nb::arg("num_out_blocks") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("negative_mask") = nb::none(),
-        nb::arg("use_welford") = false,
-        nb::arg("synthesize_negative_mask") = false);
+        nb::arg("use_welford") = false);
     mod.def(
         "create_group_norm_input_mask",
         [](int64_t num_channel,


### PR DESCRIPTION
## Summary                                                                                       
                                                                                                   
  The `ttnn.group_norm` input mask is a deterministic per-group `{0.0, 1.0}` column selector, fully determined by `num_channels` and `num_groups`. It was built on host as a DRAM tensor in which one row of selectors is replicated across all 32 rows. This PR makes the writer kernel synthesize the mask directly into L1 — writing only face 0 row 0 + face 1 row 0 — and switches the compute kernels to a row-broadcast multiply, so row-0-only data is sufficient. This covers every shape, including non-tile-aligned H*W, on all four (sharded/interleaved x Welford/legacy) kernel pairs.
  Omitting `input_mask` means: no host mask build. Caller-supplied mask tensors remain fully supported (see *Behavior*).

## How it works                                                                                  
                                                                                                   
  ### Mask synthesis (writer kernels)                                                              
                                                                                                   
  The `{0, 1}` column pattern is a simple wrapping recurrence over `num_channels / num_groups`. The writer runs the same recurrence the host builder used and stores the pattern straight into the mask CB. Because compute consumes the mask with a row broadcast (below), only row 0 of faces 0/1  needs to be written. Synthesis is ran only when the caller did not pass an `input_mask`; a caller-supplied tensor is always NOC-read instead.

  ### Mask consumption (compute kernels)

  `mul_tiles` -> `mul_tiles_bcast_rows` for the positive and negative mask multiplies: the FPU replicates the mask's row 0 down all rows. One constraint drove a reorder in the Welford kernels: a broadcast op has exactly one `BroadcastType` for the whole instruction, and the broadcast source is always operand B. The Welford per-group body computed `((x-mu)*mask)*rsqrt`, where the mask sat in operand A and the single broadcast slot was spent on the scalar — so it is reassociated to `((x-mu)*rsqrt)*mask`, making the mask the RHS row-source. Reassociating float multiplies is not generally safe; it is bit-equivalent here only because the mask is exactly 0.0 or 1.0.

### Non-tile-aligned H*W (the row exclusion)                                                     

  Tile-padding rows are not guaranteed to hold zeros, so on non-tile-aligned shapes both accumulation passes must exclude them — done with a row-masked mask variant on each batch's final row-tile.                    

  - **Interleaved**: the writer synthesizes **both** mask sets full-tile (all 32 rows); the second 
  set zeroes rows >= the per-core valid-row count, which ships as a runtime arg. Compute consumes  
  them exactly as it consumes host-built doubled masks.
  - **Sharded (non-Welford)**: The writer ships only the row-0-only column selector plus  a once-per-core `rowvalid` tile (c_18). The compute kernel composes the final row-tile's mask into c_19 with one `mul_tiles_bcast_rows` per tile per group.

  Welford is unaffected: ttnn routes non-tile-aligned Welford to the two-pass path.

### Negative mask: automatic layout decision

  The negative mask makes the sharded kernel's in-place accumulation into the tilized-input CB (c_1) valid, letting the factory drop the full-shard untilize-out CB (c_30). That trades ~one shard of L1 for an extra multiply per block-tile per group. This is the algorithm from #31778, same approach as #45292. CB sizing moved to `compute_sharded_gn_static_cb_sizes()`, so the decision and allocation cannot diverge.

  ## Behavior                                     

  - **Positive mask:** omitting `input_mask` makes the writer synthesize it in L1, on any shape. A caller-supplied mask is always honoured.        
  - **Caller masks on non-tile-aligned shapes — no contract change:** doubled masks (built with `rows_in_last_tile`) are accepted as before; single-set masks still get the second set derived per call (pre-existing fallback, unchanged). On the sharded path the second set is required by validation but **never read** — the row exclusion comes from the on-device composition.
  
## Device-time A/B (Blackhole p100a)                                                    [94/1826]

  Tracy `GroupNormDeviceOperation` device kernel duration, AVG of 8 samples. Delta reported as `synth - dram` (negative = synthesis faster). 46 tile-aligned cases: delta spans **-5.2% to +0.10%**, 39 favour synthesis; the losses are <= +0.10%. The wins are a fixed per-call cost eliminated, so they grow as shapes shrink.

  ### Input mask, non-Welford — SDXL UNet shapes (8x8 grid)

  | shape | dram AVG (ns) | synth AVG (ns) | Δ (%) |
  |---|---:|---:|---:|                            
  | 320x128x128 | 321484 | 321418 | -0.02% |      
  | 320x64x64 | 97133 | 97074 | -0.06% |          
  | 640x64x64 | 97336 | 97254 | -0.08% |
  | 640x32x32 | 41400 | 41354 | -0.11% |
  | 960x64x64 | 97226 | 97153 | -0.08% |          
  | 1280x64x64 | 85090 | 85104 | +0.02% |
  | 1280x32x32 | 39642 | 38640 | -2.53% |
  | 1920x64x64 | 122048 | 121964 | -0.07% |       
  | 1920x32x32 | 48044 | 48044 | 0.00% |
  | 2560x32x32 | 46978 | 45837 | -2.43% |
  | 640x16x16 | 28905 | 27942 | -3.33% |          
  | 1280x16x16 | 28660 | 27696 | -3.37% |
  | 1920x16x16 | 31403 | 29833 | -5.00% |
  | 2560x16x16 | 31108 | 29490 | -5.20% |         
  | 960x32x32 | 41412 | 41376 | -0.09% |
  | 320x32x32 | 41272 | 41245 | -0.07% |

  ### Input mask, Welford — SDXL UNet shapes

  | shape | dram AVG (ns) | synth AVG (ns) | Δ (%) |
  |---|---:|---:|---:|
  | 320x128x128 | 796808 | 796413 | -0.05% |
  | 320x64x64 | 238921 | 238730 | -0.08% |        
  | 640x64x64 | 359620 | 359370 | -0.07% |
  | 640x32x32 | 131742 | 129640 | -1.60% |
  | 960x64x64 | 499814 | 499624 | -0.04% |        
  | 1280x64x64 | 595449 | 593420 | -0.34% |
  | 1280x32x32 | 191642 | 188283 | -1.75% |
  | 1920x64x64 | 865417 | 865016 | -0.05% |       
  | 1920x32x32 | 260916 | 256221 | -1.80% |
  | 2560x32x32 | 317531 | 311942 | -1.76% |
  | 640x16x16 | 76922 | 73935 | -3.88% |          
  | 1280x16x16 | 91169 | 87827 | -3.67% |
  | 1920x16x16 | 110714 | 105626 | -4.60% |
  | 2560x16x16 | 124476 | 118228 | -5.02% |       
  | 960x32x32 | 167130 | 164952 | -1.30% |
  | 320x32x32 | 101799 | 99687 | -2.07% |

### Input mask, non-Welford — other model shapes                                        [45/1826]

  | shape | dram | synth | Δ (%) |                
  |---|---:|---:|---:|
  | sd_vae_C128_H128 | 227380 | 227075 | -0.13% | 
  | sd_vae_C256_H64 | 56776 | 56821 | +0.08% |    
  | sd_vae_C512_H64 | 56589 | 56574 | -0.03% |
  | sd_vae_C512_H32 | 32050 | 31421 | -1.96% |
  | sd35_vae_C128_H128 | 227200 | 227177 | -0.01% |
  | sd35_vae_C256_H64 | 56780 | 56807 | +0.05% |
  | sd35_vae_C512_H32 | 32045 | 31436 | -1.90% |
  | oft_C256_H96 | 54507 | 54498 | -0.02% |       
  | oft_C256_H48 | 22992 | 22343 | -2.83% |
  | retinanet_C256_H128 | 161302 | 161471 | +0.10% |
  | retinanet_C256_H64 | 56778 | 56798 | +0.04% | 
  | retinanet_C256_H32 | 32147 | 31683 | -1.45% |
  | unet3d_C128_H128 | 227383 | 227140 | -0.11% | 
  | unet3d_C256_H64 | 56781 | 56796 | +0.03% |    

  ### Negative-mask overlap cost (justifies the automatic decision)

  Supplying a `negative_mask` (forcing the c_1-overlap layout) vs letting the op decide, on shapes where the cheap layout fits — this is the price a default-on overlap would charge:
  
  | shape | overlap forced | op decides | Δ (%) |
  |---|---:|---:|---:|
  | 320x128x128 | 356571 | 321416 | -9.9% |       
  | 1280x32x32 | 43646 | 38660 | -11.4% |
  | 2560x32x32 | 52354 | 45842 | -12.4% |
  | 2560x16x16 | 34245 | 29491 | -13.9% |         

  (16 shapes measured; all in the -7.8%..-13.9% band.)

### Non-tile-aligned (block-sharded, composed mask) — vs the doubled host mask

  | shape | doubled | single-set¹ | synth | synth Δ vs doubled |
  |---|---:|---:|---:|---:|                       
  | nta C=1024 H*W=200 | 32370 | 32387 | 31658 | -2.2% |
  | nta C=1024 H*W=269 (XTTS-v2) | 30000 | 30043 | 29612 | -1.3% |
  | nta C=512 H*W=100 | 27403 | 27493 | 27001 | -1.5% |
  | nta C=256 H*W=100 | 80716 | 80734 | 80601 | -0.1% |
  | aligned control C=1024 H*W=224 | 26688 | — | 25979 | -2.7% |
  | aligned control C=512 H*W=128 | 21452 | — | 21020 | -2.0% |

  ¹ GroupNorm op only; single-set callers additionally pay the per-call set-2 derive (~3.6 us of 
  `multiply`+`concat`, pre-existing behavior).

## Follow-ups
  - **BFP8 mask synthesis.** Shared exponent + `0x7F`/`0x00` mantissa bytes are uniform per row; 
  encoding sketched in `groupnorm_mask_synthesize.hpp`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/groupnorm-mask-synthesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/groupnorm-mask-synthesize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/groupnorm-mask-synthesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/groupnorm-mask-synthesize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/groupnorm-mask-synthesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/groupnorm-mask-synthesize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/groupnorm-mask-synthesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/groupnorm-mask-synthesize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/groupnorm-mask-synthesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/groupnorm-mask-synthesize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/groupnorm-mask-synthesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/groupnorm-mask-synthesize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/groupnorm-mask-synthesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/groupnorm-mask-synthesize)



