### PR TITLE
mla: use sparse_sdpa in-kernel block-cyclic remap (drop host KV reorder)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -14,7 +14,6 @@ import ttnn
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import NullIndexer, TtIndexer, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.mla_config import MLA_MATMUL_CONFIG, MLA_SDPA_CONFIG
-from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_to_natural
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
 
@@ -1099,10 +1098,10 @@ class ttMLA:
         **_,
     ):
         assert indices is not None, "sparse MLA forward requires indexer top-k indices"
-        start_pos = kv_actual_isl or 0
-        end_pos = start_pos + seq_len_local * self.sp_factor
 
-        # Chunked: the prefix lives in the BLOCK-CYCLIC cache; gather + un-rotate on device.
+        # Chunked: the prefix lives in the BLOCK-CYCLIC cache. Gather it on device and hand it to
+        # sparse_sdpa still block-cyclic — the op remaps the natural top-k indices to physical pages
+        # in-kernel (block_cyclic_chunk_local = per-shard chunk = seq_len_local), so no host reorder.
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
             kvpe_cache,
             tt_kvpe_b8,
@@ -1112,11 +1111,11 @@ class ttMLA:
             kv_actual_global=kv_actual_isl,
             cluster_axis=self.sp_axis,
         )
-        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, seq_len_local, end_pos, cache_user_id, cache_layer_idx)
+        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, cache_user_id, cache_layer_idx)
         ttnn.deallocate(tt_kvpe_b8)
 
         # Sparse attention runs over latent V; project to v_head_dim afterwards.
-        attn_out = self._sparse_mla(tt_q, kvpe_dev, indices)
+        attn_out = self._sparse_mla(tt_q, kvpe_dev, indices, block_cyclic_chunk_local=seq_len_local)
         ttnn.deallocate(kvpe_dev)
         ttnn.deallocate(tt_q)
         return self._apply_wkv_b2(attn_out, seq_len_local)
@@ -1229,7 +1228,9 @@ class ttMLA:
         heads_local = self.num_heads // self.tp_factor
         return self.tp_factor > 1 and (heads_local < 32 or heads_local % 32 != 0)
 
