### PR TITLE
[CI] Disable BH Galaxy Socket Pipeline e2e job pending auto-mapper support (#48239)

### DIFF
--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -96,13 +96,17 @@
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
 
-- id: bh-galaxy-socket-pipeline
-  name: BH Galaxy Socket Pipeline Single Galaxy
-  cmd: |
-    python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
-    tt-run --rank-binding bh_galaxy_split_4x2_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/multihost/socket_pipeline/multiprocess/unit_tests_pipeline
-  skus:
-    bh_galaxy:
-      timeout: 10
-  owner_id: U08UBDUKH6Z # Neel Nyamagoudar
-  team: scaleout
+# Disabled (issue #48239): the BH Galaxy Socket Pipeline single-galaxy test relies on the topology
+# auto-mapper to bind its four 4x2 meshes, but the auto-mapper does not yet support the 4-stage single
+# galaxy configuration (tracked in issue #47717). Until auto-mapper support lands (or the test is switched
+# to explicit rank bindings), this job fails in topology mapping. Re-enable once #47717 is resolved.
+# - id: bh-galaxy-socket-pipeline
+#   name: BH Galaxy Socket Pipeline Single Galaxy
+#   cmd: |
+#     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+#     tt-run --rank-binding bh_galaxy_split_4x2_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/multihost/socket_pipeline/multiprocess/unit_tests_pipeline
+#   skus:
+#     bh_galaxy:
+#       timeout: 10
+#   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
+#   team: scaleout


### PR DESCRIPTION
### Problem

Fixes #48239. The `(Galaxy) e2e tests` job `bh-galaxy-socket-pipeline` (BH Galaxy Socket Pipeline Single
Galaxy, `bh_galaxy`) fails all four `BlitzDecodePipelineFixture` tests with a topology-mapper fatal:

```
TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology.
... Inter-mesh validation mode: STRICT. Solver error: Strict mode validation failed:
target graph edge from node 0 to 1 requires 16 channels, but physical edge from 0 to 1
only has 8 channels.
```

(ranks 1–3 then cascade with `Timeout while waiting for chip info header from rank 0`).

### Root cause

The physical topology *does* support binding these four 4×2 meshes under STRICT. The real problem is that
the topology **auto-mapper does not yet support the 4-stage single galaxy configuration** this test uses —
tracked in #47717 ("[Auto-mapper] Support 4-stage single galaxy topology in auto-mapper"). The job runs the
test through the auto-mapper, which cannot resolve this layout, so control-plane init fatals.

### Fix

Disable the `bh-galaxy-socket-pipeline` e2e job (`tests/pipeline_reorg/galaxy_e2e_tests.yaml`) until the
auto-mapper supports this configuration (#47717), or the test is switched to explicit rank bindings instead
of the auto-mapper. The entry is commented out with a pointer to #47717 so it is trivial to re-enable.

I deliberately did **not** relax the MGD channel policy — that would mask the auto-mapper gap rather than
fix it.

### Follow-up

- #47717 — add 4-stage single galaxy support to the auto-mapper, then re-enable this job.
- Alternatively, switch `BlitzDecodePipelineFixture` to the explicit eth-coord / rank-binding control-plane
  path (`set_custom_fabric_topology`, as the InterMesh fixtures do) so it bypasses the auto-mapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
