### PR TITLE
Add residual correction to div int32

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -642,7 +642,7 @@ def test_binary_implicit_broadcast(device, shapes, ttnn_op):
     output_tensor = ttnn.to_torch(output_tensor)
 
     if ttnn_op == ttnn.div:
-        assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
+        assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
     else:
         assert torch.equal(output_tensor, torch_output_tensor)
 
@@ -754,8 +754,7 @@ def test_binary_div_int32_full_range(input_shapes, device):
     output_tensor = ttnn.div(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
-    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=2.0)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
 def test_div_int32_optional_output(device):
@@ -772,7 +771,7 @@ def test_div_int32_optional_output(device):
     ttnn.div(input_tensor_a, input_tensor_b, output_tensor=preallocated_tensor)
     output_tensor = ttnn.to_torch(preallocated_tensor)
 
-    assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
 @pytest.mark.parametrize(
@@ -846,7 +845,7 @@ def test_div_int32_rounding_modes(input_shapes, low_a, high_a, low_b, high_b, ro
     if rounding_mode is not None:
         assert_equal(torch_output_tensor, output_tensor)
     else:
-        assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
+        assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
 @pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
@@ -900,7 +899,7 @@ def test_div_edge_cases(rounding_mode, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     if rounding_mode is None:
-        assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
+        assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
     else:
         assert torch.equal(torch_output_tensor, output_tensor)
 
@@ -930,7 +929,92 @@ def test_div_inf_nan_cases(device):
     output_tensor = ttnn.div(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-5, equal_nan=True)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0, allow_nonfinite=True)
+
+
+def test_div_exact_quotient_cases(device):
+    pairs = [
+        (28, 14),
+        (56, 14),
+        (-28, 14),
+        (28, -14),
+        (-56, -14),
+        (100, 10),
+        (144, 12),
+        (1000000, 1000),
+        (2147483646, 2),
+        (-2147483646, 2),
+        (2147483646, -1),
+        (7, 7),
+        (-7, -7),
+    ]
+
+    numerators, denominators = zip(*pairs)
+    torch_input_tensor_a = torch.tensor(numerators, dtype=torch.int32)
+    torch_input_tensor_b = torch.tensor(denominators, dtype=torch.int32)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    output_tensor = ttnn.div(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+# FP32 mantissa precision boundary: Bit-exactness only holds when the operands and the quotient fit within the fp32 mantissa
+# (|value| <= 2**24 = 16777216). div_int32 converts int32 -> fp32 before dividing,
+# so operands above 2**24 are rounded before the reciprocal even runs and the residual step cannot
+# recover the lost bits.
+def test_div_int32_large_magnitude_cases(device):
+    pairs = [
+        (2147483647, 1),  # 2**31 - 1 -> rounds up to 2**31         (2147483648.0)
+        (16777217, 1),  # 2**24 + 1 -> rounds to even 2**24        (16777216.0)
+        (1073741825, 1),  # 2**30 + 1 -> rounds down to 2**30        (1073741824.0)
+        (33554435, 1),  # 2**25 + 3 -> rounds to 2**25 + 4         (33554436.0)
+    ]
+    numerators, denominators = zip(*pairs)
+    torch_input_tensor_a = torch.tensor(numerators, dtype=torch.int32)
+    torch_input_tensor_b = torch.tensor(denominators, dtype=torch.int32)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    output_tensor = ttnn.div(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    # Device still matches the torch fp32 golden bit-exact but the result has lost integer precision above 2**24.
+    assert torch.equal(output_tensor, torch_output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -998,11 +1082,7 @@ def test_binary_divide_int32_full_range(input_shapes, device):
 
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b)
 
-    ARCH_NAME = ttnn.get_arch_name()
-    if "blackhole" in ARCH_NAME:
-        assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=2.0)
-    elif "wormhole" in ARCH_NAME:
-        assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
 def test_divide_edge_cases(device):
@@ -1074,7 +1154,7 @@ def test_divide_inf_nan_cases(device):
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-5, equal_nan=True)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0, allow_nonfinite=True)
 
 
 def test_binary_scalar_div_int32(device):
@@ -1097,7 +1177,7 @@ def test_binary_scalar_div_int32(device):
     tt_out_trunc = ttnn.to_torch(z_tt_trunc)
     z_torch_trunc = torch.divide(x_torch, y_torch, rounding_mode="trunc")
 
-    assert torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=True)
+    assert_with_ulp(tt_out, z_torch, ulp_threshold=1.0, allow_nonfinite=True)
     assert torch.equal(z_torch_floor, tt_out_floor)
     assert torch.equal(z_torch_trunc, tt_out_trunc)
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -25,7 +25,19 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
         v_if(in0 == 0 || in0 != in1) {
             sfpi::vFloat float_in0 = sfpi::convert<sfpi::vFloat>(in0, sfpi::RoundMode::Nearest);
             sfpi::vFloat float_in1 = sfpi::convert<sfpi::vFloat>(in1, sfpi::RoundMode::Nearest);
-            result = float_in0 * sfpu_reciprocal_iter<2>(float_in1);
+            sfpi::vFloat recip_in1 = sfpu_reciprocal_iter<2>(float_in1);
+            result = float_in0 * recip_in1;
+            // Residual correction using the remainder (a - q*b) * (1/b). The reciprocal is only
+            // accurate to ~1 ulp, so exact quotients (e.g. 28/14) can land 1 ulp off (2.0000001).
+            // One residual step snaps exact quotients to the correct value
+            // Note: this cannot recover precision already lost when |operand| > 2^24 is rounded during
+            // the int32 -> fp32 conversion.
+            // Gate on the integer operands (in0/in1 are the vSMag values we already loaded):
+            //   in1 == 0: recip is +/-inf and (a - inf*0) would produce a NaN, corrupting the
+            //             intended inf/-inf/NaN result of division by zero.
+            //   in0 == 0: the quotient is already exactly 0, so the residual is dead work.
+            v_if(in0 != 0 && in1 != 0) { result = result + (float_in0 - result * float_in1) * recip_in1; }
+            v_endif;
         }
         v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -32,11 +32,9 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
             // One residual step snaps exact quotients to the correct value
             // Note: this cannot recover precision already lost when |operand| > 2^24 is rounded during
             // the int32 -> fp32 conversion.
