### PR TITLE
[Performance] Gemma4 decode layer l1 optimizations

### DIFF
--- a/models/demos/gemma4/tt/layer.py
+++ b/models/demos/gemma4/tt/layer.py
@@ -269,7 +269,7 @@ class Gemma4DecoderLayer:
         # 2. MLP + MoE block
         residual = hidden_states
         normed = self.pre_feedforward_layernorm.forward(hidden_states)
-        mlp_output = self.shared_mlp(normed)
+        mlp_output = self.shared_mlp(normed, is_decode=is_decode)
         normed.deallocate(True)
 
         if self.enable_moe_block:

--- a/models/demos/gemma4/tt/rms_norm.py
+++ b/models/demos/gemma4/tt/rms_norm.py
@@ -148,19 +148,30 @@ class RMSNorm(nn.Module):
             # Prefill (height > 32) and the no-weight per-head norms keep the
             # plain path. Sharded config is dim-specific, so rebuild if the
             # activation width ever changes.
-            if (
+            decode_fast_path_eligible = (
                 self.with_scale
                 and self.tt_weight is not None
                 and len(x.shape) == 4
                 and 1 <= x.shape[-2] <= ttnn.TILE_SIZE
-                and not x.is_sharded()
-            ):
+            )
+            if decode_fast_path_eligible:
                 dim = x.shape[-1]
                 if self._sharded_cfg is None or self._sharded_dim != dim:
                     self._sharded_dim = dim
                     self._sharded_cfg = self._build_sharded_cfg(dim)
+
                 if self._sharded_cfg:
