### PR TITLE
GLM-5.1 sparse MLA at tp=4 (head→sequence reshard)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -82,13 +82,13 @@ def _sparse_cases(seqs, anchor_only):
     """Generate (variant, mesh, seq_len) params for the CURRENT box — only valid combos, so the
     collected matrix equals the run matrix (validity is enforced here, not via runtime skips)."""
     meshes = _sparse_meshes()
+    chosen = [_anchor_mesh(meshes)] if (anchor_only and meshes) else meshes
     cases = []
-    for variant_name in SPARSE_VARIANTS:
-        chosen = [_anchor_mesh(meshes)] if (anchor_only and meshes) else meshes
-        for mesh in chosen:
-            for seq_len in seqs:
-                if not _seq_ok_for_mesh(seq_len, mesh):
-                    continue
+    for mesh in chosen:
+        for seq_len in seqs:
+            if not _seq_ok_for_mesh(seq_len, mesh):
+                continue
+            for variant_name in SPARSE_VARIANTS:
                 cases.append(
                     pytest.param(variant_name, mesh, seq_len, id=f"{variant_name}-{mesh[0]}x{mesh[1]}-seq{seq_len}")
                 )

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -68,25 +68,14 @@ def _sparse_meshes():
     return SPARSE_MESH_BY_DEVICES.get(n, [(1, max(n, 1))])
 
 
-# GLM exception (expected to be temporary): sparse_sdpa needs per-chip n_heads/tp >= 32, and GLM has
-# only 64 q-heads, so it caps at TP=2. DeepSeek (128 heads) has no such limit. Handled locally here
-# rather than as a TestVariant field, so this soon-to-be-lifted limitation doesn't leak into the
-# generic variant metadata (and the other models).
-_GLM_MAX_TP = 2
-
-
-def _mesh_ok_for_variant(variant_name, mesh):
-    return not (variant_name == "glm_5_1" and mesh[1] > _GLM_MAX_TP)
-
-
 def _seq_ok_for_mesh(seq_len, mesh):
     # kvpe ND-shard cache needs >= KVPE_MIN_TOKENS_PER_CHIP tokens per SP shard.
     return seq_len // mesh[0] >= KVPE_MIN_TOKENS_PER_CHIP
 
 
-def _anchor_mesh(variant_name, meshes):
-    """Production-closest mesh for a variant: the highest TP it supports among the box's meshes."""
-    return max((m for m in meshes if _mesh_ok_for_variant(variant_name, m)), key=lambda m: m[1])
+def _anchor_mesh(meshes):
+    """Production-closest mesh: the highest-TP mesh among the box's meshes."""
+    return max(meshes, key=lambda m: m[1])
 
 
 def _sparse_cases(seqs, anchor_only):
@@ -95,8 +84,7 @@ def _sparse_cases(seqs, anchor_only):
     meshes = _sparse_meshes()
     cases = []
     for variant_name in SPARSE_VARIANTS:
-        usable = [m for m in meshes if _mesh_ok_for_variant(variant_name, m)]
-        chosen = [_anchor_mesh(variant_name, meshes)] if (anchor_only and usable) else usable
+        chosen = [_anchor_mesh(meshes)] if (anchor_only and meshes) else meshes
         for mesh in chosen:
             for seq_len in seqs:
                 if not _seq_ok_for_mesh(seq_len, mesh):

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1219,6 +1219,29 @@ class ttMLA:
             cluster_axis=self.sp_axis,
         )
 
+    def _tp_all_gather(self, t, dim):
+        """All-gather across the TP axis → replicated on TP. tp=1: no-op."""
+        if self.tp_factor == 1:
+            return t
+        return ttnn.experimental.all_gather_async(
+            t,
+            dim=dim,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.ccl_topology,
+            cluster_axis=self.tp_axis,
+        )
+
+    @property
+    def _sparse_head_reshard(self) -> bool:
+        """True when the per-chip MLA head shard is too thin for sparse_sdpa (needs H % 32 == 0 and
+        H >= 32). When the TP head shard is too thin (e.g. GLM's 64 heads at tp=4 → 16), _sparse_mla
+        transposes the TP sharding axis heads → sequence for the duration of the attention."""
+        h_local = self.num_heads // self.tp_factor
+        return self.tp_factor > 1 and (h_local < 32 or h_local % 32 != 0)
+
     def _sparse_mla(self, q: ttnn.Tensor, kvpe: ttnn.Tensor, indices: ttnn.Tensor) -> ttnn.Tensor:
         """Absorbed MQA over the top-k selected latents (FlashMLA sparse contract: no causal mask —
         ``indices`` already encode it via the 0xFFFFFFFF sentinel). Invoked SPMD on the SP×TP mesh:
@@ -1229,13 +1252,38 @@ class ttMLA:
         replicated (K = full 576, V = leading kv_lora_rank). indices: [1, 1, S_global, k] uint32 replicated,
         re-sharded onto SP (dim2) to match q when sp > 1 (or already SP-sharded → pass through)."""
         assert self.sp_axis == 0 and self.tp_axis == 1, "sparse_mla assumes sp_axis=0 (outer), tp_axis=1"
