### PR TITLE
[LLK] [Test Only] Add pack and unpack reconfig tests

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from itertools import product
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import (
+    DestAccumulation,
+)
+from helpers.param_config import parametrize
+from helpers.tensix import TensixState
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import CONFIGURE_TEST_RUN_IDX
+
+# exp_section_size is only required in a reconfig when the next dest is BFP, INT8, or FP8.
+# set_packer_config writes it for all dest formats, so reconfig leaves it stale and that leak is expected.
+_BFP_FORMATS = {
+    DataFormat.Bfp8,
+    DataFormat.Bfp8_b,
+    DataFormat.Bfp4_b,
+    DataFormat.Bfp2_b,
+}
+_FP8_FORMATS = {
+    f
+    for f in (getattr(DataFormat, "Fp8_e4m3", None), getattr(DataFormat, "Lf8", None))
+    if f is not None
+}
+_EXP_SECTION_SIZE_KEY = "exp_section_size"
+
+
+def _exp_section_size_required(dst: DataFormat) -> bool:
+    return dst in _BFP_FORMATS or dst == DataFormat.Int8 or dst in _FP8_FORMATS
+
+
+def _drop_key(state, key):
+    if isinstance(state, dict):
+        return {k: _drop_key(v, key) for k, v in state.items() if k != key}
+    if isinstance(state, list):
+        return [_drop_key(v, key) for v in state]
+    return state
+
+
+def generate_valid_formats(
+    formats: list[DataFormat],
+) -> list[tuple[DataFormat, DataFormat, DataFormat, DataFormat]]:
+    groups = [
+        [f for f in formats if f.is_exponent_A()],
+        [f for f in formats if f.is_exponent_B()],
+        [f for f in formats if f.is_integer()],
+    ]
+
+    return [
+        combo
+        for prev_group in groups
+        for next_group in groups
+        for combo in product(prev_group, prev_group, next_group, next_group)
+    ]
+
+
+def get_valid_dest_acc(
+    formats: tuple[DataFormat, DataFormat, DataFormat, DataFormat],
+) -> bool:
+    return (
+        [DestAccumulation.Yes]
+        if any(f.is_integer() for f in formats)
+        else [DestAccumulation.No, DestAccumulation.Yes]
+    )
+
+
+@parametrize(
+    formats=generate_valid_formats(
+        [
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+            DataFormat.Bfp8,
+            DataFormat.Bfp8_b,
+            DataFormat.Float32,
+            DataFormat.Int32,
+            DataFormat.Tf32,
+            DataFormat.UInt32,
+            DataFormat.UInt16,
+            DataFormat.Int8,
+            DataFormat.UInt8,
+        ]
+    ),
+    dest_acc=lambda formats: get_valid_dest_acc(formats),
+)
+def test_pack_reconfig(
+    formats,
+    dest_acc,
+):
+    prev_src, prev_dst, next_src, next_dst = formats
+
+    configuration = TestConfig(
+        "sources/state/reconfig/pack_reconfig_test.cpp",
+        FormatConfig(
+            prev_src, prev_dst, next_src, next_dst, DataFormat.Float32
+        ),  # slot overload: unpack_A_src/dst = prev, pack_src/dst = next
+        runtimes=[
+            CONFIGURE_TEST_RUN_IDX(0),
+        ],
+        dest_acc=dest_acc,
+    )
+
+    configuration.run()
+    expected = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    # Only the runtime parameter changes between runs.
+    configuration.runtimes = [CONFIGURE_TEST_RUN_IDX(1)]
+
+    configuration.run()
+    actual = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    if not _exp_section_size_required(next_dst):
+        expected = _drop_key(expected, _EXP_SECTION_SIZE_KEY)
+        actual = _drop_key(actual, _EXP_SECTION_SIZE_KEY)
+
+    TensixState.assert_equal(expected, actual)

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
@@ -32,7 +32,11 @@ _IGNORED_GROUPS = ("address_counters", "register_window_counters")
 
 
 def _exp_section_size_required(dst: DataFormat) -> bool:
