### PR TITLE
[skip ci] Fix startup_failure on Blackhole sanity + l2-nightly (ttnn-post-commit renamed)

### DIFF
--- a/.github/workflows/blackhole-sanity-tests.yaml
+++ b/.github/workflows/blackhole-sanity-tests.yaml
@@ -193,7 +193,7 @@ jobs:
     needs: [resolve-docker-pull-refs, build-artifact, check-harbor]
     if: ${{ always() && !cancelled() && (inputs.run-ttnn-unit-tests == true || (github.event_name == 'schedule' && toJSON(inputs.schedule-runs-all-tests) != 'false')) }}
     secrets: inherit
-    uses: ./.github/workflows/ttnn-post-commit.yaml
+    uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml
     with:
       enabled-skus: "bh_p150b_civ2"
       docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -284,7 +284,7 @@ jobs:
     needs: [check-harbor, build-artifact]
     if: ${{ github.event_name == 'schedule' || (inputs.run_blackhole && inputs.run_p100_sanity_tests) }}
     secrets: inherit
-    uses: ./.github/workflows/ttnn-post-commit.yaml
+    uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml
     with:
       enabled-skus: "bh_p100"
       docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Every workflow_dispatch of the Blackhole sanity tests workflow has been failing with startup_failure since #48183 landed yesterday. The reorg PR renamed the ttnn post-commit workflow but left two stale references to `ttnn-post-commit.yaml`:

- `.github/workflows/blackhole-sanity-tests.yaml` line 196 (ttnn-unit-tests job)
- `.github/workflows/tt-metal-l2-nightly.yaml` line 287 (ttnn-p100-tests job, added in the same reorg)

GitHub Actions cannot resolve the reusable-workflow reference at dispatch time, so the run completes as `startup_failure` after ~6s with 0 jobs spawned.

Repro: https://github.com/tenstorrent/tt-metal/actions/runs/28515132120

### Changes
One-line fix in each file: `uses: ./.github/workflows/ttnn-post-commit.yaml` → `uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml`. Input schema matches; no other changes needed.

cc @tdowdall (author of #48183)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-blackhole-sanity-ttnn-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-blackhole-sanity-ttnn-ref)