### PR TITLE
Use float literals 0.0f, 1.0f, -1.0f

### DIFF
--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -237,8 +237,6 @@ The clamping of the intermediate value ``t`` to the [0, 1] range is implemented 
 
 The ``v_if`` and ``v_elseif`` instructions perform element-wise conditional assignments on the ``vFloat`` vector ``t``. Each lane of the SIMD vector is evaluated independently. A ``v_endif`` is required to terminate the conditional block.
 
-The SFPI constants ``0.0f`` and ``1.0f`` are vectors with all 32 lanes set to 0.0f and 1.0f, respectively. These constants are hardware-defined, readily available for SFPI programs, and do not require manual initialization. Using these pre-defined constants is more efficient than using literal values because the SFPU operates on vectors. Literal values would require broadcasting to a vector, which adds instructions and overhead.
-
 This is analogous to conditional execution in other parallel programming models, where a mask is used to control which processing elements are active.
 
 Runtime Arguments and Execution

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -184,8 +184,8 @@ The ``my_smoothstep_tiles`` function uses the layered abstraction pattern shown 
         for (size_t i = 0; i < vectors_per_face; i++) {
             sfpi::vFloat x = sfpi::dst_reg[i];
             sfpi::vFloat t = (x - edge0) * inv_delta;
-            v_if(t < 0.0f) { t = 0.0f; }
-            v_elseif(t > 1.0f) { t = 1.0f; }
+            v_if(t < sfpi::vConst0) { t = sfpi::vConst0; }
+            v_elseif(t > sfpi::vConst1) { t = sfpi::vConst1; }
             v_endif;
             sfpi::vFloat result = t * t * (3.0f - 2.0f * t);
             sfpi::dst_reg[i] = result;
@@ -231,11 +231,13 @@ The clamping of the intermediate value ``t`` to the [0, 1] range is implemented 
 
 .. code-block:: cpp
 
-    v_if(t < 0.0f) { t = 0.0f; }
-    v_elseif(t > 1.0f) { t = 1.0f; }
+    v_if(t < sfpi::vConst0) { t = sfpi::vConst0; }
+    v_elseif(t > sfpi::vConst1) { t = sfpi::vConst1; }
     v_endif;
 
 The ``v_if`` and ``v_elseif`` instructions perform element-wise conditional assignments on the ``vFloat`` vector ``t``. Each lane of the SIMD vector is evaluated independently. A ``v_endif`` is required to terminate the conditional block.
+
+The SFPI constants ``sfpi::vConst0`` and ``sfpi::vConst1`` are vectors with all 32 lanes set to 0.0f and 1.0f, respectively. These constants are hardware-defined, readily available for SFPI programs, and do not require manual initialization. Using these pre-defined constants is more efficient than using literal values because the SFPU operates on vectors. Literal values would require broadcasting to a vector, which adds instructions and overhead.
 
 This is analogous to conditional execution in other parallel programming models, where a mask is used to control which processing elements are active.
 

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -184,8 +184,8 @@ The ``my_smoothstep_tiles`` function uses the layered abstraction pattern shown 
         for (size_t i = 0; i < vectors_per_face; i++) {
             sfpi::vFloat x = sfpi::dst_reg[i];
             sfpi::vFloat t = (x - edge0) * inv_delta;
-            v_if(t < sfpi::vConst0) { t = sfpi::vConst0; }
-            v_elseif(t > sfpi::vConst1) { t = sfpi::vConst1; }
+            v_if(t < 0.0f) { t = 0.0f; }
+            v_elseif(t > 1.0f) { t = 1.0f; }
             v_endif;
             sfpi::vFloat result = t * t * (3.0f - 2.0f * t);
             sfpi::dst_reg[i] = result;
@@ -231,13 +231,13 @@ The clamping of the intermediate value ``t`` to the [0, 1] range is implemented 
 
 .. code-block:: cpp
 
-    v_if(t < sfpi::vConst0) { t = sfpi::vConst0; }
-    v_elseif(t > sfpi::vConst1) { t = sfpi::vConst1; }
+    v_if(t < 0.0f) { t = 0.0f; }
+    v_elseif(t > 1.0f) { t = 1.0f; }
     v_endif;
 
 The ``v_if`` and ``v_elseif`` instructions perform element-wise conditional assignments on the ``vFloat`` vector ``t``. Each lane of the SIMD vector is evaluated independently. A ``v_endif`` is required to terminate the conditional block.
 
-The SFPI constants ``sfpi::vConst0`` and ``sfpi::vConst1`` are vectors with all 32 lanes set to 0.0f and 1.0f, respectively. These constants are hardware-defined, readily available for SFPI programs, and do not require manual initialization. Using these pre-defined constants is more efficient than using literal values because the SFPU operates on vectors. Literal values would require broadcasting to a vector, which adds instructions and overhead.
+The SFPI constants ``0.0f`` and ``1.0f`` are vectors with all 32 lanes set to 0.0f and 1.0f, respectively. These constants are hardware-defined, readily available for SFPI programs, and do not require manual initialization. Using these pre-defined constants is more efficient than using literal values because the SFPU operates on vectors. Literal values would require broadcasting to a vector, which adds instructions and overhead.
 
 This is analogous to conditional execution in other parallel programming models, where a mask is used to control which processing elements are active.
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sampling.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sampling.h
@@ -50,16 +50,16 @@ inline void calculate_sampling_binary_comp_first_column(
     for (int d = 0; d < ITERATIONS_FIRST_COLUMN; d++) {
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vFloat result = sfpi::vConst0;
+        sfpi::vFloat result = 0.0f;
 
         if constexpr (OP == SfpuType::le) {
-            v_if(in0 <= in1) { result = sfpi::vConst1; }
+            v_if(in0 <= in1) { result = 1.0f; }
             v_endif;
         } else if constexpr (OP == SfpuType::lt) {
-            v_if(in0 < in1) { result = sfpi::vConst1; }
+            v_if(in0 < in1) { result = 1.0f; }
             v_endif;
         } else {
-            v_if(in0 >= in1) { result = sfpi::vConst1; }
+            v_if(in0 >= in1) { result = 1.0f; }
             v_endif;
         }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sampling.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sampling.h
@@ -50,16 +50,16 @@ inline void calculate_sampling_binary_comp_first_column(
     for (int d = 0; d < ITERATIONS_FIRST_COLUMN; d++) {
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vFloat result = 0.0f;
+        sfpi::vFloat result = sfpi::vConst0;
 
         if constexpr (OP == SfpuType::le) {
-            v_if(in0 <= in1) { result = 1.0f; }
+            v_if(in0 <= in1) { result = sfpi::vConst1; }
             v_endif;
         } else if constexpr (OP == SfpuType::lt) {
-            v_if(in0 < in1) { result = 1.0f; }
+            v_if(in0 < in1) { result = sfpi::vConst1; }
             v_endif;
         } else {
-            v_if(in0 >= in1) { result = 1.0f; }
+            v_if(in0 >= in1) { result = sfpi::vConst1; }
             v_endif;
         }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -170,11 +170,11 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     v_endif;
 
     // Transform to z = (m - 1) / (m + 1)
-    sfpi::vFloat m_plus_1 = m + sfpi::vConst1;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
-    sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
+    sfpi::vFloat m_plus_1 = m + 1.0f;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
+    sfpi::vFloat m_minus_1 = m - 1.0f;
     // 1/t: initial guess 1.0f - 0.2426406871192851f*t (linear interp on [1.7,2.4]), then Newton-Raphson y = y*(2 -
     // t*y).
-    sfpi::vFloat recip = sfpi::vConst1 - 0.2426406871192851f * m_plus_1;
+    sfpi::vFloat recip = 1.0f - 0.2426406871192851f * m_plus_1;
     recip = recip * (2.0f - m_plus_1 * recip);  // 1st NR
     recip = recip * (2.0f - m_plus_1 * recip);  // 2nd NR for float32
     sfpi::vFloat z = m_minus_1 * recip;
@@ -183,7 +183,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vFloat z2 = z * z;
     // Polynomial approximation using odd powers
     sfpi::vFloat p = PolynomialEvaluator::eval(
-        z2, sfpi::vConst1, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
+        z2, 1.0f, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
     sfpi::vFloat ln_m = 2.0f * (z * p);
 
     sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(sfpi::convert<sfpi::vSMag>(exp), sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -37,7 +37,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     // Accuracy is sufficient because we apply an integer correction later.
     sfpi::vFloat inv_b_f = sfpi::approx_recip(b_f);
     // One NR step: inv_b = inv_b * (2 - b * inv_b)
-    sfpi::vFloat e = -inv_b_f * b_f + sfpi::vConst1;
+    sfpi::vFloat e = -inv_b_f * b_f + 1.0f;
     inv_b_f = e * inv_b_f + inv_b_f;
 
     // Initial quotient approximation: q = a * (1/b)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -50,9 +50,9 @@ inline void calculate_cube_root() {
             y = y * (c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0);
 
             sfpi::vFloat d = x * (y * y);
-            c = d * y + sfpi::vConstNeg1;
+            c = d * y + -1.0f;
             sfpi::vFloat negative_third = sfpi::addexp(negative_third_256, 8);
-            sfpi::vFloat t = c * negative_third + sfpi::vConst1;
+            sfpi::vFloat t = c * negative_third + 1.0f;
             d = sfpi::copysgn(d, a);
             y = d * (t * t);
         } else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -38,7 +38,7 @@ sfpi_inline void calculate_div_int32_body(
     // initial approximation.
     // We interleave SFPMAD with the loading and conversion of `a`.
     sfpi::vFloat inv_b_f = sfpi::approx_recip(b_f);
-    sfpi::vFloat e = -inv_b_f * b_f + sfpi::vConst1;
+    sfpi::vFloat e = -inv_b_f * b_f + 1.0f;
     sfpi::vInt a_orig = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
     e = e * e + e;
     sfpi::vMag a = sfpi::abs(a_orig);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -43,7 +43,7 @@ inline void calculate_dropout(uint probability, uint scale) {
         ////////////////////////
         // Drop samples
         // v_if (rand < probability)
-        //   dst_reg[0] = vConst0;
+        //   dst_reg[0] = 0.0f;
         ///////////////////////
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG3, 10);
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -23,7 +23,7 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat x) {
     // function)
 
     // Compute log(1 - x^2)
-    sfpi::vFloat log_value = calculate_log_body<false, false, false>(sfpi::vConst1 - x * x, 0);
+    sfpi::vFloat log_value = calculate_log_body<false, false, false>(1.0f - x * x, 0);
 
     // Paper sets a constant a = 0.147.
     // This constant is used to compute two constant expressions:

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -426,7 +426,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val) {
 
     // Run series in Horner form
     sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::sFloat16b(0.863281f);
-    val = val * tmp + sfpi::vConst1;
+    val = val * tmp + 1.0f;
 
     v_if(exp >= 0) {
         val = val * val;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -36,7 +36,7 @@ inline void calculate_fmod(const uint value, const uint recip) {
 
         vFloat quotient;
         vInt exp = exexp(v * recip_val);
-        v_if(exp < 0) { quotient = vConst0; }
+        v_if(exp < 0) { quotient = 0.0f; }
         // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
         // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
         // shifting it back using (0 - (exp - 23)).

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -374,13 +374,7 @@ inline void calculate_gelu_tanh() {
         sfpi::vFloat inner = x + kx3;
 
         sfpi::vFloat scaled = inner * SQRT_2_OVER_PI;
-
-        // Handle +-0 by using the sign of x to prevent 1 ULP difference.
-        // NOTE: 0.0f is a vCReg<vFloat>, not a vFloat. copysgn's overloads are
-        // constrained templates whose argument deduction does not apply the implicit
-        // vCReg->vFloat conversion, so materialize a real vFloat first.
-        sfpi::vFloat zero = 0.0f;
-        sfpi::vFloat result = sfpi::copysgn(zero, x);
+        sfpi::vFloat result = sfpi::copysgn(sfpi::vFloat(0.0f), x);
 
         v_if(scaled >= TANH_SAT_THRESHOLD) {
             // Saturated positive tail: gelu_tanh(x) = x.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -92,7 +92,7 @@ sfpi_inline sfpi::vFloat x_times_exp_negative_tail(sfpi::vFloat x, sfpi::vFloat 
     sfpi::vInt new_exp = xpoly_exp + k_int;                                    // Shift by 2^k
 
     // Step 6: FTZ check on FINAL result (x * exp(t)), not intermediate exp(t)
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
     v_if(new_exp > 0) { result = sfpi::setexp(x_poly, new_exp); }
     v_endif;
 
@@ -147,7 +147,7 @@ constexpr float GELU_HCORR_C3 = 7.5950479368e-04f;
 // Forward GELU Evaluation with CDF Polynomial Approximation
 // GELU(x) = x * Phi(x) where Phi is approximated piecewise
 sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
-    sfpi::vFloat result = sfpi::vConst0;  // Default: 0 for x <= -5.54259443 (torch saturation)
+    sfpi::vFloat result = 0.0f;  // Default: 0 for x <= -5.54259443 (torch saturation)
     sfpi::vFloat x2 = x * x;
 
     v_if(x > -5.54259443f) {
@@ -309,7 +309,7 @@ inline void calculate_gelu() {
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat x = sfpi::dst_reg[0];
-            sfpi::vFloat result = sfpi::vConst0;  // default 0 for x <= GELU_SAT
+            sfpi::vFloat result = 0.0f;  // default 0 for x <= GELU_SAT
             v_if(x > GELU_SAT) {
                 sfpi::vFloat scaled = x * INV_SQRT2;
                 sfpi::vFloat threshold = 10.0f;
@@ -376,10 +376,10 @@ inline void calculate_gelu_tanh() {
         sfpi::vFloat scaled = inner * SQRT_2_OVER_PI;
 
         // Handle +-0 by using the sign of x to prevent 1 ULP difference.
-        // NOTE: vConst0 is a vCReg<vFloat>, not a vFloat. copysgn's overloads are
+        // NOTE: 0.0f is a vCReg<vFloat>, not a vFloat. copysgn's overloads are
         // constrained templates whose argument deduction does not apply the implicit
         // vCReg->vFloat conversion, so materialize a real vFloat first.
-        sfpi::vFloat zero = sfpi::vConst0;
+        sfpi::vFloat zero = 0.0f;
         sfpi::vFloat result = sfpi::copysgn(zero, x);
 
         v_if(scaled >= TANH_SAT_THRESHOLD) {
@@ -451,10 +451,10 @@ constexpr float GELU_DERIV_H8 = 4.2734988881e-09f;
 // Note: GELU'(x) has a "hump" exceeding 1.0 for x in [0.77, 3.16]
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
-    sfpi::vFloat result = sfpi::vConst0;  // Default: 0 for x <= -13.375
+    sfpi::vFloat result = 0.0f;  // Default: 0 for x <= -13.375
 
     // For x >= 3.1719, output saturates to 1 (verified saturation threshold)
-    v_if(x >= 3.1719f) { result = sfpi::vConst1; }
+    v_if(x >= 3.1719f) { result = 1.0f; }
     // Core region [-3, 3.1719]: GELU'(x) = 0.5 + x * h(x²)
     // Odd-function decomposition: GELU'(x) + GELU'(-x) = 1, so GELU'(x) - 0.5
     // is odd and can be written as x * h(x²). Degree-8 in u=x² (~12 ops vs ~32).

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
@@ -23,7 +23,7 @@ inline void calculate_hardshrink(uint32_t param0) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat abs_v = sfpi::setsgn(v, 0);
-        v_if(abs_v <= lambda) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        v_if(abs_v <= lambda) { sfpi::dst_reg[0] = 0.0f; }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -60,7 +60,7 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
     sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
-    c0 = sfpi::vConst1 + (-rsqrt_y) * (abs_x * rsqrt_y);
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
 
     // 1/|x| = (1/√|x|)² — reuses the refined rsqrt instead of a fresh reciprocal.
@@ -116,7 +116,7 @@ inline void calculate_i1() {
                 1.2293555930e-12f);
             sfpi::vFloat denom = PolynomialEvaluator::eval(
                 t,
-                sfpi::vConst1,
+                1.0f,
                 -1.1361218989e-02f,
                 6.1268139689e-05f,
                 -1.9771712800e-07f,
@@ -128,7 +128,7 @@ inline void calculate_i1() {
             sfpi::vFloat numer = PolynomialEvaluator::eval(
                 t, 4.9992737740e-01f, 5.4503594600e-02f, 1.6126291630e-03f, 2.0223499130e-05f);
             sfpi::vFloat denom =
-                PolynomialEvaluator::eval(t, sfpi::vConst1, -1.6242591070e-02f, 1.0333660750e-04f, -2.5076132990e-07f);
+                PolynomialEvaluator::eval(t, 1.0f, -1.6242591070e-02f, 1.0333660750e-04f, -2.5076132990e-07f);
 #endif
             val = numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom);
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -65,8 +65,8 @@ inline void calculate_sfpu_isclose(
         // tolerance formula yields inf<=inf=true even for mismatched signs,
         // and for NaN inputs the hardware comparison can be unreliable; both
         // are corrected in the single fix-up branch below.
-        sfpi::vFloat result = sfpi::vConst0;
-        v_if(abs_diff <= tol) { result = sfpi::vConst1; }
+        sfpi::vFloat result = 0.0f;
+        v_if(abs_diff <= tol) { result = 1.0f; }
         v_endif;
 
         // Single fix-up branch covering every "special" lane (Inf or NaN).
@@ -79,11 +79,11 @@ inline void calculate_sfpu_isclose(
         // Folding both old fix-ups into one v_if removes two predicate-stack
         // push/pop pairs from the hot loop.
         v_if(a_abs >= inf_bits || b_abs >= inf_bits) {
-            result = sfpi::vConst0;
-            v_if(a_abs == inf_bits && a_bits == b_bits) { result = sfpi::vConst1; }
+            result = 0.0f;
+            v_if(a_abs == inf_bits && a_bits == b_bits) { result = 1.0f; }
             v_endif;
             if constexpr (EQUAL_NAN) {
-                v_if(a_abs > inf_bits && b_abs > inf_bits) { result = sfpi::vConst1; }
+                v_if(a_abs > inf_bits && b_abs > inf_bits) { result = 1.0f; }
                 v_endif;
             }
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -46,7 +46,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_
 
     if constexpr (!FAST_APPROX) {
         // normalise a (-0.0 and subnormals become +0.0)
-        a = a * sfpi::vConst1 + sfpi::vConst0;
+        a = a * 1.0f + 0.0f;
     }
 
     e = sfpi::as<sfpi::vInt>(sfpi::setman(sfpi::as<sfpi::vFloat>(e), 0));
@@ -54,7 +54,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_
     sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
 
     // m in [0.75, 1.5). Compute log1p(m - 1) for m - 1 in [-0.25, 0.5).
-    m -= sfpi::vConst1;
+    m -= 1.0f;
 
     v_if(a >= 0.0f) {
         sfpi::vFloat r;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -49,7 +49,7 @@ namespace sfpu {
 // it still evaluates to -inf via the same bit-level reduction path.
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
-    sfpi::vFloat u = a + sfpi::vConst1;
+    sfpi::vFloat u = a + 1.0f;
     sfpi::vFloat r = std::numeric_limits<float>::quiet_NaN();
 
     v_if(u >= 0.0f) {
@@ -73,7 +73,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
 
         // Use -0.25 (instead of 0.25) so we can reuse it in the bf16 Horner step later.
         sfpi::vFloat neg_quarter = -0.25f;
-        sfpi::vFloat neg1 = sfpi::vConstNeg1;
+        sfpi::vFloat neg1 = -1.0f;
         // t = -s' / 4 - 1 = 2^(-k) - 1
         sfpi::vFloat t = __builtin_rvtt_sfpmad(neg_quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
@@ -54,8 +54,8 @@ inline void calculate_mish() {
             }
 
             // denominator = (1 + u)^2 + 1 = u^2 + 2u + 2
-            sfpi::vFloat one_plus_u = u + sfpi::vConst1;
-            sfpi::vFloat denom = one_plus_u * one_plus_u + sfpi::vConst1;
+            sfpi::vFloat one_plus_u = u + 1.0f;
+            sfpi::vFloat denom = one_plus_u * one_plus_u + 1.0f;
 
             sfpi::vFloat inv_denom;
             if constexpr (APPROXIMATION_MODE) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -32,17 +32,17 @@ sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat x) {
         sfpi::vFloat t = x * y - sfpi::vConstFloatPrgm0;
 
         if constexpr (max_iter > 1) {
-            sfpi::vFloat y1 = y * -t - sfpi::vConst0;
+            sfpi::vFloat y1 = y * -t - 0.0f;
             // If t=NaN, then t>=0.  This check consumes the SFPNOP slot of the preceding SFPMAD.
             v_if(t < 0) {
                 t = x * y1 - sfpi::vConstFloatPrgm0;
-                y = y1 * -t - sfpi::vConst0;
+                y = y1 * -t - 0.0f;
             }
             v_endif;
         } else {
             // If t=NaN, then t>=0.  This check cannot be hidden in a SFPNOP slot as it depends on the result of the
             // preceding SFPMAD.
-            v_if(t < 0) { y = y * -t - sfpi::vConst0; }
+            v_if(t < 0) { y = y * -t - 0.0f; }
             v_endif;
         }
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -37,7 +37,7 @@ inline void calculate_remainder(const uint value, const uint recip) {
 
         vFloat quotient;
         vInt exp = exexp(v * recip_val);
-        v_if(exp < 0) { quotient = vConst0; }
+        v_if(exp < 0) { quotient = 0.0f; }
         // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
         // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
         // shifting it back using (0 - (exp - 23)).

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -27,7 +27,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
         exp_neg_x = _sfpu_exp_21f_bf16_<true>(-x);
     }
 
-    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
+    sfpi::vFloat denominator = 1.0f + exp_neg_x;
 
     sfpi::vFloat result;
     if constexpr (is_fp32_acc_to_dest_mode) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -61,10 +61,10 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
 #ifdef INP_FLOAT32
     // FP32: degree 7 for < 1 ULP
     sfpi::vFloat poly = PolynomialEvaluator::eval(
-        r, sfpi::vConst1, sfpi::vConst1, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f, 0.00138888889f, 0.000198412698f);
+        r, 1.0f, 1.0f, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f, 0.00138888889f, 0.000198412698f);
 #else
     // BF16: degree 5 sufficient
-    sfpi::vFloat poly = PolynomialEvaluator::eval(r, sfpi::vConst1, sfpi::vConst1, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f);
+    sfpi::vFloat poly = PolynomialEvaluator::eval(r, 1.0f, 1.0f, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f);
 #endif
 
     // Scale by 2^k via exponent manipulation
@@ -72,7 +72,7 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
     sfpi::vInt new_exp = p_exp + k_int;
 
     // FTZ: if exponent underflows, result is 0
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
     v_if(new_exp > 0) { result = sfpi::setexp(poly, new_exp); }
     v_endif;
 
@@ -107,7 +107,7 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
 #ifdef INP_FLOAT32
             // FP32: inline Cody-Waite exp + 3-term Taylor ln(1+e) = e*(1 + e*(-1/2 + e/3))
             sfpi::vFloat e = softplus_exp_negative(neg_a);
-            residual = e * (sfpi::vConst1 + e * (-0.5f + e * 0.333333343f));
+            residual = e * (1.0f + e * (-0.5f + e * 0.333333343f));
 #else
             // BF16: exp_21f is faster than inline Cody-Waite (~8 vs ~15 ops)
             residual = _sfpu_exp_21f_bf16_<false>(neg_a);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -16,7 +16,7 @@ inline void calculate_softshrink(uint32_t param0) {
     sfpi::vFloat lambda = Converter::as_float(param0);
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst0;
+        sfpi::dst_reg[0] = 0.0f;
         v_if(v > lambda) { sfpi::dst_reg[0] = v - lambda; }
         v_elseif(v < (-lambda)) { sfpi::dst_reg[0] = v + lambda; }
         v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -14,7 +14,7 @@ inline void calculate_softsign() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = sfpi::abs(v) + sfpi::vConst1;
+        sfpi::vFloat tmp = sfpi::abs(v) + 1.0f;
         tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
         sfpi::dst_reg[0] = v * tmp;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -56,7 +56,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
         y = y * (sfpi::vConstFloatPrgm1 + c * (sfpi::vConstFloatPrgm2 + c));
         xy = x * y;
         negative_y = -y;
-        sfpi::vFloat one_minus_xyy = sfpi::vConst1 + (negative_y * xy);
+        sfpi::vFloat one_minus_xyy = 1.0f + (negative_y * xy);
 
         if constexpr (RECIPROCAL) {
             sfpi::vFloat half_y = sfpi::addexp(y, -1);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -27,7 +27,7 @@ namespace ckernel::sfpu {
  */
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
 
     constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
 
@@ -37,7 +37,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
     v_if(exponent == 255) {
         result = std::numeric_limits<float>::quiet_NaN();
         v_if(mantissa == 0) {
-            sfpi::vFloat one = sfpi::vConst1;
+            sfpi::vFloat one = 1.0f;
             result = sfpi::copysgn(one, val);
         }
         v_endif;
@@ -68,7 +68,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
             sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
             // Compute 2*sigmoid(2x) - 1
-            result = 2.f * sig - sfpi::vConst1;
+            result = 2.f * sig - 1.0f;
         }
         v_endif;
     }
@@ -117,7 +117,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // (5.876733921468257904052734375e-3))))));
     sfpi::vFloat result = PolynomialEvaluator::eval(
         val,
-        sfpi::vConst0,
+        0.0f,
         0.999004364013671875,
         3.0897438526153564453125e-2,
         -0.4890659749507904052734375,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -32,7 +32,7 @@ inline void calculate_tanh_derivative() {
             val = lut(val, l0, l1, l2);
         }
 
-        val = val * (-val) + vConst1;
+        val = val * (-val) + 1.0f;
         dst_reg[0] = val;
 
         dst_reg++;
@@ -103,14 +103,14 @@ sfpi_inline sfpi::vFloat inline_exp_sech2_tail(sfpi::vFloat a) {
     r = k * LN2_LO + r;
 
     // Degree-4 Taylor for exp(r)
-    sfpi::vFloat poly = PolynomialEvaluator::eval(r, sfpi::vConst1, sfpi::vConst1, C2, C3, C4);
+    sfpi::vFloat poly = PolynomialEvaluator::eval(r, 1.0f, 1.0f, C2, C3, C4);
 
     // 2^k scaling via direct exponent bit manipulation (FREE)
     sfpi::vInt p_exp = sfpi::exexp(poly, sfpi::ExponentMode::NoDebias);
     sfpi::vInt new_exp = p_exp + k_int;
 
     // FTZ: if exponent underflows, result is 0 (natural zero saturation)
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
     v_if(new_exp > 0) { result = sfpi::setexp(poly, new_exp); }
     v_endif;
 
@@ -173,7 +173,7 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATI
 inline void calculate_tanh_derivative_sech2() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::vFloat result = sfpi::vConst0;
+        sfpi::vFloat result = 0.0f;
 
         // sech²(x) is an even function: sech²(-x) = sech²(x)
         sfpi::vFloat a = sfpi::abs(val);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -59,8 +59,8 @@ inline void calculate_tanhshrink() {
                 sfpi::vFloat clamp = 9.0f;
                 sfpi::vec_min_max(axc, clamp);  // axc = min(|x|, 9)
                 sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
-                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
-                sfpi::vFloat tanh_ax = 2.f * sig - sfpi::vConst1;            // tanh(|x|)
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(1.0f + e);  // sigmoid(2|x|)
+                sfpi::vFloat tanh_ax = 2.f * sig - 1.0f;               // tanh(|x|)
                 result = sfpi::copysgn(ax - tanh_ax, x);
             } else {
                 // tanh(|x|) via a degree-3 minimax fit on [1,3.3].

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -48,19 +48,19 @@ sfpi_inline sfpi::vFloat sfpu_tan<true>(sfpi::vFloat a, sfpi::vInt i) {
     v_if(i < 0) {
         // Compensated residual for the reciprocal-correction branch.
         // This preserves precision when tan(x) is near its poles.
-        s = sfpi::vConstNeg1 * r + a;
+        s = -1.0f * r + a;
         s = t * a + s;
 
         t = sfpi::approx_recip(r);
 
         // Newton-Raphson refinement.
         // e = 1 - r*t, then t <- t*(1 + e) = t*(2 - r*t)
-        sfpi::vFloat e = -r * t + sfpi::vConst1;
+        sfpi::vFloat e = -r * t + 1.0f;
         // Negate to get t = -1/r.
         t = -t * e - t;
 
         // Reconstruct tan from corrected reciprocal terms.
-        r = r * t + sfpi::vConst1;
+        r = r * t + 1.0f;
         r = s * t + r;
         r = r * t + t;
     }
@@ -84,7 +84,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
     v_if(i < 0) {
         t = sfpi::approx_recip(r);
         // Newton-Raphson refinement resulting in r = -1/r.
-        sfpi::vFloat e = -r * t + sfpi::vConst1;
+        sfpi::vFloat e = -r * t + 1.0f;
         // Negate to get t = -1/r.
         r = -t * e - t;
     }
@@ -243,7 +243,7 @@ inline void calculate_cosine() {
         // Force v * (1/PI) + 0.5 to compile as a single SFPMAD sequence for consistent instruction scheduling.
         sfpi::vFloat half = sfpi::sFloat16b(0.5f);
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
-        sfpi::vFloat neg_one = sfpi::vConstNeg1;
+        sfpi::vFloat neg_one = -1.0f;
 
         // Start from j = v * (1 / PI) + 0.5; after bias-round and 2*j - 1, j is an odd quadrant index.
         // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest.
@@ -298,14 +298,14 @@ inline void calculate_cosine() {
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
     sfpi::vFloat t0 = sfpi::abs(val);
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
 
     // If input is NaN then output must be NaN as well
     sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
     sfpi::vInt mantissa = sfpi::exman(val);
     v_if(exponent == 255 && mantissa != 0) { result = std::numeric_limits<float>::quiet_NaN(); }
     v_else {
-        sfpi::vFloat absval_minus_1 = t0 - sfpi::vConst1;
+        sfpi::vFloat absval_minus_1 = t0 - 1.0f;
 
         v_if(absval_minus_1 > 0.0f) { t0 = sfpu_reciprocal<false>(t0); }
         v_endif;
@@ -326,7 +326,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
             // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
             t1 = PolynomialEvaluator::eval(
                 t1,
-                sfpi::vConst1,
+                1.0f,
                 -0.3333314359188079833984375f,
                 0.19993579387664794921875f,
                 -0.14209578931331634521484375f,
@@ -385,7 +385,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_ratio_poly_direct(sfpi::vFloat val) {
         // Higher-degree series coefficients for fp32 destination path.
         ratio = PolynomialEvaluator::eval(
             z2,
-            sfpi::vConst1,
+            1.0f,
             0.16666666666666666f,
             0.075f,
             0.044642857142857144f,
@@ -424,7 +424,7 @@ inline void calculate_asin_acos_impl() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
-        v_if(sfpi::abs(v) <= sfpi::vConst1) {
+        v_if(sfpi::abs(v) <= 1.0f) {
             sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE, is_fp32_dest_acc_en>(v);
             if constexpr (IS_ACOS) {
                 result = PI_2 - a;
@@ -817,7 +817,7 @@ sfpi_inline sfpi::vFloat _sfpu_sqrt_ge0_(sfpi::vFloat x) {
     a = a + 0.5f * (x - a * a) * y;
 
     // sqrt(0) must be exactly 0; the reciprocal seed produces inf*0 = NaN there.
-    v_if(x == 0.0f) { a = sfpi::vConst0; }
+    v_if(x == 0.0f) { a = 0.0f; }
     v_endif;
     return a;
 }
@@ -854,10 +854,8 @@ inline void calculate_acosh() {
         //   1 < x < 2^28     -> arg += sqrt((x-1)(x+1))     (sqrt(x^2-1) without the
         //                                                    x^2-1 cancellation)
         // The large region falls through the predicated block and keeps arg = x-1.
-        sfpi::vFloat arg = inp - sfpi::vConst1;
-        v_if(inp < LOG1P_LARGE) {
-            arg = arg + _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>((inp + sfpi::vConst1) * arg);
-        }
+        sfpi::vFloat arg = inp - 1.0f;
+        v_if(inp < LOG1P_LARGE) { arg = arg + _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>((inp + 1.0f) * arg); }
         v_endif;
         sfpi::dst_reg[0] = arg;
 
@@ -867,8 +865,8 @@ inline void calculate_acosh() {
         v_endif;
 
         // Domain fix-ups: x == 1 -> +0, x < 1 -> NaN.
-        v_if(inp == sfpi::vConst1) { res = sfpi::vConst0; }
-        v_elseif(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_if(inp == 1.0f) { res = 0.0f; }
+        v_elseif(inp < 1.0f) { res = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
@@ -914,14 +912,13 @@ inline void calculate_asinh() {
         // which avoids the subtract-1 cancellation that otherwise costs ~3-4 ulp
         // near the crossover. Lanes below 0.75 are clamped here and overwritten by
         // the polynomial after log1p.
-        sfpi::vFloat arg = sfpi::vConst0;
+        sfpi::vFloat arg = 0.0f;
         v_if(sfpi::abs(inp) >= LOG1P_LARGE) {
-            arg = sfpi::abs(inp) - sfpi::vConst1;
+            arg = sfpi::abs(inp) - 1.0f;
         }
         v_elseif(sfpi::abs(inp) >= 0.75f) {
-            sfpi::vFloat root = _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>(inp * inp + sfpi::vConst1);
-            arg = sfpi::abs(inp) +
-                  (inp * inp) * _sfpu_reciprocal_gt0_<is_fp32_dest_acc_en>(sfpi::vConst1 + root);
+            sfpi::vFloat root = _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>(inp * inp + 1.0f);
+            arg = sfpi::abs(inp) + (inp * inp) * _sfpu_reciprocal_gt0_<is_fp32_dest_acc_en>(1.0f + root);
         }
         v_endif;
         sfpi::dst_reg[0] = arg;
@@ -973,7 +970,7 @@ inline void calculate_atanh() {
 
         // Clamp |x| >= 1 lanes to 0 so the interior formula stays finite there;
         // those lanes are overwritten by the boundary fix-up below.
-        v_if(a >= sfpi::vConst1) { a = sfpi::vConst0; }
+        v_if(a >= 1.0f) { a = 0.0f; }
         v_endif;
 
         // Build the log1p argument, then materialise it to DST before the log1p
@@ -981,7 +978,7 @@ inline void calculate_atanh() {
         // expression so the SFPU register allocator does not exceed its reload
         // budget (the fused form overflows it). The boundary lanes are restored
         // from `inp` afterwards, so clobbering DST here is safe.
-        sfpi::vFloat den = sfpi::vConst1 - a;
+        sfpi::vFloat den = 1.0f - a;
         sfpi::dst_reg[0] = (a + a) * _sfpu_reciprocal_gt0_<is_fp32_dest_acc_en>(den);
 
         sfpi::vFloat res = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
@@ -990,8 +987,8 @@ inline void calculate_atanh() {
         // Boundary fix-ups: |x| == 1 -> +/-inf, |x| > 1 -> NaN. abs(inp) is
         // recomputed inline here rather than cached in a register; a cached
         // |x| - 1 variant pushed the allocator past the reload budget.
-        v_if(sfpi::abs(inp) > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(sfpi::abs(inp) == sfpi::vConst1) {
+        v_if(sfpi::abs(inp) > 1.0f) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(sfpi::abs(inp) == 1.0f) {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
             res = sfpi::copysgn(inf, inp);
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -166,7 +166,7 @@ sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_(sfpi::vFloat z) {
     sfpi::vFloat r = k * LN2_LO + r_hi;
 
     sfpi::vFloat p = PolynomialEvaluator::eval(
-        r, sfpi::vConst1, sfpi::vConst1, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
+        r, 1.0f, 1.0f, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
 
     sfpi::vFloat result = sfpi::setexp(p, sfpi::exexp(p, sfpi::ExponentMode::NoDebias) + k_int);
 
@@ -198,8 +198,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     v_endif;
 
     // Transform to z = (m - 1) / (m + 1)
-    sfpi::vFloat m_plus_1 = m + sfpi::vConst1;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
-    sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
+    sfpi::vFloat m_plus_1 = m + 1.0f;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
+    sfpi::vFloat m_minus_1 = m - 1.0f;
     // 1/t: initial guess 1.003f - 0.244f*t (linear interp on [1.7,2.4]), then Newton-Raphson y = y*(2 - t*y).
     sfpi::vFloat recip = 1.003f - 0.244f * m_plus_1;
     recip = recip * (2.0f - m_plus_1 * recip);  // 1st NR
@@ -210,7 +210,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vFloat z2 = z * z;
     // Polynomial approximation using odd powers
     sfpi::vFloat p = PolynomialEvaluator::eval(
-        z2, sfpi::vConst1, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
+        z2, 1.0f, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
     sfpi::vFloat ln_m = 2.0f * (z * p);
 
     sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(sfpi::convert<sfpi::vSMag>(exp), sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -12,7 +12,7 @@
 namespace ckernel::sfpu {
 
 sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
 
     constexpr float UNDERFLOW_THRESHOLD = -126.5f;
 
@@ -64,8 +64,8 @@ sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
     // Coefficients in ascending order of powers: c0, c1, c2, c3, c4, c5, c6, c7
     sfpi::vFloat p = PolynomialEvaluator::eval(
         r,
-        sfpi::vConst1,  // c0 = 1
-        sfpi::vConst1,  // c1 = 1
+        1.0f,           // c0 = 1
+        1.0f,           // c1 = 1
         0.5f,           // c2 = 1/2!
         1.0f / 6.0f,    // c3 = 1/3!
         1.0f / 24.0f,   // c4 = 1/4!
@@ -148,7 +148,7 @@ inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
             _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
         }
         v_else {  // large negative
-            sfpi::vFloat exp_term = _sfpu_neg_exp_f32_(x) - sfpi::vConst1 - x;
+            sfpi::vFloat exp_term = _sfpu_neg_exp_f32_(x) - 1.0f - x;
             _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
         }
         v_endif;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -88,7 +88,7 @@ inline void calculate_sfpu_binary(
                 }
                 v_endif;
             }
-            v_elseif(in0 == in1) { result = sfpi::vConst1; }
+            v_elseif(in0 == in1) { result = 1.0f; }
             v_endif;
 
             if constexpr (!is_fp32_dest_acc_en) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -171,11 +171,11 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     v_endif;
 
     // Transform to z = (m - 1) / (m + 1)
-    sfpi::vFloat m_plus_1 = m + sfpi::vConst1;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
-    sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
+    sfpi::vFloat m_plus_1 = m + 1.0f;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
+    sfpi::vFloat m_minus_1 = m - 1.0f;
     // 1/t: initial guess 1.0f - 0.2426406871192851f*t (linear interp on [1.7,2.4]), then Newton-Raphson y = y*(2 -
     // t*y).
-    sfpi::vFloat recip = sfpi::vConst1 - 0.2426406871192851f * m_plus_1;
+    sfpi::vFloat recip = 1.0f - 0.2426406871192851f * m_plus_1;
     recip = recip * (2.0f - m_plus_1 * recip);  // 1st NR
     recip = recip * (2.0f - m_plus_1 * recip);  // 2nd NR for float32
     sfpi::vFloat z = m_minus_1 * recip;
@@ -184,7 +184,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vFloat z2 = z * z;
     // Polynomial approximation using odd powers
     sfpi::vFloat p = PolynomialEvaluator::eval(
-        z2, sfpi::vConst1, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
+        z2, 1.0f, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
     sfpi::vFloat ln_m = 2.0f * (z * p);
 
     sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(sfpi::convert<sfpi::vSMag>(exp), sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -37,12 +37,12 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vFloat scale = sfpi::setman(b_f, 0);
 
     // First Newton-Raphson iteration: inv_b_f = inv_b_f * (2 - inv_b_f * b_f)
-    sfpi::vFloat t = inv_b_f * neg_b_f + sfpi::vConst1;
+    sfpi::vFloat t = inv_b_f * neg_b_f + 1.0f;
     scale = sfpi::as<sfpi::vFloat>((254 << 23) - sfpi::as<sfpi::vInt>(scale));
     inv_b_f = t * inv_b_f + inv_b_f;
 
     // Second Newton-Raphson iteration (interleaved with abs(a) computation)
-    sfpi::vFloat e = inv_b_f * neg_b_f + sfpi::vConst1;
+    sfpi::vFloat e = inv_b_f * neg_b_f + 1.0f;
     sfpi::vMag a = sfpi::abs(a_signed);
     inv_b_f = e * inv_b_f + inv_b_f;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -50,9 +50,9 @@ inline void calculate_cube_root() {
             y = y * (c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0);
 
             sfpi::vFloat d = x * (y * y);
-            c = d * y + sfpi::vConstNeg1;
+            c = d * y + -1.0f;
             sfpi::vFloat negative_third = sfpi::addexp(negative_third_256, 8);
-            sfpi::vFloat t = c * negative_third + sfpi::vConst1;
+            sfpi::vFloat t = c * negative_third + 1.0f;
             d = sfpi::copysgn(d, a);
             y = d * (t * t);
         } else {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -53,12 +53,12 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vFloat scale = sfpi::setman(b_f, 0);
 
     // Newton-Raphson
-    sfpi::vFloat t = inv_b_f * neg_b_f + sfpi::vConst1;
+    sfpi::vFloat t = inv_b_f * neg_b_f + 1.0f;
     scale = sfpi::as<sfpi::vFloat>((254 << 23) - sfpi::as<sfpi::vInt>(scale));
     inv_b_f = t * inv_b_f + inv_b_f;
 
     // Halley's Method
-    sfpi::vFloat e = inv_b_f * neg_b_f + sfpi::vConst1;
+    sfpi::vFloat e = inv_b_f * neg_b_f + 1.0f;
 
     sfpi::vInt a_s = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -43,7 +43,7 @@ inline void calculate_dropout(uint probability, uint scale) {
         ////////////////////////
         // Drop samples
         // v_if (rand < probability)
-        //   sfpi::dst_reg[0] = vConst0;
+        //   sfpi::dst_reg[0] = 0.0f;
         ///////////////////////
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG3, 10);
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -23,7 +23,7 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat x) {
     // function)
 
     // Compute log(1 - x^2)
-    sfpi::vFloat log_value = calculate_log_body<false, false, false>(sfpi::vConst1 - x * x, 0);
+    sfpi::vFloat log_value = calculate_log_body<false, false, false>(1.0f - x * x, 0);
 
     // Paper sets a constant a = 0.147.
     // This constant is used to compute two constant expressions:

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -425,7 +425,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val) {
 
     // Run series in Horner form
     sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::sFloat16b(0.863281f);
-    val = val * tmp + sfpi::vConst1;
+    val = val * tmp + 1.0f;
 
     v_if(exp >= 0) {
         val = val * val;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -36,7 +36,7 @@ inline void calculate_fmod(const uint value, const uint recip) {
 
         vFloat quotient;
         vInt exp = exexp(v * recip_val);
-        v_if(exp < 0) { quotient = vConst0; }
+        v_if(exp < 0) { quotient = 0.0f; }
         // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
         // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
         // shifting it back using (0 - (exp - 23)).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -374,13 +374,7 @@ inline void calculate_gelu_tanh() {
         sfpi::vFloat inner = x + kx3;
 
         sfpi::vFloat scaled = inner * SQRT_2_OVER_PI;
-
-        // Handle +-0 using the sign of x to prevent 1 ULP difference.
-        // NOTE: 0.0f is a vCReg<vFloat>, not a vFloat. copysgn's overloads are
-        // constrained templates whose argument deduction does not apply the implicit
-        // vCReg->vFloat conversion, so materialize a real vFloat first.
-        sfpi::vFloat zero = 0.0f;
-        sfpi::vFloat result = sfpi::copysgn(zero, x);
+        sfpi::vFloat result = sfpi::copysgn(sfpi::vFloat(0.0f), x);
 
         v_if(scaled >= TANH_SAT_THRESHOLD) {
             // Saturated positive tail: gelu_tanh(x) = x.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -92,7 +92,7 @@ sfpi_inline sfpi::vFloat x_times_exp_negative_tail(sfpi::vFloat x, sfpi::vFloat 
     sfpi::vInt new_exp = xpoly_exp + k_int;               // Shift by 2^k
 
     // Step 6: FTZ check on FINAL result (x * exp(t)), not intermediate exp(t)
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
     v_if(new_exp > 0) { result = sfpi::setexp(x_poly, new_exp); }
     v_endif;
 
@@ -147,7 +147,7 @@ constexpr float GELU_HCORR_C3 = 7.5950479368e-04f;
 // Forward GELU Evaluation with CDF Polynomial Approximation
 // GELU(x) = x * Phi(x) where Phi is approximated piecewise
 sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
-    sfpi::vFloat result = sfpi::vConst0;  // Default: 0 for x <= -5.54259443 (torch saturation)
+    sfpi::vFloat result = 0.0f;  // Default: 0 for x <= -5.54259443 (torch saturation)
     sfpi::vFloat x2 = x * x;
 
     v_if(x > -5.54259443f) {
@@ -309,7 +309,7 @@ inline void calculate_gelu() {
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat x = sfpi::dst_reg[0];
-            sfpi::vFloat result = sfpi::vConst0;  // default 0 for x <= GELU_SAT
+            sfpi::vFloat result = 0.0f;  // default 0 for x <= GELU_SAT
             v_if(x > GELU_SAT) {
                 sfpi::vFloat scaled = x * INV_SQRT2;
                 sfpi::vFloat threshold = 10.0f;
@@ -376,10 +376,10 @@ inline void calculate_gelu_tanh() {
         sfpi::vFloat scaled = inner * SQRT_2_OVER_PI;
 
         // Handle +-0 using the sign of x to prevent 1 ULP difference.
-        // NOTE: vConst0 is a vCReg<vFloat>, not a vFloat. copysgn's overloads are
+        // NOTE: 0.0f is a vCReg<vFloat>, not a vFloat. copysgn's overloads are
         // constrained templates whose argument deduction does not apply the implicit
         // vCReg->vFloat conversion, so materialize a real vFloat first.
-        sfpi::vFloat zero = sfpi::vConst0;
+        sfpi::vFloat zero = 0.0f;
         sfpi::vFloat result = sfpi::copysgn(zero, x);
 
         v_if(scaled >= TANH_SAT_THRESHOLD) {
@@ -451,10 +451,10 @@ constexpr float GELU_DERIV_H8 = 4.2734988881e-09f;
 // Note: GELU'(x) has a "hump" exceeding 1.0 for x in [0.77, 3.16]
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
-    sfpi::vFloat result = sfpi::vConst0;  // Default: 0 for x <= -13.375
+    sfpi::vFloat result = 0.0f;  // Default: 0 for x <= -13.375
 
     // For x >= 3.1719, output saturates to 1 (verified saturation threshold)
-    v_if(x >= 3.1719f) { result = sfpi::vConst1; }
+    v_if(x >= 3.1719f) { result = 1.0f; }
     // Core region [-3, 3.1719]: GELU'(x) = 0.5 + x * h(x²)
     // Odd-function decomposition: GELU'(x) + GELU'(-x) = 1, so GELU'(x) - 0.5
     // is odd and can be written as x * h(x²). Degree-8 in u=x² (~12 ops vs ~32).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
@@ -23,7 +23,7 @@ inline void calculate_hardshrink(uint32_t param0) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat abs_v = sfpi::setsgn(v, 0);
-        v_if(abs_v <= lambda) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        v_if(abs_v <= lambda) { sfpi::dst_reg[0] = 0.0f; }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -60,7 +60,7 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
     sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
-    c0 = sfpi::vConst1 + (-rsqrt_y) * (abs_x * rsqrt_y);
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
 
     // 1/|x| = (1/√|x|)² — reuses the refined rsqrt instead of a fresh reciprocal.
@@ -116,7 +116,7 @@ inline void calculate_i1() {
                 1.2293555930e-12f);
             sfpi::vFloat denom = PolynomialEvaluator::eval(
                 t,
-                sfpi::vConst1,
+                1.0f,
                 -1.1361218989e-02f,
                 6.1268139689e-05f,
                 -1.9771712800e-07f,
@@ -128,7 +128,7 @@ inline void calculate_i1() {
             sfpi::vFloat numer = PolynomialEvaluator::eval(
                 t, 4.9992737740e-01f, 5.4503594600e-02f, 1.6126291630e-03f, 2.0223499130e-05f);
             sfpi::vFloat denom =
-                PolynomialEvaluator::eval(t, sfpi::vConst1, -1.6242591070e-02f, 1.0333660750e-04f, -2.5076132990e-07f);
+                PolynomialEvaluator::eval(t, 1.0f, -1.6242591070e-02f, 1.0333660750e-04f, -2.5076132990e-07f);
 #endif
             val = numer * x * sfpu_reciprocal<APPROXIMATION_MODE>(denom);
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -65,8 +65,8 @@ inline void calculate_sfpu_isclose(
         // tolerance formula yields inf<=inf=true even for mismatched signs,
         // and for NaN inputs the hardware comparison can be unreliable; both
         // are corrected in the single fix-up branch below.
-        sfpi::vFloat result = sfpi::vConst0;
-        v_if(abs_diff <= tol) { result = sfpi::vConst1; }
+        sfpi::vFloat result = 0.0f;
+        v_if(abs_diff <= tol) { result = 1.0f; }
         v_endif;
 
         // Single fix-up branch covering every "special" lane (Inf or NaN).
@@ -79,11 +79,11 @@ inline void calculate_sfpu_isclose(
         // Folding both old fix-ups into one v_if removes two predicate-stack
         // push/pop pairs from the hot loop.
         v_if(a_abs >= inf_bits || b_abs >= inf_bits) {
-            result = sfpi::vConst0;
-            v_if(a_abs == inf_bits && a_bits == b_bits) { result = sfpi::vConst1; }
+            result = 0.0f;
+            v_if(a_abs == inf_bits && a_bits == b_bits) { result = 1.0f; }
             v_endif;
             if constexpr (EQUAL_NAN) {
-                v_if(a_abs > inf_bits && b_abs > inf_bits) { result = sfpi::vConst1; }
+                v_if(a_abs > inf_bits && b_abs > inf_bits) { result = 1.0f; }
                 v_endif;
             }
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -46,7 +46,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_
 
     if constexpr (!FAST_APPROX) {
         // normalise a (-0.0 and subnormals become +0.0)
-        a = a * sfpi::vConst1 + sfpi::vConst0;
+        a = a * 1.0f + 0.0f;
     }
 
     e = sfpi::as<sfpi::vInt>(sfpi::setman(sfpi::as<sfpi::vFloat>(e), 0));
@@ -54,7 +54,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const uint log_base_
     sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
 
     // m in [0.75, 1.5). Compute log1p(m - 1) for m - 1 in [-0.25, 0.5).
-    m -= sfpi::vConst1;
+    m -= 1.0f;
 
     v_if(a >= 0.0f) {
         sfpi::vFloat r;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -49,7 +49,7 @@ namespace sfpu {
 // it still evaluates to -inf via the same bit-level reduction path.
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
-    sfpi::vFloat u = a + sfpi::vConst1;
+    sfpi::vFloat u = a + 1.0f;
     sfpi::vFloat r = std::numeric_limits<float>::quiet_NaN();
 
     v_if(u >= 0.0f) {
@@ -73,7 +73,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
 
         // Use -0.25 (instead of 0.25) so we can reuse it in the bf16 Horner step later.
         sfpi::vFloat neg_quarter = -0.25f;
-        sfpi::vFloat neg1 = sfpi::vConstNeg1;
+        sfpi::vFloat neg1 = -1.0f;
         // t = -s' / 4 - 1 = 2^(-k) - 1
         sfpi::vFloat t = __builtin_rvtt_sfpmad(neg_quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
@@ -52,8 +52,8 @@ inline void calculate_mish() {
             sfpi::vFloat numer = u * (u + 2.0f);
 
             // denominator = (1 + u)^2 + 1 = u^2 + 2u + 2
-            sfpi::vFloat one_plus_u = u + sfpi::vConst1;
-            sfpi::vFloat denom = one_plus_u * one_plus_u + sfpi::vConst1;
+            sfpi::vFloat one_plus_u = u + 1.0f;
+            sfpi::vFloat denom = one_plus_u * one_plus_u + 1.0f;
 
             sfpi::vFloat inv_denom;
             if constexpr (APPROXIMATION_MODE) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -27,7 +27,7 @@ sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat in) {
     // If in ≠ ±0 and in ≠ ±inf, then x = in * 2**(127-in.Exp).
     // If in = ±0 or in = ±inf, then x = ±1.
     // Then negative_x = -x.
-    sfpi::vFloat negative_x = sfpi::copyman(sfpi::vConstNeg1, in);
+    sfpi::vFloat negative_x = sfpi::copyman(-1.0f, in);
 
     // Quadratic initial estimate: y = k2 - k1*x + k0*x**2.
     sfpi::vFloat y = sfpi::vConstFloatPrgm1 + sfpi::vConstFloatPrgm0 * negative_x;
@@ -51,7 +51,7 @@ sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat in) {
     sfpi::vFloat scale = sfpi::setman(sfpi::as<sfpi::vFloat>(scale_bits), 0);
 
     // First iteration of Newton-Raphson: t = 1.0 - x*y.
-    sfpi::vFloat t = sfpi::vConst1 + negative_x * y;
+    sfpi::vFloat t = 1.0f + negative_x * y;
 
     // Scale factor adjustment: scale = scale*0.5.
     // If scale = ±inf, then scale*0.5 = ±inf and scale.Exp=255.
@@ -64,7 +64,7 @@ sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat in) {
 
     if constexpr (max_iter > 1) {
         // Second iteration of Newton-Raphson: t = 1.0 - x*y; y = y + y*t.
-        t = sfpi::vConst1 + negative_x * y;
+        t = 1.0f + negative_x * y;
         y = y + y * t;
     }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -37,7 +37,7 @@ inline void calculate_remainder(const uint value, const uint recip) {
 
         vFloat quotient;
         vInt exp = exexp(v * recip_val);
-        v_if(exp < 0) { quotient = vConst0; }
+        v_if(exp < 0) { quotient = 0.0f; }
         // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
         // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
         // shifting it back using (0 - (exp - 23)).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -27,7 +27,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
         exp_neg_x = _sfpu_exp_21f_bf16_<true>(-x);
     }
 
-    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
+    sfpi::vFloat denominator = 1.0f + exp_neg_x;
 
     sfpi::vFloat result;
     if constexpr (is_fp32_acc_to_dest_mode) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -61,10 +61,10 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
 #ifdef INP_FLOAT32
     // FP32: degree 7 for < 1 ULP
     sfpi::vFloat poly = PolynomialEvaluator::eval(
-        r, sfpi::vConst1, sfpi::vConst1, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f, 0.00138888889f, 0.000198412698f);
+        r, 1.0f, 1.0f, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f, 0.00138888889f, 0.000198412698f);
 #else
     // BF16: degree 5 sufficient
-    sfpi::vFloat poly = PolynomialEvaluator::eval(r, sfpi::vConst1, sfpi::vConst1, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f);
+    sfpi::vFloat poly = PolynomialEvaluator::eval(r, 1.0f, 1.0f, 0.5f, 0.166666667f, 0.0416666667f, 0.00833333333f);
 #endif
 
     // Scale by 2^k via exponent manipulation
@@ -72,7 +72,7 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
     sfpi::vInt new_exp = p_exp + k_int;
 
     // FTZ: if exponent underflows, result is 0
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
     v_if(new_exp > 0) { result = sfpi::setexp(poly, new_exp); }
     v_endif;
 
@@ -107,7 +107,7 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
 #ifdef INP_FLOAT32
             // FP32: inline Cody-Waite exp + 3-term Taylor ln(1+e) = e*(1 + e*(-1/2 + e/3))
             sfpi::vFloat e = softplus_exp_negative(neg_a);
-            residual = e * (sfpi::vConst1 + e * (-0.5f + e * 0.333333343f));
+            residual = e * (1.0f + e * (-0.5f + e * 0.333333343f));
 #else
             // BF16: exp_21f is faster than inline Cody-Waite (~8 vs ~15 ops)
             residual = _sfpu_exp_21f_bf16_<false>(neg_a);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -16,7 +16,7 @@ inline void calculate_softshrink(uint32_t param0) {
     sfpi::vFloat lambda = Converter::as_float(param0);
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst0;
+        sfpi::dst_reg[0] = 0.0f;
         v_if(v > lambda) { sfpi::dst_reg[0] = v - lambda; }
         v_elseif(v < (-lambda)) { sfpi::dst_reg[0] = v + lambda; }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -14,7 +14,7 @@ inline void calculate_softsign() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = sfpi::abs(v) + sfpi::vConst1;
+        sfpi::vFloat tmp = sfpi::abs(v) + 1.0f;
         tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
         sfpi::dst_reg[0] = v * tmp;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -56,7 +56,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
         y = y * (sfpi::vConstFloatPrgm1 + c * (sfpi::vConstFloatPrgm2 + c));
         xy = x * y;
         negative_y = -y;
-        sfpi::vFloat one_minus_xyy = sfpi::vConst1 + (negative_y * xy);
+        sfpi::vFloat one_minus_xyy = 1.0f + (negative_y * xy);
 
         if constexpr (RECIPROCAL) {
             sfpi::vFloat half_y = sfpi::addexp(y, -1);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -27,7 +27,7 @@ namespace ckernel::sfpu {
  */
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
 
     constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
 
@@ -37,7 +37,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
     v_if(exponent == 255) {
         result = std::numeric_limits<float>::quiet_NaN();
         v_if(mantissa == 0) {
-            sfpi::vFloat one = sfpi::vConst1;
+            sfpi::vFloat one = 1.0f;
             result = sfpi::copysgn(one, val);
         }
         v_endif;
@@ -68,7 +68,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
             sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
             // Compute 2*sigmoid(2x) - 1
-            result = 2.f * sig - sfpi::vConst1;
+            result = 2.f * sig - 1.0f;
         }
         v_endif;
     }
@@ -115,7 +115,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // (5.876733921468257904052734375e-3))))));
     sfpi::vFloat result = PolynomialEvaluator::eval(
         val,
-        sfpi::vConst0,
+        0.0f,
         0.999004364013671875,
         3.0897438526153564453125e-2,
         -0.4890659749507904052734375,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -32,7 +32,7 @@ inline void calculate_tanh_derivative() {
             val = lut(val, l0, l1, l2);
         }
 
-        val = val * (-val) + vConst1;
+        val = val * (-val) + 1.0f;
         dst_reg[0] = val;
 
         dst_reg++;
@@ -103,14 +103,14 @@ sfpi_inline sfpi::vFloat inline_exp_sech2_tail(sfpi::vFloat a) {
     r = k * LN2_LO + r;
 
     // Degree-4 Taylor for exp(r)
-    sfpi::vFloat poly = PolynomialEvaluator::eval(r, sfpi::vConst1, sfpi::vConst1, C2, C3, C4);
+    sfpi::vFloat poly = PolynomialEvaluator::eval(r, 1.0f, 1.0f, C2, C3, C4);
 
     // 2^k scaling via direct exponent bit manipulation (FREE)
     sfpi::vInt p_exp = sfpi::exexp(poly, sfpi::ExponentMode::NoDebias);
     sfpi::vInt new_exp = p_exp + k_int;
 
     // FTZ: if exponent underflows, result is 0 (natural zero saturation)
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
     v_if(new_exp > 0) { result = sfpi::setexp(poly, new_exp); }
     v_endif;
 
@@ -173,7 +173,7 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATI
 inline void calculate_tanh_derivative_sech2() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::vFloat result = sfpi::vConst0;
+        sfpi::vFloat result = 0.0f;
 
         // sech²(x) is an even function: sech²(-x) = sech²(x)
         sfpi::vFloat a = sfpi::abs(val);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -59,8 +59,8 @@ inline void calculate_tanhshrink() {
                 sfpi::vFloat clamp = 9.0f;
                 sfpi::vec_min_max(axc, clamp);  // axc = min(|x|, 9)
                 sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
-                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(sfpi::vConst1 + e);  // sigmoid(2|x|)
-                sfpi::vFloat tanh_ax = 2.f * sig - sfpi::vConst1;            // tanh(|x|)
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(1.0f + e);  // sigmoid(2|x|)
+                sfpi::vFloat tanh_ax = 2.f * sig - 1.0f;               // tanh(|x|)
                 result = sfpi::copysgn(ax - tanh_ax, x);
             } else {
                 // tanh(|x|) via a degree-3 minimax fit on [1,3.3].

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<true>(sfpi::vFloat a, sfpi::vInt i) {
     v_if(i < 0) {
         // Compensated residual for the reciprocal-correction branch.
         // This preserves precision when tan(x) is near its poles.
-        s = sfpi::vConstNeg1 * r + a;
+        s = -1.0f * r + a;
         sfpi::vFloat negative_x = sfpi::copyman(-1.0f, r);
         s = t * a + s;
 
@@ -64,12 +64,12 @@ sfpi_inline sfpi::vFloat sfpu_tan<true>(sfpi::vFloat a, sfpi::vInt i) {
         scale *= 0.5f;
 
         // Newton-Raphson refinement.
-        sfpi::vFloat e = sfpi::vConst1 + negative_x * t;
+        sfpi::vFloat e = 1.0f + negative_x * t;
         t = t * e + t;
         t = t * scale;
 
         // Reconstruct tan from corrected reciprocal terms.
-        r = r * t + sfpi::vConst1;
+        r = r * t + 1.0f;
         r = s * t + r;
         r = r * t + t;
     }
@@ -103,7 +103,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
         sfpi::vFloat scale = sfpi::setman(sfpi::as<sfpi::vFloat>(scale_bits), 0);
 
         // Newton-Raphson refinement.
-        sfpi::vFloat e = sfpi::vConst1 + negative_x * t;
+        sfpi::vFloat e = 1.0f + negative_x * t;
         scale *= 0.5f;
         t = t * e + t;
         r = t * scale;
@@ -263,7 +263,7 @@ inline void calculate_cosine() {
         // Force v * (1/PI) + 0.5 to compile as a single SFPMAD sequence for consistent instruction scheduling.
         sfpi::vFloat half = sfpi::sFloat16b(0.5f);  // 0.5
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
-        sfpi::vFloat neg_one = sfpi::vConstNeg1;
+        sfpi::vFloat neg_one = -1.0f;
 
         // Start from j = v * (1 / PI) + 0.5; after bias-round and 2*j - 1, j is an odd quadrant index.
         // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest.
@@ -319,14 +319,14 @@ inline void calculate_cosine() {
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
     sfpi::vFloat t0 = sfpi::abs(val);
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
 
     // If input is NaN then output must be NaN as well
     sfpi::vInt exponent = sfpi::exexp(val, sfpi::ExponentMode::NoDebias);
     sfpi::vInt mantissa = sfpi::exman(val);
     v_if(exponent == 255 && mantissa != 0) { result = std::numeric_limits<float>::quiet_NaN(); }
     v_else {
-        sfpi::vFloat absval_minus_1 = t0 - sfpi::vConst1;
+        sfpi::vFloat absval_minus_1 = t0 - 1.0f;
 
         v_if(absval_minus_1 > 0.0f) { t0 = sfpu_reciprocal<false>(t0); }
         v_endif;
@@ -347,7 +347,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
             // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
             t1 = PolynomialEvaluator::eval(
                 t1,
-                sfpi::vConst1,
+                1.0f,
                 -0.3333314359188079833984375f,
                 0.19993579387664794921875f,
                 -0.14209578931331634521484375f,
@@ -406,7 +406,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_ratio_poly_direct(sfpi::vFloat val) {
         // Higher-degree series coefficients for fp32 destination path.
         ratio = PolynomialEvaluator::eval(
             z2,
-            sfpi::vConst1,
+            1.0f,
             0.16666666666666666f,
             0.075f,
             0.044642857142857144f,
@@ -445,7 +445,7 @@ inline void calculate_asin_acos_impl() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
-        v_if(sfpi::abs(v) <= sfpi::vConst1) {
+        v_if(sfpi::abs(v) <= 1.0f) {
             sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE, is_fp32_dest_acc_en>(v);
             if constexpr (IS_ACOS) {
                 result = PI_2 - a;
@@ -845,7 +845,7 @@ sfpi_inline sfpi::vFloat _sfpu_sqrt_ge0_(sfpi::vFloat x) {
     a = a + 0.5f * (x - a * a) * y;
 
     // sqrt(0) must be exactly 0; the reciprocal seed produces inf*0 = NaN there.
-    v_if(x == 0.0f) { a = sfpi::vConst0; }
+    v_if(x == 0.0f) { a = 0.0f; }
     v_endif;
     return a;
 }
@@ -882,10 +882,8 @@ inline void calculate_acosh() {
         //   1 < x < 2^28     -> arg += sqrt((x-1)(x+1))     (sqrt(x^2-1) without the
         //                                                    x^2-1 cancellation)
         // The large region falls through the predicated block and keeps arg = x-1.
-        sfpi::vFloat arg = inp - sfpi::vConst1;
-        v_if(inp < LOG1P_LARGE) {
-            arg = arg + _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>((inp + sfpi::vConst1) * arg);
-        }
+        sfpi::vFloat arg = inp - 1.0f;
+        v_if(inp < LOG1P_LARGE) { arg = arg + _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>((inp + 1.0f) * arg); }
         v_endif;
         sfpi::dst_reg[0] = arg;
 
@@ -895,8 +893,8 @@ inline void calculate_acosh() {
         v_endif;
 
         // Domain fix-ups: x == 1 -> +0, x < 1 -> NaN.
-        v_if(inp == sfpi::vConst1) { res = sfpi::vConst0; }
-        v_elseif(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_if(inp == 1.0f) { res = 0.0f; }
+        v_elseif(inp < 1.0f) { res = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
@@ -942,14 +940,11 @@ inline void calculate_asinh() {
         // which avoids the subtract-1 cancellation that otherwise costs ~3-4 ulp
         // near the crossover. Lanes below 0.75 are clamped here and overwritten by
         // the polynomial after log1p.
-        sfpi::vFloat arg = sfpi::vConst0;
-        v_if(sfpi::abs(inp) >= LOG1P_LARGE) {
-            arg = sfpi::abs(inp) - sfpi::vConst1;
-        }
+        sfpi::vFloat arg = 0.0f;
+        v_if(sfpi::abs(inp) >= LOG1P_LARGE) { arg = sfpi::abs(inp) - 1.0f; }
         v_elseif(sfpi::abs(inp) >= 0.75f) {
-            sfpi::vFloat root = _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>(inp * inp + sfpi::vConst1);
-            arg = sfpi::abs(inp) +
-                  (inp * inp) * _sfpu_reciprocal_gt0_<is_fp32_dest_acc_en>(sfpi::vConst1 + root);
+            sfpi::vFloat root = _sfpu_sqrt_ge0_<is_fp32_dest_acc_en>(inp * inp + 1.0f);
+            arg = sfpi::abs(inp) + (inp * inp) * _sfpu_reciprocal_gt0_<is_fp32_dest_acc_en>(1.0f + root);
         }
         v_endif;
         sfpi::dst_reg[0] = arg;
@@ -1001,7 +996,7 @@ inline void calculate_atanh() {
 
         // Clamp |x| >= 1 lanes to 0 so the interior formula stays finite there;
         // those lanes are overwritten by the boundary fix-up below.
-        v_if(a >= sfpi::vConst1) { a = sfpi::vConst0; }
+        v_if(a >= 1.0f) { a = 0.0f; }
         v_endif;
 
         // Build the log1p argument, then materialise it to DST before the log1p
@@ -1009,7 +1004,7 @@ inline void calculate_atanh() {
         // expression so the SFPU register allocator does not exceed its reload
         // budget (the fused form overflows it). The boundary lanes are restored
         // from `inp` afterwards, so clobbering DST here is safe.
-        sfpi::vFloat den = sfpi::vConst1 - a;
+        sfpi::vFloat den = 1.0f - a;
         sfpi::dst_reg[0] = (a + a) * _sfpu_reciprocal_gt0_<is_fp32_dest_acc_en>(den);
 
         sfpi::vFloat res = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
@@ -1018,8 +1013,8 @@ inline void calculate_atanh() {
         // Boundary fix-ups: |x| == 1 -> +/-inf, |x| > 1 -> NaN. abs(inp) is
         // recomputed inline here rather than cached in a register; a cached
         // |x| - 1 variant pushed the allocator past the reload budget.
-        v_if(sfpi::abs(inp) > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(sfpi::abs(inp) == sfpi::vConst1) {
+        v_if(sfpi::abs(inp) > 1.0f) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(sfpi::abs(inp) == 1.0f) {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
             res = sfpi::copysgn(inf, inp);
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -169,7 +169,7 @@ sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_(sfpi::vFloat z) {
     sfpi::vFloat r = k * LN2_LO + r_hi;
 
     sfpi::vFloat p = PolynomialEvaluator::eval(
-        r, sfpi::vConst1, sfpi::vConst1, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
+        r, 1.0f, 1.0f, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
 
     sfpi::vFloat result = sfpi::setexp(p, sfpi::exexp(p, sfpi::ExponentMode::NoDebias) + k_int);
 
@@ -201,8 +201,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     v_endif;
 
     // Transform to z = (m - 1) / (m + 1)
-    sfpi::vFloat m_plus_1 = m + sfpi::vConst1;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
-    sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
+    sfpi::vFloat m_plus_1 = m + 1.0f;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
+    sfpi::vFloat m_minus_1 = m - 1.0f;
     // 1/t: initial guess 1.003f - 0.244f*t (linear interp on [1.7,2.4]), then Newton-Raphson y = y*(2 - t*y).
     sfpi::vFloat recip = 1.003f - 0.244f * m_plus_1;
     recip = recip * (2.0f - m_plus_1 * recip);  // 1st NR
@@ -213,7 +213,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vFloat z2 = z * z;
     // Polynomial approximation using odd powers
     sfpi::vFloat p = PolynomialEvaluator::eval(
-        z2, sfpi::vConst1, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
+        z2, 1.0f, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
     sfpi::vFloat ln_m = 2.0f * (z * p);
 
     sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(sfpi::convert<sfpi::vSMag>(exp), sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -12,7 +12,7 @@
 namespace ckernel::sfpu {
 
 sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = 0.0f;
 
     constexpr float UNDERFLOW_THRESHOLD = -126.5f;
 
@@ -61,8 +61,8 @@ sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
     // Coefficients in ascending order of powers: c0, c1, c2, c3, c4, c5, c6, c7
     sfpi::vFloat p = PolynomialEvaluator::eval(
         r,
-        sfpi::vConst1,  // c0 = 1
-        sfpi::vConst1,  // c1 = 1
+        1.0f,           // c0 = 1
+        1.0f,           // c1 = 1
         0.5f,           // c2 = 1/2!
         1.0f / 6.0f,    // c3 = 1/3!
         1.0f / 24.0f,   // c4 = 1/4!
@@ -145,7 +145,7 @@ inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
             _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
         }
         v_else {  // large negative
-            sfpi::vFloat exp_term = _sfpu_neg_exp_f32_(x) - sfpi::vConst1 - x;
+            sfpi::vFloat exp_term = _sfpu_neg_exp_f32_(x) - 1.0f - x;
             _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
         }
         v_endif;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
@@ -42,17 +42,17 @@ sfpi_inline sfpi::vFloat expm1_cw_clamped(sfpi::vFloat x)
 
     // expm1(r) = r * h(r), Horner evaluation of h
 #ifdef INP_FLOAT32
-    sfpi::vFloat h = PolynomialEvaluator::eval(r, sfpi::vConst1, 5.0000000000e-01f, 1.6666504741e-01f, 4.1666239500e-02f, 8.3691505715e-03f, 1.3948583510e-03f);
+    sfpi::vFloat h = PolynomialEvaluator::eval(r, 1.0f, 5.0000000000e-01f, 1.6666504741e-01f, 4.1666239500e-02f, 8.3691505715e-03f, 1.3948583510e-03f);
 #else
-    sfpi::vFloat h = PolynomialEvaluator::eval(r, sfpi::vConst1, 4.9999371171e-01f, 1.6666433215e-01f, 4.1875664145e-02f, 8.3751315251e-03f);
+    sfpi::vFloat h = PolynomialEvaluator::eval(r, 1.0f, 4.9999371171e-01f, 1.6666433215e-01f, 4.1875664145e-02f, 8.3751315251e-03f);
 #endif
     h = r * h;
 
     // Reconstruct: exp(x)-1 = (2^k - 1) + 2^k * expm1(r)
     // 0x4B3FFF81 = 0x4B400000 - 127: fuses k_int ISUB + bias IADD into a single ISUB
     constexpr int kC231Bias = 0x4B3FFF81;
-    sfpi::vFloat two_k      = sfpi::setexp(sfpi::vConst1, sfpi::as<sfpi::vInt>(tmp) - kC231Bias);
-    return (two_k - sfpi::vConst1) + two_k * h;
+    sfpi::vFloat two_k      = sfpi::setexp(1.0f, sfpi::as<sfpi::vInt>(tmp) - kC231Bias);
+    return (two_k - 1.0f) + two_k * h;
 }
 
 } // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -28,7 +28,7 @@ inline void _calculate_tanh_derivative_(const int iterations)
             val = lut(val, l0, l1, l2);
         }
 
-        val              = val * (-val) + sfpi::vConst1;
+        val              = val * (-val) + 1.0f;
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -51,12 +51,12 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat x)
 
         if constexpr (max_iter == 2)
         {
-            sfpi::vFloat y1 = y * -t - sfpi::vConst0;
+            sfpi::vFloat y1 = y * -t - 0.0f;
             // If t=NaN, then t>=0.  This check consumes the SFPNOP slot of the preceding SFPMAD.
             v_if (t < 0)
             {
                 t = x * y1 - sfpi::vConstFloatPrgm0;
-                y = y1 * -t - sfpi::vConst0;
+                y = y1 * -t - 0.0f;
             }
             v_endif;
         }
@@ -65,7 +65,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat x)
             // If t=NaN, then t>=0.  This check cannot be hidden in a SFPNOP slot as it depends on the result of the preceding SFPMAD.
             v_if (t < 0)
             {
-                y = y * -t - sfpi::vConst0;
+                y = y * -t - 0.0f;
             }
             v_endif;
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
@@ -42,17 +42,17 @@ sfpi_inline sfpi::vFloat expm1_cw_clamped(sfpi::vFloat x)
 
     // expm1(r) = r * h(r), Horner evaluation of h
 #ifdef INP_FLOAT32
-    sfpi::vFloat h = PolynomialEvaluator::eval(r, sfpi::vConst1, 5.0000000000e-01f, 1.6666504741e-01f, 4.1666239500e-02f, 8.3691505715e-03f, 1.3948583510e-03f);
+    sfpi::vFloat h = PolynomialEvaluator::eval(r, 1.0f, 5.0000000000e-01f, 1.6666504741e-01f, 4.1666239500e-02f, 8.3691505715e-03f, 1.3948583510e-03f);
 #else
-    sfpi::vFloat h = PolynomialEvaluator::eval(r, sfpi::vConst1, 4.9999371171e-01f, 1.6666433215e-01f, 4.1875664145e-02f, 8.3751315251e-03f);
+    sfpi::vFloat h = PolynomialEvaluator::eval(r, 1.0f, 4.9999371171e-01f, 1.6666433215e-01f, 4.1875664145e-02f, 8.3751315251e-03f);
 #endif
     h = r * h;
 
     // Reconstruct: exp(x)-1 = (2^k - 1) + 2^k * expm1(r)
     // 0x4B3FFF81 = 0x4B400000 - 127: fuses k_int ISUB + bias IADD into a single ISUB
     constexpr int kC231Bias = 0x4B3FFF81;
-    sfpi::vFloat two_k      = sfpi::setexp(sfpi::vConst1, sfpi::as<sfpi::vInt>(tmp) - kC231Bias);
-    return (two_k - sfpi::vConst1) + two_k * h;
+    sfpi::vFloat two_k      = sfpi::setexp(1.0f, sfpi::as<sfpi::vInt>(tmp) - kC231Bias);
+    return (two_k - 1.0f) + two_k * h;
 }
 
 } // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -28,7 +28,7 @@ inline void _calculate_tanh_derivative_(const int iterations)
             val = lut(val, l0, l1, l2);
         }
 
-        val              = val * (-val) + sfpi::vConst1;
+        val              = val * (-val) + 1.0f;
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -54,7 +54,7 @@ sfpi_inline sfpi::vFloat _swiglu_sigmoid_(sfpi::vFloat x) {
     } else {
         exp_neg_x = _sfpu_exp_21f_bf16_<true>(-x);
     }
-    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
+    sfpi::vFloat denominator = 1.0f + exp_neg_x;
     if constexpr (is_fp32_dest_acc_en) {
         return sfpu_reciprocal_iter<2>(denominator);
     } else {
@@ -87,7 +87,7 @@ inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, c
         v_endif;
 
         // up = up + 1
-        up = up + sfpi::vConst1;
+        up = up + 1.0f;
 
         // sigmoid(alpha * gate)
         sfpi::vFloat alpha_gate = gate * alpha;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -54,7 +54,7 @@ sfpi_inline sfpi::vFloat _swiglu_sigmoid_(sfpi::vFloat x) {
     } else {
         exp_neg_x = _sfpu_exp_21f_bf16_<true>(-x);
     }
-    sfpi::vFloat denominator = 1.0f + exp_neg_x;
+    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
     if constexpr (is_fp32_dest_acc_en) {
         return sfpu_reciprocal_iter<2>(denominator);
     } else {
@@ -87,7 +87,7 @@ inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, c
         v_endif;
 
         // up = up + 1
-        up = up + 1.0f;
+        up = up + sfpi::vConst1;
 
         // sigmoid(alpha * gate)
         sfpi::vFloat alpha_gate = gate * alpha;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
The compiler is (now) quite capable of spotting uses of the constants held in the fixed registers.  Just use the appropriate literal and the right things will happen.  Thus lowering the cognitive load.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsidwell/consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/consts)