-    return dst in _BFP_FORMATS or dst in {DataFormat.Int8, DataFormat.UInt8} or dst in _FP8_FORMATS
+    return (
+        dst in _BFP_FORMATS
+        or dst in {DataFormat.Int8, DataFormat.UInt8}
+        or dst in _FP8_FORMATS
+    )
 
 
 def _drop_key(state, key):

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
@@ -32,7 +32,7 @@ _IGNORED_GROUPS = ("address_counters", "register_window_counters")
 
 
 def _exp_section_size_required(dst: DataFormat) -> bool:
-    return dst in _BFP_FORMATS or dst == DataFormat.Int8 or dst in _FP8_FORMATS
+    return dst in _BFP_FORMATS or dst in {DataFormat.Int8, DataFormat.UInt8} or dst in _FP8_FORMATS
 
 
 def _drop_key(state, key):

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
@@ -27,6 +27,9 @@ _FP8_FORMATS = {
 }
 _EXP_SECTION_SIZE_KEY = "exp_section_size"
 
+# These may vary run to run. Excluded so that tests don't fail spuriously.
+_IGNORED_GROUPS = ("address_counters", "register_window_counters")
+
 
 def _exp_section_size_required(dst: DataFormat) -> bool:
     return dst in _BFP_FORMATS or dst == DataFormat.Int8 or dst in _FP8_FORMATS
