### PR TITLE
Remove erroneous writes of DBG_ARRAY_RD_CMD=0

### DIFF
--- a/tt_metal/hw/inc/internal/tensix_functions.h
+++ b/tt_metal/hw/inc/internal/tensix_functions.h
@@ -697,8 +697,6 @@ inline uint breakpoint_data() {
 inline void dbg_dump_array_enable() { memory_write(RISCV_DEBUG_REG_DBG_ARRAY_RD_EN, 1); }
 
 inline void dbg_dump_array_disable() {
-    // Invalidate array_id to invalid to set logic rd_en to 0
-    memory_write(RISCV_DEBUG_REG_DBG_ARRAY_RD_CMD, DBG_RD_CMD_PAYLOAD(0, 0xF, 0));
     memory_write(RISCV_DEBUG_REG_DBG_ARRAY_RD_EN, 0);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -359,8 +359,6 @@ inline void dbg_get_array_row(const std::uint32_t array_id, const std::uint32_t 
     }
 
     // Disable debug control
-    dbg_array_rd_cmd.val = 0;
-    reg_write(RISCV_DEBUG_REG_DBG_ARRAY_RD_CMD, dbg_array_rd_cmd.val);
     dbg_array_rd_en.val = 0;
     reg_write(RISCV_DEBUG_REG_DBG_ARRAY_RD_EN, dbg_array_rd_en.val);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_debug.h
@@ -265,8 +265,6 @@ inline void dbg_get_array_row(const std::uint32_t array_id, const std::uint32_t 
     }
 
     // Disable debug control
-    dbg_array_rd_cmd.val = 0;
-    reg_write(RISCV_DEBUG_REG_DBG_ARRAY_RD_CMD, dbg_array_rd_cmd.val);
     dbg_array_rd_en.val = 0;
     reg_write(RISCV_DEBUG_REG_DBG_ARRAY_RD_EN, dbg_array_rd_en.val);
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Writing DBG_ARRAY_RD_CMD=0 erroneously selects reading from SrcA (array_id=0). Do not select a SrcA read; simply disable the debug read path at the end of the sequence by setting DBG_ARRAY_RD_EN=0. Selecting SrcA is potentially dangerous as the reads are continuous (every cycle) as long as EN=1 (i.e. not delayed until the next DATA read).

This is consistent with how our ttsim tests work. 

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/dbg-array-rd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/dbg-array-rd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/dbg-array-rd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/dbg-array-rd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/dbg-array-rd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/dbg-array-rd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/dbg-array-rd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/dbg-array-rd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/dbg-array-rd)