-            // Gate on the integer operands (in0/in1 are the vSMag values we already loaded):
             //   in1 == 0: recip is +/-inf and (a - inf*0) would produce a NaN, corrupting the
             //             intended inf/-inf/NaN result of division by zero.
-            //   in0 == 0: the quotient is already exactly 0, so the residual is dead work.
-            v_if(in0 != 0 && in1 != 0) { result = result + (float_in0 - result * float_in1) * recip_in1; }
+            v_if(in1 != 0) { result = result + (float_in0 - result * float_in1) * recip_in1; }
             v_endif;
         }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -32,11 +32,9 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
             // One residual step snaps exact quotients to the correct value.
             // Note: this cannot recover precision already lost when |operand| > 2^24 is rounded during
             // the int32 -> fp32 conversion.
-            // Gate on the integer operands (in0/in1 are the vSMag values we already loaded):
             //   in1 == 0: recip is +/-inf and (a - inf*0) would produce a NaN, corrupting the
             //             intended inf/-inf/NaN result of division by zero.
-            //   in0 == 0: the quotient is already exactly 0, so the residual is dead work.
-            v_if(in0 != 0 && in1 != 0) { result = result + (float_in0 - result * float_in1) * recip_in1; }
+            v_if(in1 != 0) { result = result + (float_in0 - result * float_in1) * recip_in1; }
             v_endif;
         }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -25,7 +25,19 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
         v_if(in0 == 0 || in0 != in1) {
             sfpi::vFloat float_in0 = sfpi::convert<sfpi::vFloat>(in0, sfpi::RoundMode::Nearest);
             sfpi::vFloat float_in1 = sfpi::convert<sfpi::vFloat>(in1, sfpi::RoundMode::Nearest);
-            result = float_in0 * sfpu_reciprocal_iter<2>(float_in1);
+            sfpi::vFloat recip_in1 = sfpu_reciprocal_iter<2>(float_in1);
+            result = float_in0 * recip_in1;
+            // Residual correction using the remainder (a - q*b) * (1/b). The reciprocal is only
+            // accurate to ~1 ulp, so exact quotients (e.g. 28/14) can land 1 ulp low (1.9999998).
+            // One residual step snaps exact quotients to the correct value.
+            // Note: this cannot recover precision already lost when |operand| > 2^24 is rounded during
+            // the int32 -> fp32 conversion.
+            // Gate on the integer operands (in0/in1 are the vSMag values we already loaded):
+            //   in1 == 0: recip is +/-inf and (a - inf*0) would produce a NaN, corrupting the
+            //             intended inf/-inf/NaN result of division by zero.
+            //   in0 == 0: the quotient is already exactly 0, so the residual is dead work.
+            v_if(in0 != 0 && in1 != 0) { result = result + (float_in0 - result * float_in1) * recip_in1; }
+            v_endif;
         }
         v_endif;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/48732

