### PR TITLE
removing compile() from prefill runner

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -128,7 +128,7 @@ class PrefillModelAdapter(ABC):
         """Allocate (and zero) this model's KV cache on device and return it. This is
         the single place a model's KV layout is defined. The engine OWNS the returned
         cache's lifetime: it allocates it once, passes it into every runtime call that
-        touches it (compile / prefill_chunk / build_kv_chunk_table / kv_cache_pcc_check),
+        touches it (prefill_chunk / build_kv_chunk_table / kv_cache_pcc_check),
         and frees it with the mesh at shutdown. ``params`` carries the per-rank knobs
         (max_seq_len, mesh_shape, this rank's num_layers, num_users, …)."""
 
@@ -136,9 +136,10 @@ class PrefillModelAdapter(ABC):
     def build_runtime(self, *, mesh_device: "ttnn.MeshDevice", hf_config, params: PrefillRunParams):
         """Construct the model for this rank and return a runtime handle. The runtime
         is stateless w.r.t. the KV cache — it receives the engine-owned cache as an
-        argument on each call. The engine then calls ``.compile(kv_cache)`` and drives
-        it (make_chunk_input, prefill_chunk, and — when enabled — build_kv_chunk_table /
-        kv_cache_pcc_check / set_layer_ack_channel). ``params`` carries the per-rank knobs."""
+        argument on each call. The engine drives it (make_chunk_input, prefill_chunk,
+        and — when enabled — build_kv_chunk_table / kv_cache_pcc_check /
+        set_layer_ack_channel); the first chunk compiles lazily (warm-up is the input
+        driver's throwaway first chunk, not a runtime step). ``params`` carries the per-rank knobs."""
 
     # =====================================================================
     # Test-only metadata (HF download coordinates + reference modeling).

--- a/models/demos/common/prefill/runners/ADDING_A_PREFILL_MODEL.md
+++ b/models/demos/common/prefill/runners/ADDING_A_PREFILL_MODEL.md
@@ -72,7 +72,7 @@ class MyModelAdapter(PrefillModelAdapter):
     def build_runtime(self, *, mesh_device, hf_config, params: PrefillRunParams):
         """Construct the model for this rank and return the runtime handle (section 2).
         The runtime is stateless w.r.t. the KV cache — it receives the engine-owned cache
-        as an argument on each call. The engine calls `.compile(kv_cache)` next. `params`
+        as an argument on each call. `params`
         carries the resolved per-rank knobs (mesh shape, this rank's num_layers /
         first_layer_idx / is_first_rank / is_last_rank, chunk_size, num_users, max_seq_len,
         capacity_factor, num_links, gate_mode_name, kv_only_last_layer, weight_cache_path)
@@ -95,11 +95,13 @@ for the H2D producers.
 ## 2. The runtime interface
 
 `build_runtime` returns a runtime handle. This is where the model actually lives: the
-engine compiles it, drives it per chunk, and reads a few attributes off it. The
+engine drives it per chunk and reads a few attributes off it. The
 runtime knows how to read/write the KV cache but does NOT own it — the engine
 allocates the cache (via the adapter's `allocate_kv_cache`) and passes it into every
 call that touches it. The engine owns the loop, the sockets, the cache lifetime, and
-all comms (migration publish, LayerAck channel lifecycle, shutdown).
+all comms (migration publish, LayerAck channel lifecycle, shutdown). There is no
+`compile`/warm-up step: the first chunk compiles lazily, so the input driver sends one
+throwaway warm-up chunk before timed/production traffic (see "Validate").
 
 ```python
 class PrefillRuntime:  # structural contract — not a base class you must inherit
@@ -111,14 +113,10 @@ class PrefillRuntime:  # structural contract — not a base class you must inher
     is_first_rank, is_last_rank. The engine reads these to drive the chunk schedule
     and the per-rank pipeline role."""
 
-    def compile(self, kv_cache: "ttnn.Tensor") -> None:
-        """Warm up / compile the model so the per-chunk loop hits no first-run cost.
-        The engine calls this once, after build_runtime, with the cache it owns."""
-
     def make_chunk_input(self, token_ids: list[int]) -> "ttnn.Tensor":
-        """Build one chunk's device input for prefill_chunk: the chunk's token IDs on
-        the first rank, or a placeholder hidden-state activation on a non-first pipeline
-        rank (which receives the real activation over the D2D socket)."""
+        """Build one chunk's first-rank device input for prefill_chunk (SP-sharded token IDs).
+        Only the first rank embeds; a non-first pipeline rank receives its input activation over
+        the D2D socket (the engine's recv), so it never calls this."""
 
     def prefill_chunk(self, input_tensor, kv_cache, *, slot_id, actual_start, actual_end):
         """Prefill ONE chunk into user `slot_id`'s slice of `kv_cache` (the engine-owned
@@ -199,6 +197,10 @@ swapping the manifest. (A manifest may also carry a migration `users[]` block fo
 KV-migration validation; see `_apply_manifest_env`.)
 
 ## 4. Validate
+
+There is no compile step — the first chunk pays a one-time lazy-compile cost, so treat chunk 0 as
+warm-up (the standalone loop's first chunk; a synthetic first request in production) and measure from
+chunk 1.
 
 **Standalone + KV PCC** — single galaxy, golden-trace input, no external producer:
 

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -245,7 +245,12 @@ def _socket_next(h2d_service) -> tuple:
         h2d_service, metadata_size_bytes=METADATA_SIZE_BYTES
     )
     m = ttnn.to_torch(ttnn.get_device_tensors(tt_metadata)[0]).view(torch.int32).flatten()
-    return tt_tokens, {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
+    meta = {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
+    # Receipt marker at the IS boundary (rank 0 pulled a request off the H2D socket). With no runner
+    # warm-up, this is the scheduler's signal the model is up: if it logs but no CHUNK_START follows the
+    # model hung in the forward; if it never logs, the request never reached the runner (server side).
+    logger.info(f"[pp rank 0] REQUEST_RECV slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})")
+    return tt_tokens, meta
 
 
 def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_size: int, hidden_size: int):
@@ -591,7 +596,6 @@ def main() -> None:
     # The engine owns the KV cache: allocate it once (the adapter defines the layout), pass it into
     # every runtime call, and let it free with the mesh at shutdown.
     kv_cache = ADAPTER.allocate_kv_cache(mesh_device=mesh_device, hf_config=hf_config, params=params)
-    runtime.compile(kv_cache)
 
     if os.environ.get("PREFILL_STANDALONE", "0") == "1":
         _serve_standalone(runtime, kv_cache, mesh_device, hf_config, rank, num_ranks, is_first_rank)
@@ -608,14 +612,16 @@ def _serve_standalone(
 ) -> None:
     """Bring-up / benchmark path: golden-trace input on rank 0, D2D-socket transport between ranks,
     per-rank KV PCC. Self-contained (no external producer); covers num_ranks 1..N."""
-    # Warm-up sync — the ONLY barrier. Every rank finishes compile before any chunk enters the
-    # pipeline, so a downstream rank isn't still warming up while an upstream one races ahead. The
-    # per-chunk loop takes no barrier. Trade-off: a rank that dies during compile hangs the others here.
+    # Setup sync — the ONLY barrier. Every rank finishes model build before any chunk enters the
+    # pipeline, so a downstream rank isn't still building while an upstream one races ahead. The
+    # per-chunk loop takes no barrier. (The first chunk compiles lazily as it flows — the input driver
+    # sends it as a throwaway warm-up; no explicit compile step here.) Trade-off: a rank that dies
+    # during build hangs the others here.
     ttnn.distributed_context_barrier()
 
-    # D2D transport: with >1 rank, every rank stands up its pipeline endpoints (revert the custom
-    # sub-device as above). The post-compile barrier guarantees all ranks reach the chained create
-    # rendezvous. A single rank owns the whole model — no transport.
+    # D2D transport: with >1 rank, every rank stands up its pipeline endpoints. The setup barrier
+    # above guarantees all ranks reach the chained create rendezvous. A single rank owns the whole
+    # model — no transport.
     d2d_in = d2d_out = None
     if num_ranks > 1:
         mesh_device.clear_loaded_sub_device_manager()
@@ -656,11 +662,12 @@ def _serve_request(runtime, kv_cache, mesh_device, hf_config, rank: int, num_ran
             "is not implemented); run single-rank or unset PREFILL_ENABLE_MIGRATION."
         )
 
-    ttnn.distributed_context_barrier()  # warm-up: all ranks finish compile before chunks flow
+    ttnn.distributed_context_barrier()  # setup sync: all ranks finish model build before chunks flow
 
-    # H2D input service lives on the first rank only (downstream ranks read from D2D). compile() leaves
-    # a custom sub-device manager loaded; the service's init program validates its cores against the
-    # default whole-chip sub-device, so revert first.
+    # H2D input service lives on the first rank only (downstream ranks read from D2D). The service's
+    # init program validates its cores against the default whole-chip sub-device, so make sure the
+    # default manager is loaded first (a per-chunk MoE sub-device swap could otherwise leave a custom
+    # one active).
     h2d_service = None
     if is_first_rank:
         mesh_device.clear_loaded_sub_device_manager()

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -2,12 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-import torch
 from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
@@ -69,8 +67,9 @@ class TtPrefillRuntimeConfig:
 
 
 class TtPrefillRuntime:
-    """Single-rank prefill execution lifecycle: build model -> allocate KV cache ->
-    compile -> prefill(chunk). Owns the KVPE cache and the per-layer LayerAck wiring.
+    """Single-rank prefill execution lifecycle: build model -> prefill(chunk). Owns the per-layer
+    LayerAck wiring. The engine allocates the KV cache and passes it into each call; warm-up is the
+    input driver's job (it sends one throwaway chunk before timed work — no first-run cost is hidden here).
 
     A runtime owns one rank's layer slice. For single-rank prefill the slice is the
     whole model (the config defaults). For pipeline-parallel prefill, a driver builds
@@ -90,7 +89,7 @@ class TtPrefillRuntime:
         self.hf_config = hf_config
         self.config = config
         assert config.model_cfg is not None, "TtPrefillRuntimeConfig.model_cfg must be set by the model adapter"
-        # Per-layer LayerAck callback, built once in set_layer_ack_channel() after compile.
+        # Per-layer LayerAck callback, built once in set_layer_ack_channel().
         self._on_layer_complete = None
 
         assert (
@@ -98,7 +97,6 @@ class TtPrefillRuntime:
         ), f"max_seq_len ({config.max_seq_len}) must be a multiple of chunk_size ({config.chunk_size})"
 
         self.model_built = False
-        self.compiled = False
 
         self._build_model(state_dict)
 
@@ -162,57 +160,18 @@ class TtPrefillRuntime:
         )
         self.model_built = True
 
-    def make_placeholder_activation(self) -> ttnn.Tensor:
-        """Allocate a zero hidden-state activation matching the embedding output:
-        [1, 1, chunk_per_chip, emb_dim/tp], TILE_LAYOUT, DRAM, replicated.
-
-        Stand-in input for a non-first rank until the upstream D2D-socket sync op
-        delivers the real activation. The first block's attn_norm reads from this
-        tensor; once the sync op lands, the wait-op overwrites it in place.
-        """
-        chunk_per_chip = self.config.chunk_size // self.config.sp_factor
-        emb_per_tp = self.hf_config.hidden_size // self.config.tp_factor
-        zeros = torch.zeros(1, 1, chunk_per_chip, emb_per_tp, dtype=torch.bfloat16)
-        return ttnn.from_torch(
-            zeros,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-        )
-
     def make_chunk_input(self, token_ids: list[int]) -> ttnn.Tensor:
-        """Build one chunk's device input for `prefill_chunk`. First-rank input is
-        SP-sharded token IDs; a non-first pipeline rank instead gets a placeholder
-        hidden-state activation (it does not embed — it receives the real activation
-        over the D2D socket)."""
-        if self.config.is_first_rank:
-            return prepare_prefill_input_tensor(
-                token_ids,
-                self.mesh_device,
-                self.config.sp_factor,
-                False,  # chunked prefill is block-cyclic (non-balanced)
-                self.config.mesh_shape,
-                self.config.sp_axis,
-            )
-        return self.make_placeholder_activation()
-
-    def compile(self, kv_cache: ttnn.Tensor) -> None:
-        """Warm up one chunk so the per-chunk loop hits no first-run cost. The engine
-        passes the cache it owns; the warm-up writes into it (slot 0) and is harmless."""
-        assert self.model_built
-        chunk = self.config.chunk_size
-        logger.info(f"TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
-        t0 = time.perf_counter()
-        tt_input = self.make_chunk_input([0] * chunk)
-        self.prefill_chunk(tt_input, kv_cache, slot_id=0, actual_start=0, actual_end=chunk)
-        ttnn.synchronize_device(self.mesh_device)
-        warmup_ms = (time.perf_counter() - t0) * 1000.0
-        logger.info(
-            f"[prefill timing] task_id=WARMUP num_tokens={chunk} runtime.prefill_chunk(chunk) = {warmup_ms:.2f} ms"
+        """Build one chunk's first-rank device input for `prefill_chunk`: SP-sharded token IDs. Only
+        the first rank embeds; a non-first pipeline rank receives its input activation over the D2D
+        socket (the engine's `_d2d_recv`), so it never calls this."""
+        return prepare_prefill_input_tensor(
+            token_ids,
+            self.mesh_device,
+            self.config.sp_factor,
+            False,  # chunked prefill is block-cyclic (non-balanced)
+            self.config.mesh_shape,
+            self.config.sp_axis,
         )
-        self.compiled = True
 
     def prefill_chunk(
         self,
@@ -252,8 +211,6 @@ class TtPrefillRuntime:
             actual_start: absolute KV pos of the chunk's first real token (the cache write offset).
             actual_end: absolute KV pos past the chunk's last real token.
         """
-        # Not gated on self.compiled: compile() warms up by calling prefill_chunk() once before
-        # marking the runtime compiled. The model must exist, though.
         assert self.model_built, "build the model before prefill_chunk()"
         assert 0 <= slot_id < self.config.num_users, f"slot_id {slot_id} out of range [0, {self.config.num_users})"
         assert (
@@ -290,7 +247,6 @@ class TtPrefillRuntime:
         Per-layer cadence means NUM_LAYERS acks per chunk, so the scheduler must
         be configured with layers_per_chunk == NUM_LAYERS.
         """
-        assert self.compiled, "Call compile() before set_layer_ack_channel()"
 
         def on_layer_complete(layer_idx: int) -> None:
             layer_ack_channel.inject(1)


### PR DESCRIPTION
The runtime no longer has a compile()/warm-up step: the first chunk compiles lazily, so whoever drives input (producer in request mode, the loop in standalone) treats chunk 0 as a throwaway warm-up. Shrinks the model<->engine contract and shifts the one-time compile cost from startup to first chunk. Validated 1-rank Kimi: c0=74.6s (lazy compile), c1/c2=~1.24s steady.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-remove-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-remove-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jjovicic/prefill-remove-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-remove-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-remove-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-remove-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-remove-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-remove-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-remove-compile)