### PR TITLE
[skip ci] Add BH-Quietbox-2 as a supported runner for bisect-dispatch

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -23,6 +23,7 @@ on:
           - P100
           - config-t3000
           - BH-LoudBox
+          - BH-Quietbox-2
           - topology-6u
         description: "Runner Type Label"
       commit-range:
@@ -76,8 +77,8 @@ jobs:
 
           # Determine runs-on labels based on runner type
 
-          if [[ "$RUNNER_LABEL" == "topology-6u" ]] || [[ "$RUNNER_LABEL" == "BH-LoudBox" ]]; then
-            # Galaxy/topology-6u runners and BH-LoudBox require bare-metal (not cloud-virtual-machine)
+          if [[ "$RUNNER_LABEL" == "topology-6u" ]] || [[ "$RUNNER_LABEL" == "BH-LoudBox" ]] || [[ "$RUNNER_LABEL" == "BH-Quietbox-2" ]]; then
+            # Galaxy/topology-6u runners, BH-LoudBox, and BH-Quietbox-2 require bare-metal (not cloud-virtual-machine)
             RUNS_ON='["'$RUNNER_LABEL'", "in-service", "bare-metal"]'
           elif [[ "$RUNNER_LABEL" =~ ^(N150|N300|P150|P100|config-t3000)$ ]]; then
             # Standard single-card runners use cloud-virtual-machine
@@ -126,7 +127,11 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /home/ubuntu/.ccache-ci:/github/home/.ccache # HOME is hardcoded for no clear reason: https://github.com/actions/runner/issues/863
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        # BH-Quietbox-2 (qb2) exposes the model store at /mnt/models on the host rather than
+        # /mnt/MLPerf, so mount that into the container's /mnt/MLPerf. All other runners use the
+        # direct 1:1 /mnt/MLPerf mount. See .github/workflows/models-unit-tests-impl.yaml
+        # (yyz4-mnt-models cache mode) for the equivalent mapping.
+        - ${{ inputs.runner-label == 'BH-Quietbox-2' && '/mnt/models:/mnt/MLPerf:ro' || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
       options: >
         --device /dev/tenstorrent
         --group-add 1457


### PR DESCRIPTION
## What

Adds the `bh_quietbox_2` (BH-Quietbox-2) machine as a supported runner option in `bisect-dispatch.yaml`.

## Changes

- Add `BH-Quietbox-2` to the `runner-label` workflow_dispatch choices.
- Route `BH-Quietbox-2` through the bare-metal `runs-on` path (`["BH-Quietbox-2", "in-service", "bare-metal"]`), alongside `BH-LoudBox` and `topology-6u`. Arch resolves to `blackhole` via the existing fallback (qb2 is P300-based).
- qb2 exposes the model store at `/mnt/models` on the host rather than `/mnt/MLPerf`, so the container mount is now conditional: qb2 mounts `/mnt/models:/mnt/MLPerf:ro` while all other runners keep the direct 1:1 `/mnt/MLPerf:/mnt/MLPerf:ro` mount. This mirrors the `yyz4-mnt-models` cache mode used in `models-unit-tests-impl.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jameslee/bisect-dispatch-add-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jameslee/bisect-dispatch-add-qb2)