-    def _sparse_mla(self, q: ttnn.Tensor, kvpe: ttnn.Tensor, indices: ttnn.Tensor) -> ttnn.Tensor:
+    def _sparse_mla(
+        self, q: ttnn.Tensor, kvpe: ttnn.Tensor, indices: ttnn.Tensor, block_cyclic_chunk_local: Optional[int] = None
+    ) -> ttnn.Tensor:
         """Absorbed MQA over the top-k selected latents (FlashMLA sparse contract: no causal mask —
         ``indices`` already encode it via the 0xFFFFFFFF sentinel). Invoked SPMD on the SP×TP mesh:
         each chip runs the single-chip ``ttnn.transformer.sparse_sdpa`` over its own q shard, so q's
@@ -1237,7 +1238,12 @@ class ttMLA:
 
         q: [1, H/tp, S/sp, 576] absorbed (TILE bf16); kvpe: [1, 1, T, 576] full latent prefix, ROW_MAJOR
         replicated (K = full 576, V = leading kv_lora_rank). indices: [1, 1, S_global, k] uint32 replicated,
-        re-sharded onto SP (dim2) to match q when sp > 1 (or already SP-sharded → pass through)."""
+        re-sharded onto SP (dim2) to match q when sp > 1 (or already SP-sharded → pass through).
+
+        block_cyclic_chunk_local: when set, ``kvpe`` is the KVPE cache in its native BLOCK-CYCLIC SP layout
+        (not natural order) and ``indices`` are natural positions; sparse_sdpa remaps each index to its
+        physical page in-kernel (invP) over the SP mesh axis, so the host reorder is eliminated. It is the
+        per-shard chunk length (chunk_size_global / sp). None → natural-order kvpe (single-shot path)."""
         assert self.sp_axis == 0 and self.tp_axis == 1, "sparse_mla assumes sp_axis=0 (outer), tp_axis=1"
         sp = self.sp_factor
         seq_len_local = q.shape[2]  # per-chip query rows == S / sp
@@ -1277,7 +1283,14 @@ class ttMLA:
         # k_chunk_size must be a multiple of 32 that divides TOPK (prod TOPK=2048 → 128).
         k_chunk = next((c for c in (128, 64, 32) if idx.shape[-1] % c == 0), 32)
         out = ttnn.transformer.sparse_sdpa(
-            q_rm, kvpe, idx, v_dim=self.kv_lora_rank, scale=self.scale, k_chunk_size=k_chunk
+            q_rm,
+            kvpe,
+            idx,
+            v_dim=self.kv_lora_rank,
+            scale=self.scale,
+            k_chunk_size=k_chunk,
+            block_cyclic_sp_axis=self.sp_axis if block_cyclic_chunk_local is not None else None,
+            block_cyclic_chunk_local=block_cyclic_chunk_local,
         )
         ttnn.deallocate(q_rm)
         if idx is not indices:
@@ -1294,13 +1307,14 @@ class ttMLA:
             ttnn.deallocate(out_all_heads)
         return ret
 
-    def _gather_kvpe_prefix(self, kvpe_cache, seq_len_local, end_pos, cache_user_id, cache_layer_idx):
+    def _gather_kvpe_prefix(self, kvpe_cache, cache_user_id, cache_layer_idx):
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
-        bf8 / TILE / ND-sharded / block-cyclic across SP; the sparse op wants the full prefix
-        bf16 / ROW_MAJOR / replicated / natural order. Pipeline (all on device — replaces the
-        former host ConcatMesh2dToTensor + blockcyclic_positions read): ND→interleaved, SP
-        all-gather to full-T (no-op at sp==1), select this user/layer slot, bf8→bf16, TILE→RM,
-        un-rotate block-cyclic→natural, trim to end_pos. Returns [1, 1, end_pos, 576] bf16 RM."""
+        bf8 / TILE / ND-sharded / block-cyclic across SP; sparse_sdpa consumes it bf16 / ROW_MAJOR /
+        replicated and remaps the natural-position indices to physical block-cyclic pages in-kernel
+        (invP), so the buffer is LEFT in block-cyclic order — no host reorder. Pipeline (all on
+        device): ND→interleaved, SP all-gather to full-T (no-op at sp==1), select this user/layer
+        slot, bf8→bf16, TILE→RM. Returns the whole preallocated cache [1, 1, seq_len_cache, 576] bf16
+        RM (block-cyclic); the unwritten suffix is never addressed since indices stay < populated."""
         cache_i = ttnn.to_memory_config(kvpe_cache, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
         full = self._all_gather(
             cache_i, dim=2, cluster_axis=self.sp_axis
@@ -1316,6 +1330,4 @@ class ttMLA:
         ttnn.deallocate(full)
         full_rm = ttnn.to_layout(full16, ttnn.ROW_MAJOR_LAYOUT)
         ttnn.deallocate(full16)
-        out = blockcyclic_to_natural(full_rm, self.sp_factor, seq_len_local, end_pos)
-        ttnn.deallocate(full_rm)
-        return out
+        return full_rm

--- a/models/demos/deepseek_v3_d_p/tt/mla/utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/utils.py
@@ -145,39 +145,6 @@ def blockcyclic_cache_host(
     return out.reshape(1, 1, seq_len_cache, kvpe_dim)
 
 
-def blockcyclic_to_natural(t, sp: int, seq_len_local: int, end_pos: int):
-    """Reorder a gathered full-cache tensor from the cache's block-cyclic SP layout into natural
-    token order, on device — the inverse of blockcyclic_positions. t is [1, 1, seq_len_cache, 576]
-    ROW_MAJOR (block-cyclic); returns [1, 1, end_pos, 576] natural order. Identity order at sp==1."""
-    seq_len_cache, d = t.shape[2], t.shape[3]
-    chunk_local = seq_len_local  # = chunk_size_global / sp
-    slabs = seq_len_cache // (sp * chunk_local)  # chunks written into the cache
-    if sp == 1:
-        return ttnn.slice(t, (0, 0, 0, 0), (1, 1, end_pos, d))  # identity order
-    # Reorder block-cyclic [chip, slab, off] → natural [slab, chip, off]. A reshape+permute leaves
-    # the result physically NON-contiguous (a strided view): to_torch honours the strides, but the
-    # sparse_sdpa reader consumes raw physical order and silently reads garbage. Concatenating
-    # contiguous per-(slab,chip) slabs materialises a fresh contiguous tensor instead.
-    seq_local_cache = slabs * chunk_local  # rows held by one chip
-    blocks = [
-        ttnn.slice(
-            t,
-            (0, 0, c * seq_local_cache + s * chunk_local, 0),
-            (1, 1, c * seq_local_cache + (s + 1) * chunk_local, d),
-        )
-        for s in range(slabs)
-        for c in range(sp)
-    ]
-    flat = ttnn.concat(blocks, dim=2)
-    for b in blocks:
-        ttnn.deallocate(b)
-    if end_pos == seq_len_cache:
-        return flat
-    out = ttnn.slice(flat, (0, 0, 0, 0), (1, 1, end_pos, d))
-    ttnn.deallocate(flat)  # the slice is a fresh tensor; free the full concat
-    return out
-
-
 def global_to_local_token_id(
     global_token_id: int,
     sp_factor: int,

--- a/models/demos/deepseek_v3_d_p/tt/mla/utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/utils.py
@@ -3,8 +3,6 @@
 
 import torch
 
-import ttnn
-
 
 def create_balanced_chunk_order(sp_factor: int) -> list[int]:
     """Create balanced chunk order for sequence reordering.


