### PR TITLE
[skip ci] Llama-3.1-8B N150: dynamic trace region allocation (fixes #48636)

### DIFF
--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -5,7 +5,10 @@ sizes:
     aliases: ["Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"]
     skus:
       wh_n150:
-        trace_region_size: 25000000
+        # 0 = dynamic runtime allocation. The fixed 25000000 was sized for the
+        # greedy performance-ci-eval-32 path but is too small for the traced
+        # performance-batch-32 demo (full sampling op captured). See #48636.
+        trace_region_size: 0
       wh_n300:
         trace_region_size: 38000000
       wh_llmbox_perf:

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -81,7 +81,7 @@ def test_resolve_trace_region_size_matches_yaml(model_name, sku, expected_size):
 @pytest.mark.parametrize(
     "model_name,legacy_sku,expected_size",
     [
-        ("Llama-3.1-8B", "N150", 25000000),
+        ("Llama-3.1-8B", "N150", 0),  # dynamic allocation, see #48636
         ("Llama-3.1-8B", "T3K", 50000000),
         ("Llama-3.3-70B", "P150x4", 96000000),
         ("meta-llama/Llama-3.1-8B-Instruct", "bh_quietbox_2", 52000000),


### PR DESCRIPTION
## Summary

Fixes #48636 — the Llama-3.1-8B `performance-batch-32` traced demo fails on **N150** with a `trace_region_size` too small error.

The `wh_n150` override (`25000000`) was sized for the greedy `performance-ci-eval-32` path (which doesn't capture the full sampling op). The `performance-batch-32` path captures the full sampling op and overflows the fixed region.

## Change

`models/model_trace_region_sizes.yaml` — Llama-3.1-8B `wh_n150`: `25000000` → **`0`** (dynamic runtime allocation, same approach as the deepseek-v3 demo). Also updated the hardcoded legacy-alias expectation in `test_trace_region_sizes.py` (the data-driven yaml test tracks the value automatically).

## Validation

- [x] YAML parses; resolver returns `0` for (Llama-3.1-8B, N150).
- [x] **Tier 1 E2E** (existing N150 variants: token-matching + ci-eval-32) — green, so dynamic allocation doesn't regress the paths that already pass.
- [x] **`performance-batch-32` on N150** — validated green in a throwaway CI run (test ran with no trace-region / trace-buffer error). That temporary CI line was **not** included in this PR to keep it to the minimal fix; batch-32 is still not part of the standing CI matrix.

Relates to #47574 (exploring `trace_region_size=0` automatic allocation for models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)