### PR TITLE
Add support for fused swiglu to minimal matmul variants 

### DIFF
--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -10,6 +10,7 @@ import ttnn
 from models.common.utility_functions import is_blackhole
 
 from ..utils.matmul import get_fused_mmrs_config, get_matmul_config, get_matmul_core_grid
+from ..utils.tensor import interleave_swiglu_tiles
 from .module import Module, Parameter
 
 MATH_FIDELITY = {
@@ -37,17 +38,28 @@ class Linear(Module):
     Linear layer with replicated weights
     """
 
-    def __init__(self, in_features, out_features, bias=True, activation_fn=None, dtype=ttnn.bfloat16, mesh_device=None):
+    def __init__(
+        self,
+        in_features,
+        out_features,
+        bias=True,
+        activation_fn=None,
+        dtype=ttnn.bfloat16,
+        mesh_device=None,
+    ):
         super().__init__()
 
         self.in_features = in_features
         self.out_features = out_features
-        if activation_fn == "swiglu":
-            # Double out features for fused swiglu activation
-            self.out_features = self.out_features * 2
         self.activation_fn = activation_fn
         self.fused_activation_fn = None
-        if self.activation_fn in _FUSED_GELU_VARIANTS:
+        self.fuse_swiglu = False
+        if self.activation_fn == "swiglu":
+            # Double out features for the packed [gate|up] swiglu weight.
+            self.out_features = self.out_features * 2
+            self.fuse_swiglu = True
+            self.activation_fn = None
+        elif self.activation_fn in _FUSED_GELU_VARIANTS:
             self.fused_activation_fn = _FUSED_GELU_VARIANTS[self.activation_fn]
             self.activation_fn = None
         self.mesh_device = mesh_device
@@ -69,9 +81,15 @@ class Linear(Module):
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         if "weight" in state:
-            state["weight"] = state["weight"].transpose(0, 1)
+            weight = state["weight"].transpose(0, 1)
+            if self.fuse_swiglu:
+                weight = interleave_swiglu_tiles(weight, ndev=1)
+            state["weight"] = weight
         if "bias" in state:
-            state["bias"] = state["bias"].reshape(1, -1)
+            bias = state["bias"].reshape(1, -1)
+            if self.fuse_swiglu:
+                bias = interleave_swiglu_tiles(bias, ndev=1)
+            state["bias"] = bias
 
     def forward(self, x: ttnn.Tensor, compute_kernel_config=None, dtype=None, default_block_size=None) -> ttnn.Tensor:
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], self.weight.data.padded_shape[-1]
@@ -85,6 +103,7 @@ class Linear(Module):
             fused_activation=self.fused_activation_fn,
             compute_kernel_config=compute_kernel_config or self.compute_config,
             dtype=dtype,
+            fuse_swiglu=self.fuse_swiglu,
         )
 
         return _apply_activation_fn(output, self.activation_fn)
@@ -127,14 +146,18 @@ class ColParallelLinear(Module):
         self.in_features = in_features
         self.out_features = out_features
         self.activation_fn = activation_fn
-        if activation_fn == "swiglu":
-            # Double out features for fused swiglu activation
-            self.out_features = self.out_features * 2
         self.fused_activation_fn = None
-        if self.activation_fn in _FUSED_GELU_VARIANTS:
+        self.fuse_swiglu = False
+        if self.activation_fn == "swiglu":
+            # Double out features for the packed [gate|up] swiglu weight.
+            self.out_features = self.out_features * 2
+            self.fuse_swiglu = True
+            self.activation_fn = None
+        elif self.activation_fn in _FUSED_GELU_VARIANTS:
             self.fused_activation_fn = _FUSED_GELU_VARIANTS[self.activation_fn]
             self.activation_fn = None
         self.mesh_device = mesh_device
+
         self.mesh_axis = mesh_axis
         self.fsdp_mesh_axis = fsdp_mesh_axis
         self.ccl_manager = ccl_manager
@@ -181,12 +204,16 @@ class ColParallelLinear(Module):
 
         if weight is not None:
             weight = weight.transpose(0, 1)
-            if self.activation_fn == "swiglu":
+            if self.fuse_swiglu:
+                weight = interleave_swiglu_tiles(weight, ndev=self._mesh_axis_size)
+            elif self.activation_fn == "swiglu":
                 weight = permute_for_swiglu(weight)
             state["weight"] = weight
         if bias is not None:
             bias = bias.reshape(1, -1)
-            if self.activation_fn == "swiglu":
+            if self.fuse_swiglu:
+                bias = interleave_swiglu_tiles(bias, ndev=self._mesh_axis_size)
+            elif self.activation_fn == "swiglu":
                 bias = permute_for_swiglu(bias)
             state["bias"] = bias
 
@@ -238,6 +265,7 @@ class ColParallelLinear(Module):
                 num_buffers_per_channel=48 if not is_blackhole() else 24,
                 chunks=self.chunks if self.chunks is not None else 1,
                 dtype=dtype,
+                fuse_swiglu=self.fuse_swiglu,
             )
 
             if self.chunks is not None and (self.chunks > 1):
@@ -260,18 +288,21 @@ class ColParallelLinear(Module):
                     compute_kernel_config=compute_kernel_config or self.compute_config,
                     config=matmul_config,
                     dtype=dtype,
+                    fuse_swiglu=self.fuse_swiglu,
                 )
                 return [_apply_activation_fn(o, self.activation_fn) for o in outputs]
-
-            output = ttnn.experimental.minimal_matmul(
-                input_tensor=x,
-                weight_tensor=weight,
-                bias_tensor=self.bias.data if self.bias is not None else None,
-                config=matmul_config,
-                fused_activation=self.fused_activation_fn,
-                compute_kernel_config=compute_kernel_config or self.compute_config,
-                dtype=dtype,
-            )
+            else:
+                matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
+                output = ttnn.experimental.minimal_matmul(
+                    input_tensor=x,
+                    weight_tensor=weight,
+                    bias_tensor=self.bias.data if self.bias is not None else None,
+                    config=matmul_config,
+                    fused_activation=self.fused_activation_fn,
+                    compute_kernel_config=compute_kernel_config or self.compute_config,
+                    dtype=dtype,
+                    fuse_swiglu=self.fuse_swiglu,
+                )
 
         return _apply_activation_fn(output, self.activation_fn)
 

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import is_blackhole
 
 from ..utils.matmul import get_fused_mmrs_config, get_matmul_config, get_matmul_core_grid
-from ..utils.tensor import interleave_swiglu_tiles
+from ..utils.tensor import prepare_for_fused_swiglu
 from .module import Module, Parameter
 
 MATH_FIDELITY = {
@@ -83,12 +83,12 @@ class Linear(Module):
         if "weight" in state:
             weight = state["weight"].transpose(0, 1)
             if self.fuse_swiglu:
-                weight = interleave_swiglu_tiles(weight, ndev=1)
+                weight = prepare_for_fused_swiglu(weight, ndev=1)
             state["weight"] = weight
         if "bias" in state:
             bias = state["bias"].reshape(1, -1)
             if self.fuse_swiglu:
-                bias = interleave_swiglu_tiles(bias, ndev=1)
+                bias = prepare_for_fused_swiglu(bias, ndev=1)
             state["bias"] = bias
 
     def forward(self, x: ttnn.Tensor, compute_kernel_config=None, dtype=None, default_block_size=None) -> ttnn.Tensor:
@@ -205,14 +205,14 @@ class ColParallelLinear(Module):
         if weight is not None:
             weight = weight.transpose(0, 1)
             if self.fuse_swiglu:
-                weight = interleave_swiglu_tiles(weight, ndev=self._mesh_axis_size)
+                weight = prepare_for_fused_swiglu(weight, ndev=self._mesh_axis_size)
             elif self.activation_fn == "swiglu":
                 weight = permute_for_swiglu(weight)
             state["weight"] = weight
         if bias is not None:
             bias = bias.reshape(1, -1)
             if self.fuse_swiglu:
-                bias = interleave_swiglu_tiles(bias, ndev=self._mesh_axis_size)
+                bias = prepare_for_fused_swiglu(bias, ndev=self._mesh_axis_size)
             elif self.activation_fn == "swiglu":
                 bias = permute_for_swiglu(bias)
             state["bias"] = bias

--- a/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
+++ b/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.tt_dit.utils.tensor import interleave_swiglu_tiles
 
 
 def create_global_semaphores(mesh_device, num_devices, cores, initial_value):
@@ -70,6 +71,7 @@ def run_test_linear_impl(
     addcmul_scalar=1.0,
     chunks=1,
     broadcast_gate=True,
+    fuse_swiglu=False,
 ):
     ccl_cores = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(core_grid.x - 1, core_grid.y - 1))}
@@ -85,6 +87,9 @@ def run_test_linear_impl(
     M = torch_input.shape[2] if use_non_fused else torch_input.shape[0]
     K = torch_input.shape[3] if use_non_fused else torch_input.shape[1]
     N = weight_input.shape[3] if use_non_fused else weight_input.shape[1]
+    if fuse_swiglu:
+        # weight is the packed [gate|up] of width 2*out_N; the fused op emits out_N.
+        N = N // 2
     per_device_M = M // device.shape[sp_axis]
     if use_persistent_buffers:
         persistent_output_buffers = [
@@ -146,6 +151,9 @@ def run_test_linear_impl(
         torch_output = torch_input @ weight_input
         if bias_input is not None:
             torch_output = torch_output + bias_input
+        if fuse_swiglu:
+            first, second = torch.chunk(torch_output, 2, dim=-1)
+            torch_output = first * torch.nn.functional.silu(second)
         if fuse_addcmul:
             torch_output = torch.addcmul(torch_addcmul_a, torch_output, torch_addcmul_b, value=addcmul_scalar)
 
@@ -245,6 +253,7 @@ def run_test_linear_impl(
                 addcmul_input_tensor1=tt_addcmul_a,
                 addcmul_input_tensor2=tt_addcmul_b,
                 chunks=chunks,
+                fuse_swiglu=fuse_swiglu,
             )
 
         return tt_output
@@ -375,22 +384,26 @@ def run_test_linear(
     addcmul_scalar=1.0,
     chunks=1,
     broadcast_gate=True,
+    fuse_swiglu=False,
 ):
     logger.info(f"Running test_linear with M={M}, K={K}, N={N}")
     torch_dtype = torch.float32
 
+    # For fused SwiGLU the weight packs [gate|up] -> width 2N; the op emits out width N.
+    weight_N = 2 * N if fuse_swiglu else N
+
     if use_non_fused:
         torch_input = torch.randn((1, 1, M, K), dtype=torch_dtype)
-        weight_input = torch.randn((1, 1, K, N), dtype=torch_dtype)
+        weight_input = torch.randn((1, 1, K, weight_N), dtype=torch_dtype)
     else:
         torch_input = torch.randn((M, K), dtype=torch_dtype)
-        weight_input = torch.randn((K, N), dtype=torch_dtype)
+        weight_input = torch.randn((K, weight_N), dtype=torch_dtype)
     bias_input = None
     if use_bias:
         if use_non_fused:
-            bias_input = torch.randn((1, 1, 1, N), dtype=torch_dtype)
+            bias_input = torch.randn((1, 1, 1, weight_N), dtype=torch_dtype)
         else:
-            bias_input = torch.randn((1, N), dtype=torch_dtype)
+            bias_input = torch.randn((1, weight_N), dtype=torch_dtype)
 
     if fuse_addcmul:
         if use_non_fused:
@@ -428,10 +441,21 @@ def run_test_linear(
         mesh_mapper=ttnn.ShardTensor2dMesh(device, mesh_shape=tuple(device.shape), dims=shard_dims),
     )
 
-    tt_weight = ttnn.from_torch(weight_input, dtype=weight_dtype or dtype, device=device, layout=ttnn.TILE_LAYOUT)
+    # Fused SwiGLU: tile-pair interleave the (replicated) weight/bias so each ring device's
+    # N-slice holds whole [second(silu'd), first] pairs. ndev = ring size (cluster_axis).
+    weight_to_load = weight_input
+    bias_to_load = bias_input
+    if fuse_swiglu:
+        ring_size = device.shape[cluster_axis]
+        weight_2d = weight_input.reshape(K, weight_input.shape[-1])
+        weight_to_load = interleave_swiglu_tiles(weight_2d, ndev=ring_size).reshape(weight_input.shape)
+        if use_bias:
+            bias_to_load = interleave_swiglu_tiles(bias_input.reshape(1, -1), ndev=ring_size).reshape(bias_input.shape)
+
+    tt_weight = ttnn.from_torch(weight_to_load, dtype=weight_dtype or dtype, device=device, layout=ttnn.TILE_LAYOUT)
     tt_bias = None
     if use_bias:
-        tt_bias = ttnn.from_torch(bias_input, dtype=bias_dtype or dtype, device=device, layout=ttnn.TILE_LAYOUT)
+        tt_bias = ttnn.from_torch(bias_to_load, dtype=bias_dtype or dtype, device=device, layout=ttnn.TILE_LAYOUT)
 
     return run_test_linear_impl(
         device=device,
@@ -469,6 +493,7 @@ def run_test_linear(
         addcmul_scalar=addcmul_scalar,
         chunks=chunks,
         broadcast_gate=broadcast_gate,
+        fuse_swiglu=fuse_swiglu,
     )
 
 
@@ -1366,6 +1391,92 @@ def test_linear_k_tail(
     for c in range(1):
         for i in range(submesh.get_num_devices()):
             assert check_result[0][c][i]["pcc"] > 0.999_500
+            assert check_result[0][c][i]["relative_rmse"] < 0.02
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params, topology, num_links, num_workers_per_link, sp_axis, tp_axis, core_grid_x, core_grid_y, cluster_axis",
+    [
+        [
+            (4, 8),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(4096),
+                "trace_region_size": 90112,
+            },
+            ttnn.Topology.Ring,
+            2,
+            6,
+            1,
+            0,
+            12,
+            9,
+            0,
+        ],
+    ],
+    ids=["bh4x8links2"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no_bias", "bias"])
+@pytest.mark.parametrize(
+    "M, K, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w",
+    [
+        (3072, 5120, 1280, 8, 8, 8, 2, 1),
+        (3072, 5120, 3840, 8, 8, 8, 2, 2),
+    ],
+    ids=["3072x5120x1280", "3072x5120x3840"],
+)
+def test_linear_swiglu(
+    mesh_device,
+    M,
+    K,
+    N,
+    M_block_size,
+    K_block_size,
+    N_block_size,
+    subblock_h,
+    subblock_w,
+    topology,
+    core_grid_x,
+    core_grid_y,
+    num_workers_per_link,
+    num_links,
+    sp_axis,
+    tp_axis,
+    cluster_axis,
+    use_bias,
+):
+    """Ring-fused all_gather_minimal_matmul_async with FUSE_SWIGLU.
+
+    The (replicated) weight is the packed [gate|up] of width 2N, tile-pair interleaved so each
+    ring device's N-slice holds whole pairs; the op emits silu(gate)*up of width N in one matmul.
+    N here is the OUTPUT width (weight width is 2N).
+    """
+    submesh = _create_cluster_submesh(mesh_device, cluster_axis)
+    check_result = run_test_linear(
+        submesh,
+        M,
+        K,
+        N,
+        M_block_size,
+        K_block_size,
+        N_block_size,
+        subblock_h,
+        subblock_w,
+        topology,
+        core_grid=ttnn.CoreCoord(core_grid_x, core_grid_y),
+        num_workers_per_link=num_workers_per_link,
+        num_links=num_links,
+        force_transpose=True,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        use_bias=use_bias,
+        cluster_axis=cluster_axis,
+        fuse_swiglu=True,
+    )
+    for c in range(1):
+        for i in range(submesh.get_num_devices()):
+            assert check_result[0][c][i]["pcc"] > 0.999_000
             assert check_result[0][c][i]["relative_rmse"] < 0.02
 
 

--- a/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
+++ b/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
-from models.tt_dit.utils.tensor import interleave_swiglu_tiles
+from models.tt_dit.utils.tensor import prepare_for_fused_swiglu
 
 
 def create_global_semaphores(mesh_device, num_devices, cores, initial_value):
@@ -448,9 +448,9 @@ def run_test_linear(
     if fuse_swiglu:
         ring_size = device.shape[cluster_axis]
         weight_2d = weight_input.reshape(K, weight_input.shape[-1])
-        weight_to_load = interleave_swiglu_tiles(weight_2d, ndev=ring_size).reshape(weight_input.shape)
+        weight_to_load = prepare_for_fused_swiglu(weight_2d, ndev=ring_size).reshape(weight_input.shape)
         if use_bias:
-            bias_to_load = interleave_swiglu_tiles(bias_input.reshape(1, -1), ndev=ring_size).reshape(bias_input.shape)
+            bias_to_load = prepare_for_fused_swiglu(bias_input.reshape(1, -1), ndev=ring_size).reshape(bias_input.shape)
 
     tt_weight = ttnn.from_torch(weight_to_load, dtype=weight_dtype or dtype, device=device, layout=ttnn.TILE_LAYOUT)
     tt_bias = None

--- a/models/tt_dit/utils/sweep_mm_block_sizes.py
+++ b/models/tt_dit/utils/sweep_mm_block_sizes.py
@@ -174,6 +174,19 @@ USE_CASE_CONFIGS = {
         "math_approx_mode": True,
         "use_matmul_split": True,
     },
+    # Single-block to_qkv via minimal_matmul_split with chunks=3, approx math.
+    # Mirrors cross_attn_kv but splits into 3 Q/K/V chunks instead of 2.
+    "qkv_mm_split": {
+        "chunks": 3,
+        "math_approx_mode": True,
+        "use_matmul_split": True,
+    },
+    # ff1 (proj_mlp) with fused SwiGLU — gate+up packed into N=4608 weight.
+    # fp32_dest_acc_en=True (always on), N_block MUST be even (pitfall 1).
+    # No fused_activation (incompatible with fuse_swiglu per TT_FATAL).
+    "ff1_swiglu": {
+        "fuse_swiglu": True,
+    },
 }
 
 # Whether the sweep uses fp32 dest accumulator. With fp32 dest, the DEST tile
@@ -326,12 +339,21 @@ def pick_subblock(m_block, n_block, max_dest_volume=4):
 
 
 def generate_kn_combos(K_per_device, N_per_core, m_block=1, use_case="plain"):
-    """Generate (K_block, N_block) combos filtered by L1 budget."""
+    """Generate (K_block, N_block) combos filtered by L1 budget.
+
+    For fuse_swiglu use_cases, N_block MUST be even (TT_FATAL pitfall 1 from
+    sweep_fused_gelu.md: gate/up tile-pairs are interleaved along N, so a block
+    must never split a pair).  Odd N candidates are skipped pre-sweep to avoid
+    hard asserts that would abort the program.
+    """
     k_candidates = get_k_block_candidates(K_per_device)
     n_candidates = get_mn_block_candidates(N_per_core)
+    require_even_n = USE_CASE_CONFIGS.get(use_case, {}).get("fuse_swiglu", False)
     combos = []
     for k in k_candidates:
         for n in n_candidates:
+            if require_even_n and n % 2 != 0:
+                continue
             if estimate_l1_kb(m_block, k, n, use_case) <= L1_BUDGET_KB:
                 combos.append((k, n))
     return combos
@@ -488,6 +510,7 @@ def _build_op_runner(cfg, mesh_device, M, K, N, dtype, is_agmm, uc_cfg, core_gri
     )
 
     fused_activation = uc_cfg.get("fused_activation", None)
+    fuse_swiglu = uc_cfg.get("fuse_swiglu", False)
     chunks = uc_cfg.get("chunks", 1)
     scalar = uc_cfg.get("scalar", None)
     mesh_shape = tuple(mesh_device.shape)
@@ -584,6 +607,7 @@ def _build_op_runner(cfg, mesh_device, M, K, N, dtype, is_agmm, uc_cfg, core_gri
                 addcmul_input_tensor1=addcmul_tensor1,
                 addcmul_input_tensor2=addcmul_tensor2,
                 chunks=chunks,
+                fuse_swiglu=fuse_swiglu,
             )
             if sync:
                 ttnn.synchronize_device(mesh_device)
@@ -626,6 +650,7 @@ def _build_op_runner(cfg, mesh_device, M, K, N, dtype, is_agmm, uc_cfg, core_gri
                 fused_activation=fused_activation,
                 compute_kernel_config=compute_config,
                 config=cfg_obj,
+                fuse_swiglu=fuse_swiglu,
             )
         else:
             ttnn.experimental.minimal_matmul(
@@ -635,6 +660,7 @@ def _build_op_runner(cfg, mesh_device, M, K, N, dtype, is_agmm, uc_cfg, core_gri
                 config=cfg_obj,
                 fused_activation=fused_activation,
                 compute_kernel_config=compute_config,
+                fuse_swiglu=fuse_swiglu,
             )
         if sync:
             ttnn.synchronize_device(mesh_device)
@@ -946,12 +972,19 @@ def main():
         help="Filter to a single shape as M,K,N (e.g. 6144,5120,3456)",
     )
     parser.add_argument("--csv", type=str, default=CSV_FILE)
+    parser.add_argument(
+        "--use-case",
+        type=str,
+        default=None,
+        choices=list(USE_CASE_CONFIGS.keys()),
+        help="Restrict sweep to a single use_case (e.g. ff1_swiglu)",
+    )
     args = parser.parse_args()
 
     device_config = args.device_config
     cfg = resolve_config(device_config)
 
-    # Filter shapes
+    # Filter shapes by M,K,N then optionally by use_case
     if args.shape:
         m, k, n = [int(x) for x in args.shape.split(",")]
         shapes = [s for s in SHAPES if s[0] == m and s[1] == k and s[2] == n]
@@ -960,6 +993,12 @@ def main():
             return
     else:
         shapes = SHAPES
+
+    if args.use_case:
+        shapes = [s for s in shapes if s[6] == args.use_case]
+        if not shapes:
+            print(f"No shapes match use_case={args.use_case!r}")
+            return
 
     write_csv_header(args.csv)
     all_best = {}

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -17,6 +17,35 @@ if TYPE_CHECKING:
     from types import EllipsisType
 
 
+def interleave_swiglu_tiles(tensor: torch.Tensor, ndev: int, tile_width: int = 32) -> torch.Tensor:
+    """Reorder a packed [.., 2N] SwiGLU weight/bias for the fused matmul kernel.
+
+    Input columns are torch order ``[first (N) | second (N)]`` where the activation is
+    ``first * silu(second)`` (torch ``x, gate = chunk(.,2,-1); x * silu(gate)``), column-
+    parallel sharded into ``ndev`` contiguous blocks. The fused kernel emits
+    ``silu(even_tile) * odd_tile`` per pair, so each device's local block is laid out as
+    tile-pairs ``[second_t0, first_t0, second_t1, first_t1, ...]`` (32-col tiles): the silu'd
+    half (``second``) goes to the even slot, the multiplicand (``first``) to the odd slot.
+
+    This subsumes the old "[first_d | second_d] contiguous per device" permute: it additionally
+    interleaves the two halves at tile granularity (and orders them silu-half-first) within
+    each device block.
+    """
+    rows = tensor.shape[0]
+    two_N = tensor.shape[-1]
+    N = two_N // 2
+    assert (
+        N % (ndev * tile_width) == 0
+    ), f"SwiGLU half-width N={N} must be divisible by ndev*tile_width={ndev * tile_width}"
+    tiles_per_dev = N // ndev // tile_width
+    # [rows, half=2, d=ndev, t=tiles_per_dev, c=tile_width] -> [rows, d, t, half, c]
+    t = tensor.reshape(rows, 2, ndev, tiles_per_dev, tile_width)
+    t = t.permute(0, 2, 3, 1, 4)
+    # flip the half axis so each pair is [second (silu'd), first] -> even slot is silu'd
+    t = t.flip(3)
+    return t.reshape(rows, two_N)
+
+
 def typed_tensor(
     x: torch.Tensor,
     dtype: ttnn.DataType,

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -17,19 +17,26 @@ if TYPE_CHECKING:
     from types import EllipsisType
 
 
-def interleave_swiglu_tiles(tensor: torch.Tensor, ndev: int, tile_width: int = 32) -> torch.Tensor:
+def prepare_for_fused_swiglu(
+    tensor: torch.Tensor, ndev: int, tile_width: int = 32, *, gate_is_first: bool = False
+) -> torch.Tensor:
     """Reorder a packed [.., 2N] SwiGLU weight/bias for the fused matmul kernel.
 
-    Input columns are torch order ``[first (N) | second (N)]`` where the activation is
-    ``first * silu(second)`` (torch ``x, gate = chunk(.,2,-1); x * silu(gate)``), column-
-    parallel sharded into ``ndev`` contiguous blocks. The fused kernel emits
-    ``silu(even_tile) * odd_tile`` per pair, so each device's local block is laid out as
-    tile-pairs ``[second_t0, first_t0, second_t1, first_t1, ...]`` (32-col tiles): the silu'd
-    half (``second``) goes to the even slot, the multiplicand (``first``) to the odd slot.
+    The fused kernel emits ``silu(even_tile) * odd_tile`` per pair, so gate (the silu'd half)
+    must occupy the even tile slot and up (the multiplicand) the odd tile slot within each
+    device block.
 
-    This subsumes the old "[first_d | second_d] contiguous per device" permute: it additionally
-    interleaves the two halves at tile granularity (and orders them silu-half-first) within
-    each device block.
+    ``gate_is_first`` specifies the input column ordering:
+
+    - ``gate_is_first=False`` (default): input is ``[up (N) | gate (N)]``, i.e.
+      ``up, gate = chunk(., 2, -1); up * silu(gate)`` — torch/HuggingFace convention.
+    - ``gate_is_first=True``: input is ``[gate (N) | up (N)]``, i.e.
+      ``gate, up = chunk(., 2, -1); silu(gate) * up``.
+
+    In both cases the output is laid out as ``ndev`` contiguous device blocks, each containing
+    interleaved gate/up tile pairs ``[gate_t0, up_t0, gate_t1, up_t1, ...]`` for that device's shard.
+    Splitting the output evenly across ``ndev`` devices along the last dimension gives each device
+    a correctly interleaved local block.
     """
     rows = tensor.shape[0]
     two_N = tensor.shape[-1]
@@ -41,8 +48,9 @@ def interleave_swiglu_tiles(tensor: torch.Tensor, ndev: int, tile_width: int = 3
     # [rows, half=2, d=ndev, t=tiles_per_dev, c=tile_width] -> [rows, d, t, half, c]
     t = tensor.reshape(rows, 2, ndev, tiles_per_dev, tile_width)
     t = t.permute(0, 2, 3, 1, 4)
-    # flip the half axis so each pair is [second (silu'd), first] -> even slot is silu'd
-    t = t.flip(3)
+
+    if not gate_is_first:
+        t = t.flip(3)
     return t.reshape(rows, two_N)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -8,6 +8,7 @@ import ttnn
 from loguru import logger
 
 from models.common.utility_functions import comp_pcc
+from models.tt_dit.utils.tensor import prepare_for_fused_swiglu
 
 from tracy.process_model_log import (
     get_latest_ops_log_filename,
@@ -343,6 +344,67 @@ def test_linear_padded_wan_shapes(device, M, K, N, M_block_size, K_block_size, N
     check_result = run_test_linear(device, M, K, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w)
     assert check_result["pcc"] > 0.999_500
     assert check_result["relative_rmse"] < 0.02
+
+
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no_bias", "bias"])
+@pytest.mark.parametrize("gate_is_first", [False, True], ids=["up_gate", "gate_up"])
+def test_linear_swiglu(device, gate_is_first, use_bias):
+    """fuse_swiglu=True: silu(gate)*up with both [up|gate] and [gate|up] weight layouts."""
+    M, K, out_N = 256, 256, 256  # weight is [K, 2*out_N]; output is [M, out_N]
+    two_N = 2 * out_N
+    torch_dtype = torch.float32
+
+    torch_input = torch.randn((M, K), dtype=torch_dtype)
+    weight_input = torch.randn((K, two_N), dtype=torch_dtype)
+    bias_input = torch.randn((1, two_N), dtype=torch_dtype) if use_bias else None
+
+    with torch.no_grad():
+        full = torch_input @ weight_input
+        if bias_input is not None:
+            full = full + bias_input
+        if gate_is_first:
+            gate, up = torch.chunk(full, 2, dim=-1)
+        else:
+            up, gate = torch.chunk(full, 2, dim=-1)
+        golden = torch.nn.functional.silu(gate) * up
+
+    weight_il = prepare_for_fused_swiglu(weight_input, ndev=1, gate_is_first=gate_is_first)
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_weight = ttnn.from_torch(weight_il, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_bias = None
+    if use_bias:
+        bias_il = prepare_for_fused_swiglu(bias_input, ndev=1, gate_is_first=gate_is_first)
+        tt_bias = ttnn.from_torch(bias_il, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    matmul_config = ttnn.MinimalMatmulConfig(
+        M_block_size=8,
+        K_block_size=8,
+        N_block_size=8,
+        subblock_h=2,
+        subblock_w=2,
+        compute_with_storage_grid_size=ttnn.CoreCoord(4, 4),
+    )
+
+    tt_output = ttnn.experimental.minimal_matmul(
+        tt_input,
+        tt_weight,
+        bias_tensor=tt_bias,
+        compute_kernel_config=compute_config,
+        config=matmul_config,
+        fuse_swiglu=True,
+    )
+
+    tt_output = ttnn.to_torch(tt_output)
+    result = assert_quality(golden, tt_output)
+    logger.info(f"gate_is_first={gate_is_first}, use_bias={use_bias}: PCC={result['pcc']:.7f}")
+    assert result["pcc"] > 0.9999, f"PCC {result['pcc']:.7f}"
 
 
 def test_run_performance(device):

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul_split.py
@@ -8,6 +8,7 @@ import ttnn
 from loguru import logger
 
 from models.common.utility_functions import comp_pcc
+from models.tt_dit.utils.tensor import interleave_swiglu_tiles
 
 from tracy.process_model_log import (
     get_latest_ops_log_filename,
@@ -125,6 +126,70 @@ def run_test_linear_split(
         "pcc": min(r["pcc"] for r in results),
         "relative_rmse": max(r["relative_rmse"] for r in results),
     }
+
+
+@pytest.mark.parametrize("chunks", [1, 2, 3])
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no_bias", "bias"])
+def test_linear_split_swiglu(device, chunks, use_bias):
+    """FUSE_SWIGLU + chunked split: each chunk is silu(gate)*up of its output slice."""
+    M, K = 256, 256
+    out_N = 192 * chunks  # output width; weight width is 2*out_N
+    two_N = 2 * out_N
+    torch_dtype = torch.float32
+
+    torch_input = torch.randn((M, K), dtype=torch_dtype)
+    weight_input = torch.randn((K, two_N), dtype=torch_dtype)  # cols [first(out_N) | second(out_N)]
+    bias_input = torch.randn((1, two_N), dtype=torch_dtype) if use_bias else None
+
+    with torch.no_grad():
+        full = torch_input @ weight_input
+        if bias_input is not None:
+            full = full + bias_input
+        first, second = torch.chunk(full, 2, dim=-1)
+        golden = first * torch.nn.functional.silu(second)  # [M, out_N]
+        golden_chunks = torch.chunk(golden, chunks, dim=-1)
+
+    weight_il = interleave_swiglu_tiles(weight_input, ndev=1)  # weight is already [K, 2N]
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_weight = ttnn.from_torch(weight_il, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_bias = None
+    if use_bias:
+        bias_il = interleave_swiglu_tiles(bias_input, ndev=1)
+        tt_bias = ttnn.from_torch(bias_il, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    matmul_config = ttnn.MinimalMatmulConfig(
+        M_block_size=8,
+        K_block_size=8,
+        N_block_size=8,
+        subblock_h=2,
+        subblock_w=2,
+        compute_with_storage_grid_size=ttnn.CoreCoord(4, 4),
+    )
+
+    tt_chunks = ttnn.experimental.minimal_matmul_split(
+        tt_input,
+        tt_weight,
+        chunks=chunks,
+        dim=-1,
+        bias_tensor=tt_bias,
+        compute_kernel_config=compute_config,
+        config=matmul_config,
+        fuse_swiglu=True,
+    )
+
+    assert len(tt_chunks) == chunks
+    for i in range(chunks):
+        tt_out_i = ttnn.to_torch(tt_chunks[i])
+        res = assert_quality(golden_chunks[i], tt_out_i)
+        logger.info(f"swiglu chunk {i}: PCC={res['pcc']:.7f}")
+        assert res["pcc"] > 0.9999, f"chunk {i} PCC {res['pcc']}"
 
 
 def test_linear_split_bias(device):

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul_split.py
@@ -8,7 +8,7 @@ import ttnn
 from loguru import logger
 
 from models.common.utility_functions import comp_pcc
-from models.tt_dit.utils.tensor import interleave_swiglu_tiles
+from models.tt_dit.utils.tensor import prepare_for_fused_swiglu
 
 from tracy.process_model_log import (
     get_latest_ops_log_filename,
@@ -149,12 +149,12 @@ def test_linear_split_swiglu(device, chunks, use_bias):
         golden = first * torch.nn.functional.silu(second)  # [M, out_N]
         golden_chunks = torch.chunk(golden, chunks, dim=-1)
 
-    weight_il = interleave_swiglu_tiles(weight_input, ndev=1)  # weight is already [K, 2N]
+    weight_il = prepare_for_fused_swiglu(weight_input, ndev=1)  # weight is already [K, 2N]
     tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
     tt_weight = ttnn.from_torch(weight_il, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
     tt_bias = None
     if use_bias:
-        bias_il = interleave_swiglu_tiles(bias_input, ndev=1)
+        bias_il = prepare_for_fused_swiglu(bias_input, ndev=1)
         tt_bias = ttnn.from_torch(bias_il, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
 
     compute_config = ttnn.init_device_compute_kernel_config(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.cpp
@@ -38,7 +38,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     std::optional<uint32_t> fsdp_cluster_axis,
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore,
     const std::optional<ttnn::Tensor>& persistent_weight_buffer,
-    std::optional<ttnn::ccl::Topology> fsdp_topology) {
+    std::optional<ttnn::ccl::Topology> fsdp_topology,
+    bool fuse_swiglu) {
     return ttnn::prim::all_gather_minimal_matmul_async(
         input_tensor,
         weight_tensor,
@@ -65,7 +66,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
         fsdp_cluster_axis,
         fsdp_multi_device_global_semaphore,
         persistent_weight_buffer,
-        fsdp_topology);
+        fsdp_topology,
+        fuse_swiglu);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.hpp
@@ -41,6 +41,7 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     std::optional<uint32_t> fsdp_cluster_axis = std::nullopt,
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore = {},
     const std::optional<ttnn::Tensor>& persistent_weight_buffer = std::nullopt,
-    std::optional<ttnn::ccl::Topology> fsdp_topology = std::nullopt);
+    std::optional<ttnn::ccl::Topology> fsdp_topology = std::nullopt,
+    bool fuse_swiglu = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async_nanobind.cpp
@@ -230,7 +230,8 @@ void bind_all_gather_minimal_matmul_async(nb::module_& mod) {
             nb::arg("fsdp_cluster_axis") = nb::none(),
             nb::arg("fsdp_multi_device_global_semaphore") = std::vector<GlobalSemaphore>{},
             nb::arg("persistent_weight_buffer") = nb::none(),
-            nb::arg("fsdp_topology") = nb::none()});
+            nb::arg("fsdp_topology") = nb::none(),
+            nb::arg("fuse_swiglu") = false});
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async_nanobind.cpp
@@ -23,7 +23,7 @@ void bind_all_gather_minimal_matmul_async(nb::module_& mod) {
     ttnn::bind_function<"experimental.all_gather_minimal_matmul_async">(
         mod,
         R"doc(
-        all_gather_minimal_matmul_async(input_tensor, weight_tensor, bias_tensor=None, *, fused_activation=None, config=None, memory_config=None, dtype=None, compute_kernel_config=None)
+        all_gather_minimal_matmul_async(input_tensor, weight_tensor, bias_tensor=None, *, fused_activation=None, config=None, memory_config=None, dtype=None, compute_kernel_config=None, fuse_swiglu=False)
 
         Experimental, high-performance matrix multiply (A @ B [+ bias]) with optional fused activation.
         This op expects TILE layout tensors on device and operates in tile units internally. It is designed
@@ -72,6 +72,14 @@ void bind_all_gather_minimal_matmul_async(nb::module_& mod) {
             Optional fused unary activation applied per output tile during packing. See ttnn unary utilities
             for supported ops and parameters. Typical examples include relu/gelu/etc. If provided, it is applied
             after bias (if any) and before the tile is written out.
+
+        fuse_swiglu : bool, default: False
+            If True, applies SwiGLU activation fused into the matmul: the weight tensor's N columns are
+            interpreted as a tile-pair-interleaved [gate|up] layout — column tile 2p is the gate and 2p+1 is
+            the up projection for each pair p (``models.tt_dit.utils.tensor.prepare_for_fused_swiglu``
+            can be used to produce this layout). The op computes silu(gate) * up and the output width is therefore N/2.
+            The bias (if provided) must use the same column layout. N must be divisible by 2*32 (two
+            tile-aligned halves). Mutually exclusive with fused_activation.
 
         config : Optional[MinimalMatmulConfig], default: None
             Execution configuration in tile units. If omitted, reasonable defaults are selected based on tensor
@@ -145,8 +153,9 @@ void bind_all_gather_minimal_matmul_async(nb::module_& mod) {
         Returns
         -------
         std::vector<ttnn.Tensor>
-            Output tensor with shape [..., M, N], TILE layout, and dtype specified by `dtype` parameter
-            (or same dtype as `input_tensor` if `dtype` is not provided).
+            Output tensor in TILE layout with dtype specified by `dtype` (or same as `input_tensor` if not provided).
+            - fuse_swiglu=False: shape [..., M, N].
+            - fuse_swiglu=True: shape [..., M, N/2] (SwiGLU halves the output width).
 
         Shape Semantics
         ----------------
@@ -155,7 +164,7 @@ void bind_all_gather_minimal_matmul_async(nb::module_& mod) {
         - bias_tensor (optional): [..., N] (row-broadcast)
         - addcmul_input_tensor1: [..., M, N] (full output shape)
         - addcmul_input_tensor2: [..., 1, N] (broadcast like bias)
-        - output: [..., M, N]
+        - output: [..., M, N] normally; [..., M, N/2] when fuse_swiglu=True
         Note: All leading dims (dims < -2) are required to be 1 (no batching). Tensors are read/written in tile units;
         if logical sizes are not tile-aligned, padding is handled internally (reads fill zeros; writes skip outside
         logical bounds).

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.cpp
@@ -99,6 +99,19 @@ void AllGatherMinimalMatmulAsyncOp::validate_on_program_cache_miss(
     TT_FATAL(K == K_w, "all_gather_minimal_matmul_async inner dimensions must match, got K={} and K_w={}", K, K_w);
     TT_FATAL(M > 0 && K > 0 && N > 0, "all_gather_minimal_matmul_async dimensions must be positive");
 
+    if (attributes.fuse_swiglu) {
+        TT_FATAL(
+            !attributes.fused_activation.has_value() && !attributes.fused_ternary_scalar.has_value(),
+            "all_gather_minimal_matmul_async fuse_swiglu is mutually exclusive with fused_activation / ternary");
+        TT_FATAL(attributes.chunks == 1, "all_gather_minimal_matmul_async fuse_swiglu does not yet support chunks > 1");
+        TT_FATAL(
+            N % (2 * tt::constants::TILE_WIDTH) == 0,
+            "all_gather_minimal_matmul_async fuse_swiglu requires weight width N={} to be a multiple of "
+            "2*TILE_WIDTH={}",
+            N,
+            2 * tt::constants::TILE_WIDTH);
+    }
+
     // FSDP fusion validation
     if (attributes.fsdp_cluster_axis.has_value()) {
         TT_FATAL(
@@ -322,7 +335,8 @@ AllGatherMinimalMatmulAsyncOp::spec_return_value_t AllGatherMinimalMatmulAsyncOp
     const auto& in1_input_tensor = tensor_args.weight_tensor;
     const auto& in0_input_tensor_shape = in0_input_tensor.logical_shape();
     const auto& in1_input_tensor_shape = in1_input_tensor.logical_shape();
-    const uint32_t N = in1_input_tensor_shape[-1];
+    // SwiGLU halves the output along N (weight is the packed [gate|up] of width 2N).
+    const uint32_t N = attributes.fuse_swiglu ? (in1_input_tensor_shape[-1] / 2) : in1_input_tensor_shape[-1];
     const int32_t chunks = attributes.chunks;
     const bool fsdp_fused = attributes.fsdp_cluster_axis.has_value();
 
@@ -424,7 +438,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     std::optional<uint32_t> fsdp_cluster_axis,
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore,
     const std::optional<ttnn::Tensor>& persistent_weight_buffer,
-    std::optional<ttnn::ccl::Topology> fsdp_topology) {
+    std::optional<ttnn::ccl::Topology> fsdp_topology,
+    bool fuse_swiglu) {
     using OperationType = ttnn::experimental::prim::AllGatherMinimalMatmulAsyncOp;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -470,7 +485,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
         fsdp_num_devices,
         fsdp_multi_device_global_semaphore,
         using_persistent_weight_buffer,
-        fsdp_topology_};
+        fsdp_topology_,
+        fuse_swiglu};
     auto tensor_args = OperationType::tensor_args_t{
         input_tensor,
         weight_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.hpp
@@ -68,6 +68,7 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     std::optional<uint32_t> fsdp_cluster_axis = std::nullopt,
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore = {},
     const std::optional<ttnn::Tensor>& persistent_weight_buffer = std::nullopt,
-    std::optional<ttnn::ccl::Topology> fsdp_topology = std::nullopt);
+    std::optional<ttnn::ccl::Topology> fsdp_topology = std::nullopt,
+    bool fuse_swiglu = false);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -43,6 +43,11 @@ struct AllGatherMinimalMatmulAsyncParams {
     bool using_persistent_weight_buffer = false;
     ttnn::ccl::Topology fsdp_topology;
 
+    // Fused SwiGLU: weight is a tile-pair-interleaved [gate|up] matrix of width 2N; the op
+    // emits silu(gate)*up of width N in a single matmul. Mutually exclusive with
+    // fused_activation / ternary.
+    bool fuse_swiglu = false;
+
     AllGatherMinimalMatmulAsyncParams(
         std::optional<const MinimalMatmulConfig> config,
         std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation,
@@ -66,7 +71,8 @@ struct AllGatherMinimalMatmulAsyncParams {
         uint32_t fsdp_ring_size,
         std::vector<GlobalSemaphore> fsdp_semaphore,
         bool using_persistent_weight_buffer,
-        ttnn::ccl::Topology fsdp_topology) :
+        ttnn::ccl::Topology fsdp_topology,
+        bool fuse_swiglu = false) :
         config(config),
         fused_activation(fused_activation),
         output_mem_config(output_mem_config),
@@ -89,7 +95,8 @@ struct AllGatherMinimalMatmulAsyncParams {
         fsdp_ring_size(fsdp_ring_size),
         fsdp_semaphore(std::move(fsdp_semaphore)),
         using_persistent_weight_buffer(using_persistent_weight_buffer),
-        fsdp_topology(fsdp_topology) {}
+        fsdp_topology(fsdp_topology),
+        fuse_swiglu(fuse_swiglu) {}
 
     // Structural fields that affect program-cache key.
     static constexpr auto attribute_names = std::make_tuple(
@@ -104,7 +111,8 @@ struct AllGatherMinimalMatmulAsyncParams {
         "config",
         "fsdp_cluster_axis",
         "fsdp_ring_size",
-        "using_persistent_weight_buffer");
+        "using_persistent_weight_buffer",
+        "fuse_swiglu");
 
     auto attribute_values() const {
         return std::forward_as_tuple(
@@ -119,7 +127,8 @@ struct AllGatherMinimalMatmulAsyncParams {
             this->config,
             this->fsdp_cluster_axis,
             this->fsdp_ring_size,
-            this->using_persistent_weight_buffer);
+            this->using_persistent_weight_buffer,
+            this->fuse_swiglu);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -204,7 +204,8 @@ all_gather_minimal_matmul_async_factory_helper(
     uint32_t fsdp_ring_size,
     uint32_t fsdp_ring_index,
     const std::vector<ttnn::GlobalSemaphore>& fsdp_semaphore,
-    ttnn::ccl::Topology fsdp_topology) {
+    ttnn::ccl::Topology fsdp_topology,
+    bool fuse_swiglu = false) {
     auto* device = input_tensor.device();
 
     if (!config.has_value()) {
@@ -324,8 +325,17 @@ all_gather_minimal_matmul_async_factory_helper(
      * Most output blocks are the full block size, but the last block in M or N can be partial.
      */
     uint32_t padded_M_tiles = tt::round_up(M_tiles, in0_parallel_axis_cores);
-    uint32_t padded_N_tiles = tt::round_up(N_tiles, in1_parallel_axis_cores);
     uint32_t padded_K_tiles = tt::round_up(K_tiles, K_block_tiles);
+
+    // SwiGLU partitions on gate/up PAIRS (= output tiles) so a pair never splits across cores.
+    uint32_t padded_N_tiles;
+    if (fuse_swiglu) {
+        uint32_t out_N_tiles = N_tiles / 2;
+        uint32_t padded_out_N_tiles = tt::round_up(out_N_tiles, in1_parallel_axis_cores);
+        padded_N_tiles = 2 * padded_out_N_tiles;
+    } else {
+        padded_N_tiles = tt::round_up(N_tiles, in1_parallel_axis_cores);
+    }
 
     // K is sharded equally across devices (validated upstream: K_tiles % ring_size == 0).
     // Within a device, K_per_device tiles are processed in K_blocks_per_device blocks (div_up).
@@ -341,6 +351,16 @@ all_gather_minimal_matmul_async_factory_helper(
 
     uint32_t M_blocks_per_core = tt::div_up(M_tiles_per_core, M_block_tiles);
     uint32_t N_blocks_per_core = tt::div_up(N_tiles_per_core, N_block_tiles);
+
+    if (fuse_swiglu) {
+        TT_FATAL(
+            N_tiles % 2 == 0 && N_tiles_per_core % 2 == 0 && N_block_tiles % 2 == 0,
+            "all_gather_minimal_matmul_async fuse_swiglu requires N_tiles ({}), N_tiles_per_core ({}) and "
+            "N_block_tiles ({}) all even",
+            N_tiles,
+            N_tiles_per_core,
+            N_block_tiles);
+    }
 
     log_debug(tt::LogOp, "M_tiles_per_core: {}", M_tiles_per_core);
     log_debug(tt::LogOp, "N_tiles_per_core: {}", N_tiles_per_core);
@@ -366,7 +386,9 @@ all_gather_minimal_matmul_async_factory_helper(
     const uint32_t double_buffer_factor = 2;
     uint32_t in0_cb_num_tiles = in0_block_num_tiles * double_buffer_factor;
     uint32_t in1_cb_num_tiles = in1_block_num_tiles * double_buffer_factor;
-    uint32_t out_cb_num_tiles = out_block_num_tiles;     // single-buffered
+    // SwiGLU writes half the N tiles per block (one per gate/up pair); the intermediate
+    // still holds the full (2N) block.
+    uint32_t out_cb_num_tiles = fuse_swiglu ? (out_block_num_tiles / 2) : out_block_num_tiles;  // single-buffered
     uint32_t interm_cb_num_tiles = out_block_num_tiles;  // not double buffered
     uint32_t in2_cb_num_tiles = in2_block_num_tiles;     // not double buffered
 
@@ -623,6 +645,11 @@ all_gather_minimal_matmul_async_factory_helper(
     std::map<std::string, std::string> in0_fabric_defines;
     if (use_bias) {
         defines["FUSE_BIAS"] = "1";
+    }
+    // Added to `defines` before the per-kernel copies below (in0/in1/compute) so every
+    // kernel containing output-writer or compute code sees FUSE_SWIGLU.
+    if (fuse_swiglu) {
+        defines["FUSE_SWIGLU"] = "1";
     }
     if (use_fused_ternary) {
         defines["FUSE_TERNARY"] = "1";
@@ -1651,7 +1678,8 @@ all_gather_minimal_matmul_async_factory(
     uint32_t fsdp_ring_size,
     uint32_t fsdp_ring_index,
     const std::vector<ttnn::GlobalSemaphore>& fsdp_semaphore,
-    ttnn::ccl::Topology fsdp_topology) {
+    ttnn::ccl::Topology fsdp_topology,
+    bool fuse_swiglu) {
     tt::tt_metal::Program program{};
 
     return {
@@ -1689,7 +1717,8 @@ all_gather_minimal_matmul_async_factory(
             fsdp_ring_size,
             fsdp_ring_index,
             fsdp_semaphore,
-            fsdp_topology)};
+            fsdp_topology,
+            fuse_swiglu)};
 }
 
 ttnn::device_operation::CachedProgram<AllGatherMinimalMatmulAsyncProgramFactory::shared_variables_t>
@@ -1765,7 +1794,8 @@ AllGatherMinimalMatmulAsyncProgramFactory::create_at(
         attributes.fsdp_ring_size,
         fsdp_ring_index,
         attributes.fsdp_semaphore,
-        attributes.fsdp_topology);
+        attributes.fsdp_topology,
+        attributes.fuse_swiglu);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
@@ -17,48 +17,20 @@
 
 #ifdef FUSE_SWIGLU
 // Fused SwiGLU output stage. The matmul produced an interleaved gate/up block in `in_cb`:
-// within each M row, column tile 2p is the silu'd half and 2p+1 the multiplicand (the weight
-// was tile-pair interleaved on the host). Each pair emits one output tile = silu(tile2p)*tile2p+1,
+// within each M row, column tile 2p is the gate projection and 2p+1 the up projection (the
+// weight was tile-pair interleaved on the host). Each pair emits one output tile = silu(gate)*up,
 // so the block shrinks from N_block_tiles to N_block_tiles/2 along N. No extra CB / DRAM
 // round-trip. N_block_tiles must be even (enforced host-side). silu and mul_binary are distinct
 // SFPU programs, so each is re-initialised right before use.
-void swiglu_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
-    reconfig_data_format_srca(in_cb);
-    pack_reconfig_data_format(out_cb);
-
-    constexpr uint32_t GATE_DST = 0;
-    constexpr uint32_t UP_DST = 1;
-    const uint32_t out_N_block_tiles = N_block_tiles >> 1;
-
-    for (uint32_t m = 0; m < M_block_tiles; m++) {
-        const uint32_t row_base = m * N_block_tiles;
-        for (uint32_t p = 0; p < out_N_block_tiles; p++) {
-            const uint32_t gate_tile_id = row_base + (p << 1);
-            const uint32_t up_tile_id = gate_tile_id + 1;
-
-            tile_regs_acquire();
-            copy_tile_to_dst_init_short(in_cb);
-            copy_tile(in_cb, gate_tile_id, GATE_DST);
-            copy_tile(in_cb, up_tile_id, UP_DST);
-            silu_tile_init();
-            silu_tile(GATE_DST);
-            mul_binary_tile_init();
-            mul_binary_tile(GATE_DST, UP_DST, GATE_DST);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile(GATE_DST, out_cb);
-            tile_regs_release();
-        }
-        cb_push_back(out_cb, out_N_block_tiles);
-    }
-}
-
-// SwiGLU output stage with fused bias (interleaved identically to the weight):
-// out = silu(second + bias_second) * (first + bias_first).
-void swiglu_bias_block(
-    uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+//
+// With FUSE_BIAS: bias is interleaved identically (tile 2p = gate bias, 2p+1 = up bias)
+// and added via row-broadcast before silu/mul: out = silu(gate + bias_gate) * (up + bias_up).
+void swiglu_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+#ifdef FUSE_BIAS
     reconfig_data_format(in_cb, bias_cb);
+#else
+    reconfig_data_format_srca(in_cb);
+#endif
     pack_reconfig_data_format(out_cb);
 
     constexpr uint32_t GATE_DST = 0;
@@ -74,9 +46,15 @@ void swiglu_bias_block(
             const uint32_t up_tile_id = gate_tile_id + 1;
 
             tile_regs_acquire();
+#ifdef FUSE_BIAS
             add_bcast_rows_init_short(in_cb, bias_cb);
             add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, gate_tile_id, gate_n, GATE_DST);
             add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, up_tile_id, up_n, UP_DST);
+#else
+            copy_tile_to_dst_init_short(in_cb);
+            copy_tile(in_cb, gate_tile_id, GATE_DST);
+            copy_tile(in_cb, up_tile_id, UP_DST);
+#endif
             silu_tile_init();
             silu_tile(GATE_DST);
             mul_binary_tile_init();
@@ -542,14 +520,14 @@ void kernel_main() {
             // SwiGLU collapses the interleaved gate/up block to half its N width.
             out_cb.reserve_back(out_block_num_tiles >> 1);
             intermediate_cb.wait_front(out_block_num_tiles);
-#ifndef FUSE_BIAS
-            swiglu_block(intermediate_cb.get_cb_id(), out_cb.get_cb_id(), M_block_tiles, N_block_tiles);
-#else
+#ifdef FUSE_BIAS
             in2_cb.wait_front(N_block_tiles);
-            swiglu_bias_block(
+#endif
+            swiglu_block(
                 intermediate_cb.get_cb_id(), in2_cb.get_cb_id(), out_cb.get_cb_id(), M_block_tiles, N_block_tiles);
+#ifdef FUSE_BIAS
             in2_cb.pop_front(N_block_tiles);
-#endif  // FUSE_BIAS
+#endif
             intermediate_cb.pop_front(out_block_num_tiles);
 
 #elif !defined(FUSE_TERNARY)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
@@ -15,6 +15,83 @@
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/dataflow/circular_buffer.h"
 
+#ifdef FUSE_SWIGLU
+// Fused SwiGLU output stage. The matmul produced an interleaved gate/up block in `in_cb`:
+// within each M row, column tile 2p is the silu'd half and 2p+1 the multiplicand (the weight
+// was tile-pair interleaved on the host). Each pair emits one output tile = silu(tile2p)*tile2p+1,
+// so the block shrinks from N_block_tiles to N_block_tiles/2 along N. No extra CB / DRAM
+// round-trip. N_block_tiles must be even (enforced host-side). silu and mul_binary are distinct
+// SFPU programs, so each is re-initialised right before use.
+void swiglu_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    reconfig_data_format_srca(in_cb);
+    pack_reconfig_data_format(out_cb);
+
+    constexpr uint32_t GATE_DST = 0;
+    constexpr uint32_t UP_DST = 1;
+    const uint32_t out_N_block_tiles = N_block_tiles >> 1;
+
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        const uint32_t row_base = m * N_block_tiles;
+        for (uint32_t p = 0; p < out_N_block_tiles; p++) {
+            const uint32_t gate_tile_id = row_base + (p << 1);
+            const uint32_t up_tile_id = gate_tile_id + 1;
+
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short(in_cb);
+            copy_tile(in_cb, gate_tile_id, GATE_DST);
+            copy_tile(in_cb, up_tile_id, UP_DST);
+            silu_tile_init();
+            silu_tile(GATE_DST);
+            mul_binary_tile_init();
+            mul_binary_tile(GATE_DST, UP_DST, GATE_DST);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(GATE_DST, out_cb);
+            tile_regs_release();
+        }
+        cb_push_back(out_cb, out_N_block_tiles);
+    }
+}
+
+// SwiGLU output stage with fused bias (interleaved identically to the weight):
+// out = silu(second + bias_second) * (first + bias_first).
+void swiglu_bias_block(
+    uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    reconfig_data_format(in_cb, bias_cb);
+    pack_reconfig_data_format(out_cb);
+
+    constexpr uint32_t GATE_DST = 0;
+    constexpr uint32_t UP_DST = 1;
+    const uint32_t out_N_block_tiles = N_block_tiles >> 1;
+
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        const uint32_t row_base = m * N_block_tiles;
+        for (uint32_t p = 0; p < out_N_block_tiles; p++) {
+            const uint32_t gate_n = p << 1;
+            const uint32_t up_n = gate_n + 1;
+            const uint32_t gate_tile_id = row_base + gate_n;
+            const uint32_t up_tile_id = gate_tile_id + 1;
+
+            tile_regs_acquire();
+            add_bcast_rows_init_short(in_cb, bias_cb);
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, gate_tile_id, gate_n, GATE_DST);
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, up_tile_id, up_n, UP_DST);
+            silu_tile_init();
+            silu_tile(GATE_DST);
+            mul_binary_tile_init();
+            mul_binary_tile(GATE_DST, UP_DST, GATE_DST);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(GATE_DST, out_cb);
+            tile_regs_release();
+        }
+        cb_push_back(out_cb, out_N_block_tiles);
+    }
+}
+#endif  // FUSE_SWIGLU
+
 void copy_block(CircularBuffer& in_cb, CircularBuffer& out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
     copy_tile_to_dst_init_short(in_cb.get_cb_id());
     reconfig_data_format_srca(in_cb.get_cb_id());
@@ -461,8 +538,22 @@ void kernel_main() {
             intermediate_cb.push_back(out_block_num_tiles);
             PACK((llk_pack_reconfig_l1_acc(0)));
 
+#ifdef FUSE_SWIGLU
+            // SwiGLU collapses the interleaved gate/up block to half its N width.
+            out_cb.reserve_back(out_block_num_tiles >> 1);
+            intermediate_cb.wait_front(out_block_num_tiles);
+#ifndef FUSE_BIAS
+            swiglu_block(intermediate_cb.get_cb_id(), out_cb.get_cb_id(), M_block_tiles, N_block_tiles);
+#else
+            in2_cb.wait_front(N_block_tiles);
+            swiglu_bias_block(
+                intermediate_cb.get_cb_id(), in2_cb.get_cb_id(), out_cb.get_cb_id(), M_block_tiles, N_block_tiles);
+            in2_cb.pop_front(N_block_tiles);
+#endif  // FUSE_BIAS
+            intermediate_cb.pop_front(out_block_num_tiles);
+
+#elif !defined(FUSE_TERNARY)
             out_cb.reserve_back(out_block_num_tiles);
-#ifndef FUSE_TERNARY
             intermediate_cb.wait_front(out_block_num_tiles);
 #ifndef FUSE_BIAS
             copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
@@ -474,6 +565,7 @@ void kernel_main() {
             intermediate_cb.pop_front(out_block_num_tiles);
 
 #else   // FUSE_TERNARY is set
+            out_cb.reserve_back(out_block_num_tiles);
             add_bias_and_addcmul_block(
                 intermediate_cb,
                 in2_cb,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -197,6 +197,14 @@ void kernel_main() {
     constexpr uint32_t in0_block_num_tiles = M_block_tiles * K_block_tiles;
     constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
 
+#ifdef FUSE_SWIGLU
+    // SwiGLU emits one output tile per interleaved gate/up pair -> output N is half the
+    // matmul (weight) N. Weight-space n ranges are halved at each write call site.
+    constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
+    constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
+    const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
+#endif
+
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
     constexpr uint32_t cb_id_out = tt::CBIndex::c_2;
 #ifdef FUSE_BIAS
@@ -309,6 +317,21 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                        cb_out.wait_front(out_block_num_tiles_swiglu);
+                        uint32_t out_read_ptr_swiglu = cb_out.get_read_ptr();
+                        write_block_sync<M_block_tiles, out_N_block_tiles>(
+                            noc_obj,
+                            std::get<0>(outputs_tuple),
+                            out_shape_swiglu,
+                            out_read_ptr_swiglu,
+                            out_tile_size,
+                            defer_write_m_tile,
+                            defer_write_m_tile_end,
+                            defer_write_n_tile / 2,
+                            defer_write_n_tile_end / 2);
+                        cb_out.pop_front(out_block_num_tiles_swiglu);
+#else
                         cb_out.wait_front(out_block_num_tiles);
                         uint32_t out_read_ptr = cb_out.get_read_ptr();
 
@@ -338,6 +361,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         }
                         cb_out.pop_front(out_block_num_tiles);
+#endif  // FUSE_SWIGLU
                     }
                 }
                 if (reuse_block && k_block_iter == 0) {
@@ -628,6 +652,18 @@ void kernel_main() {
 
             if (!defer_write) {
                 if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                    write_block_sync_granular<M_block_tiles, out_N_block_tiles>(
+                        noc_obj,
+                        std::get<0>(outputs_tuple),
+                        out_shape_swiglu,
+                        cb_out,
+                        out_tile_size,
+                        m_tile,
+                        m_tile_end,
+                        n_tile / 2,
+                        n_tile_end / 2);
+#else
                     // write_block_sync_granular_split is more generic (support multiple output tensors)
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
@@ -653,6 +689,7 @@ void kernel_main() {
                             n_tile,
                             n_tile_end);
                     }
+#endif  // FUSE_SWIGLU
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -193,6 +193,14 @@ void kernel_main() {
     constexpr uint32_t in1_block_num_tiles = K_block_tiles * N_block_tiles;
     constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
 
+#ifdef FUSE_SWIGLU
+    // SwiGLU emits one output tile per interleaved gate/up pair -> output N is half the
+    // matmul (weight) N. Weight-space n ranges are halved at each write call site.
+    constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
+    constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
+    const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
+#endif
+
     constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
     constexpr uint32_t cb_id_out = tt::CBIndex::c_2;
 #ifdef FUSE_BIAS
@@ -305,6 +313,21 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                        cb_out.wait_front(out_block_num_tiles_swiglu);
+                        uint32_t out_read_ptr = cb_out.get_read_ptr();
+                        write_block_sync<M_block_tiles, out_N_block_tiles>(
+                            noc_obj,
+                            std::get<0>(outputs_tuple),
+                            out_shape_swiglu,
+                            out_read_ptr,
+                            out_tile_size,
+                            defer_write_m_tile,
+                            defer_write_m_tile_end,
+                            defer_write_n_tile / 2,
+                            defer_write_n_tile_end / 2);
+                        cb_out.pop_front(out_block_num_tiles_swiglu);
+#else
                         cb_out.wait_front(out_block_num_tiles);
                         uint32_t out_read_ptr = cb_out.get_read_ptr();
                         // write_block_sync_split is more generic (support multiple output tensors)
@@ -333,6 +356,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         }
                         cb_out.pop_front(out_block_num_tiles);
+#endif  // FUSE_SWIGLU
                     }
                 }
 
@@ -637,6 +661,18 @@ void kernel_main() {
 
             if (!defer_write) {
                 if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                    write_block_sync_granular<M_block_tiles, out_N_block_tiles>(
+                        noc_obj,
+                        std::get<0>(outputs_tuple),
+                        out_shape_swiglu,
+                        cb_out,
+                        out_tile_size,
+                        m_tile,
+                        m_tile_end,
+                        n_tile / 2,
+                        n_tile_end / 2);
+#else
                     // write_block_sync_granular_split is more generic (support multiple output tensors)
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
@@ -662,6 +698,7 @@ void kernel_main() {
                             n_tile,
                             n_tile_end);
                     }
+#endif  // FUSE_SWIGLU
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -48,48 +48,16 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_
 // shrinks from N_block_tiles to N_block_tiles/2 along N. No extra CB / no extra DRAM
 // round-trip: silu runs on the gate DST reg and the multiply is an SFPU dst*dst op.
 //
+// With FUSE_BIAS: bias is interleaved identically (tile 2p = gate bias, 2p+1 = up bias)
+// and added via row-broadcast before silu/mul: out = silu(gate + bias_gate) * (up + bias_up).
+//
 // N_block_tiles must be even (enforced host-side).
-void swiglu_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
-    reconfig_data_format_srca(in_cb);
-    pack_reconfig_data_format(out_cb);
-
-    constexpr uint32_t GATE_DST = 0;
-    constexpr uint32_t UP_DST = 1;
-    const uint32_t out_N_block_tiles = N_block_tiles >> 1;
-
-    for (uint32_t m = 0; m < M_block_tiles; m++) {
-        const uint32_t row_base = m * N_block_tiles;
-        for (uint32_t p = 0; p < out_N_block_tiles; p++) {
-            const uint32_t gate_tile_id = row_base + (p << 1);
-            const uint32_t up_tile_id = gate_tile_id + 1;
-
-            tile_regs_acquire();
-            // copy gate/up into adjacent DST regs, then activate. silu and mul_binary are
-            // distinct SFPU programs, so each op is re-initialised right before use (mirrors
-            // the addcmul float32 path) — otherwise silu would run with the mul SFPU config.
-            copy_tile_to_dst_init_short(in_cb);
-            copy_tile(in_cb, gate_tile_id, GATE_DST);
-            copy_tile(in_cb, up_tile_id, UP_DST);
-            silu_tile_init();
-            silu_tile(GATE_DST);
-            mul_binary_tile_init();
-            mul_binary_tile(GATE_DST, UP_DST, GATE_DST);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile(GATE_DST, out_cb);
-            tile_regs_release();
-        }
-        cb_push_back(out_cb, out_N_block_tiles);
-    }
-}
-
-// SwiGLU output stage with fused bias. Bias is interleaved identically to the weight
-// (bias tile 2p = gate bias, 2p+1 = up bias) and added (row-broadcast) before silu/mul:
-// out = silu(gate + bias_gate) * (up + bias_up).
-void swiglu_bias_block(
-    uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+void swiglu_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+#ifdef FUSE_BIAS
     reconfig_data_format(in_cb, bias_cb);
+#else
+    reconfig_data_format_srca(in_cb);
+#endif
     pack_reconfig_data_format(out_cb);
 
     constexpr uint32_t GATE_DST = 0;
@@ -105,11 +73,17 @@ void swiglu_bias_block(
             const uint32_t up_tile_id = gate_tile_id + 1;
 
             tile_regs_acquire();
-            // gate/up + row-broadcast bias into adjacent DST regs, then activate. Each SFPU
-            // op is re-initialised right before use (silu/mul_binary are distinct programs).
+            // silu and mul_binary are distinct SFPU programs — each op is re-initialised
+            // right before use; otherwise silu would run with the mul SFPU config.
+#ifdef FUSE_BIAS
             add_bcast_rows_init_short(in_cb, bias_cb);
             add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, gate_tile_id, gate_n, GATE_DST);
             add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, up_tile_id, up_n, UP_DST);
+#else
+            copy_tile_to_dst_init_short(in_cb);
+            copy_tile(in_cb, gate_tile_id, GATE_DST);
+            copy_tile(in_cb, up_tile_id, UP_DST);
+#endif
             silu_tile_init();
             silu_tile(GATE_DST);
             mul_binary_tile_init();
@@ -540,13 +514,13 @@ void kernel_main() {
             // SwiGLU collapses the interleaved gate/up block to half its N width.
             cb_out.reserve_back(out_block_num_tiles >> 1);
             cb_intermediate.wait_front(out_block_num_tiles);
-#ifndef FUSE_BIAS
-            swiglu_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
-#else
+#ifdef FUSE_BIAS
             cb_in2.wait_front(N_block_tiles);
-            swiglu_bias_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);
+#endif
+            swiglu_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);
+#ifdef FUSE_BIAS
             cb_in2.pop_front(N_block_tiles);
-#endif  // FUSE_BIAS
+#endif
             cb_intermediate.pop_front(out_block_num_tiles);
 
 #elif !defined(FUSE_TERNARY)

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -40,6 +40,91 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_
     }
 }
 
+#ifdef FUSE_SWIGLU
+// Fused SwiGLU output stage. The matmul produced an interleaved gate/up block in
+// `in_cb` (the intermediate accumulator): within each M row, column tile 2p is the
+// gate projection and 2p+1 is the up projection (the weight was tile-pair interleaved
+// on the host). For each pair we emit one output tile = silu(gate) * up, so the block
+// shrinks from N_block_tiles to N_block_tiles/2 along N. No extra CB / no extra DRAM
+// round-trip: silu runs on the gate DST reg and the multiply is an SFPU dst*dst op.
+//
+// N_block_tiles must be even (enforced host-side).
+void swiglu_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    reconfig_data_format_srca(in_cb);
+    pack_reconfig_data_format(out_cb);
+
+    constexpr uint32_t GATE_DST = 0;
+    constexpr uint32_t UP_DST = 1;
+    const uint32_t out_N_block_tiles = N_block_tiles >> 1;
+
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        const uint32_t row_base = m * N_block_tiles;
+        for (uint32_t p = 0; p < out_N_block_tiles; p++) {
+            const uint32_t gate_tile_id = row_base + (p << 1);
+            const uint32_t up_tile_id = gate_tile_id + 1;
+
+            tile_regs_acquire();
+            // copy gate/up into adjacent DST regs, then activate. silu and mul_binary are
+            // distinct SFPU programs, so each op is re-initialised right before use (mirrors
+            // the addcmul float32 path) — otherwise silu would run with the mul SFPU config.
+            copy_tile_to_dst_init_short(in_cb);
+            copy_tile(in_cb, gate_tile_id, GATE_DST);
+            copy_tile(in_cb, up_tile_id, UP_DST);
+            silu_tile_init();
+            silu_tile(GATE_DST);
+            mul_binary_tile_init();
+            mul_binary_tile(GATE_DST, UP_DST, GATE_DST);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(GATE_DST, out_cb);
+            tile_regs_release();
+        }
+        cb_push_back(out_cb, out_N_block_tiles);
+    }
+}
+
+// SwiGLU output stage with fused bias. Bias is interleaved identically to the weight
+// (bias tile 2p = gate bias, 2p+1 = up bias) and added (row-broadcast) before silu/mul:
+// out = silu(gate + bias_gate) * (up + bias_up).
+void swiglu_bias_block(
+    uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    reconfig_data_format(in_cb, bias_cb);
+    pack_reconfig_data_format(out_cb);
+
+    constexpr uint32_t GATE_DST = 0;
+    constexpr uint32_t UP_DST = 1;
+    const uint32_t out_N_block_tiles = N_block_tiles >> 1;
+
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        const uint32_t row_base = m * N_block_tiles;
+        for (uint32_t p = 0; p < out_N_block_tiles; p++) {
+            const uint32_t gate_n = p << 1;
+            const uint32_t up_n = gate_n + 1;
+            const uint32_t gate_tile_id = row_base + gate_n;
+            const uint32_t up_tile_id = gate_tile_id + 1;
+
+            tile_regs_acquire();
+            // gate/up + row-broadcast bias into adjacent DST regs, then activate. Each SFPU
+            // op is re-initialised right before use (silu/mul_binary are distinct programs).
+            add_bcast_rows_init_short(in_cb, bias_cb);
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, gate_tile_id, gate_n, GATE_DST);
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, up_tile_id, up_n, UP_DST);
+            silu_tile_init();
+            silu_tile(GATE_DST);
+            mul_binary_tile_init();
+            mul_binary_tile(GATE_DST, UP_DST, GATE_DST);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(GATE_DST, out_cb);
+            tile_regs_release();
+        }
+        cb_push_back(out_cb, out_N_block_tiles);
+    }
+}
+#endif  // FUSE_SWIGLU
+
 // For caller: if FUSE_TERNARY defined then out_cb == in_cb
 /**
  * Add bias to input block
@@ -451,8 +536,21 @@ void kernel_main() {
             cb_intermediate.push_back(out_block_num_tiles);
             PACK((llk_pack_reconfig_l1_acc(0)));
 
+#ifdef FUSE_SWIGLU
+            // SwiGLU collapses the interleaved gate/up block to half its N width.
+            cb_out.reserve_back(out_block_num_tiles >> 1);
+            cb_intermediate.wait_front(out_block_num_tiles);
+#ifndef FUSE_BIAS
+            swiglu_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
+#else
+            cb_in2.wait_front(N_block_tiles);
+            swiglu_bias_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);
+            cb_in2.pop_front(N_block_tiles);
+#endif  // FUSE_BIAS
+            cb_intermediate.pop_front(out_block_num_tiles);
+
+#elif !defined(FUSE_TERNARY)
             cb_out.reserve_back(out_block_num_tiles);
-#ifndef FUSE_TERNARY
             cb_intermediate.wait_front(out_block_num_tiles);
 #ifndef FUSE_BIAS
             copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
@@ -464,6 +562,7 @@ void kernel_main() {
             cb_intermediate.pop_front(out_block_num_tiles);
 
 #else   // FUSE_TERNARY is set
+            cb_out.reserve_back(out_block_num_tiles);
             add_bias_and_addcmul_block(
                 intermediate_cb,
                 in2_cb,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -73,8 +73,6 @@ void swiglu_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_
             const uint32_t up_tile_id = gate_tile_id + 1;
 
             tile_regs_acquire();
-            // silu and mul_binary are distinct SFPU programs — each op is re-initialised
-            // right before use; otherwise silu would run with the mul SFPU config.
 #ifdef FUSE_BIAS
             add_bcast_rows_init_short(in_cb, bias_cb);
             add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, gate_tile_id, gate_n, GATE_DST);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -124,6 +124,17 @@ void kernel_main() {
     constexpr uint32_t in0_block_num_tiles = M_block_tiles * K_block_tiles;
     constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
 
+#ifdef FUSE_SWIGLU
+    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N
+    // is half the matmul (weight) N. The weight-space n ranges are halved at each write.
+    constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
+    constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
+    const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
+    // Split (chunks>1): each output chunk is half the weight per-chunk width.
+    constexpr uint32_t out_N_tiles_per_chunk = N_tiles_per_chunk / 2;
+    const TensorShape2D out0_shape_swiglu(M_tiles, out_N_tiles_per_chunk, padded_M_tiles, out_N_tiles_per_chunk);
+#endif
+
     constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
     constexpr uint32_t cb_out_id = tt::CBIndex::c_2;
 #ifdef FUSE_BIAS
@@ -234,6 +245,32 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                        cb_out.wait_front(out_block_num_tiles_swiglu);
+                        uint32_t out_read_ptr_swiglu = get_read_ptr(cb_out_id);
+                        if constexpr (N_chunks == 1) {
+                            write_block_sync<M_block_tiles, out_N_block_tiles>(
+                                std::get<0>(outputs_tuple),
+                                out_shape_swiglu,
+                                out_read_ptr_swiglu,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        } else {
+                            write_block_sync_split<M_block_tiles, out_N_block_tiles, N_chunks, out_N_tiles_per_chunk>(
+                                outputs_tuple,
+                                out0_shape_swiglu,
+                                out_read_ptr_swiglu,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        }
+                        cb_out.pop_front(out_block_num_tiles_swiglu);
+#else
                         cb_out.wait_front(out_block_num_tiles);
                         uint32_t out_read_ptr = get_read_ptr(cb_out_id);
 
@@ -261,6 +298,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         }
                         cb_out.pop_front(out_block_num_tiles);
+#endif  // FUSE_SWIGLU
                     }
                 }
 
@@ -388,6 +426,33 @@ void kernel_main() {
 
             if (!defer_write) {
                 if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                    if constexpr (N_chunks == 1) {
+                        write_block_sync_granular<M_block_tiles, out_N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    } else {
+                        write_block_sync_granular_split<
+                            M_block_tiles,
+                            out_N_block_tiles,
+                            N_chunks,
+                            out_N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    }
+#else
                     // write_block_sync_granular_split is more generic (support multiple output tensors)
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
@@ -411,6 +476,7 @@ void kernel_main() {
                             n_tile,
                             n_tile_end);
                     }
+#endif  // FUSE_SWIGLU
 #ifdef SRS_FUSE_OP_SIGNALER
                     if (is_last_block) {
                         noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -105,6 +105,18 @@ void kernel_main() {
     constexpr uint32_t in1_block_num_tiles = K_block_tiles * N_block_tiles;
     constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
 
+#ifdef FUSE_SWIGLU
+    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N
+    // is half the matmul (weight) N. Compute the halved output geometry once here; the
+    // weight-space n ranges (n_tile, N_tiles, ...) are halved at each write call site.
+    constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
+    constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
+    const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
+    // Split (chunks>1): each output chunk is half the weight per-chunk width.
+    constexpr uint32_t out_N_tiles_per_chunk = N_tiles_per_chunk / 2;
+    const TensorShape2D out0_shape_swiglu(M_tiles, out_N_tiles_per_chunk, padded_M_tiles, out_N_tiles_per_chunk);
+#endif
+
     constexpr uint32_t cb_in1_id = tt::CBIndex::c_1;
     constexpr uint32_t cb_out_id = tt::CBIndex::c_2;
 #ifdef FUSE_BIAS
@@ -198,6 +210,32 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                        cb_out.wait_front(out_block_num_tiles_swiglu);
+                        uint32_t out_read_ptr = get_read_ptr(cb_out_id);
+                        if constexpr (N_chunks == 1) {
+                            write_block_sync<M_block_tiles, out_N_block_tiles>(
+                                std::get<0>(outputs_tuple),
+                                out_shape_swiglu,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        } else {
+                            write_block_sync_split<M_block_tiles, out_N_block_tiles, N_chunks, out_N_tiles_per_chunk>(
+                                outputs_tuple,
+                                out0_shape_swiglu,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        }
+                        cb_out.pop_front(out_block_num_tiles_swiglu);
+#else
                         cb_out.wait_front(out_block_num_tiles);
                         uint32_t out_read_ptr = get_read_ptr(cb_out_id);
 
@@ -225,6 +263,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         }
                         cb_out.pop_front(out_block_num_tiles);
+#endif  // FUSE_SWIGLU
                     }
                 }
 
@@ -345,6 +384,33 @@ void kernel_main() {
 
             if (!defer_write) {
                 if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                    if constexpr (N_chunks == 1) {
+                        write_block_sync_granular<M_block_tiles, out_N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    } else {
+                        write_block_sync_granular_split<
+                            M_block_tiles,
+                            out_N_block_tiles,
+                            N_chunks,
+                            out_N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    }
+#else
                     // write_block_sync_granular_split is more generic (support multiple output tensors)
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
@@ -368,6 +434,7 @@ void kernel_main() {
                             n_tile,
                             n_tile_end);
                     }
+#endif  // FUSE_SWIGLU
 #ifdef SRS_FUSE_OP_SIGNALER
                     if (is_last_block) {
                         noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -86,6 +86,31 @@ void MinimalMatmulDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(chunks >= 1, "minimal_matmul requires chunks >= 1, got chunks={}", chunks);
     TT_FATAL(dim == -1, "minimal_matmul currently only supports dim=-1, got dim={}", dim);
 
+    // Validate fused SwiGLU constraints. The weight packs gate/up tile-pairs along N, so
+    // its width must be an even number of tiles; the matmul output collapses each pair to
+    // one tile (silu(gate)*up).
+    if (operation_attributes.fuse_swiglu) {
+        TT_FATAL(
+            !operation_attributes.fused_activation.has_value(),
+            "minimal_matmul cannot combine fuse_swiglu with a unary fused_activation");
+        TT_FATAL(
+            !operation_attributes.fused_ternary_scalar.has_value(),
+            "minimal_matmul cannot combine fuse_swiglu with fused ternary (addcmul)");
+        TT_FATAL(
+            N % (2 * tt::constants::TILE_WIDTH) == 0,
+            "minimal_matmul fuse_swiglu requires weight width N={} to be a multiple of 2*TILE_WIDTH={}",
+            N,
+            2 * tt::constants::TILE_WIDTH);
+        // For chunked split each chunk must hold whole gate/up pairs, so the per-chunk weight
+        // width must be a multiple of 2 tiles (the output per-chunk width is a multiple of 1 tile).
+        TT_FATAL(
+            (N / chunks) % (2 * tt::constants::TILE_WIDTH) == 0,
+            "minimal_matmul fuse_swiglu requires per-chunk weight width N/chunks={} to be a multiple of "
+            "2*TILE_WIDTH={}",
+            N / chunks,
+            2 * tt::constants::TILE_WIDTH);
+    }
+
     if (chunks > 1) {
         // Validate N is divisible by chunks
         TT_FATAL(N % chunks == 0, "Output width N={} must be divisible by chunks={}", N, chunks);
@@ -215,7 +240,9 @@ MinimalMatmulDeviceOperation::spec_return_value_t MinimalMatmulDeviceOperation::
     const auto& in1_input_tensor = tensor_args.weight_tensor;
     const auto& in0_input_tensor_shape = in0_input_tensor.logical_shape();
     const auto& in1_input_tensor_shape = in1_input_tensor.logical_shape();
-    const uint32_t N = in1_input_tensor_shape[-1];
+    // For SwiGLU the weight is a [gate|up] matrix of width 2*N; the op emits silu(gate)*up
+    // of width N, so the output along the last dim is half the weight width.
+    const uint32_t N = operation_attributes.fuse_swiglu ? (in1_input_tensor_shape[-1] / 2) : in1_input_tensor_shape[-1];
     const int32_t chunks = operation_attributes.chunks;
 
     const auto& memory_config = operation_attributes.output_mem_config.value_or(in0_input_tensor.memory_config());
@@ -267,7 +294,8 @@ std::vector<Tensor> minimal_matmul(
     int32_t dim,
     std::optional<float> fused_ternary_scalar,
     const std::optional<Tensor>& fused_ternary_input_a,
-    const std::optional<Tensor>& fused_ternary_input_b) {
+    const std::optional<Tensor>& fused_ternary_input_b,
+    bool fuse_swiglu) {
     using OperationType = experimental::prim::MinimalMatmulDeviceOperation;
     const auto arch = input_tensor.device()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -288,7 +316,8 @@ std::vector<Tensor> minimal_matmul(
             .fused_ternary_scalar = fused_ternary_scalar,
             .compute_kernel_config = kernel_config_val,
             .chunks = chunks,
-            .dim = dim},
+            .dim = dim,
+            .fuse_swiglu = fuse_swiglu},
         OperationType::tensor_args_t{
             .input_tensor = input_tensor,
             .weight_tensor = weight_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
@@ -44,7 +44,8 @@ struct MinimalMatmulDeviceOperation {
         int32_t dim = -1,
         std::optional<float> fused_ternary_scalar = std::nullopt,
         const std::optional<Tensor>& fused_ternary_input_a = std::nullopt,
-        const std::optional<Tensor>& fused_ternary_input_b = std::nullopt);
+        const std::optional<Tensor>& fused_ternary_input_b = std::nullopt,
+        bool fuse_swiglu = false);
 };
 
 }  // namespace ttnn::experimental::prim
@@ -64,6 +65,7 @@ std::vector<Tensor> minimal_matmul(
     int32_t dim = -1,
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<Tensor>& fused_ternary_input_a = std::nullopt,
-    const std::optional<Tensor>& fused_ternary_input_b = std::nullopt);
+    const std::optional<Tensor>& fused_ternary_input_b = std::nullopt,
+    bool fuse_swiglu = false);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp
@@ -34,6 +34,10 @@ struct MinimalMatmulParams {
     DeviceComputeKernelConfig compute_kernel_config;
     int32_t chunks = 1;  // Number of output tensors to split into (default 1 for backward compat)
     int32_t dim = -1;    // Dimension to split along (default -1)
+
+    // Fused SwiGLU: the weight is a tile-pair-interleaved [gate|up] matrix of width 2N.
+    // The op emits silu(gate) * up of width N (half the weight width) in a single matmul.
+    bool fuse_swiglu = false;
 };
 
 struct MinimalMatmulInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -129,7 +129,8 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     std::optional<float> fused_ternary_scalar,
     const std::optional<const Tensor>& fused_ternary_input_a,
     const std::optional<const Tensor>& fused_ternary_input_b,
-    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler) {
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler,
+    bool fuse_swiglu) {
     (void)fused_ternary_scalar;  // Scalar not needed in dataflow kernel, only in compute kernel
     auto* device = input_tensor.device();
 
@@ -255,16 +256,40 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
      * Most output blocks are the full block size, but the last block in M or N can be partial.
      */
     uint32_t padded_M_tiles = tt::round_up(M_tiles, in0_parallel_axis_cores);
-    uint32_t padded_N_tiles = tt::round_up(N_tiles, in1_parallel_axis_cores);
     uint32_t padded_K_tiles = tt::round_up(K_tiles, K_block_tiles);
 
+    uint32_t padded_N_tiles;
+    uint32_t N_tiles_per_core;
+    if (fuse_swiglu) {
+        // Partition on gate/up PAIRS (= output tiles), so every core's weight-tile range is
+        // 2 * (pairs per core): even, and never splitting a pair across cores.
+        uint32_t out_N_tiles = N_tiles / 2;
+        uint32_t padded_out_N_tiles = tt::round_up(out_N_tiles, in1_parallel_axis_cores);
+        padded_N_tiles = 2 * padded_out_N_tiles;
+        N_tiles_per_core = 2 * (padded_out_N_tiles / in1_parallel_axis_cores);
+    } else {
+        padded_N_tiles = tt::round_up(N_tiles, in1_parallel_axis_cores);
+        N_tiles_per_core = padded_N_tiles / in1_parallel_axis_cores;
+    }
+
     uint32_t M_tiles_per_core = padded_M_tiles / in0_parallel_axis_cores;
-    uint32_t N_tiles_per_core = padded_N_tiles / in1_parallel_axis_cores;
 
     uint32_t K_blocks = padded_K_tiles / K_block_tiles;
 
     uint32_t M_blocks_per_core = tt::div_up(M_tiles_per_core, M_block_tiles);
     uint32_t N_blocks_per_core = tt::div_up(N_tiles_per_core, N_block_tiles);
+
+    if (fuse_swiglu) {
+        // The gate/up tile pairs are interleaved along N (gate=2p, up=2p+1). Every core's
+        // N range and every N block must start on an even tile and span an even number of
+        // tiles so a pair is never split across cores or blocks.
+        TT_FATAL(
+            N_tiles % 2 == 0 && N_tiles_per_core % 2 == 0 && N_block_tiles % 2 == 0,
+            "minimal_matmul fuse_swiglu requires N_tiles ({}), N_tiles_per_core ({}) and N_block_tiles ({}) all even",
+            N_tiles,
+            N_tiles_per_core,
+            N_block_tiles);
+    }
 
     log_debug(tt::LogOp, "M_tiles_per_core: {}", M_tiles_per_core);
     log_debug(tt::LogOp, "N_tiles_per_core: {}", N_tiles_per_core);
@@ -280,7 +305,10 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     uint32_t in0_cb_num_tiles = in0_block_num_tiles * double_buffer_factor;
     uint32_t in1_cb_num_tiles = in1_block_num_tiles * double_buffer_factor;
     // TODO: consider not double buffering the output
-    uint32_t out_cb_num_tiles = out_block_num_tiles * double_buffer_factor;
+    // SwiGLU emits half the N tiles per block (one per gate/up pair), so the output CB only
+    // needs to hold half a block. The intermediate CB still holds the full (2N) block.
+    uint32_t out_block_num_tiles_written = fuse_swiglu ? (out_block_num_tiles / 2) : out_block_num_tiles;
+    uint32_t out_cb_num_tiles = out_block_num_tiles_written * double_buffer_factor;
     uint32_t interm_cb_num_tiles = out_block_num_tiles;  // not double buffered
     uint32_t in2_cb_num_tiles = in2_block_num_tiles;     // not double buffered
 
@@ -381,6 +409,10 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     std::map<std::string, std::string> in0_injector_defines;
     if (use_bias) {
         defines["FUSE_BIAS"] = "1";
+    }
+
+    if (fuse_swiglu) {
+        defines["FUSE_SWIGLU"] = "1";
     }
 
     if (use_fused_ternary) {
@@ -854,7 +886,8 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper(
     const Tensor& output_tensor,
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler>& fused_op_signaler,
-    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler>& srs_fused_op_signaler) {
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler>& srs_fused_op_signaler,
+    bool fuse_swiglu) {
     std::vector<Tensor> output_tensors = {output_tensor};
     return minimal_matmul_factory_helper_common(
         program,
@@ -870,7 +903,8 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper(
         std::nullopt,
         std::nullopt,
         std::nullopt,
-        srs_fused_op_signaler);
+        srs_fused_op_signaler,
+        fuse_swiglu);
 }
 
 MinimalMatmulProgramFactory::cached_program_t MinimalMatmulProgramFactory::create(
@@ -895,7 +929,8 @@ MinimalMatmulProgramFactory::cached_program_t MinimalMatmulProgramFactory::creat
         operation_attributes.fused_ternary_scalar,
         tensor_args.fused_ternary_input_a,
         tensor_args.fused_ternary_input_b,
-        empty_srs_fused_op_signaler);
+        empty_srs_fused_op_signaler,
+        operation_attributes.fuse_swiglu);
 
     return {std::move(program), std::move(shared_vars)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
@@ -46,7 +46,8 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper(
     const Tensor& output_tensor,
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler>& fused_op_signaler,
-    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler>& srs_fused_op_signaler);
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler>& srs_fused_op_signaler,
+    bool fuse_swiglu = false);
 
 // Shared implementation for variable number of output tensors (used by both minimal_matmul and minimal_matmul_split)
 // Unlike minimal_matmul_factory_helper, this function takes a number of output tensors as an argument (N_chunks) and
@@ -65,6 +66,7 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& fused_ternary_input_a = std::nullopt,
     const std::optional<const Tensor>& fused_ternary_input_b = std::nullopt,
-    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler = std::nullopt);
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler = std::nullopt,
+    bool fuse_swiglu = false);
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.cpp
@@ -19,7 +19,8 @@ ttnn::Tensor minimal_matmul(
     const std::optional<const ttnn::experimental::prim::MinimalMatmulConfig>& config,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<const DataType> dtype,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    bool fuse_swiglu) {
     // Call device operation with chunks=1 (default), which returns a vector with 1 element
     auto outputs = ttnn::prim::minimal_matmul(
         input_tensor,
@@ -29,7 +30,13 @@ ttnn::Tensor minimal_matmul(
         config,
         memory_config,
         dtype,
-        compute_kernel_config);
+        compute_kernel_config,
+        /*chunks=*/1,
+        /*dim=*/-1,
+        /*fused_ternary_scalar=*/std::nullopt,
+        /*fused_ternary_input_a=*/std::nullopt,
+        /*fused_ternary_input_b=*/std::nullopt,
+        fuse_swiglu);
 
     // Extract and return the single output
     TT_FATAL(outputs.size() == 1, "Expected single output from minimal_matmul, got {}", outputs.size());

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.hpp
@@ -29,5 +29,6 @@ ttnn::Tensor minimal_matmul(
     const std::optional<const ttnn::experimental::prim::MinimalMatmulConfig>& config,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<const DataType> dtype = std::nullopt,
-    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    bool fuse_swiglu = false);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
@@ -135,7 +135,8 @@ void bind_minimal_matmul(nb::module_& mod) {
         nb::arg("config") = nb::none(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("dtype") = nb::none(),
-        nb::arg("compute_kernel_config") = nb::none());
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("fuse_swiglu") = false);
 
     auto py_minimal_matmul_config = nb::class_<MinimalMatmulConfig>(
                                         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
@@ -56,11 +56,12 @@ void bind_minimal_matmul(nb::module_& mod) {
             after bias (if any) and before the tile is written out.
 
         fuse_swiglu : bool, default: False
-            If True, applies SwiGLU activation after the matmul (and bias, if provided): the output of width N is
-            treated as interleaved gate/up pairs, and the result is silu(gate) * up. The output width is therefore
-            N/2. The weight (and bias, if present) must be pre-interleaved on the host so that column tile 2p is
-            the gate and 2p+1 is the up projection for each pair p. N must be divisible by 2*32 (two tile-aligned
-            halves). Mutually exclusive with fused_activation.
+            If True, applies SwiGLU activation fused into the matmul: the weight tensor's N columns are
+            interpreted as a tile-pair-interleaved [gate|up] layout — column tile 2p is the gate and 2p+1 is
+            the up projection for each pair p (``models.tt_dit.utils.tensor.prepare_for_fused_swiglu``
+            can be used to produce this layout). The op computes silu(gate) * up and the output width is therefore N/2.
+            The bias (if provided) must use the same column layout. N must be divisible by 2*32 (two
+            tile-aligned halves). Mutually exclusive with fused_activation.
 
         config : Optional[MinimalMatmulConfig], default: None
             Execution configuration in tile units. If omitted, reasonable defaults are selected based on tensor

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
@@ -21,7 +21,7 @@ void bind_minimal_matmul(nb::module_& mod) {
     ttnn::bind_function<"minimal_matmul", "ttnn.experimental.">(
         mod,
         R"doc(
-        minimal_matmul(input_tensor, weight_tensor, bias_tensor=None, *, fused_activation=None, config=None, memory_config=None, dtype=None, compute_kernel_config=None)
+        minimal_matmul(input_tensor, weight_tensor, bias_tensor=None, *, fused_activation=None, config=None, memory_config=None, dtype=None, compute_kernel_config=None, fuse_swiglu=False)
 
         Experimental, high-performance matrix multiply (A @ B [+ bias]) with optional fused activation.
         This op expects TILE layout tensors on device and operates in tile units internally. It is designed
@@ -54,6 +54,13 @@ void bind_minimal_matmul(nb::module_& mod) {
             Optional fused unary activation applied per output tile during packing. See ttnn unary utilities
             for supported ops and parameters. Typical examples include relu/gelu/etc. If provided, it is applied
             after bias (if any) and before the tile is written out.
+
+        fuse_swiglu : bool, default: False
+            If True, applies SwiGLU activation after the matmul (and bias, if provided): the output of width N is
+            treated as interleaved gate/up pairs, and the result is silu(gate) * up. The output width is therefore
+            N/2. The weight (and bias, if present) must be pre-interleaved on the host so that column tile 2p is
+            the gate and 2p+1 is the up projection for each pair p. N must be divisible by 2*32 (two tile-aligned
+            halves). Mutually exclusive with fused_activation.
 
         config : Optional[MinimalMatmulConfig], default: None
             Execution configuration in tile units. If omitted, reasonable defaults are selected based on tensor
@@ -93,15 +100,16 @@ void bind_minimal_matmul(nb::module_& mod) {
         Returns
         -------
         ttnn.Tensor
-            Output tensor with shape [..., M, N], TILE layout, and dtype specified by `dtype` parameter
-            (or same dtype as `input_tensor` if `dtype` is not provided).
+            Output tensor in TILE layout with dtype specified by `dtype` (or same as `input_tensor` if not provided).
+            - fuse_swiglu=False: shape [..., M, N].
+            - fuse_swiglu=True: shape [..., M, N/2] (SwiGLU halves the output width).
 
         Shape Semantics
         ----------------
         - input_tensor: [..., M, K]
         - weight_tensor: [..., K, N]
-        - bias_tensor (optional): [..., N] (row-broadcast)
-        - output: [..., M, N]
+        - bias_tensor (optional): [..., N] (row-broadcast; width N regardless of fuse_swiglu)
+        - output: [..., M, N] normally; [..., M, N/2] when fuse_swiglu=True
         Note: All leading dims (dims < -2) are required to be 1 (no batching). Tensors are read/written in tile units;
         if logical sizes are not tile-aligned, padding is handled internally (reads fill zeros; writes skip outside
         logical bounds).

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split.cpp
@@ -24,7 +24,8 @@ std::vector<ttnn::Tensor> minimal_matmul_split(
     const std::optional<const ttnn::experimental::prim::MinimalMatmulConfig>& config,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<const DataType> dtype,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    bool fuse_swiglu) {
     // Validate chunks
     TT_FATAL(chunks >= 1, "minimal_matmul_split requires chunks >= 1, got chunks={}", chunks);
 
@@ -55,7 +56,11 @@ std::vector<ttnn::Tensor> minimal_matmul_split(
         dtype,
         compute_kernel_config,
         chunks,
-        dim);
+        dim,
+        /*fused_ternary_scalar=*/std::nullopt,
+        /*fused_ternary_input_a=*/std::nullopt,
+        /*fused_ternary_input_b=*/std::nullopt,
+        fuse_swiglu);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split.hpp
@@ -25,6 +25,7 @@ std::vector<ttnn::Tensor> minimal_matmul_split(
     const std::optional<const ttnn::experimental::prim::MinimalMatmulConfig>& config,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<const DataType> dtype = std::nullopt,
-    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    bool fuse_swiglu = false);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.cpp
@@ -112,7 +112,8 @@ void bind_minimal_matmul_split(nb::module_& mod) {
         nb::arg("config") = nb::none(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("dtype") = nb::none(),
-        nb::arg("compute_kernel_config") = nb::none());
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("fuse_swiglu") = false);
 }
 
 }  // namespace ttnn::operations::experimental::minimal_matmul::detail

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.cpp
@@ -72,11 +72,12 @@ void bind_minimal_matmul_split(nb::module_& mod) {
             and before writing to output buffers.
 
         fuse_swiglu : bool, default: False
-            If True, applies SwiGLU activation after the matmul (and bias, if provided): each output chunk of width
-            N/chunks is treated as interleaved gate/up pairs, and the result is silu(gate) * up. The output width
-            per chunk is therefore N/chunks/2. The weight (and bias, if present) must be pre-interleaved on the
-            host so that column tile 2p is the gate and 2p+1 is the up projection for each pair p.
-            Mutually exclusive with fused_activation.
+            If True, applies SwiGLU activation fused into the matmul: the weight tensor's N columns are
+            interpreted as a tile-pair-interleaved [gate|up] layout — column tile 2p is the gate and 2p+1 is
+            the up projection for each pair p (``models.tt_dit.utils.tensor.prepare_for_fused_swiglu`` can be used to produce this layout).
+            Each output chunk of width N/chunks has SwiGLU applied, so the output width
+            per chunk is N/chunks/2. The bias (if provided) must use the same column layout. N/chunks must be
+            divisible by 2*32. Mutually exclusive with fused_activation.
 
         config : Optional[MinimalMatmulConfig], default: None
             Execution configuration in tile units. If omitted, reasonable defaults are selected based on tensor

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.cpp
@@ -21,7 +21,7 @@ void bind_minimal_matmul_split(nb::module_& mod) {
     ttnn::bind_function<"minimal_matmul_split", "ttnn.experimental.">(
         mod,
         R"doc(
-        minimal_matmul_split(input_tensor, weight_tensor, *, chunks=3, dim=-1, bias_tensor=None, fused_activation=None, config=None, memory_config=None, dtype=None, compute_kernel_config=None)
+        minimal_matmul_split(input_tensor, weight_tensor, *, chunks=3, dim=-1, bias_tensor=None, fused_activation=None, config=None, memory_config=None, dtype=None, compute_kernel_config=None, fuse_swiglu=False)
 
         Experimental, high-performance matrix multiply (A @ B [+ bias]) with output splitting along the last dimension.
         This op performs a matmul and splits the result into `chunks` separate output tensors, fusing the common
@@ -71,6 +71,13 @@ void bind_minimal_matmul_split(nb::module_& mod) {
             Optional fused unary activation applied per output tile during packing. Applied after bias (if any)
             and before writing to output buffers.
 
+        fuse_swiglu : bool, default: False
+            If True, applies SwiGLU activation after the matmul (and bias, if provided): each output chunk of width
+            N/chunks is treated as interleaved gate/up pairs, and the result is silu(gate) * up. The output width
+            per chunk is therefore N/chunks/2. The weight (and bias, if present) must be pre-interleaved on the
+            host so that column tile 2p is the gate and 2p+1 is the up projection for each pair p.
+            Mutually exclusive with fused_activation.
+
         config : Optional[MinimalMatmulConfig], default: None
             Execution configuration in tile units. If omitted, reasonable defaults are selected based on tensor
             sizes and kernel flags. See ttnn.experimental.minimal_matmul documentation for config details.
@@ -89,14 +96,17 @@ void bind_minimal_matmul_split(nb::module_& mod) {
         Returns
         -------
         List[ttnn.Tensor]
-            List of `chunks` output tensors, each with shape [..., M, N/chunks], TILE layout, and the specified dtype.
-            For chunks=3, returns [output0, output1, output2] where each has width N/3.
+            List of `chunks` output tensors, each in TILE layout with the specified dtype.
+            - fuse_swiglu=False: each tensor has shape [..., M, N/chunks]. E.g For chunks=3, returns [output0, output1, output2].
+            - fuse_swiglu=True: each tensor has shape [..., M, N/chunks/2] (SwiGLU halves the output width per chunk).
 
         Constraints
         -----------
         - dim must be -1 (last dimension)
         - N must be divisible by chunks (N % chunks == 0)
         - N/chunks must be a multiple of 32 (tile-aligned: (N/chunks) % 32 == 0)
+        - If fuse_swiglu=True: N/chunks must additionally be divisible by 2 (each chunk holds interleaved gate/up pairs);
+          fuse_swiglu is mutually exclusive with fused_activation
         - All tensors must be on the same device and allocated in device buffers
         - All tensors must be in TILE layout
         - Weight and bias must have 1 in all leading dimensions (dims < -2)


### PR DESCRIPTION
### PR Category
Feature

### Summary
This PR adds supports for fused swiglu to the following minimal matmul variants:
minimal_matmul
all_gather_minimal_matmul_async
minimal_matmul_split

Issue: [46897](https://github.com/tenstorrent/tt-metal/issues/46897)

### Model Test
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/matmul_fused_swiglu) Galaxy Mochi

Duplicate from auto below to givetrack failures:
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/matmul_fused_swiglu) -[Same (unrelated) failure as main](https://github.com/tenstorrent/tt-metal/actions/runs/28824645552)
- - [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/matmul_fused_swiglu) -unrelated failure

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/matmul_fused_swiglu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/matmul_fused_swiglu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sadesoye/matmul_fused_swiglu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/matmul_fused_swiglu) -[Same (unrelated) failure as main](https://github.com/tenstorrent/tt-metal/actions/runs/28824645552)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/matmul_fused_swiglu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/matmul_fused_swiglu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/matmul_fused_swiglu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/matmul_fused_swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/matmul_fused_swiglu)