-        sp = list(q.device().shape)[self.sp_axis]
-        q_rm = ttnn.to_layout(q, ttnn.ROW_MAJOR_LAYOUT)  # the op is ROW_MAJOR-only; q comes in TILE
+        sp = self.sp_factor
+        s_local = q.shape[2]  # per-chip query rows == S / sp
+
+        # sparse_sdpa requires per-chip heads H % 32 == 0 and H >= 32. When the TP head shard is too
+        # thin (e.g. GLM's 64 heads at tp=4 → 16), transpose the TP sharding axis from heads to sequence
+        # for the duration of the attention: all-gather q's heads over TP (each chip regains all H heads),
+        # then re-shard the sequence over TP so every chip attends a DISTINCT seq slice in parallel at full
+        # H. After the op we invert it (gather seq, re-shard heads) to restore the head-sharded layout the
+        # wkv_b2 / o_proj epilogue expects. No padded/wasted heads; tp=1 and already-fat shards are untouched.
+        # The SP indexer emits S/sp indices; we split them over TP below to match the resharded q rows.
+        reshard = self._sparse_head_reshard
+
+        q_work = q
+        if reshard:
+            q_work = self._tp_all_gather(q, dim=1)  # [1, H, S/sp, 576] replicated on TP
+            q_work = ttnn.mesh_partition(q_work, dim=2, cluster_axis=self.tp_axis)  # [1, H, S/(sp·tp), 576]
+
+        q_rm = ttnn.to_layout(q_work, ttnn.ROW_MAJOR_LAYOUT)  # the op is ROW_MAJOR-only; q comes in TILE
+        if q_work is not q:
+            ttnn.deallocate(q_work)
+
+        # indices must match q_rm's seq sharding. Incoming is replicated full-glob [1,1,S_global,k] or
+        # SP-sharded [1,1,S/sp,k]; under reshard the row count must drop to S/(sp·tp), so split over TP.
         idx = indices
-        if sp > 1 and indices.shape[2] == q.shape[2] * sp:
-            # Replicated full-glob indices → reshard rows onto the SP axis (inverse of all_gather), matching
-            # q's per-chip seq shard. Already-SP-sharded indices ([1,1,S/sp,k]) match q and pass through.
+        if sp > 1 and indices.shape[2] == s_local * sp:
+            # Replicated full-glob indices → reshard rows onto the SP axis (inverse of all_gather).
             idx = ttnn.mesh_partition(indices, dim=2, cluster_axis=self.sp_axis)