-                    return self._forward_sharded(x)
+                    # Input already L1 width-sharded, do the norm in place.
+                    if x.is_sharded() and x.memory_config() == self._sharded_cfg[0]:
+                        return ttnn.rms_norm(
+                            x,
+                            weight=self.tt_weight,
+                            epsilon=self.eps,
+                            program_config=self._sharded_cfg[1],
+                        )
+                    # Interleaved input, reshard and do the norm.
+                    if not x.is_sharded():
+                        return self._forward_sharded(x)
 
             if self.with_scale:
                 tt_output = ttnn.rms_norm(

--- a/models/demos/gemma4/tt/shared_mlp.py
+++ b/models/demos/gemma4/tt/shared_mlp.py
@@ -14,6 +14,8 @@ HF weight shapes:
   down_proj.weight: [hidden_size, intermediate_size] = [2816, 2112]
 """
 
+import torch
+
 import ttnn
 from models.demos.gemma4.tt.ccl import ccl_allreduce
 from models.demos.gemma4.utils.general_utils import get_cache_file_name
@@ -37,6 +39,7 @@ class SharedMLP:
         self.intermediate_size = hf_config.intermediate_size
 
         tp = mesh_config.tp if mesh_config else 1
+        self.tp = tp
         tp_suffix = f"_tp{tp}" if tp > 1 else ""
 
         # Tag the cache filenames with the weight dtype so that flipping a
@@ -55,31 +58,35 @@ class SharedMLP:
             row_mapper = None
 
         if state_dict:
-            gate_proj_weight = state_dict["gate_proj.weight"].transpose(-2, -1).unsqueeze(0).unsqueeze(0)
-            up_proj_weight = state_dict["up_proj.weight"].transpose(-2, -1).unsqueeze(0).unsqueeze(0)
+            # Fuse gate_proj + up_proj into a single column-parallel weight so the
+            # forward runs ONE matmul producing a [gate | up] slab (mirrors the wqkv
+            # fusion in attention/weights.py). 
+            gate_w = state_dict["gate_proj.weight"]  # [intermediate_size, hidden_size]
+            up_w = state_dict["up_proj.weight"]  # [intermediate_size, hidden_size]
+            if tp > 1:
+                fused_list = []
+                for i in range(tp):
+                    wg_chunk = torch.chunk(gate_w, tp, dim=0)[i].transpose(-2, -1)
+                    wu_chunk = torch.chunk(up_w, tp, dim=0)[i].transpose(-2, -1)
+                    fused_list.append(torch.cat([wg_chunk, wu_chunk], dim=-1))  # [hidden, 2*int/tp]
+                gate_up_proj_weight = torch.cat(fused_list, dim=-1).unsqueeze(0).unsqueeze(0)
+            else:
+                gate_up_proj_weight = (
+                    torch.cat([gate_w.transpose(-2, -1), up_w.transpose(-2, -1)], dim=-1).unsqueeze(0).unsqueeze(0)
+                )
             down_proj_weight = state_dict["down_proj.weight"].transpose(-2, -1).unsqueeze(0).unsqueeze(0)
         else:
-            gate_proj_weight = None
-            up_proj_weight = None
+            gate_up_proj_weight = None
             down_proj_weight = None
 
-        # gate/up: column-parallel (shard output dim across TP devices)
-        self.gate_proj = ttnn.as_tensor(
-            gate_proj_weight,
+        # gate+up fused: column-parallel (shard output dim across TP devices)
+        self.gate_up_proj = ttnn.as_tensor(
+            gate_up_proj_weight,
             device=mesh_device,
             dtype=dtype,
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=col_mapper,
-            cache_file_name=get_cache_file_name(tensor_cache_path, f"gate_proj.weight{tp_suffix}{dtype_suffix}"),
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-        self.up_proj = ttnn.as_tensor(
-            up_proj_weight,
-            device=mesh_device,
-            dtype=dtype,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=col_mapper,
-            cache_file_name=get_cache_file_name(tensor_cache_path, f"up_proj.weight{tp_suffix}{dtype_suffix}"),
+            cache_file_name=get_cache_file_name(tensor_cache_path, f"gate_up_proj.weight{tp_suffix}{dtype_suffix}"),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         # down: row-parallel (shard input dim, allreduce after)
@@ -97,19 +104,27 @@ class SharedMLP:
         """
         GeGLU MLP forward with TP support.
 
-        gate/up are column-parallel, down is row-parallel + allreduce.
+        gate+up are fused (column-parallel), down is row-parallel + allreduce.
         """
-        # gate = GELU(x @ gate_proj)
-        gate = ttnn.linear(hidden_states, self.gate_proj)
-        gate = ttnn.gelu(gate, fast_and_approximate_mode=True)
+        # Fused gate+up projection: one matmul produces the [gate | up] slab.
+        gate_up = ttnn.linear(hidden_states, self.gate_up_proj)
 
-        # up = x @ up_proj
-        up = ttnn.linear(hidden_states, self.up_proj)
-
-        # hidden = gate * up
-        hidden = ttnn.mul(gate, up)
-        gate.deallocate(True)
-        up.deallocate(True)
+        # Split the slab into gate / up halves (per-device width when column-parallel)
+        # and fuse GeGLU into the multiply: fast-approx GELU on the gate half
+        # (operand a) only, then elementwise * up. Replaces the separate ttnn.gelu +
+        # ttnn.mul, matching the original fast_and_approximate_mode=True semantics.
+        #
+        # NOTE: when intermediate_size/tp is not a multiple of TILE_WIDTH (32) — e.g.
+        # 2112/8 = 264 on T3K — this split is not tile-aligned, so ttnn.slice falls
+        # back to a row-major composite path (correct, but a layout round-trip). Making
+        # it tile-aligned means padding each per-device half up to a tile multiple in
+        # the fused weight AND padding down_proj's per-device input dim to match;
+        # deferred to the down_proj mem-config / config-tuning work.
+        split = self.intermediate_size // self.tp
+        gate = gate_up[..., :split]
+        up = gate_up[..., split:]
+        hidden = ttnn.mul(gate, up, input_tensor_a_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, True)])
+        gate_up.deallocate(True)
 
         # output = hidden @ down_proj
         output = ttnn.linear(hidden, self.down_proj)

--- a/models/demos/gemma4/tt/shared_mlp.py
+++ b/models/demos/gemma4/tt/shared_mlp.py
@@ -17,8 +17,73 @@ HF weight shapes:
 import torch
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.gemma4.tt.ccl import ccl_allreduce
 from models.demos.gemma4.utils.general_utils import get_cache_file_name
+
+
+def _tiles(dim):
+    return (dim + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE
+
+
+def find_largest_divisor(n, max_divisor=8):
+    for i in range(max_divisor, 0, -1):
+        if n % i == 0:
+            return i
+    return 1
+
+
+def _best_core_grid(n_tiles, max_x, max_y):
+    """Largest grid (cx<=max_x, cy<=max_y) whose core count divides n_tiles.
+
+    Exact division keeps per_core_N * num_cores == n_tiles (no over-allocation),
+    mirroring experts/_build_sparse_matmul_config.
+    """
+    best_cores, best = 1, (1, 1)
+    for cy in range(1, max_y + 1):
+        for cx in range(1, max_x + 1):
+            cores = cx * cy
+            if n_tiles % cores == 0 and cores > best_cores:
+                best_cores, best = cores, (cx, cy)
+    return best
+
+
+def _decode_linear_1d_config(m_tiles, k_tiles, n_tiles, grid_size, is_bh):
+    """1D (N-parallel) matmul program config for a decode-mode Linear.
+
+    Decode has small M, so we use 1d splitting across N 
+
+    Constraints satisfied here:
+      - in0_block_w divides k_tiles (K streamed in even chunks)
+      - per_core_N * num_cores == n_tiles (grid chosen to divide n_tiles)
+      - out_subblock_w divides per_core_N; out_subblock_h divides per_core_M
+      - out_subblock_h * out_subblock_w <= arch cap (4 Blackhole / 8 Wormhole)
+    """
+    cx, cy = _best_core_grid(n_tiles, grid_size.x, grid_size.y)
+    num_cores = cx * cy
+
+    per_core_M = m_tiles
+    per_core_N = n_tiles // num_cores
+
+    # Must divide k_tiles exactly; derive straight from k_tiles rather than the
+    # tt_transformers k_tiles//num_cores form, which isn't guaranteed to divide.
+    in0_block_w = find_largest_divisor(k_tiles)
+
+    max_subblock = 4 if is_bh else 8
+    out_subblock_w = find_largest_divisor(per_core_N, max_subblock)
+    out_subblock_h = find_largest_divisor(per_core_M, max(1, max_subblock // out_subblock_w))
+
+    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(cx, cy),
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    )
 
 
 class SharedMLP:
@@ -100,14 +165,28 @@ class SharedMLP:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-    def __call__(self, hidden_states):
+    def __call__(self, hidden_states, is_decode=False):
         """
         GeGLU MLP forward with TP support.
 
         gate+up are fused (column-parallel), down is row-parallel + allreduce.
+        In decode the two matmuls use tuned 1D program configs; prefill falls
+        back to the ttnn-chosen default (program_config=None).
         """
+        gate_up_pc = down_pc = None
+        if is_decode:
+            grid = self.mesh_device.compute_with_storage_grid_size()
+            is_bh = is_blackhole()
+            m_tiles = _tiles(hidden_states.shape[-2])
+            gate_up_pc = _decode_linear_1d_config(
+                m_tiles, _tiles(self.gate_up_proj.shape[-2]), _tiles(self.gate_up_proj.shape[-1]), grid, is_bh
+            )
+            down_pc = _decode_linear_1d_config(
+                m_tiles, _tiles(self.down_proj.shape[-2]), _tiles(self.down_proj.shape[-1]), grid, is_bh
+            )
+
         # Fused gate+up projection: one matmul produces the [gate | up] slab.
-        gate_up = ttnn.linear(hidden_states, self.gate_up_proj)
+        gate_up = ttnn.linear(hidden_states, self.gate_up_proj, program_config=gate_up_pc)
 
         # Split the slab into gate / up halves (per-device width when column-parallel)
         # and fuse GeGLU into the multiply: fast-approx GELU on the gate half
@@ -127,7 +206,7 @@ class SharedMLP:
         gate_up.deallocate(True)
 
         # output = hidden @ down_proj
-        output = ttnn.linear(hidden, self.down_proj)
+        output = ttnn.linear(hidden, self.down_proj, program_config=down_pc)
         hidden.deallocate(True)
 
         # Allreduce after row-parallel down_proj

--- a/models/demos/gemma4/tt/shared_mlp.py
+++ b/models/demos/gemma4/tt/shared_mlp.py
@@ -152,8 +152,7 @@ class SharedMLP:
 
         if state_dict:
             # Fuse gate_proj + up_proj into a single column-parallel weight so the
-            # forward runs ONE matmul producing a [gate | up] slab (mirrors the wqkv
-            # fusion in attention/weights.py).
+            # forward runs ONE matmul producing a [gate | up] slab
             gate_w = state_dict["gate_proj.weight"]  # [intermediate_size, hidden_size]
             up_w = state_dict["up_proj.weight"]  # [intermediate_size, hidden_size]
             pad = self._intermediate_pad
@@ -225,8 +224,7 @@ class SharedMLP:
                 m_tiles, _tiles(self.gate_up_proj.shape[-2]), _tiles(self.gate_up_proj.shape[-1]), grid, is_bh
             )
             # Request a matching L1 width-sharded output config for down_proj so
-            # the matmul writes its result into L1 instead of DRAM (saves the
-            # output DRAM write; the following allreduce/norm can read locally).
+            # the matmul writes its result into L1 instead of DRAM
             down_pc, down_out_memcfg = _decode_linear_1d_config(
                 m_tiles,
                 _tiles(self.down_proj.shape[-2]),
@@ -242,13 +240,6 @@ class SharedMLP:
         # Split the slab into gate / up halves and fuse GeGLU into the multiply:
         # fast-approx GELU on the gate half (operand a) only, then elementwise * up.
         # Matches the original fast_and_approximate_mode=True GeGLU semantics.
-        #
-        # The split uses the *tile-aligned* per-device width (padded_split): with TP
-        # the raw per-device width (e.g. 264) is mid-tile, so both halves were padded
-        # to padded_split (e.g. 288) at load time. Slicing there lands on a tile
-        # boundary, keeping gate/up lanes from mixing within a tile. The padded zero
-        # lanes pass through GeGLU as zeros and are dropped by the row-parallel
-        # down_proj, whose input rows were padded to match.
         split = self.padded_split
         gate = gate_up[..., :split]
         up = gate_up[..., split:]
@@ -259,8 +250,11 @@ class SharedMLP:
         output = ttnn.linear(hidden, self.down_proj, program_config=down_pc, memory_config=down_out_memcfg)
         hidden.deallocate(True)
 
-        # Allreduce after row-parallel down_proj
+        # Allreduce after row-parallel down_proj. down_proj is row-parallel so
+        # the all-reduce sums partials over the *full* hidden width — its output
+        # spans the same N as the matmul, so the matmul's L1 width-sharded
+        # output config (down_out_memcfg) also describes the all-reduce output.
         if self.mesh_config is not None and self.mesh_config.tp > 1:
-            output = ccl_allreduce(output, self.mesh_config, self.ccl_manager)
+            output = ccl_allreduce(output, self.mesh_config, self.ccl_manager, memory_config=down_out_memcfg)
 
         return output

--- a/models/demos/gemma4/tt/shared_mlp.py
+++ b/models/demos/gemma4/tt/shared_mlp.py
@@ -48,7 +48,7 @@ def _best_core_grid(n_tiles, max_x, max_y):
     return best
 
 
-def _decode_linear_1d_config(m_tiles, k_tiles, n_tiles, grid_size, is_bh):
+def _decode_linear_1d_config(m_tiles, k_tiles, n_tiles, grid_size, is_bh, return_output_memcfg=False):
     """1D (N-parallel) matmul program config for a decode-mode Linear.
 
     Decode has small M, so we use 1d splitting across N
@@ -58,6 +58,11 @@ def _decode_linear_1d_config(m_tiles, k_tiles, n_tiles, grid_size, is_bh):
       - per_core_N * num_cores == n_tiles (grid chosen to divide n_tiles)
       - out_subblock_w divides per_core_N; out_subblock_h divides per_core_M
       - out_subblock_h * out_subblock_w <= arch cap (4 Blackhole / 8 Wormhole)
+
+    When ``return_output_memcfg`` is set, also returns a WIDTH-sharded L1
+    MemoryConfig laid out on the *same* (cx, cy) grid the matmul uses, with each
+    core holding ``per_core_N`` output tiles. This lets the matmul write its
+    result straight into L1 (skipping the DRAM write).
     """
     cx, cy = _best_core_grid(n_tiles, grid_size.x, grid_size.y)
     num_cores = cx * cy
@@ -73,7 +78,7 @@ def _decode_linear_1d_config(m_tiles, k_tiles, n_tiles, grid_size, is_bh):
     out_subblock_w = find_largest_divisor(per_core_N, max_subblock)
     out_subblock_h = find_largest_divisor(per_core_M, max(1, max_subblock // out_subblock_w))
 
-    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=ttnn.CoreCoord(cx, cy),
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -84,6 +89,18 @@ def _decode_linear_1d_config(m_tiles, k_tiles, n_tiles, grid_size, is_bh):
         fused_activation=None,
         mcast_in0=True,
     )
+
+    if not return_output_memcfg:
+        return program_config
+
+    output_memcfg = ttnn.create_sharded_memory_config(
+        shape=(per_core_M * ttnn.TILE_SIZE, per_core_N * ttnn.TILE_SIZE),
+        core_grid=ttnn.CoreGrid(x=cx, y=cy),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    return program_config, output_memcfg
 
 
 class SharedMLP:
@@ -199,7 +216,7 @@ class SharedMLP:
         In decode the two matmuls use tuned 1D program configs; prefill falls
         back to the ttnn-chosen default (program_config=None).
         """
-        gate_up_pc = down_pc = None
+        gate_up_pc = down_pc = down_out_memcfg = None
         if is_decode:
             grid = self.mesh_device.compute_with_storage_grid_size()
             is_bh = is_blackhole()
@@ -207,8 +224,16 @@ class SharedMLP:
             gate_up_pc = _decode_linear_1d_config(
                 m_tiles, _tiles(self.gate_up_proj.shape[-2]), _tiles(self.gate_up_proj.shape[-1]), grid, is_bh
             )
-            down_pc = _decode_linear_1d_config(
-                m_tiles, _tiles(self.down_proj.shape[-2]), _tiles(self.down_proj.shape[-1]), grid, is_bh
+            # Request a matching L1 width-sharded output config for down_proj so
+            # the matmul writes its result into L1 instead of DRAM (saves the
+            # output DRAM write; the following allreduce/norm can read locally).
+            down_pc, down_out_memcfg = _decode_linear_1d_config(
+                m_tiles,
+                _tiles(self.down_proj.shape[-2]),
+                _tiles(self.down_proj.shape[-1]),
+                grid,
+                is_bh,
+                return_output_memcfg=True,
             )
 
         # Fused gate+up projection: one matmul produces the [gate | up] slab.
@@ -231,7 +256,7 @@ class SharedMLP:
         gate_up.deallocate(True)
 
         # output = hidden @ down_proj
-        output = ttnn.linear(hidden, self.down_proj, program_config=down_pc)
+        output = ttnn.linear(hidden, self.down_proj, program_config=down_pc, memory_config=down_out_memcfg)
         hidden.deallocate(True)
 
         # Allreduce after row-parallel down_proj

--- a/models/demos/gemma4/tt/shared_mlp.py
+++ b/models/demos/gemma4/tt/shared_mlp.py
@@ -51,7 +51,7 @@ def _best_core_grid(n_tiles, max_x, max_y):
 def _decode_linear_1d_config(m_tiles, k_tiles, n_tiles, grid_size, is_bh):
     """1D (N-parallel) matmul program config for a decode-mode Linear.
 
-    Decode has small M, so we use 1d splitting across N 
+    Decode has small M, so we use 1d splitting across N
 
     Constraints satisfied here:
       - in0_block_w divides k_tiles (K streamed in even chunks)
@@ -107,6 +107,17 @@ class SharedMLP:
         self.tp = tp
         tp_suffix = f"_tp{tp}" if tp > 1 else ""
 
+        # Per-device intermediate width, tile-aligned. With TP the raw per-device
+        # split (e.g. 2112/8 = 264) is not a multiple of TILE_SIZE, so the fused
+        # [gate | up] slab would have its split point land mid-tile — slicing it
+        # then mixes gate/up lanes within a tile and tanks PCC. We pad each
+        # per-device gate/up half (and, symmetrically, the down_proj input rows)
+        # up to a tile multiple so the split lands on a tile boundary and every
+        # matmul's N/K stays tile-aligned. Mirrors experts/weights.py.
+        split = self.intermediate_size // tp
+        self.padded_split = ((split + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+        self._intermediate_pad = self.padded_split - split if tp > 1 else 0
+
         # Tag the cache filenames with the weight dtype so that flipping a
         # SharedMLP weight's dtype (e.g. bf16 → bfp8 for DRAM-pressure relief)
         # doesn't collide with a previously-cached file that holds the same
@@ -125,21 +136,36 @@ class SharedMLP:
         if state_dict:
             # Fuse gate_proj + up_proj into a single column-parallel weight so the
             # forward runs ONE matmul producing a [gate | up] slab (mirrors the wqkv
-            # fusion in attention/weights.py). 
+            # fusion in attention/weights.py).
             gate_w = state_dict["gate_proj.weight"]  # [intermediate_size, hidden_size]
             up_w = state_dict["up_proj.weight"]  # [intermediate_size, hidden_size]
+            pad = self._intermediate_pad
             if tp > 1:
                 fused_list = []
                 for i in range(tp):
-                    wg_chunk = torch.chunk(gate_w, tp, dim=0)[i].transpose(-2, -1)
-                    wu_chunk = torch.chunk(up_w, tp, dim=0)[i].transpose(-2, -1)
-                    fused_list.append(torch.cat([wg_chunk, wu_chunk], dim=-1))  # [hidden, 2*int/tp]
+                    wg_chunk = torch.chunk(gate_w, tp, dim=0)[i].transpose(-2, -1)  # [hidden, split]
+                    wu_chunk = torch.chunk(up_w, tp, dim=0)[i].transpose(-2, -1)  # [hidden, split]
+                    if pad:
+                        # Pad each half's N dim with zeros so the slab is
+                        # [gate(padded_split) | up(padded_split)] per device
+                        wg_chunk = torch.nn.functional.pad(wg_chunk, (0, pad))
+                        wu_chunk = torch.nn.functional.pad(wu_chunk, (0, pad))
+                    fused_list.append(torch.cat([wg_chunk, wu_chunk], dim=-1))  # [hidden, 2*padded_split]
                 gate_up_proj_weight = torch.cat(fused_list, dim=-1).unsqueeze(0).unsqueeze(0)
             else:
                 gate_up_proj_weight = (
                     torch.cat([gate_w.transpose(-2, -1), up_w.transpose(-2, -1)], dim=-1).unsqueeze(0).unsqueeze(0)
                 )
-            down_proj_weight = state_dict["down_proj.weight"].transpose(-2, -1).unsqueeze(0).unsqueeze(0)
+
+            # need to pad down_proj so it matches the padding for the gate+up proj
+            down_proj_weight = state_dict["down_proj.weight"].transpose(-2, -1)  # [intermediate, hidden]
+            if tp > 1 and pad:
+                down_chunks = torch.chunk(down_proj_weight, tp, dim=-2)  # each [split, hidden]
+                down_chunks = [
+                    torch.nn.functional.pad(c, (0, 0, 0, pad)) for c in down_chunks
+                ]  # [padded_split, hidden]
+                down_proj_weight = torch.cat(down_chunks, dim=-2)  # [tp*padded_split, hidden]
+            down_proj_weight = down_proj_weight.unsqueeze(0).unsqueeze(0)
         else:
             gate_up_proj_weight = None
             down_proj_weight = None
@@ -165,7 +191,7 @@ class SharedMLP:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-    def __call__(self, hidden_states, is_decode=False):
+    def __call__(self, hidden_states, is_decode=True):
         """
         GeGLU MLP forward with TP support.
 
@@ -188,18 +214,17 @@ class SharedMLP:
         # Fused gate+up projection: one matmul produces the [gate | up] slab.
         gate_up = ttnn.linear(hidden_states, self.gate_up_proj, program_config=gate_up_pc)
 
-        # Split the slab into gate / up halves (per-device width when column-parallel)
-        # and fuse GeGLU into the multiply: fast-approx GELU on the gate half
-        # (operand a) only, then elementwise * up. Replaces the separate ttnn.gelu +
-        # ttnn.mul, matching the original fast_and_approximate_mode=True semantics.
+        # Split the slab into gate / up halves and fuse GeGLU into the multiply:
+        # fast-approx GELU on the gate half (operand a) only, then elementwise * up.
+        # Matches the original fast_and_approximate_mode=True GeGLU semantics.
         #
-        # NOTE: when intermediate_size/tp is not a multiple of TILE_WIDTH (32) — e.g.
-        # 2112/8 = 264 on T3K — this split is not tile-aligned, so ttnn.slice falls
-        # back to a row-major composite path (correct, but a layout round-trip). Making
-        # it tile-aligned means padding each per-device half up to a tile multiple in
-        # the fused weight AND padding down_proj's per-device input dim to match;
-        # deferred to the down_proj mem-config / config-tuning work.
-        split = self.intermediate_size // self.tp
+        # The split uses the *tile-aligned* per-device width (padded_split): with TP
+        # the raw per-device width (e.g. 264) is mid-tile, so both halves were padded
+        # to padded_split (e.g. 288) at load time. Slicing there lands on a tile
+        # boundary, keeping gate/up lanes from mixing within a tile. The padded zero
+        # lanes pass through GeGLU as zeros and are dropped by the row-parallel
+        # down_proj, whose input rows were padded to match.
+        split = self.padded_split
         gate = gate_up[..., :split]
         up = gate_up[..., split:]
         hidden = ttnn.mul(gate, up, input_tensor_a_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, True)])


