### PR TITLE
Use rotate-based SFPU horizontal reductions

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -342,31 +342,30 @@ inline void perform_reduce_col_sum_avg() {
  * We run two reductions in lockstep (LREG0/LREG1 and LREG4/LREG5) so that the second SFPSHFT2
  * fills the latency slot of the first, avoiding extra NOPs and reducing total cycle count.
  *
- * Algorithm (log2(8) = 3 reduction stages + 1 rotate). Each stage: copy to temp, shift right
- * by the appropriate amount so columns align, then add (SFPIADD or SFPADD) to fold halves together.
+ * Algorithm (log2(8) = 3 reduction stages). Each stage: copy to temp, rotate right by the appropriate
+ * amount so columns align, then add (SFPIADD or SFPADD) to fold halves together.
  *
- *   Phase 1: Shift by 4 and add -> 8 partial sums (cols 0-7) become 4 sums (cols 4-7).
- *   Phase 2: Shift by 2 and add -> 4 sums become 2 sums (cols 6-7).
- *   Phase 3: Shift by 1 and add -> 2 sums become 1 sum (col 7).
- *   Phase 4: Rotate right by 1  -> move the single sum from col 7 to col 0.
+ *   Phase 1: Rotate by 4 and add -> 8 partial sums (cols 0-7) become 4 duplicated pair sums.
+ *   Phase 2: Rotate by 2 and add -> pair sums become 2 duplicated quad sums.
+ *   Phase 3: Rotate by 1 and add -> quad sums become the full 8-column sum in every column.
  *
  * @tparam is_integer_mode True for integer types (uses SFPIADD), false for float (uses SFPADD)
  */
 template <bool is_integer_mode>
 inline void horizontal_reduce() {
-    // Phase 1: Shift by 4 and add -> 8 partial sums (cols 0-7) become 4 sums (cols 4-7).
+    // Phase 1: Rotate by 4 and add -> 8 partial sums (cols 0-7) become 4 duplicated pair sums.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
 
-    // Four right-shifts-by-4 in lockstep for both pairs; second SFPSHFT2 hides first's latency
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    // Four right-rotates-by-1 in lockstep for both pairs; second SFPSHFT2 hides first's latency.
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
 
     if constexpr (is_integer_mode) {
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
@@ -378,13 +377,13 @@ inline void horizontal_reduce() {
             p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0);  // lreg4 = lreg4 * 1.0 + lreg5 (float)
     }
 
-    // Phase 2: Shift by 2 and add -> 4 sums become 2 sums (cols 6-7).
+    // Phase 2: Rotate by 2 and add -> pair sums become 2 duplicated quad sums.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     if constexpr (is_integer_mode) {
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, 4);
@@ -393,11 +392,11 @@ inline void horizontal_reduce() {
         TTI_SFPADD(p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0);
     }
 
-    // Phase 3: Shift by 1 and add -> 2 sums become 1 sum (col 7).
+    // Phase 3: Rotate by 1 and add -> quad sums become the full 8-column sum in every column.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     if constexpr (is_integer_mode) {
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, 4);
@@ -408,9 +407,6 @@ inline void horizontal_reduce() {
             p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0);  // lreg4 = lreg4 * 1.0 + lreg5 (float)
     }
 
-    // Phase 4: Rotate right by 1 -> move single sum from col 7 to col 0 for store.
-    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG0, 3);
-    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG4, 3);
     // LREG0[0 column slice] = sum of all elements in the first 4 rows of this 8-row block (first half)
     // LREG4[0 column slice] = sum of all elements in the next 4 rows of this 8-row block (second half)
 }
@@ -421,10 +417,10 @@ constexpr std::uint32_t HORIZONTAL_REDUCE_MAX_REPLAY_LEN = 16;
  * @brief Records phases 2-4 of horizontal max reduction into replay buffer at slot 0 (16 instructions).
  *
  * The full horizontal max reduction has 28 instructions across 4 phases:
- *   Phase 1: 2 MOV + 8 SHFT2 + 2 SWAP = 12 (inline, shift-by-4)
- *   Phase 2: 2 MOV + 4 SHFT2 + 2 SWAP =  8 (replay, shift-by-2)
- *   Phase 3: 2 MOV + 2 SHFT2 + 2 SWAP =  6 (replay, shift-by-1)
- *   Phase 4: 2 SHFT2                   =  2 (replay, rotate to col 0)
+ *   Phase 1: 2 MOV + 8 SHFT2 + 2 SWAP = 12 (inline, rotate-by-4)
+ *   Phase 2: 2 MOV + 4 SHFT2 + 2 SWAP =  8 (replay, rotate-by-2)
+ *   Phase 3: 2 MOV + 2 SHFT2 + 2 SWAP =  6 (replay, rotate-by-1)
+ *   Phase 4: 2 SHFT2                   =  2 (replay, rotate to col 0, redundant after rotate reduction)
  *
  * Phase 1 (12 instr) stays inline; phases 2+3+4 (16 instr) fit exactly in one replay buffer.
  * Must be called once before perform_reduce_row_max_tile.
