### PR TITLE
Fix scalar divide-by-zero checks

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -18,6 +18,41 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 )
 
 
+def _data_gen_div_scalar_input(input_shapes, low, high, device, divisor):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, low, high, device)
+    if divisor == 0.0:
+        # Avoid 0/0: bf16 fast_and_approximate divide returns 0 instead of NaN.
+        zero_mask = in_data1 == 0
+        if zero_mask.any():
+            in_data1 = in_data1.clone()
+            in_data1[zero_mask] = 1.0
+            input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    return in_data1, input_tensor1
+
+
+def _assert_div_by_zero_outputs(golden_tensor, tt_tensor):
+    """Divide-by-zero: match non-finite positions and inf signs; ULP on any finite elements."""
+    tt_out = tt_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    g_nonfinite = ~torch.isfinite(golden_tensor)
+    d_nonfinite = ~torch.isfinite(tt_out)
+    assert torch.equal(g_nonfinite, d_nonfinite), "Non-finite positions differ between golden and device"
+    both_inf = torch.isinf(golden_tensor) & torch.isinf(tt_out)
+    if both_inf.any():
+        assert torch.equal(
+            torch.sign(golden_tensor[both_inf]),
+            torch.sign(tt_out[both_inf]),
+        ), "Inf sign mismatch between golden and device"
+    finite_mask = torch.isfinite(golden_tensor) & torch.isfinite(tt_out)
+    if finite_mask.any():
+        # Safety net: non-zero / 0.0 always yields ±inf after zero replacement above,
+        # so this branch is not reached under current parametrization.
+        assert_with_ulp(
+            golden_tensor[finite_mask],
+            tt_out[finite_mask],
+            ulp_threshold=3,
+        )
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -226,7 +261,13 @@ def test_binary_div_ttnn_opt(fast_and_approximate_mode, rounding_mode, input_sha
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
 def test_binary_div_scalar_ttnn(fast_and_approximate_mode, rounding_mode, input_shapes, value, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    # Skip only rounding_mode=None + fast_and_approximate: trunc/floor of non-zero/0.0
+    # always yields ±inf and is verifiable; rounding_mode=None returns 0 instead (#43209).
+    if value == 0.0 and rounding_mode is None and fast_and_approximate_mode:
+        pytest.skip(
+            "Skipping test case due to division by zero not being handled properly in bfloat16 with rounding_mode=None and fast_and_approximate_mode=True"
+        )
+    in_data1, input_tensor1 = _data_gen_div_scalar_input(input_shapes, -100, 100, device, value)
 
     output_tensor = ttnn.div(
         input_tensor1, value, fast_and_approximate_mode=fast_and_approximate_mode, rounding_mode=rounding_mode
@@ -234,8 +275,11 @@ def test_binary_div_scalar_ttnn(fast_and_approximate_mode, rounding_mode, input_
     golden_function = ttnn.get_golden_function(ttnn.div)
     golden_tensor = golden_function(in_data1, value, rounding_mode)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    if value == 0.0:
+        _assert_div_by_zero_outputs(golden_tensor, output_tensor)
+    else:
+        comp_pass = compare_pcc([output_tensor], [golden_tensor])
+        assert comp_pass
 
 
 @pytest.mark.parametrize("fast_and_approximate_mode", [True, False])
@@ -250,7 +294,13 @@ def test_binary_div_scalar_ttnn(fast_and_approximate_mode, rounding_mode, input_
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
 def test_binary_div_scalar_ttnn_opt(fast_and_approximate_mode, rounding_mode, input_shapes, value, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    # Skip only rounding_mode=None + fast_and_approximate: trunc/floor of non-zero/0.0
+    # always yields ±inf and is verifiable; rounding_mode=None returns 0 instead (#43209).
+    if value == 0.0 and rounding_mode is None and fast_and_approximate_mode:
+        pytest.skip(
+            "Skipping test case due to division by zero not being handled properly in bfloat16 with rounding_mode=None and fast_and_approximate_mode=True"
+        )
+    in_data1, input_tensor1 = _data_gen_div_scalar_input(input_shapes, -100, 100, device, value)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
     cq_id = 0
@@ -264,8 +314,11 @@ def test_binary_div_scalar_ttnn_opt(fast_and_approximate_mode, rounding_mode, in
     golden_function = ttnn.get_golden_function(ttnn.div)
     golden_tensor = golden_function(in_data1, value, rounding_mode)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    if value == 0.0:
+        _assert_div_by_zero_outputs(golden_tensor, output_tensor)
+    else:
+        comp_pass = compare_pcc([output_tensor], [golden_tensor])
+        assert comp_pass
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -12,7 +12,7 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     compare_pcc,
     compare_equal,
 )
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_div_by_zero_outputs
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -21,36 +21,15 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 def _data_gen_div_scalar_input(input_shapes, low, high, device, divisor):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, low, high, device)
     if divisor == 0.0:
-        # Avoid 0/0: bf16 fast_and_approximate divide returns 0 instead of NaN.
+        # Avoid 0/0: bf16 fast_and_approximate divide returns 0 instead of NaN (#43209).
         zero_mask = in_data1 == 0
         if zero_mask.any():
             in_data1 = in_data1.clone()
             in_data1[zero_mask] = 1.0
-            input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            input_tensor1 = ttnn.from_torch(
+                in_data1, dtype=input_tensor1.dtype, layout=input_tensor1.layout, device=device
+            )
     return in_data1, input_tensor1
-
-
-def _assert_div_by_zero_outputs(golden_tensor, tt_tensor):
-    """Divide-by-zero: match non-finite positions and inf signs; ULP on any finite elements."""
-    tt_out = tt_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-    g_nonfinite = ~torch.isfinite(golden_tensor)
-    d_nonfinite = ~torch.isfinite(tt_out)
-    assert torch.equal(g_nonfinite, d_nonfinite), "Non-finite positions differ between golden and device"
-    both_inf = torch.isinf(golden_tensor) & torch.isinf(tt_out)
-    if both_inf.any():
-        assert torch.equal(
-            torch.sign(golden_tensor[both_inf]),
-            torch.sign(tt_out[both_inf]),
-        ), "Inf sign mismatch between golden and device"
-    finite_mask = torch.isfinite(golden_tensor) & torch.isfinite(tt_out)
-    if finite_mask.any():
-        # Safety net: non-zero / 0.0 always yields ±inf after zero replacement above,
-        # so this branch is not reached under current parametrization.
-        assert_with_ulp(
-            golden_tensor[finite_mask],
-            tt_out[finite_mask],
-            ulp_threshold=3,
-        )
 
 
 @pytest.mark.parametrize(
@@ -276,7 +255,7 @@ def test_binary_div_scalar_ttnn(fast_and_approximate_mode, rounding_mode, input_
     golden_tensor = golden_function(in_data1, value, rounding_mode)
 
     if value == 0.0:
-        _assert_div_by_zero_outputs(golden_tensor, output_tensor)
+        assert_div_by_zero_outputs(golden_tensor, ttnn.to_torch(output_tensor))
     else:
         comp_pass = compare_pcc([output_tensor], [golden_tensor])
         assert comp_pass
@@ -315,7 +294,7 @@ def test_binary_div_scalar_ttnn_opt(fast_and_approximate_mode, rounding_mode, in
     golden_tensor = golden_function(in_data1, value, rounding_mode)
 
     if value == 0.0:
-        _assert_div_by_zero_outputs(golden_tensor, output_tensor)
+        assert_div_by_zero_outputs(golden_tensor, ttnn.to_torch(output_tensor))
     else:
         comp_pass = compare_pcc([output_tensor], [golden_tensor])
         assert comp_pass

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -9,7 +9,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_div_by_zero_outputs
 
 pytestmark = pytest.mark.use_module_device
 
@@ -822,27 +822,7 @@ def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, 
     torch_output_tensor = golden_fn(torch_input_tensor_a, scalar)
 
     if ttnn_fn == "divide" and scalar == 0.0:
-        # Golden/device can disagree on NaN vs Inf at a position; compare non-finite
-        # positions, then verify inf signs match where both sides are inf.
-        g_nonfinite = ~torch.isfinite(torch_output_tensor)
-        d_nonfinite = ~torch.isfinite(tt_output_tensor)
-        assert torch.equal(g_nonfinite, d_nonfinite), "Non-finite positions differ between golden and device"
-        both_inf = torch.isinf(torch_output_tensor) & torch.isinf(tt_output_tensor)
-        if both_inf.any():
-            assert torch.equal(
-                torch.sign(torch_output_tensor[both_inf]),
-                torch.sign(tt_output_tensor[both_inf]),
-            ), "Inf sign mismatch between golden and device"
-        # ULP on elements where both sides are finite. Device-finite vs golden-non-finite
-        # is already caught by the mask assert above. Not reached today (randn/0.0 is
-        # all non-finite); guards future parametrizations with finite golden elements.
-        finite_mask = torch.isfinite(torch_output_tensor) & torch.isfinite(tt_output_tensor)
-        if finite_mask.any():
-            assert_with_ulp(
-                torch_output_tensor[finite_mask],
-                tt_output_tensor[finite_mask],
-                ulp_threshold=3,
-            )
+        assert_div_by_zero_outputs(torch_output_tensor, tt_output_tensor)
     else:
         assert_with_ulp(
             torch_output_tensor,

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -848,3 +848,29 @@ def assert_numeric_metrics(
         assert overall_passed, full_message
     else:
         return overall_passed, full_message
+
+
+def assert_div_by_zero_outputs(
+    golden_tensor: torch.Tensor, device_tensor: torch.Tensor, *, ulp_threshold: int = 3
+) -> None:
+    """Assert correctness of divide-by-zero outputs (golden assumed all-±inf after zero-replacement).
+
+    Three-part check:
+    1. Non-finite position mask matches exactly.
+    2. Inf sign matches where both sides are inf.
+    3. ULP safety net on any finite elements (not reached under current parametrization
+       when the numerator contains no zeros and divisor is 0.0).
+    """
+    g_nonfinite = ~torch.isfinite(golden_tensor)
+    d_nonfinite = ~torch.isfinite(device_tensor)
+    assert torch.equal(g_nonfinite, d_nonfinite), "Non-finite positions differ between golden and device"
+    both_inf = torch.isinf(golden_tensor) & torch.isinf(device_tensor)
+    if both_inf.any():
+        assert torch.equal(
+            torch.sign(golden_tensor[both_inf]),
+            torch.sign(device_tensor[both_inf]),
+        ), "Inf sign mismatch between golden and device"
+    finite_mask = torch.isfinite(golden_tensor) & torch.isfinite(device_tensor)
+    if finite_mask.any():
+        # Safety net: not reached when golden is all ±inf after zero replacement.
+        assert_with_ulp(golden_tensor[finite_mask], device_tensor[finite_mask], ulp_threshold=ulp_threshold)


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/49480

### PR Category
Test Only

### Summary

Three targeted test-only fixes:
* Skip `value=0.0` + `fast_and_approximate_mode=True` + `rounding_mode=None` (same as `test_binary_fp32.py` / [#29953](https://github.com/tenstorrent/tt-metal/pull/29953), bug [#43209](https://github.com/tenstorrent/tt-metal/issues/43209)); device returns `0` instead of `NaN`/`inf` for `0/0`, making assertion meaningless
* `_data_gen_div_scalar_input` — replaces any zero numerators with `1.0` when `divisor=0.0`, ensuring golden never produces `NaN`
* Replace `compare_pcc` for `value=0.0` with a three-part check: non-finite position mask → inf sign match → ULP safety net on finite elements

Also extracted the divide-by-zero assertion as `assert_div_by_zero_outputs` into `tests/ttnn/utils_for_testing.py`, replacing the equivalent inline block in `test_binary_ng_typecast.py` 


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/div_pcc_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/div_pcc_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/div_pcc_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/div_pcc_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/div_pcc_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/div_pcc_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/div_pcc_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/div_pcc_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/div_pcc_issue)