### PR TITLE
[Draft][Llama-3.1-8B][BH] Fix prefetcher trace replay across sub-device managers (#47820)

### DIFF
--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -100,7 +100,11 @@ class DistributedNorm(LightweightModule):
                 if self.ag_config_key and mode == "decode"
                 else 2,
                 num_buffers_per_channel=2,
-                subdevice_id=self.prefetcher.worker_sub_device_id if self.prefetcher is not None else None,
+                # Only use the prefetcher's worker sub-device in decode. Prefill runs on the device's
+                # default sub-device manager, where that sub-device doesn't exist (#47820).
+                subdevice_id=self.prefetcher.worker_sub_device_id
+                if (self.prefetcher is not None and mode == Mode.DECODE)
+                else None,
             )
         else:
             x = ttnn.to_memory_config(x, input_mem_cfg)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -541,23 +541,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         **kwargs,
     ):
         self.mode = Mode.PREFILL
-        # Prefill norms / LM-head all-gathers are pinned to prefetcher.worker_sub_device_id
-        # (sub-device 1), which only exists on the prefetcher's sub-device manager (#47820). So once
-        # the prefetcher is active, keep prefill on that manager -- load its sub-device topology
-        # (decode prefetch runtime is not needed for prefill) so prefill ops and traces use the same
-        # manager as decode. Prefill traces captured during early warmup, before the prefetcher
-        # initialized (on the device's default manager, worker_sub_device_id=None), are stale once it
-        # takes over, so drop them once so they recapture under the prefetcher's manager.
-        prefetcher_active = False
+        # Prefill runs on the device's default sub-device manager (full Tensix grid). When the DRAM
+        # prefetcher is enabled it loads its own sub-device manager for decode (#47820); revert to the
+        # default manager here so prefill programs fit the grid and prefill traces are captured and
+        # replayed on the same manager. Decode re-loads the prefetcher's manager via switch_mode().
+        # Prefill norms avoid the prefetcher's worker sub-device via the mode gate in DistributedNorm.
         for i in range(len(self.model)):
             prefetcher = getattr(self.model[i], "prefetcher", None)
             if prefetcher is not None and prefetcher.is_initialized:
-                prefetcher.prefetcher_sub_device.load()
-                prefetcher_active = True
-        if prefetcher_active and not getattr(self, "_prefill_traces_on_prefetcher_mgr", False):
-            self.trace_id_prefill = defaultdict(lambda: None)
-            self.trace_id_prefill_sampling = defaultdict(lambda: None)
-            self._prefill_traces_on_prefetcher_mgr = True
+                self.model_args[i].mesh_device.clear_loaded_sub_device_manager()
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         else:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -541,6 +541,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         **kwargs,
     ):
         self.mode = Mode.PREFILL
+        # Prefill runs on the device's default sub-device manager. When the DRAM prefetcher is
+        # enabled it loads its own sub-device manager for decode (#47820), so prefill traces --
+        # captured on the default manager -- would otherwise be replayed against the prefetcher's
+        # manager and fail (trace_buffer != nullptr). Revert to the default manager here; the next
+        # decode_forward re-loads the prefetcher's manager via switch_mode(Mode.DECODE).
+        for i in range(len(self.model)):
+            prefetcher = getattr(self.model[i], "prefetcher", None)
+            if prefetcher is not None and prefetcher.is_initialized:
+                self.model_args[i].mesh_device.clear_loaded_sub_device_manager()
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         else:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -550,13 +550,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             prefetcher = getattr(self.model[i], "prefetcher", None)
             if prefetcher is not None and prefetcher.is_initialized:
                 self.model_args[i].mesh_device.clear_loaded_sub_device_manager()
