### PR TITLE
[skip ci] remove flux1 dev demo test from m galaxy_demo_tests.yaml

### DIFF
--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -32,17 +32,6 @@
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
 
-- name: Galaxy Flux.1-dev demo tests
-  cmd: |
-    export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache NO_PROMPT=1 TT_MM_THROTTLE_PERF=5
-    pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k "4x8sp0tp1-dev" --timeout 1200
-  model: flux1
-  skus:
-    wh_galaxy_perf:
-      timeout: 15
-  owner_id: U08TED0JM9D # Samuel Adesoye
-  team: models
-
 - name: Galaxy Motif-Image-6B-Preview demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache NO_PROMPT=1


### PR DESCRIPTION
This pull request removes the "Galaxy Flux.1-dev demo tests" job from the `galaxy_demo_tests.yaml` file. The job definition, including its command, model, SKUs, and ownership information, has been deleted. No other changes are present.

([tests/pipeline_reorg/galaxy_demo_tests.yamlL35-L45](diffhunk://#diff-6682ab9cd7c742371b94cdfd884a4dccade913d758bf82c7655b9b8cccedeacdL35-L45))### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jameslee/remove_flux1_galaxy_demo_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jameslee/remove_flux1_galaxy_demo_test)