### PR TITLE
Feature: increase max number of RTAs beyond 341 via WRITE_PACKED_LARGE_UNICAST

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -817,8 +817,13 @@ TEST_F(MeshDeviceFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
 // Test that active ethernet cores correctly validate max runtime args
 TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    // Mirror the enforced ceiling in Kernel::validate_runtime_args_size: 2 words are reserved for the watcher
+    // count words (one for the unique RTA region, one for the common) unconditionally, whether or not watcher
+    // asserts are enabled, so the usable max is the kernel-config size minus those 2 words.
+    constexpr uint32_t watcher_reserved_count_words = 2;
     uint32_t active_eth_max_runtime_args =
-        hal.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t);
+        hal.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
+        watcher_reserved_count_words;
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];
@@ -898,8 +903,13 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
 // Test that idle ethernet cores correctly validate max runtime args using IDLE_ETH kernel config size
 TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    // Mirror the enforced ceiling in Kernel::validate_runtime_args_size: 2 words are reserved for the watcher
+    // count words (one for the unique RTA region, one for the common) unconditionally, whether or not watcher
+    // asserts are enabled, so the usable max is the kernel-config size minus those 2 words.
+    constexpr uint32_t watcher_reserved_count_words = 2;
     uint32_t idle_eth_max_runtime_args =
-        hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t);
+        hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
+        watcher_reserved_count_words;
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <memory>
 #include <cstddef>
@@ -719,16 +720,20 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
             mesh_device, core_range_set, 0, 0);  // Kernel isn't run here.
         auto& program = workload.get_programs().at(device_range);
 
-        // Set 100 unique args, then try to set max_runtime_args + 1 common args and fail.
+        // The enforced TENSIX ceiling is bounded by the uint16_t RTA offset field (see
+        // Kernel::validate_runtime_args_size). Mirror that here.
+        const uint32_t tensix_max_rt_args = std::numeric_limits<uint16_t>::max() / sizeof(uint32_t);
+
+        // Set 100 unique args, then try to set enough common args to overflow the combined ceiling and fail.
         std::vector<uint32_t> initial_runtime_args(100);
         SetRuntimeArgs(program, kernel, core_range_set, initial_runtime_args);
-        std::vector<uint32_t> common_runtime_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> common_runtime_args(tensix_max_rt_args + 1);
         EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, common_runtime_args));
 
-        // Set 100 common args, then try to set another tt::tt_metal::max_runtime_args + 1 unique args and fail.
+        // Set 100 common args, then try to set enough unique args to overflow the combined ceiling and fail.
         std::vector<uint32_t> more_common_runtime_args(100);
         SetCommonRuntimeArgs(program, kernel, more_common_runtime_args);
-        std::vector<uint32_t> more_unique_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> more_unique_args(tensix_max_rt_args + 1);
         EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, core_range_set, more_unique_args));
     }
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1795,6 +1795,88 @@ TEST_F(UnitMeshCQFixture, TensixLargeUniqueRuntimeArgsLargeUnicast) {
     }
 }
 
+// Large common (multicast) RTAs: > 341 words, sent via the multicast CQ_DISPATCH_CMD_WRITE_PACKED_LARGE
+// path (BatchedTransferGenerator). Confirms the raised RTA ceiling permits large common args and that they
+// are delivered correctly. Uses the full worker grid.
+TEST_F(UnitMeshCQFixture, TensixLargeCommonRuntimeArgsLargeMulticast) {
+    for (const auto& device : devices_) {
+        CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+        CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+        CoreRangeSet cr_set(cr);
+        DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
+        // 0 unique, 1100 common words (> 341); COMPUTE common-arg L1 slot is offset well past the unique
+        // slot (see get_args_addr) so it does not overlap.
+        EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
+            device,
+            dummy_program_config,
+            0,
+            1100,
+            {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0}));
+    }
+}
+
+// Patch large unique RTAs and re-run: after the first enqueue repoints RuntimeArgsData into the command
+// stream, a second SetRuntimeArgs must update the large-unicast payload in place so the next enqueue sends
+// the new values. Full grid (> 35 cores) so the update spans multiple LARGE_UNICAST commands.
+TEST_F(UnitMeshCQFixture, TensixLargeUniqueRuntimeArgsPatchedAcrossRuns) {
+    constexpr uint32_t kNumArgs = 1100;  // > 1024 words → large-unicast path
+    for (const auto& device : devices_) {
+        auto* dev = device->get_devices()[0];
+        CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+        CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+        CoreRangeSet cr_set(cr);
+
+        distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
+        distributed::MeshCoordinateRange device_range(zero_coord, zero_coord);
+
+        const uint32_t rta_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        Program program;
+        std::map<std::string, std::string> defines = {
+            {"DATA_MOVEMENT", "1"},
+            {"NUM_RUNTIME_ARGS", std::to_string(kNumArgs)},
+            {"RESULTS_ADDR", std::to_string(rta_base)}};
+        auto kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
+
+        auto make_args = [](const CoreCoord& c, uint32_t phase) {
+            std::vector<uint32_t> args(kNumArgs);
+            const uint32_t base = (c.x * 100000) + (c.y * 1000) + (phase * 7);
+            for (uint32_t i = 0; i < kNumArgs; i++) {
+                args[i] = base + i;
+            }
+            return args;
+        };
+
+        distributed::MeshWorkload workload;
+        for (const CoreCoord& core : cr) {
+            SetRuntimeArgs(program, kernel, core, make_args(core, 0));
+        }
+        workload.add_program(device_range, std::move(program));
+
+        // Run twice: phase 0 initial, then patch in place with phase 1 values and re-run.
+        for (uint32_t phase = 0; phase < 2; phase++) {
+            auto& prog = workload.get_programs().at(device_range);
+            if (phase == 1) {
+                for (const CoreCoord& core : cr) {
+                    SetRuntimeArgs(prog, kernel, core, make_args(core, 1));
+                }
+            }
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, false);
+            Finish(device->mesh_command_queue());
+
+            for (const CoreCoord& core : cr) {
+                std::vector<uint32_t> readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(dev, core, rta_base, kNumArgs * sizeof(uint32_t), readback);
+                EXPECT_EQ(readback, make_args(core, phase)) << "core " << core.str() << " phase " << phase;
+            }
+        }
+    }
+}
+
 // Sanity test for setting and verifying common and unique runtime args to multiple cores via BRISC.
 TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementBrisc) {
     CoreRange cr0({1, 1}, {2, 2});

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1774,6 +1774,27 @@ TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_MaxRu
     }
 }
 