### PR DESCRIPTION
### PR Category
Performance

### Summary
Closes https://github.com/tenstorrent/tt-metal/issues/48279

layer.pr has 

TABLE 1 (before '- new row-')
OP CODE                                   DEVICE KERNEL DURATION [ns]
----------------------------------------------------------------------
LayerNormDeviceOperation                                         6999
LayerNormDeviceOperation                                         6952
LayerNormDeviceOperation                                         6987
LayerNormDeviceOperation                                         6972

TABLE 2 (after '- new row-')
OP CODE                                   DEVICE KERNEL DURATION [ns]
----------------------------------------------------------------------
InterleavedToShardedDeviceOperation                              924
InterleavedToShardedDeviceOperation                              884
InterleavedToShardedDeviceOperation                              923
InterleavedToShardedDeviceOperation                              907
LayerNormDeviceOperation                                         6964
LayerNormDeviceOperation                                         6942
LayerNormDeviceOperation                                         6976
LayerNormDeviceOperation                                         6990
ShardedToInterleavedDeviceOperation                              965
ShardedToInterleavedDeviceOperation                             1076
ShardedToInterleavedDeviceOperation                             1022
ShardedToInterleavedDeviceOperation                              940

Difference (with L1 optimization − without L1 optimization): 7603 ns
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lzhang/gemma-downproj-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lzhang/gemma-downproj-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lzhang/gemma-downproj-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lzhang/gemma-downproj-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lzhang/gemma-downproj-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lzhang/gemma-downproj-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lzhang/gemma-downproj-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lzhang/gemma-downproj-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lzhang/gemma-downproj-l1)