### PR TITLE
Keep SFPU min/max loadmacro fallback internal to reduce helpers

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1240,6 +1240,13 @@ inline void init_reduce_max_min_int32() {
  */
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
 inline void init_reduce_max_min(std::uint32_t num_cols) {
+#ifdef DISABLE_SFPLOADMACRO
+    if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP && !clear_high_bits) {
+        init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
+        return;
+    }
+#endif
+
     // Initialize SFPU config and set swap direction before defining LOADMACRO sequences
     _init_sfpu_config_reg();
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -940,6 +940,13 @@ inline void init_reduce_max_min_int32() {
  */
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
 inline void init_reduce_max_min(std::uint32_t num_cols) {
+#ifdef DISABLE_SFPLOADMACRO
+    if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP && !clear_high_bits) {
+        init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
+        return;
+    }
+#endif
+
     // Initialize SFPU config and set swap direction before defining LOADMACRO sequences
     _init_sfpu_config_reg();
 
@@ -1193,6 +1200,15 @@ inline void calculate_reduce_max_min(const std::uint32_t block_ct_dim = 1, const
         reduce_dim == ReduceDim::REDUCE_COL ||
             ((pool_type == PoolType::MAX || pool_type == PoolType::MIN) && reduce_dim == ReduceDim::REDUCE_ROW),
         "Only column reduction (REDUCE_COL) and row MAX/MIN reduction (REDUCE_ROW with MAX/MIN) are supported");
+
+#ifdef DISABLE_SFPLOADMACRO
+    if constexpr (
+        reduce_dim == ReduceDim::REDUCE_COL && INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP &&
+        !clear_high_bits) {
+        calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>();
+        return;
+    }
+#endif
 
     if constexpr (reduce_dim == ReduceDim::REDUCE_ROW) {
         static_assert(


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max_sfpu.py` failed under the simulator when `TT_METAL_DISABLE_SFPLOADMACRO=1` because the Int32 SFPU min/max reduce path still initialized and executed the generic LOADMACRO-based compare/swap sequence. That exposed the macro implementation detail above the max/min helper boundary and left callers responsible for selecting a compatible manual path. This change moves the fallback into the max/min helpers themselves: when LOADMACRO is disabled, the Int32 max/min init path records the existing manual compare/swap replay buffer, and the Wormhole column calculate helper uses the corresponding manual load/swap/store body. Blackhole gets the same internalized init handling while keeping its existing explicit Int32 calculate path. The public reduce dispatch remains semantic (`MAX`/`MIN` dispatches to max/min helpers), LOADMACRO-enabled builds keep the existing path, and the disabled-LOADMACRO configuration no longer emits `SFPLOADMACRO`.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/reduce-disable-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/reduce-disable-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/reduce-disable-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/reduce-disable-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/reduce-disable-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/reduce-disable-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/reduce-disable-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/reduce-disable-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/reduce-disable-loadmacro)