### PR TITLE
[skip ci] Qwen2.5-VL perf gates: rebaseline 32B; investigate 72B decode drop

### DIFF
--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -1047,22 +1047,22 @@ targets:
             seq_len: 128
             status: active
             perf:
-              # TTFT is run-to-run unstable (observed 217–351ms across runs);
-              # target the slower observation with a wide tolerance so it gates
-              # gross regressions without flaking on the swing.
-              prefill_time_to_first_token: 351
+              # TTFT is run-to-run unstable and bimodal (observed ~205ms and ~327ms
+              # clusters across the last 8 scheduled runs, mean ~296ms). The old 351
+              # center left the tol-0.4 floor at 211ms, which the ~205ms cluster kept
+              # tripping ("much better than expected"). Center on the observed mean so
+              # the [178, 414] band spans both clusters and still gates gross regressions.
+              prefill_time_to_first_token: 296
               prefill_time_to_first_token_tolerance: 0.4
-              # decode_t/s/u is run-to-run unstable (observed 14.4-21.1 across runs,
-              # see #48510). The earlier 23.8 target was set pre-#48037; the on-device
-              # gibberish fix (#48037) traded decode throughput for correctness
-              # (per-step decode-input re-staging + eager, un-traced sampling), so
-              # sustained perf now centers ~18. This is a Tier 3 model (minimum
-              # coverage, not perf-optimized), so center on the post-fix mean with a
-              # wide 0.2 tolerance ([14.4, 21.6]) to gate gross regressions without
-              # flaking on the swing.
-              decode_t/s/u: 18.0
+              # decode_t/s/u is run-to-run unstable (see #48510). The earlier 18.0 center
+              # (set pre-data, post-#48037) is now stale-low: the last 8 scheduled runs
+              # measured ~19-25 t/s (mean ~22), so 22+ readings tripped the old 21.6
+              # ceiling ("better than expected"). Recenter on the observed mean ~22 with a
+              # wide 0.2 tolerance ([17.6, 26.4]) to absorb the swing while still catching
+              # gross regressions (e.g. a halving to ~11).
+              decode_t/s/u: 22.0
               decode_t_s_u_tolerance: 0.2
-              decode_t/s: 18.0
+              decode_t/s: 22.0
               decode_t_s_tolerance: 0.2
             accuracy: {}
             owner_id: U07RY6B5FLJ # Gongyu Wang

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -976,8 +976,17 @@ targets:
             status: active
             perf:
               prefill_time_to_first_token: 419
-              decode_t/s/u: 13.77
-              decode_t/s: 13.77
+              # b1 decode is run-to-run unstable: measured ~10.9-13.2 t/s across
+              # recent scheduled runs + 3 targeted reruns. The old 13.77 center
+              # sat at the top of the range, so its tol-0.15 floor (11.70) tripped
+              # on the low observations (10.87 on 06-30, 10.96 on a rerun).
+              # Recenter on the observed mean ~12 with a wide 0.2 tolerance
+              # ([9.6, 14.4]) to absorb the swing while still catching gross
+              # regressions (the one-off 07-01 collapse to 6.2 would still fail).
+              decode_t/s/u: 12.0
+              decode_t_s_u_tolerance: 0.2
+              decode_t/s: 12.0
+              decode_t_s_tolerance: 0.2
             accuracy: {}
             owner_id: U07RY6B5FLJ # Gongyu Wang
             team: models
@@ -985,6 +994,9 @@ targets:
             seq_len: 2048
             status: active
             perf:
+              # b32 aggregate decode verified healthy (324-381 t/s) across 3
+              # targeted reruns; the 07-01 scheduled drop to 184 t/s did not
+              # reproduce (confirmed one-off). Target/tolerance unchanged.
               prefill_time_to_first_token: 1163
               decode_t/s/u: 10.86
               decode_t/s: 347.6


### PR DESCRIPTION
## Summary

Group-D perf triage from the 2026-07-01 scheduled Tier 1/2/3 runs on `main`. Two Qwen2.5-VL perf efforts, both now resolved as **perf-gate rebaselines** (no model/code regressions):

1. **Qwen2.5-VL-32B (Tier 3 E2E, wh_llmbox_perf)** — gate flaking on TTFT + decode.
2. **Qwen2.5-VL-72B (Tier 2 E2E, wh_llmbox_perf)** — 07-01 decode collapse investigated → one-off anomaly + a separate flaky b1 gate.

## 1. Qwen2.5-VL-32B — gate rebaseline

The b1/seq128 gate flaked on both metrics vs the last 8 scheduled runs:

| Metric | Old center → band | New center → band | Why |
|---|---|---|---|
| `prefill_time_to_first_token` | 351ms → floor 211ms | **296ms** → [178, 414]ms | TTFT bimodal (~205 / ~327ms); old floor tripped the fast cluster |
| `decode_t/s(/u)` | 18.0 → [14.4, 21.6] | **22.0** → [17.6, 26.4] | recent runs 19–25 t/s; 22+ tripped the old ceiling |

## 2. Qwen2.5-VL-72B — collapse was a one-off; b1 gate recentered

Investigation of the 07-01 ~2× decode drop (b32 324→184 t/s, rising per-token curve):
- **Not a code regression.** The rising curve was **72B-only** (identical-code-path 32B-VL stayed flat), exonerating all shared SDPA-decode/KV changes incl. #47311.
- **3 targeted reruns confirmed it was a one-off**: b32 measured 324–381 t/s (healthy, flat) in all three; the collapse did not reproduce. b32 target/tolerance left **unchanged**.
- **Separate real finding:** the b1/seq128 decode gate is miscentered-high. b1 decode is run-to-run unstable (~10.9–13.2 t/s) but the 13.77 center put its tol-0.15 floor at 11.70, tripped by low reads (10.87 on 06-30, 10.96 on a rerun). **Recenter b1 decode 13.77 → 12.0 with 0.2 tolerance ([9.6, 14.4])** — absorbs the swing, still fails a gross regression (the 07-01 collapse to 6.2 would still trip).

All changes validated with `validate_perf_targets.py` (schema passes; recent nominal observations in-band; gross regressions still fail). Context: #48510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)