-                # #47820 diagnostic (throwaway): dump the resident L1 map once, right before prefill
-                # norms, to identify what persistent prefetcher buffer occupies core (0,0) (global_cb
-                # vs address tensor) and clashes with the origin-anchored sharded RMSNorm.
-                if not getattr(self, "_dumped_l1_prefill", False):
-                    logger.info(f"[#47820] Dumping L1 state before prefill norm (model {i}, prefetcher active)")
-                    ttnn.dump_device_memory_state(self.model_args[i].mesh_device, prefix=f"prefill_m{i}_")
-                    self._dumped_l1_prefill = True
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         else:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -541,15 +541,23 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         **kwargs,
     ):
         self.mode = Mode.PREFILL
-        # Prefill runs on the device's default sub-device manager. When the DRAM prefetcher is
-        # enabled it loads its own sub-device manager for decode (#47820), so prefill traces --
-        # captured on the default manager -- would otherwise be replayed against the prefetcher's
-        # manager and fail (trace_buffer != nullptr). Revert to the default manager here; the next
-        # decode_forward re-loads the prefetcher's manager via switch_mode(Mode.DECODE).
+        # Prefill norms / LM-head all-gathers are pinned to prefetcher.worker_sub_device_id
+        # (sub-device 1), which only exists on the prefetcher's sub-device manager (#47820). So once
+        # the prefetcher is active, keep prefill on that manager -- load its sub-device topology
+        # (decode prefetch runtime is not needed for prefill) so prefill ops and traces use the same
+        # manager as decode. Prefill traces captured during early warmup, before the prefetcher
+        # initialized (on the device's default manager, worker_sub_device_id=None), are stale once it
+        # takes over, so drop them once so they recapture under the prefetcher's manager.
+        prefetcher_active = False
         for i in range(len(self.model)):
             prefetcher = getattr(self.model[i], "prefetcher", None)
             if prefetcher is not None and prefetcher.is_initialized:
-                self.model_args[i].mesh_device.clear_loaded_sub_device_manager()
+                prefetcher.prefetcher_sub_device.load()
+                prefetcher_active = True
+        if prefetcher_active and not getattr(self, "_prefill_traces_on_prefetcher_mgr", False):
+            self.trace_id_prefill = defaultdict(lambda: None)
+            self.trace_id_prefill_sampling = defaultdict(lambda: None)
+            self._prefill_traces_on_prefetcher_mgr = True
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         else:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -550,6 +550,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             prefetcher = getattr(self.model[i], "prefetcher", None)
             if prefetcher is not None and prefetcher.is_initialized:
                 self.model_args[i].mesh_device.clear_loaded_sub_device_manager()
+                # #47820 diagnostic (throwaway): dump the resident L1 map once, right before prefill
+                # norms, to identify what persistent prefetcher buffer occupies core (0,0) (global_cb
+                # vs address tensor) and clashes with the origin-anchored sharded RMSNorm.
+                if not getattr(self, "_dumped_l1_prefill", False):
+                    logger.info(f"[#47820] Dumping L1 state before prefill norm (model {i}, prefetcher active)")
+                    ttnn.dump_device_memory_state(self.model_args[i].mesh_device, prefix=f"prefill_m{i}_")
+                    self._dumped_l1_prefill = True
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         else:

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -221,6 +221,13 @@ class PrefetcherSubDevice:
     def init_sub_device_manager(self):
         assert len(self.sub_devices) > 0, "No subdevices have been created. Cannot create sub device manager."
         self.manager_id = self.mesh_device.create_sub_device_manager(self.sub_devices, 0)
+        self.load()
+
+    def load(self):
+        # (Re)activate this prefetcher's sub-device manager. Split out from
+        # init_sub_device_manager so an already-created manager can be re-loaded
+        # without recreating it -- e.g. after prefill trace replay temporarily
+        # reverts to the device's default sub-device manager (#47820).
         self.mesh_device.load_sub_device_manager(self.manager_id)
         self.mesh_device.set_sub_device_stall_group(self.sub_devices_id)
 