+// Unique RTAs whose per-core payload exceeds one 4096B dispatch page (> 1024 words) are dispatched via
+// CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST instead of the page-limited packed-write path. Uses the full
+// worker grid (> 35 cores) to also exercise the multi-command chunk boundary
+// (CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS = 35).
+TEST_F(UnitMeshCQFixture, TensixLargeUniqueRuntimeArgsLargeUnicast) {
+    for (const auto& device : devices_) {
+        CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+        CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+        CoreRangeSet cr_set(cr);
+        DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
+        // 1100 words * 4 = 4400 B > 4096 B page. COMPUTE unique-arg L1 slot has 1280 words of headroom
+        // before the common-arg region (see get_args_addr), so 1100 unique + 0 common fits.
+        EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
+            device,
+            dummy_program_config,
+            1100,
+            0,
+            {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0}));
+    }
+}
+
 // Sanity test for setting and verifying common and unique runtime args to multiple cores via BRISC.
 TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementBrisc) {
     CoreRange cr0({1, 1}, {2, 2});

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -532,7 +532,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     Program program;
     bool pass = true;
 
-    // TODO: this test would be better if it varied args across core ranges and kernel type
+    // This varies the unique arg count across the two core ranges; TODO: it could also vary the kernel type.
 
     CoreRangeSet cr_set = program_config.cr_set;
     constexpr uint32_t kCommonRTASeparation = 1024 * sizeof(uint32_t);
@@ -540,258 +540,121 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     uint32_t rta_base_dm0 = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
     uint32_t rta_base_dm1 = rta_base_dm0 + (2048 * sizeof(uint32_t));
     uint32_t rta_base_compute = rta_base_dm1 + (4096 * sizeof(uint32_t));
-    // Copy max # runtime args in the kernel for simplicity
-    std::map<std::string, std::string> dm_defines0 = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"DATA_MOVEMENT", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm0)}};
-    std::map<std::string, std::string> dm_defines1 = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"DATA_MOVEMENT", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm1)}};
-    std::map<std::string, std::string> compute_defines = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"COMPUTE", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_compute)}};
 
-    auto dummy_kernel0 = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = dm_defines0});
-
-    auto dummy_kernel1 = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .defines = dm_defines1});
-
-    auto dummy_compute_kernel = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        ComputeConfig{.defines = compute_defines});
-
-    vector<uint32_t> dummy_cr0_args;
-    vector<uint32_t> dummy_cr1_args;
-    vector<uint32_t> dummy_common_args;
-
-    auto it = program_config.cr_set.ranges().begin();
+    auto it = cr_set.ranges().begin();
     CoreRange core_range_0 = *it;
     std::advance(it, 1);
     CoreRange core_range_1 = *it;
 
-    uint32_t idx = 0;
+    // A single set of kernels runs on both core ranges. The ranges are given different unique-arg counts, so the
+    // kernel selects its per-core count from its logical y coordinate (cores at absolute logical y >= the second
+    // range's start belong to core_range_1) and reads exactly the args that were set, which keeps the watcher's
+    // runtime-arg bounds check satisfied. Common args are uniform across all cores.
     constexpr uint32_t num_common_runtime_args = 13;
+    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp";
+    auto make_defines = [&](const char* role, uint32_t results_addr) {
+        return std::map<std::string, std::string>{
+            {"COMMON_RUNTIME_ARGS", "1"},
+            {role, "1"},
+            {"NUM_RUNTIME_ARGS", std::to_string(num_runtime_args_for_cr0)},
+            {"NUM_RUNTIME_ARGS_CR1", std::to_string(num_runtime_args_for_cr1)},
+            {"CR1_START_Y", std::to_string(core_range_1.start_coord.y)},
+            {"NUM_COMMON_RUNTIME_ARGS", std::to_string(num_common_runtime_args)},
+            {"RESULTS_ADDR", std::to_string(results_addr)}};
+    };
+    std::vector<KernelHandle> kernels = {
+        CreateKernel(
+            program,
+            kernel_path,
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .defines = make_defines("DATA_MOVEMENT", rta_base_dm0)}),
+        CreateKernel(
+            program,
+            kernel_path,
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .defines = make_defines("DATA_MOVEMENT", rta_base_dm1)}),
+        CreateKernel(
+            program, kernel_path, cr_set, ComputeConfig{.defines = make_defines("COMPUTE", rta_base_compute)})};
+    const uint32_t rta_bases[] = {rta_base_dm0, rta_base_dm1, rta_base_compute};
+
+    uint32_t idx = 0;
     workload.add_program(device_range, std::move(program));
 
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
         auto& program_ = workload.get_programs().at(device_range);
         SCOPED_TRACE(iter);
-        dummy_cr0_args.clear();
-        dummy_cr1_args.clear();
-        dummy_common_args.clear();
 
+        // cr0 cores are set num_runtime_args_for_cr0 unique args and cr1 cores num_runtime_args_for_cr1; the shared
+        // kernel reads the matching count per core from its coordinate. Common args are uniform. Values change each
+        // iteration to exercise in-place RTA/CRTA updates.
+        std::vector<uint32_t> cr0_args, cr1_args, common_args;
         for (uint32_t i = 0; i < num_runtime_args_for_cr0; i++) {
-            dummy_cr0_args.push_back(idx++);
+            cr0_args.push_back(idx++);
         }
-
         for (uint32_t i = 0; i < num_runtime_args_for_cr1; i++) {
-            dummy_cr1_args.push_back(idx++);
+            cr1_args.push_back(idx++);
         }
-
         for (uint32_t i = 0; i < num_common_runtime_args; i++) {
-            dummy_common_args.push_back(idx++);
+            common_args.push_back(idx++);
         }
 
