### PR TITLE
Regain sfpu abs int32 perf on wh

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -24,11 +24,13 @@ inline void calculate_abs() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs_int32() {
-    constexpr int32_t sign_magnitude_mask = 0x7FFFFFFF;
-    // SFPU microcode
+    // Kept as raw TTI intrinsics on purpose: SFPABS computes int32 abs in a single SFPU op. The sfpi
+    // `v & 0x7FFFFFFF` form (#48598) needed two extra per-element SFPLOADI to rebuild the mask inside
+    // the replay block, costing +30% cyc/tile. See docs/SFPI_ABS_INT32_REGRESSION_WH.md.
     for (int d = 0; d < ITERATIONS; d++) {
-        vInt v = dst_reg[0];
-        dst_reg[0] = v & sign_magnitude_mask;
+        TT_SFPLOAD(1, InstrModLoadStore::INT32, 3, 0);
+        TTI_SFPABS(0, 1, 0, 0);
+        TTI_SFPSTORE(0, InstrModLoadStore::INT32, 3, 0);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -26,7 +26,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs_int32() {
     // Kept as raw TTI intrinsics on purpose: SFPABS computes int32 abs in a single SFPU op. The sfpi
     // `v & 0x7FFFFFFF` form (#48598) needed two extra per-element SFPLOADI to rebuild the mask inside
-    // the replay block, costing +30% cyc/tile. See docs/SFPI_ABS_INT32_REGRESSION_WH.md.
+    // the replay block, costing +30% cyc/tile.
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(1, InstrModLoadStore::INT32, 3, 0);
         TTI_SFPABS(0, 1, 0, 0);


### PR DESCRIPTION
### PR Category
SFPU WH cleanup

### Summary
In code that was merged by https://github.com/tenstorrent/tt-metal/pull/48598/ it was observed that abs function for int32 perf has degraded. This was because of how code was generated from sfpi.

### Before — raw `TTI_SFPABS` (`main`): 36 instr / 144 B, fully unrolled ×8

```
00000000 <bench>:
   0: lui      a5,0x0
   4: mv       a5,a5
   8: lui      a4,0x7014c
   c: sw       a4,0(a5)        # push pre-encoded SFPLOAD (TT_SFPLOAD dynamic/register form)
  10: sfpabs   L0,L1,0         # single-instruction integer abs
  14: sfpstore L0,0,4,3
  18: ttincrwc 0,2,0,0
  ... (sw / sfpabs / sfpstore / ttincrwc block repeated 8×) ...
  8c: ret
```

Per element: `SFPLOAD` (via GPR push) + `SFPABS` + `SFPSTORE` = **3 SFPU ops**.

### After — sfpi `v & 0x7FFFFFFF` (merged): 15 instr / 60 B, replay-compressed

```
00000000 <bench>:
   0: ttreplay 0,6,1,1         # record 6 instructions
   4: sfpload  L0,0,12,3
   8: sfploadi L1,-1,2         # build mask 0x7FFFFFFF (low half)  <-- inside replay body
   c: sfploadi L1,32767,8      # build mask 0x7FFFFFFF (high half) <-- inside replay body
  10: sfpand   L0,L1           # abs via AND, not a dedicated abs op
  14: sfpstore L0,0,12,3
  18: ttincrwc 0,2,0,0
  1c: ttreplay 0,6,0,0         # replay ×7
  ...
  38: ret
```

Per element: `SFPLOAD` + `SFPLOADI` + `SFPLOADI` + `SFPAND` + `SFPSTORE` = **5 SFPU ops**.

This PR reverts the change back to TTI

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/regain_abs_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/regain_abs_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ldjurovic/regain_abs_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/regain_abs_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/regain_abs_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/regain_abs_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/regain_abs_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/regain_abs_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/regain_abs_perf)