### PR TITLE
[welford] static_assert Ht >= 1 to prevent Ht=0 tile_regs deadlock (#48486)

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_h.cpp
@@ -28,6 +28,12 @@ void kernel_main() {
     // Compile-time args:
     // Number of tiles along the H (reduction) dimension.
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    // The DST window is opened with tile_regs_acquire() before the ht loop and only closed by
+    // tile_regs_commit() inside the last-tile (ht == Ht-1) branch. If Ht were 0 the loop body would
+    // never run, tile_regs_commit() would be skipped, and the paired tile_regs_wait() below would
+    // deadlock with cb_out reserved-but-never-pushed. All current callers guarantee Ht >= 1 for an
+    // H-reduce; enforce it so a future Ht=0 caller fails to compile instead of hanging (issue #48486).
+    static_assert(Ht >= 1, "Welford H-reduce requires at least one height tile (Ht >= 1)");
     // The actual number of elements along H (before padding).
     constexpr uint32_t H = get_compile_time_arg_val(1);
     // Number of elements per tile in the H dimension (typically 32).

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
@@ -39,6 +39,12 @@ void kernel_main() {
 
     // Compile-time args:
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    // The DST window is opened with tile_regs_acquire() before the ht loop and only closed by
+    // tile_regs_commit() inside the last-tile (ht == Ht-1) branch. If Ht were 0 the loop body would
+    // never run, tile_regs_commit() would be skipped, and the paired tile_regs_wait() below would
+    // deadlock with cb_partial reserved-but-never-pushed. All current callers guarantee Ht >= 1 for
+    // an H-reduce; enforce it so a future Ht=0 caller fails to compile instead of hanging (issue #48486).
+    static_assert(Ht >= 1, "Welford H-reduce requires at least one height tile (Ht >= 1)");
     constexpr uint32_t H = get_compile_time_arg_val(1);
     constexpr uint32_t tile_height = get_compile_time_arg_val(2);
     constexpr uint32_t Wt = get_compile_time_arg_val(3);


### PR DESCRIPTION
## Summary

Closes #48486 (sub-issue of #48393, Section C — real latent; not live today but unguarded).

`welford_reduce_h.cpp` and `welford_reduce_hw.cpp` open the DST window with `tile_regs_acquire()` **before** the `ht` loop and only close it with `tile_regs_commit()` **inside** the last-tile (`ht == Ht-1`) branch:

```cpp
tile_regs_acquire();
for (uint32_t ht = 0; ht < Ht; ++ht) {
    ...
    if (ht < (Ht - 1)) { welford_update(...); }
    else { ...; tile_regs_commit(); }   // only path that commits
}
cb_out_obj.reserve_back(onetile);
tile_regs_wait();                        // deadlocks if commit never ran
```

If `Ht == 0` the loop body never runs → `tile_regs_commit()` is skipped → the paired `tile_regs_wait()` deadlocks and the output CB (`cb_out` / `cb_partial`) is left reserved-but-never-pushed.

Not reachable today (an H-reduce always has `Ht >= 1` in every caller), but nothing prevents a future caller from passing `Ht=0`.

## Fix

`Ht` is a compile-time arg (`get_compile_time_arg_val(0)`), so add the issue's preferred guard to both kernels:

```cpp
static_assert(Ht >= 1, "Welford H-reduce requires at least one height tile (Ht >= 1)");
```

An `Ht=0` caller now **fails to compile** instead of hanging on device. Chosen over hoisting `tile_regs_commit()` out of the branch because it keeps the intended single-DST-window structure intact and surfaces the misuse at build time rather than papering over it. Each assert carries a comment explaining the acquire/commit/wait pairing it protects.

## Validation (p150b Blackhole)

`tests/ttnn/unit_tests/operations/reduce/test_reduction.py::test_std` and `::test_var` — **240 passed**, covering:
- H-reduce (`dim=-2`) → `welford_reduce_h`, and HW-reduce (`dim=(-2,-1)`) → `welford_reduce_hw`,
- `Ht=1` (h=32) and `Ht=2` (h=64) — both the last-tile-only and non-last+last branches,
- both `correction` modes.

Both edited kernels JIT-compile with the assert in place (it only fires for the never-produced `Ht=0`); numerics are unchanged (pure compile-time guard).

## Definition of done
- [x] `static_assert(Ht >= 1)` added to both `welford_reduce_h.cpp` and `welford_reduce_hw.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/48486)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/48486)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/48486)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/48486)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/48486)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/48486)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/48486)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/48486)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/48486)