### PR TITLE
[Cleanup] Avoid enumeration of disabled dfb implicit sync

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -113,15 +113,11 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
     // DM kernel configs (Gen1 + Gen2 variants so the same spec runs everywhere).
     const DataMovementHardwareConfig producer_cfg{
         .gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_0},
-        .gen2_config =
-            DataMovementHardwareConfig::Gen2Config{
-                .disable_implicit_sync_for = {experimental::DFBSpecName{"dfb_a"}, experimental::DFBSpecName{"dfb_b"}}},
+        .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
     const DataMovementHardwareConfig consumer_cfg{
         .gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1},
-        .gen2_config =
-            DataMovementHardwareConfig::Gen2Config{
-                .disable_implicit_sync_for = {experimental::DFBSpecName{"dfb_a"}, experimental::DFBSpecName{"dfb_b"}}},
+        .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
 
     DataflowBufferSpec dfb_a{
@@ -327,17 +323,11 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
 
     const DataMovementHardwareConfig producer_cfg{
         .gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_0},
-        .gen2_config =
-            DataMovementHardwareConfig::Gen2Config{
-                .disable_implicit_sync_for =
-                    {experimental::DFBSpecName{"dfb_borrowed"}, experimental::DFBSpecName{"dfb_alias"}}},
+        .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
     const DataMovementHardwareConfig consumer_cfg{
         .gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1},
-        .gen2_config =
-            DataMovementHardwareConfig::Gen2Config{
-                .disable_implicit_sync_for =
-                    {experimental::DFBSpecName{"dfb_borrowed"}, experimental::DFBSpecName{"dfb_alias"}}},
+        .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
 
     // dfb_borrowed: backed by ring_tensor (L1)

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -167,11 +167,11 @@ void run_borrowed_memory_dfb_program(
     // Disable implicit sync on the borrowed DFB for every DM endpoint (Gen2 only;
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
-        std::get<DataMovementHardwareConfig>(producer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(experimental::DFBSpecName{"borrowed_dfb"});
+        std::get<DataMovementHardwareConfig>(producer_spec.hw_config).gen2_config->disable_dfb_implicit_sync_for_all =
+            true;
         if (!cfg.tensix_consumer) {
             std::get<DataMovementHardwareConfig>(consumer_spec.hw_config)
-                .gen2_config->disable_implicit_sync_for.push_back(experimental::DFBSpecName{"borrowed_dfb"});
+                .gen2_config->disable_dfb_implicit_sync_for_all = true;
         }
     }
 
@@ -341,10 +341,10 @@ void run_update_address_test(
     // Disable implicit sync on the borrowed DFB for both DM endpoints (Gen2 only;
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
-        std::get<DataMovementHardwareConfig>(producer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(experimental::DFBSpecName{"borrowed_dfb"});
-        std::get<DataMovementHardwareConfig>(consumer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(experimental::DFBSpecName{"borrowed_dfb"});
+        std::get<DataMovementHardwareConfig>(producer_spec.hw_config).gen2_config->disable_dfb_implicit_sync_for_all =
+            true;
+        std::get<DataMovementHardwareConfig>(consumer_spec.hw_config).gen2_config->disable_dfb_implicit_sync_for_all =
+            true;
     }
 
     DataflowBufferSpec dfb_spec{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -212,9 +212,9 @@ void run_single_dfb_program(
     const auto consumer_pattern =
         is_all ? experimental::DFBAccessPattern::ALL : experimental::DFBAccessPattern::STRIDED;
 
-    // Per-DM-kernel disable_implicit_sync_for entries below mirror the boolean derived from
-    // dfb_config.enable_producer_implicit_sync (the lower-level legacy config still drives the value;
-    // each DM endpoint votes per-DFB on the spec side).
+    // Per-DM-kernel disable_dfb_implicit_sync_for_all flags below mirror the boolean derived from
+    // dfb_config.enable_producer_implicit_sync (the lower-level legacy config still drives the value).
+    // Each DM kernel here binds exactly one DFB, so opting out for all bound DFBs opts out for that DFB.
     experimental::DataflowBufferSpec dfb_spec{
         .unique_id = DFB_NAME,
         .entry_size = entry_size,
@@ -318,15 +318,15 @@ void run_single_dfb_program(
         };
     }
 
-    // Each DM endpoint votes per-DFB on opting out of implicit sync.
+    // Each DM endpoint votes on opting out of implicit sync (for the single DFB it binds).
     const bool disable_isync = !dfb_config.enable_producer_implicit_sync;
     if (producer_type == DFBPorCType::DM && disable_isync) {
         std::get<experimental::DataMovementHardwareConfig>(producer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(DFB_NAME);
+            .gen2_config->disable_dfb_implicit_sync_for_all = true;
     }
     if (consumer_type == DFBPorCType::DM && disable_isync) {
         std::get<experimental::DataMovementHardwareConfig>(consumer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(DFB_NAME);
+            .gen2_config->disable_dfb_implicit_sync_for_all = true;
     }
 
     experimental::WorkUnitSpec wu{
@@ -669,7 +669,7 @@ void run_concurrent_dfbs_program(
         });
         if (disable_isync) {
             std::get<experimental::DataMovementHardwareConfig>(kernel_specs.back().hw_config)
-                .gen2_config->disable_implicit_sync_for.push_back(dfb_name);
+                .gen2_config->disable_dfb_implicit_sync_for_all = true;
         }
         kernel_names.push_back(producer_name);
 
@@ -696,7 +696,7 @@ void run_concurrent_dfbs_program(
         });
         if (disable_isync) {
             std::get<experimental::DataMovementHardwareConfig>(kernel_specs.back().hw_config)
-                .gen2_config->disable_implicit_sync_for.push_back(dfb_name);
+                .gen2_config->disable_dfb_implicit_sync_for_all = true;
         }
         kernel_names.push_back(consumer_name);
     }
@@ -862,7 +862,7 @@ void run_concurrent_tensix_dm_dfbs_program(
         });
         if (!dfb_config.enable_producer_implicit_sync) {
             std::get<experimental::DataMovementHardwareConfig>(kernel_specs.back().hw_config)
-                .gen2_config->disable_implicit_sync_for.push_back(dfb_name);
+                .gen2_config->disable_dfb_implicit_sync_for_all = true;
         }
         kernel_names.push_back(consumer_name);
     }
@@ -1232,7 +1232,7 @@ void run_in_dfb_out_dfb_program(
     };
     if (!dm2tensix_config.enable_producer_implicit_sync) {
         std::get<experimental::DataMovementHardwareConfig>(producer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(IN_DFB);
+            .gen2_config->disable_dfb_implicit_sync_for_all = true;
     }
 
     experimental::KernelSpec compute_spec{
@@ -1292,7 +1292,7 @@ void run_in_dfb_out_dfb_program(
     };
     if (!tensix2dm_config.enable_producer_implicit_sync) {
         std::get<experimental::DataMovementHardwareConfig>(consumer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(OUT_DFB);
+            .gen2_config->disable_dfb_implicit_sync_for_all = true;
     }
 
     experimental::WorkUnitSpec wu{
@@ -1717,9 +1717,9 @@ static void run_dfb_size_override_test(
     };
     if (!implicit_sync) {
         std::get<experimental::DataMovementHardwareConfig>(producer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(DFB_NAME);
+            .gen2_config->disable_dfb_implicit_sync_for_all = true;
         std::get<experimental::DataMovementHardwareConfig>(consumer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(DFB_NAME);
+            .gen2_config->disable_dfb_implicit_sync_for_all = true;
     }
 
     const CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
@@ -2341,7 +2341,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
     };
     if (!remapper_dfb_config.enable_producer_implicit_sync) {
         std::get<experimental::DataMovementHardwareConfig>(dm_producer_spec.hw_config)
-            .gen2_config->disable_implicit_sync_for.push_back(REMAPPER_DFB);
+            .gen2_config->disable_dfb_implicit_sync_for_all = true;
     }
 
     // Combined compute kernel: BLOCKED consumer of remapper DFB ("remapper_in"),

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -1067,9 +1067,9 @@ void run_sequential_dfbs_program(
         const bool disable_isync = !configs[i].enable_producer_implicit_sync;
         if (disable_isync) {
             std::get<experimental::DataMovementHardwareConfig>(producer_spec.hw_config)
-                .gen2_config->disable_implicit_sync_for.push_back(dfb_name);
+                .gen2_config->disable_dfb_implicit_sync_for.push_back(dfb_name);
             std::get<experimental::DataMovementHardwareConfig>(consumer_spec.hw_config)
-                .gen2_config->disable_implicit_sync_for.push_back(dfb_name);
+                .gen2_config->disable_dfb_implicit_sync_for.push_back(dfb_name);
         }
         tensor_parameters.push_back(experimental::TensorParameter{
             .unique_id = in_tensor_name,

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -828,7 +828,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
 // DFB implicit-sync opt-out (Gen2)
 // ----------------------------------------------------------------------------
 // Implicit sync is ON by default for any DFB side that has a DM endpoint. A DM kernel can
-// opt out per-DFB (disable_implicit_sync_for) or for all the DFBs it binds at once
+// opt out per-DFB (disable_dfb_implicit_sync_for) or for all the DFBs it binds at once
 // (disable_dfb_implicit_sync_for_all). These tests pin the per-kernel "all" hammer.
 
 TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllDisablesProducerSide) {
@@ -918,7 +918,7 @@ TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllAgreesWithExplicitList) {
     // Both express the same per-side decision (disable), so they agree and the side lowers off.
     std::get<DataMovementHardwareConfig>(producer1.hw_config).gen2_config->disable_dfb_implicit_sync_for_all = true;
     std::get<DataMovementHardwareConfig>(producer2.hw_config)
-        .gen2_config->disable_implicit_sync_for.push_back(DFBSpecName{"dfb"});
+        .gen2_config->disable_dfb_implicit_sync_for.push_back(DFBSpecName{"dfb"});
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -1005,7 +1005,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
 
 TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigSucceeds) {
     // Gen2 config is fully optional even on Quasar: absence is treated as "use defaults"
-    // (empty disable_implicit_sync_for). A Gen1-only DM kernel building on Quasar is
+    // (empty disable_dfb_implicit_sync_for). A Gen1-only DM kernel building on Quasar is
     // permitted at the spec layer (whether such a kernel actually does anything useful on
     // Gen2 hardware is a separate question, outside the validator's scope).
     NodeCoord node{0, 0};

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -404,7 +404,7 @@ bool reader_datacopy_writer(
     const experimental::KernelSpecName COMPUTE{"compute"};
 
     // Implicit sync is enabled by default for both DFBs (no DM kernel opts out
-    // via Gen2Config::disable_implicit_sync_for). The program-level
+    // via Gen2Config::disable_dfb_implicit_sync_for). The program-level
     // reservation flag set below is independent of per-DFB sync mode.
     experimental::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -74,7 +74,7 @@ experimental::DataMovementHardwareConfig make_dm_config(DataMovementProcessor pr
     return experimental::DataMovementHardwareConfig{
         .gen1_config = experimental::DataMovementHardwareConfig::Gen1Config{.processor = processor, .noc = noc},
         .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{
-            .disable_implicit_sync_for = {SCRATCH_DFB},
+            .disable_dfb_implicit_sync_for_all = true,
         }};
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -86,8 +86,7 @@ void RunTest(
         .hw_config =
             experimental::DataMovementHardwareConfig{
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {TILE_COUNTER_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     // NEO compute consumer kernel (4 threads = 4 Neo clusters)

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_zero_mode_guard.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_zero_mode_guard.cpp
@@ -49,8 +49,7 @@ constexpr uint32_t kZeroBytes = 2 * 1024;
 
 experimental::DataMovementHardwareConfig make_hw_config() {
     return experimental::DataMovementHardwareConfig{
-        .gen2_config =
-            experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {SCRATCH_DFB}}};
+        .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}};
 }
 
 Program make_program(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -285,8 +285,7 @@ static void matmul_tile_block(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {SRC0_DFB, SRC1_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -303,7 +302,7 @@ static void matmul_tile_block(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {DST_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     // matmul_block.cpp uses named CTAs. Map cfg.compute_kernel_args (positional) to the

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -339,8 +339,7 @@ void run_single_core_broadcast(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {INP0_DFB, INP1_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -357,7 +356,7 @@ void run_single_core_broadcast(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {OUT_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -127,7 +127,7 @@ void run_single_core_copy_block_matmul_partials(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {SRC0_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -145,7 +145,7 @@ void run_single_core_copy_block_matmul_partials(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {DST_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -462,8 +462,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
         .hw_config =
             experimental::DataMovementHardwareConfig{
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {INP0_DFB, INP1_DFB, INP2_DFB, INP3_DFB, INP4_DFB, INP5_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -480,7 +479,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
         .hw_config =
             experimental::DataMovementHardwareConfig{
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {OUT_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec compute_spec{
@@ -783,7 +782,8 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
                             .processor = tt_metal::DataMovementProcessor::RISCV_0,
                             .noc = tt_metal::NOC::RISCV_0_default},
                     .gen2_config =
-                        experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {out_dfb}}},
+                        experimental::DataMovementHardwareConfig::Gen2Config{
+                            .disable_dfb_implicit_sync_for_all = true}},
         };
     };
 
@@ -816,8 +816,7 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
         .hw_config =
             experimental::DataMovementHardwareConfig{
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {INP0_DFB, INP1_DFB, INP2_DFB, INP3_DFB, INP4_DFB, INP5_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer0_spec = make_writer_spec(WRITER0, OUT0_DFB);

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -401,8 +401,7 @@ void run_single_core_reduce_program(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {SRC0_DFB, SRC1_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -420,7 +419,7 @@ void run_single_core_reduce_program(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {DST_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -695,7 +695,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {IN_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -715,7 +715,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {OUT_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec compute_spec{
@@ -891,7 +891,7 @@ experimental::KernelSpec make_writer_unary_quasar_spec(
         .hw_config =
             experimental::DataMovementHardwareConfig{
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {out_dfb_id}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 }
 
@@ -1025,8 +1025,7 @@ bool run_sfpu_binary_two_input_buffer(
         .hw_config =
             experimental::DataMovementHardwareConfig{
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {IN0_DFB, IN1_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec compute_spec{
@@ -1196,7 +1195,7 @@ bool run_sfpu_ternary_three_input_buffer(
                 experimental::DataMovementHardwareConfig{
                     .gen2_config =
                         experimental::DataMovementHardwareConfig::Gen2Config{
-                            .disable_implicit_sync_for = {IN0_DFB, IN1_DFB, IN2_DFB}}},
+                            .disable_dfb_implicit_sync_for_all = true}},
         };
 
         experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -340,8 +340,7 @@ bool single_core_binary(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {INP0_DFB, INP1_DFB, INP2_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -358,7 +357,7 @@ bool single_core_binary(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {OUT_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -214,7 +214,7 @@ void run_single_core_transpose(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {INPUT_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -232,7 +232,7 @@ void run_single_core_transpose(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {OUTPUT_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -333,7 +333,7 @@ void run_single_core_unary_broadcast_quasar(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {SRC_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -349,7 +349,7 @@ void run_single_core_unary_broadcast_quasar(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {DST_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -610,8 +610,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{
-                        .disable_implicit_sync_for = {INP_DATA_DFB, INP_SCALER_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -627,7 +626,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
                     experimental::DataMovementHardwareConfig::Gen1Config{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_config =
-                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_implicit_sync_for = {OUT_DFB}}},
+                    experimental::DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec::CompilerOptions::Defines compute_defines = {

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -97,8 +97,8 @@ experimental::ProgramSpec build_bmm_program_spec(
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default},
         .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}};
     if (!use_implicit_sync) {
-        reader_config.gen2_config->disable_implicit_sync_for = {SRC0_DFB, SRC1_DFB};
-        writer_config.gen2_config->disable_implicit_sync_for = {DST_DFB};
+        reader_config.gen2_config->disable_dfb_implicit_sync_for_all = true;
+        writer_config.gen2_config->disable_dfb_implicit_sync_for_all = true;
     }
 
     experimental::DataflowBufferSpec src0_dfb_spec{

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -64,7 +64,7 @@ static void run_pack_relu_test(
     const experimental::KernelSpecName COMPUTE{"compute"};
 
     // Implicit sync is enabled by default for both DFBs (no DM kernel opts out
-    // via Gen2Config::disable_implicit_sync_for). The program-level
+    // via Gen2Config::disable_dfb_implicit_sync_for). The program-level
     // reservation flag set below is independent of per-DFB sync mode.
     experimental::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -61,8 +61,7 @@ struct DataMovementHardwareConfig {
         //  - Use this control to revert to legacy explicit sync APIs (for specific bound DFBs).
         //  - This feature is mainly for debug purposes, or for backwards-compatible code style.
         // Any bound DFB not listed here will use implicit sync by default.
-        Group<DFBSpecName> disable_implicit_sync_for;
-        // TODO -- rename to disable_dfb_implicit_sync_for (need to update existing users)
+        Group<DFBSpecName> disable_dfb_implicit_sync_for;
 
         // Opt out of DFB implicit sync for ALL the DFBs this kernel binds.
         // (The per-kernel hammer; equivalent to listing every bound DFB above.)

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -629,14 +629,14 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
 // Whether a Gen2 DM kernel opts out of implicit sync for a particular DFB.
 // Two routes lead to the same opt-out:
 //   - disable_dfb_implicit_sync_for_all: the per-kernel hammer, covering every DFB the kernel binds.
-//   - disable_implicit_sync_for: an explicit per-DFB list.
+//   - disable_dfb_implicit_sync_for: an explicit per-DFB list.
 // Precondition: the caller has already established this is a DM kernel with a gen2_config.
 bool DmKernelDisablesImplicitSync(
     const DataMovementHardwareConfig::Gen2Config& gen2_config, const DFBSpecName& dfb_name) {
     if (gen2_config.disable_dfb_implicit_sync_for_all) {
         return true;
     }
-    const auto& vec = gen2_config.disable_implicit_sync_for;
+    const auto& vec = gen2_config.disable_dfb_implicit_sync_for;
     return std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
 }
 
@@ -932,11 +932,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.unique_id);
     }
 
-    // Validate DM kernel disable_implicit_sync_for entries.
+    // Validate DM kernel disable_dfb_implicit_sync_for entries.
     //
     // Implicit sync is a Gen2-only, DM-only mechanism (ISR-based credit posting from NoC
     // transaction completion). A DM kernel can opt out per-DFB by listing the DFB's name in
-    // its Gen2Config::disable_implicit_sync_for vector, or opt out of all the DFBs it binds at
+    // its Gen2Config::disable_dfb_implicit_sync_for vector, or opt out of all the DFBs it binds at
     // once via Gen2Config::disable_dfb_implicit_sync_for_all. Either way the opt-out applies to the
     // side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
     //
@@ -960,10 +960,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             for (const auto& binding : kernel.dfb_bindings) {
                 bound_dfbs.insert(binding.dfb_spec_name);
             }
-            for (const auto& dfb_name : dm_config.gen2_config->disable_implicit_sync_for) {
+            for (const auto& dfb_name : dm_config.gen2_config->disable_dfb_implicit_sync_for) {
                 TT_FATAL(
                     bound_dfbs.contains(dfb_name),
-                    "Kernel '{}' disable_implicit_sync_for entry references DFB '{}', which the kernel does not bind",
+                    "Kernel '{}' disable_dfb_implicit_sync_for entry references DFB '{}', which the kernel does not "
+                    "bind",
                     kernel.unique_id,
                     dfb_name);
             }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

`disable_dfb_implicit_sync_for_all` was introduced in #48551 as a shorthand for disabling implicit sync across all of a kernel's DFBs. This PR migrates existing call-sites to use it wherever a kernel was enumerating *every* DFB it binds, replacing the explicit list with the single flag.

The migration is behavior-preserving: only call-sites whose `disable_dfb_implicit_sync_for` list already covered the kernel's complete set of bound DFBs were converted. Two usages were intentionally left as explicit lists — one where the opt-out is conditional per-DFB (so it may be a strict subset), and one test that specifically validates that the explicit list and the `_all` flag agree.

This also includes a drive-by rename, `disable_implicit_sync_for` => `disable_dfb_implicit_sync_for`, resolving a leftover TODO. Implicit sync is a DFB-specific mechanism, so the new name is more descriptive of what the feature does.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/disable-sync-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/disable-sync-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/disable-sync-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/disable-sync-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/disable-sync-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/disable-sync-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/disable-sync-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/disable-sync-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/disable-sync-all)