### PR TITLE
[Blackhole] Add NoC flush guard between multicast payload and flag in test kernels (#48481)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel.cpp
@@ -69,6 +69,11 @@ void kernel_main() {
                         src_addr, dst_data_mcast_addr, k_subblock_size_bytes, num_cores_c_dim, true);
 
                     uint64_t dst_receiver_sem_mcast_addr = row_mcast_base | receiver_sem_addr;
+#ifdef ARCH_BLACKHOLE
+                    // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush
+                    // the payload multicast before signaling so receivers don't read stale data.
+                    noc_async_writes_flushed();
+#endif
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
                 } else {

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_2d.cpp
@@ -74,6 +74,11 @@ void kernel_main() {
                         src_addr, dst_data_mcast_addr, k_subblock_size_bytes, num_cores_c_dim, true);
 
                     uint64_t dst_receiver_sem_mcast_addr = row_mcast_base | receiver_sem_addr;
+#ifdef ARCH_BLACKHOLE
+                    // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush
+                    // the payload multicast before signaling so receivers don't read stale data.
+                    noc_async_writes_flushed();
+#endif
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
                 } else {

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_v2.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_v2.cpp
@@ -74,6 +74,11 @@ void kernel_main() {
                         src_addr, dst_data_mcast_addr, k_subblock_size_bytes, num_cores_c_dim, true);
 
                     uint64_t dst_receiver_sem_mcast_addr = row_mcast_base | receiver_sem_addr;
+#ifdef ARCH_BLACKHOLE
+                    // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush
+                    // the payload multicast before signaling so receivers don't read stale data.
+                    noc_async_writes_flushed();
+#endif
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
                 } else {

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel.cpp
@@ -82,6 +82,11 @@ void kernel_main() {
                         src_addr, dst_data_mcast_addr, k_subblock_size_bytes, num_cores_r_dim, true);
 
                     uint64_t dst_receiver_sem_mcast_addr = col_mcast_base | receiver_sem_addr;
+#ifdef ARCH_BLACKHOLE
+                    // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush
+                    // the payload multicast before signaling so receivers don't read stale data.
+                    noc_async_writes_flushed();
+#endif
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_r_dim, false);
                 } else {

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel_2d.cpp
@@ -75,6 +75,11 @@ void kernel_main() {
                         src_addr, dst_data_mcast_addr, k_subblock_size_bytes, num_cores_r_dim, true);
 
                     uint64_t dst_receiver_sem_mcast_addr = col_mcast_base | receiver_sem_addr;
+#ifdef ARCH_BLACKHOLE
+                    // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush
+                    // the payload multicast before signaling so receivers don't read stale data.
+                    noc_async_writes_flushed();
+#endif
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_r_dim, false);
                 } else {

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem.cpp
@@ -52,11 +52,19 @@ void kernel_main() {
             if constexpr (loopback) {
                 noc_async_write_multicast_loopback_src(
                     mst_base_addr, dst_noc_addr_multicast, bytes_per_transaction, num_subordinates, is_linked);
+#ifdef ARCH_BLACKHOLE
+                // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush
+                // the payload multicast before signaling so receivers don't read stale data.
+                noc_async_writes_flushed();
+#endif
                 noc_semaphore_set_multicast_loopback_src(
                     sender_valid_sem_addr, dst_sem_noc_addr_multicast, num_subordinates, is_linked);
             } else {
                 noc_async_write_multicast(
                     mst_base_addr, dst_noc_addr_multicast, bytes_per_transaction, num_subordinates, is_linked);
+#ifdef ARCH_BLACKHOLE
+                noc_async_writes_flushed();
+#endif
                 noc_semaphore_set_multicast(
                     sender_valid_sem_addr, dst_sem_noc_addr_multicast, num_subordinates, is_linked);
             }
@@ -71,11 +79,19 @@ void kernel_main() {
         if constexpr (loopback) {
             noc_async_write_multicast_loopback_src(
                 mst_base_addr, dst_noc_addr_multicast, bytes_per_transaction, num_subordinates, false);
+#ifdef ARCH_BLACKHOLE
+            // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush
+            // the payload multicast before signaling so receivers don't read stale data.
+            noc_async_writes_flushed();
+#endif
             noc_semaphore_set_multicast_loopback_src(
                 sender_valid_sem_addr, dst_sem_noc_addr_multicast, num_subordinates, false);
         } else {
             noc_async_write_multicast(
                 mst_base_addr, dst_noc_addr_multicast, bytes_per_transaction, num_subordinates, false);
+#ifdef ARCH_BLACKHOLE
+            noc_async_writes_flushed();
+#endif
             noc_semaphore_set_multicast(sender_valid_sem_addr, dst_sem_noc_addr_multicast, num_subordinates, false);
         }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/receiver_final_ack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/receiver_final_ack.cpp
@@ -39,6 +39,11 @@ void kernel_main() {
         sizeof(SocketReceiverInterface) /* Not the correct sizes */,
         num_worker_cores,
         true);
+#ifdef ARCH_BLACKHOLE
+    // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush the config
+    // payload multicast before signaling so workers don't read a stale config.
+    noc_async_writes_flushed();
+#endif
     noc_semaphore_set_multicast((uint32_t)worker_config_sem_ptr, worker_config_sem_mcast_noc_addr, num_worker_cores);
 
     constexpr uint32_t num_pages = data_size / page_size;

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/receiver_loop_ack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/receiver_loop_ack.cpp
@@ -40,6 +40,11 @@ void kernel_main() {
         sizeof(SocketReceiverInterface) /* Not the correct sizes */,
         num_worker_cores,
         true);
+#ifdef ARCH_BLACKHOLE
+    // Separate cmd-buffer FIFOs can reorder payload vs flag on Blackhole; flush the config
+    // payload multicast before signaling so workers don't read a stale config.
+    noc_async_writes_flushed();
+#endif
     noc_semaphore_set_multicast((uint32_t)worker_config_sem_ptr, worker_config_sem_mcast_noc_addr, num_worker_cores);
 
     constexpr uint32_t num_pages = data_size / page_size;


### PR DESCRIPTION
## Summary

Closes #48481 (sub-issue of #48393, Section B — Blackhole-conditional race).

Eight data-movement / socket **test kernels** follow the `noc_async_write_multicast(payload)` → `noc_semaphore_set_multicast(flag)` pattern with **no flush between the two**. On Wormhole the NoC delivers both along the same route in order, so a receiver never observes the flag before the payload. On Blackhole separate cmd-buffer FIFOs can reorder them, letting a receiver read **stale data** after seeing the flag (CI-flake risk on BH + pattern-copy risk).

This inserts the established guard between the payload multicast and the flag multicast in each kernel, matching the production idiom in `tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_sender.cpp`:

```cpp
#ifdef ARCH_BLACKHOLE
    noc_async_writes_flushed();
#endif
```

The guard is a **no-op on Wormhole** and only adds a flush on Blackhole.

## Files patched (all 8 from the issue DoD)

- `data_movement/matmul/kernels/in0_kernel.cpp`, `in0_kernel_v2.cpp`, `in0_kernel_2d.cpp`, `in1_kernel.cpp`, `in1_kernel_2d.cpp` — multicast branch (the C=1/R=1 fallback already uses `noc_async_write_barrier`).
- `data_movement/one_to_all/kernels/sender_multicast_sem.cpp` — 4 sites (loopback + non-loopback, in both the per-iteration loop and the final unlinked packet).
- `test_kernels/misc/socket/receiver_final_ack.cpp`, `receiver_loop_ack.cpp` — startup config broadcast.

## `receiver_final_ack.cpp` address-mismatch review (DoD item 2)

Reviewed: the config payload and the config-ready flag target the **same multicast rectangle** (same set of worker cores), differing only in L1 offset (config CB vs semaphore word). That is the identical shape as the matmul / `sender_multicast_sem` cases and the production reference kernel — Wormhole preserves per-route in-order delivery, so the existing code is safe on WH and the Blackhole guard closes the reordering gap. `receiver_loop_ack.cpp` has a byte-identical config broadcast and gets the same guard. The flush was kept conditional (not unconditional) to stay consistent with the established convention; if a HW ordering review concludes different-address mcast is genuinely WH-unsafe, that would apply equally to the production kernel and should be changed together.

## Open dependency (DoD item 3)

"Blackhole NoC ordering fact confirmed" is a HW-team confirmation the issue lists as a blocking dependency (shared with the `coordinator_kernel` item in #48393 §B). This change is safe regardless: WH no-op, BH adds a flush.

## Test results (8× p150b Blackhole)

- All 8 kernels JIT-compile cleanly with the guard.
- `MeshSocketTest.{Single,Multi}ConnectionSingleDeviceSocketWithWorkers{Final,Loop}Ack` — **4/4 PASS** with the fix (exercise both receiver kernels).
- Matmul (1D / 1Dv2 / 2D) and one_to_all multicast-semaphore tests fail **identically on clean `main` and with this change** — pre-existing **deterministic** failures on this board (data mismatch), i.e. not a regression and not the intermittent flake this issue targets. Flagging separately; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/48481-blackhole-mcast-flush-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/48481-blackhole-mcast-flush-guard)