### PR TITLE
Feat: Add support for uint32 binary remainder

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -806,3 +806,85 @@ def test_binary_relational_uint32_edge_cases(ttnn_op, device):
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.uint32)
 
     assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (torch.Size([1, 1, 64, 128])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (0, 1000, 1, 100),
+        (0, 1_000_000, 1, 10_000),
+        (0, 2147483647, 1, 2147483647),
+        (2147483648, 4294967295, 1, 2147483647),  # a in upper half, b < 2^31
+        (0, 2147483647, 2147483648, 4294967295),  # b in upper half
+        (2147483648, 4294967295, 2147483648, 4294967295),  # both in upper half
+        (0, 4294967295, 1, 4294967295),  # full range
+    ],
+)
+def test_binary_remainder_uint32_full_range(shape, low_a, high_a, low_b, high_b, device):
+    num_elements = max(int(torch.prod(torch.tensor(shape)).item()), 1)
+    torch_input_tensor_a = (
+        torch.linspace(low_a, high_a, num_elements, dtype=torch.float64).to(torch.uint32).reshape(shape)
+    )
+    # Clamp to >= 1 in float64 (uint32 doesn't support masked_fill) to avoid divide-by-zero.
+    b_f = torch.clamp(torch.linspace(high_b, low_b, num_elements, dtype=torch.float64), min=1.0)
+    torch_input_tensor_b = b_f.to(torch.uint32).reshape(shape)
+
+    # Unsigned remainder computed exactly in int64 (both operands are non-negative).
+    torch_golden = (torch_input_tensor_a.to(torch.int64) % torch_input_tensor_b.to(torch.int64)).to(torch.uint32)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn.remainder(input_tensor_a, input_tensor_b)
+
+    assert torch.equal(ttnn.to_torch(output_tensor, dtype=torch.uint32), torch_golden)
+
+
+def test_binary_remainder_uint32_edge_cases(device):
+    torch_input_tensor_a = torch.tensor(
+        [0, 1, 100, 2147483647, 2147483648, 4294967295, 4294967295, 3000000000, 2147483648, 0, 12345, 4294967294],
+        dtype=torch.uint32,
+    )
+    torch_input_tensor_b = torch.tensor(
+        [1, 1, 7, 2147483647, 2147483648, 4294967295, 1, 7, 3000000001, 5, 4294967295, 2],
+        dtype=torch.uint32,
+    )
+
+    torch_golden = (torch_input_tensor_a.to(torch.int64) % torch_input_tensor_b.to(torch.int64)).to(torch.uint32)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn.remainder(input_tensor_a, input_tensor_b)
+
+    assert torch.equal(ttnn.to_torch(output_tensor, dtype=torch.uint32), torch_golden)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -811,7 +811,7 @@ def test_binary_relational_uint32_edge_cases(ttnn_op, device):
 @pytest.mark.parametrize(
     "shape",
     [
-        (torch.Size([1, 1, 64, 128])),
+        (torch.Size([1, 1, 256, 256])),
     ],
 )
 @pytest.mark.parametrize(
@@ -860,11 +860,11 @@ def test_binary_remainder_uint32_full_range(shape, low_a, high_a, low_b, high_b,
 
 def test_binary_remainder_uint32_edge_cases(device):
     torch_input_tensor_a = torch.tensor(
-        [0, 1, 100, 2147483647, 2147483648, 4294967295, 4294967295, 3000000000, 2147483648, 0, 12345, 4294967294],
+        [0, 1, 28, 100, 2147483647, 2147483648, 4294967295, 4294967295, 3000000000, 2147483648, 0, 12345, 4294967294],
         dtype=torch.uint32,
     )
     torch_input_tensor_b = torch.tensor(
-        [1, 1, 7, 2147483647, 2147483648, 4294967295, 1, 7, 3000000001, 5, 4294967295, 2],
+        [1, 1, 14, 7, 2147483647, 2147483648, 4294967295, 1, 7, 3000000001, 5, 4294967295, 2],
         dtype=torch.uint32,
     )
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -102,15 +102,16 @@ sfpi_inline void calculate_remainder_int32_body(
     sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
 }
 
-// Unsigned (uint32) remainder = a - floor(a / b) * b
-// compute_unsigned_remainder_int32() is exact only when both operands are in [0, 2^31)
-// (abs() is a no-op there), so we range-reduce into that regime:
-// * b >= 2^31: a < 2^32 <= 2*b, so a % b = a (a < b) or a - b. Both upper-half values
-//              compare correctly with a signed compare, so no helper call is needed.
+// Unsigned (uint32) remainder. compute_unsigned_remainder_int32() is exact only when both
+// operands are in [0, 2^31) (abs() is a no-op there), so we range-reduce into that regime:
 // * b <  2^31: halve a to clear the problematic top bit. With t = a >> 1 (logical) and
-//              a = 2*t + (a & 1), a % b = (2*(t % b) + (a & 1)) % b. t < 2^31 for every
-//              uint32 a, so the single helper call always sees operands in [0, 2^31) and the
-//              same path handles a < 2^31 and a >= 2^31 (one heavy divide instead of two).
+//              a = 2*t + (a & 1), a % b = (2*(t % b) + (a & 1)) % b. t < 2^31 for every uint32 a,
+//              so the single helper call always sees operands in [0, 2^31).
+// * b >= 2^31: a < 2^32 <= 2*b, so a is already in [0, 2b) and needs no helper (a % b = a or a - b).
+// Both regimes yield a value x in [0, 2b), reduced by one conditional subtract: x % b =
+// (x >=u b) ? x - b : x. The SFPU integer compare only tests sign(x - b), which equals the true
+// unsigned x >=u b except when b >= 2^31 and x < 2^31; a second predicate corrects those lanes
+// (there x < b, so the remainder is x).
 sfpi_inline void calculate_remainder_uint32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
@@ -120,37 +121,26 @@ sfpi_inline void calculate_remainder_uint32_body(
     sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
     sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
-    // Call the helper once at top level (mirrors int32, nesting it inside predication crashes
-    // the SFPI rvtt_live pass). t = (uint32)a >> 1 is always < 2^31 (vUInt shift is logical), so
-    // the helper always sees valid [0, 2^31) operands. When b < 2^31 we use its result:
-    // a % b = (2*rt + (a & 1)) % b. When b >= 2^31 the helper's result is discarded and the
-    // v_if(b < 0) branch below uses a / a - b directly. But we still pay the call because SFPI
-    // predication requires both branches to be materialized. The single helper call thus covers
-    // a < 2^31 and a >= 2^31 uniformly inside the b < 2^31 branch.
+    // Call the helper unconditionally (nesting it inside predication crashes the SFPI rvtt_live
+    // pass). t = (uint32)a >> 1 is always < 2^31, so the helper sees valid [0, 2^31) operands; rt
+    // is only used on the b < 2^31 lanes, but every lane pays the call.
     sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
     sfpi::vInt rt = compute_unsigned_remainder_int32(t, b);
 
     // Reload a from DEST instead of keeping it live across the helper
     a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
 
-    // 2*rt + low bit, in [0, 2b); may wrap negative (as signed) when >= 2^31
-    sfpi::vInt val = rt + rt + (a & 1);
+    // b < 2^31 uses x = 2*rt + (a & 1); b >= 2^31 keeps x = a
+    v_if(b >= 0) { a = rt + rt + (a & 1); }
+    v_endif;
 
-    sfpi::vInt r;
-    // Negative b (signed view): b >= 2^31 -> a % b = a (a < b) or a - b.
-    v_if(b < 0) {
-        r = a;  // a < 2^31 <= b, or a >= 2^31 with a < b
-        // a >= 2^31 and a >= b: both in upper half, signed compare matches unsigned order.
-        v_if(a < 0 && a >= b) { r = a - b; }
-        v_endif;
-    }
-    // Positive b: b < 2^31
-    v_else {
-        r = val;
-        v_if(val < 0) { r = val - b; }  // val (unsigned) >= 2^31 > b
-        v_elseif(val >= b) { r = val - b; }
-        v_endif;
-    }
+    // x % b = (x >=u b) ? x - b : x, valid for both regimes since x in [0, 2b)
+    sfpi::vInt r = a;
+    v_if(sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
+    v_endif;
+    // The above compare only tests sign(x - b), matching x >=u b except when b >= 2^31 and x < 2^31
+    // Then x < b, remainder = x
+    v_if(b < 0 && a >= 0) { r = a; }
     v_endif;
 
     sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -102,6 +102,60 @@ sfpi_inline void calculate_remainder_int32_body(
     sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
 }
 
+// Unsigned (uint32) remainder = a - floor(a / b) * b
+// compute_unsigned_remainder_int32() is exact only when both operands are in [0, 2^31)
+// (abs() is a no-op there), so we range-reduce into that regime:
+// * b >= 2^31: a < 2^32 <= 2*b, so a % b = a (a < b) or a - b. Both upper-half values
+//              compare correctly with a signed compare, so no helper call is needed.
+// * b <  2^31: halve a to clear the problematic top bit. With t = a >> 1 (logical) and
+//              a = 2*t + (a & 1), a % b = (2*(t % b) + (a & 1)) % b. t < 2^31 for every
+//              uint32 a, so the single helper call always sees operands in [0, 2^31) and the
+//              same path handles a < 2^31 and a >= 2^31 (one heavy divide instead of two).
+sfpi_inline void calculate_remainder_uint32_body(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+
+    // Load raw 32-bit patterns (interpreted as unsigned)
+    sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // Call the helper once at top level (mirrors int32, nesting it inside predication crashes
+    // the SFPI rvtt_live pass). t = (uint32)a >> 1 is always < 2^31 (vUInt shift is logical), so
+    // the helper always sees valid [0, 2^31) operands. When b < 2^31 we use its result:
+    // a % b = (2*rt + (a & 1)) % b. When b >= 2^31 the helper's result is discarded and the
+    // v_if(b < 0) branch below uses a / a - b directly. But we still pay the call because SFPI
+    // predication requires both branches to be materialized. The single helper call thus covers
+    // a < 2^31 and a >= 2^31 uniformly inside the b < 2^31 branch.
+    sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
+    sfpi::vInt rt = compute_unsigned_remainder_int32(t, b);
+
+    // Reload a from DEST instead of keeping it live across the helper
+    a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+
+    // 2*rt + low bit, in [0, 2b); may wrap negative (as signed) when >= 2^31
+    sfpi::vInt val = rt + rt + (a & 1);
+
+    sfpi::vInt r;
+    // Negative b (signed view): b >= 2^31 -> a % b = a (a < b) or a - b.
+    v_if(b < 0) {
+        r = a;  // a < 2^31 <= b, or a >= 2^31 with a < b
+        // a >= 2^31 and a >= b: both in upper half, signed compare matches unsigned order.
+        v_if(a < 0 && a >= b) { r = a - b; }
+        v_endif;
+    }
+    // Positive b: b < 2^31
+    v_else {
+        r = val;
+        v_if(val < 0) { r = val - b; }  // val (unsigned) >= 2^31 > b
+        v_elseif(val >= b) { r = val - b; }
+        v_endif;
+    }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
+}
+
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat in1) {
     // remainder(a, b) = a - floor(a/b) * b
@@ -162,6 +216,15 @@ inline void calculate_remainder_int32(const uint dst_index_in0, const uint dst_i
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_remainder_uint32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+#pragma GCC unroll 2
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_remainder_uint32_body(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
 inline void calculate_sfpu_binary_remainder(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
@@ -180,6 +243,12 @@ inline void calculate_sfpu_binary_remainder(
 
 template <bool APPROXIMATION_MODE>
 inline void remainder_int32_init() {
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+template <bool APPROXIMATION_MODE>
+inline void remainder_uint32_init() {
+    // Shares the int32 setup: the unsigned path reuses compute_unsigned_remainder_int32().
     div_floor_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -86,6 +86,7 @@ enum class SfpuType {
     div_int32_floor,
     div_int32_trunc,
     remainder_int32,
+    remainder_uint32,
     fmod_int32,
     lt,
     gt,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -146,15 +146,16 @@ sfpi_inline void calculate_remainder_int32_body(
     sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() = r;
 }
 
-// Unsigned (uint32) remainder = a - floor(a / b) * b
-// compute_unsigned_remainder_int32() is exact only when both operands are in [0, 2^31)
-// (abs() is a no-op there), so we range-reduce into that regime:
-// * b >= 2^31: a < 2^32 <= 2*b, so a % b = a (a < b) or a - b. Both upper-half values
-//              compare correctly with a signed compare, so no helper call is needed.
+// Unsigned (uint32) remainder. compute_unsigned_remainder_int32() is exact only when both
+// operands are in [0, 2^31) (abs() is a no-op there), so we range-reduce into that regime:
 // * b <  2^31: halve a to clear the problematic top bit. With t = a >> 1 (logical) and
-//              a = 2*t + (a & 1), a % b = (2*(t % b) + (a & 1)) % b. t < 2^31 for every
-//              uint32 a, so the single helper call always sees operands in [0, 2^31) and the
-//              same path handles a < 2^31 and a >= 2^31 (one heavy divide instead of two).
+//              a = 2*t + (a & 1), a % b = (2*(t % b) + (a & 1)) % b. t < 2^31 for every uint32 a,
+//              so the single helper call always sees operands in [0, 2^31).
+// * b >= 2^31: a < 2^32 <= 2*b, so a is already in [0, 2b) and needs no helper (a % b = a or a - b).
+// Both regimes yield a value x in [0, 2b), reduced by one conditional subtract: x % b =
+// (x >=u b) ? x - b : x. The SFPU integer compare only tests sign(x - b), which equals the true
+// unsigned x >=u b except when b >= 2^31 and x < 2^31; a second predicate corrects those lanes
+// (there x < b, so the remainder is x).
 sfpi_inline void calculate_remainder_uint32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
@@ -164,37 +165,26 @@ sfpi_inline void calculate_remainder_uint32_body(
     sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
     sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
 
-    // Call the helper once at top level (mirrors int32, nesting it inside predication crashes
-    // the SFPI rvtt_live pass). t = (uint32)a >> 1 is always < 2^31 (vUInt shift is logical), so
-    // the helper always sees valid [0, 2^31) operands. When b < 2^31 we use its result:
-    // a % b = (2*rt + (a & 1)) % b. When b >= 2^31 the helper's result is discarded and the
-    // v_if(b < 0) branch below uses a / a - b directly. But we still pay the call because SFPI
-    // predication requires both branches to be materialized. The single helper call thus covers
-    // a < 2^31 and a >= 2^31 uniformly inside the b < 2^31 branch.
+    // Call the helper unconditionally (nesting it inside predication crashes the SFPI rvtt_live
+    // pass). t = (uint32)a >> 1 is always < 2^31, so the helper sees valid [0, 2^31) operands; rt
+    // is only used on the b < 2^31 lanes, but every lane pays the call.
     sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
     sfpi::vInt rt = compute_unsigned_remainder_int32(t, b);
 
     // Reload a from DEST instead of keeping it live across the helper
     a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
 
-    // 2*rt + low bit, in [0, 2b); may wrap negative (as signed) when >= 2^31
-    sfpi::vInt val = rt + rt + (a & 1);
+    // b < 2^31 uses x = 2*rt + (a & 1); b >= 2^31 keeps x = a
+    v_if(b >= 0) { a = rt + rt + (a & 1); }
+    v_endif;
 
-    sfpi::vInt r;
-    // Negative b (signed view): b >= 2^31 -> a % b = a (a < b) or a - b.
-    v_if(b < 0) {
-        r = a;  // a < 2^31 <= b, or a >= 2^31 with a < b
-        // a >= 2^31 and a >= b: both in upper half, signed compare matches unsigned order.
-        v_if(a < 0 && a >= b) { r = a - b; }
-        v_endif;
-    }
-    // Positive b: b < 2^31
-    v_else {
-        r = val;
-        v_if(val < 0) { r = val - b; }  // val (unsigned) >= 2^31 > b
-        v_elseif(val >= b) { r = val - b; }
-        v_endif;
-    }
+    // x % b = (x >=u b) ? x - b : x, valid for both regimes since x in [0, 2b)
+    sfpi::vInt r = a;
+    v_if(sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
+    v_endif;
+    // The above compare only tests sign(x - b), matching x >=u b except when b >= 2^31 and x < 2^31
+    // Then x < b, remainder = x
+    v_if(b < 0 && a >= 0) { r = a; }
     v_endif;
 
     sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() = r;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -116,7 +116,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     return r;
 }
 
-// Remainder = a - floor(a / b) * b
+// Signed (int32) remainder = a - floor(a / b) * b
 sfpi_inline void calculate_remainder_int32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
@@ -139,6 +139,60 @@ sfpi_inline void calculate_remainder_int32_body(
             v_endif;
         }
         v_elseif(a_signed < 0 && b_signed < 0) { r = -r; }
+        v_endif;
+    }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() = r;
+}
+
+// Unsigned (uint32) remainder = a - floor(a / b) * b
+// compute_unsigned_remainder_int32() is exact only when both operands are in [0, 2^31)
+// (abs() is a no-op there), so we range-reduce into that regime:
+// * b >= 2^31: a < 2^32 <= 2*b, so a % b = a (a < b) or a - b. Both upper-half values
+//              compare correctly with a signed compare, so no helper call is needed.
+// * b <  2^31: halve a to clear the problematic top bit. With t = a >> 1 (logical) and
+//              a = 2*t + (a & 1), a % b = (2*(t % b) + (a & 1)) % b. t < 2^31 for every
+//              uint32 a, so the single helper call always sees operands in [0, 2^31) and the
+//              same path handles a < 2^31 and a >= 2^31 (one heavy divide instead of two).
+sfpi_inline void calculate_remainder_uint32_body(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+
+    // Load raw 32-bit patterns (interpreted as unsigned)
+    sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+    sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+
+    // Call the helper once at top level (mirrors int32, nesting it inside predication crashes
+    // the SFPI rvtt_live pass). t = (uint32)a >> 1 is always < 2^31 (vUInt shift is logical), so
+    // the helper always sees valid [0, 2^31) operands. When b < 2^31 we use its result:
+    // a % b = (2*rt + (a & 1)) % b. When b >= 2^31 the helper's result is discarded and the
+    // v_if(b < 0) branch below uses a / a - b directly. But we still pay the call because SFPI
+    // predication requires both branches to be materialized. The single helper call thus covers
+    // a < 2^31 and a >= 2^31 uniformly inside the b < 2^31 branch.
+    sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
+    sfpi::vInt rt = compute_unsigned_remainder_int32(t, b);
+
+    // Reload a from DEST instead of keeping it live across the helper
+    a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+
+    // 2*rt + low bit, in [0, 2b); may wrap negative (as signed) when >= 2^31
+    sfpi::vInt val = rt + rt + (a & 1);
+
+    sfpi::vInt r;
+    // Negative b (signed view): b >= 2^31 -> a % b = a (a < b) or a - b.
+    v_if(b < 0) {
+        r = a;  // a < 2^31 <= b, or a >= 2^31 with a < b
+        // a >= 2^31 and a >= b: both in upper half, signed compare matches unsigned order.
+        v_if(a < 0 && a >= b) { r = a - b; }
+        v_endif;
+    }
+    // Positive b: b < 2^31
+    v_else {
+        r = val;
+        v_if(val < 0) { r = val - b; }  // val (unsigned) >= 2^31 > b
+        v_elseif(val >= b) { r = val - b; }
         v_endif;
     }
     v_endif;
@@ -206,6 +260,15 @@ inline void calculate_remainder_int32(const uint dst_index_in0, const uint dst_i
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_remainder_uint32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_remainder_uint32_body(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en>
 inline void calculate_sfpu_binary_remainder(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
@@ -224,6 +287,12 @@ inline void calculate_sfpu_binary_remainder(
 
 template <bool APPROXIMATION_MODE>
 inline void remainder_int32_init() {
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+template <bool APPROXIMATION_MODE>
+inline void remainder_uint32_init() {
+    // Shares the int32 setup: the unsigned path reuses compute_unsigned_remainder_int32().
     div_floor_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -87,6 +87,7 @@ enum class SfpuType {
     div_int32_floor,
     div_int32_trunc,
     remainder_int32,
+    remainder_uint32,
     fmod_int32,
     lt,
     gt,

--- a/tt_metal/hw/inc/api/compute/binary_remainder.h
+++ b/tt_metal/hw/inc/api/compute/binary_remainder.h
@@ -49,6 +49,43 @@ ALWI void remainder_int32_tile_init() {
     MATH((SFPU_BINARY_INIT_FN(remainder_int32, sfpu::remainder_int32_init, (APPROX))));
 }
 
+// clang-format off
+/**
+ * Performs an elementwise remainder operation with the two unsigned 32-bit integer inputs: y = remainder(x0,x1)
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     */
+// clang-format on
+ALWI void remainder_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_remainder_uint32,
+        (APPROX, 8 /* ITERATIONS */),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for remainder_uint32_tile.
+ */
+ALWI void remainder_uint32_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(remainder_uint32, sfpu::remainder_uint32_init, (APPROX))));
+}
+
 // BF16, FP32
 
 // clang-format off

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -58,7 +58,7 @@ constexpr auto kRelationalDtypes =
     "UINT8 "
     "(cast to UINT16)";
 constexpr auto kFloatAndInt32Dtypes = "BFLOAT16, BFLOAT8_B, BFLOAT4_B, FLOAT32, INT32";
-constexpr auto kMaximumMinimumDtypes =
+constexpr auto kFloatAndInt32UInt32Dtypes =
     "BFLOAT16, BFLOAT8_B, BFLOAT4_B, FLOAT32, INT32, UINT32 (range: [0, 4294967295])";
 constexpr auto kFloatOnlyDtypes = "BFLOAT16, BFLOAT8_B, BFLOAT4_B, FLOAT32";
 constexpr auto kBitwiseShiftDtypes = "INT32, UINT16 (range: [0, 65535]), UINT32 (range: [0, 4294967295])";
@@ -1748,7 +1748,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::remainder),
         static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::remainder),
         R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
-        detail::kFloatAndInt32Dtypes,
+        detail::kFloatAndInt32UInt32Dtypes,
         detail::kSameDtypeRequiredFootnote);
 
     detail::bind_binary_operation<"add">(
@@ -2051,7 +2051,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryUnaryMaxScalarFn>(&ttnn::minimum),
         static_cast<detail::BinaryUnaryMaxTensorFn>(&ttnn::minimum),
         " ",
-        detail::kMaximumMinimumDtypes);
+        detail::kFloatAndInt32UInt32Dtypes);
 
     detail::bind_binary_composite<"atan2">(
         mod,
@@ -2196,7 +2196,7 @@ void py_module(nb::module_& mod) {
         static_cast<detail::BinaryUnaryMaxScalarFn>(&ttnn::maximum),
         static_cast<detail::BinaryUnaryMaxTensorFn>(&ttnn::maximum),
         R"doc(Supported range for :attr:`input_tensor_b` when its of scalar type is [-16777216, 16777216])doc",
-        detail::kMaximumMinimumDtypes);
+        detail::kFloatAndInt32UInt32Dtypes);
 
     detail::bind_prelu<"prelu">(
         mod,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
@@ -28,12 +28,12 @@ std::span<const DataType> supported_tensor_a_dtypes(BinaryOpType op) {
         case BinaryOpType::GE:
         case BinaryOpType::EQ:
         case BinaryOpType::NE: return relational;
-        case BinaryOpType::DIV:
         case BinaryOpType::REMAINDER:
+        case BinaryOpType::MAXIMUM:
+        case BinaryOpType::MINIMUM: return float_and_int32_uint32;
+        case BinaryOpType::DIV:
         case BinaryOpType::FMOD:
         case BinaryOpType::ISCLOSE: return float_and_int32;
-        case BinaryOpType::MAXIMUM:
-        case BinaryOpType::MINIMUM: return maximum_minimum;
         case BinaryOpType::BITWISE_XOR:
         case BinaryOpType::BITWISE_AND:
         case BinaryOpType::BITWISE_OR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.hpp
@@ -20,8 +20,8 @@ inline constexpr std::array float_only{DT::BFLOAT16, DT::FLOAT32, DT::BFLOAT8_B,
 
 inline constexpr std::array float_and_int32{DT::BFLOAT16, DT::FLOAT32, DT::BFLOAT8_B, DT::BFLOAT4_B, DT::INT32};
 
-inline constexpr std::array maximum_minimum{
-    DT::BFLOAT16, DT::FLOAT32, DT::BFLOAT8_B, DT::BFLOAT4_B, DT::UINT32, DT::INT32};
+inline constexpr std::array float_and_int32_uint32{
+    DT::BFLOAT16, DT::FLOAT32, DT::BFLOAT8_B, DT::BFLOAT4_B, DT::INT32, DT::UINT32};
 
 inline constexpr std::array int32_only{DT::INT32};
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -435,6 +435,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case REMAINDER:
             if (dtype == DataType::INT32) {
                 return {"remainder_int32_tile_init();", "remainder_int32_tile"};
+            } else if (dtype == DataType::UINT32) {
+                return {"remainder_uint32_tile_init();", "remainder_uint32_tile"};
             } else {
                 return {"remainder_binary_tile_init();", "remainder_binary_tile"};
             }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/48693
Related to: https://github.com/tenstorrent/tt-xla/issues/5423, https://github.com/tenstorrent/tt-forge-models/pull/790#discussion_r3504960167

### PR Category
Feature

### Summary
- Updated device kernels (Wormhole + Blackhole ckernel_sfpu_binary_remainder.h) to add calculate_remainder_uint32_body, its unrolled wrapper calculate_remainder_uint32, and remainder_uint32_init (shares div_floor_init with int32).
- Algorithm: range-reduce into the shared `compute_unsigned_remainder_int32` helper's safe `[0, 2³¹)` regime:
```
    - b ≥ 2³¹: result is a or a − b, no helper call (cheap signed compares).
    - b < 2³¹: halving identity a = 2·(a>>1) + (a&1), so a % b = (2·rt + (a&1)) % b with a single heavy divide — handles a < 2³¹ and a ≥ 2³¹ uniformly.
```
- Includes the specific instruction ordering (top-level helper call + reload a from DEST after the call, forming val from the reloaded a) required to keep this under the SFPI compiler's rvtt_live and reload-pass limits.

### Perf Comparison with existing INT32 remainder
| Shape| Existing int32 [ns] | Newly Added uint32 [ns] | Change |
|---|---|---|---|
| [1, 1, 32, 32] | 7349 | 7192 | -2.14%  |
| [1, 1, 1024, 1024] | 96209 | 92668 | -3.68% |
| [1, 1, 4096, 4096] | 1207864 | 1256059 | +3.99% |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/remainder_uint32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/remainder_uint32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anasuya/remainder_uint32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/remainder_uint32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/remainder_uint32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/remainder_uint32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/remainder_uint32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/remainder_uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/remainder_uint32)