+        if reshard and idx.shape[2] != q_rm.shape[2]:
+            idx_tp = ttnn.mesh_partition(idx, dim=2, cluster_axis=self.tp_axis)  # split seq across TP to match q
+            if idx is not indices:
+                ttnn.deallocate(idx)
+            idx = idx_tp
         # k_chunk_size must be a multiple of 32 that divides TOPK (prod TOPK=2048 → 128).
         k_chunk = next((c for c in (128, 64, 32) if idx.shape[-1] % c == 0), 32)
         out = ttnn.transformer.sparse_sdpa(
@@ -1246,6 +1294,14 @@ class ttMLA:
             ttnn.deallocate(idx)
         ret = ttnn.to_layout(out, ttnn.TILE_LAYOUT)  # back to TILE for the downstream wkv_b2 linear
         ttnn.deallocate(out)
+
+        if reshard:
+            # Invert the transpose: gather the per-TP seq slices back to S/sp, then re-shard heads onto TP
+            # so the result matches the head-sharded [1, H/tp, S/sp, v_dim] the epilogue consumes.
+            full = self._tp_all_gather(ret, dim=2)  # [1, H, S/sp, v_dim] replicated on TP
+            ttnn.deallocate(ret)
+            ret = ttnn.mesh_partition(full, dim=1, cluster_axis=self.tp_axis)  # [1, H/tp, S/sp, v_dim]
+            ttnn.deallocate(full)
         return ret
 
     def _gather_kvpe_prefix(self, kvpe_cache, seq_len_local, end_pos, cache_user_id, cache_layer_idx):

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1072,7 +1072,7 @@ class ttMLA:
         # Single-shot: the live kvpe IS the whole sequence (natural order, contiguous SP shard).
         assert tt_kvpe is not None
         self._write_kvpe(kvpe_cache, tt_kvpe_b8, cache_layer_idx)
-        gathered = self._sp_all_gather(tt_kvpe, dim=2)  # [1,1,T,576] bf16 TILE, replicated, natural
+        gathered = self._all_gather(tt_kvpe, dim=2, cluster_axis=self.sp_axis)  # [1,1,T,576] bf16 TILE, repl, natural
         kvpe_dev = ttnn.to_layout(gathered, ttnn.ROW_MAJOR_LAYOUT)
         if self.sp_factor > 1:
             ttnn.deallocate(gathered)
@@ -1204,43 +1204,30 @@ class ttMLA:
     # only sparse-specific gather/attention helpers live below.
     # ----------------------------------------------------------------------------------------
 
-    def _sp_all_gather(self, t, dim):
-        """All-gather across the SP axis (sequence) → full-S replicated on SP. sp=1: no-op."""
-        if self.sp_factor == 1:
+    def _all_gather(self, t, dim, cluster_axis):
+        """All-gather across a mesh cluster axis → replicated on that axis. factor==1: no-op.
+        cluster_axis picks SP (sequence) or TP; the guard reads the matching mesh factor."""
+        factor = self.sp_factor if cluster_axis == self.sp_axis else self.tp_factor
+        if factor == 1:
             return t
         return ttnn.experimental.all_gather_async(
             t,
             dim=dim,
-            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
-            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=cluster_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=cluster_axis),
             num_links=self.ccl_num_links,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=self.ccl_topology,
-            cluster_axis=self.sp_axis,
-        )
-
-    def _tp_all_gather(self, t, dim):
-        """All-gather across the TP axis → replicated on TP. tp=1: no-op."""
-        if self.tp_factor == 1:
-            return t
-        return ttnn.experimental.all_gather_async(
-            t,
-            dim=dim,
-            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
-            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
-            num_links=self.ccl_num_links,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=self.ccl_topology,
-            cluster_axis=self.tp_axis,
+            cluster_axis=cluster_axis,
         )
 
     @property
-    def _sparse_head_reshard(self) -> bool:
+    def _needs_head_to_seq_reshard(self) -> bool:
         """True when the per-chip MLA head shard is too thin for sparse_sdpa (needs H % 32 == 0 and
         H >= 32). When the TP head shard is too thin (e.g. GLM's 64 heads at tp=4 → 16), _sparse_mla
         transposes the TP sharding axis heads → sequence for the duration of the attention."""
-        h_local = self.num_heads // self.tp_factor
-        return self.tp_factor > 1 and (h_local < 32 or h_local % 32 != 0)
+        heads_local = self.num_heads // self.tp_factor
+        return self.tp_factor > 1 and (heads_local < 32 or heads_local % 32 != 0)
 
     def _sparse_mla(self, q: ttnn.Tensor, kvpe: ttnn.Tensor, indices: ttnn.Tensor) -> ttnn.Tensor:
         """Absorbed MQA over the top-k selected latents (FlashMLA sparse contract: no causal mask —
@@ -1253,7 +1240,7 @@ class ttMLA:
         re-sharded onto SP (dim2) to match q when sp > 1 (or already SP-sharded → pass through)."""
         assert self.sp_axis == 0 and self.tp_axis == 1, "sparse_mla assumes sp_axis=0 (outer), tp_axis=1"
         sp = self.sp_factor
-        s_local = q.shape[2]  # per-chip query rows == S / sp
+        seq_len_local = q.shape[2]  # per-chip query rows == S / sp
 
         # sparse_sdpa requires per-chip heads H % 32 == 0 and H >= 32. When the TP head shard is too
         # thin (e.g. GLM's 64 heads at tp=4 → 16), transpose the TP sharding axis from heads to sequence
@@ -1262,28 +1249,31 @@ class ttMLA:
         # H. After the op we invert it (gather seq, re-shard heads) to restore the head-sharded layout the
         # wkv_b2 / o_proj epilogue expects. No padded/wasted heads; tp=1 and already-fat shards are untouched.
         # The SP indexer emits S/sp indices; we split them over TP below to match the resharded q rows.
-        reshard = self._sparse_head_reshard
+        transpose_head_to_seq = self._needs_head_to_seq_reshard
 