-        bool first = true;
         for (const CoreCoord& core_coord : core_range_0) {
-            // Don't set RTAs on all cores
-            if (first) {
-                first = false;
-                continue;
+            for (KernelHandle k : kernels) {
+                SetRuntimeArgs(program_, k, core_coord, cr0_args);
             }
-
-            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr0_args);
         }
-
-        first = true;
         for (const CoreCoord& core_coord : core_range_1) {
-            // Don't set RTAs on all cores
-            if (first) {
-                first = false;
-                continue;
+            for (KernelHandle k : kernels) {
+                SetRuntimeArgs(program_, k, core_coord, cr1_args);
             }
-
-            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr1_args);
         }
 
         if (iter == 0) {
-            SetCommonRuntimeArgs(program_, dummy_kernel0, dummy_common_args);
-            SetCommonRuntimeArgs(program_, dummy_kernel1, dummy_common_args);
-            SetCommonRuntimeArgs(program_, dummy_compute_kernel, dummy_common_args);
+            for (KernelHandle k : kernels) {
+                SetCommonRuntimeArgs(program_, k, common_args);
+            }
         } else {
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_kernel0).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_kernel1).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_compute_kernel).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
+            for (KernelHandle k : kernels) {
+                memcpy(
+                    GetCommonRuntimeArgs(program_, k).rt_args_data,
+                    common_args.data(),
+                    common_args.size() * sizeof(uint32_t));
+            }
         }
 
         distributed::EnqueueMeshWorkload(cq, workload, false);
         Finish(cq);
 
