### PR TITLE
Mark mux-region MoE core placement tests Blackhole-only

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/test_moe_core_placement.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_moe_core_placement.py
@@ -5,6 +5,7 @@
 import pytest
 import ttnn
 
+from models.common.utility_functions import is_wormhole_b0
 from ttnn.experimental.moe_compute_utils import auto_output_width_shard_dim, effective_matmul_ring_size
 
 
@@ -82,6 +83,7 @@ def test_get_moe_tilize_drain_core_structural(device):
     assert drain_core.y >= grid.y - 2, "drain core should be in the top two worker rows (tilize region)"
 
 
+@pytest.mark.skipif(is_wormhole_b0(), reason="mux placement geometry is Blackhole-only")
 def test_get_moe_combine_cores_avoids_mux_cores(device):
     """Combine and tilize cores must not overlap a caller-specified mux region."""
     hidden_size = 4096
@@ -105,6 +107,7 @@ def test_get_moe_combine_cores_avoids_mux_cores(device):
     }, "tilize drain core overlaps mux region"
 
 
+@pytest.mark.skipif(is_wormhole_b0(), reason="mux placement geometry is Blackhole-only")
 def test_moe_worker_mcast_bbox_consistent_with_mux_placement(device):
     """get_moe_worker_mcast_bounding_box must agree with the worker placement
     the op actually uses when mux cores are present.


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Two MoE core placement unit tests were failing on Wormhole because they assert a mux-avoidance placement that requires Blackhole-sized geometry: a compact 12-core matmul ring, 16 combine cores, and tilize cores all disjoint from the requested mux region cannot be placed on the 8x9 Wormhole worker grid. The tests are intended to validate the mux-region placement behavior used by the Blackhole MoE path, so they now skip on Wormhole using the existing test utility idiom. This preserves the Blackhole coverage while avoiding treating an impossible Wormhole placement as a placement regression.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/moe-coordinates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/moe-coordinates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/moe-coordinates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/moe-coordinates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/moe-coordinates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/moe-coordinates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/moe-coordinates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/moe-coordinates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/moe-coordinates)