-        q_work = q
-        if reshard:
-            q_work = self._tp_all_gather(q, dim=1)  # [1, H, S/sp, 576] replicated on TP
-            q_work = ttnn.mesh_partition(q_work, dim=2, cluster_axis=self.tp_axis)  # [1, H, S/(sp·tp), 576]
+        q_seq_sharded = q
+        if transpose_head_to_seq:
+            q_all_heads = self._all_gather(q, dim=1, cluster_axis=self.tp_axis)  # [1, H, S/sp, 576] repl on TP
+            q_seq_sharded = ttnn.mesh_partition(q_all_heads, dim=2, cluster_axis=self.tp_axis)  # [1,H,S/(sp·tp),576]
+            ttnn.deallocate(q_all_heads)
 
-        q_rm = ttnn.to_layout(q_work, ttnn.ROW_MAJOR_LAYOUT)  # the op is ROW_MAJOR-only; q comes in TILE
-        if q_work is not q:
-            ttnn.deallocate(q_work)
+        q_rm = ttnn.to_layout(q_seq_sharded, ttnn.ROW_MAJOR_LAYOUT)  # the op is ROW_MAJOR-only; q comes in TILE
+        if q_seq_sharded is not q:
+            ttnn.deallocate(q_seq_sharded)
 
         # indices must match q_rm's seq sharding. Incoming is replicated full-glob [1,1,S_global,k] or
         # SP-sharded [1,1,S/sp,k]; under reshard the row count must drop to S/(sp·tp), so split over TP.
         idx = indices
-        if sp > 1 and indices.shape[2] == s_local * sp:
+        if sp > 1 and indices.shape[2] == seq_len_local * sp:
             # Replicated full-glob indices → reshard rows onto the SP axis (inverse of all_gather).
             idx = ttnn.mesh_partition(indices, dim=2, cluster_axis=self.sp_axis)
-        if reshard and idx.shape[2] != q_rm.shape[2]:
-            idx_tp = ttnn.mesh_partition(idx, dim=2, cluster_axis=self.tp_axis)  # split seq across TP to match q
+        if transpose_head_to_seq and idx.shape[2] != q_rm.shape[2]:
+            idx_seq_sharded = ttnn.mesh_partition(
+                idx, dim=2, cluster_axis=self.tp_axis
+            )  # split seq across TP to match q
             if idx is not indices:
                 ttnn.deallocate(idx)