-        first = true;
-        for (const CoreCoord& core_coord : core_range_0) {
-            // Don't test RTAs on first cores
-            if (first) {
-                first = false;
-                continue;
+        // Each of the three kernels on a core writes its own copy of the unique args to a distinct result address
+        // and the common args at kCommonRTASeparation past it; verify every core got its args back.
+        auto check_range = [&](const CoreRange& range, const std::vector<uint32_t>& unique_args) {
+            for (const CoreCoord& core_coord : range) {
+                for (uint32_t base : rta_bases) {
+                    std::vector<uint32_t> unique_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device, core_coord, base, unique_args.size() * sizeof(uint32_t), unique_readback);
+                    pass &= (unique_args == unique_readback);
+
+                    std::vector<uint32_t> common_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        base + kCommonRTASeparation,
+                        common_args.size() * sizeof(uint32_t),
+                        common_readback);
+                    EXPECT_EQ(common_args, common_readback);
+                    pass &= (common_args == common_readback);
+                }
             }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                pass &= (dummy_cr0_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                pass &= (dummy_cr0_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                pass &= (dummy_cr0_args == dummy_compute_args_readback);
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
-                pass &= (dummy_common_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
-                pass &= (dummy_common_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
-                pass &= (dummy_common_args == dummy_compute_args_readback);
-            }
-        }
-
-        first = true;
-        for (const CoreCoord& core_coord : core_range_1) {
-            // Don't test RTAs on first cores
-            if (first) {
-                first = false;
-                continue;
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                pass &= (dummy_cr1_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                pass &= (dummy_cr1_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                pass &= (dummy_cr1_args == dummy_compute_args_readback);
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
-                pass &= (dummy_common_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
-                pass &= (dummy_common_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
-                pass &= (dummy_common_args == dummy_compute_args_readback);
-            }
-        }
+        };
+        check_range(core_range_0, cr0_args);
+        check_range(core_range_1, cr1_args);
     }
 
     return pass;

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -12,15 +12,37 @@
 #include "defines_generated.h"
 #endif
 
+// Callers that use common runtime args may specify a separate common-arg count; otherwise it matches the unique
+// count, preserving behavior for existing callers.
+#ifdef COMMON_RUNTIME_ARGS
+#ifndef NUM_COMMON_RUNTIME_ARGS
+#define NUM_COMMON_RUNTIME_ARGS NUM_RUNTIME_ARGS
+#endif
+#endif
+
 void kernel_main() {
     volatile uint32_t tt_l1_ptr* results = (volatile uint32_t tt_l1_ptr*)RESULTS_ADDR;
     constexpr uint32_t kCommonRTASeparation = 1024;
-    for (uint32_t i = 0; i < NUM_RUNTIME_ARGS; i++) {
-#ifdef COMMON_RUNTIME_ARGS
-        results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
+
+    // Number of unique runtime args set on this core. When the same kernel binary is placed across two core ranges
+    // with different arg counts, the host defines CR1_START_Y and NUM_RUNTIME_ARGS_CR1 so each core reads exactly
+    // the count it was given (cores at absolute logical y >= CR1_START_Y belong to the second range). Reading only
+    // the args that were actually set keeps the watcher's runtime-arg bounds check satisfied.
+    uint32_t num_unique_runtime_args = NUM_RUNTIME_ARGS;
+#if defined(NUM_RUNTIME_ARGS_CR1) && defined(CR1_START_Y)
+    if (get_absolute_logical_y() >= CR1_START_Y) {
+        num_unique_runtime_args = NUM_RUNTIME_ARGS_CR1;
+    }
 #endif
+
+    for (uint32_t i = 0; i < num_unique_runtime_args; i++) {
         results[i] = get_arg_val<uint32_t>(i);
     }
+#ifdef COMMON_RUNTIME_ARGS
+    for (uint32_t i = 0; i < NUM_COMMON_RUNTIME_ARGS; i++) {
+        results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
+    }
+#endif
 
 #ifdef COORDS_ADDR
 #ifdef DATA_MOVEMENT

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -465,7 +465,8 @@ void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program&
 // ==================================================
 /**
  * Set runtime args for a kernel that are sent to the core during runtime. This API needs to be called to update the runtime args for the kernel.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *
@@ -507,7 +508,8 @@ void SetRuntimeArgs(
 // clang-format off
 /**
  * Set multiple runtime arguments of a kernel at once during runtime, each mapping to a specific core. The runtime args for each core may be unique.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *
@@ -528,7 +530,8 @@ void SetRuntimeArgs(
 // clang-format off
 /**
  * Set common (shared by all cores) runtime args for a kernel that are sent to all cores during runtime. This API needs to be called to update the common runtime args for the kernel.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *
@@ -544,7 +547,8 @@ void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, stl::S
 // clang-format off
 /**
  * Set common (shared by all cores) runtime args for a kernel that are sent to all cores during runtime. This API needs to be called to update the common runtime args for the kernel.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -487,7 +487,8 @@ void SetRuntimeArgs(
 // clang-format off
 /**
  * Set runtime args for a kernel that are sent to the core during runtime. This API needs to be called to update the runtime args for the kernel.
- * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -42,9 +42,10 @@ enum NOC_MODE : uint8_t {
     DM_DYNAMIC_NOC = 1,
 };
 
-// 341 = (4096/(3 * sizeof(uint32_t)), where
-// - 4096 - packet size in dispatch
-// - 3 - number of kernels per tensix
+// Conservative minimum number of runtime args (unique + common combined) guaranteed to be settable on
+// any core type. This is a stable floor for callers that want a portable limit; it is NOT the enforced
+// hard cap. The actual per-core ceiling is larger and computed by the runtime from the available L1
+// kernel-config space for the target core type (see Kernel::validate_runtime_args_size).
 constexpr uint32_t max_runtime_args = 341;
 
 using KernelHandle = std::uint32_t;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -605,8 +605,7 @@ std::vector<uint32_t>& Kernel::common_runtime_args() { return this->common_runti
 RuntimeArgsData& Kernel::common_runtime_args_data() { return this->common_runtime_args_data_; }
 
 // Ensure that unique and common runtime args do not overflow reserved region in L1.
-// When watcher asserts are enabled the caller-provided counts already include the reserved count words
-// (one for the unique RTAs, one for the common RTAs), so no extra reservation is applied here.
+// num_unique_rt_args and num_common_rt_args are user-visible arg counts (excluding any watcher count words).
 void Kernel::validate_runtime_args_size(
     size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const {
     uint32_t total_rt_args = (num_unique_rt_args + num_common_rt_args);
@@ -632,6 +631,13 @@ void Kernel::validate_runtime_args_size(
             break;
         default: TT_THROW("Invalid programmable core type: {}", this->get_kernel_programmable_core_type());
     }
+
+    // Reserve the watcher count words unconditionally so the usable limit does not depend on whether watcher
+    // asserts are enabled. When enabled the device prepends one count word to the unique RTA region and one to
+    // the common RTA region ([count | args]); reserving them even when disabled keeps the user-visible limit stable.
+    constexpr uint32_t watcher_reserved_count_words = 2;
+    expected_max_rt_args =
+        expected_max_rt_args > watcher_reserved_count_words ? expected_max_rt_args - watcher_reserved_count_words : 0;
 
     if (total_rt_args > expected_max_rt_args) {
         TT_THROW(
@@ -662,14 +668,15 @@ void Kernel::set_runtime_args(const CoreCoord& logical_core, stl::Span<const uin
         // When watcher assert is enabled, we store [arg count | args]
         size_t effective_limit = runtime_args.size() + watcher_count_word_offset_;
 
-        // Validate against the per-core RTA/CRTA L1 ceiling. The RTA count word (watcher) is already
-        // included via effective_limit above; the CRTA count word is reserved in set_common_runtime_args.
-        this->validate_runtime_args_size(effective_limit, this->common_runtime_args_.size(), logical_core);
+        // Validate user-visible arg counts; the watcher count-word reservation is applied inside
+        // validate_runtime_args_size so the limit is identical whether or not watcher asserts are enabled.
+        size_t common_user_args =
+            this->common_runtime_args_.empty() ? 0 : this->common_runtime_args_.size() - watcher_count_word_offset_;
+        this->validate_runtime_args_size(runtime_args.size(), common_user_args, logical_core);
 
-        // Track maximum dispatch size for CRTA validation
-        // Note: max_runtime_args_per_core_ stores effective size (includes count word if watcher enabled)
-        if (effective_limit > max_runtime_args_per_core_) {
-            max_runtime_args_per_core_ = effective_limit;
+        // Track the max user-visible unique arg count for the later combined CRTA validation.
+        if (runtime_args.size() > max_runtime_args_per_core_) {
+            max_runtime_args_per_core_ = runtime_args.size();
             core_with_max_runtime_args_ = logical_core;
         }
 
@@ -710,10 +717,11 @@ void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_ar
 
     size_t effective_crta_limit = common_runtime_args.size() + watcher_count_word_offset_;
 
-    // Validate combined RTA + CRTA size against the per-core L1 ceiling. When watcher asserts are enabled
-    // both count words are reserved here: max_runtime_args_per_core_ already includes the RTA count word,
-    // and effective_crta_limit includes the CRTA count word.
-    this->validate_runtime_args_size(max_runtime_args_per_core_, effective_crta_limit, core_with_max_runtime_args_);
+    // Validate combined user-visible RTA + CRTA size. max_runtime_args_per_core_ holds the max user-visible
+    // unique arg count; the watcher count-word reservation is applied inside validate_runtime_args_size so the
+    // limit does not depend on whether watcher asserts are enabled.
+    this->validate_runtime_args_size(
+        max_runtime_args_per_core_, common_runtime_args.size(), core_with_max_runtime_args_);
 
     // Prepend count when watcher enabled for device-side bounds checking
     if (watcher_assert_enabled_) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
+#include <limits>
 #include <set>
 #include <string_view>
 #include <type_traits>
@@ -609,8 +610,17 @@ void Kernel::validate_runtime_args_size(
     uint32_t total_rt_args = (num_unique_rt_args + num_common_rt_args);
     uint32_t expected_max_rt_args = 0;
 
+    // The enforced ceiling is no longer the conservative public floor (kernel_types.hpp:max_runtime_args).
+    // Large unique RTAs are dispatched via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST, so they are no longer
+    // bounded by a single dispatch page. The RTA/CRTA region offset is stored in a uint16_t launch-message
+    // field (dev_msgs.h rta_offset_t), which caps the region at uint16_t max bytes.
     switch (this->get_kernel_programmable_core_type()) {
-        case HalProgrammableCoreType::TENSIX: expected_max_rt_args = max_runtime_args; break;
+        case HalProgrammableCoreType::TENSIX:
+            // The TENSIX kernel-config L1 size is device-dependent (derived from the allocator at program
+            // finalize, not available from the HAL here), so bound only by the uint16_t RTA offset field.
+            // The actual L1 fit is enforced later against the kernel-config ring buffer.
+            expected_max_rt_args = std::numeric_limits<uint16_t>::max() / sizeof(uint32_t);
+            break;
         case HalProgrammableCoreType::ACTIVE_ETH:
         case HalProgrammableCoreType::IDLE_ETH:
         case HalProgrammableCoreType::DRAM:

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -605,6 +605,8 @@ std::vector<uint32_t>& Kernel::common_runtime_args() { return this->common_runti
 RuntimeArgsData& Kernel::common_runtime_args_data() { return this->common_runtime_args_data_; }
 
 // Ensure that unique and common runtime args do not overflow reserved region in L1.
+// When watcher asserts are enabled the caller-provided counts already include the reserved count words
+// (one for the unique RTAs, one for the common RTAs), so no extra reservation is applied here.
 void Kernel::validate_runtime_args_size(
     size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const {
     uint32_t total_rt_args = (num_unique_rt_args + num_common_rt_args);
@@ -660,7 +662,8 @@ void Kernel::set_runtime_args(const CoreCoord& logical_core, stl::Span<const uin
         // When watcher assert is enabled, we store [arg count | args]
         size_t effective_limit = runtime_args.size() + watcher_count_word_offset_;
 
-        // Validate against hardware limit (341 words)
+        // Validate against the per-core RTA/CRTA L1 ceiling. The RTA count word (watcher) is already
+        // included via effective_limit above; the CRTA count word is reserved in set_common_runtime_args.
         this->validate_runtime_args_size(effective_limit, this->common_runtime_args_.size(), logical_core);
 
         // Track maximum dispatch size for CRTA validation
@@ -707,8 +710,9 @@ void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_ar
 
     size_t effective_crta_limit = common_runtime_args.size() + watcher_count_word_offset_;
 
-    // Validate combined RTA + CRTA size doesn't exceed hardware limit (341 words)
-    // max_runtime_args_per_core_ already includes count word if watcher enabled
+    // Validate combined RTA + CRTA size against the per-core L1 ceiling. When watcher asserts are enabled
+    // both count words are reserved here: max_runtime_args_per_core_ already includes the RTA count word,
+    // and effective_crta_limit includes the CRTA count word.
     this->validate_runtime_args_size(max_runtime_args_per_core_, effective_crta_limit, core_with_max_runtime_args_);
 
     // Prepend count when watcher enabled for device-side bounds checking

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -283,7 +283,7 @@ protected:
     std::vector<uint32_t> common_runtime_args_;
     RuntimeArgsData common_runtime_args_data_{};
     std::set<CoreCoord> core_with_runtime_args_;
-    std::size_t max_runtime_args_per_core_{0};  // For validation
+    std::size_t max_runtime_args_per_core_{0};  // Max user-visible unique RTA count, for validation
     CoreCoord core_with_max_runtime_args_;      // For validation
     std::map<std::string, std::string>
         defines_;  // preprocessor defines. this is to be able to generate generic instances.

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -459,6 +459,16 @@ void insert_stall_cmds(
         0);
 }
 
+// Watcher only: pre-fill an RTA payload region with 0xBEEF0000 | rand16 so unused runtime-arg slots are
+// obviously unset on device (equality tests are likely to fail). With watcher off the region stays zero.
+void fill_runtime_args_watcher_pattern(uint32_t* dst, uint32_t num_words) {
+    thread_local static std::mt19937 gen(std::random_device{}());
+    std::uniform_int_distribution<int> dist(0, 65535);
+    for (uint32_t i = 0; i < num_words; i++) {
+        dst[i] = WATCHER_RTA_UNSET_PATTERN | static_cast<uint16_t>(dist(gen));
+    }
+}
+
 template <typename PackedSubCmd>
 void generate_runtime_args_cmds(
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
@@ -529,20 +539,12 @@ void generate_runtime_args_cmds(
             no_stride);
         auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
         uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
-        // Watcher only: pre-fill the RTA payload region with 0xBEEF0000 | rand16
-        // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand
-        // This makes any unused runtime-arg slots obvious on device (equality tests likely to fail)
+        // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand.
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
             uint32_t total_words = (calculator.write_offset_bytes() - data_offset) / sizeof(uint32_t);
             uint32_t* command_start_ptr =
                 reinterpret_cast<uint32_t*>(command_obj.data()) + (data_offset / sizeof(uint32_t));
-            thread_local static std::mt19937 gen(std::random_device{}());
-            std::uniform_int_distribution<int> dist(0, 65535);
-            for (uint32_t count = 0; count < total_words; count++) {
-                uint16_t rnd = static_cast<uint16_t>(dist(gen));
-                const uint32_t known_garbage = WATCHER_RTA_UNSET_PATTERN | rnd;
-                command_start_ptr[count] = known_garbage;
-            }
+            fill_runtime_args_watcher_pattern(command_start_ptr, total_words);
         }
 
         runtime_args_command_sequences.back().add_dispatch_write_packed<PackedSubCmd>(
@@ -641,15 +643,10 @@ void generate_runtime_args_cmds_large_unicast(
 
             auto& buf = core_payloads[k];
             buf.assign(aligned_core_payload, 0);
-            // Watcher only: pre-fill unused arg slots with 0xBEEF0000 | rand16 so they are obviously unset
-            // on device (mirrors the packed path). With watcher off the buffer stays zero.
+            // With watcher off the buffer stays zero; mirrors the packed path.
             if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
-                thread_local static std::mt19937 gen(std::random_device{}());
-                std::uniform_int_distribution<int> dist(0, 65535);
-                auto* words = reinterpret_cast<uint32_t*>(buf.data());
-                for (uint32_t w = 0; w < aligned_core_payload / sizeof(uint32_t); ++w) {
-                    words[w] = WATCHER_RTA_UNSET_PATTERN | static_cast<uint16_t>(dist(gen));
-                }
+                fill_runtime_args_watcher_pattern(
+                    reinterpret_cast<uint32_t*>(buf.data()), aligned_core_payload / sizeof(uint32_t));
             }
             // Lay out each kernel's [count | args] data at the same per-kernel stride the packed path uses.
             uint32_t offset = 0;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -469,6 +469,38 @@ void fill_runtime_args_watcher_pattern(uint32_t* dst, uint32_t num_words) {
     }
 }
 
+using RtaDataPair =
+    std::pair<std::reference_wrapper<RuntimeArgsData>, std::reference_wrapper<const std::vector<uint32_t>>>;
+
+// Retarget one core's per-kernel RuntimeArgsData at the payload just written into the command stream, so
+// later in-place RTA edits (and re-enqueues) update the command directly. If a kernel's rt_args_data was
+// already retargeted by a previous command sequence, schedule an rta_update copy from there instead.
+// `base` points at the start of this core's RTA payload in the command buffer; kernels are laid out back
+// to back at their [count | args] stride. Shared by the packed and large-unicast RTA emission paths.
+void repoint_rta_data_into_command_stream(
+    char* base,
+    std::vector<RtaDataPair>& kernel_rta_pairs,
+    [[maybe_unused]] const std::vector<std::tuple<const void*, uint32_t, uint32_t>>& kernel_data_and_sizes,
+    uint32_t count_word_offset,
+    std::vector<ProgramCommandSequence::RtaUpdate>& rta_updates) {
+    uint32_t offset = 0;
+    for (uint32_t j = 0; j < kernel_rta_pairs.size(); ++j) {
+        auto& data = kernel_rta_pairs[j];
+        uint32_t* data_in_sequence = reinterpret_cast<uint32_t*>(base + offset) + count_word_offset;
+        // rt_args_data points to args; data.second.get().data() points to count when watcher enabled.
+        if (data.first.get().rt_args_data == (data.second.get().data() + count_word_offset)) {
+            data.first.get().rt_args_data = data_in_sequence;
+        } else {
+            TT_ASSERT(
+                data.first.get().rt_args_data ==
+                (reinterpret_cast<const uint32_t*>(std::get<0>(kernel_data_and_sizes[j])) + count_word_offset));
+            rta_updates.emplace_back(
+                data.first.get().rt_args_data, data_in_sequence, data.first.get().rt_args_count * sizeof(uint32_t));
+        }
+        offset += (data.first.get().rt_args_count + count_word_offset) * sizeof(uint32_t);
+    }
+}
+
 template <typename PackedSubCmd>
 void generate_runtime_args_cmds(
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
@@ -570,30 +602,12 @@ void generate_runtime_args_cmds(
         const uint32_t data_inc = tt::align(max_runtime_args_len * sizeof(uint32_t), l1_alignment);
         uint32_t num_data_copies = no_stride ? 1 : num_packed_cmds;
         for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
-            uint32_t offset = 0;
-            for (uint32_t j = 0; j < rt_args_data[i].size(); ++j) {
-                auto& data = rt_args_data[i][j];
-                uint32_t* data_in_sequence =
-                    reinterpret_cast<uint32_t*>(
-                        reinterpret_cast<char*>(runtime_args_command_sequences.back().data()) + data_offset + offset) +
-                    count_word_offset;
-                // rt_args_data points to args; data.second.get().data() points to count when watcher enabled
-                if (data.first.get().rt_args_data == (data.second.get().data() + count_word_offset)) {
-                    // Update the pointer to point into the command sequence. Future RTA updates will modify the command
-                    // sequence directly.
-                    data.first.get().rt_args_data = data_in_sequence;
-                } else {
-                    TT_ASSERT(
-                        data.first.get().rt_args_data ==
-                        (reinterpret_cast<const uint32_t*>(std::get<0>(rt_data_and_sizes[i][j])) + count_word_offset));
-                    // Pointer already points into another command sequence. Schedule a copy from there.
-                    rta_updates.emplace_back(
-                        data.first.get().rt_args_data,
-                        data_in_sequence,
-                        data.first.get().rt_args_count * sizeof(uint32_t));
-                }
-                offset += (data.first.get().rt_args_count + count_word_offset) * sizeof(uint32_t);
-            }
+            repoint_rta_data_into_command_stream(
+                reinterpret_cast<char*>(runtime_args_command_sequences.back().data()) + data_offset,
+                rt_args_data[i],
+                rt_data_and_sizes[i],
+                count_word_offset,
+                rta_updates);
             data_offset += data_inc;
         }
         num_packed_cmds_in_seq -= num_packed_cmds;
@@ -675,25 +689,16 @@ void generate_runtime_args_cmds_large_unicast(
             write_offset_index);
         TT_ASSERT(command_obj.size_bytes() == command_obj.write_offset_bytes());
 
-        // Repoint each kernel's RuntimeArgsData into the command stream (or schedule an rta_update copy),
-        // exactly as the packed path and BatchedTransferGenerator do.
+        // Repoint each core's kernels' RuntimeArgsData into the command stream (or schedule an rta_update
+        // copy). Each core's payload is a distinct data_collection entry (no fixed inter-core stride).
         for (uint32_t k = 0; k < num_in_chunk; ++k) {
             const uint32_t i = offset_idx + k;
-            uint8_t* base = data_collection_location[k];
-            uint32_t offset = 0;
-            for (uint32_t j = 0; j < rt_args_data[i].size(); ++j) {
-                auto& data = rt_args_data[i][j];
-                uint32_t* data_in_sequence = reinterpret_cast<uint32_t*>(base + offset) + count_word_offset;
-                if (data.first.get().rt_args_data == (data.second.get().data() + count_word_offset)) {
-                    data.first.get().rt_args_data = data_in_sequence;
-                } else {
-                    rta_updates.emplace_back(
-                        data.first.get().rt_args_data,
-                        data_in_sequence,
-                        data.first.get().rt_args_count * sizeof(uint32_t));
-                }
-                offset += (data.first.get().rt_args_count + count_word_offset) * sizeof(uint32_t);
-            }
+            repoint_rta_data_into_command_stream(
+                reinterpret_cast<char*>(data_collection_location[k]),
+                rt_args_data[i],
+                rt_data_and_sizes[i],
+                count_word_offset,
+                rta_updates);
         }
         offset_idx += num_in_chunk;
     }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -599,6 +599,118 @@ void generate_runtime_args_cmds(
     }
 }
 
+// Emit unique runtime args for a kernel group using CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST instead of
+// CQ_DISPATCH_CMD_WRITE_PACKED. Unlike the packed path, the large-unicast dispatch handler wraps CB pages
+// per sub-command, so a single core's RTA payload is no longer limited to one dispatch page. Used when a
+// kernel group's per-core payload exceeds that page (see assemble_runtime_args_commands). The command
+// layout mirrors BatchedTransferGenerator: one sub-command (core) per unicast destination, up to
+// CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS per command, with each core's payload laid out
+// exactly as the packed path lays out its per-core data region so the RTA-update pointers stay valid.
+void generate_runtime_args_cmds_large_unicast(
+    std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
+    std::vector<ProgramCommandSequence::RtaUpdate>& rta_updates,
+    uint32_t l1_arg_base_addr,
+    const std::vector<CQDispatchWritePackedUnicastSubCmd>& sub_cmds,
+    const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>& rt_data_and_sizes,
+    uint32_t rta_payload_sizeB,
+    std::vector<std::vector<
+        std::pair<std::reference_wrapper<RuntimeArgsData>, std::reference_wrapper<const std::vector<uint32_t>>>>>&
+        rt_args_data,
+    uint32_t write_offset_index) {
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    // Device reads rta_payload_sizeB bytes per sub-command, then pads the read pointer to `alignment`, so
+    // consecutive per-core payloads in the command stream are separated by this aligned size.
+    const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
+    const uint32_t count_word_offset = is_watcher_assert_enabled() ? 1 : 0;
+
+    const uint32_t num_cores = sub_cmds.size();
+    uint32_t offset_idx = 0;
+    while (offset_idx < num_cores) {
+        const uint32_t num_in_chunk =
+            std::min<uint32_t>(num_cores - offset_idx, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+
+        std::vector<CQDispatchWritePackedLargeUnicastSubCmd> large_sub_cmds(num_in_chunk);
+        // Per-core payload backing storage. Must outlive the add_dispatch call (memcpy'd into the command).
+        std::vector<std::vector<uint8_t>> core_payloads(num_in_chunk);
+        std::vector<tt::stl::Span<const uint8_t>> data_collection(num_in_chunk);
+
+        for (uint32_t k = 0; k < num_in_chunk; ++k) {
+            const uint32_t i = offset_idx + k;
+            large_sub_cmds[k] = CQDispatchWritePackedLargeUnicastSubCmd{
+                .noc_xy_addr = sub_cmds[i].noc_xy_addr, .addr = l1_arg_base_addr, .length = rta_payload_sizeB};
+
+            auto& buf = core_payloads[k];
+            buf.assign(aligned_core_payload, 0);
+            // Watcher only: pre-fill unused arg slots with 0xBEEF0000 | rand16 so they are obviously unset
+            // on device (mirrors the packed path). With watcher off the buffer stays zero.
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+                thread_local static std::mt19937 gen(std::random_device{}());
+                std::uniform_int_distribution<int> dist(0, 65535);
+                auto* words = reinterpret_cast<uint32_t*>(buf.data());
+                for (uint32_t w = 0; w < aligned_core_payload / sizeof(uint32_t); ++w) {
+                    words[w] = WATCHER_RTA_UNSET_PATTERN | static_cast<uint16_t>(dist(gen));
+                }
+            }
+            // Lay out each kernel's [count | args] data at the same per-kernel stride the packed path uses.
+            uint32_t offset = 0;
+            for (const auto& data : rt_data_and_sizes[i]) {
+                if (std::get<0>(data)) {
+                    std::memcpy(buf.data() + offset, std::get<0>(data), std::get<1>(data));
+                }
+                offset += std::get<2>(data);
+            }
+            data_collection[k] = tt::stl::Span<const uint8_t>(buf.data(), buf.size());
+        }
+
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_packed_large_unicast(num_in_chunk, num_in_chunk * aligned_core_payload);
+        auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
+
+        std::vector<uint8_t*> data_collection_location;
+        command_obj.add_dispatch_write_packed_large_unicast(
+            CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS,
+            l1_alignment,
+            num_in_chunk,
+            large_sub_cmds,
+            data_collection,
+            &data_collection_location,
+            0,
+            write_offset_index);
+        TT_ASSERT(command_obj.size_bytes() == command_obj.write_offset_bytes());
+
+        // Repoint each kernel's RuntimeArgsData into the command stream (or schedule an rta_update copy),
+        // exactly as the packed path and BatchedTransferGenerator do.
+        for (uint32_t k = 0; k < num_in_chunk; ++k) {
+            const uint32_t i = offset_idx + k;
+            uint8_t* base = data_collection_location[k];
+            uint32_t offset = 0;
+            for (uint32_t j = 0; j < rt_args_data[i].size(); ++j) {
+                auto& data = rt_args_data[i][j];
+                uint32_t* data_in_sequence = reinterpret_cast<uint32_t*>(base + offset) + count_word_offset;
+                if (data.first.get().rt_args_data == (data.second.get().data() + count_word_offset)) {
+                    data.first.get().rt_args_data = data_in_sequence;
+                } else {
+                    rta_updates.emplace_back(
+                        data.first.get().rt_args_data,
+                        data_in_sequence,
+                        data.first.get().rt_args_count * sizeof(uint32_t));
+                }
+                offset += (data.first.get().rt_args_count + count_word_offset) * sizeof(uint32_t);
+            }
+        }
+        offset_idx += num_in_chunk;
+    }
+}
+
+// A kernel group's unique RTAs must go through CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST when their
+// per-core payload exceeds one dispatch page: the CQ_DISPATCH_CMD_WRITE_PACKED device handler asserts each
+// per-core write fits a single dispatch page (its `size` field is uint16_t and it does not wrap CB pages).
+bool unique_rta_requires_large_unicast(uint32_t total_rta_size) {
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t dispatch_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+    return tt::align(total_rta_size, l1_alignment) > dispatch_page_size;
+}
+
 struct Transfer {
     uint32_t start;
     tt::stl::Span<const uint8_t> data;
@@ -657,14 +769,18 @@ BatchedTransfers assemble_runtime_args_commands(
         for (auto& kg : program.get_kernel_groups(programmable_core_type_index)) {
             if (kg->total_rta_size != 0) {
                 uint32_t num_sub_cmds = kg->core_ranges.num_cores();
-                uint32_t max_runtime_args_len = kg->total_rta_size / sizeof(uint32_t);
-                uint32_t max_packed_cmds =
-                    calculator.get_max_write_packed_sub_cmds<decltype(unique_sub_cmds)::value_type>(
-                        max_runtime_args_len,
-                        constants.max_prefetch_command_size,
-                        constants.packed_write_max_unicast_sub_cmds,
-                        false);
-                command_count += div_up(num_sub_cmds, max_packed_cmds);
+                if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
+                    command_count += div_up(num_sub_cmds, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+                } else {
+                    uint32_t max_runtime_args_len = kg->total_rta_size / sizeof(uint32_t);
+                    uint32_t max_packed_cmds =
+                        calculator.get_max_write_packed_sub_cmds<decltype(unique_sub_cmds)::value_type>(
+                            max_runtime_args_len,
+                            constants.max_prefetch_command_size,
+                            constants.packed_write_max_unicast_sub_cmds,
+                            false);
+                    command_count += div_up(num_sub_cmds, max_packed_cmds);
+                }
             }
         }
     }
@@ -792,17 +908,31 @@ BatchedTransfers assemble_runtime_args_commands(
                     }
                 }
                 uint32_t rta_offset = program.get_program_config(index).rta_offset;
-                generate_runtime_args_cmds(
-                    program_command_sequence.runtime_args_command_sequences,
-                    program_command_sequence.rta_updates,
-                    rta_offset,
-                    unique_sub_cmds,
-                    unique_rt_data_and_sizes,
-                    kg->total_rta_size / sizeof(uint32_t),
-                    unique_rt_args_data,
-                    constants,
-                    false,
-                    get_dispatch_write_offset(programmable_core_type));
+                if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
+                    // Per-core payload exceeds one dispatch page; the packed-write handler cannot span
+                    // pages, so send these unique RTAs via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST.
+                    generate_runtime_args_cmds_large_unicast(
+                        program_command_sequence.runtime_args_command_sequences,
+                        program_command_sequence.rta_updates,
+                        rta_offset,
+                        unique_sub_cmds,
+                        unique_rt_data_and_sizes,
+                        kg->total_rta_size,
+                        unique_rt_args_data,
+                        get_dispatch_write_offset(programmable_core_type));
+                } else {
+                    generate_runtime_args_cmds(
+                        program_command_sequence.runtime_args_command_sequences,
+                        program_command_sequence.rta_updates,
+                        rta_offset,
+                        unique_sub_cmds,
+                        unique_rt_data_and_sizes,
+                        kg->total_rta_size / sizeof(uint32_t),
+                        unique_rt_args_data,
+                        constants,
+                        false,
+                        get_dispatch_write_offset(programmable_core_type));
+                }
                 for (auto& data_per_kernel : unique_rt_data_and_sizes) {
                     for (auto& data_and_sizes : data_per_kernel) {
                         RecordDispatchData(program.get_id(), DISPATCH_DATA_RTARGS, std::get<1>(data_and_sizes));


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #48674.

The max number of unique runtime args per kernel was capped at `max_runtime_args`
(341 words) because unique RTAs are dispatched with `CQ_DISPATCH_CMD_WRITE_PACKED`,
whose device handler (`process_write_packed`) requires each per-core payload to fit
in a single 4096B dispatch page (`ASSERT(xfer_size <= dispatch_cb_page_size)`; the
`size` field is `uint16_t` and it does not wrap CB pages).

This PR routes unique RTAs whose per-core payload exceeds one dispatch page through
the existing `CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST` command, whose handler
(`process_write_packed_large_unicast`) wraps CB pages per sub-command, so a single
core's payload is no longer limited to one page. The efficient packed-write path is
kept for the common small-RTA case (hybrid switch on per-core payload size).

- New `generate_runtime_args_cmds_large_unicast()` in `tt_metal/impl/program/dispatch.cpp`,
  modeled on `BatchedTransferGenerator`: chunks cores into groups of
  `CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS` (35), lays out each core's
  `[count|args]` payload exactly like the packed path, and repoints
  `RuntimeArgsData`/`rta_updates` into the command stream so in-place RTA updates and
  cached re-enqueues keep working.
- `Kernel::validate_runtime_args_size` TENSIX ceiling is now the `uint16_t` RTA-offset
  bound (`dev_msgs.h rta_offset_t`, 16383 words) instead of 341; the actual L1 fit is
  enforced later against the kernel-config ring buffer at program finalize.
- The public `max_runtime_args` constant is retained as a conservative, portable floor
  (its dispatch-page-derived comment is removed since it is no longer the hard cap).
- Common (multicast) RTAs already use the large path via `BatchedTransferGenerator`, so
  no change is needed there.

### Notes for reviewers
- Correctness hinge is the per-core payload layout + RTA-update repoint in
  `generate_runtime_args_cmds_large_unicast` (no fixed inter-core stride — per-core
  destination comes from the builder-returned `data_collection_location`). It mirrors the
  packed path's `count_word_offset`/stride math and `BatchedTransferGenerator`'s repoint.
- The hybrid threshold (`unique_rta_requires_large_unicast`) uses the dispatch buffer page
  size from `DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE`.
- Testing: fast-dispatch coverage is in `test_EnqueueProgram.cpp`
  (`UnitMeshCQFixture.TensixLargeUniqueRuntimeArgsLargeUnicast`, full worker grid = >35
  cores forcing multiple LARGE_UNICAST commands, 1100 words/core). Note the api-suite
  `MeshDeviceFixture` runs only in slow dispatch, which bypasses the CQ command path, so it
  cannot validate this — hence the test lives in the dispatch suite. Verified passing on
  Blackhole, including with `TT_METAL_WATCHER=1`; the 341 packed-path tests still pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/increase-max-rtas)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/increase-max-rtas)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/increase-max-rtas)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/increase-max-rtas)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/increase-max-rtas)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/increase-max-rtas)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/increase-max-rtas)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/increase-max-rtas)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/increase-max-rtas)