@@ -362,8 +369,11 @@ class Prefetcher(LightweightModule):
         NOTE: All DRAM prefetcher APIs can only be called after init() is called for the given mode
         NOTE: Calling init() again for the same mode is a no-op
         """
-        # If the prefetcher has already been initialized for the given mode, we do not need to initialize it again
-        if mode == Mode.DECODE and self.init_decode_done or mode == Mode.PREFILL and self.init_prefill_done:
+        # If the prefetcher has already been initialized for the given mode, we do not need to initialize it again.
+        # We still re-load the manager: it may have been swapped out (prefill trace replay reverts to the device's
+        # default sub-device manager, #47820), so the prefetcher's manager must be re-activated before decode runs.
+        if (mode == Mode.DECODE and self.init_decode_done) or (mode == Mode.PREFILL and self.init_prefill_done):
+            self.prefetcher_sub_device.load()
             return
         self.mode = mode
         self.sender_cores = self.core_config.sender_cores
@@ -400,6 +410,11 @@ class Prefetcher(LightweightModule):
         logger.info("=" * 50)
         self.init_decode_done = True if mode == Mode.DECODE else False
         self.init_prefill_done = True if mode == Mode.PREFILL else False
+
+    @property
+    def is_initialized(self) -> bool:
+        # True once a prefetcher sub-device manager has been created/loaded for any mode.
+        return self.init_decode_done or self.init_prefill_done
 
     def create_address_tensor(self):
         """


### PR DESCRIPTION
## Problem
`Llama 3.1-8B e2e tests [bh_quietbox_2]` (`--use_prefetcher`) fails **every** scheduled run during prefill trace replay (issue #47820):
```
TT_FATAL @ mesh_device.cpp:1360: trace_buffer != nullptr
Trace instance 1 must exist on Mesh device 0's active sub-device manager 1
```

## Root cause
Traces are stored **per sub-device manager**. The prefill trace is first captured during early warmup under the device's **default** manager (before the DRAM prefetcher initializes — `prefetcher.worker_sub_device_id` is `None`, so norms run on the default sub-device). The first `decode_forward` → `switch_mode(Mode.DECODE)` → `prefetcher.init` creates+loads the prefetcher's manager (id 1). The cached prefill trace is then replayed while manager 1 is active → trace absent → fatal.

Crucially, prefill norms / LM-head all-gathers are pinned to `prefetcher.worker_sub_device_id` (sub-device **1**) whenever a prefetcher exists (`distributed_norm.py:103`, `model.py:835`), and that sub-device only exists on the prefetcher's manager. **So once the prefetcher is active, prefill must run on the prefetcher's manager** — it cannot run on the default one.

## Fix
1. **`generator.prefill_forward_text`** — when the prefetcher is initialized, **load its sub-device manager** for prefill (topology only; the decode prefetch runtime isn't needed for prefill), so prefill ops + traces use the same manager as decode. Drop the prefill trace cache **once** when the prefetcher takes over, so the stale default-manager trace is recaptured under the prefetcher's manager.
2. **`prefetcher`** — split manager (re)activation into `PrefetcherSubDevice.load()`; on the already-initialized `init()` path, **re-load** the manager instead of early-returning. Add `Prefetcher.is_initialized`.

Net: **prefill and decode both run on the prefetcher's manager** (with sub-device 1) once it's active; prefill traces are captured + replayed there consistently.

## Validation
⚠️ **Draft — HW-only.** Requires 4-device Blackhole (`bh_quietbox_2`).
- Run 1 ([28462442651](https://github.com/tenstorrent/tt-metal/actions/runs/28462442651)): original `trace_buffer` fatal **fixed**, but revealed prefill needs sub-device 1 (revert-to-default approach hit `sub_device_manager.cpp:186`). Fix revised accordingly.
- Run 2 ([28465864457](https://github.com/tenstorrent/tt-metal/actions/runs/28465864457)): in progress on the revised fix.

Open question for trace/prefetcher owners: is it valid to run prefill under the prefetcher's *decode* sub-device layout? Progress tracked on #47820.

Closes #47820

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-trace-subdevice-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/llama8b-prefetcher-trace-subdevice-fix)