-            idx = idx_tp
+            idx = idx_seq_sharded
         # k_chunk_size must be a multiple of 32 that divides TOPK (prod TOPK=2048 → 128).
         k_chunk = next((c for c in (128, 64, 32) if idx.shape[-1] % c == 0), 32)
         out = ttnn.transformer.sparse_sdpa(
@@ -1295,13 +1285,13 @@ class ttMLA:
         ret = ttnn.to_layout(out, ttnn.TILE_LAYOUT)  # back to TILE for the downstream wkv_b2 linear
         ttnn.deallocate(out)
 
-        if reshard:
+        if transpose_head_to_seq:
             # Invert the transpose: gather the per-TP seq slices back to S/sp, then re-shard heads onto TP
             # so the result matches the head-sharded [1, H/tp, S/sp, v_dim] the epilogue consumes.
-            full = self._tp_all_gather(ret, dim=2)  # [1, H, S/sp, v_dim] replicated on TP
+            out_all_heads = self._all_gather(ret, dim=2, cluster_axis=self.tp_axis)  # [1, H, S/sp, v_dim] repl on TP
             ttnn.deallocate(ret)
-            ret = ttnn.mesh_partition(full, dim=1, cluster_axis=self.tp_axis)  # [1, H/tp, S/sp, v_dim]
-            ttnn.deallocate(full)
+            ret = ttnn.mesh_partition(out_all_heads, dim=1, cluster_axis=self.tp_axis)  # [1, H/tp, S/sp, v_dim]
+            ttnn.deallocate(out_all_heads)
         return ret
 
     def _gather_kvpe_prefix(self, kvpe_cache, seq_len_local, end_pos, cache_user_id, cache_layer_idx):
@@ -1312,7 +1302,9 @@ class ttMLA:
         all-gather to full-T (no-op at sp==1), select this user/layer slot, bf8→bf16, TILE→RM,
         un-rotate block-cyclic→natural, trim to end_pos. Returns [1, 1, end_pos, 576] bf16 RM."""
         cache_i = ttnn.to_memory_config(kvpe_cache, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
-        full = self._sp_all_gather(cache_i, dim=2)  # → [B, 1, seq_len_cache, 576] replicated, block-cyclic
+        full = self._all_gather(
+            cache_i, dim=2, cluster_axis=self.sp_axis
+        )  # → [B,1,seq_len_cache,576] repl, block-cyclic
         if self.sp_factor > 1:
             ttnn.deallocate(cache_i)
         if full.shape[0] > 1:  # user-major slot select (no-op for the single-slot cache)

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -211,10 +211,11 @@
     # collected fabric id back to `line` — which the -k filter below then selects.
     export DS_SPARSE_FABRIC=line
     # Sparse MLA (V3.2 + GLM-5.1) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.
-    # GLM (tp<=2) gets its primary coverage on the 4x2 full-box mesh; DeepSeek-V3.2 covers the asymmetric
-    # 2x4 mesh (its 8x4 coverage is on Galaxy). The sparse suite carries no tier markers (the determinism
-    # test is pinned to each variant's anchor mesh, not selected here), so there is no -m gate.
-    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 4x2 and line" -vvv --tb=short || exit_code=$?
+    # GLM-5.1 reshards heads->sequence in _sparse_mla so it now runs at tp=4; 2x4 is its coverage (accuracy
+    # + the determinism/chunked anchor cases, which pin to the highest-TP mesh). DeepSeek-V3.2 covers the
+    # asymmetric 2x4 mesh (its 8x4 coverage is on Galaxy). The sparse suite carries no tier markers, so
+    # there is no -m gate.
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 2x4 and line" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 2x4 and line" -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:


### PR DESCRIPTION
## What

Enable **GLM-5.1 sparse MLA (DSA) at tp=4** on the `deepseek_v3_d_p` stack, on top of the sparse-MLA support that just merged (#47832).

`ttnn.transformer.sparse_sdpa` (and `indexer_score`) require per-chip heads `H % 32 == 0 and H >= 32`. GLM has 64 q-heads → at tp=4 the head shard is `64/4 = 16`, too thin, so GLM was previously capped at tp=2. This PR adds a **head→sequence reshard** inside `ttMLA._sparse_mla` that transposes the TP sharding axis (heads → sequence) for the duration of the attention, so every chip runs `sparse_sdpa` over a **distinct seq slice at full H = 64** (legal), then inverts to restore the head-sharded layout the epilogue expects.

## How

Gated by `ttMLA._sparse_head_reshard` (`tp>1 and (H_local < 32 or H_local % 32 != 0)`):
- **all-gather** q's heads over TP (each chip regains all H) → **mesh_partition** the sequence over TP → `sparse_sdpa` at full H over `S/(sp·tp)` → invert (gather seq, re-shard heads).
- The indexer is **unchanged**: its `S/sp` indices are split over TP locally to match the resharded q rows. The index-reshard is robust to both replicated-full-glob and SP-sharded indices.
- `tp=1` and already-fat shards (`H_local >= 32`, e.g. DeepSeek's 128 heads) are **byte-identical** to before.

## Changes

- `tt/mla/mla.py` — `_sparse_mla` reshard path + `_tp_all_gather` / `_sparse_head_reshard` helpers.
- `tests/sparse_mla/test_sparse_mla.py` — drop the `_GLM_MAX_TP` cap (GLM now sweeps every mesh like DeepSeek); `_anchor_mesh` loses its now-unused variant arg.
- `tests/pipeline_reorg/blackhole_e2e_tests.yaml` — `bh_lb_DeepSeek_DSA` runs GLM sparse MLA at tp=4 (`2x4`) instead of `4x2`. Removing the cap moved GLM's anchor mesh from `4x2` → `2x4`, so this both adds tp=4 accuracy and keeps the determinism/chunked cases (which pin to the anchor).

## Validation (8× Blackhole, 2x4 = sp2×tp4)

All 4 GLM-5.1 tp=4 cases pass:

| Test | PCC |
|---|---|
| accuracy seq256 | Output **0.9988**, KVPE kv=0.99989 / pe=0.99990 |
| accuracy seq5120 | Output **0.9967**, KVPE kv=0.99988 / pe=0.99989 |
| determinism seq5120 | exact=True, pcc=1.0 (×2 reruns) |
| chunked seq5120 | Output **0.9964** (known per-chunk degrade; KVPE cache ~0.9999) |

## TODO (follow-up)

- [ ] **Enable GLM tp=4 on the Galaxy CI leg.** The Galaxy `DSA MLA` job (`tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml`) currently runs DeepSeek-V3.2 only on `8x4` (tp=4); its comment still says *"GLM is tp<=2, so it skips on the 8x4 … covered on the LoudBox instead"*, which is now stale. Add a `glm_5_1 and 8x4 and line` run (+`GLM51_MLA_REF_CACHE` env) and fix the comment once GLM `8x4` is validated on real Galaxy hardware (so far validated on p150b / LoudBox-class only) and the `bh_galaxy` time budget (405/410) has room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/sparse-attn-tp4-glm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/sparse-attn-tp4-glm)