### PR TITLE
Add groups to conv cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -147,6 +147,7 @@ ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
     hashable_operation_attributes_t hashable_args = {
         .sliding_window_config = args.sliding_window_config,
         .output_channels = args.output_channels,
+        .groups = args.groups,
         .untilize_out = args.untilize_out,
         .has_bias = args.has_bias,
         .activation = args.activation,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -221,6 +221,7 @@ struct Conv2dParams {
 struct Conv2dHashableParams {
     sliding_window::SlidingWindowConfig sliding_window_config{};
     uint32_t output_channels = 0;
+    uint32_t groups = 0;
     bool untilize_out = false;
     bool has_bias = false;
     std::optional<ttnn::operations::unary::UnaryWithParam> activation;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -408,9 +408,7 @@ void kernel_main() {
                     }
                 }
 
-                if constexpr (packer_l1_acc) {
-                    pack_reconfig_data_format(curr_matmul_out_cb);
-                }
+                pack_reconfig_data_format(curr_matmul_out_cb);
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     uint32_t in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -408,7 +408,9 @@ void kernel_main() {
                     }
                 }
 
-                pack_reconfig_data_format(curr_matmul_out_cb);
+                if constexpr (packer_l1_acc) {
+                    pack_reconfig_data_format(curr_matmul_out_cb);
+                }
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     uint32_t in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -147,6 +147,7 @@ ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
     hashable_operation_attributes_t hashable_args = {
         .sliding_window_config = args.sliding_window_config,
         .output_channels = args.output_channels,
+        .groups = args.groups,
         .untilize_out = args.untilize_out,
         .has_bias = args.has_bias,
         .activation = args.activation,


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Related https://github.com/tenstorrent/tt-metal/issues/48492

Adds groups to cache hash.  Found when attempting to diagnose the above issue.

**Issue**: conv2d’s program cache hash omitted groups, so grouped convs could incorrectly reuse a cached program from a conv with different grouping but otherwise matching parameters.

**Fix**: added groups to Conv2dHashableParams and copied args.groups into compute_program_hash().

### Notes for reviewers

/cc @mstaletovicTT