### PR TITLE
[DS Prefill] Support arbitrary ISL in test_prefill_transformer via trace slicing

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -69,6 +69,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     load_debug_trace,
     load_reference_cache,
     save_reference_cache,
+    slice_debug_trace,
     slice_non_padded,
     tokenize_prompt_to_isl,
 )
@@ -214,16 +215,24 @@ def run_model(
 
     # Priority 1: debug trace on disk
     trace = None
-    trace_dir = (
+    trace_dir = None
+    trace_sliced = False
+    trace_match = (
         find_trace_dir(input_source, isl_total, padding_side, use_pretrained, n_routed_experts)
         if pcc_validation
         else None
     )
-    if trace_dir is not None:
+    if trace_match is not None:
+        trace_dir, trace_isl = trace_match
         trace = load_debug_trace(trace_dir, num_layers=num_layers)
+        if trace_isl > isl_total:
+            trace = slice_debug_trace(trace, isl_total)
+            trace_sliced = True
+            logger.info(f"Sliced trace {trace_dir.name} from native isl={trace_isl} to requested isl={isl_total}")
         logger.info(
             f"Loaded debug trace from {trace_dir} "
-            f"(trace n_layers={trace.metadata.get('n_layers')}, test num_layers={num_layers})"
+            f"(trace n_layers={trace.metadata.get('n_layers')}, test num_layers={num_layers}, "
+            f"native_isl={trace_isl}, sliced={trace_sliced})"
         )
 
     cache_key = ReferenceCacheKey(
@@ -699,7 +708,9 @@ def run_model(
         # --- Logits PCC check (last-token logits vs trace reference) ---
         # Trace logits / next-token are products of the full traced model. They are
         # only meaningful when the TT model ran the same number of layers as the trace.
-        trace_full_model = trace is not None and num_layers == trace.metadata.get("n_layers")
+        # A sliced trace's stored logits/next-token belong to the full (longer) sequence,
+        # so they are not a valid reference for the shorter prefill — skip those checks.
+        trace_full_model = trace is not None and not trace_sliced and num_layers == trace.metadata.get("n_layers")
         if trace_full_model and trace.logits is not None and "logits" in tt_intermediates:
             try:
                 _, logits_pcc = comp_pcc(trace.logits.float(), tt_intermediates["logits"].float())
@@ -709,10 +720,12 @@ def run_model(
                 logger.error(f"{'logits':<20s}  PCC comparison failed: {e}")
                 pcc_results.append(("logits", -1.0))
         elif trace is not None and not trace_full_model:
-            logger.info(
-                f"Skipping trace logits/first-token checks: "
-                f"num_layers={num_layers} != trace n_layers={trace.metadata.get('n_layers')}"
+            reason = (
+                "trace sliced to a shorter isl (full-sequence logits/next-token invalid)"
+                if trace_sliced
+                else f"num_layers={num_layers} != trace n_layers={trace.metadata.get('n_layers')}"
             )
+            logger.info(f"Skipping trace logits/first-token checks: {reason}")
 
         profiler.end("pcc_validation")
 
@@ -737,7 +750,8 @@ def run_model(
         )
 
         # First-token cross-check against the reference
-        if trace is not None and num_layers == trace.metadata.get("n_layers"):
+        # (skipped for a sliced trace: its next_token_id is the full sequence's, not the prefix's)
+        if trace is not None and not trace_sliced and num_layers == trace.metadata.get("n_layers"):
             token_match = check_first_token_match(trace, trace_dir, first_token_id, first_token_prob)
             if token_match is False:
                 failures.append(("first_token_match", -1.0))

--- a/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
+++ b/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
@@ -1,0 +1,228 @@
+# Environment variables for `test_prefill_transformer.py`
+
+This documents every environment variable reachable from
+`models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py` — the test file
+itself, its `conftest.py`, and the helper modules it imports.
+
+## How env vars get resolved
+
+The test runs the **`DSV3` variant** by default (from `tests/model_variants.py`).
+Several env var *names* are indirected through the variant definition — that's why
+the DSV3 run uses `DEEPSEEK_V3_HF_MODEL`, `TT_DS_PREFILL_TTNN_CACHE`, and
+`TT_DS_PREFILL_HOST_REF_CACHE`. For the Kimi variant the same roles map to
+different names (see the Kimi section).
+
+The three reference sources for PCC checks are tried in priority order:
+
+1. **On-disk golden trace** (`DEEPSEEK_V3_TRACE_DIR`)
+2. **Reference cache** (`TT_DS_PREFILL_HOST_REF_CACHE`)
+3. **Live HF model computation**
+
+---
+
+## Tier 1 — paths/data that matter to run the test
+
+### `DEEPSEEK_V3_HF_MODEL`  (`variant.env_var`)
+Path to the HF model dir (weights + `config.json` + `*.index.json` + tokenizer).
+Drives the `model_path`, `hf_config`, `state_dict`, and `tokenizer` fixtures.
+If unset/invalid it falls back to `default_local_path` → `shared_path`
+(`/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528`) → **auto-download from HuggingFace**.
+
+### `TT_DS_PREFILL_TTNN_CACHE`  (`variant.ttnn_cache_env`)
+Directory for cached TTNN weight tensors (`.tensorbin`). First run dumps converted
+weights; later runs load directly, skipping torch conversion. Subdir is
+`{variant}_{bh|wh}_{Ndev}`. Fallback: `<model_path>/tensor_cache_...`.
+
+### `TT_DS_PREFILL_HOST_REF_CACHE`  (`variant.ref_cache_env`)
+Directory of cached **PyTorch reference outputs** (`.pt`, keyed by
+weight/input/isl/layers/experts/padding). Used as reference source #2 for PCC checks
+so it doesn't recompute the HF forward each run.
+Fallback: `/tmp/deepseek_v3_d_p_transformer_ref_cache`.
+
+### `DEEPSEEK_V3_TRACE_DIR`
+Base dir for pre-computed **golden debug traces** (safetensors) — reference source #1
+(highest priority, via `find_trace_dir`/`TRACE_LOOKUP`).
+Default `/mnt/MLPerf/deepseek-prefill-cache`. Only used for pretrained + 256-expert
+configs; the trace is chosen by `(input_source, padding_side)` and an isl that is either
+an exact match or the smallest available trace `>= isl_total` (sliced down — see
+"Arbitrary ISL via trace slicing" below).
+
+#### How the trace directory is located (it is a fixed lookup, not a search)
+
+`DEEPSEEK_V3_TRACE_DIR` is only the **base** directory. The code never scans/globs
+inside it to "find" a matching trace — the subdirectory names are hardcoded, and a trace
+is chosen by dictionary lookup with an isl fallback (exact key match, else the smallest
+registered trace whose key length is `>= isl_total`, then sliced).
+
+**Step 1 — the base path**. The env var replaces the leading path; the subdirectory
+names are baked in:
+
+```python
+TRACE_DIR_BASE = Path(os.getenv("DEEPSEEK_V3_TRACE_DIR", "/mnt/MLPerf/deepseek-prefill-cache")).resolve()
+ILLIAD_1024_TRACE     = TRACE_DIR_BASE / "illiad_prefill_fa2"
+ILLIAD_25024_TRACE    = TRACE_DIR_BASE / "illiad_prefill_fa2_25024"
+ABC_1K_PAD_RIGHT_1024 = TRACE_DIR_BASE / "ABC_1k_prefill_padd_right_1024"
+ABC_1K_PAD_LEFT_1024  = TRACE_DIR_BASE / "ABC_1k_prefill_padd_left_1024"
+LONGBOOK_QA_ENG_25600 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_25600_nopad"
+LONGBOOK_QA_ENG_5120  = TRACE_DIR_BASE / "longbook_qa_eng_prefill_5120_nopad"
+LONGBOOK_QA_ENG_56320 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_56320_nopad"
+```
+
+**Step 2 — the lookup table**. The key is the tuple
+`(input_source, isl_total, padding_side)`, where `isl_total` is the trace's native
+(generated) sequence length:
+
+```python
+TRACE_LOOKUP: dict[tuple[str, int, str], Path] = {
+    ("json_prompts",    1024,  "right"): ILLIAD_1024_TRACE,
+    ("json_prompts",    25600, "right"): ILLIAD_25024_TRACE,
+    ("abc_1k",          1024,  "right"): ABC_1K_PAD_RIGHT_1024,
+    ("abc_1k",          1024,  "left"):  ABC_1K_PAD_LEFT_1024,
+    ("longbook_qa_eng", 5120,  "right"): LONGBOOK_QA_ENG_5120,
+    ("longbook_qa_eng", 25600, "right"): LONGBOOK_QA_ENG_25600,
+    ("longbook_qa_eng", 56320, "right"): LONGBOOK_QA_ENG_56320,
+}
+```
+
+**Step 3 — `find_trace_dir`**. Requires `use_pretrained` is True **and**
+`n_routed_experts == 256` (traces were captured from the full pretrained DeepSeek-R1,
+so they are invalid for random-weight or reduced-expert runs), and the directory must be
+"ready" (physically exists **and** contains `metadata.json`). It returns
+`(trace_dir, lookup_isl)` or `None`, resolving in two stages:
+
+1. **Exact match** — `TRACE_LOOKUP.get((input_source, isl_total, padding_side))`; e.g.
+   `("longbook_qa_eng", 5120, "right")`. Normally no slicing.
+2. **Arbitrary-ISL fallback** — if there is no exact match, pick the **smallest ready
+   trace with the same `(input_source, padding_side)` whose key length is `>= isl_total`**.
+   The caller then slices the first `isl_total` positions. So asking for `longbook_qa_eng`
+   at `isl=25000` with only a `56320` trace present resolves to the `56320` trace, sliced
+   to `25000`.
+
+### Arbitrary ISL via trace slicing
+
+`test_prefill_transformer.py` supports **any requested `isl_total`** as long as a trace
+with the same `(input_source, padding_side)` and a **native isl `>= isl_total`** exists.
+When the matched trace is longer than requested, `slice_debug_trace()` truncates it to the
+first `isl_total` positions.
+
+This is **exact** for causal, `*_nopad` prefill traces: a transformer's per-layer decoder
+output and KV-cache entry at position `i` depend only on positions `0..i` (causal
+attention + absolute-position RoPE), so they are identical whether the full sequence or
+just its first `isl_total` tokens are prefilled. The per-layer hidden-state PCC and the
+KVPE PCC checks therefore remain valid on the sliced reference.
+
+**Caveat:** the trace's stored `logits` / `next_token_id` belong to the *full* sequence's
+final position, so they are meaningless for a shorter prefill. For a sliced trace,
+`slice_debug_trace()` drops `logits` (→ `None`) and the test **skips the logits PCC and
+first-token-match checks** (per-layer + KVPE PCC still run). An exact-length match keeps
+all checks.
+
+Requesting an `isl_total` **larger** than every available trace still yields no trace
+(the test then falls back to reference cache / live HF compute).
+
+**Step 4 — reading the trace** (`load_debug_trace`, line 941+). Once a directory passes,
+the loader reads by **fixed filenames/keys**, not by searching:
+
+- `metadata.json` → `token_ids` and `n_layers`.
+- Hidden states: per-layer files `hidden_states/layer_{i}.safetensors`
+  (key `decoder_output_layer_{i}`) **or** a flat `hidden_states.safetensors` — per-layer
+  is used if the `hidden_states/` subdir exists.
+- KV cache: `kv_cache/layer_{i}.safetensors` or flat `kv_cache.safetensors`, preferring
+  the key `kv_post_transform_layer_{i}` and falling back to `compressed_kv_layer_{i}`
+  (with a warning that PCC will be unreliable).
+- Optional `logits.safetensors`.
+
+**What this means for you:**
+
+- To point at a custom trace location, set `DEEPSEEK_V3_TRACE_DIR` to a base dir that
+  **contains the exact hardcoded subdirectory names** above — e.g.
+  `$DEEPSEEK_V3_TRACE_DIR/ABC_1k_prefill_padd_right_1024/metadata.json`.
+- If no trace matches your `(input_source, padding_side)` with a native isl `>= isl_total`,
+  **no trace is used regardless of the env var** — the test falls back to the reference
+  cache / live HF compute.
+- This is a different mechanism from the variant's `prefill_trace_default` field
+  (`/mnt/models/.../golden/...`), which is consumed by the *chunked* transformer test and
+  the standalone runners via `PREFILL_TRACE_DIR` — not by this `find_trace_dir` path.
+
+### `HF_HOME`
+HuggingFace cache dir used for the auto-download fallback (weights, config, tokenizer).
+Default `~/.cache/huggingface`.
+
+---
+
+## Tier 2 — optional behavior toggles
+
+### `TT_DS_PREFILL_INFINITEBENCH_CACHE`
+Where InfiniteBench prompt subsets are cached (only relevant when `input_source` is
+`passkey`/`kv_retrieval`/`longdialogue_qa_eng`/`longbook_qa_eng`). Falls back under `HF_HOME`.
+
+### `TT_DS_PREFILL_DEBUG_TOKEN_COUNT`
+`1/true/yes` enables a token-count debug path inside the MoE block (`tt_moe.py`).
+
+### `MESH_DEVICE`
+If `TG`/`GALAXY`, the code treats the device as a Galaxy (`is_tg` in `perf_utils.py`).
+
+### `PCC_SUMMARY_DIR`
+Where PCC summary files/plots are written. Default `/tmp/pcc_summaries_<user>`.
+
+### `<NAME>_OUTPUT_DIR`
+Per-stage dump dir for `save_intermediate_output` — e.g. `NORM_OUTPUT_DIR`,
+`LM_HEAD_OUTPUT_DIR`. Default `/tmp/{name}_outputs`.
+
+### `DEEPSEEK_V3_MLA_REF_CACHE`  (`variant.mla_ref_cache_env`)
+MLA-layer reference cache dir. Primarily exercised by `test_mla.py`, defined on the variant.
+
+---
+
+## Tier 3 — CI-only (no effect on a normal local run)
+
+### `GITHUB_ACTIONS`
+When **unset** and a trace dir exists, the test does an extra local-only branch
+(line 826). Set by CI.
+
+### `EXPECT_NUM_TESTS`
+Optional guardrail: warns (never fails) if collected test count ≠ this. Inert unless set.
+
+### `GITHUB_STEP_SUMMARY`
+Path where the above warning is also appended (CI job summary).
+
+---
+
+## Kimi variant equivalents (only if you run the `kimi_k2_6` variant)
+
+Same roles as the DSV3 names above:
+
+- `DEEPSEEK_V3_HF_MODEL` → `KIMI_K2_6_HF_MODEL`
+- `TT_DS_PREFILL_TTNN_CACHE` → `TT_KIMI_PREFILL_TTNN_CACHE`
+- `TT_DS_PREFILL_HOST_REF_CACHE` → `TT_KIMI_PREFILL_HOST_REF_CACHE`
+- `DEEPSEEK_V3_MLA_REF_CACHE` → `KIMI_MLA_REF_CACHE`
+
+---
+
+## NOT used by this test
+
+A large `PREFILL_*` family exists in this module
+(`PREFILL_HF_MODEL`, `PREFILL_TTNN_CACHE`, `PREFILL_NUM_LAYERS`, `PREFILL_SP`/`PREFILL_TP`,
+`PREFILL_STANDALONE*`, `PREFILL_CHUNK_SIZE`, `PREFILL_MIGRATE_*`, `PREFILL_STRESS_*`,
+`PREFILL_H2D_*`, `MIGRATION_DONE_FILE`, `DEEPSEEK_PREFILL_TRACE_DIR/PT`, etc.).
+
+These belong to the standalone multi-process prefill runner (`tt/runners/*`) and the
+chunked/migration/stress tests — they are **not** read by `test_prefill_transformer.py`,
+so setting them here has no effect. Note the runner uses `PREFILL_TTNN_CACHE` /
+`PREFILL_HF_MODEL` while this test uses the `TT_DS_PREFILL_*` / `DEEPSEEK_V3_HF_MODEL`
+names — don't confuse the two families.
+
+---
+
+## Minimal working example (DSV3)
+
+```bash
+TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure \
+DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528 \
+TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/ \
+pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+```
+
+The effective working set for this test is: `DEEPSEEK_V3_HF_MODEL`,
+`TT_DS_PREFILL_TTNN_CACHE`, `TT_DS_PREFILL_HOST_REF_CACHE` (+ optionally
+`DEEPSEEK_V3_TRACE_DIR` and `HF_HOME`).

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -69,17 +69,30 @@ ILLIAD_25024_TRACE = TRACE_DIR_BASE / "illiad_prefill_fa2_25024"
 ABC_1K_PAD_RIGHT_1024 = TRACE_DIR_BASE / "ABC_1k_prefill_padd_right_1024"
 ABC_1K_PAD_LEFT_1024 = TRACE_DIR_BASE / "ABC_1k_prefill_padd_left_1024"
 LONGBOOK_QA_ENG_25600 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_25600_nopad"
+LONGBOOK_QA_ENG_5120 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_5120_nopad"
+LONGBOOK_QA_ENG_56320 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_56320_nopad"
 
-# Identity-based trace lookup: (input_source, isl_total, padding_side) -> Path.
+# Identity-based trace lookup: (input_source, isl_total, padding_side) -> Path, where
+# isl_total is the trace's NATIVE (generated) sequence length.
 # Traces are only used when use_pretrained=True and n_routed_experts=256, since they
 # were generated from the full pretrained model.
+# A test may request an isl that is not a native trace length: find_trace_dir() falls
+# back to the smallest native trace with the same (input_source, padding_side) whose
+# length is >= the requested isl, and the caller slices it (see slice_debug_trace).
 TRACE_LOOKUP: dict[tuple[str, int, str], Path] = {
     ("json_prompts", 1024, "right"): ILLIAD_1024_TRACE,
     ("json_prompts", 25600, "right"): ILLIAD_25024_TRACE,
     ("abc_1k", 1024, "right"): ABC_1K_PAD_RIGHT_1024,
     ("abc_1k", 1024, "left"): ABC_1K_PAD_LEFT_1024,
+    ("longbook_qa_eng", 5120, "right"): LONGBOOK_QA_ENG_5120,
     ("longbook_qa_eng", 25600, "right"): LONGBOOK_QA_ENG_25600,
+    ("longbook_qa_eng", 56320, "right"): LONGBOOK_QA_ENG_56320,
 }
+
+
+def _trace_dir_ready(path: Path) -> bool:
+    """A trace dir is usable only if it exists and carries a metadata.json."""
+    return path.exists() and (path / "metadata.json").exists()
 
 
 def find_trace_dir(
@@ -88,21 +101,41 @@ def find_trace_dir(
     padding_side: str,
     use_pretrained: bool,
     n_routed_experts: int,
-) -> Path | None:
-    """Return the trace directory for an exact test configuration, or None.
+) -> tuple[Path, int] | None:
+    """Return ``(trace_dir, trace_isl)`` for a test configuration, or ``None``.
+
+    ``trace_isl`` is the trace's NATIVE sequence length. When it is larger than the
+    requested ``isl_total`` the caller must slice the trace down to ``isl_total``
+    (see :func:`slice_debug_trace`) — valid for causal, nopad prefill traces.
 
     A trace is eligible only when:
     - the model uses pretrained weights with 256 experts (traces were generated from
       the full pretrained DeepSeek-R1 model)
-    - (input_source, isl_total, padding_side) match a known trace exactly
     - the directory exists and contains a metadata.json
+
+    Resolution order:
+    1. Exact ``(input_source, isl_total, padding_side)`` match (no slicing).
+    2. Otherwise the smallest ready trace with the same ``(input_source, padding_side)``
+       whose native isl is ``>= isl_total`` (caller slices the first ``isl_total`` tokens).
     """
     if not use_pretrained or n_routed_experts != 256:
         return None
 
-    path = TRACE_LOOKUP.get((input_source, isl_total, padding_side))
-    if path is not None and path.exists() and (path / "metadata.json").exists():
-        return path
+    # 1. Exact native-length match — preferred, no slicing needed.
+    exact = TRACE_LOOKUP.get((input_source, isl_total, padding_side))
+    if exact is not None and _trace_dir_ready(exact):
+        return exact, isl_total
+
+    # 2. Fall back to the smallest ready trace that is at least as long as requested,
+    #    with matching input_source + padding_side.
+    candidates = sorted(
+        (trace_isl, path)
+        for (src, trace_isl, pad), path in TRACE_LOOKUP.items()
+        if src == input_source and pad == padding_side and trace_isl >= isl_total and _trace_dir_ready(path)
+    )
+    if candidates:
+        trace_isl, path = candidates[0]
+        return path, trace_isl
     return None
 
 
@@ -1037,6 +1070,39 @@ def load_debug_trace(trace_dir: Path, num_layers: int | None = None) -> DebugTra
         ref_kvpe_list=ref_kvpe_list,
         logits=logits,
         metadata=metadata,
+    )
+
+
+def slice_debug_trace(trace: DebugTraceData, isl_total: int) -> DebugTraceData:
+    """Slice a debug trace down to its first ``isl_total`` sequence positions.
+
+    This is exact for causal (autoregressive) prefill traces generated WITHOUT padding
+    (the ``*_nopad`` traces): a transformer's per-layer decoder output and KV-cache entry
+    at position ``i`` depend only on positions ``0..i`` (causal attention + absolute-position
+    RoPE), so they are identical whether the full sequence or only its first ``isl_total``
+    tokens are prefilled.
+
+    The stored ``logits`` / ``next_token_id`` are the FULL sequence's final-position
+    products and are meaningless for the shorter prefill, so ``logits`` is dropped
+    (set to ``None``); callers must skip the logits / first-token checks for a sliced
+    trace (``metadata`` is left untouched, so ``next_token_id`` must not be trusted).
+
+    Args:
+        trace: Trace to slice (typically longer than the requested isl).
+        isl_total: Target sequence length; must be <= the trace's native length.
+
+    Returns:
+        A new :class:`DebugTraceData` truncated along the sequence dimension.
+    """
+    trace_len = trace.token_ids.shape[1]
+    if isl_total > trace_len:
+        raise ValueError(f"Cannot slice trace of length {trace_len} up to isl_total={isl_total}")
+    return DebugTraceData(
+        token_ids=trace.token_ids[:, :isl_total],
+        ref_snapshots={label: snap[:, :isl_total, :] for label, snap in trace.ref_snapshots.items()},
+        ref_kvpe_list=[kv[:, :, :isl_total, :] for kv in trace.ref_kvpe_list],
+        logits=None,  # full-sequence final-position logits are invalid after slicing
+        metadata=trace.metadata,
     )
 
 


### PR DESCRIPTION
## Summary

Adds support for running `test_prefill_transformer.py` at an **arbitrary requested ISL**, as long as a debug trace exists with the same `(input_source, padding_side)` and a native ISL **>=** the requested `isl_total`. When the matched trace is longer than requested, it is sliced to the first `isl_total` positions.

This is **exact** for causal, `*_nopad` prefill traces: a transformer's per-layer decoder output and KV-cache entry at position `i` depend only on positions `0..i` (causal attention + absolute-position RoPE), so the first `isl_total` positions of a longer trace are a valid reference for a shorter prefill. The trace's stored full-sequence logits / next-token are invalid after slicing, so the logits + first-token checks are skipped for a sliced trace (per-layer + KVPE PCC still run).

Changes:
- `transformer_helpers.py`: `find_trace_dir` now returns `(trace_dir, native_isl)` and, on an exact-match miss, falls back to the smallest ready trace with matching `(input_source, padding_side)` whose native ISL `>= isl_total`. Add `slice_debug_trace()`. Register the on-disk `longbook_qa_eng` 5120 / 56320 traces.
- `test_prefill_transformer.py`: consume the new return type, slice when `native_isl > isl_total`, and skip the logits / first-token checks for a sliced trace.
- Add env-var / trace-resolution documentation (`tt/prefill_transformer_test_env_vars.md`).

## CI Pipelines
[![Galaxy DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch%3Afbajraktari%2Fsupport_for_arbitrary_isl)
[![T3K e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch%3Afbajraktari%2Fsupport_for_arbitrary_isl)
[![SP Release DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch%3Afbajraktari%2Fsupport_for_arbitrary_isl)
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Afbajraktari%2Fsupport_for_arbitrary_isl)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/support_for_arbitrary_isl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/support_for_arbitrary_isl)