### PR DESCRIPTION
## What

Adapt the DeepSeek V3.2 / GLM-5.1 chunked sparse-MLA path to consume the **new `sparse_sdpa` in-kernel block-cyclic index remap** ([op-side PR #48428](https://github.com/tenstorrent/tt-metal/pull/48428)), eliminating the per-layer host-side block-cyclic→natural KV reorder.

## Background

The chunked KVPE cache is stored **block-cyclic** across SP shards, but the indexer emits **natural-position** top-k indices. Previously `_gather_kvpe_prefix` reordered the whole `[1,1,T,576]` prefix to natural order every layer (`sp*slabs` slices + 1 concat via `blockcyclic_to_natural`) so the op's indices addressed the right rows. #48428 teaches `sparse_sdpa` to remap each natural index to its physical block-cyclic page on the fly (invP), so the buffer can stay block-cyclic and the host reorder goes away.

## Changes (model only — `models/demos/deepseek_v3_d_p/tt/mla/`)

- **`_gather_kvpe_prefix`** — no longer calls `blockcyclic_to_natural`; returns the gathered buffer still block-cyclic (the whole preallocated cache; the op only ever addresses populated rows). Drops the now-unused `seq_len_local`/`end_pos` params.
- **`_sparse_mla`** — new `block_cyclic_chunk_local` arg; when set, passes `block_cyclic_sp_axis=self.sp_axis` + `block_cyclic_chunk_local` through to `sparse_sdpa`. `None` → natural-order kvpe (single-shot path), byte-identical to before.
- **`_sparse_chunked_attn`** — wires `block_cyclic_chunk_local=seq_len_local` (the per-shard chunk = `chunk_size_global/sp`); drops the now-unused `start_pos`/`end_pos`.
- Removes the now-dead `blockcyclic_to_natural` helper from `utils.py`.

## Validation (8× Blackhole)

`test_sparse_mla_chunked` (the path that used the reorder) passes with PCC matching the host-reorder path:

| variant | mesh | chunked output PCC | kvpe |
|---|---|---|---|
| `deepseek_v32` | 2x4 (tp=4) | **0.9961** | 0.9999 |
| `glm_5_1` | 4x2 (tp=2) | **0.9963** | 0.9999 |

The single-shot accuracy/determinism path is unchanged (passes `block_cyclic=None`).

## Dependency #48428 — landed ✅

The op-side dependency [#48428](https://github.com/tenstorrent/tt-metal/pull/48428) (`sparse_sdpa`: in-kernel block-cyclic index remap) has merged to `main`. This branch has been rebased onto latest `main`; the temporary squash commit that carried #48428 is dropped, so **this PR now contains only the model change** and is ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/mla-sparse-blockcyclic-in-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/mla-sparse-blockcyclic-in-kernel)
