### PR TITLE
Add token-level causal mask to MSA

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -571,3 +571,62 @@ def test_msa_native_determinism(device, q_dtype, kv_dtype):
             marker = m if marker is None else ttnn.maximum(marker, m)
     mismatch = float(ttnn.to_torch(ttnn.from_device(marker)).max())  # one scalar to host, once
     assert mismatch == 0.0, "sparse_sdpa_msa output is not deterministic across repeated runs"
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [((8, 4), {"fabric_config": ttnn.FabricConfig.FABRIC_1D})],
+    indirect=True,
+)
+@run_for_blackhole()
+def test_msa_native_causal_per_rank_sp(mesh_device):
+    """Multi-device (8x4): q/indices are sharded on the sequence axis across the SP (row) axis and replicated
+    across the TP (col) axis, so SP rank r owns global query positions [r*s_local, (r+1)*s_local). The op must
+    derive its causal chunk_start from each device's mesh coordinate (device_index = rank along cluster_axis 0);
+    otherwise rank>0 masks against a local position, its diagonal block isn't in the selected set, and it
+    attends future tokens. K/V are the full context, replicated. Gathering col 0 of each SP row must match one
+    global-causal reference. Needs 32 devices (skips otherwise)."""
+    rows, cols = tuple(mesh_device.shape)  # SP rows (cluster_axis 0) x TP cols
+    d, H, n_kv, nblk = 128, 16, 1, 16
+    s_local = 128
+    S = rows * s_local
+    T = nblk * BLK_KV
+    scale = d**-0.5
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=True, seed=31)
+    gold = sparse_attention_ref_msa(q, k, v, indices, scale, causal=True)
+
+    def shard_seq_rm(t, dt):  # row-major q/indices: seq sharded on the SP (row) axis, replicated on TP (col)
+        return ttnn.from_torch(
+            t,
+            dtype=dt,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(2, None), mesh_shape=(rows, cols)),
+        )
+
+    def repl_tile(t, dt):  # pre-tiled K/V full context, replicated to every device
+        return ttnn.from_torch(
+            t.to(torch.bfloat16),
+            dtype=dt,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+    tt_out = ttnn.transformer.sparse_sdpa_msa(
+        shard_seq_rm(q.to(torch.float32), ttnn.bfloat16),
+        repl_tile(k, ttnn.bfloat16),
+        repl_tile(v, ttnn.bfloat16),
+        shard_seq_rm(indices.to(torch.int32), ttnn.uint32),
+        scale=scale,
+        block_size=BLK_KV,
+        chunk_start_idx=0,  # base 0; each device adds rank*s_local from its coordinate along cluster_axis 0
+        cluster_axis=0,
+    )
+    # seq is sharded across SP rows and replicated across TP cols -> take col 0 of each row, concat on seq.
+    dts = ttnn.get_device_tensors(tt_out)
+    out = torch.cat([ttnn.to_torch(dts[r * cols]).float()[:, :H] for r in range(rows)], dim=2)
+    p = pcc(out, gold)
+    assert p > 0.99, f"per-rank SP causal PCC {p}"

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
@@ -26,9 +26,8 @@ def sparse_attention_ref_msa(q, k, v, indices, scale, *, blk_kv=BLK_KV, causal=F
         indices [B, n_kv, S, topk]      block-ids per (group, query); SENTINEL (-1) = masked, contiguous tail
         -> out  [B, H, S, v_dim]        (v_dim = v.shape[-1])
 
-    Block selection (`indices`) bounds causality to block granularity. With `causal=True` a token-level
-    causal mask is added on top — required for correctness on the diagonal block, whose selected tokens
-    after the query position are future and must not be attended.
+    `causal=True` enables a token-level causality — required for correctness on the diagonal block,
+    whose selected tokens after the query position are future and must not be attended.
 
     Query heads sharing a KV head also share that KV head's block selection. All-masked rows return 0.
     """

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
@@ -18,14 +18,17 @@ SENTINEL = -1  # masked/invalid block id; contiguous tail per (group, query) row
 BLK_KV = 128  # MSA block size in tokens (= 4 tile-rows)
 
 
-def sparse_attention_ref_msa(q, k, v, indices, scale, *, blk_kv=BLK_KV):
+def sparse_attention_ref_msa(q, k, v, indices, scale, *, blk_kv=BLK_KV, causal=False, chunk_start_idx=0):
     """MSA block-sparse reference: attend the selected blocks, softmax, then PV with separate V.
-    Causal behavior is encoded by block selection in `indices`; there is no token-level causal mask.
 
         q       [B, H, S, d]            (post-rope, post-qk-norm — done upstream)
         k, v    [B, n_kv, T, d]         (separate tensors; T % blk_kv == 0)
         indices [B, n_kv, S, topk]      block-ids per (group, query); SENTINEL (-1) = masked, contiguous tail
         -> out  [B, H, S, v_dim]        (v_dim = v.shape[-1])
+
+    Block selection (`indices`) bounds causality to block granularity. With `causal=True` a token-level
+    causal mask is added on top — required for correctness on the diagonal block, whose selected tokens
+    after the query position are future and must not be attended.
 
     Query heads sharing a KV head also share that KV head's block selection. All-masked rows return 0.
     """
@@ -57,15 +60,23 @@ def sparse_attention_ref_msa(q, k, v, indices, scale, *, blk_kv=BLK_KV):
 
     scores = torch.einsum("bhsd,bhtd->bhst", qf * scale, kf)  # [B,H,S,T]
     scores = scores.masked_fill(~token_mask, float("-inf"))
+    if causal:
+        # Strictly-future keys (only ever inside the diagonal block; past blocks are all <= query pos).
+        q_pos = (torch.arange(S) + chunk_start_idx).view(1, 1, S, 1)
+        kv_pos = torch.arange(T).view(1, 1, 1, T)
+        scores = scores.masked_fill(kv_pos > q_pos, float("-inf"))
 
-    row_has_value = token_mask.any(dim=-1, keepdim=True)
+    row_has_value = (scores > float("-inf")).any(dim=-1, keepdim=True)
     scores = torch.where(row_has_value, scores, torch.zeros_like(scores))
     attn = torch.where(row_has_value, scores.softmax(dim=-1, dtype=torch.float32), torch.zeros_like(scores))
     return torch.einsum("bhst,bhtd->bhsd", attn, vf[..., :v_dim])  # [B,H,S,v_dim]
 
 
-def sparse_attention_ref_msa_sampled_tokens(q, k, v, indices, scale, sample_tokens, *, blk_kv=BLK_KV):
-    """Memory-light MSA reference for selected query tokens."""
+def sparse_attention_ref_msa_sampled_tokens(
+    q, k, v, indices, scale, sample_tokens, *, blk_kv=BLK_KV, causal=False, chunk_start_idx=0
+):
+    """Memory-light MSA reference for selected query tokens. `causal=True` adds the token-level causal
+    mask (a selected key may be a future token only inside the diagonal block; mask those out)."""
     B, H, _, d = q.shape
     n_kv, v_dim = k.shape[1], v.shape[-1]
     assert B == 1 and H % n_kv == 0
@@ -75,6 +86,7 @@ def sparse_attention_ref_msa_sampled_tokens(q, k, v, indices, scale, sample_toke
     outs = []
     for s in sample_tokens:
         out = torch.zeros(H, v_dim, dtype=torch.float32)
+        p = s + chunk_start_idx
         for g in range(n_kv):
             row = indices[0, g, s]
             valid_blocks = row[row >= 0].long()
@@ -84,6 +96,9 @@ def sparse_attention_ref_msa_sampled_tokens(q, k, v, indices, scale, sample_toke
             k_sel = torch.cat([kf[0, g, int(blk) * blk_kv : (int(blk) + 1) * blk_kv] for blk in valid_blocks], dim=0)
             v_sel = torch.cat([vf[0, g, int(blk) * blk_kv : (int(blk) + 1) * blk_kv] for blk in valid_blocks], dim=0)
             scores = torch.matmul(qf[0, h0:h1, s] * scale, k_sel.transpose(0, 1))
+            if causal:
+                key_ids = torch.cat([torch.arange(int(blk) * blk_kv, (int(blk) + 1) * blk_kv) for blk in valid_blocks])
+                scores = scores.masked_fill(key_ids.view(1, -1) > p, float("-inf"))
             attn = scores.softmax(dim=-1, dtype=torch.float32)
             out[h0:h1] = torch.matmul(attn, v_sel)
         outs.append(out)
@@ -180,7 +195,19 @@ def run_op_msa_composed(q, k, v, indices, device, *, k_chunk_size=128):
     return ttnn.to_torch(tt_out)[:, :H]  # drop dummy heads
 
 
-def run_op_msa_native(q, k, v, indices, device, *, block_size=BLK_KV, kv_dtype=ttnn.bfloat16, q_dtype=ttnn.bfloat16):
+def run_op_msa_native(
+    q,
+    k,
+    v,
+    indices,
+    device,
+    *,
+    block_size=BLK_KV,
+    kv_dtype=ttnn.bfloat16,
+    q_dtype=ttnn.bfloat16,
+    chunk_start_idx=None,
+    cluster_axis=None,
+):
     """Run the native op. K/V are pre-tiled; q/indices/output stay row-major."""
     _, H, _, d = q.shape
     scale = d**-0.5
@@ -206,6 +233,8 @@ def run_op_msa_native(q, k, v, indices, device, *, block_size=BLK_KV, kv_dtype=t
         dev_rm(indices.to(torch.int32), ttnn.uint32),  # -1 sentinel -> 0xFFFFFFFF bit pattern
         scale=scale,
         block_size=block_size,
+        chunk_start_idx=chunk_start_idx,  # set -> enable token-level diagonal-block causal mask
+        cluster_axis=cluster_axis,
     )
     # Output dtype matches q. fp8 can't be to_torch'd directly, so typecast fp8 -> bf16 on device first.
     if tt_out.dtype == ttnn.fp8_e4m3:

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -180,3 +180,62 @@ def test_msa_bad_n_kv_rejected_on_hit(device, expect_error):
     q_bad, k_bad, v_bad, _ = make_msa_inputs(H, 2, S, T, topk, _D, causal=False, seed=42)
     with expect_error(RuntimeError, "indices must be"):
         _msa_op(device, q_bad, _tile(k_bad, device), _tile(v_bad, device), indices)
+
+
+# ---- Causal (diagonal-block token-level mask) coverage ----
+# Block selection alone is causal only at block granularity; a query's own (diagonal) block holds future
+# tokens that must be masked. These exercise the chunk_start_idx path that enables the token-level mask.
+
+
+@pytest.mark.parametrize("H,n_kv", [(16, 1), (64, 4)], ids=["mha", "gqa"])
+def test_golden_all_blocks_causal_equals_dense_causal(H, n_kv):
+    # With every causally-visible block selected, the masked reference must equal full causal attention.
+    d, S, nblk = _D, 320, 4  # S spans blocks 0..2; the diagonal block is partially filled.
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=True, seed=7)
+    scale = d**-0.5
+    causal_ref = sparse_attention_ref_msa(q, k, v, indices, scale, causal=True)
+    dense_causal = dense_grouped_kv_attention(q, k, v, scale, causal=True)
+    assert (
+        pcc(causal_ref, dense_causal) > REFERENCE_PCC
+    ), f"sparse(causal) != dense(causal), pcc={pcc(causal_ref, dense_causal)}"
+    # And the legacy block-only reference is NOT causal -> the fixed reference genuinely tests something new.
+    block_only = sparse_attention_ref_msa(q, k, v, indices, scale, causal=False)
+    assert pcc(block_only, dense_causal) < 0.95, "block-only reference unexpectedly matches causal"
+
+
+@run_for_blackhole()
+def test_msa_native_causal_pcc(device):
+    # S spans multiple blocks with the diagonal block partially filled, so the token-level mask matters.
+    # nblk/topk=16 keeps TOPK*4 64B-aligned; causal selection still picks only blocks 0..local (rest sentinel).
+    d, H, n_kv, S, nblk = _D, 64, 4, 320, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=True, seed=31)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5, causal=True)
+    # chunk_start_idx=0 enables the token-level diagonal-block causal mask.
+    out = run_op_msa_native(q, k, v, indices, device, chunk_start_idx=0)
+    assert pcc(out, gold) > DEVICE_PCC, f"causal MSA pcc={pcc(out, gold)}"
+
+
+@run_for_blackhole()
+def test_msa_native_causal_fp8_q_rejected(device, expect_error):
+    # fp8 q is silently inaccurate with the causal mask: fp8-specific, and not fp32-DEST-related -- bf16 q with
+    # fp32_dest_acc_en forced on passes -- but the root cause is not yet identified. The op rejects the combo
+    # rather than returning wrong scores; bf16 q is the supported causal path.
+    d, H, n_kv, S, nblk = _D, 64, 4, 320, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=True, seed=31)
+    with expect_error(RuntimeError, "fp8_e4m3 q is not supported"):
+        run_op_msa_native(q, k, v, indices, device, kv_dtype=ttnn.bfloat8_b, q_dtype=ttnn.fp8_e4m3, chunk_start_idx=0)
+
+
+@run_for_blackhole()
+def test_msa_native_causal_vs_noncausal_differs(device):
+    # Sanity that the mask is actually applied: with the diagonal block partially filled, the causal output
+    # must differ from the block-only (no chunk_start_idx) output.
+    d, H, S, nblk = _D, 16, 320, 16  # nblk/topk=16 -> TOPK*4 is 64B-aligned
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, 1, S, T, topk=nblk, d=d, causal=True, seed=9)
+    out_causal = run_op_msa_native(q, k, v, indices, device, chunk_start_idx=0)
+    out_block_only = run_op_msa_native(q, k, v, indices, device)  # chunk_start_idx=None -> legacy path
+    assert pcc(out_causal, out_block_only) < 0.999, "causal mask had no effect vs block-only"

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -218,6 +218,19 @@ def test_msa_native_causal_pcc(device):
 
 
 @run_for_blackhole()
+def test_msa_native_causal_multiband_pcc(device):
+    # Query heads per KV group padded to > dst_size tile-rows force the compute kernel to process the heads
+    # in more than one DEST band (qg>0). The token-level causal mask must land on every band, not just the
+    # first. bf16 DEST holds 8 tiles, so H_logical must exceed 256: H=288, n_kv=1 -> Sqt=9 -> 3 bands.
+    d, H, n_kv, S, nblk = _D, 288, 1, 320, 16
+    T = nblk * BLK_KV
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=True, seed=31)
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5, causal=True)
+    out = run_op_msa_native(q, k, v, indices, device, chunk_start_idx=0)
+    assert pcc(out, gold) > DEVICE_PCC, f"multi-band causal MSA pcc={pcc(out, gold)}"
+
+
+@run_for_blackhole()
 def test_msa_native_causal_fp8_q_rejected(device, expect_error):
     # fp8 q is silently inaccurate with the causal mask: fp8-specific, and not fp32-DEST-related -- bf16 q with
     # fp32_dest_acc_en forced on passes -- but the root cause is not yet identified. The op rejects the combo

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1126,14 +1126,16 @@ void apply_padded_mask_lightweight_runtime(
     uint32_t out_cb,
     uint32_t num_padded,
     uint32_t num_cols,
-    uint32_t num_rows) {
+    uint32_t num_rows,
+    uint32_t row_base = 0) {  // first out_cb tile-row of this query band; nonzero when heads span >1 DEST band
     uint32_t start = num_cols - num_padded;
 
     copy_tile_to_dst_init_short(neginf_cb);
     PACK((llk_pack_reconfig_l1_acc(1)));
 
     for (uint32_t row = 0; row < num_rows; row++) {
-        stamp_tile_range_l1_acc<dst_batch>(neginf_cb, neginf_tile_idx, out_cb, row * num_cols + start, num_padded);
+        stamp_tile_range_l1_acc<dst_batch>(
+            neginf_cb, neginf_tile_idx, out_cb, (row_base + row) * num_cols + start, num_padded);
     }
 
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -1156,7 +1158,8 @@ void apply_partial_mask_lightweight(
     uint32_t out_cb,
     uint32_t boundary_col,
     uint32_t num_cols,
-    uint32_t num_rows) {
+    uint32_t num_rows,
+    uint32_t row_base = 0) {  // first out_cb tile-row of this query band; nonzero when heads span >1 DEST band
     copy_tile_to_dst_init_short(mask_cb);
     PACK((llk_pack_reconfig_l1_acc(1)));
 
@@ -1165,7 +1168,7 @@ void apply_partial_mask_lightweight(
         copy_tile(mask_cb, partial_tile_idx, 0);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile<true>(0, out_cb, row * num_cols + boundary_col);
+        pack_tile<true>(0, out_cb, (row_base + row) * num_cols + boundary_col);
         tile_regs_release();
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
@@ -58,6 +58,10 @@ void kernel_main() {
     constexpr uint32_t cb_recip_scratch = get_compile_time_arg_val(22);
 
     constexpr uint32_t qsb = get_compile_time_arg_val(23);    // query tile-rows per DST group (<= dst_size)
+    // Causal masking (token-level diagonal-block mask).
+    constexpr bool CAUSAL_MASK_ENABLED = get_compile_time_arg_val(24) != 0;
+    constexpr uint32_t cb_neginf = get_compile_time_arg_val(25);  // persistent all -inf tile (future key-tiles)
+    constexpr uint32_t cb_vmask = get_compile_time_arg_val(26);   // per-token partial-column boundary tile
     constexpr uint32_t Sqt = H / tt::constants::TILE_HEIGHT;  // total query tile-rows (32 heads each)
     constexpr uint32_t q_groups = Sqt / qsb;                  // DST-bound work runs in this many query-row passes
     constexpr uint32_t KT_stride = Skt;                       // cb_qk_im physical row width
@@ -76,6 +80,9 @@ void kernel_main() {
     matmul_init(cb_q_in, cb_k_in);  // one-time matmul init; the no_mop matmuls reinit off this
 
     scale_cb.wait_front(1);  // persistent reduce scaler; the streaming reduce assumes it is ready
+    if constexpr (CAUSAL_MASK_ENABLED) {
+        CircularBuffer(cb_neginf).wait_front(1);  // persistent -inf mask tile; built once by the writer, never popped
+    }
 
     for (uint32_t tok = 0; tok < tok_count; ++tok) {
         // tilize Q rows -> [Sqt, DHt]
@@ -83,10 +90,22 @@ void kernel_main() {
         // fp8 Q tilize leaves the packer in bfp8 format; restore bf16 before QK writes scores.
         pack_reconfig_data_format(cb_qk_im);
 
-        // Per-token control from the reader: active full-block count.
+        // Per-token control from the reader: active block count, and (causal) the diagonal block's chunk
+        // index + within-block mask boundary.
         ctrl_cb.wait_front(1);
         const uint32_t num_active_chunks = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/0);
+        [[maybe_unused]] uint32_t diag_chunk = 0xFFFFFFFFu;
+        [[maybe_unused]] uint32_t boundary_tile = 0;
+        [[maybe_unused]] uint32_t boundary_col = 0;
+        if constexpr (CAUSAL_MASK_ENABLED) {
+            diag_chunk = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/1);
+            boundary_tile = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/2);
+            boundary_col = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/3);
+        }
         ctrl_cb.pop_front(1);
+        // vmask is pushed by the reader exactly when the boundary key-tile is split (boundary_col > 0).
+        [[maybe_unused]] const bool diag_has_vmask =
+            CAUSAL_MASK_ENABLED && (diag_chunk != 0xFFFFFFFFu) && (boundary_col > 0);
 
         // Flash running state, ping-pong. Reset every token; all buffers start empty.
         CircularBuffer max_prev(cb_max_a), max_cur(cb_max_b);
@@ -99,6 +118,13 @@ void kernel_main() {
 
             const bool is_first = (chunk == 0);
             const bool is_last = (chunk == num_active_chunks - 1);
+
+            // The diagonal block needs a token-level causal mask. Front the per-token boundary tile once.
+            if constexpr (CAUSAL_MASK_ENABLED) {
+                if ((chunk == diag_chunk) && diag_has_vmask) {
+                    CircularBuffer(cb_vmask).wait_front(1);
+                }
+            }
 
             // cb_qk_im / sum_cur / out_cur span all Sqt rows; the qg loop fills them band-by-band (sub_exp & PV
             // pack at absolute row offsets; reduce/corr reserve+push per band).
@@ -138,6 +164,25 @@ void kernel_main() {
                     }
                     // Publish the band to UNPACK while holding wr_ptr for in-place sub_exp.
                     cb_push_back_hold_wr_ptr(cb_qk_im, qsb * KT_stride);
+                }
+
+                // Causal mask on the diagonal block: -inf the future-token columns (a contiguous tail beyond
+                // the query position) BEFORE the row-max reduce, so they never inflate the max and map to ~0
+                // after sub_exp. All score rows are heads sharing one query position -> a pure column mask.
+                if constexpr (CAUSAL_MASK_ENABLED) {
+                    if (chunk == diag_chunk) {
+                        if (boundary_col > 0) {  // boundary key-tile is split: partial-column mask
+                            apply_partial_mask_lightweight(cb_vmask, 0, cb_qk_im, boundary_tile, KT_stride, qsb);
+                        }
+                        // Key-tiles entirely after the boundary are fully future -> stamp -inf.
+                        const uint32_t full_neginf =
+                            (boundary_col > 0) ? (Skt - boundary_tile - 1) : (Skt - boundary_tile);
+                        if (full_neginf > 0) {
+                            apply_padded_mask_lightweight_runtime<dst_size>(
+                                cb_neginf, 0, cb_qk_im, full_neginf, KT_stride, qsb);
+                        }
+                        pack_to_unpack_sync();  // masked writes must be visible to the row-max reduce's UNPACK
+                    }
                 }
 
                 {
@@ -224,6 +269,13 @@ void kernel_main() {
                     out_prev.pop_front(qsb * vDHt);  // this band's prev.out consumed into cur
                 }
             }  // query groups
+
+            // Release the per-token boundary mask tile once the diagonal chunk's bands are done.
+            if constexpr (CAUSAL_MASK_ENABLED) {
+                if ((chunk == diag_chunk) && diag_has_vmask) {
+                    CircularBuffer(cb_vmask).pop_front(1);
+                }
+            }
 
             // prev max/sum consumed into cur (out_prev popped per band above).
             if (!is_first) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_msa_compute.cpp
@@ -172,14 +172,15 @@ void kernel_main() {
                 if constexpr (CAUSAL_MASK_ENABLED) {
                     if (chunk == diag_chunk) {
                         if (boundary_col > 0) {  // boundary key-tile is split: partial-column mask
-                            apply_partial_mask_lightweight(cb_vmask, 0, cb_qk_im, boundary_tile, KT_stride, qsb);
+                            apply_partial_mask_lightweight(
+                                cb_vmask, 0, cb_qk_im, boundary_tile, KT_stride, qsb, row_base);
                         }
                         // Key-tiles entirely after the boundary are fully future -> stamp -inf.
                         const uint32_t full_neginf =
                             (boundary_col > 0) ? (Skt - boundary_tile - 1) : (Skt - boundary_tile);
                         if (full_neginf > 0) {
                             apply_padded_mask_lightweight_runtime<dst_size>(
-                                cb_neginf, 0, cb_qk_im, full_neginf, KT_stride, qsb);
+                                cb_neginf, 0, cb_qk_im, full_neginf, KT_stride, qsb, row_base);
                         }
                         pack_to_unpack_sync();  // masked writes must be visible to the row-max reduce's UNPACK
                     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
@@ -9,6 +9,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
+#include "dataflow_common.hpp"         // fill_vertical_tile_bf16 (causal partial-column mask tile)
 
 constexpr uint32_t sentinel = 0xFFFFFFFFu;
 
@@ -37,8 +38,13 @@ void kernel_main() {
     constexpr uint32_t k_tile_bytes = get_compile_time_arg_val(18);  // K is tiled: per-tile read size
     constexpr uint32_t v_tile_bytes = get_compile_time_arg_val(19);  // V is tiled: per-tile read size
 
+    // Causal masking (token-level diagonal-block mask)
+    constexpr bool CAUSAL_MASK_ENABLED = get_compile_time_arg_val(20) != 0;
+    constexpr uint32_t block_size = get_compile_time_arg_val(21);  // tokens per block (for p%bs, p/bs)
+    constexpr uint32_t cb_vmask = get_compile_time_arg_val(22);    // per-token partial-column mask tile
+
     // K/V use RuntimeTensorShape so T can vary without recompilation.
-    constexpr auto q_args = TensorAccessorArgs<20, 0>();
+    constexpr auto q_args = TensorAccessorArgs<23, 0>();
     constexpr auto k_args =
         TensorAccessorArgs<q_args.next_compile_time_args_offset(), q_args.next_common_runtime_args_offset()>();
     constexpr auto v_args =
@@ -61,6 +67,9 @@ void kernel_main() {
         k_group_tile_stride = get_arg_val<uint32_t>(8);
         v_group_tile_stride = get_arg_val<uint32_t>(9);
     }
+    // Per-device global position of this core's query row 0 (chunk_start_idx + rank*S); patched at dispatch.
+    const uint32_t chunk_start_local = CAUSAL_MASK_ENABLED ? get_arg_val<uint32_t>(10) : 0;
+    constexpr uint32_t keys_per_tile = tt::constants::TILE_WIDTH;
 
     Noc noc;
     experimental::CB q_cb(cb_q_rm), k_cb(cb_k_in), v_cb(cb_v_in), idx_cb(cb_idx), ctrl_cb(cb_ctrl);
@@ -122,13 +131,45 @@ void kernel_main() {
         }
         const uint32_t n_active = nv_blocks;  // each active chunk is one full block
 
-        // Compute sees full selected blocks; no token-level boundary mask is applied.
+        // Causal control: locate the diagonal block (the query's own) among the selected blocks and the
+        // within-block boundary, so compute masks the future tokens inside it. Non-causal -> sentinel, no mask.
+        uint32_t diag_chunk = sentinel;
+        uint32_t boundary_tile = 0;  // first fully-masked key-tile within the diagonal block
+        uint32_t boundary_col = 0;   // within-tile column where masking starts (0 -> boundary_tile fully masked)
+        if constexpr (CAUSAL_MASK_ENABLED) {
+            const uint32_t p = chunk_start_local + tok;  // global query position
+            const uint32_t diag_block = p / block_size;
+            for (uint32_t c = 0; c < n_active; ++c) {  // block_ids are topk-ordered (unsorted) -> linear scan
+                if (idx_ptr[c] == diag_block) {
+                    diag_chunk = c;
+                    break;
+                }
+            }
+            const uint32_t first_masked = (p % block_size) + 1;  // local offset of the first future token
+            boundary_tile = first_masked / keys_per_tile;
+            boundary_col = first_masked % keys_per_tile;
+        }
+        [[maybe_unused]] const bool build_vmask = (diag_chunk != sentinel) && (boundary_col > 0);
+
         ctrl_cb.reserve_back(1);
         {
             volatile tt_l1_ptr uint32_t* cp = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ctrl_cb.get_write_ptr());
             cp[0] = n_active;
+            cp[1] = diag_chunk;     // chunk index of the diagonal block (sentinel = none -> no token mask)
+            cp[2] = boundary_tile;  // key-tiles >= this are fully masked in the diagonal block
+            cp[3] = boundary_col;   // partial-column boundary within boundary_tile (0 -> none)
         }
         ctrl_cb.push_back(1);
+
+        // Build the partial-column mask tile for the boundary key-tile (only when it splits a tile).
+        if constexpr (CAUSAL_MASK_ENABLED) {
+            if (build_vmask) {
+                constexpr uint32_t mask_tile_bytes = get_tile_size(cb_vmask);
+                experimental::CB(cb_vmask).reserve_back(1);
+                fill_vertical_tile_bf16<mask_tile_bytes>(noc, cb_vmask, 0, boundary_col);
+                experimental::CB(cb_vmask).push_back(1);
+            }
+        }
 
         for (uint32_t chunk = 0; chunk < n_active; ++chunk) {
             const uint32_t block_id = idx_ptr[chunk];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp"  // generate_bcast_col_scalar
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
+#include "dataflow_common.hpp"         // fill_neginf_tile (persistent causal -inf mask tile)
 
 constexpr uint32_t one_bf16_packed = 0x3F803F80u;  // bf16(1.0) double-packed; generate_bcast_col_scalar uses >>16
 
@@ -36,7 +37,9 @@ void kernel_main() {
     constexpr uint32_t cb_kack = get_compile_time_arg_val(15);
     constexpr uint32_t k_tile_bytes = get_compile_time_arg_val(16);
     constexpr uint32_t v_tile_bytes = get_compile_time_arg_val(17);
-    constexpr auto out_args = TensorAccessorArgs<18, 0>();
+    constexpr bool CAUSAL_MASK_ENABLED = get_compile_time_arg_val(18) != 0;
+    constexpr uint32_t cb_neginf = get_compile_time_arg_val(19);  // persistent all -inf causal mask tile
+    constexpr auto out_args = TensorAccessorArgs<20, 0>();
     // K/V use RuntimeTensorShape so T can vary without recompilation.
     constexpr auto k_args =
         TensorAccessorArgs<out_args.next_compile_time_args_offset(), out_args.next_common_runtime_args_offset()>();
@@ -69,6 +72,14 @@ void kernel_main() {
 
     // Col-identity for final row-sum reduction.
     generate_bcast_col_scalar(experimental::CB(cb_col_identity), one_bf16_packed);
+
+    // Persistent all -inf tile for the causal mask
+    if constexpr (CAUSAL_MASK_ENABLED) {
+        constexpr uint32_t mask_tile_bytes = get_tile_size(cb_neginf);
+        experimental::CB(cb_neginf).reserve_back(1);
+        fill_neginf_tile<mask_tile_bytes>(cb_neginf, 0);
+        experimental::CB(cb_neginf).push_back(1);
+    }
 
     uint32_t tok = work_start;
     uint32_t kv_group = 0;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
     constexpr uint32_t k_tile_bytes = get_compile_time_arg_val(16);
     constexpr uint32_t v_tile_bytes = get_compile_time_arg_val(17);
     constexpr bool CAUSAL_MASK_ENABLED = get_compile_time_arg_val(18) != 0;
-    constexpr uint32_t cb_neginf = get_compile_time_arg_val(19);  // persistent all -inf causal mask tile
+    constexpr uint32_t cb_neginf = get_compile_time_arg_val(19);
     constexpr auto out_args = TensorAccessorArgs<20, 0>();
     // K/V use RuntimeTensorShape so T can vary without recompilation.
     constexpr auto k_args =

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -204,7 +204,8 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAMsaOperation::get_dynamic
         return {};
     }
     // Per-device causal start: chunk_start_idx + rank*S along cluster_axis (rank 0 on a single device).
-    // Mirrors indexer_score_msa so this op's token-level causality matches the indexer's block causality.
+    // Derived exactly as indexer_score_msa's start, so the mask and the indexer's selection share one
+    // global-position frame.
     uint32_t chunk_start_local = 0;
     if (attrs.causal_enabled()) {
         const uint32_t S = t.q.logical_shape()[2];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -191,6 +191,23 @@ ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
         t.indices.dtype());
 }
 
+uint32_t SparseSDPAMsaOperation::compute_chunk_start_local(
+    const SparseSDPAMsaParams& attrs,
+    const SparseSDPAMsaInputs& t,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    // Derived exactly as indexer_score_msa's start, so the mask and the indexer's selection share one
+    // global-position frame.
+    if (!attrs.causal_enabled()) {
+        return 0;
+    }
+    const uint32_t S = t.q.logical_shape()[2];
+    const uint32_t device_index =
+        mesh_dispatch_coordinate.has_value()
+            ? ttnn::ccl::get_linearized_index_from_physical_coord(t.q, *mesh_dispatch_coordinate, attrs.cluster_axis)
+            : 0;
+    return attrs.chunk_start_idx.value() + device_index * S;
+}
+
 std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAMsaOperation::get_dynamic_runtime_args(
     const SparseSDPAMsaParams& attrs,
     const SparseSDPAMsaInputs& t,
@@ -203,18 +220,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAMsaOperation::get_dynamic
     if (!patch_kv && !attrs.causal_enabled()) {
         return {};
     }
-    // Per-device causal start: chunk_start_idx + rank*S along cluster_axis (rank 0 on a single device).
-    // Derived exactly as indexer_score_msa's start, so the mask and the indexer's selection share one
-    // global-position frame.
-    uint32_t chunk_start_local = 0;
-    if (attrs.causal_enabled()) {
-        const uint32_t S = t.q.logical_shape()[2];
-        const uint32_t device_index = mesh_dispatch_coordinate.has_value()
-                                          ? ttnn::ccl::get_linearized_index_from_physical_coord(
-                                                t.q, *mesh_dispatch_coordinate, attrs.cluster_axis)
-                                          : 0;
-        chunk_start_local = attrs.chunk_start_idx.value() + device_index * S;
-    }
+    const uint32_t chunk_start_local = compute_chunk_start_local(attrs, t, mesh_dispatch_coordinate);
     // Indexed programs patch per-slot tile offsets on every dispatch. GQA programs also patch per-KV-group strides
     // because interleaved K/V T is intentionally excluded from the program hash.
     constexpr uint32_t tw = tt::constants::TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/device.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 #include <bit>
@@ -107,6 +108,10 @@ void SparseSDPAMsaOperation::validate_on_program_cache_miss(
     // q is bf16 or fp8_e4m3. K/V are tiled bf16 or bfp8_b. Indices are uint32 block ids.
     const bool q_is_fp8 = (q.dtype() == DataType::FP8_E4M3);
     TT_FATAL(q.dtype() == DataType::BFLOAT16 || q_is_fp8, "sparse_sdpa_msa: q must be bf16 or fp8_e4m3");
+    // fp8 Q is silently inaccurate with the token-level causal mask (fp8-specific; root cause not yet identified)
+    TT_FATAL(
+        !(attrs.causal_enabled() && q_is_fp8),
+        "sparse_sdpa_msa: causal masking (chunk_start_idx) with fp8_e4m3 q is not supported; use bf16 q");
     TT_FATAL(
         k.dtype() == DataType::BFLOAT16 || k.dtype() == DataType::BFLOAT8_B,
         "sparse_sdpa_msa: k must be bf16 or bfp8_b");
@@ -181,6 +186,7 @@ ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
         t.v.memory_config().is_sharded() ? t.v.logical_shape() : tt::tt_metal::Shape{},
         t.v.logical_shape()[3],
         attrs.has_indexed_kv_cache(),
+        attrs.causal_enabled(),
         t.indices.logical_shape(),
         t.indices.dtype());
 }
@@ -189,11 +195,24 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAMsaOperation::get_dynamic
     const SparseSDPAMsaParams& attrs,
     const SparseSDPAMsaInputs& t,
     Tensor& /*output*/,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     const uint32_t n_kv = t.k.logical_shape()[1];
-    // n_kv==1 non-indexed programs use zero K/V tile offsets and do not need per-group strides.
-    if (!attrs.has_indexed_kv_cache() && n_kv == 1) {
+    const bool patch_kv = attrs.has_indexed_kv_cache() || n_kv > 1;
+    // n_kv==1 non-indexed programs use zero K/V tile offsets and need no per-group strides; but causal
+    // masking still patches the per-device chunk_start every dispatch, so don't early-return then.
+    if (!patch_kv && !attrs.causal_enabled()) {
         return {};
+    }
+    // Per-device causal start: chunk_start_idx + rank*S along cluster_axis (rank 0 on a single device).
+    // Mirrors indexer_score_msa so this op's token-level causality matches the indexer's block causality.
+    uint32_t chunk_start_local = 0;
+    if (attrs.causal_enabled()) {
+        const uint32_t S = t.q.logical_shape()[2];
+        const uint32_t device_index = mesh_dispatch_coordinate.has_value()
+                                          ? ttnn::ccl::get_linearized_index_from_physical_coord(
+                                                t.q, *mesh_dispatch_coordinate, attrs.cluster_axis)
+                                          : 0;
+        chunk_start_local = attrs.chunk_start_idx.value() + device_index * S;
     }
     // Indexed programs patch per-slot tile offsets on every dispatch. GQA programs also patch per-KV-group strides
     // because interleaved K/V T is intentionally excluded from the program hash.
@@ -212,9 +231,20 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAMsaOperation::get_dynamic
     const uint32_t num_cores = grid.x * grid.y;
     std::vector<tt::tt_metal::DynamicRuntimeArg> args;
     // Reader and writer both gather K/V halves, so patch both kernels.
-    args.reserve((attrs.has_indexed_kv_cache() ? 4 : 0) * num_cores + (n_kv > 1 ? 4 : 0) * num_cores);
+    args.reserve(
+        (attrs.has_indexed_kv_cache() ? 4 : 0) * num_cores + (n_kv > 1 ? 4 : 0) * num_cores +
+        (attrs.causal_enabled() ? 1 : 0) * num_cores);
     for (uint32_t i = 0; i < num_cores; ++i) {
         const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
+        if (attrs.causal_enabled()) {
+            // Same per-device chunk_start on every core (the reader derives per-token global pos from it).
+            args.push_back(
+                {sparse_sdpa_msa_rt::kReaderKernelIdx,
+                 core,
+                 sparse_sdpa_msa_rt::kReaderChunkStartArg,
+                 chunk_start_local,
+                 /*is_common=*/false});
+        }
         if (attrs.has_indexed_kv_cache()) {
             args.push_back(
                 {sparse_sdpa_msa_rt::kReaderKernelIdx,
@@ -279,7 +309,9 @@ Tensor sparse_sdpa_msa(
     float scale,
     uint32_t block_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
-    std::optional<uint32_t> cache_batch_idx) {
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> chunk_start_idx,
+    std::optional<uint32_t> cluster_axis) {
     using OperationType = ttnn::prim::SparseSDPAMsaOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -287,6 +319,8 @@ Tensor sparse_sdpa_msa(
             .block_size = block_size,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
+            .chunk_start_idx = chunk_start_idx,
+            .cluster_axis = cluster_axis,
         },
         OperationType::tensor_args_t{
             .q = q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -28,6 +28,8 @@ inline constexpr uint32_t kReaderKBatchOffsetArg = 6;
 inline constexpr uint32_t kReaderVBatchOffsetArg = 7;
 inline constexpr uint32_t kReaderKGroupStrideArg = 8;
 inline constexpr uint32_t kReaderVGroupStrideArg = 9;
+// Per-device causal chunk_start (chunk_start_idx + rank*S); patched at dispatch when causal masking is on.
+inline constexpr uint32_t kReaderChunkStartArg = 10;
 // writer args: {out, work_start, work_count, k, v, k_batch_tile_offset, v_batch_tile_offset,
 //               k_group_tile_stride, v_group_tile_stride}
 inline constexpr uint32_t kWriterKBatchOffsetArg = 5;
@@ -72,6 +74,8 @@ Tensor sparse_sdpa_msa(
     float scale,
     uint32_t block_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
-    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+    std::optional<uint32_t> cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> chunk_start_idx = std::nullopt,
+    std::optional<uint32_t> cluster_axis = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -45,8 +45,14 @@ struct SparseSDPAMsaOperation {
     using tensor_return_value_t = Tensor;
 
     struct SparseSDPAMsaProgramFactory {
+        // The MeshCoordinate overload opts this op into per-coordinate program creation, so each device bakes
+        // its own causal chunk_start (see compute_chunk_start_local). Without it the mesh adapter builds one
+        // program for the whole device range and every rank shares rank 0's offset.
         static tt::tt_metal::ProgramDescriptor create_descriptor(
-            const operation_attributes_t& attrs, const tensor_args_t& t, tensor_return_value_t& output);
+            const operation_attributes_t& attrs,
+            const tensor_args_t& t,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
     };
 
     using program_factory_t = std::variant<SparseSDPAMsaProgramFactory>;
@@ -57,6 +63,14 @@ struct SparseSDPAMsaOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // Per-device causal start: chunk_start_idx + rank*S along cluster_axis (rank from the coordinate; 0 on a
+    // single device or when non-causal). Shared by create_descriptor (miss-bake) and get_dynamic_runtime_args
+    // (hit-patch) so the two paths cannot drift.
+    static uint32_t compute_chunk_start_local(
+        const operation_attributes_t& attrs,
+        const tensor_args_t& t,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 
     // Patches per-slot K/V tile offsets and runtime K/V group strides on cache hits.
     static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
@@ -18,9 +18,9 @@ struct SparseSDPAMsaParams {
     DeviceComputeKernelConfig compute_kernel_config;
     // Selects one [B,n_kv,T,*] cache slot. The value is patched as runtime K/V tile offsets and is not hashed.
     std::optional<uint32_t> cache_batch_idx = std::nullopt;
-    // Global position of query row 0. Set -> enforce a token-level causal mask on the diagonal block (the
-    // query's own block, whose later tokens are future). Unset -> legacy block-only causality. The value is a
-    // hash-excluded runtime arg (per-device start patched at dispatch); only its presence flips the binary.
+    // Global position of query row 0.
+    // Set -> enforce a token-level causal mask on the diagonal block (the query's own block, whose later tokens are
+    // future). Unset -> no token-level causality; the op attends the full selected blocks.
     std::optional<uint32_t> chunk_start_idx = std::nullopt;
     // SP mesh axis used to derive the per-device chunk_start (chunk_start_idx + rank*S); host-side only.
     std::optional<uint32_t> cluster_axis = std::nullopt;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
@@ -18,7 +18,14 @@ struct SparseSDPAMsaParams {
     DeviceComputeKernelConfig compute_kernel_config;
     // Selects one [B,n_kv,T,*] cache slot. The value is patched as runtime K/V tile offsets and is not hashed.
     std::optional<uint32_t> cache_batch_idx = std::nullopt;
+    // Global position of query row 0. Set -> enforce a token-level causal mask on the diagonal block (the
+    // query's own block, whose later tokens are future). Unset -> legacy block-only causality. The value is a
+    // hash-excluded runtime arg (per-device start patched at dispatch); only its presence flips the binary.
+    std::optional<uint32_t> chunk_start_idx = std::nullopt;
+    // SP mesh axis used to derive the per-device chunk_start (chunk_start_idx + rank*S); host-side only.
+    std::optional<uint32_t> cluster_axis = std::nullopt;
     bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
+    bool causal_enabled() const { return chunk_start_idx.has_value(); }
 };
 
 struct SparseSDPAMsaInputs {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -41,6 +41,8 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
         cb_recip_scratch,  // 1-tile reciprocal scratch for normalize_row_streaming
         cb_kreq,           // reader->writer dual-NoC handoff {block_id, is_last} (writer co-gathers the lower half)
         cb_kack,           // writer->reader ack that its half of the block landed in cb_k_in/cb_v_in
+        cb_neginf,         // causal mask: persistent all -inf tile (writer-built); masks full future key-tiles
+        cb_vmask,          // causal mask: per-token partial-column "vertical" tile (reader-built) for the boundary
         cb_count
     };
 
@@ -130,6 +132,8 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     cb(tile_bytes, 1, bf);                   // cb_recip_scratch
     cb(16, 2, bf);                           // cb_kreq : {block_id, is_last} reader->writer (double-buffered)
     cb(16, 2, bf);                           // cb_kack : writer->reader ack (double-buffered)
+    cb(tile_bytes, 1, bf);                   // cb_neginf : persistent all -inf mask tile (causal only)
+    cb(tile_bytes, 2, bf);                   // cb_vmask : per-token partial-column mask tile (causal only)
 
     // ---- compile-time args ----
     // Reader args: scalars, derived geometry, CB ids, element sizes, then q/k/v/indices accessors.
@@ -139,8 +143,11 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     for (uint32_t id : {cb_q_rm, cb_k_in, cb_v_in, cb_idx, cb_ctrl, cb_kreq, cb_kack}) {
         reader_ct.push_back(id);
     }
-    reader_ct.push_back(k_tile_bytes);  // K is tiled: per-tile read size
-    reader_ct.push_back(v_tile_bytes);  // V is tiled: per-tile read size
+    reader_ct.push_back(k_tile_bytes);                      // K is tiled: per-tile read size
+    reader_ct.push_back(v_tile_bytes);                      // V is tiled: per-tile read size
+    reader_ct.push_back(attrs.causal_enabled() ? 1u : 0u);  // CAUSAL_MASK_ENABLED
+    reader_ct.push_back(block_size);                        // block_size: for diag_block = p/bs, offset = p%bs
+    reader_ct.push_back(cb_vmask);                          // reader builds the per-token partial-column tile
     std::vector<uint32_t> reader_crt;
     tt::tt_metal::TensorAccessorArgs(t.q.buffer()).append_to(reader_ct, reader_crt);
     tt::tt_metal::TensorAccessorArgs(t.k.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
@@ -170,6 +177,8 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     }
     writer_ct.push_back(k_tile_bytes);
     writer_ct.push_back(v_tile_bytes);
+    writer_ct.push_back(attrs.causal_enabled() ? 1u : 0u);  // CAUSAL_MASK_ENABLED
+    writer_ct.push_back(cb_neginf);                         // writer builds the persistent -inf mask tile
     std::vector<uint32_t> writer_crt;
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_ct, writer_crt);
     tt::tt_metal::TensorAccessorArgs(t.k.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
@@ -214,6 +223,9 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
         }
     }
     compute_ct.push_back(qsb);
+    compute_ct.push_back(attrs.causal_enabled() ? 1u : 0u);  // CAUSAL_MASK_ENABLED
+    compute_ct.push_back(cb_neginf);                         // full -inf mask tile (future key-tiles)
+    compute_ct.push_back(cb_vmask);                          // partial-column mask tile (boundary key-tile)
 
     tt::tt_metal::KernelDescriptor compute_desc;
     compute_desc.kernel_source = kdir + "compute/sparse_sdpa_msa_compute.cpp";
@@ -265,7 +277,8 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
              k_batch_tile_offset,
              v_batch_tile_offset,
              k_group_tile_stride,
-             v_group_tile_stride});
+             v_group_tile_stride,
+             /*chunk_start_local=*/0u});  // arg 10: patched per-device at dispatch when causal masking is on
         // Writer args 5/6 are the K/V cache-slot offsets patched on cache hits.
         writer_desc.emplace_runtime_args(
             core,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -16,7 +16,10 @@
 namespace ttnn::prim {
 
 tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFactory::create_descriptor(
-    const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t, Tensor& output) {
+    const SparseSDPAMsaParams& attrs,
+    const SparseSDPAMsaInputs& t,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     // Fixed CB ids shared with the kernels. Function scope avoids unity-build collisions with sparse_sdpa.
     // K/V are separate pre-tiled caches. Reader and writer co-gather each block into shared K/V CBs.
     enum SparseCB : uint32_t {
@@ -265,6 +268,9 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     const uint32_t v_group_tile_stride = tiles_per_row * vDHt;
     const uint32_t k_batch_tile_offset = cache_batch_idx * n_kv * k_group_tile_stride;
     const uint32_t v_batch_tile_offset = cache_batch_idx * n_kv * v_group_tile_stride;
+    // Baked per coordinate (one program per device) so each rank masks against its own global position.
+    const uint32_t chunk_start_local =
+        SparseSDPAMsaOperation::compute_chunk_start_local(attrs, t, mesh_dispatch_coordinate);
     for (uint32_t i = 0; i < num_cores; ++i) {
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t work_start = i * base_work + std::min(i, extra);
@@ -282,7 +288,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
              v_batch_tile_offset,
              k_group_tile_stride,
              v_group_tile_stride,
-             /*chunk_start_local=*/0u});  // arg 10: patched per-device at dispatch when causal masking is on
+             chunk_start_local});  // arg 10: baked per-coordinate; re-patched on cache hits (get_dynamic_runtime_args)
         // Writer args 5/6 are the K/V cache-slot offsets patched on cache hits.
         writer_desc.emplace_runtime_args(
             core,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -132,8 +132,12 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     cb(tile_bytes, 1, bf);                   // cb_recip_scratch
     cb(16, 2, bf);                           // cb_kreq : {block_id, is_last} reader->writer (double-buffered)
     cb(16, 2, bf);                           // cb_kack : writer->reader ack (double-buffered)
-    cb(tile_bytes, 1, bf);                   // cb_neginf : persistent all -inf mask tile (causal only)
-    cb(tile_bytes, 2, bf);                   // cb_vmask : per-token partial-column mask tile (causal only)
+    // Mask tiles are touched only under CAUSAL_MASK_ENABLED in the kernels, so skip their L1 when causal
+    // masking is off. Safe to gate: these are the trailing CBs, so omitting them shifts no other buffer index.
+    if (attrs.causal_enabled()) {
+        cb(tile_bytes, 1, bf);  // cb_neginf : persistent all -inf mask tile
+        cb(tile_bytes, 2, bf);  // cb_vmask : per-token partial-column mask tile
+    }
 
     // ---- compile-time args ----
     // Reader args: scalars, derived geometry, CB ids, element sizes, then q/k/v/indices accessors.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -394,9 +394,8 @@ void bind_sdpa(nb::module_& mod) {
             cache_batch_idx (int, optional): select the batch slot of a shared [B, n_kv, T, feature_dim] K/V cache.
                 It is a dynamic runtime arg, so changing it (or T) does not recompile the kernels.
             chunk_start_idx (int, optional): global position of query row 0. When set, enforces a token-level
-                causal mask on the diagonal block (the query's own block). Unset keeps legacy block-only
-                causality. Hash-excluded runtime arg; changing it does not recompile. Requires bf16 q; fp8 q
-                with this set is rejected.
+                causal mask on the diagonal block (the query's own block); toggling set/unset (None vs int)
+		selects a different cached program. Requires bf16 q; fp8 q with this set is rejected.
             cluster_axis (int, optional): SP mesh axis used to derive the per-device chunk_start
                 (chunk_start_idx + rank*S) under sequence parallelism. Host-side only.
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -375,7 +375,8 @@ void bind_sdpa(nb::module_& mod) {
         R"doc(
         MSA block-sparse prefill (MiniMax Sparse Attention), Blackhole single-chip.
         Attends the block_size-token K/V blocks named in `indices`; -1 (0xFFFFFFFF) sentinels mask a contiguous
-        tail. The op has no causal flag; causal behavior must be encoded by the selected blocks. RoPE and
+        tail. Block selection bounds causality to block granularity; pass `chunk_start_idx` to additionally
+        enforce a token-level causal mask on the diagonal block (required for correct causal prefill). RoPE and
         QK-norm are applied upstream.
 
         Args:
@@ -392,6 +393,12 @@ void bind_sdpa(nb::module_& mod) {
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional). fp8 q requires fp32_dest_acc_en.
             cache_batch_idx (int, optional): select the batch slot of a shared [B, n_kv, T, feature_dim] K/V cache.
                 It is a dynamic runtime arg, so changing it (or T) does not recompile the kernels.
+            chunk_start_idx (int, optional): global position of query row 0. When set, enforces a token-level
+                causal mask on the diagonal block (the query's own block). Unset keeps legacy block-only
+                causality. Hash-excluded runtime arg; changing it does not recompile. Requires bf16 q; fp8 q
+                with this set is rejected.
+            cluster_axis (int, optional): SP mesh axis used to derive the per-device chunk_start
+                (chunk_start_idx + rank*S) under sequence parallelism. Host-side only.
 
         Returns:
             ttnn.Tensor: [1, H, S, v_dim] ROW-MAJOR, dtype = q.
@@ -408,7 +415,9 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("scale") = nb::none(),
         nb::arg("block_size") = 128,
         nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("cache_batch_idx") = nb::none());
+        nb::arg("cache_batch_idx") = nb::none(),
+        nb::arg("chunk_start_idx") = nb::none(),
+        nb::arg("cluster_axis") = nb::none());
 
     const auto* const chunked_doc =
         R"doc(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.cpp
@@ -17,7 +17,9 @@ ttnn::Tensor sparse_sdpa_msa(
     std::optional<float> scale,
     uint32_t block_size,
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    std::optional<uint32_t> cache_batch_idx) {
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> chunk_start_idx,
+    std::optional<uint32_t> cluster_axis) {
     const uint32_t d = q.logical_shape()[3];  // head dim, from the tensor
     const float resolved_scale = scale.value_or(1.0f / std::sqrt(static_cast<float>(d)));
 
@@ -31,7 +33,8 @@ ttnn::Tensor sparse_sdpa_msa(
         /*default_fp32_acc=*/q_is_fp8,
         /*default_l1_acc=*/false);
 
-    return ttnn::prim::sparse_sdpa_msa(q, k, v, indices, resolved_scale, block_size, kernel_config, cache_batch_idx);
+    return ttnn::prim::sparse_sdpa_msa(
+        q, k, v, indices, resolved_scale, block_size, kernel_config, cache_batch_idx, chunk_start_idx, cluster_axis);
 }
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
@@ -24,13 +24,12 @@ namespace ttnn::transformer {
 // Preconditions: d, v_dim, and block_size are multiples of 32; block_size divides T; TOPK*4 and output row
 // bytes meet DRAM alignment; each index row has at least one valid block; all valid block ids are < T/block_size.
 //
-// Causality: block selection in `indices` bounds it to block granularity. Pass `chunk_start_idx` (the global
-// position of query row 0) to additionally enforce a token-level causal mask on the diagonal block — required
-// for correct causal prefill, where a query's own block holds future tokens that must not be attended. Unset
-// (default) keeps the legacy block-only behavior. `cluster_axis` derives the per-device start under sequence
-// parallelism (chunk_start = chunk_start_idx + rank*S), mirroring `indexer_score_msa`. Causal masking requires
-// bf16 q: with fp8 q the mask is numerically wrong (fp8-specific; root cause not identified), so fp8 q with
-// `chunk_start_idx` is rejected.
+// `chunk_start_idx` needs to be passed (the global position of query row 0) to enforce a token-level causal
+// mask on the diagonal block — required for correct causal prefill, where a query's own block holds future
+// tokens that must not be attended. Unset (default) can be used for full attention.
+// `cluster_axis` derives the per-device start under sequence parallelism (chunk_start = chunk_start_idx + rank*S).
+// Causal masking requires bf16 q: with fp8 q the mask is numerically wrong (fp8-specific;
+// root cause not identified), so fp8 q with `chunk_start_idx` asserts.
 ttnn::Tensor sparse_sdpa_msa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
@@ -23,6 +23,14 @@ namespace ttnn::transformer {
 //
 // Preconditions: d, v_dim, and block_size are multiples of 32; block_size divides T; TOPK*4 and output row
 // bytes meet DRAM alignment; each index row has at least one valid block; all valid block ids are < T/block_size.
+//
+// Causality: block selection in `indices` bounds it to block granularity. Pass `chunk_start_idx` (the global
+// position of query row 0) to additionally enforce a token-level causal mask on the diagonal block — required
+// for correct causal prefill, where a query's own block holds future tokens that must not be attended. Unset
+// (default) keeps the legacy block-only behavior. `cluster_axis` derives the per-device start under sequence
+// parallelism (chunk_start = chunk_start_idx + rank*S), mirroring `indexer_score_msa`. Causal masking requires
+// bf16 q: with fp8 q the mask is numerically wrong (fp8-specific; root cause not identified), so fp8 q with
+// `chunk_start_idx` is rejected.
 ttnn::Tensor sparse_sdpa_msa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
@@ -31,6 +39,8 @@ ttnn::Tensor sparse_sdpa_msa(
     std::optional<float> scale = std::nullopt,
     uint32_t block_size = 128,
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+    std::optional<uint32_t> cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> chunk_start_idx = std::nullopt,
+    std::optional<uint32_t> cluster_axis = std::nullopt);
 
 }  // namespace ttnn::transformer


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Current MSA implementation didn't apply intra-block causal attention. 
Block selection enforced causality only at block granularity, so a query's own block (if chosen) was attended in full, including the tokens after the query's position.

This PR introduces a token-level causal mask on the query token's own block, preventing it from attending to future tokens, improving accuracy in minimax M3 prefill.

Causal mask is opt-in via `chunk_start_idx`. 
The query's global position is computed using `chunk_start_idx` and per-device SP offset, and the mask is applied in the block containing the query.
```
chunk_start_idx + rank*S + s
S = per-device query length
s = local query row (0…S−1)
rank = device index along `cluster_axis`, 0 without SP
```

fp8 Q + causal now asserts due to accuracy issues (root cause not identified); bf16 is supported.

### Results
Minimax M3, France prompt: 
```
K PCC
  ┌────────┬────────┬────────┐
  │ layer  │ before │ after  │
  ├────────┼────────┼────────┤
  │ L4     │ 0.9952 │ 0.9981 │
  ├────────┼────────┼────────┤
  │ L24    │ 0.8857 │ 0.9871 │
  ├────────┼────────┼────────┤
  │ L44    │ 0.7774 │ 0.9765 │
  ├────────┼────────┼────────┤
  │ L52    │ 0.7565 │ 0.9666 │
  ├────────┼────────┼────────┤
  │ min/60 │ 0.73   │ 0.947  │
  └────────┴────────┴────────┘

V PCC
  ┌────────┬────────┬────────┐
  │ layer  │ before │ after  │
  ├────────┼────────┼────────┤
  │ L4     │ 0.9908 │ 0.9953 │
  ├────────┼────────┼────────┤
  │ L24    │ 0.8437 │ 0.9779 │
  ├────────┼────────┼────────┤
  │ L44    │ 0.6282 │ 0.9284 │
  ├────────┼────────┼────────┤
  │ L52    │ 0.5986 │ 0.9103 │
  ├────────┼────────┼────────┤
  │ min/60 │ 0.56   │ 0.879  │
  └────────┴────────┴────────┘
```
Minimax M3, 5120-token prompt
```
K PCC
    ┌────────┬────────┬────────┐
    │ layer  │ before │ after  │
    ├────────┼────────┼────────┤
    │ L4     │ 0.9951 │ 0.9980 │
    ├────────┼────────┼────────┤
    │ L24    │ 0.9068 │ 0.9918 │
    ├────────┼────────┼────────┤
    │ L44    │ 0.7196 │ 0.9704 │
    ├────────┼────────┼────────┤
    │ L52    │ 0.7554 │ 0.9674 │
    ├────────┼────────┼────────┤
    │ min/60 │ 0.72   │ 0.959  │
    └────────┴────────┴────────┘

  V PCC
    ┌────────┬────────┬────────┐
    │ layer  │ before │ after  │
    ├────────┼────────┼────────┤
    │ L4     │ 0.9916 │ 0.9958 │
    ├────────┼────────┼────────┤
    │ L24    │ 0.7462 │ 0.9742 │
    ├────────┼────────┼────────┤
    │ L44    │ 0.4746 │ 0.9277 │
    ├────────┼────────┼────────┤
    │ L52    │ 0.5440 │ 0.9061 │
    ├────────┼────────┼────────┤
    │ min/60 │ 0.446  │ 0.879  │
    └────────┴────────┴────────┘
```
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zbaczewski/sparse-sdpa-msa-causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zbaczewski/sparse-sdpa-msa-causal-mask)