@@ -110,6 +113,10 @@ def test_pack_reconfig(
 
     configuration.run()
     actual = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    for group in _IGNORED_GROUPS:
+        expected.pop(group, None)
+        actual.pop(group, None)
 
     if not _exp_section_size_required(next_dst):
         expected = _drop_key(expected, _EXP_SECTION_SIZE_KEY)

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_pack_reconfig.py
@@ -12,8 +12,6 @@ from helpers.tensix import TensixState
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import CONFIGURE_TEST_RUN_IDX
 
-# exp_section_size is only required in a reconfig when the next dest is BFP, INT8, or FP8.
-# set_packer_config writes it for all dest formats, so reconfig leaves it stale and that leak is expected.
 _BFP_FORMATS = {
     DataFormat.Bfp8,
     DataFormat.Bfp8_b,
@@ -25,18 +23,14 @@ _FP8_FORMATS = {
     for f in (getattr(DataFormat, "Fp8_e4m3", None), getattr(DataFormat, "Lf8", None))
     if f is not None
 }
-_EXP_SECTION_SIZE_KEY = "exp_section_size"
+_INT8_FORMATS = {DataFormat.Int8, DataFormat.UInt8}
 
 # These may vary run to run. Excluded so that tests don't fail spuriously.
 _IGNORED_GROUPS = ("address_counters", "register_window_counters")
 
 
 def _exp_section_size_required(dst: DataFormat) -> bool:
-    return (
-        dst in _BFP_FORMATS
-        or dst in {DataFormat.Int8, DataFormat.UInt8}
-        or dst in _FP8_FORMATS
-    )
+    return dst in _BFP_FORMATS or dst in _INT8_FORMATS or dst in _FP8_FORMATS
 
 
 def _drop_key(state, key):
@@ -123,7 +117,7 @@ def test_pack_reconfig(
         actual.pop(group, None)
 
     if not _exp_section_size_required(next_dst):
-        expected = _drop_key(expected, _EXP_SECTION_SIZE_KEY)
-        actual = _drop_key(actual, _EXP_SECTION_SIZE_KEY)
+        expected = _drop_key(expected, "exp_section_size")
+        actual = _drop_key(actual, "exp_section_size")
 
     TensixState.assert_equal(expected, actual)

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_unpack_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_unpack_reconfig.py
@@ -10,6 +10,9 @@ from helpers.tensix import TensixState
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import CONFIGURE_TEST_RUN_IDX, TO_FROM_INT8
 
+# These may vary run to run. Excluded so that tests don't fail spuriously.
+_IGNORED_GROUPS = ("address_counters", "register_window_counters")
+
 FORMATS = [
     (
         DataFormat.Float16,
@@ -120,5 +123,9 @@ def test_unpack_reconfig(
 
     configuration.run()
     actual = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    for group in _IGNORED_GROUPS:
+        expected.pop(group, None)
+        actual.pop(group, None)
 
     TensixState.assert_equal(expected, actual)

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_unpack_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_unpack_reconfig.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import (
+    DestAccumulation,
+)
+from helpers.param_config import parametrize
+from helpers.tensix import TensixState
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import CONFIGURE_TEST_RUN_IDX, TO_FROM_INT8
+
+FORMATS = [
+    (
+        DataFormat.Float16,
+        DataFormat.Float16,
+        DataFormat.Bfp8,
+        DataFormat.Bfp8,
+    ),  # expA->expA
+    (
+        DataFormat.Float32,
+        DataFormat.Float32,
+        DataFormat.Float16,
+        DataFormat.Float16,
+    ),  # expB->expA
+    (
+        DataFormat.Float16,
+        DataFormat.Float16,
+        DataFormat.Float16_b,
+        DataFormat.Float16_b,
+    ),  # expA->expB
+    (
+        DataFormat.Bfp8,
+        DataFormat.Bfp8,
+        DataFormat.Bfp8_b,
+        DataFormat.Bfp8_b,
+    ),  # expA->expB
+    (
+        DataFormat.Float16,
+        DataFormat.Float16,
+        DataFormat.Int8,
+        DataFormat.Int8,
+    ),  # expA->int
+    (
+        DataFormat.Float16_b,
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+        DataFormat.Float16,
+    ),  # expB->expA
+    (
+        DataFormat.Float16_b,
+        DataFormat.Float16_b,
+        DataFormat.Bfp8_b,
+        DataFormat.Bfp8_b,
+    ),  # expB->expB
+    (
+        DataFormat.Float16_b,
+        DataFormat.Float16_b,
+        DataFormat.Int8,
+        DataFormat.Int8,
+    ),  # expB->int
+    (
+        DataFormat.Int8,
+        DataFormat.Int8,
+        DataFormat.Float16,
+        DataFormat.Float16,
+    ),  # int->expA
+    (
+        DataFormat.Int8,
+        DataFormat.Int8,
+        DataFormat.Bfp8_b,
+        DataFormat.Bfp8_b,
+    ),  # int->expB
+    (
+        DataFormat.Int8,
+        DataFormat.Int8,
+        DataFormat.Int32,
+        DataFormat.Int32,
+    ),  # int->int
+    (
+        DataFormat.Bfp8_b,
+        DataFormat.Bfp8_b,
+        DataFormat.Float16_b,
+        DataFormat.Float16_b,
+    ),  # leave BFP
+]
+
+
+@parametrize(
+    formats=FORMATS,
+    to_from_int8=lambda formats: any(f.is_integer() for f in formats),
+    dest_acc=DestAccumulation.Yes,
+)
+def test_unpack_reconfig(
+    formats,
+    to_from_int8,
+    dest_acc,
+):
+    prev_src, prev_dst, next_src, next_dst = formats
+
+    configuration = TestConfig(
+        "sources/state/reconfig/unpack_reconfig_test.cpp",
+        FormatConfig(
+            prev_src, prev_dst, next_src, next_dst, DataFormat.Float32
+        ),  # slot overload: unpack_A_src/dst = prev, pack_src/dst = next
+        templates=[
+            TO_FROM_INT8(to_from_int8),
+        ],
+        runtimes=[
+            CONFIGURE_TEST_RUN_IDX(0),
+        ],
+        dest_acc=dest_acc,
+    )
+
+    configuration.run()
+    expected = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    # Only the runtime parameter changes between runs.
+    configuration.runtimes = [CONFIGURE_TEST_RUN_IDX(1)]
+
+    configuration.run()
+    actual = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    TensixState.assert_equal(expected, actual)

--- a/tt_metal/tt-llk/tests/sources/state/reconfig/pack_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/state/reconfig/pack_reconfig_test.cpp
@@ -1,0 +1,67 @@
+
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Configuring a format directly (run_idx 0) must leave the same packer state as
+// reconfiguring to it from another format (run_idx 1). FormatConfig carries the
+// prev formats in the unpack_A slots and the next formats in the pack slots.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "params.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    const std::uint32_t prev_src = (std::uint32_t)params.formats.unpack_A_src;
+    const std::uint32_t prev_dst = (std::uint32_t)params.formats.unpack_A_dst;
+    const std::uint32_t next_src = (std::uint32_t)params.formats.pack_src;
+    const std::uint32_t next_dst = (std::uint32_t)params.formats.pack_dst;
+
+    // Distinct prev/next tile sizes; both paths need to hit NEXT_SIZE.
+    constexpr std::uint32_t PREV_SIZE = 16 * 16 * 2;
+    constexpr std::uint32_t NEXT_SIZE = 16 * 16 * 4;
+
+    if (params.CONFIGURE_TEST_RUN_IDX == 0)
+    {
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(next_src, next_dst, NEXT_SIZE);
+    }
+    else
+    {
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(prev_src, prev_dst, PREV_SIZE);
+        _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(next_src, next_dst, NEXT_SIZE);
+    }
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/state/reconfig/pack_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/state/reconfig/pack_reconfig_test.cpp
@@ -62,6 +62,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(prev_src, prev_dst, PREV_SIZE);
         _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(next_src, next_dst, NEXT_SIZE);
     }
+
+    ckernel::packer::are_packers_configured_correctly(next_src, next_dst);
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/state/reconfig/unpack_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/state/reconfig/unpack_reconfig_test.cpp
@@ -1,0 +1,73 @@
+
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Configuring a format directly (run_idx 0) must leave the same unpack state as
+// reconfiguring srcA/srcB to it from another format (run_idx 1). FormatConfig carries
+// the prev formats in the unpack_A slots and the next formats in the pack slots.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "params.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    const std::uint32_t prev_src = (std::uint32_t)params.formats.unpack_A_src;
+    const std::uint32_t prev_dst = (std::uint32_t)params.formats.unpack_A_dst;
+    const std::uint32_t next_src = (std::uint32_t)params.formats.pack_src;
+    const std::uint32_t next_dst = (std::uint32_t)params.formats.pack_dst;
+
+    // Distinct prev/next tile sizes; both paths need to hit NEXT_SIZE.
+    constexpr std::uint32_t PREV_SIZE = 16 * 16 * 2;
+    constexpr std::uint32_t NEXT_SIZE = 16 * 16 * 4;
+    constexpr std::uint32_t num_faces = 4;
+
+    if (params.CONFIGURE_TEST_RUN_IDX == 0)
+    {
+        _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+            next_src, next_src, next_dst, next_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces, NEXT_SIZE, NEXT_SIZE);
+    }
+    else
+    {
+        _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+            prev_src, prev_src, prev_dst, prev_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces, PREV_SIZE, PREV_SIZE);
+
+        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, TO_FROM_INT8>(
+            next_src, next_dst, NEXT_SIZE, FACE_R_DIM, num_faces);
+        _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, TO_FROM_INT8>(
+            next_src, next_dst, NEXT_SIZE, FACE_R_DIM, num_faces);
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/state/reconfig/unpack_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/state/reconfig/unpack_reconfig_test.cpp
@@ -52,6 +52,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, TO_FROM_INT8>(
             next_src, next_dst, NEXT_SIZE, FACE_R_DIM, num_faces);
     }
+
+    ckernel::unpacker::are_unpackers_AB_configured_correctly(next_src, next_dst, next_src, next_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 }
 
 #endif


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Closes #48721.
`test_pack_reconfig.py`: `exp_section_size` is asserted for bfp, fp8 and int8, and ignored for other formats since it's irrelevant, packer doesn't consume it. Unlike pack reconfig, the full config sets that field so it's technically an escape but an inconsequential one.
`test_unpack_reconfig.py`: only allowed combinations are tested.

### Notes for reviewers
No code change. The two new tests exclude `address_counters` and `register_window_counters` from the assertions. Those two fields make the test seldom fail spuriously.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iklikovac/llk_reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iklikovac/llk_reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iklikovac/llk_reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iklikovac/llk_reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iklikovac/llk_reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iklikovac/llk_reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iklikovac/llk_reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iklikovac/llk_reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iklikovac/llk_reconfig)