### PR Category
Bug

### Problem
ttnn.div on int32 inputs (true division → float) computes the quotient as float(a) * recip(float(b)). The SFPU reciprocal is only accurate to ~1 ULP, so exact integer quotients are not produced. The results also do not agree across architectures

Example:
28 / 14 | Wormhole | Blackhole | Expected
-- | -- | -- | --
result | 1.9999998807 | 2.0000000894 | 2.0

### Fix
Add a single residual-correction step to calculate_div_int32 on both Wormhole and Blackhole:
```
q = a * (1/b)
q = q + (a - q*b) * (1/b)
```
The correction is guarded by `v_if(b != 0)`: when dividing by zero the reciprocal is ±inf, and (a - inf*0) would produce a NaN.

### Result
Exact quotients (e.g. 28/14, 56/14, sign variants, large magnitudes) are now bit-exact on WH and BH.
**Max ULP** reduced from 2.0 to **1.0**

### Accuracy
INT32 Inputs: 3737 numerators × 3736 divisors = 13,961,432 pairs
| ULP | Without residual correction | With residual correction |
|---|---|---|
| Max ULP | 2 | 1 |
| ULP 0 | 10,267,930 (73.5450%) | 12,396,508 (88.7911%) |
| ULP 1 | 3,691,634 (26.4417%) | 1,564,924 (11.2089%) |
| ULP 2 | 1,868 (0.0134%) | 0 (0.0000%) |
| ULP 3–10 | 0 (0.0000%) | 0 (0.0000%) |
| ULP 11–100 | 0 (0.0000%) | 0 (0.0000%) |
| ULP >100 | 0 (0.0000%) | 0 (0.0000%) |
| Worst case | `-2134580070 / -533965280`<br>tt=3.997600555419922<br>ref=3.99760103225708<br>(2 ULP) | `-2147483647 / -2143236739`<br>tt=1.0019816160202026<br>ref=1.001981496810913<br>(1 ULP) |

### Perf
| Tensor Shape | Old [ns] | New [ns] | Change |
|---|---|---|---|
| [1, 1, 32, 32] | 3890 | 3877 | -0.33% |
| [1, 1, 1024, 1024] | 78041 | 78270 | +0.29% |
| [1, 1, 4096, 4096] | 926811 | 940829 | +1.51% |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/improve_div_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/improve_div_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anasuya/improve_div_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/improve_div_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/improve_div_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/improve_div_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/improve_div_int32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/improve_div_int32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/improve_div_int32)