@@ -432,21 +428,21 @@ constexpr std::uint32_t HORIZONTAL_REDUCE_MAX_REPLAY_LEN = 16;
 inline void record_horizontal_reduce_max() {
     lltt::record(0, HORIZONTAL_REDUCE_MAX_REPLAY_LEN);
 
-    // Phase 2: Shift by 2 and max -> 4 maxes become 2 maxes (cols 6-7).
+    // Phase 2: Rotate by 2 and max -> pair maxes become duplicated quad maxes.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, 1);
 
-    // Phase 3: Shift by 1 and max -> 2 maxes become 1 max (col 7).
+    // Phase 3: Rotate by 1 and max -> quad maxes become the full 8-column max in every column.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, 1);
 
@@ -460,18 +456,18 @@ inline void record_horizontal_reduce_max() {
  *        record_horizontal_reduce_max() must have been called before first use.
  */
 inline void horizontal_reduce_max() {
-    // Phase 1 (inline): Shift by 4 and max -> 8 values become 4 maxes (cols 4-7).
+    // Phase 1 (inline): Rotate by 4 and max -> 8 values become 4 duplicated pair maxes.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
 
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, 1);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -298,31 +298,30 @@ inline void perform_reduce_col_sum_avg() {
  * We run two reductions in lockstep (LREG0/LREG1 and LREG4/LREG5) so that the second SFPSHFT2
  * fills the latency slot of the first, avoiding extra NOPs and reducing total cycle count.
  *
- * Algorithm (log2(8) = 3 reduction stages + 1 rotate). Each stage: copy to temp, shift right
- * by the appropriate amount so columns align, then add (SFPIADD or SFPADD) to fold halves together.
+ * Algorithm (log2(8) = 3 reduction stages). Each stage: copy to temp, rotate right by the appropriate
+ * amount so columns align, then add (SFPIADD or SFPADD) to fold halves together.
  *
- *   Phase 1: Shift by 4 and add -> 8 partial sums (cols 0-7) become 4 sums (cols 4-7).
- *   Phase 2: Shift by 2 and add -> 4 sums become 2 sums (cols 6-7).
- *   Phase 3: Shift by 1 and add -> 2 sums become 1 sum (col 7).
- *   Phase 4: Rotate right by 1  -> move the single sum from column 7 to column 0.
+ *   Phase 1: Rotate by 4 and add -> 8 partial sums (cols 0-7) become 4 duplicated pair sums.
+ *   Phase 2: Rotate by 2 and add -> pair sums become 2 duplicated quad sums.
+ *   Phase 3: Rotate by 1 and add -> quad sums become the full 8-column sum in every column.
  *
  * @tparam is_integer_mode True for integer types (uses SFPIADD), false for float (uses SFPADD)
  */
 template <bool is_integer_mode>
 inline void horizontal_reduce() {
-    // Phase 1: Shift by 4 and add -> 8 partial sums (cols 0-7) become 4 sums (cols 4-7).
+    // Phase 1: Rotate by 4 and add -> 8 partial sums (cols 0-7) become 4 duplicated pair sums.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
 
-    // Four right-shifts-by-4 in lockstep for both pairs; second SFPSHFT2 hides first's latency
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    // Four right-rotates-by-1 in lockstep for both pairs; second SFPSHFT2 hides first's latency.
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
 
     if constexpr (is_integer_mode) {
         TTI_SFPNOP;
@@ -333,13 +332,13 @@ inline void horizontal_reduce() {
         TTI_SFPADD(p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0);
     }
 
-    // Phase 2: Shift by 2 and add -> 4 sums become 2 sums (cols 6-7).
+    // Phase 2: Rotate by 2 and add -> pair sums become 2 duplicated quad sums.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     if constexpr (is_integer_mode) {
         TTI_SFPNOP;
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
@@ -351,11 +350,11 @@ inline void horizontal_reduce() {
             p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0);  // lreg4 = lreg4 * 1.0 + lreg5 (float)
     }
 
-    // Phase 3: Shift by 1 and add -> 2 sums become 1 sum (col 7).
+    // Phase 3: Rotate by 1 and add -> quad sums become the full 8-column sum in every column.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     if constexpr (is_integer_mode) {
         TTI_SFPNOP;
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
@@ -365,9 +364,6 @@ inline void horizontal_reduce() {
         TTI_SFPADD(p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0);
     }
 
-    // Phase 4: Rotate right by 1 -> move single sum from col 7 to col 0 for store.
-    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG0, 3);
-    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG4, 3);
     // LREG0[0 column slice] = sum of all elements in the first 4 rows of this 8-row block (first half)
     // LREG4[0 column slice] = sum of all elements in the next 4 rows of this 8-row block (second half)
 }
@@ -378,10 +374,10 @@ constexpr std::uint32_t HORIZONTAL_REDUCE_MAX_REPLAY_LEN = 16;
  * @brief Records phases 2-4 of horizontal max reduction into replay buffer at slot 0 (16 instructions).
  *
  * The full horizontal max reduction has 28 instructions across 4 phases:
- *   Phase 1: 2 MOV + 8 SHFT2 + 2 SWAP = 12 (inline, shift-by-4)
- *   Phase 2: 2 MOV + 4 SHFT2 + 2 SWAP =  8 (replay, shift-by-2)
- *   Phase 3: 2 MOV + 2 SHFT2 + 2 SWAP =  6 (replay, shift-by-1)
- *   Phase 4: 2 SHFT2                   =  2 (replay, rotate to col 0)
+ *   Phase 1: 2 MOV + 8 SHFT2 + 2 SWAP = 12 (inline, rotate-by-4)
+ *   Phase 2: 2 MOV + 4 SHFT2 + 2 SWAP =  8 (replay, rotate-by-2)
+ *   Phase 3: 2 MOV + 2 SHFT2 + 2 SWAP =  6 (replay, rotate-by-1)
+ *   Phase 4: 2 SHFT2                   =  2 (replay, rotate to col 0, redundant after rotate reduction)
  *
  * Phase 1 (12 instr) stays inline; phases 2+3+4 (16 instr) fit exactly in one replay buffer.
  * Must be called once before perform_reduce_row_max_tile.
@@ -391,21 +387,21 @@ inline void record_horizontal_reduce_max() {
     // Phase 1 (12 instructions) is too large to combine, so it stays inline.
     lltt::record(0, HORIZONTAL_REDUCE_MAX_REPLAY_LEN);
 
-    // Phase 2: Shift by 2 and max -> 4 maxes become 2 maxes (cols 6-7).
+    // Phase 2: Rotate by 2 and max -> pair maxes become duplicated quad maxes.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, 1);
 
-    // Phase 3: Shift by 1 and max -> 2 maxes become 1 max (col 7).
+    // Phase 3: Rotate by 1 and max -> quad maxes become the full 8-column max in every column.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, 1);
 
@@ -419,18 +415,18 @@ inline void record_horizontal_reduce_max() {
  *        record_horizontal_reduce_max() must have been called before first use.
  */
 inline void horizontal_reduce_max() {
-    // Phase 1 (inline): Shift by 4 and max -> 8 values become 4 maxes (cols 4-7).
+    // Phase 1 (inline): Rotate by 4 and max -> 8 values become 4 duplicated pair maxes.
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
     TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG5, 0);
 
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 4);
-    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 4);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, 3);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, 3);
 
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, 1);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The Wormhole row-reduction SFPU path used `SFPSHFT2` subvector logical shift-right stages, which trips the documented Wormhole `SUBVEC_SHFLSHR1` hardware bug, and then needed an extra rotate to move the final lane-7 result back to lane 0 for storage. The reduction is over an 8-lane subvector, so using rotate-right stages for the 4/2/1 butterfly is mathematically equivalent for sum and max reductions: each stage folds the intended lane groups, and after the final stage the complete reduction value is present in every lane, including lane 0. This change replaces the shift stages with rotate stages in the Wormhole reduce kernel, removes the now-redundant final rotate from the sum path, and applies the same sequence to the Blackhole copy to keep the arch implementations aligned while also using the shorter reduction sequence there.

### Notes for reviewers
New sequences should be both faster and safer

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/reduce-with-rotate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/reduce-with-rotate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/reduce-with-rotate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/reduce-with-rotate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/reduce-with-rotate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/reduce-with-rotate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/reduce-with-rotate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/reduce-with-rotate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/reduce-with-rotate)