### PR TITLE
[P0] Revert #47311 (reduce.h rewrite) to fix Gemma-4 PCC regression

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -197,24 +197,16 @@ ALWI void sampling_add_binary_tile_first_column(uint32_t idst0, uint32_t idst1, 
 // these local so the core API can continue defaulting to the kernel-wide
 // MATH_FIDELITY macro, while sampling can force HiFi4 in only the softmax
 // normalization path.
-template <PoolType reduce_type, ReduceDim reduce_dim, MathFidelity math_fidelity>
+template <PoolType reduce_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation, MathFidelity math_fidelity>
 ALWI void sampling_reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-#ifdef ARCH_BLACKHOLE
-    // BH REDUCE_ROW SUM/AVG uses MVMUL with swapped operands (scaler→SrcA, data→SrcB)
-    // Reconfig formats to match: SrcA=scaler format, SrcB=data
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (reduce_type != PoolType::MAX);
-    if constexpr (swap_operands) {
-        state_configure(icb_scaler, icb, ocb, call_line);
-        reconfig_data_format(icb_scaler, icb);
-    } else {
-        state_configure(icb, icb_scaler, ocb, call_line);
-    }
-#else
     state_configure(icb, icb_scaler, ocb, call_line);
-#endif
 #ifndef ARCH_QUASAR
-    UNPACK((llk_unpack_AB_reduce_init<reduce_type, reduce_dim>(icb, icb_scaler)));
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, math_fidelity>(icb, icb_scaler)));
+    UNPACK((llk_unpack_AB_reduce_init<reduce_type, reduce_dim, enforce_fp32_accumulation>(icb, icb_scaler)));
+    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, math_fidelity, enforce_fp32_accumulation>()));
+    if constexpr (enforce_fp32_accumulation) {
+        MATH((tensix_sync()));
+        MATH((reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11)));
+    }
 #else
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, math_fidelity>(icb)));
@@ -222,11 +214,12 @@ ALWI void sampling_reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, 
     PACK((llk_pack_reduce_mask_config<reduce_dim, ckernel::PackMode::Default>(ocb)));
 }
 
-template <PoolType reduce_type, ReduceDim reduce_dim, MathFidelity math_fidelity>
+template <PoolType reduce_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation, MathFidelity math_fidelity>
 ALWI void sampling_reduce_tile(
     uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_scaler, uint32_t idst) {
 #ifndef ARCH_QUASAR
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, math_fidelity>(icb, icb_scaler, idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, math_fidelity, false, enforce_fp32_accumulation>(
+        icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB_reduce<reduce_type, reduce_dim>(icb, icb_scaler, itile, itile_scaler)));
 #else
     MATH((llk_math_reduce(idst)));
@@ -271,10 +264,12 @@ void trisc_fused_softmax_top_p_sampling_block() {
     {
         DeviceZoneScopedN("SP-TOPP-TRISC-1");
         reconfig_data_format(in_cb, scaler_cb);
-        sampling_reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW, MathFidelity::HiFi4>(in_cb, scaler_cb, exp_cb);
+        sampling_reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW, false, MathFidelity::HiFi4>(
+            in_cb, scaler_cb, exp_cb);
 
         tile_regs_acquire();
-        sampling_reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW, MathFidelity::HiFi4>(in_cb, scaler_cb, 0, 0, 0);
+        sampling_reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW, false, MathFidelity::HiFi4>(
+            in_cb, scaler_cb, 0, 0, 0);
         reduce_uninit();
     }
     // Step 2: Compute DST[0, 0, 0] = x_i - max(x_i, dim=0), x_i = in_cb,
@@ -318,10 +313,12 @@ void trisc_fused_softmax_top_p_sampling_block() {
         // Since the result is a column strip, we need to reduce along the column dimension
         DeviceZoneScopedN("SP-TOPP-TRISC-5");
         reconfig_data_format(exp_cb, scaler_cb);
-        sampling_reduce_init<PoolType::SUM, ReduceDim::REDUCE_COL, MathFidelity::HiFi4>(exp_cb, scaler_cb, probs_cb);
+        sampling_reduce_init<PoolType::SUM, ReduceDim::REDUCE_COL, false, MathFidelity::HiFi4>(
+            exp_cb, scaler_cb, probs_cb);
         tile_regs_acquire();
         // MATH wait for DST register to be available
-        sampling_reduce_tile<PoolType::SUM, ReduceDim::REDUCE_COL, MathFidelity::HiFi4>(exp_cb, scaler_cb, 0, 0, 0);
+        sampling_reduce_tile<PoolType::SUM, ReduceDim::REDUCE_COL, false, MathFidelity::HiFi4>(
+            exp_cb, scaler_cb, 0, 0, 0);
         reduce_uninit();
         // Step 6: Compute DST[0, 0, 0] = 1/sum(exp(x_i - max(x_i, dim=0))), sum(exp(x_i - max(x_i, dim=0))) comes from
         // DST in Step 5

--- a/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
@@ -82,15 +82,12 @@ void kernel_main() {
     pack_untilize_init(cb_in0, cb_out1);
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_PACK));
 
-    reconfig_data_format(cb_in0, cb_in1);
-    // REDUCE_ROW+SUM swaps operands: state_configure(icb_scaler=cb_in0, icb=cb_in1, cb_out0)
-    // SrcA stays cb_in0 (unchanged from pack_untilize_init above), SrcB and Pack change.
     reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_in1, cb_in0, cb_out0);
-    ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCB | RECONFIG_CHANGED_PACK));
+    ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_SRCB | RECONFIG_CHANGED_PACK));
     reduce_uninit();
 
     tilize_init(cb_in0, 1, cb_out1);
-    ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_PACK));
+    ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_PACK));
 
     fast_tilize_init(cb_in2, 1, cb_out0);
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_PACK));
@@ -111,5 +108,5 @@ void kernel_main() {
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA));
 
     tilizeA_B_reduce_init<false, true>(cb_in0, cb_in1, 1, cb_out1);
-    ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA));
+    ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_SRCB));
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -95,7 +95,6 @@ void kernel_main() {
          */
         tile_regs_acquire();
         cb_reserve_back(cb_ex, 1 * onetile);
-        reconfig_data_format(cb_scaler, cb_x);
         reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_x, cb_scaler, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
@@ -162,7 +161,6 @@ void kernel_main() {
          * TODO(AP): can save space here by reusing CB
          */
         cb_reserve_back(cb_ex2, 1);
-        reconfig_data_format(cb_scaler, cb_xmm2);
         reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_xmm2, cb_scaler, cb_ex2);
         tile_regs_acquire();
         cb_wait_front(cb_xmm2, Wt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -19,10 +19,6 @@ void kernel_main() {
     DataflowBuffer dfb_in_scaler(dfb::in_scaler);
     DataflowBuffer dfb_out(dfb::out);
     compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
-    constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-    if constexpr (swap_operands) {
-        reconfig_data_format(dfb::in_scaler, dfb::in_data);
-    }
     reduce_init<REDUCE_OP, REDUCE_DIM>(dfb::in_data, dfb::in_scaler, dfb::out);
 
     dfb_in_scaler.wait_front(onetile);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -19,10 +19,6 @@ void kernel_main() {
     DataflowBuffer dfb_in_scaler(dfb::in_scaler);
     DataflowBuffer dfb_out(dfb::out);
     compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
-    constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-    if constexpr (swap_operands) {
-        reconfig_data_format(dfb::in_scaler, dfb::in_data);
-    }
     reduce_init<REDUCE_OP, REDUCE_DIM>(dfb::in_data, dfb::in_scaler, dfb::out);
 
     dfb_in_scaler.wait_front(onetile);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -19,10 +19,6 @@ void kernel_main() {
     DataflowBuffer dfb_in_scaler(dfb::in_scaler);
     DataflowBuffer dfb_out(dfb::out);
     compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
-    constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-    if constexpr (swap_operands) {
-        reconfig_data_format(dfb::in_scaler, dfb::in_data);
-    }
     reduce_init<REDUCE_OP, REDUCE_DIM>(dfb::in_data, dfb::in_scaler, dfb::out);
 
     dfb_in_scaler.wait_front(onetile);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -112,7 +112,6 @@ void kernel_main() {
          * compute E[(x)^2]
          */
         cb_reserve_back(cb_ex2, 1);
-        reconfig_data_format(cb_scaler, cb_x2);
         reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_x2, cb_scaler, cb_ex2);
         tile_regs_acquire();
         cb_wait_front(cb_x2, Wt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -130,7 +130,6 @@ void kernel_main() {
 
         tile_regs_acquire();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reconfig_data_format(cb_bcast_scaler, cb_exps);
         reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_exps, cb_bcast_scaler, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt + 1);        // must be a cumulative wait for correctness

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -302,11 +302,6 @@ def test_layer_norm_ulp_fp32_with_weight_bias(device, h, w, desc, use_welford, d
       "weight_only" – weight only, bias=None
       "bias_only"   – bias only, weight=None
     """
-    if is_blackhole() and use_welford and w == 4096:
-        # The large-tensor Welford layer_norm kernels produce nondeterministic FP32 output on
-        # Blackhole (back-to-back runs differ; failure disappears under watcher), so the
-        # determinism check in ttnn_layer_norm trips. Tracked in issue #46523.
-        pytest.skip("Blackhole large-tensor Welford layer_norm is nondeterministic (FP32); see #46523")
     torch.manual_seed(0)
     torch_input_tensor = _make_ln_input(h, w, torch.float32, distribution)
     torch_weight = torch.rand((w,), dtype=torch.float32) if wb_mode in ("wb", "weight_only") else None

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
@@ -423,7 +423,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
         device.arch(),
         math_fidelity=fidelity,
         math_approx_mode=True,
-        fp32_dest_acc_en=True,
+        fp32_dest_acc_en=False,
         packer_l1_acc=False,
     )
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_rmsnorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_rmsnorm.py
@@ -163,13 +163,7 @@ def test_llama_4D_rms_norm(device, h, w):
     input_tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
     weight = ttnn.from_torch(torch_weight.reshape(1, 1, w // 32, 32), device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
-    compute_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.HiFi3,
-        math_approx_mode=False,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=False,
-    )
-    output_tensor = ttnn_rms_norm(input_tensor, weight=weight, compute_kernel_config=compute_config)
+    output_tensor = ttnn_rms_norm(input_tensor, weight=weight)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -692,7 +692,7 @@ def test_moreh_layer_norm_backward_callback(input_shape_normalized_dims, element
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
-def test_moreh_layer_norm_backward_rejects_invalid_mean_volume(device, expect_error):
+def test_moreh_layer_norm_backward_rejects_invalid_mean_volume(device):
     torch.manual_seed(2023)
     input_shape = [2, 32, 64]
     normalized_dims = 1
@@ -715,7 +715,7 @@ def test_moreh_layer_norm_backward_rejects_invalid_mean_volume(device, expect_er
     npu_rstd = to_ttnn(rstd, device=device, dtype=ttnn.bfloat16, shape=input_shape[:-normalized_dims])
     npu_input_grad = to_ttnn(torch.empty(input_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
 
-    with expect_error(RuntimeError, "mean must have logical shape"):
+    with pytest.raises(RuntimeError, match="mean must have logical shape"):
         ttnn.operations.moreh.layer_norm_backward(
             npu_output_grad,
             npu_input,
@@ -726,7 +726,7 @@ def test_moreh_layer_norm_backward_rejects_invalid_mean_volume(device, expect_er
         )
 
 
-def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device, expect_error):
+def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device):
     torch.manual_seed(2023)
     input_shape = [2, 32, 64]
     normalized_dims = 1
@@ -750,7 +750,7 @@ def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device, 
     npu_rstd = to_ttnn(rstd, device=device, dtype=ttnn.bfloat16, shape=valid_mean_shape)
     npu_input_grad = to_ttnn(torch.empty(input_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
 
-    with expect_error(RuntimeError, "mean must have logical shape"):
+    with pytest.raises(RuntimeError, match="mean must have logical shape"):
         ttnn.operations.moreh.layer_norm_backward(
             npu_output_grad,
             npu_input,
@@ -793,7 +793,6 @@ def test_moreh_layer_norm_no_mean_rstd(input_shape_normalized_dims, elementwise_
 
 
 # Validation test for moreh.layer_norm not populating rstd when mean=None, see #22089
-@pytest.mark.skip(reason="Broken mean/rstd output #48606")
 def test_moreh_layer_norm_rstd_only_mean_none(device):
     torch.manual_seed(2023)
     input_shape = [2, 32, 512]

--- a/tests/ttnn/unit_tests/gtests/udm/reduction/interleaved/kernels/compute_reduce.cpp
+++ b/tests/ttnn/unit_tests/gtests/udm/reduction/interleaved/kernels/compute_reduce.cpp
@@ -63,11 +63,7 @@ void kernel_main() {
 
     // ==================== Initialize reduction ====================
     binary_op_init_common(cb_in0, cb_in0, cb_out);
-    constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-    if constexpr (swap_operands) {
-        reconfig_data_format(cb_scaler, cb_in0);
-    }
-    reduce_init<REDUCE_OP, REDUCE_DIM>(cb_in0, cb_scaler, cb_out);
+    reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in0, cb_scaler, cb_out);
 
     // Wait for scaler to be ready (pushed by dataflow)
     cb_wait_front(cb_scaler, 1);
@@ -82,7 +78,7 @@ void kernel_main() {
 
         // Reduce across width for this row
         for (uint32_t col = 0; col < input_width_tiles; ++col) {
-            reduce_tile<REDUCE_OP, REDUCE_DIM>(cb_in0, cb_scaler, col, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in0, cb_scaler, col, scaler0, dst0);
         }
 
         // Commit and pack result

--- a/tests/ttnn/unit_tests/gtests/udm/reduction/interleaved/kernels/dataflow_reduce.cpp
+++ b/tests/ttnn/unit_tests/gtests/udm/reduction/interleaved/kernels/dataflow_reduce.cpp
@@ -73,7 +73,8 @@ void kernel_main() {
         cb_scaler,
         ckernel::PoolType::SUM,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
 
     // ==================== Compute Initial Page IDs ====================
     uint32_t input_page_id = iter_args.initial_page_id();

--- a/tests/ttnn/unit_tests/gtests/udm/reduction/sharded/kernels/compute_sharded_reduce.cpp
+++ b/tests/ttnn/unit_tests/gtests/udm/reduction/sharded/kernels/compute_sharded_reduce.cpp
@@ -56,11 +56,7 @@ void kernel_main() {
     // Input: cb_in0 [block_ht x block_wt tiles]
     // Output: cb_partial [block_ht tiles] - one reduced tile per row
 
-    constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-    if constexpr (swap_operands) {
-        reconfig_data_format(cb_scaler, cb_in0);
-    }
-    reduce_init<REDUCE_OP, REDUCE_DIM>(cb_in0, cb_scaler, cb_partial);
+    reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in0, cb_scaler, cb_partial);
     cb_wait_front(cb_scaler, 1);
     cb_reserve_back(cb_partial, block_ht);
 
@@ -70,7 +66,7 @@ void kernel_main() {
         // Reduce across width for this row
         for (uint32_t col = 0; col < num_reduce_tiles_per_row; ++col) {
             uint32_t tile_idx = row * block_wt + col;
-            reduce_tile<REDUCE_OP, REDUCE_DIM>(cb_in0, cb_scaler, tile_idx, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in0, cb_scaler, tile_idx, scaler0, dst0);
         }
 
         tile_regs_commit();
@@ -90,10 +86,7 @@ void kernel_main() {
     // Input: cb_external [num_rows_per_worker * num_blocks tiles]
     // Output: cb_reduced [num_rows_per_worker tiles]
 
-    if constexpr (swap_operands) {
-        reconfig_data_format(cb_scaler, cb_external);
-    }
-    reduce_init<REDUCE_OP, REDUCE_DIM>(cb_external, cb_scaler, cb_reduced);
+    reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_external, cb_scaler, cb_reduced);
     cb_reserve_back(cb_reduced, num_rows_per_worker);
 
     for (uint32_t row = 0; row < num_rows_per_worker; ++row) {
@@ -103,7 +96,7 @@ void kernel_main() {
         // Reduce across all cores' partials for this row
         for (uint32_t core = 0; core < num_blocks; ++core) {
             cb_wait_front(cb_external, 1);
-            reduce_tile<REDUCE_OP, REDUCE_DIM>(cb_external, cb_scaler, 0, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_external, cb_scaler, 0, scaler0, dst0);
             cb_pop_front(cb_external, 1);
         }
 

--- a/tests/ttnn/unit_tests/gtests/udm/reduction/sharded/kernels/reader_receiver_unary_sharded_reduce.cpp
+++ b/tests/ttnn/unit_tests/gtests/udm/reduction/sharded/kernels/reader_receiver_unary_sharded_reduce.cpp
@@ -74,7 +74,8 @@ void kernel_main() {
         cb_scaler,
         ckernel::PoolType::SUM,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
 
     // ============================================================================
     // Determine number of rows this core is responsible for

--- a/tests/ttnn/unit_tests/gtests/udm/reduction/sharded/kernels/reader_sender_unary_sharded_reduce.cpp
+++ b/tests/ttnn/unit_tests/gtests/udm/reduction/sharded/kernels/reader_sender_unary_sharded_reduce.cpp
@@ -73,7 +73,8 @@ void kernel_main() {
         cb_scaler,
         ckernel::PoolType::SUM,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
 
     // ============================================================================
     // Phase 2: Wait for local partial results

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -576,7 +576,7 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, input_d
     # Execute low-accuracy groupnorm
     config_low = ttnn.init_device_compute_kernel_config(
         device.arch(),
-        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=False,
         fp32_dest_acc_en=False,
     )

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -84,14 +84,25 @@ def test_rms_norm_row_major(device, batch_size, h, w, math_fidelity, math_approx
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_numeric_metrics(
-        torch_output_tensor,
-        output_tensor,
-        pcc_threshold=0.999,
-        rtol=0.091,
-        atol=0.129,
-        frobenius_threshold=0.09,
-    )
+    # Higher frobenius_threshold for ttsim due to issue #41530
+    if os.environ.get("TT_METAL_SIMULATOR"):
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.091,
+            atol=0.129,
+            frobenius_threshold=0.09,
+        )
+    else:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.091,
+            atol=0.129,
+            frobenius_threshold=0.052,
+        )
 
 
 @pytest.mark.parametrize("batch_size", [1])
@@ -113,16 +124,7 @@ def test_rms_norm_with_weight_and_residual(device, batch_size, h, w, dtype):
     residual_input_tensor = ttnn.fill_implicit_tile_padding(residual_input_tensor, TEST_PADDING_VALUE)
     weight = ttnn.from_torch(torch_weight, device=device, layout=ttnn.TILE_LAYOUT)
     weight = ttnn.fill_implicit_tile_padding(weight, TEST_PADDING_VALUE)
-    # Data is unpacked as Tf32, fp32 dest accumulation is required
-    compute_config = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=ttnn.MathFidelity.HiFi4,
-        fp32_dest_acc_en=True,
-        math_approx_mode=False,
-    )
-    output_tensor = ttnn.rms_norm(
-        input_tensor, residual_input_tensor=residual_input_tensor, weight=weight, compute_kernel_config=compute_config
-    )
+    output_tensor = ttnn.rms_norm(input_tensor, residual_input_tensor=residual_input_tensor, weight=weight)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
@@ -314,7 +314,7 @@ void reduce_log_sum_exp_x() {
 
     tile_regs_acquire();
     const uint32_t reduction_register = 0;
-    reconfig_data_format(cb_scaler, cb_exp_sum_before_reduction);
+    reconfig_data_format(cb_exp_sum_before_reduction, cb_scaler);
     reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
         cb_exp_sum_before_reduction, cb_scaler, cb_exp_sum_after_reduction);
     reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(

--- a/tt-train/sources/ttml/metal/ops/polynorm_bw/device/kernels/compute/polynorm_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_bw/device/kernels/compute/polynorm_bw_kernel.cpp
@@ -182,7 +182,7 @@ void reduce_sum_to_inv_rms(const uint32_t cb_sum, const uint32_t cb_inv_rms) {
         mul_binary_tile_init();
         mul_binary_tile(reg_acc, reg_scaler, reg_acc);
     } else {
-        reconfig_data_format(cb_scaler, cb_sum);
+        reconfig_data_format(cb_sum, cb_scaler);
         reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_sum, cb_scaler, cb_inv_rms);
         reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_sum, cb_scaler, 0, 0, reg_acc);
         reduce_uninit();
@@ -214,7 +214,7 @@ void reduce_sum_to_scalar(const uint32_t cb_sum, const uint32_t cb_scalar) {
         row_reduce_sum_to_reg(cb_sum, reg_acc);
     } else {
         cb_wait_front(cb_one, onetile);
-        reconfig_data_format(cb_one, cb_sum);
+        reconfig_data_format(cb_sum, cb_one);
         reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_sum, cb_one, cb_scalar);
         reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_sum, cb_one, 0, 0, reg_acc);
         reduce_uninit();

--- a/tt-train/sources/ttml/metal/ops/polynorm_fw/device/kernels/compute/polynorm_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_fw/device/kernels/compute/polynorm_fw_kernel.cpp
@@ -61,7 +61,7 @@ void reduce_sum_pows_to_inv_rms_triplet() {
     constexpr uint32_t reg_a2 = 2U;  // sum(x^6) → inv_rms(x^3)
 
     // Row-reduce the three power sums into reg_a0/reg_a1/reg_a2.
-    reconfig_data_format(cb_scaler, cb_sum_pows);
+    reconfig_data_format(cb_sum_pows, cb_scaler);
     reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_sum_pows, cb_scaler, cb_inv_rms);
     reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_sum_pows, cb_scaler, /*itile=*/0U, 0U, reg_a0);
     reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_sum_pows, cb_scaler, /*itile=*/1U, 0U, reg_a1);

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/compute/rmsnorm_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/compute/rmsnorm_fw_kernel.cpp
@@ -294,7 +294,7 @@ void kernel_main() {
             tile_regs_acquire();
 
             const uint32_t reduction_register = 0;
-            reconfig_data_format(cb_scaler, cb_rms_before_reduction_intermediate);
+            reconfig_data_format(cb_rms_before_reduction_intermediate, cb_scaler);
             reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
                 cb_rms_before_reduction_intermediate, cb_scaler, cb_rms_after_reduction_intermediate);
             reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_reduce.h"
 
@@ -16,10 +15,12 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
-    bool is_int_fpu_en = false>
-inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+    bool is_int_fpu_en = false,
+    bool enforce_fp32_accumulation = false>
+inline void llk_math_reduce(const uint dst_index, const ckernel::TensorShape& tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en>(dst_index, tensor_shape);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
+        dst_index, tensor_shape);
 }
 
 template <
@@ -27,23 +28,29 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
-    bool is_int_fpu_en = false>
+    bool is_int_fpu_en = false,
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
     const std::uint32_t operand_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en>(dst_index, tensor_shape);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
+        dst_index, tensor_shape);
 }
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
-inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
-    const std::uint32_t operand_id = get_operand_id(operandA);
-    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
-    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity>(tensor_shape);
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    bool enforce_fp32_accumulation = false /*unused*/>
+inline void llk_math_reduce_init() {
+    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity, enforce_fp32_accumulation>();
 }
 
+template <bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce_uninit() {
-    _llk_math_reduce_uninit_();
+    _llk_math_reduce_uninit_<enforce_fp32_accumulation>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -10,12 +10,12 @@
  * LLK UNPACK AB REDUCE
  *************************************************************************/
 
-template <PoolType pool_type, ReduceDim reduce_dim>
+template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
 inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
-    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(tensor_shape);
+    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim, enforce_fp32_accumulation>(tensor_shape);
 }
 
 template <PoolType pool_type, ReduceDim reduce_dim>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_reduce.h"
 
@@ -16,10 +15,12 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
-    bool is_int_fpu_en = false>
-inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+    bool is_int_fpu_en = false,
+    bool enforce_fp32_accumulation = false>
+inline void llk_math_reduce(const uint dst_index, const ckernel::TensorShape& tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en>(dst_index, tensor_shape);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
+        dst_index, tensor_shape);
 }
 
 template <
@@ -27,23 +28,30 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
-    bool is_int_fpu_en = false>
+    bool is_int_fpu_en = false,
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    const std::uint32_t operand_id = get_operand_id(operandA);
+    const std::uint32_t operand_id = get_operand_id(operandA);  // both operands must have same number of faces
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en>(dst_index, tensor_shape);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
+        dst_index, tensor_shape);
 }
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
-inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    bool enforce_fp32_accumulation = false>
+inline void llk_math_reduce_init() {
+    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity, enforce_fp32_accumulation>();
+}
+
+template <bool enforce_fp32_accumulation = false>
+inline void llk_math_reduce_uninit(const std::uint32_t operandA) {
     const std::uint32_t operand_id = get_operand_id(operandA);
-    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
-    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity>(tensor_shape);
-}
-
-inline void llk_math_reduce_uninit([[maybe_unused]] const std::uint32_t operandA = 0) {
-    _llk_math_reduce_uninit_();
+    _llk_math_reduce_uninit_<enforce_fp32_accumulation>(unpack_src_format[operand_id]);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <cstdint>
 #include "llk_unpack_AB_reduce.h"
 #include "llk_unpack_common_api.h"
 
@@ -11,12 +10,12 @@
  * LLK UNPACK AB REDUCE
  *************************************************************************/
 
-template <PoolType pool_type, ReduceDim reduce_dim>
+template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
 inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
-    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(tensor_shape);
+    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim, enforce_fp32_accumulation>(tensor_shape);
 }
 
 template <PoolType pool_type, ReduceDim reduce_dim>

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
 #include "tensor_shape.h"
@@ -56,27 +55,19 @@ namespace ckernel {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | reduce_type               | The type of reduce op - sum, average or maximum                                         | PoolType  | {SUM, AVG, MAX}                                | True     |
  * | Template   | reduce_dim                | The dimension of reduce op - row, column or both                                        | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | enforce_fp32_accumulation | Enable accumulation of reduction in full FP32 precision (Requires DST_ACCUM_MODE==true) | bool      | {true, false}                                  | True     |
  * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A                         | uint32_t  | 0 to 31                                        | True     |
  * | Function   | icb_scaler                | CB holding scaling factors (see above)                                                  | uint32_t  | 0 to 31                                        | True     |
  * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim>
-ALWI void reduce_init(
-    std::uint32_t icb, std::uint32_t icb_scaler, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
-#ifndef ARCH_QUASAR
-    // REDUCE_ROW SUM/AVG uses MVMUL with swapped operands (scaler→SrcA, data→SrcB)
-    // Caller must call reconfig_data_format(icb_scaler, icb) before reduce_init for this path.
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (reduce_type != PoolType::MAX);
-    if constexpr (swap_operands) {
-        state_configure(icb_scaler, icb, ocb, call_line);
-    } else {
-        state_configure(icb, icb_scaler, ocb, call_line);
-    }
-    UNPACK((llk_unpack_AB_reduce_init<reduce_type, reduce_dim>(icb, icb_scaler)));
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb, icb_scaler)));
-#else
+template <PoolType reduce_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
+ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb, icb_scaler, ocb, call_line);
+#ifndef ARCH_QUASAR
+    UNPACK((llk_unpack_AB_reduce_init<reduce_type, reduce_dim, enforce_fp32_accumulation>(icb, icb_scaler)));
+    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, enforce_fp32_accumulation>()));
+#else
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb, icb_scaler)));
 #endif
@@ -95,18 +86,20 @@ ALWI void reduce_init(
  *
  * | Param Type | Name                      | Description                                                                             | Type      | Valid Range                                    | Required |
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
- * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A (same as reduce_init)   | uint32_t  | 0 to 31                                        | False    |
+ * | Template   | enforce_fp32_accumulation | Must match the template parameter used in reduce_init                                   | bool      | {true, false}                                  | True     |
+ * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A (same as reduce_init). Required when enforce_fp32_accumulation=true | uint32_t  | 0 to 31 | Conditional |
  */
 // clang-format on
-ALWI void reduce_uninit(std::uint32_t icb = 0) {
+template <bool enforce_fp32_accumulation = false>
+ALWI void reduce_uninit(uint32_t icb = 0) {
 #ifndef ARCH_QUASAR
 #ifdef ARCH_BLACKHOLE
-    MATH((llk_math_reduce_uninit()));
+    MATH((llk_math_reduce_uninit<enforce_fp32_accumulation>()));
 #else
     // Required because MOVB2D/D2B depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
     // This is needed because FP32 data from L1 that is unpacked to Src registers is reduced to Tf32
     // See _llk_math_reduce_init_ for more details
-    MATH((llk_math_reduce_uninit(icb)));
+    MATH((llk_math_reduce_uninit<enforce_fp32_accumulation>(icb)));
 #endif
 #endif
     PACK((llk_pack_reduce_mask_clear()));
@@ -139,6 +132,7 @@ ALWI void reduce_uninit(std::uint32_t icb = 0) {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | reduce_type               | The type of reduce op - sum, average or maximum                                         | PoolType  | {SUM, AVG, MAX}                                | True     |
  * | Template   | reduce_dim                | The dimension of reduce op - row, column or both                                        | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | enforce_fp32_accumulation | Enable accumulation of reduction in full FP32 precision (Requires DST_ACCUM_MODE==true) | bool      | {true, false}                                  | True     |
  * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A                         | uint32_t  | 0 to 31                                        | True     |
  * | Function   | icb_scaler                | CB holding scaling factors (see above)                                                  | uint32_t  | 0 to 31                                        | True     |
  * | Function   | itile                     | The index of the tile within the first CB                                               | uint32_t  | Must be less than the size of the CB           | True     |
@@ -146,11 +140,11 @@ ALWI void reduce_uninit(std::uint32_t icb = 0) {
  * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t  | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim>
-ALWI void reduce_tile(
-    std::uint32_t icb, std::uint32_t icb_scaler, std::uint32_t itile, std::uint32_t itile_scaler, std::uint32_t idst) {
+template <PoolType reduce_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
+ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_scaler, uint32_t idst) {
 #ifndef ARCH_QUASAR
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb, icb_scaler, idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
+        icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB_reduce<reduce_type, reduce_dim>(icb, icb_scaler, itile, itile_scaler)));
 #else
     MATH((llk_math_reduce(idst)));
@@ -181,20 +175,22 @@ ALWI void reduce_tile(
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | reduce_type               | The type of reduce op - sum, average or maximum                                         | PoolType  | {SUM, AVG, MAX}                                | True     |
  * | Template   | reduce_dim                | The dimension of reduce op - row, column or both                                        | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | enforce_fp32_accumulation | Enable accumulation of reduction in full FP32 precision (Requires DST_ACCUM_MODE==true) | bool      | {true, false}                                  | True     |
  * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t  | Must be less than the acquired size of DST REG | True     |
  * | Function   | num_faces                 | Number of faces to reduce (optional, default 4)                                         | uint32_t  | 1 to 4                                         | False    |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim>
-ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = 4) {
+template <PoolType reduce_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
+ALWI void reduce_tile_math(uint32_t idst, uint32_t num_faces = 4) {
 #ifndef ARCH_QUASAR
     ASSERT(num_faces > 0 && num_faces <= MAX_NUM_FACES);
     const ckernel::TensorShape tensor_shape = {
         MAX_FACE_R_DIM,
         MAX_FACE_C_DIM,
-        (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<std::uint8_t>(1) : MAX_NUM_FACES_R_DIM,
-        (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<std::uint8_t>(num_faces) : MAX_NUM_FACES_C_DIM};
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
+        (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<uint8_t>(1) : MAX_NUM_FACES_R_DIM,
+        (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<uint8_t>(num_faces) : MAX_NUM_FACES_C_DIM};
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
+        idst, tensor_shape)));
 #else
     MATH((llk_math_reduce(idst)));
 #endif
@@ -208,14 +204,16 @@ ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = 4) {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|----------------------|------------------------------------------------|----------|
  * | Template   | reduce_type               | The type of reduce op - sum, average or maximum                                         | PoolType             | {SUM, AVG, MAX}                                | True     |
  * | Template   | reduce_dim                | The dimension of reduce op - row, column or both                                        | ReduceDim            | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | enforce_fp32_accumulation | Enable accumulation of reduction in full FP32 precision (Requires DST_ACCUM_MODE==true) | bool                 | {true, false}                                  | True     |
  * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t             | Must be less than the acquired size of DST REG | True     |
  * | Function   | tensor_shape              | The shape of the tensor to reduce                                                       | ckernel::TensorShape | N/A                                            | True     |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim>
-ALWI void reduce_tile_math(std::uint32_t idst, const ckernel::TensorShape& tensor_shape) {
+template <PoolType reduce_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
+ALWI void reduce_tile_math(uint32_t idst, const ckernel::TensorShape& tensor_shape) {
 #ifndef ARCH_QUASAR
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
+        idst, tensor_shape)));
 #else
     MATH((llk_math_reduce(idst)));
 #endif

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -201,19 +201,20 @@ ALWI void reduce_block_max_row_reinit_short_runtime(uint32_t ocb, uint32_t block
  *
  * | Param Type | Name                      | Description                                                                             | Type      | Valid Range                                    | Required |
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | clear_fp32_accumulation   | Whether to clear FP32 accumulation state                                                | bool      | {true, false}                                  | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
- * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A                         | uint32_t  | 0 to 31                                        | False    |
+ * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A. Required when clear_fp32_accumulation=true | uint32_t  | 0 to 31 | Conditional |
  */
 // clang-format on
-template <bool respect_trigger = false>
+template <bool clear_fp32_accumulation = false, bool respect_trigger = false>
 ALWI void reduce_block_max_row_uninit(uint32_t icb) {
 #ifdef ARCH_BLACKHOLE
-    MATH((llk_math_reduce_uninit()));
+    MATH((llk_math_reduce_uninit<clear_fp32_accumulation>()));
 #else
     // Required because MOVB2D/D2B depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
     // This is needed because FP32 data from L1 that is unpacked to Src registers is reduced to Tf32
     // See _llk_math_reduce_init_ for more details
-    MATH((llk_math_reduce_uninit(icb)));
+    MATH((llk_math_reduce_uninit<clear_fp32_accumulation>(icb)));
 #endif
     PACK((llk_pack_reduce_mask_clear()));
     UNPACK((llk_unpack_AB_reduce_block_max_row_uninit<respect_trigger>()));
@@ -241,9 +242,9 @@ ALWI void reduce_block_max_row_runtime(
 ALWI void reduce_block_max_row_uninit_runtime(
     uint32_t icb, bool respect_trigger = false, bool overlap_first_half = false) {
 #ifdef ARCH_BLACKHOLE
-    MATH((llk_math_reduce_uninit()));
+    MATH((llk_math_reduce_uninit<false>()));
 #else
-    MATH((llk_math_reduce_uninit(icb)));
+    MATH((llk_math_reduce_uninit<false>(icb)));
 #endif
     PACK((llk_pack_reduce_mask_clear()));
     UNPACK((llk_unpack_AB_reduce_block_max_row_uninit_runtime(respect_trigger, overlap_first_half)));

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -99,7 +99,7 @@ ALWI void tilizeA_B_reduce_init(
     UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true /*reload_srcB*/, false /*zero_srcA*/, zero_srcA_reduce>(
         icb0, icb1_scaler, block)));
 
-    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1_scaler)));
+    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
 
@@ -163,7 +163,7 @@ tilizeA_B_reduce_init(
         icb0, icb1_scaler, block, num_faces, face_r_dim, 1 /*unpB_face_r_dim*/)));
 #pragma GCC diagnostic pop
 
-    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1_scaler)));
+    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
 

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -13,9 +13,7 @@
 #include "experimental/llk_math_reduce_custom.h"
 #include "llk_math_common.h"
 #include "llk_math_eltwise_unary_datacopy.h"
-#include "llk_math_reduce.h"
 #include "llk_math_transpose_dest.h"
-#include "tensor_shape.h"
 
 using ckernel::PackMode;
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce.py
@@ -139,15 +139,13 @@ class ReduceFpu(Fpu):
         dest_acc = config.dest_acc.cpp_enum_value
         pool_type_cpp = self.reduce_pool.cpp_enum_value
         reduce_dim_cpp = self.reduce_dim.cpp_enum_value
-
-        tile_shape = compute_unit.src_a.tile_shape
-        tensor_shape_instantiation: str = (
-            f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
         )
 
         return (
             f"// Operation {stage}: Reduce {reduce_dim_cpp} FPU\n"
-            f"_llk_math_reduce_init_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}>({tensor_shape_instantiation});\n"
+            f"_llk_math_reduce_init_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}, {enforce_fp32_accumulation}>();\n"
         )
 
     def calculate(
@@ -161,7 +159,9 @@ class ReduceFpu(Fpu):
         dest_acc = config.dest_acc.cpp_enum_value
         pool_type_cpp = self.reduce_pool.cpp_enum_value
         reduce_dim_cpp = self.reduce_dim.cpp_enum_value
-
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
+        )
         _int_fpu_formats = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
         is_int_fpu_en = (
             "true"
@@ -185,7 +185,7 @@ class ReduceFpu(Fpu):
         )
 
         return (
-            f"_llk_math_reduce_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}, {is_int_fpu_en}>(\n"
+            f"_llk_math_reduce_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}, {is_int_fpu_en}, {enforce_fp32_accumulation}>(\n"
             f"    {block.tile_id_block}, {tensor_shape_instantiation}\n"
             f");\n"
         )
@@ -197,4 +197,7 @@ class ReduceFpu(Fpu):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        return "_llk_math_reduce_uninit_();\n"
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
+        )
+        return f"_llk_math_reduce_uninit_<{enforce_fp32_accumulation}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce.py
@@ -75,6 +75,9 @@ class ReduceUnpacker(Unpacker):
     ) -> str:
         reduce_dim = self.reduce_dim.cpp_enum_value
         pool_type = self.reduce_pool.cpp_enum_value
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
+        )
 
         tile_shape = compute_unit.src_a.tile_shape
         tensor_shape_instantiation: str = (
@@ -82,7 +85,7 @@ class ReduceUnpacker(Unpacker):
         )
 
         return (
-            f"_llk_unpack_AB_reduce_init_<{pool_type}, {reduce_dim}>(\n"
+            f"_llk_unpack_AB_reduce_init_<{pool_type}, {reduce_dim}, {enforce_fp32_accumulation}>(\n"
             f"{tensor_shape_instantiation});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce.py
@@ -139,15 +139,13 @@ class ReduceFpu(Fpu):
         dest_acc = config.dest_acc.cpp_enum_value
         pool_type_cpp = self.reduce_pool.cpp_enum_value
         reduce_dim_cpp = self.reduce_dim.cpp_enum_value
-        tile_shape = compute_unit.src_a.tile_shape
-        tensor_shape_instantiation: str = (
-            f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
         )
 
         return (
             f"// Operation {stage}: Reduce {reduce_dim_cpp} FPU\n"
-            f"_llk_math_reduce_init_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}>(\n"
-            f"{tensor_shape_instantiation});\n"
+            f"_llk_math_reduce_init_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}, {enforce_fp32_accumulation}>();\n"
         )
 
     def calculate(
@@ -161,6 +159,9 @@ class ReduceFpu(Fpu):
         dest_acc = config.dest_acc.cpp_enum_value
         pool_type_cpp = self.reduce_pool.cpp_enum_value
         reduce_dim_cpp = self.reduce_dim.cpp_enum_value
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
+        )
         _int_fpu_formats = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
         is_int_fpu_en = (
             "true"
@@ -177,13 +178,14 @@ class ReduceFpu(Fpu):
             else "false"
         )
 
+        # Create a temporary TensorShape object with Src_A tile dimensions
         tile_shape = compute_unit.src_a.tile_shape
         tensor_shape_instantiation: str = (
             f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
         )
 
         return (
-            f"_llk_math_reduce_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}, {is_int_fpu_en}>(\n"
+            f"_llk_math_reduce_<{pool_type_cpp}, {reduce_dim_cpp}, {dest_acc}, {math_fidelity}, {is_int_fpu_en}, {enforce_fp32_accumulation}>(\n"
             f"{block.tile_id_block}, {tensor_shape_instantiation}\n"
             f");\n"
         )
@@ -195,4 +197,7 @@ class ReduceFpu(Fpu):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        return f"_llk_math_reduce_uninit_();\n"
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
+        )
+        return f"_llk_math_reduce_uninit_<{enforce_fp32_accumulation}>({config.sentinel.math_format});\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce.py
@@ -75,13 +75,17 @@ class ReduceUnpacker(Unpacker):
     ) -> str:
         reduce_dim = self.reduce_dim.cpp_enum_value
         pool_type = self.reduce_pool.cpp_enum_value
+        enforce_fp32_accumulation = (
+            compute_unit.enforce_fp32_accumulation.cpp_enum_value
+        )
+
         tile_shape = compute_unit.src_a.tile_shape
         tensor_shape_instantiation: str = (
             f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
         )
 
         return (
-            f"_llk_unpack_AB_reduce_init_<{pool_type}, {reduce_dim}>(\n"
+            f"_llk_unpack_AB_reduce_init_<{pool_type}, {reduce_dim}, {enforce_fp32_accumulation}>(\n"
             f"{tensor_shape_instantiation});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/reduce.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/reduce.yaml
@@ -1,19 +1,16 @@
 # Column reduce with max pooling.
 
-dest_acc: true
-
 operands:
   - name: "input_A"
-    dims: [32, 32]
-    format: "Float32"
-    # const_value: 0.335
+    dims: [64, 64]
+    format: "Float16_b"
   - name: "input_B"
-    dims: [32, 32]
-    format: "Float32"
+    dims: [64, 64]
+    format: "Float16_b"
     const_value: 1.0
   - name: "reduced_output"
-    dims: [32, 32]
-    format: "Float32"
+    dims: [64, 64]
+    format: "Float16_b"
 
 operations:
   - math:
@@ -21,11 +18,10 @@ operations:
         src_a: "input_A"
         src_b: "input_B"
         operation: "Reduce"
-        reduce_dim: "REDUCE_ROW"
-        reduce_pool: "SUM"
+        reduce_dim: "REDUCE_COL"
+        reduce_pool: "MAX"
         unpacker: "ReduceUnpacker"
-        math_fidelity: "HiFi4"
+        math_fidelity: "HiFi2"
     pack:
       - output: "reduced_output"
         packer: "Packer"
-    block_size: [64, 64]

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce.py
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+# buongiorno
 import math
 
+import pytest
 import torch
+from helpers.chip_architecture import ChipArchitecture
 from helpers.format_config import DataFormat, is_dest_acc_needed
 from helpers.golden_generators import ReduceGolden, get_golden_generator
 from helpers.llk_params import (
@@ -153,6 +156,12 @@ def test_reduce(
         )
         else DestAccumulation.No
     )
+
+    if (
+        TestConfig.CHIP_ARCH != ChipArchitecture.WORMHOLE
+        and dest_acc == DestAccumulation.Yes
+    ):
+        pytest.skip("https://github.com/tenstorrent/tt-llk/issues/1568")
 
     output_tile_count = 1 if is_reduce_to_one else tile_cnt_A
 
@@ -333,6 +342,12 @@ def test_reduce_bfp4_b(
         )
         else DestAccumulation.No
     )
+
+    if (
+        TestConfig.CHIP_ARCH != ChipArchitecture.WORMHOLE
+        and dest_acc == DestAccumulation.Yes
+    ):
+        pytest.skip("https://github.com/tenstorrent/tt-llk/issues/1568")
 
     output_tile_count = 1 if is_reduce_to_one else tile_cnt_A
 

--- a/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
@@ -81,8 +81,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_MATH
 
-#include "llk_lib_math_wrappers.h"
 #include "llk_math_common.h"
+#include "llk_math_reduce.h"
 #include "tensor_shape.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
@@ -96,15 +96,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     constexpr MathFidelity MATH_FIDELITY = MathFidelity::HiFi4;
 
-    constexpr bool IS_INT_FPU = false;
+    // todo: INT32 reduce is not supported yet
+    constexpr bool ENFORCE_FP32_ACC = false;
+    constexpr bool IS_INT_FPU       = false;
 
+    // Create a default 32x32 tile with 4 faces of 16x16
     const ckernel::TensorShape DEFAULT_TENSOR_SHAPE = {FACE_R_DIM, FACE_C_DIM, MAX_NUM_FACES_R_DIM, MAX_NUM_FACES_C_DIM};
 
     {
         START_PERF_MEASURE("INIT")
         _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY>(DEFAULT_TENSOR_SHAPE);
+        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, ENFORCE_FP32_ACC>();
         PROFILER_SYNC();
     }
     {
@@ -129,7 +132,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     LLK_ASSERT(
                         (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                         "block_tile exceeds max dest tiles");
-                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU>(block_tile, DEFAULT_TENSOR_SHAPE);
+                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU, ENFORCE_FP32_ACC>(
+                        block_tile, DEFAULT_TENSOR_SHAPE);
                 }
             }
         }
@@ -145,7 +149,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     LLK_ASSERT(
                         (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                         "block_tile exceeds max dest tiles");
-                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU>(block_tile, DEFAULT_TENSOR_SHAPE);
+                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU, ENFORCE_FP32_ACC>(
+                        block_tile, DEFAULT_TENSOR_SHAPE);
                 }
                 _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }

--- a/tt_metal/tt-llk/tests/sources/reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_test.cpp
@@ -43,7 +43,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         tensor_shape.total_num_faces(),
         params.TILE_SIZE_UNPACK_A,
         params.TILE_SIZE_UNPACK_B);
-    _llk_unpack_AB_reduce_init_<POOL_TYPE, REDUCE_DIM>(tensor_shape);
+    _llk_unpack_AB_reduce_init_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en>(tensor_shape);
     for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
     {
         _llk_unpack_AB_reduce_<POOL_TYPE, REDUCE_DIM>(L1_ADDRESS(params.buffer_A[i]), L1_ADDRESS(params.buffer_B[0]));
@@ -54,8 +54,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_MATH
 
-#include "llk_lib_math_wrappers.h"
 #include "llk_math_common.h"
+#include "llk_math_reduce.h"
 #include "params.h"
 #include "tensor_shape.h"
 
@@ -65,6 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     const bool is_int_fpu_en                = false;
+    const bool enforce_fp32_accumulation    = is_fp32_dest_acc_en;
     const ckernel::TensorShape tensor_shape = {
         static_cast<std::uint8_t>(params.in0_face_r_dim),
         static_cast<std::uint8_t>(params.in0_face_c_dim),
@@ -73,14 +74,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY>(tensor_shape);
+    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, false>();
 
     if (params.IS_REDUCE_TO_ONE)
     {
         _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
         for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
         {
-            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, is_int_fpu_en>(0, tensor_shape);
+            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, is_int_fpu_en, enforce_fp32_accumulation>(0, tensor_shape);
         }
         _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
@@ -93,7 +94,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
             for (int i = 0; i < tiles_to_dest; ++i)
             {
-                _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, is_int_fpu_en>(i, tensor_shape);
+                _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, is_int_fpu_en, enforce_fp32_accumulation>(i, tensor_shape);
             }
             _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             remaining_tiles -= tiles_to_dest;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -15,6 +15,54 @@
 using namespace ckernel::math;
 
 /**
+ * @brief Set debug feature disable bit 11 to work around an FPU HW bug.
+ *
+ * DO NOT call this unless absolutely necessary.
+ * We need to wait for both math and pack to be fully idle before writing
+ * this bit because it affects both dest banks.
+ * Changing it while either pipeline is active can cause a race condition.
+ *
+ * @note Workaround for bug tt-metal#46219. Paired with @ref _llk_math_dbg_feature_enable_ to restore.
+ */
+inline void _llk_math_dbg_feature_disable_()
+{
+    const std::uint32_t val = reg_read(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE);
+    if (val & (1 << 11))
+    {
+        return;
+    }
+    tensix_sync();
+    while (semaphore_read(semaphore::MATH_PACK) > 0)
+    {
+        asm volatile("nop");
+    };
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, val | (1 << 11));
+}
+
+/**
+ * @brief Clear debug feature disable bit 11, restoring default FPU behavior.
+ *
+ * Clears bit 11 to disable 32 bit mode for dest.
+ * Same synchronization as @ref _llk_math_dbg_feature_disable_ is needed here to avoid racing.
+ *
+ * @note Reverses @ref _llk_math_dbg_feature_disable_ (workaround for bug tt-metal#46219).
+ */
+inline void _llk_math_dbg_feature_enable_()
+{
+    const std::uint32_t val = reg_read(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE);
+    if (!(val & (1 << 11)))
+    {
+        return;
+    }
+    tensix_sync();
+    while (semaphore_read(semaphore::MATH_PACK) > 0)
+    {
+        asm volatile("nop");
+    };
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, val & ~(1 << 11));
+}
+
+/**
  * @brief Enable or disable FP32 accumulation in the destination register for both FPU and SFPU.
  *
  * @param enable: True to enable FP32 dest accumulation, false to disable.
@@ -36,6 +84,7 @@ inline void _llk_math_set_fp32_dest_acc_(bool enable)
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @param srca_data_format: Data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: Data format of source B (DataFormat enum underlying value).
+ * @note May disable debug feature bit 11 via @ref _llk_math_dbg_feature_disable_ for INT8/UInt16 workarounds (budabackend#1948).
  * @note The SFPU reads ALU_FORMAT_SPEC_REG1_SrcB (the SrcB ALU format, programmed unpack-side on Blackhole, not here) to
  *       interpret data it loads from DEST. For SFPU work, ensure that format's exponent family (BF16 vs FP16) matches
  *       the data in DEST (tt-llk #951).

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -543,6 +543,7 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
  * @note On the unpack thread, pair with @ref _llk_unpack_A_init_ (copy/transpose), @ref _llk_unpack_tilize_init_ (tilize) or @ref _llk_unpack_untilize_init_
  * (untilize) which feed the tile.
  * @note @ref _llk_math_eltwise_unary_datacopy_ runs the configured op with matching template args.
+ * @note May disable debug feature bit 11 (@ref _llk_math_dbg_feature_disable_) for tilize with UInt32/Int32 (budabackend#1948).
  */
 template <
     DataCopyType type,
@@ -600,6 +601,7 @@ inline void _llk_math_eltwise_unary_datacopy_init_(
  *
  * @tparam src_b_bcast_type: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
  * @tparam unpack_to_dest: Whether unpack wrote directly to dest.
+ * @note Reverses @ref _llk_math_eltwise_unary_datacopy_init_; re-enables debug feature bit 11 (@ref _llk_math_dbg_feature_enable_) only for broadcast
  * unpack-to-dest.
  */
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "ckernel.h"
 #include "ckernel_globals.h"
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
@@ -19,58 +18,108 @@
 using namespace ckernel;
 
 // local function declarations
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape);
+inline void reduce_configure_addrmod();
 
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape);
+template <ReduceDim dim, MathFidelity math_fidelity>
+inline void reduce_configure_mop();
 
 /**
- * @brief Transpose the pooled row result through SrcB so a row reduction lands as a column in the destination register.
+ * @brief Transpose the pooled row result through SrcB so a row-reduction lands as a column in the destination register.
  *
- * Only used for MAX pool (GMPOOL does column wise max of SrcA only).
+ * The FP32-accumulation path transposes the hi16 and lo16 halves separately (MOVD2B/TRNSPSRCB/MOVB2D) to avoid
+ * precision loss; otherwise it casts int32 dest datums to int8 (when integer FPU is enabled) before the SrcB transpose.
  *
+ * @tparam enforce_fp32_accumulation: Transpose in two 16-bit halves to preserve FP32 accumulation.
  * @tparam is_int_fpu_en: Cast int32 dest datums to int8 (via SFPU) before moving to SrcB.
  */
-template <bool is_int_fpu_en>
+template <bool enforce_fp32_accumulation, bool is_int_fpu_en>
 inline void reduce_row_perform_transpose()
 {
-    // The MOVD2B/ELWADD below read the Src zero substitution flag (FlushDenormals = !flag).
+    // The MOVB2D/MOVD2B/ELWADD below read the Src zero-substitution flag (FlushDenormals = !flag).
     // A datum whose low byte is zero (e.g. bf16 0x4400 = 768.0) would be flushed to 0 mid-reduction,
     // corrupting the sum. Disable the flag (via the math state tracker) around the transpose+add, then
-    // return it to the operand driven baseline. WH does the same in its fp32 transpose.
+    // return it to the operand-driven baseline. WH does the same in its fp32 transpose.
     math::_configure_mov_ops_zero_flag_state_();
-
-    if constexpr (is_int_fpu_en)
+    if (enforce_fp32_accumulation)
     {
-        TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 0);
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 2);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 2);
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
-        TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x1);
+        // needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
+        // move back to B and transpose in 2 parts, first hi16 bits then lo16 bits
+
+        // move hi16 bits D2B
+        // we avoid clobbering weights in src B by moving to rows 16 - 31
+        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        // note: transpose on src B on works on rows 16 - 31
+        TTI_TRNSPSRCB;
+        // move row D2B again for cases of reducing across multiple tiles
+        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+
+        // move hi16 bits B2D
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+
+        // move lo16 bits D2B
+        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        // transpose face
+        TTI_TRNSPSRCB;
+        // move row again for cases of reducing multiple tiles
+        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+
+        // move lo16 bits B2D
+        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
+        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
+        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
+        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
     }
-
-    // Move pooled result to SrcB rows 16–31 and transpose
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, 0, 0, p_setrwc::SET_AB);
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-    TTI_TRNSPSRCB;
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-
-    if constexpr (is_int_fpu_en)
+    else
     {
-        TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x0);
+        // Datums stored in int32 dest cannot be moved to SrcB which is configured for int8 inputs
+        // Cast int32 datums to int8 using SFPU instructions (load int32, store int8) before moving data to srcB
+        // Besides SFPU instructions to do cast we also need to set chicken bit FP16A_FORCE_Enable to force dest
+        // view to be fp16a as int8 datums are stored in src registers as fp16a
+        if constexpr (is_int_fpu_en)
+        {
+            TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 0 /*DEST offset*/);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 0 /*DEST offset*/);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 2 /*DEST offset*/);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 2 /*DEST offset*/);
+            TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
+            TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x1);
+        }
+
+        // Move back to B and transpose
+        // we avoid clobbering weights in src B by moving to rows 16 - 31
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, 0, 0, p_setrwc::SET_AB);
+        /*
+        if constexpr (is_fp32_dest_acc_en) {
+            if (0 == (((std::uint32_t)unpack_dst_format[0]>>2)&0x1)) { // fp32 to fp16_a conversion
+                TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+                TTI_SFPLOAD(0, 0, 3, 0);
+                TTI_SFP_STOCH_RND(0,0,0,0,0,8);
+                TTI_SFPSTORE(0,1,3,0);
+            }
+        }
+        */
+        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        // Note: transpose on src B on works on rows 16 - 31
+        TTI_TRNSPSRCB;
+        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        if constexpr (is_int_fpu_en)
+        {
+            TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x0);
+        }
+
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
+        TTI_ZEROSRC(0, 1, 0, 1); // Clear src A
+        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
+        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
     }
-
-    // Add transposed SrcB into Dest through a zeroed SrcA
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
-    TTI_ZEROSRC(0, 1, 0, 1);
-    TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
-    TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
-
-    // Restore the operand-driven baseline for the currently configured formats.
+    // Restore the operand-driven baseline for the currently-configured formats.
     math::_configure_default_zero_flag_state_(math::src_zero_flag_srca_fmt, math::src_zero_flag_srcb_fmt);
 }
 
@@ -87,6 +136,7 @@ inline void reduce_row_perform_transpose()
 template <PoolType type, bool high_fidelity, std::uint32_t clear_mode, std::uint32_t index = 0>
 inline void reduce_pool_op()
 {
+    // Transpose for each face in src A done at unpacker, and pool
     if constexpr (type == PoolType::MAX)
     {
         TTI_GMPOOL(clear_mode, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, index);
@@ -106,131 +156,29 @@ inline void reduce_pool_op()
 }
 
 /**
- * @brief Pool one row of faces, clearing SrcA/B between faces and keeping the final result.
- *
- * @tparam type: Pooling op, values = <SUM/AVG/MAX>
- * @tparam high_fidelity: Run the multi-phase fidelity MOP instead of a single GAPOOL.
- * @param num_faces_c_dim: Number of column faces in the row.
- */
-template <PoolType type, bool high_fidelity>
-inline void reduce_row_pool_all_faces(const std::uint32_t num_faces_c_dim)
-{
-    for (std::uint32_t col_num = 0; col_num < num_faces_c_dim - 1; col_num++)
-    {
-        reduce_pool_op<type, high_fidelity, p_setrwc::CLR_AB, 0>();
-    }
-    reduce_pool_op<type, high_fidelity, p_setrwc::CLR_NONE, 0>();
-}
-
-/**
- * @brief Advance the dest counter past the current face row so the next row writes to the correct offset.
- *
- * @param is_narrow_tile: True when tile width < tile height (num_faces_c < num_faces_r), halving the stride.
- */
-inline void reduce_row_advance_dest(const bool is_narrow_tile)
-{
-    if (!is_narrow_tile)
-    {
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-    }
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-    TTI_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_BD);
-}
-
-/**
- * @brief Configure the reduce MOP for all paths: REDUCE_ROW SUM/AVG records a dual replay-buffer
- *        MOP, high-fidelity COL/SCALAR programs a multi-phase GAPOOL loop, all other paths need no MOP.
- *
- * @tparam type: Pooling op, values = <SUM/AVG/MAX>
- * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
- * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
- * @param tensor_shape: Tile shape determining face count and dest stride.
- */
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
-{
-    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
-
-    if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
-    {
-        // MVMUL multiplies the scaler column (SrcA) by each data face (SrcB), accumulating the
-        // reduced column directly in dest. The replay buffer records all column faces so a single
-        // replay covers one row of faces; the MOP outer loop repeats it for each row.
-        constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
-        const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
-
-        const std::uint32_t replay_start = ckernel::math::replay_buf_offset;
-
-        load_replay_buf(
-            replay_start,
-            replay_buf_len,
-            [&tensor_shape]
-            {
-                for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
-                {
-                    // Top half of face (dst=0): run fidelity phases, last phase advances SrcB by 8 rows
-                    for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                    {
-                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                    }
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-
-                    // Bottom half of face (dst=8): run fidelity phases, last phase resets SrcB
-                    for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                    {
-                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
-                    }
-                    if (faces_remaining == 1)
-                    {
-                        // Last face in row: reset SrcB, advance dest to next row
-                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
-                    }
-                    else
-                    {
-                        // More faces remain: reset SrcB, clear sources for next face
-                        TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
-                    }
-                }
-            });
-
-        const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
-        // Outer loop = num_faces_r_dim: replay the column face reduction for each row
-        ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
-        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
-        tmp.program();
-    }
-    else if constexpr (high_fidelity)
-    {
-        constexpr int inner_loop_len = to_underlying(math_fidelity);
-        constexpr std::uint32_t dst  = (dim == ReduceDim::REDUCE_SCALAR) ? 4 : 0;
-
-        ckernel_template tmp(1, inner_loop_len, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, dst));
-        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, dst));
-        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, dst));
-        tmp.program();
-    }
-}
-
-/**
  * @brief Perform a reduction on the math thread, pooling faces into the destination register.
  *
- * REDUCE_ROW SUM/AVG uses MVMUL to multiply each face row by a column-scaler in SrcA, producing the reduced
- * column directly in dest; MAX pools each face row then transposes the result into dest via SrcB.
- * REDUCE_COL pools down rows of faces; REDUCE_SCALAR pools all faces then transposes the partial result
- * into a single column for a final pool.
+ * For REDUCE_ROW the per-row pooled result is transposed back into dest; REDUCE_COL pools down rows of faces;
+ * REDUCE_SCALAR pools all faces then transposes the partial result into a single column for a final pool.
  *
  * @tparam type: Pooling op, values = <SUM/AVG/MAX>
  * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
  * @tparam is_int_fpu_en: Enable integer FPU datapath (casts int32 dest datums to int8 before moving to SrcB).
+ * @tparam enforce_fp32_accumulation: Force FP32 accumulation through the transpose (requires is_fp32_dest_acc_en).
  * @param dst_index: Tile index into the destination register.
  * @param tensor_shape: Tensor shape describing tile dimensions.
  * @note Call @ref _llk_math_reduce_init_ with matching template args before this
  *       function, and @ref _llk_math_reduce_uninit_ after it to restore modified state.
  */
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool is_int_fpu_en = false>
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    bool is_int_fpu_en             = false,
+    bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
@@ -245,26 +193,36 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
 
     if constexpr (dim == ReduceDim::REDUCE_ROW)
     {
-        const bool is_narrow_tile = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
-
-        if constexpr (type == PoolType::MAX)
+        // Reduce all faces in a row and perform transpose
+        for (std::uint32_t col_num = 0; col_num < static_cast<std::uint32_t>(tensor_shape.num_faces_c_dim - 1); col_num++)
         {
-            reduce_row_pool_all_faces<type, high_fidelity>(tensor_shape.num_faces_c_dim);
-            reduce_row_perform_transpose<is_int_fpu_en>();
+            reduce_pool_op<type, high_fidelity, p_setrwc::CLR_AB, 0>();
+        }
+        reduce_pool_op<type, high_fidelity, p_setrwc::CLR_NONE, 0>();
+        reduce_row_perform_transpose<enforce_fp32_accumulation, is_int_fpu_en>();
 
-            if (tensor_shape.num_faces_r_dim > 1)
+        // If there is only 1 row of faces, then we are done
+        if (tensor_shape.num_faces_r_dim > 1)
+        {
+            // Increment dest by 32 or 16 if narrow tile for the next accumulation
+            if (!(tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim) /* narrow_tile */)
             {
-                reduce_row_advance_dest(is_narrow_tile);
-                reduce_row_pool_all_faces<type, high_fidelity>(tensor_shape.num_faces_c_dim);
-                reduce_row_perform_transpose<is_int_fpu_en>();
+                TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+                TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
             }
-            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_BD);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_BD);
+
+            // Reduce all faces in a row and perform transpose
+            for (std::uint32_t col_num = 0; col_num < static_cast<std::uint32_t>(tensor_shape.num_faces_c_dim - 1); col_num++)
+            {
+                reduce_pool_op<type, high_fidelity, p_setrwc::CLR_AB, 0>();
+            }
+            reduce_pool_op<type, high_fidelity, p_setrwc::CLR_NONE, 0>();
+            reduce_row_perform_transpose<enforce_fp32_accumulation, is_int_fpu_en>();
         }
-        else
-        {
-            ckernel_template::run();
-            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
-        }
+
+        TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_BD);
     }
     else if constexpr (dim == ReduceDim::REDUCE_COL)
     {
@@ -323,7 +281,7 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
             {
                 for (std::uint32_t i = 0; i < to_underlying(math_fidelity) - 1; i++)
                 {
-                    TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+                    TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0);
                 }
             }
             TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
@@ -332,101 +290,92 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
 }
 
 /**
- * @brief Program address mod registers for the reduce operation.
+ * @brief Program the address-mod slots for a reduce: no-op/fidelity-clear, single-row, 8-row, and (high fidelity) fidelity-step.
  *
  * @tparam type: Pooling op, values = <SUM/AVG/MAX>
- * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
- * @param tensor_shape: Tile shape determining dest stride for REDUCE_ROW.
  */
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape)
+template <PoolType type, MathFidelity math_fidelity>
+inline void reduce_configure_addrmod()
 {
-    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+    constexpr bool high_fidelity               = is_high_fidelity(math_fidelity);
+    constexpr std::uint32_t fidelity_increment = high_fidelity ? 1 : 0;
 
-    if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
-    {
-        if constexpr (high_fidelity)
-        {
-            addr_mod_t {
-                .fidelity = {.incr = 1},
-            }
-                .set(ADDR_MOD_0);
-        }
+    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_0);
 
-        addr_mod_t {
-            .srcb     = {.incr = 8},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_1);
-
-        addr_mod_t {
-            .srcb     = {.cr = 1},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_2);
-
-        if (tensor_shape.num_faces_c_dim == 2)
-        {
-            addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 32},
-                .fidelity = {.clr = 1},
-            }
-                .set(ADDR_MOD_3);
-        }
-        else
-        {
-            addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 16},
-                .fidelity = {.clr = 1},
-            }
-                .set(ADDR_MOD_3);
-        }
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 1},
+        .dest = {.incr = 1},
     }
-    else
-    {
-        addr_mod_t {
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_0);
+        .set(ADDR_MOD_1);
 
-        if constexpr (type == PoolType::MAX)
-        {
-            addr_mod_t {
-                .srcb = {.incr = 8},
-                .dest = {.incr = 8},
-            }
-                .set(ADDR_MOD_1);
-        }
-        else if constexpr (high_fidelity)
-        {
-            addr_mod_t {
-                .fidelity = {.incr = 1},
-            }
-                .set(ADDR_MOD_1);
-        }
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 8},
+        .dest = {.incr = 8},
+    }
+        .set(ADDR_MOD_2);
+
+    if constexpr (high_fidelity)
+    {
+        addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = fidelity_increment}}.set(ADDR_MOD_3);
     }
 }
 
 /**
- * @brief Configure the math (FPU) thread for a reduce operation: programs address mods and the MOP.
+ * @brief Build the high-fidelity reduce MOP: a multi-phase GAPOOL sequence (one inner-loop iteration per fidelity phase).
+ *
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam math_fidelity: Math fidelity for controlling precision; sets the inner-loop length, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ */
+template <ReduceDim dim, MathFidelity math_fidelity>
+inline void reduce_configure_mop()
+{
+    constexpr int inner_loop_len = to_underlying(math_fidelity); // inner loop length is the number of fidelity phases 0, 2, 3, 4 (LoFi, Hifi2, Hifi3, Hifi4)
+
+    if constexpr (dim == ReduceDim::REDUCE_SCALAR)
+    {
+        ckernel_template tmp(1, inner_loop_len, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 4));
+        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
+        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
+        tmp.program();
+    }
+    else
+    {
+        ckernel_template tmp(1, inner_loop_len, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0));
+        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
+        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
+        tmp.program();
+    }
+}
+
+/**
+ * @brief Configure the math (FPU) thread for a reduce operation: programs address mods and, for high fidelity, the pool MOP.
  *
  * @tparam type: Pooling op, values = <SUM/AVG/MAX>
  * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
- * @param tensor_shape: Tile shape describing tile dimensions.
- * @note Call @ref _llk_math_reduce_ with matching template args after this function,
- *       and @ref _llk_math_reduce_uninit_ after the last reduce to restore modified state.
+ * @tparam enforce_fp32_accumulation: Force FP32 accumulation (requires is_fp32_dest_acc_en).
+ * @note @ref _llk_math_reduce_ runs the configured reduction with matching template args.
  */
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
-inline void _llk_math_reduce_init_(const ckernel::TensorShape& tensor_shape)
+template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool enforce_fp32_accumulation = false>
+inline void _llk_math_reduce_init_()
 {
-    reduce_configure_addrmod<type, dim, math_fidelity>(tensor_shape);
-    reduce_configure_mop<type, dim, math_fidelity>(tensor_shape);
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
 
+    reduce_configure_addrmod<type, math_fidelity>();
+    if constexpr (high_fidelity)
+    {
+        reduce_configure_mop<dim, math_fidelity>();
+    }
+
+    if constexpr (enforce_fp32_accumulation)
+    {
+        static_assert(is_fp32_dest_acc_en, "FP32 Dest must be enabled for FP32 accumulation");
+        _llk_math_dbg_feature_disable_();
+    }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 
     math::reset_counters(p_setrwc::SET_ABD_F);
@@ -435,8 +384,17 @@ inline void _llk_math_reduce_init_(const ckernel::TensorShape& tensor_shape)
 /**
  * @brief Uninitialize after a reduce operation, undoing any init/execute-time workarounds.
  *
- * @note Reverses @ref _llk_math_reduce_init_
+ * @tparam enforce_fp32_accumulation: Must match the value used at init.
+ * @note Reverses @ref _llk_math_reduce_init_; re-enables debug feature bit 11 (@ref _llk_math_dbg_feature_enable_) only when FP32 accumulation was enforced.
  */
+template <bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_uninit_()
 {
+    if constexpr (enforce_fp32_accumulation)
+    {
+        // Clear bit 11 (restore from workaround for tt-metal#46219)
+        // Uses helper from llk_math_common.h which includes tensix_sync()
+        _llk_math_dbg_feature_enable_();
+        // Note: BH doesn't need format restoration (init doesn't change it)
+    }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <sys/_stdint.h>
-
 #include <cstdint>
 
 #include "ckernel.h"
@@ -41,8 +39,6 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     // pool_type == PoolType::MAX sets the clear value to neginf if the pool-type is MAX and 0 if the pool-type is AVG/SUM
     static constexpr std::uint32_t clear_pool_dep_srca =
         TT_OP_UNPACR_NOP(Srcs::SrcA, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, pool_type == PoolType::MAX /* 0 or neginf */, p_unpacr_nop::CLR_SRC);
-    static constexpr std::uint32_t clear_pool_dep_srcb =
-        TT_OP_UNPACR_NOP(Srcs::SrcB, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, pool_type == PoolType::MAX /* 0 or neginf */, p_unpacr_nop::CLR_SRC);
     static constexpr std::uint32_t clear_zero_srca =
         TT_OP_UNPACR_NOP(Srcs::SrcA, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, p_unpacr_nop::CLR_SRC_0, p_unpacr_nop::CLR_SRC);
 
@@ -62,14 +58,11 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     constexpr std::uint32_t outerloop = 1;
     const std::uint32_t innerloop     = tensor_shape.total_num_faces();
 
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-
     // Padding should only be done when using tiny tiles otherwise the entire face overwrites the data read in Math
     if (tensor_shape.face_r_dim < FACE_R_DIM) // Using tiny faces
     {
-        // Swapped REDUCE_ROW: data is in SrcB, pad SrcB; otherwise data is in SrcA, pad SrcA
-        static constexpr std::uint32_t clear_pool_dep = swap_operands ? clear_pool_dep_srcb : clear_pool_dep_srca;
-        ckernel_template tmp(outerloop, innerloop, clear_pool_dep, lltt::replay_insn(0, REPLAY_BUF_LEN));
+        // Fill SrcA with pool-type dependent padding value for tiny tiles before unpacking a face
+        ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
         tmp.program();
     }
     else // Using standard faces (face_r_dim = FACE_R_DIM)
@@ -100,31 +93,35 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
  *
  * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
  * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam enforce_fp32_accumulation: Configure the ALU for FP32 accumulation (MOVB2D hi16/lo16 path).
  * @param tensor_shape: Shape of the tensor, including face_r_dim and num_faces.
  *
- * @note For SUM/AVG REDUCE_ROW, operands are swapped: scaler→SrcA, data→SrcB.
- * @note For MAX REDUCE_ROW, original layout is kept: data→SrcA (transposed via haloize), scaler→SrcB.
- * @note For REDUCE_COL/REDUCE_SCALAR: Unpacker 0 (SrcA) reads face_r_dim*FACE_R_DIM datums,
- *       Unpacker 1 (SrcB) reads one row (FACE_R_DIM datums).
+ * @note For REDUCE_ROW operations, the face is transposed using haloize mode.
+ * @note Unpacker 0 (SrcA) reads face_r_dim*FACE_R_DIM datums.
+ * @note Unpacker 1 (SrcB) reads one row (FACE_R_DIM datums).
  * @ref _llk_unpack_AB_reduce_ is the matching execute call.
- * @ref _llk_math_reduce_init_ is the matching init on the math thread (this is the scaler operand unpack pairing).
+ * @ref _llk_math_reduce_init_ is the matching init on the math thread (this is the scaler-operand unpack pairing).
  */
-template <PoolType pool_type, ReduceDim reduce_dim>
+template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
 inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
-    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>((reduce_dim == ReduceDim::REDUCE_ROW));
+    if constexpr (enforce_fp32_accumulation)
+    {
+        // Set necessary config regs for MOVB2D hi16/lo16 to work
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 
+    // Enable transpose (haloize mode) if reducing along rows
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(reduce_dim == ReduceDim::REDUCE_ROW);
+
+    // Sets up Unpacker 0 to read face_r_dim*16 datums into SrcA register
     config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
 
-    // UNP_B reads data faces (face_r_dim rows) in swapped mode, or a single
-    // scaler row in the non-swapped (MAX / COL / SCALAR) mode.
-    config_unpacker_x_end<p_setadc::UNP_B>(swap_operands ? tensor_shape.face_r_dim : 1);
+    // Sets up Unpacker 1 to read one row (16 datums) into SrcB register
+    config_unpacker_x_end<p_setadc::UNP_B>(1);
 
     // Configure unpack MOP
     _llk_unpack_AB_reduce_mop_config_<pool_type, reduce_dim>(tensor_shape);
@@ -162,17 +159,8 @@ inline void _llk_unpack_AB_reduce_(const std::uint32_t address_a, const std::uin
     // Wait for free context
     wait_for_next_context(2);
 
-    // SUM/AVG REDUCE_ROW: swap operands so scaler→SrcA, data→SrcB
-    // MAX REDUCE_ROW: keep original order (data→SrcA, scaler→SrcB)
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-    if constexpr (swap_operands)
-    {
-        _llk_unpack_configure_addresses_(address_b, address_a, cfg);
-    }
-    else
-    {
-        _llk_unpack_configure_addresses_(address_a, address_b, cfg);
-    }
+    // Validate and configure addresses
+    _llk_unpack_configure_addresses_(address_a, address_b, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -14,6 +14,53 @@
 
 using namespace ckernel::math;
 
+// DO NOT call this unless absolutely necessary
+// Bit 11 enables 32 bit mode for dest as a workaround for tt-metal#46219.
+// We need to wait for both math and pack to be fully idle before writing this bit
+// because it affects dest bank access which is shared by both pipelines.
+// Changing it while either pipeline is active can cause a race condition.
+/**
+ * @brief Set debug feature disable bit 11 to work around an FPU HW bug.
+ *
+ * @note Workaround for bug tt-metal#46219. Paired with @ref _llk_math_dbg_feature_enable_ to restore.
+ */
+inline void _llk_math_dbg_feature_disable_()
+{
+    const std::uint32_t val = reg_read(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE);
+    if (val & (1 << 11))
+    {
+        return;
+    }
+    tensix_sync();
+    while (semaphore_read(semaphore::MATH_PACK) > 0)
+    {
+        asm volatile("nop");
+    };
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, val | (1 << 11));
+}
+
+// Clears bit 11 to disable 32 bit mode for dest.
+// Same synchronization is needed here to avoid racing.
+/**
+ * @brief Clear debug feature disable bit 11, restoring default FPU behavior.
+ *
+ * @note Reverses @ref _llk_math_dbg_feature_disable_ (workaround for bug tt-metal#46219). Issues a tensix_sync() first.
+ */
+inline void _llk_math_dbg_feature_enable_()
+{
+    const std::uint32_t val = reg_read(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE);
+    if (!(val & (1 << 11)))
+    {
+        return;
+    }
+    tensix_sync();
+    while (semaphore_read(semaphore::MATH_PACK) > 0)
+    {
+        asm volatile("nop");
+    };
+    reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, val & ~(1 << 11));
+}
+
 /**
  * @brief Enable or disable FP32 accumulation in the destination register for both FPU and SFPU.
  *
@@ -36,6 +83,7 @@ inline void _llk_math_set_fp32_dest_acc_(bool enable)
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @param srca_data_format: Data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: Data format of source B (DataFormat enum underlying value).
+ * @note Clears debug feature bit 11 via @ref _llk_math_dbg_feature_enable_; it is never set here.
  * @note srcb_data_format programs ALU_FORMAT_SPEC_REG1_SrcB, which the SFPU also reads to interpret data it loads from DEST.
  *       For SFPU work, pass a srcb_data_format whose exponent family (BF16 vs FP16) matches the data in DEST (tt-llk #951).
  */

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "ckernel.h"
 #include "ckernel_globals.h"
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
@@ -14,65 +13,126 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
-#include "lltt.h"
 #include "tensor_shape.h"
 
 using namespace ckernel;
 
 // local function declarations
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape);
+inline void reduce_configure_addrmod();
 
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape);
+template <ReduceDim dim, MathFidelity math_fidelity>
+inline void reduce_configure_mop();
 
 /**
- * @brief Transpose the pooled row result through SrcB so a row reduction lands as a column in the destination register.
+ * @brief Transpose the pooled row result through SrcB so a row-reduction lands as a column in the destination register.
  *
- * Only used for MAX pool (GMPOOL does column wise max of SrcA only).
+ * The FP32-accumulation path transposes the hi16 and lo16 halves separately (MOVD2B/TRNSPSRCB/MOVB2D) to avoid
+ * precision loss; otherwise it casts int32 dest datums to int8 (when integer FPU is enabled) before the SrcB transpose.
  *
+ * @tparam enforce_fp32_accumulation: Transpose in two 16-bit halves to preserve FP32 accumulation.
  * @tparam is_int_fpu_en: Cast int32 dest datums to int8 (via SFPU) before moving to SrcB.
  */
-template <bool is_int_fpu_en>
+template <bool enforce_fp32_accumulation, bool is_int_fpu_en>
 inline void reduce_row_perform_transpose()
 {
-    // The MOVD2B/ELWADD below read the Src zero substitution flag (FlushDenormals = !flag).
-    // A datum whose low byte is zero (e.g. bf16 0x4400 = 768.0) would be flushed to 0 mid-reduction,
-    // corrupting the sum. Disable the flag (via the math state tracker) around the transpose+add, then
-    // return it to the operand driven baseline.
-    math::_configure_mov_ops_zero_flag_state_();
-
-    if constexpr (is_int_fpu_en)
+    if constexpr (enforce_fp32_accumulation)
     {
-        TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 0);
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 2);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 2);
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
-        TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x1);
+        // Transpose 32-bit data in dest by splitting into hi16 and lo16.
+        // TRNSPSRCB only operates on SrcB rows 16-31, so data goes through SRC_ROW16_OFFSET.
+        // SrcA_val=Tf32 addresses hi16 (DEST_NORM), SrcA_val=Float32 addresses lo16 (DEST_32B_LOW).
+        // Writing hi16 via MOVB2D(Tf32) clobbers lo16, so we cache lo16 in SrcA first.
+
+        // Enable SrcA format override to control MOVB2D hi16/lo16 addressing, and disable the Src
+        // zero-substitution flag (via the math state tracker) to prevent mantissa flushing during
+        // the MOV operations.
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+        math::_configure_mov_ops_zero_flag_state_();
+
+        // Step 1: Read lo16 from dest into SrcB rows 16-31 and transpose.
+        // DEST_32B_LOW reads the lo16 half of 32-bit dest.
+        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        // note: transpose on src B on works on rows 16 - 31
+        TTI_TRNSPSRCB;
+        // move row D2B again for cases of reducing across multiple tiles
+        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+
+        // Step 2: Cache the transposed lo16 data from SrcB rows 16-31 into SrcA rows 0-15.
+        // This preserves lo16 before hi16 MOVB2D(Tf32) clobbers it in dest.
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
+
+        // Step 3: Read hi16 from dest into SrcB rows 16-31 and transpose.
+        // DEST_NORM reads the hi16 half of 32-bit dest.
+        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        TTI_TRNSPSRCB;
+        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+
+        // Step 4: Write transposed hi16 back to dest. SrcA_val=Tf32 makes MOVB2D target
+        // the hi16 (DEST_NORM) address space. This clobbers lo16 and that's why we cached it.
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
+        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+
+        // Step 5: Write cached lo16 from SrcA back to dest. SrcA_val=Float32 makes MOVA2D
+        // target the lo16 (DEST_32B_LOW) address space, restoring the mantissa bits.
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Float32));
+        TTI_MOVA2D(p_mov::DEST_32B_LOW, 0, ADDR_MOD_0, p_mova2d::MOV_8_ROWS, 0);
+        TTI_MOVA2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_0, p_mova2d::MOV_8_ROWS, 8);
+
+        // Restore: disable SrcA format override and return the Src zero-substitution flag to the
+        // operand-driven baseline for the currently-configured formats.
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+        math::_configure_default_zero_flag_state_(src_zero_flag_srca_fmt, src_zero_flag_srcb_fmt);
     }
-
-    // Move pooled result to SrcB rows 16–31 and transpose
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, 0, 0, p_setrwc::SET_AB);
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-    TTI_TRNSPSRCB;
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-
-    if constexpr (is_int_fpu_en)
+    else
     {
-        TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x0);
+        // Datums stored in int32 dest cannot be moved to SrcB which is configured for int8 inputs
+        // Cast int32 datums to int8 using SFPU instructions (load int32, store int8) before moving data to srcB
+        // Besides SFPU instructions to do cast we also need to set chicken bit FP16A_FORCE_Enable to force dest
+        // view to be fp16a as int8 datums are stored in src registers as fp16a
+        if constexpr (is_int_fpu_en)
+        {
+            TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 0 /*DEST offset*/);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 0 /*DEST offset*/);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 2 /*DEST offset*/);
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT8, ADDR_MOD_0, 2 /*DEST offset*/);
+            TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
+            TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x1);
+        }
+
+        // Move back to B and transpose
+        // we avoid clobbering weights in src B by moving to rows 16 - 31
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, 0, 0, p_setrwc::SET_AB);
+        /*
+        if constexpr (is_fp32_dest_acc_en) {
+            if (0 == (((std::uint32_t)unpack_dst_format[0]>>2)&0x1)) { // fp32 to fp16_a conversion
+                TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+                TTI_SFPLOAD(0, 0, 3, 0);
+                TTI_SFP_STOCH_RND(0,0,0,0,0,8);
+                TTI_SFPSTORE(0,1,3,0);
+            }
+        }
+        */
+        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        // Note: transpose on src B on works on rows 16 - 31
+        TTI_TRNSPSRCB;
+        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+        if constexpr (is_int_fpu_en)
+        {
+            TTI_SETC16(FP16A_FORCE_Enable_ADDR32, 0x0);
+        }
+
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
+        TTI_ZEROSRC(0, 1, 0, 1); // Clear src A
+        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
+        TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
     }
-
-    // Add transposed SrcB into Dest through a zeroed SrcA
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_B, 0, 8, 0, p_setrwc::SET_B);
-    TTI_ZEROSRC(0, 1, 0, 1);
-    TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
-    TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
-
-    // Restore the operand-driven baseline for the currently configured formats.
-    math::_configure_default_zero_flag_state_(src_zero_flag_srca_fmt, src_zero_flag_srcb_fmt);
 }
 
 /**
@@ -88,6 +148,7 @@ inline void reduce_row_perform_transpose()
 template <PoolType type, bool high_fidelity, std::uint32_t clear_mode, std::uint32_t index = 0>
 inline void reduce_pool_op()
 {
+    // Transpose for each face in src A done at unpacker, and pool
     if constexpr (type == PoolType::MAX)
     {
         TTI_GMPOOL(clear_mode, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, index);
@@ -107,118 +168,29 @@ inline void reduce_pool_op()
 }
 
 /**
- * @brief Pool one row of faces, clearing SrcA/B between faces and keeping the final result.
- *
- * @tparam type: Pooling op, values = <SUM/AVG/MAX>
- * @tparam high_fidelity: Run the multi-phase fidelity MOP instead of a single GAPOOL.
- * @param num_faces_c_dim: Number of column faces in the row.
- */
-template <PoolType type, bool high_fidelity>
-inline void reduce_row_pool_all_faces(const std::uint32_t num_faces_c_dim)
-{
-    for (std::uint32_t col_num = 0; col_num < num_faces_c_dim - 1; col_num++)
-    {
-        reduce_pool_op<type, high_fidelity, p_setrwc::CLR_AB, 0>();
-    }
-    reduce_pool_op<type, high_fidelity, p_setrwc::CLR_NONE, 0>();
-}
-
-/**
- * @brief Advance the dest counter past the current face row so the next row writes to the correct offset.
- *
- * @param is_narrow_tile: True when tile width < tile height (num_faces_c < num_faces_r), halving the stride.
- */
-inline void reduce_row_advance_dest(const bool is_narrow_tile)
-{
-    if (!is_narrow_tile)
-    {
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-    }
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
-    TTI_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_BD);
-}
-
-/**
- * @brief Configure the reduce MOP for all paths: REDUCE_ROW SUM/AVG records a dual replay-buffer
- *        MOP, high-fidelity COL/SCALAR programs a multi-phase GAPOOL loop, all other paths need no MOP.
- *
- * @tparam type: Pooling op, values = <SUM/AVG/MAX>
- * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
- * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
- * @param tensor_shape: Tile shape determining face count and dest stride.
- */
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
-{
-    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
-
-    if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
-    {
-        constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
-        const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
-
-        const std::uint32_t replay_start = ckernel::math::replay_buf_offset;
-
-        lltt::record<lltt::NoExec>(replay_start, replay_buf_len);
-        for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
-        {
-            for (std::uint32_t p = 0; p < fid_count - 1; p++)
-            {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-            }
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-
-            for (std::uint32_t p = 0; p < fid_count - 1; p++)
-            {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
-            }
-            if (faces_remaining == 1)
-            {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
-            }
-            else
-            {
-                TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
-            }
-        }
-
-        const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
-        ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
-        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
-        tmp.program();
-    }
-    else if constexpr (high_fidelity)
-    {
-        constexpr int inner_loop_len = to_underlying(math_fidelity);
-        constexpr std::uint32_t dst  = (dim == ReduceDim::REDUCE_SCALAR) ? 4 : 0;
-
-        ckernel_template tmp(1, inner_loop_len, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, dst));
-        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, dst));
-        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, dst));
-        tmp.program();
-    }
-}
-
-/**
  * @brief Perform a reduction on the math thread, pooling faces into the destination register.
  *
- * REDUCE_ROW SUM/AVG uses MVMUL to multiply each face row by a column-scaler in SrcA, producing the reduced
- * column directly in dest; MAX pools each face row then transposes the result into dest via SrcB.
- * REDUCE_COL pools down rows of faces; REDUCE_SCALAR pools all faces then transposes the partial result
- * into a single column for a final pool.
+ * For REDUCE_ROW the per-row pooled result is transposed back into dest; REDUCE_COL pools down rows of faces;
+ * REDUCE_SCALAR pools all faces then transposes the partial result into a single column for a final pool.
  *
  * @tparam type: Pooling op, values = <SUM/AVG/MAX>
  * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
  * @tparam is_int_fpu_en: Enable integer FPU datapath (casts int32 dest datums to int8 before moving to SrcB).
+ * @tparam enforce_fp32_accumulation: Force FP32 accumulation through the transpose (requires is_fp32_dest_acc_en).
  * @param dst_index: Tile index into the destination register.
  * @param tensor_shape: Tensor shape describing tile dimensions.
- * @note Call @ref _llk_math_reduce_init_ with matching template args before this
- *       function, and @ref _llk_math_reduce_uninit_ after it to restore modified state.
+ * @note Call @ref _llk_math_reduce_init_ with matching template args before this function, and
+ *       @ref _llk_math_reduce_uninit_ after it to restore modified state.
  */
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool is_int_fpu_en = false>
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    bool is_int_fpu_en             = false,
+    bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
@@ -233,26 +205,36 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
 
     if constexpr (dim == ReduceDim::REDUCE_ROW)
     {
-        const bool is_narrow_tile = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
-
-        if constexpr (type == PoolType::MAX)
+        // Reduce all faces in a row and perform transpose
+        for (std::uint32_t col_num = 0; col_num < static_cast<std::uint32_t>(tensor_shape.num_faces_c_dim - 1); col_num++)
         {
-            reduce_row_pool_all_faces<type, high_fidelity>(tensor_shape.num_faces_c_dim);
-            reduce_row_perform_transpose<is_int_fpu_en>();
+            reduce_pool_op<type, high_fidelity, p_setrwc::CLR_AB, 0>();
+        }
+        reduce_pool_op<type, high_fidelity, p_setrwc::CLR_NONE, 0>();
+        reduce_row_perform_transpose<enforce_fp32_accumulation, is_int_fpu_en>();
 
-            if (tensor_shape.num_faces_r_dim > 1)
+        // If there is only 1 row of faces, then we are done
+        if (tensor_shape.num_faces_r_dim > 1)
+        {
+            // Increment dest by 32 or 16 if narrow tile for the next accumulation
+            if (!(tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim) /* narrow_tile */)
             {
-                reduce_row_advance_dest(is_narrow_tile);
-                reduce_row_pool_all_faces<type, high_fidelity>(tensor_shape.num_faces_c_dim);
-                reduce_row_perform_transpose<is_int_fpu_en>();
+                TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+                TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
             }
-            TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_BD);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_BD);
+
+            // Reduce all faces in a row and perform transpose
+            for (std::uint32_t col_num = 0; col_num < static_cast<std::uint32_t>(tensor_shape.num_faces_c_dim - 1); col_num++)
+            {
+                reduce_pool_op<type, high_fidelity, p_setrwc::CLR_AB, 0>();
+            }
+            reduce_pool_op<type, high_fidelity, p_setrwc::CLR_NONE, 0>();
+            reduce_row_perform_transpose<enforce_fp32_accumulation, is_int_fpu_en>();
         }
-        else
-        {
-            ckernel_template::run();
-            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
-        }
+
+        TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_BD);
     }
     else if constexpr (dim == ReduceDim::REDUCE_COL)
     {
@@ -311,7 +293,7 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
             {
                 for (std::uint32_t i = 0; i < to_underlying(math_fidelity) - 1; i++)
                 {
-                    TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+                    TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0);
                 }
             }
             TTI_GAPOOL(p_setrwc::CLR_AB, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
@@ -320,111 +302,107 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
 }
 
 /**
- * @brief Program address mod registers for the reduce operation.
+ * @brief Program the address-mod slots for a reduce: no-op/fidelity-clear, single-row, 8-row, and (high fidelity) fidelity-step.
  *
  * @tparam type: Pooling op, values = <SUM/AVG/MAX>
- * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
- * @param tensor_shape: Tile shape determining dest stride for REDUCE_ROW.
  */
-template <PoolType type, ReduceDim dim, MathFidelity math_fidelity>
-inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape)
+template <PoolType type, MathFidelity math_fidelity>
+inline void reduce_configure_addrmod()
 {
-    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+    constexpr bool high_fidelity               = is_high_fidelity(math_fidelity);
+    constexpr std::uint32_t fidelity_increment = high_fidelity ? 1 : 0;
 
-    if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
-    {
-        if constexpr (high_fidelity)
-        {
-            addr_mod_t {
-                .fidelity = {.incr = 1},
-            }
-                .set(ADDR_MOD_0);
-        }
+    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_0);
 
-        addr_mod_t {
-            .srcb     = {.incr = 8},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_1);
-
-        addr_mod_t {
-            .srcb     = {.cr = 1},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_2);
-
-        if (tensor_shape.num_faces_c_dim == 2)
-        {
-            addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 32},
-                .fidelity = {.clr = 1},
-            }
-                .set(ADDR_MOD_3);
-        }
-        else
-        {
-            addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 16},
-                .fidelity = {.clr = 1},
-            }
-                .set(ADDR_MOD_3);
-        }
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 1},
+        .dest = {.incr = 1},
     }
-    else
-    {
-        addr_mod_t {
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_0);
+        .set(ADDR_MOD_1);
 
-        if constexpr (type == PoolType::MAX)
-        {
-            addr_mod_t {
-                .srcb = {.incr = 8},
-                .dest = {.incr = 8},
-            }
-                .set(ADDR_MOD_1);
-        }
-        else if constexpr (high_fidelity)
-        {
-            addr_mod_t {
-                .fidelity = {.incr = 1},
-            }
-                .set(ADDR_MOD_1);
-        }
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 8},
+        .dest = {.incr = 8},
+    }
+        .set(ADDR_MOD_2);
+
+    if constexpr (high_fidelity)
+    {
+        addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = fidelity_increment}}.set(ADDR_MOD_3);
     }
 }
 
 /**
- * @brief Configure the math (FPU) thread for a reduce operation: programs address mods and the MOP.
+ * @brief Build the high-fidelity reduce MOP: a multi-phase GAPOOL sequence (one inner-loop iteration per fidelity phase).
+ *
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam math_fidelity: Math fidelity for controlling precision; sets the inner-loop length, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ */
+template <ReduceDim dim, MathFidelity math_fidelity>
+inline void reduce_configure_mop()
+{
+    constexpr int inner_loop_len = to_underlying(math_fidelity);
+    if constexpr (dim == ReduceDim::REDUCE_SCALAR)
+    {
+        ckernel_template tmp(1, inner_loop_len, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 4));
+        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
+        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 4));
+        tmp.program();
+    }
+    else
+    {
+        ckernel_template tmp(1, inner_loop_len, TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_3, p_gpool::INDEX_DIS, 0));
+        tmp.set_last_inner_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
+        tmp.set_last_outer_loop_instr(TT_OP_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0));
+        tmp.program();
+    }
+}
+
+/**
+ * @brief Configure the math (FPU) thread for a reduce operation: programs address mods and, for high fidelity, the pool MOP.
  *
  * @tparam type: Pooling op, values = <SUM/AVG/MAX>
  * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
- * @param tensor_shape: Tile shape describing tile dimensions.
- * @note Call @ref _llk_math_reduce_ with matching template args after this function,
- *       and @ref _llk_math_reduce_uninit_ after the last reduce to restore modified state.
+ * @tparam enforce_fp32_accumulation: Force FP32 accumulation (requires is_fp32_dest_acc_en).
+ * @note @ref _llk_math_reduce_ runs the configured reduction with matching template args.
  */
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
-inline void _llk_math_reduce_init_(const ckernel::TensorShape& tensor_shape)
+template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool enforce_fp32_accumulation = false>
+inline void _llk_math_reduce_init_()
 {
-    reduce_configure_addrmod<type, dim, math_fidelity>(tensor_shape);
-    reduce_configure_mop<type, dim, math_fidelity>(tensor_shape);
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
 
+    reduce_configure_addrmod<type, math_fidelity>();
+    if constexpr (high_fidelity)
+    {
+        reduce_configure_mop<dim, math_fidelity>();
+    }
+
+    if constexpr (enforce_fp32_accumulation)
+    {
+        static_assert(is_fp32_dest_acc_en, "FP32 Dest must be enabled for FP32 accumulation");
+    }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
 
 /**
- * @brief Uninitialize after a reduce operation, undoing any init/execute-time workarounds.
+ * @brief Uninitialize after a reduce operation.
  *
- * @note Reverses @ref _llk_math_reduce_init_
+ * Currently a no-op: the FP32 transpose path in @ref reduce_row_perform_transpose saves and restores
+ * every register it touches (SrcA format override, zero-flag), so there is no init/execute-time state
+ * left to undo here.
+ *
+ * @tparam enforce_fp32_accumulation: Must match the value used at init.
+ * @param srca_data_format: Unused; retained for API symmetry with the matching init/uninit signature.
+ * @note Reverses @ref _llk_math_reduce_init_.
  */
-inline void _llk_math_reduce_uninit_()
+template <bool enforce_fp32_accumulation = false>
+inline void _llk_math_reduce_uninit_([[maybe_unused]] const std::uint32_t srca_data_format)
 {
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
@@ -49,8 +49,6 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     // pool_type == PoolType::MAX sets the clear value to neginf if the pool-type is MAX and 0 if the pool-type is AVG/SUM
     static constexpr std::uint32_t clear_pool_dep_srca =
         TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, (pool_type == PoolType::MAX) ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC);
-    static constexpr std::uint32_t clear_pool_dep_srcb =
-        TT_OP_UNPACR_NOP(p_unpacr_nop::UNP1, (pool_type == PoolType::MAX) ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC);
     static constexpr std::uint32_t clear_zero_srca = TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, p_unpacr_nop::UNP_ZEROSRC);
 
     constexpr std::uint32_t REPLAY_BUF_LEN = 2;
@@ -64,22 +62,12 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     constexpr std::uint32_t outerloop = 1;
     const std::uint32_t innerloop     = tensor_shape.total_num_faces();
 
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-
     // Padding should only be done when using tiny tiles otherwise the entire face overwrites the data read in Math
     if (tensor_shape.face_r_dim < FACE_R_DIM) // Using tiny faces
     {
-        // Swapped REDUCE_ROW: data is in SrcB, pad SrcB; otherwise data is in SrcA, pad SrcA
-        if constexpr (swap_operands)
-        {
-            ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srcb, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
-        else
-        {
-            ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
+        // Fill SrcA with pool-type dependent padding value for tiny tiles before unpacking a face
+        ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
+        tmp.program();
     }
     else // Using standard faces (face_r_dim = FACE_R_DIM)
     {
@@ -109,38 +97,29 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
  *
  * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
  * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam enforce_fp32_accumulation: Configure the ALU for FP32 accumulation (MOVB2D hi16/lo16 path).
  * @param tensor_shape: Shape of the tensor, including face_r_dim and num_faces.
  *
- * @note For SUM/AVG REDUCE_ROW, operands are swapped: scaler→SrcA, data→SrcB.
- * @note For MAX REDUCE_ROW, original layout is kept: data→SrcA (transposed via haloize), scaler→SrcB.
- * @note For REDUCE_COL/REDUCE_SCALAR: Unpacker 0 (SrcA) reads face_r_dim*FACE_R_DIM datums,
- *       Unpacker 1 (SrcB) reads one row (FACE_R_DIM datums).
+ * @note For REDUCE_ROW operations, the face is transposed using haloize mode.
+ * @note Unpacker 0 (SrcA) reads face_r_dim*FACE_R_DIM datums.
+ * @note Unpacker 1 (SrcB) reads one row (FACE_R_DIM datums).
  * @ref _llk_unpack_AB_reduce_ is the matching execute call.
- * @ref _llk_math_reduce_init_ is the matching init on the math thread (this is the scaler operand unpack pairing).
+ * @ref _llk_math_reduce_init_ is the matching init on the math thread (this is the scaler-operand unpack pairing).
  */
-template <PoolType pool_type, ReduceDim reduce_dim>
+template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
 inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
-    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>((reduce_dim == ReduceDim::REDUCE_ROW));
+    // Enable transpose (haloize mode) if reducing along rows
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(reduce_dim == ReduceDim::REDUCE_ROW);
 
+    // Sets up Unpacker 0 to read face_r_dim*16 datums into SrcA register
     config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
 
-    // UNP_B reads data faces (face_r_dim rows) in swapped mode, or a single
-    // scaler row in the non-swapped (MAX / COL / SCALAR) mode.
-    if constexpr (swap_operands)
-    {
-        config_unpacker_x_end<p_setadc::UNP_B>(tensor_shape.face_r_dim);
-    }
-    else
-    {
-        config_unpacker_x_end<p_setadc::UNP_B>(1);
-    }
+    // Sets up Unpacker 1 to read one row (16 datums) into SrcB register
+    config_unpacker_x_end<p_setadc::UNP_B>(1);
 
     // Configure unpack MOP
     _llk_unpack_AB_reduce_mop_config_<pool_type, reduce_dim>(tensor_shape);
@@ -178,17 +157,8 @@ inline void _llk_unpack_AB_reduce_(const std::uint32_t address_a, const std::uin
     // Wait for free context
     wait_for_next_context(2);
 
-    // SUM/AVG REDUCE_ROW: swap operands so scaler→SrcA, data→SrcB
-    // MAX REDUCE_ROW: keep original order (data→SrcA, scaler→SrcB)
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-    if constexpr (swap_operands)
-    {
-        _llk_unpack_configure_addresses_(address_b, address_a, cfg);
-    }
-    else
-    {
-        _llk_unpack_configure_addresses_(address_a, address_b, cfg);
-    }
+    // Validate and configure addresses
+    _llk_unpack_configure_addresses_(address_a, address_b, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -7,6 +7,18 @@
 #include "llk_defs.h"
 
 /**
+ * @brief Determines whether a reduce operation should use the matmul path.
+ *
+ * SUM/AVG along REDUCE_ROW uses matmul_tiles (col-0 scaler).
+ * All other combinations use reduce_tile LLK (row-0 scaler).
+ */
+template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim>
+constexpr bool reduce_uses_matmul() {
+    return (pool_type == ckernel::PoolType::SUM || pool_type == ckernel::PoolType::AVG) &&
+           reduce_dim == ckernel::ReduceDim::REDUCE_ROW;
+}
+
+/**
  * @brief Determines whether a reduce operation should use the SFPU path.
  *
  * Int32 MAX and SUM on REDUCE_ROW/COL use SFPU (GMPOOL/matmul have no Int32 support).
@@ -26,16 +38,4 @@ constexpr bool is_sfpu_reduce_path() {
         return false;
     }
     return reduce_dim == ckernel::ReduceDim::REDUCE_ROW || reduce_dim == ckernel::ReduceDim::REDUCE_COL;
-}
-
-/**
- * @brief Whether the FPU reduce path swaps SrcA/SrcB operands.
- *
- * REDUCE_ROW SUM/AVG uses matmul with scaler in SrcA and data in SrcB (the opposite of the
- * default data→SrcA, scaler→SrcB ordering). This does not apply to MAX (which uses GMPOOL)
- * or to the SFPU path (Int32), which bypasses matmul entirely.
- */
-template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim, bool is_sfpu>
-constexpr bool reduce_swaps_operands() {
-    return (reduce_dim == ckernel::ReduceDim::REDUCE_ROW) && (pool_type != ckernel::PoolType::MAX) && !is_sfpu;
 }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -11,6 +11,7 @@
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/typecast.h"
+#include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/pack.h"
 #include "api/debug/assert.h"
@@ -107,6 +108,28 @@ ALWI void reduce_post_mul_tile(uint32_t dst, uint32_t scaler_bits) {
 
 }  // namespace detail
 
+// HiFi4 fidelity for matmul-based reduce (higher precision than kernel default)
+constexpr ckernel::MathFidelity REDUCE_MATMUL_FIDELITY = ckernel::MathFidelity::HiFi4;
+
+// Matmul wrappers that use REDUCE_MATMUL_FIDELITY instead of MATH_FIDELITY
+ALWI void reduce_with_matmul_init(uint32_t in0_dfb_id, uint32_t in1_dfb_id) {
+    state_configure(in1_dfb_id, in0_dfb_id);
+    MATH((llk_math_matmul_init<REDUCE_MATMUL_FIDELITY, MM_THROTTLE>(in0_dfb_id, in1_dfb_id, 0)));
+    UNPACK((llk_unpack_AB_matmul_init(in0_dfb_id, in1_dfb_id, 0)));
+}
+
+ALWI void reduce_with_matmul_init_with_dt(uint32_t in0_dfb_id, uint32_t in1_dfb_id, uint32_t c_in_old_srca) {
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(c_in_old_srca, in1_dfb_id)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(c_in_old_srca, in1_dfb_id)));
+    reduce_with_matmul_init(in0_dfb_id, in1_dfb_id);
+}
+
+ALWI void reduce_matmul_tiles(
+    uint32_t in0_dfb_id, uint32_t in1_dfb_id, uint32_t in0_tile_index, uint32_t in1_tile_index, uint32_t idst) {
+    UNPACK((llk_unpack_AB_matmul(in0_dfb_id, in1_dfb_id, in0_tile_index, in1_tile_index)));
+    MATH((llk_math_matmul<REDUCE_MATMUL_FIDELITY, MM_THROTTLE>(idst)));
+}
+
 // =============================================================================
 // ReduceDataFormatReconfigMode Helper Functions
 // =============================================================================
@@ -141,18 +164,15 @@ constexpr bool manages_cb(ReduceInputPolicy p) {
 
 template <PoolType reduce_type, ReduceDim reduce_dim>
 ALWI void reduce_init_short_with_dt(uint32_t old_dfb_id, uint32_t input_dfb_id, uint32_t scaler_dfb_id) {
-    constexpr bool swap_operands = reduce_swaps_operands<reduce_type, reduce_dim, false>();
-    const uint32_t srca_dfb_id = swap_operands ? scaler_dfb_id : input_dfb_id;
-
-    // Reconfigure SRCA data format from old_dfb_id to the correct SrcA format
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_dfb_id, srca_dfb_id)));
-    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_dfb_id, srca_dfb_id)));
+    // Reconfigure SRCA data format from old_dfb_id to input_dfb_id (similar to copy_tile_to_dst_init_short_with_dt)
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_dfb_id, input_dfb_id)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_dfb_id, input_dfb_id)));
 
     // Reconfigure unpacker for reduce operation (SRCA and SRCB)
     UNPACK((llk_unpack_AB_reduce_init<reduce_type, reduce_dim>(input_dfb_id, scaler_dfb_id)));
 
     // Reconfigure math for reduce operation
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(input_dfb_id, scaler_dfb_id)));
+    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>()));
 
     // Skip packer reconfiguration - it remains valid from initial reduce_init call
 }
@@ -171,6 +191,7 @@ template <
     ReduceDim reduce_dim,
     DataFormat reduce_format,
     typename AccumulateT,
+    bool use_matmul = false,
     bool is_sfpu = false>
 ALWI void reload_accumulator_if_needed(
     DataflowBuffer& accum_dfb, uint32_t input_dfb_id, uint32_t scaler_dfb_id, const AccumulateT& accumulate) {
@@ -178,8 +199,7 @@ ALWI void reload_accumulator_if_needed(
         if (!accumulate.is_first()) {  // Reload on all iterations except first
             constexpr uint32_t onetile = 1;
             accum_dfb.wait_front(onetile);
-            constexpr bool swap_operands = reduce_swaps_operands<reduce_type, reduce_dim, is_sfpu>();
-            const uint32_t prev_srca_cb = swap_operands ? scaler_dfb_id : input_dfb_id;
+            const uint32_t prev_srca_cb = use_matmul ? scaler_dfb_id : input_dfb_id;
 
             // For MAX + REDUCE_ROW, GMPOOL's running accumulator lives at row 0 of face 0
             // (max for rows 0-15) and row 0 of face 2 (max for rows 16-31); faces 1 and 3
@@ -205,6 +225,8 @@ ALWI void reload_accumulator_if_needed(
             // Pass accumulator DFB as old_dfb_id to reconfigure data format from accumulator to input DFB
             if constexpr (is_sfpu) {
                 detail::sfpu_reduce_fold_init<reduce_type, reduce_format>();
+            } else if constexpr (use_matmul) {
+                reduce_with_matmul_init_with_dt(input_dfb_id, scaler_dfb_id, accumulate.config.cb_accumulator);
             } else {
                 reduce_init_short_with_dt<reduce_type, reduce_dim>(
                     accumulate.config.cb_accumulator, input_dfb_id, scaler_dfb_id);
@@ -315,7 +337,10 @@ ALWI void reduce(
     const uint32_t Wt = input_block_shape.cols;
     const uint32_t num_batches = input_block_shape.batches;
 
+    // is_sfpu wins over use_matmul: SUM/AVG on REDUCE_ROW would normally use matmul, but Int32 SUM
+    // has no FPU/matmul support, so it takes the SFPU path instead (matmul would force a float accumulate).
     constexpr bool is_sfpu = is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format>();
+    constexpr bool use_matmul = reduce_uses_matmul<reduce_type, reduce_dim>() && !is_sfpu;
 
     DataflowBuffer input_dfb(input_dfb_id);
     DataflowBuffer scaler_dfb(scaler_dfb_id);
@@ -326,9 +351,8 @@ ALWI void reduce(
     }());
 
     // Apply reconfig based on mode
-    constexpr bool swap_operands = reduce_swaps_operands<reduce_type, reduce_dim, is_sfpu>();
     if constexpr (reconfig_input(reconfig_mode)) {
-        if constexpr (swap_operands) {
+        if constexpr (use_matmul) {
             reconfig_data_format(scaler_dfb_id, input_dfb_id);
         } else {
             reconfig_data_format(input_dfb_id, scaler_dfb_id);
@@ -341,6 +365,8 @@ ALWI void reduce(
     if constexpr (is_sfpu) {
         init_sfpu(input_dfb_id, output_dfb_id);
         copy_tile_to_dst_init_short(input_dfb_id);
+    } else if constexpr (use_matmul) {
+        reduce_with_matmul_init(input_dfb_id, scaler_dfb_id);
     } else {
         reduce_init<reduce_type, reduce_dim>(input_dfb_id, scaler_dfb_id, output_dfb_id);
     }
@@ -383,7 +409,7 @@ ALWI void reduce(
             tile_regs_acquire();
 
             // Reload accumulator if needed (zero overhead when AccumulateT is NoAccumulation)
-            reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, is_sfpu>(
+            reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, false, is_sfpu>(
                 accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
 
             const uint32_t dst_idx = get_dst_index(accumulate);
@@ -469,7 +495,7 @@ ALWI void reduce(
                 tile_regs_acquire();
 
                 // Reload accumulator if needed (zero overhead when AccumulateT is NoAccumulation)
-                reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, is_sfpu>(
+                reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, use_matmul, is_sfpu>(
                     accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
                 if constexpr (is_sfpu) {
                     if (Wt > 1) {
@@ -497,15 +523,27 @@ ALWI void reduce(
                     } else if constexpr (waits_per_tile(input_policy)) {
                         // One-at-a-time: wait/pop per tile
                         input_dfb.wait_front(onetile);
-                        reduce_tile<reduce_type, reduce_dim>(input_dfb_id, scaler_dfb_id, 0, 0, dst_idx);
+                        if constexpr (use_matmul) {
+                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, 0, 0, dst_idx);
+                        } else {
+                            reduce_tile<reduce_type, reduce_dim>(input_dfb_id, scaler_dfb_id, 0, 0, dst_idx);
+                        }
                         input_dfb.pop_front(onetile);
                     } else if constexpr (waits_bulk(input_policy)) {
                         // BulkWaitBulkPop: use indexed access
-                        reduce_tile<reduce_type, reduce_dim>(
-                            input_dfb_id, scaler_dfb_id, wt, 0, dst_idx);
+                        if constexpr (use_matmul) {
+                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, wt, 0, dst_idx);
+                        } else {
+                            reduce_tile<reduce_type, reduce_dim>(
+                                input_dfb_id, scaler_dfb_id, wt, 0, dst_idx);
+                        }
                     } else {  // PreloadedPolicy or PersistentPolicy: indexed access
-                        reduce_tile<reduce_type, reduce_dim>(
-                            input_dfb_id, scaler_dfb_id, wt + index_offset, 0, dst_idx);
+                        if constexpr (use_matmul) {
+                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, wt + index_offset, 0, dst_idx);
+                        } else {
+                            reduce_tile<reduce_type, reduce_dim>(
+                                input_dfb_id, scaler_dfb_id, wt + index_offset, 0, dst_idx);
+                        }
                     }
                 }
 
@@ -590,7 +628,7 @@ ALWI void reduce(
                 tile_regs_acquire();
 
                 // Reload accumulator if needed (zero overhead when AccumulateT is NoAccumulation)
-                reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, is_sfpu>(
+                reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, false, is_sfpu>(
                     accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
                 if constexpr (is_sfpu) {
                     if (Ht > 1) {
@@ -689,8 +727,8 @@ ALWI void reduce(
     // Cleanup
     if constexpr (is_sfpu) {
         PACK((llk_pack_reduce_mask_clear()));
-    } else {
-        reduce_uninit();
+    } else if constexpr (!use_matmul) {
+        reduce_uninit<>();
     }
 }
 

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp
@@ -14,7 +14,7 @@ using ckernel::PoolType;
 using ckernel::ReduceDim;
 
 // Default reduce factor for SUM and MAX pool types (scaler is always 1.0).
-// Named constant for SUM and MAX where reduce_factor is unused.
+// Named constant to use when you need to pass reduce_factor explicitly to reach compute_uses_reduce_tile.
 constexpr uint32_t SUM_AND_MAX_REDUCE_FACTOR = 1;
 
 // =============================================================================
@@ -42,20 +42,27 @@ constexpr uint32_t SUM_AND_MAX_REDUCE_FACTOR = 1;
  *
  * Converts the float scaler to the appropriate bit representation based on
  * the DataflowBuffer's data format, then fills the tile with the scaler in
- * the row-0 layout required by the reduce LLK.
+ * the layout required by the reduction:
+ *   - Row-0 fill (reduce LLK path): used for REDUCE_COL, REDUCE_SCALAR, and MAX
+ *   - Col-0 fill (matmul path): used for REDUCE_ROW with SUM or AVG
  *
  * Data format and tile shape (half/full) are deduced from the DataflowBuffer.
  *
  * @tparam dfb_id DataflowBuffer ID to write the entry to (must be constexpr)
- * @tparam pool_type Type of pooling operation (SUM, AVG, MAX)
- * @tparam reduce_dim Reduction dimension (REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR)
+ * @tparam pool_type Type of pooling operation (SUM, AVG, MAX). Default MAX selects row-0 fill.
+ * @tparam reduce_dim Reduction dimension (REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR).
+ *         Default REDUCE_COL selects row-0 fill.
+ * @tparam compute_uses_reduce_tile When true, forces row-0 fill (reduce LLK layout) even for
+ *         SUM/AVG + REDUCE_ROW combinations that would normally use col-0 fill (matmul layout).
+ *         Set to true when the compute kernel uses reduce_tile LLK directly instead of
+ *         compute_kernel_lib::reduce (which auto-switches to matmul for REDUCE_ROW SUM/AVG).
  * @param scaler_f Float scaler value to fill the entry with
  * @param valid_reduce_dim_elements_in_tile Number of valid elements along the reduce dimension
  *        in the tile (1-32, default 32 = full tile). When the last tile along the reduce
  *        dimension is partially filled, this specifies how many row or column elements contain
  *        valid data; the remaining positions are zeroed out so they do not affect the result.
  */
-template <uint32_t dfb_id, PoolType pool_type, ReduceDim reduce_dim>
+template <uint32_t dfb_id, PoolType pool_type, ReduceDim reduce_dim, bool compute_uses_reduce_tile = false>
 FORCE_INLINE void prepare_reduce_scaler(
     float scaler_f, uint32_t valid_reduce_dim_elements_in_tile = tt::constants::TILE_WIDTH);
 
@@ -75,12 +82,21 @@ FORCE_INLINE void prepare_reduce_scaler(
  * @tparam reduce_dim Reduction dimension (REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR)
  * @tparam reduce_factor Number of elements being reduced (N). Must be set for AVG;
  *         use SUM_AND_MAX_REDUCE_FACTOR (default) for SUM and MAX.
+ * @tparam compute_uses_reduce_tile When true, forces row-0 fill (reduce LLK layout) even for
+ *         SUM/AVG + REDUCE_ROW combinations that would normally use col-0 fill (matmul layout).
+ *         Set to true when the compute kernel uses reduce_tile LLK directly instead of
+ *         compute_kernel_lib::reduce (which auto-switches to matmul for REDUCE_ROW SUM/AVG).
  * @param valid_reduce_dim_elements_in_tile Number of valid elements along the reduce dimension
  *        in the tile (1-32, default 32 = full tile). When the last tile along the reduce
  *        dimension is partially filled, this specifies how many row or column elements contain
  *        valid data; the remaining positions are zeroed out so they do not affect the result.
  */
-template <uint32_t dfb_id, PoolType pool_type, ReduceDim reduce_dim, uint32_t reduce_factor = SUM_AND_MAX_REDUCE_FACTOR>
+template <
+    uint32_t dfb_id,
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    uint32_t reduce_factor = SUM_AND_MAX_REDUCE_FACTOR,
+    bool compute_uses_reduce_tile = false>
 FORCE_INLINE void calculate_and_prepare_reduce_scaler(
     uint32_t valid_reduce_dim_elements_in_tile = tt::constants::TILE_WIDTH);
 

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl
@@ -10,6 +10,7 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/dfb_helpers_dataflow.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 
 namespace dataflow_kernel_lib {
 
@@ -37,6 +38,26 @@ FORCE_INLINE uint32_t float_to_scaler_bits(float value) {
         // Float16_b (bfloat16): pack two bf16 values into one uint32
         uint16_t bf16 = static_cast<uint16_t>(bits >> 16);
         return (static_cast<uint32_t>(bf16) << 16) | bf16;
+    }
+}
+
+// =============================================================================
+// Float to col-0 scaler bit conversion (matmul-based reduce)
+// =============================================================================
+
+template <DataFormat data_format>
+FORCE_INLINE uint32_t float_to_col0_scaler_bits(float value) {
+    static_assert(
+        data_format == DataFormat::Float16_b || data_format == DataFormat::Float32,
+        "float_to_col0_scaler_bits only supports Float16_b (bfloat16) and Float32 formats");
+
+    const uint32_t bits = __builtin_bit_cast(uint32_t, value);
+
+    if constexpr (data_format == DataFormat::Float32) {
+        return bits;
+    } else {
+        // Float16_b (bfloat16): return lower 16 bits only (col 0 in the u32 pair)
+        return static_cast<uint32_t>(static_cast<uint16_t>(bits >> 16));
     }
 }
 
@@ -78,6 +99,16 @@ FORCE_INLINE void fill_face_row0_cols(volatile tt_l1_ptr uint32_t* face_ptr, uin
             // Lower 16 bits = first column in pair (RISC-V little-endian)
             face_ptr[full_pairs] = scaler & 0x0000FFFFu;
         }
+    }
+}
+
+template <DataFormat data_format>
+FORCE_INLINE void fill_face_col0_rows(volatile tt_l1_ptr uint32_t* face_ptr, uint32_t scaler, uint32_t rows_in_face) {
+    constexpr uint32_t row_size_u32 =
+        (data_format == DataFormat::Float32) ? ROW_SIZE_U32_FP32 : ROW_SIZE_U32;
+
+    for (uint32_t row = 0; row < rows_in_face; ++row) {
+        face_ptr[row * row_size_u32] = scaler;
     }
 }
 
@@ -132,10 +163,62 @@ FORCE_INLINE void fill_each_face_row0_partial(
 }
 
 // =============================================================================
+// Format-aware fill_tile_col0 (matmul-based reduce — column 0 of left-side faces)
+// =============================================================================
+
+template <DataFormat data_format, uint32_t face_rows, uint32_t faces_per_row>
+FORCE_INLINE void fill_tile_col0(volatile tt_l1_ptr uint32_t* ptr, uint32_t scaler) {
+    static_assert(
+        data_format == DataFormat::Float16_b || data_format == DataFormat::Float32,
+        "fill_tile_col0 only supports Float16_b (bfloat16) and Float32 formats");
+
+    constexpr uint32_t face_size_u32 =
+        (data_format == DataFormat::Float32) ? FACE_SIZE_U32_FP32 : FACE_SIZE_U32;
+    constexpr uint32_t ROWS_PER_FACE = 16;
+
+    for (uint32_t face_row = 0; face_row < face_rows; ++face_row) {
+        const uint32_t face_idx = face_row * faces_per_row;
+        volatile tt_l1_ptr uint32_t* face_ptr = ptr + face_idx * face_size_u32;
+        fill_face_col0_rows<data_format>(face_ptr, scaler, ROWS_PER_FACE);
+    }
+}
+
+// =============================================================================
+// Format-aware fill_tile_col0_partial — fills only first valid rows of column 0
+// =============================================================================
+
+template <DataFormat data_format, uint32_t face_rows, uint32_t faces_per_row>
+FORCE_INLINE void fill_tile_col0_partial(
+    volatile tt_l1_ptr uint32_t* ptr, uint32_t scaler, uint32_t valid_reduce_dim_elements_in_tile) {
+    static_assert(
+        data_format == DataFormat::Float16_b || data_format == DataFormat::Float32,
+        "fill_tile_col0_partial only supports Float16_b (bfloat16) and Float32 formats");
+
+    constexpr uint32_t face_size_u32 =
+        (data_format == DataFormat::Float32) ? FACE_SIZE_U32_FP32 : FACE_SIZE_U32;
+    constexpr uint32_t ROWS_PER_FACE = 16;
+
+    for (uint32_t face_row = 0; face_row < face_rows; ++face_row) {
+        const uint32_t face_row_start = face_row * ROWS_PER_FACE;
+        uint32_t rows_in_face = 0;
+        if (valid_reduce_dim_elements_in_tile > face_row_start) {
+            const uint32_t remaining = valid_reduce_dim_elements_in_tile - face_row_start;
+            rows_in_face = remaining < ROWS_PER_FACE ? remaining : ROWS_PER_FACE;
+        }
+
+        if (rows_in_face > 0) {
+            const uint32_t face_idx = face_row * faces_per_row;
+            volatile tt_l1_ptr uint32_t* face_ptr = ptr + face_idx * face_size_u32;
+            fill_face_col0_rows<data_format>(face_ptr, scaler, rows_in_face);
+        }
+    }
+}
+
+// =============================================================================
 // Prepare CB tile for reduce using a caller-provided float scaler
 // =============================================================================
 
-template <uint32_t dfb_id, PoolType pool_type, ReduceDim reduce_dim>
+template <uint32_t dfb_id, PoolType pool_type, ReduceDim reduce_dim, bool compute_uses_reduce_tile>
 FORCE_INLINE void prepare_reduce_scaler(float scaler_f, uint32_t valid_reduce_dim_elements_in_tile) {
     constexpr DataFormat data_format = get_dataformat(dfb_id);
     constexpr uint32_t tile_r_dim = get_tile_r_dim<dfb_id>();
@@ -156,6 +239,11 @@ FORCE_INLINE void prepare_reduce_scaler(float scaler_f, uint32_t valid_reduce_di
 
     ASSERT(valid_reduce_dim_elements_in_tile > 0);
 
+    // Matmul-based reduce uses col-0 fill; reduce LLK uses row-0 fill
+    constexpr bool use_matmul = !compute_uses_reduce_tile && reduce_uses_matmul<pool_type, reduce_dim>();
+
+    // Full element count along the reduce axis: cols for REDUCE_ROW, rows for REDUCE_COL.
+    // Unused for REDUCE_SCALAR (which always fills the full tile).
     constexpr uint32_t full_dim = (reduce_dim == ReduceDim::REDUCE_COL) ? tile_r_dim : tile_c_dim;
 
     DataflowBuffer dfb(dfb_id);
@@ -167,16 +255,28 @@ FORCE_INLINE void prepare_reduce_scaler(float scaler_f, uint32_t valid_reduce_di
     noc.async_write_zeros(dfb, get_tile_size(dfb_id));
     noc.write_zeros_l1_barrier();
 
-    uint32_t scaler = float_to_scaler_bits<data_format>(scaler_f);
-    if (scaler != 0) {
-        if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
-            fill_each_face_row0<data_format, num_faces>(addr_to_l1_ptr(write_addr), scaler);
-        } else {
+    if constexpr (use_matmul) {
+        uint32_t scaler = float_to_col0_scaler_bits<data_format>(scaler_f);
+        if (scaler != 0) {
             if (valid_reduce_dim_elements_in_tile == full_dim) {
+                fill_tile_col0<data_format, face_rows, faces_per_row>(addr_to_l1_ptr(write_addr), scaler);
+            } else {
+                fill_tile_col0_partial<data_format, face_rows, faces_per_row>(
+                    addr_to_l1_ptr(write_addr), scaler, valid_reduce_dim_elements_in_tile);
+            }
+        }
+    } else {
+        uint32_t scaler = float_to_scaler_bits<data_format>(scaler_f);
+        if (scaler != 0) {
+            if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
                 fill_each_face_row0<data_format, num_faces>(addr_to_l1_ptr(write_addr), scaler);
             } else {
-                fill_each_face_row0_partial<data_format, reduce_dim, face_rows, faces_per_row>(
-                    addr_to_l1_ptr(write_addr), scaler, valid_reduce_dim_elements_in_tile);
+                if (valid_reduce_dim_elements_in_tile == full_dim) {
+                    fill_each_face_row0<data_format, num_faces>(addr_to_l1_ptr(write_addr), scaler);
+                } else {
+                    fill_each_face_row0_partial<data_format, reduce_dim, face_rows, faces_per_row>(
+                        addr_to_l1_ptr(write_addr), scaler, valid_reduce_dim_elements_in_tile);
+                }
             }
         }
     }
@@ -211,7 +311,8 @@ template <
     uint32_t dfb_id,
     PoolType pool_type,
     ReduceDim reduce_dim,
-    uint32_t reduce_factor>
+    uint32_t reduce_factor,
+    bool compute_uses_reduce_tile>
 FORCE_INLINE void calculate_and_prepare_reduce_scaler(uint32_t valid_reduce_dim_elements_in_tile) {
     // -------------------------------------------------------------------------
     // 1. Compute scaler value
@@ -238,7 +339,7 @@ FORCE_INLINE void calculate_and_prepare_reduce_scaler(uint32_t valid_reduce_dim_
     // -------------------------------------------------------------------------
     // 2. Fill the DFB with the computed scaler
     // -------------------------------------------------------------------------
-    prepare_reduce_scaler<dfb_id, pool_type, reduce_dim>(scaler_f, valid_reduce_dim_elements_in_tile);
+    prepare_reduce_scaler<dfb_id, pool_type, reduce_dim, compute_uses_reduce_tile>(scaler_f, valid_reduce_dim_elements_in_tile);
 }
 
 }  // namespace dataflow_kernel_lib

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
@@ -127,7 +127,8 @@ void kernel_main() {
     cb_push_back(cb_x2, num_tiles_per_block);
 
     // E(x^2)
-    reconfig_data_format(cb_scaler, cb_x2);
+    reconfig_data_format_srca(cb_in, cb_x2);
+    reconfig_data_format_srcb(cb_in, cb_scaler);
 
     cb_wait_front(cb_x2, num_tiles_per_block);
     cb_wait_front(cb_scaler, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -66,7 +66,8 @@ void kernel_main() {
         cb_in_2,
         ckernel::PoolType::AVG,
         ckernel::ReduceDim::REDUCE_ROW,
-        block_w * tt::constants::TILE_WIDTH>();
+        block_w * tt::constants::TILE_WIDTH,
+        /*compute_uses_reduce_tile=*/true>();
 
     if constexpr (is_all_to_all_worker) {
         const uint32_t scalar_c_bits = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
@@ -306,7 +306,7 @@ void normalize_scores(
     CircularBuffer cb_reciprocal_sums(cb_reciprocal_sums_id);
     CircularBuffer cb_epsilon_scalar(cb_epsilon_scalar_id);
     CircularBuffer cb_normalized_scores(cb_normalized_scores_id);
-    reconfig_data_format(cb_reduce_ones_scalar_id, cb_gathered_sigmoid_id);
+    reconfig_data_format(cb_gathered_sigmoid_id, cb_reduce_ones_scalar_id);
     pack_reconfig_data_format(cb_normalized_scores_id);
     reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
         cb_gathered_sigmoid_id, cb_reduce_ones_scalar_id, cb_reduce_intermediate_id);

--- a/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/compute.cpp
@@ -307,10 +307,9 @@ void kernel_main() {
     cb_reduce_scalar.reserve_back(1);
 
     tile_regs_acquire();
-    reconfig_data_format(cb_bcast_scaler_id, cb_softmax_tmp_id);
-    reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_softmax_tmp_id, cb_bcast_scaler_id, cb_reduce_scalar_id);
+    reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW, true>(cb_softmax_tmp_id, cb_bcast_scaler_id, cb_reduce_scalar_id);
     reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_softmax_tmp_id, cb_bcast_scaler_id, 0, 0, 0);
-    reduce_uninit(cb_reduce_scalar_id);
+    reduce_uninit<true>(cb_reduce_scalar_id);
     recip_tile_init();
     recip_tile(0);
     tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/reader_layernorm_preallgather_dit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/reader_layernorm_preallgather_dit.cpp
@@ -29,7 +29,8 @@ void kernel_main() {
         cb_reduce,
         ckernel::PoolType::SUM,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
 
     const auto src_a = TensorAccessor(src_args, src_addr);
 

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/numeric.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/numeric.h
@@ -71,11 +71,8 @@ inline void accumulate_compute_loop(
     constexpr bool sync_full_block = input_policy::sync_full_block;
 
     auto accumulate_cb = [cb_scalar, block_size, cb_out, num_tiles, last_tile_partial](CircularBuffer& cb) {
-        constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (reduce_type != PoolType::MAX);
-        if constexpr (swap_operands) {
-            reconfig_data_format(cb_scalar.get_cb_id(), cb.get_cb_id());
-        }
-        reduce_init<reduce_type, reduce_dim>(cb.get_cb_id(), cb_scalar.get_cb_id(), cb_out.get_cb_id());
+        reduce_init<reduce_type, reduce_dim, FLOAT32_REDUCTION>(
+            cb.get_cb_id(), cb_scalar.get_cb_id(), cb_out.get_cb_id());
         for (auto block : generic::blocks(num_tiles, block_size)) {
             const auto num_previous_tiles = pop_input ? 0 : block.start();
             const auto curr_block_size = sync_full_block ? block.full_block_size() : block.size();
@@ -84,7 +81,7 @@ inline void accumulate_compute_loop(
             for (auto j : block.local()) {
                 // If it's the last tile and it's partial, use the second tile in cb_scalar
                 const auto scaler_tile_idx = block.to_global(j) == num_tiles - 1 && last_tile_partial ? 1 : 0;
-                reduce_tile<reduce_type, reduce_dim>(
+                reduce_tile<reduce_type, reduce_dim, FLOAT32_REDUCTION>(
                     cb.get_cb_id(), cb_scalar.get_cb_id(), num_previous_tiles + j, scaler_tile_idx, detail::dst0);
             }
             if constexpr (pop_input) {
@@ -106,8 +103,7 @@ inline void accumulate_compute_loop(
         }
     }
 
-    reduce_uninit();
-    reconfig_data_format(cb_in.get_cb_id(), cb_scalar.get_cb_id());
+    reduce_uninit<FLOAT32_REDUCTION>();
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -190,11 +190,13 @@ void kernel_main() {
             cb_xmm2.wait_front(block.full_block_size());
 
             // Accumulate (x-E[x])^2
-            reconfig_data_format(cb_scaler_id, cb_xmm2_id);
-            reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_xmm2_id, cb_scaler_id, cb_accumulate_id);
+            reconfig_data_format(cb_xmm2_id, cb_scaler_id);
+            reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(
+                cb_xmm2_id, cb_scaler_id, cb_accumulate_id);
             for (auto i : block.local()) {
                 const auto scaler_tile_idx = block.to_global(i) == Wt - 1 && last_tile_is_partial ? 1 : 0;
-                reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_xmm2_id, cb_scaler_id, i, scaler_tile_idx, dst0);
+                reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(
+                    cb_xmm2_id, cb_scaler_id, i, scaler_tile_idx, dst0);
             }
 
             cb_xmm2.pop_front(block.full_block_size());
@@ -207,7 +209,7 @@ void kernel_main() {
                 mul_unary_tile(dst0, generic::bit_cast<uint32_t>(1.0f / W));
             }
 
-            reduce_uninit();
+            reduce_uninit<FLOAT32_REDUCTION>();
             tile_regs_commit();
             tile_regs_wait();
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -179,8 +179,8 @@ void kernel_main() {
 
     // global reduce, cb_ex_id <-- cb_ex_external_id, cb_ex_partial_id
     if constexpr (is_allgather_worker) {
-        reconfig_data_format(cb_scaler_global_id, cb_ex_external_id);
-        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_ex_external_id, cb_scaler_global_id, cb_ex_id);
+        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW, FP32_DEST_ACC>(
+            cb_ex_external_id, cb_scaler_global_id, cb_ex_id);
         cb_ex.reserve_back(num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -188,7 +188,7 @@ void kernel_main() {
             tile_regs_acquire();
             for (uint32_t w = 0; w < num_blocks_reduce; w++) {
                 cb_ex_external.wait_front(1);
-                reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(
+                reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW, FP32_DEST_ACC>(
                     cb_ex_external_id, cb_scaler_global_id, 0, scaler0, dst0);
                 cb_ex_external.pop_front(1);
             }
@@ -201,9 +201,8 @@ void kernel_main() {
             pack_tile(dst0, cb_ex_id);
             tile_regs_release();
         }
-        reduce_uninit();
+        reduce_uninit<FP32_DEST_ACC>();
         cb_ex.push_back(num_tiles_per_allgather_worker);
-        reconfig_data_format(cb_ex_external_id, cb_scaler_global_id);
         cb_ex.wait_front(num_tiles_per_allgather_worker);
     }
 
@@ -292,8 +291,8 @@ void kernel_main() {
 
     // global reduce, cb_ex_id <-- cb_ex_external_id, cb_ex_partial_id
     if constexpr (is_allgather_worker) {
-        reconfig_data_format(cb_scaler_global_id, cb_ex_external2_id);
-        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_ex_external2_id, cb_scaler_global_id, cb_ex2_id);
+        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW, FP32_DEST_ACC>(
+            cb_ex_external2_id, cb_scaler_global_id, cb_ex2_id);
         cb_ex2.reserve_back(num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -302,7 +301,7 @@ void kernel_main() {
             tile_regs_acquire();
             for (uint32_t w = 0; w < num_blocks_reduce; w++) {
                 cb_ex_external2.wait_front(1);
-                reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(
+                reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW, FP32_DEST_ACC>(
                     cb_ex_external2_id, cb_scaler_global_id, 0, scaler0, dst0);
                 cb_ex_external2.pop_front(1);
             }
@@ -315,9 +314,8 @@ void kernel_main() {
             pack_tile(dst0, cb_ex2_id);
             tile_regs_release();
         }
-        reduce_uninit();
+        reduce_uninit<FP32_DEST_ACC>();
         cb_ex2.push_back(num_tiles_per_allgather_worker);
-        reconfig_data_format(cb_xmm2_id, cb_scaler_id);
 
         if (enable_sqrt) {
             for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -128,12 +128,11 @@ void kernel_main() {
 #endif
 
             cb_scaler_global_obj.wait_front(1);
-            reconfig_data_format(cb_scaler_global, cb_stats);
-            reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_scaler_global, cb_var);
+            reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(cb_stats, cb_scaler_global, cb_var);
             tile_regs_acquire();
             // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
             for (uint32_t w = 0; w < stats_tiles * num_distributed_blocks; w++) {
-                reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(
+                reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(
                     cb_stats,
                     cb_scaler_global,
                     0,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -188,7 +188,8 @@ void kernel_main() {
     // global reduce, cb_ex <-- cb_ex_external2_id, cb_ex_partial2_id
     if constexpr (is_allgather_worker) {
         cb_scaler_global.wait_front(1);
-        reconfig_data_format(cb_scaler_global_id, cb_ex_external2_id);
+        reconfig_data_format_srca(cb_x2_id, cb_ex_external2_id);
+        reconfig_data_format_srcb(cb_scaler_id, cb_scaler_global_id);
         pack_reconfig_data_format(cb_reduction_out);
         reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_ex_external2_id, cb_scaler_global_id, cb_reduction_out);
         CircularBuffer(cb_reduction_out)

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -134,14 +134,16 @@ void kernel_main() {
             cb_scaler,
             ckernel::PoolType::SUM,
             ckernel::ReduceDim::REDUCE_ROW,
-            dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+            dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+            /*compute_uses_reduce_tile=*/true>();
 
         if constexpr (partial_last_tile_cols > 0) {
             dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
                 cb_scaler,
                 ckernel::PoolType::SUM,
                 ckernel::ReduceDim::REDUCE_ROW,
-                dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>(partial_last_tile_cols);
+                dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+                /*compute_uses_reduce_tile=*/true>(partial_last_tile_cols);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
@@ -125,14 +125,16 @@ void kernel_main() {
             cb_in_2,
             ckernel::PoolType::SUM,
             ckernel::ReduceDim::REDUCE_ROW,
-            dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+            dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+            /*compute_uses_reduce_tile=*/true>();
 
         if constexpr (partial_last_tile_cols > 0) {
             dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
                 cb_in_2,
                 ckernel::PoolType::SUM,
                 ckernel::ReduceDim::REDUCE_ROW,
-                dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>(partial_last_tile_cols);
+                dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+                /*compute_uses_reduce_tile=*/true>(partial_last_tile_cols);
         }
     }
     constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -75,14 +75,16 @@ void kernel_main() {
             cb_in_2,
             ckernel::PoolType::SUM,
             ckernel::ReduceDim::REDUCE_ROW,
-            dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+            dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+            /*compute_uses_reduce_tile=*/true>();
         constexpr uint32_t partial_last_tile_cols = W % tt::constants::TILE_WIDTH;
         if constexpr (partial_last_tile_cols > 0) {
             dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
                 cb_in_2,
                 ckernel::PoolType::SUM,
                 ckernel::ReduceDim::REDUCE_ROW,
-                dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>(partial_last_tile_cols);
+                dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+                /*compute_uses_reduce_tile=*/true>(partial_last_tile_cols);
         }
     }
     constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
@@ -67,8 +67,11 @@ void kernel_main() {
             constexpr uint32_t cb_in_4 = get_named_compile_time_arg_val("cb_in_4");
             const uint32_t scalar_c_bits = get_arg_val<uint32_t>(0);
             float scalar_c_f = __builtin_bit_cast(float, scalar_c_bits);
-            dataflow_kernel_lib::prepare_reduce_scaler<cb_in_4, ckernel::PoolType::AVG, ckernel::ReduceDim::REDUCE_ROW>(
-                scalar_c_f);
+            dataflow_kernel_lib::prepare_reduce_scaler<
+                cb_in_4,
+                ckernel::PoolType::AVG,
+                ckernel::ReduceDim::REDUCE_ROW,
+                /*compute_uses_reduce_tile=*/true>(scalar_c_f);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_pre_all_gather.cpp
@@ -20,7 +20,10 @@ void kernel_main() {
         constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
         const uint32_t scalar_c_bits = get_arg_val<uint32_t>(0);
         float scalar_c_f = __builtin_bit_cast(float, scalar_c_bits);
-        dataflow_kernel_lib::prepare_reduce_scaler<cb_in_4, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>(
-            scalar_c_f);
+        dataflow_kernel_lib::prepare_reduce_scaler<
+            cb_in_4,
+            ckernel::PoolType::SUM,
+            ckernel::ReduceDim::REDUCE_ROW,
+            /*compute_uses_reduce_tile=*/true>(scalar_c_f);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
@@ -70,8 +70,11 @@ void kernel_main() {
             constexpr uint32_t cb_in_4 = get_named_compile_time_arg_val("cb_in_4");
             const uint32_t scalar_c_bits = get_arg_val<uint32_t>(0);
             float scalar_c_f = __builtin_bit_cast(float, scalar_c_bits);
-            dataflow_kernel_lib::prepare_reduce_scaler<cb_in_4, ckernel::PoolType::AVG, ckernel::ReduceDim::REDUCE_ROW>(
-                scalar_c_f);
+            dataflow_kernel_lib::prepare_reduce_scaler<
+                cb_in_4,
+                ckernel::PoolType::AVG,
+                ckernel::ReduceDim::REDUCE_ROW,
+                /*compute_uses_reduce_tile=*/true>(scalar_c_f);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -127,7 +127,7 @@ void kernel_main() {
         constexpr int onetile = 1;
         constexpr int dst0 = 0;
 
-        reconfig_data_format(cb_reduce, cb_stats);
+        reconfig_data_format(cb_stats, cb_reduce);
         pack_reconfig_data_format(cb_stats_reduced);
 
         /*
@@ -135,17 +135,17 @@ void kernel_main() {
          * cb_stats = [sum(x0**2), sum(x0), sum(x1**2), sum(x1), ...]
          * RMSNorm packs mean(x**2) into cb_var. Layernorm just uses cb_stats_reduced.
          */
-        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_reduce, cb_stats_reduced);
+        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(cb_stats, cb_reduce, cb_stats_reduced);
         cb_wait_front(cb_stats, stats_tiles_cols);
 
         tile_regs_acquire();
         // Reduce sum(x**2) first
         for (uint32_t i = 0; i < stats_tiles_cols; i += stats_tile_stride) {
-            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_reduce, i, 0, 0);
+            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(cb_stats, cb_reduce, i, 0, 0);
         }
         // Reduce sum(x) next
         for (uint32_t i = 1; i < stats_tiles_cols; i += stats_tile_stride) {
-            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_reduce, i, 0, 1);
+            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(cb_stats, cb_reduce, i, 0, 1);
         }
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
@@ -67,7 +67,8 @@ void kernel_main() {
         cb_reduce,
         ckernel::PoolType::SUM,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
     if (is_merge_core) {
         dataflow_kernel_lib::prepare_zero_tile<cb_zero>();
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -99,7 +99,8 @@ void kernel_main() {
         cb_reduce,
         ckernel::PoolType::AVG,
         ckernel::ReduceDim::REDUCE_ROW,
-        reduce_factor>();
+        reduce_factor,
+        /*compute_uses_reduce_tile=*/true>();
     const uint32_t eps = get_arg_val<uint32_t>(5);
     generate_bcast_col_scalar(CircularBuffer(cb_eps), eps);
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -234,8 +234,7 @@ void kernel_main() {
                     UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                         in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce)));
                     // init math for reduction again since FPU gets reprogrammed by tilize
-                    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(
-                        in_cb_id_0, in_scalar_cb_id_0)));
+                    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
 #ifdef ARCH_BLACKHOLE
                     // need this on BH to set swizzle bit before pack untilize dest
                     MATH((llk_math_reconfig_remap(true)));

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -188,10 +188,6 @@ void kernel_main() {
                     }
                 }
                 pack_reconfig_data_format(cb_acc);
-                constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-                if constexpr (swap_operands) {
-                    reconfig_data_format(cb_scaler, cb_ineg);
-                }
                 reduce_init<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, cb_acc);
                 for (uint32_t i = 0; i < ntiles; ++i) {
                     reduce_tile<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, i, 0, i);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
@@ -75,10 +75,6 @@ void kernel_main() {
                     copy_tile_init(cb_acc);
                     copy_tile(cb_acc, 0, reduce_dst_idx);
                 }
-                constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-                if constexpr (swap_operands) {
-                    reconfig_data_format(cb_scaler, cb_ineg);
-                }
                 reduce_init<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, cb_acc);
                 reduce_tile<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, 0, 0, reduce_dst_idx);
                 reduce_uninit();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -150,10 +150,6 @@ void kernel_main() {
                 }
 
                 cb_ineg_obj.wait_front(onetile);
-                constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
-                if constexpr (swap_operands) {
-                    reconfig_data_format(cb_scaler, cb_ineg);
-                }
                 reduce_init<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, cb_acc);
                 reduce_tile<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, 0, 0, dst_idx);
                 reduce_uninit();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -266,7 +266,8 @@ void kernel_main() {
         cb_identity_scale_in,
         ckernel::PoolType::MAX,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
 
     // Lightweight mask: generate all mask tiles once into single CB before the ring loop.
     // Only needed when any K/joint dimension has padding that doesn't fill a chunk.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
@@ -64,7 +64,8 @@ void kernel_main() {
         cb_identity_scale_in,
         ckernel::PoolType::MAX,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
     generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
 
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -501,7 +501,8 @@ void kernel_main() {
         cb_identity_scale_in,
         ckernel::PoolType::MAX,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
 
     // Lightweight mask: generate all mask tiles once into single CB before the ring loop.
     // Needed when any K/joint dimension has padding, or when causal/chunked masking is active.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
@@ -64,8 +64,12 @@ void kernel_main() {
     const auto v = TensorAccessor(v_args, v_addr);
 
     // Reduce identity scaler; softmax scale is applied in compute.
-    dataflow_kernel_lib::
-        calculate_and_prepare_reduce_scaler<cb_scale, ckernel::PoolType::MAX, ckernel::ReduceDim::REDUCE_ROW>();
+    dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
+        cb_scale,
+        ckernel::PoolType::MAX,
+        ckernel::ReduceDim::REDUCE_ROW,
+        /*reduce_factor=*/1,
+        /*compute_uses_reduce_tile=*/true>();
 
     // Col-identity for final row-sum reduction.
     generate_bcast_col_scalar(experimental::CB(cb_col_identity), one_bf16_packed);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -63,7 +63,8 @@ void kernel_main() {
         cb_scale,
         ckernel::PoolType::MAX,
         ckernel::ReduceDim::REDUCE_ROW,
-        /*reduce_factor=*/1>();
+        /*reduce_factor=*/1,
+        /*compute_uses_reduce_tile=*/true>();
 
     // Col-identity (column 0 = 1.0): compute matmul-reduces the partial row-sum against it to finalize the
     // within-tile reduction in normalize_row_streaming.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -91,7 +91,8 @@ void kernel_main() {
         cb_identity_scale_in,
         ckernel::PoolType::MAX,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
     generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
 
     // Lightweight mask: generate template tiles once, leave permanently fronted.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -210,7 +210,8 @@ void kernel_main() {
         cb_identity_scale_in,
         ckernel::PoolType::MAX,
         ckernel::ReduceDim::REDUCE_ROW,
-        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
+        dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+        /*compute_uses_reduce_tile=*/true>();
     dataflow_kernel_lib::prepare_zero_tile<cb_zero_in>();
     generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
 


### PR DESCRIPTION
## P0: Revert #47311 to unblock Gemma-4 PCC regression across all tiers

**This is a revert-to-unblock.** #47311 is itself a valid Blackhole reduce bug-fix (#48157), so this revert reintroduces that BH issue — see the forward-fix ask below. Merging is a P0-CI tradeoff for the LLK owners to weigh.

### Symptom
Gemma-4 began failing PCC across every tier and both architectures in the scheduled `main` runs of 2026-06-30:

| Test | Model / SKU | PCC | Threshold |
|---|---|---|---|
| `test_full_model` | 26B-A4B (1x8) | 0.764 | 0.95–0.98 |
| `test_full_model` | E2B (1x1) | 0.845 | 0.90 |
| `test_full_model` | 12B (1x4) | 0.931 | 0.95 |
| `test_attention_paged_decode_via_harness[full-1x1]` | E2B, **WH & BH** | **0.986292053127704 (bit-identical)** | 0.99 |

### Root cause — bisected on hardware
`git bisect` on N150 over the 55-commit window (bisect-dispatch run 28531742382) → **`FOUND IT: 0c6d81a9a73... is the first bad commit`** (#47311). Probes bracket it exactly: `479c6da`/`2259b4f` **pass** → `0c6d81a9a73` **fails at 0.986292** → `d81dff` fails.

Per #47311's own description, for REDUCE_ROW SUM/AVG it removed the 32-bit transpose, rewrote the reduce to a swapped-operand MVMUL, and **"the `enforce_fp32_accumulation` parameter is completely removed and precision is now controlled via `math_fidelity`."** That is a small reduce **precision** loss (softmax denominator / RMSNorm mean), not a correctness break — hence PCC 0.986 rather than garbage. It's below other models' looser bars but trips Gemma-4's tight thresholds, and compounds through depth to the −0.22 full-model drop on 26B. Bit-identical across WH/BH because it is the same shared `reduce.h` algorithm on both.

### Fix validated on hardware
Reverting #47311 and re-running the failing test (test-dispatch run 28538851124, N150):
`PCC check: 0.9908532872840531 (threshold=0.99) [PASS]` — restores 0.986292 → **0.990853**.

### Forward-fix ask (LLK)
@markoradosavljevicTT — this revert is only to unblock CI. The proper fix should keep the #48157 Blackhole reduce fix **and** preserve reduce precision for the SDPA-softmax / RMSNorm callers (e.g. restore an FP32-accumulation path, or raise `math_fidelity` for the affected reduce, and ensure the new REDUCE_ROW-SUM `reconfig_data_format(scaler, data)` operand-swap contract is met by callers like `sdpa/device/kernels/compute/compute_common.hpp::reduce_c`). Tracking issue: https://github.com/tenstorrent/tt-metal/issues/48746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
## Before/after PCC — from actual CI logs (updated)

Last-passing = scheduled runs `28417909759` (e2e, SHA `f71c037`, 2026-06-30 03:19 UTC) and `28427980550` (unit, SHA `54a757158c`, 2026-06-30 07:32 UTC). First-failing = post-#47311. Revert-fix = test-dispatch `28538851124` (this branch).

| Test | Model / SKU (mesh) | Last-passing PCC | First-failing PCC | Δ | Threshold | Verdict |
|---|---|---|---|---|---|---|
| attention `via_harness[full-1x1]` | E2B / **wh_n150** | 0.9908532872840531 | 0.986292053127704 | **−0.00456** | 0.99 | pass→**FAIL** |
| attention `via_harness[full-1x1]` | E2B / **bh_p150** | 0.9908532872840531 | 0.986292053127704 | **−0.00456** | 0.99 | pass→**FAIL** |
| `test_full_model` | 12B / bh_quietbox_2 (blackhole-1x4) | 0.9605223506051259 | 0.9307378247614533 | **−0.0298** | 0.95 | pass→**FAIL** |
| `test_full_model` | 31B / bh_quietbox_2 (blackhole-1x4) | 0.9966404788091258 | still ≥0.99 | small | 0.99 | pass→pass (absorbed) |
| `test_full_model` | 26B-A4B / wh_llmbox (wormhole_b0-1x8) | *no CI baseline* †| 0.7639306581183913 | — | **0.80** | **FAIL** |
| `test_full_model` | E2B (1x1) | *not run in CI* ‡ | 0.845 (local) | — | 0.90 | — |

Both attention values are **bit-identical across WH and BH** (0.99085 before, 0.98629 after) — confirming the shared reduce-kernel (`reduce.h`) origin. Revert of #47311 restores the attention test to **0.990853 [PASS]**.

**Notes / caveats (accuracy):**
- † 26B-A4B has **no clean pre-regression CI baseline**: on the last-good e2e SKU (bh_quietbox_2, TP=4) the MoE full-model test is *SKIPPED* ("MoE too large for TP=4"); the 0.7639 failure is from a different SKU (wh_llmbox 1x8, TP=8, threshold **0.80**).
- ‡ E2B `test_full_model` does not run in CI (config-only stub + deselected in the unit job); the 0.845 figure is from a local run, not CI.
- The trustworthy both-sides-measured deltas are the attention `full-1x1` (**−0.00456**, wh & bh) and 12B full_model (**−0.0298**). The small per-layer error compounds through depth (48 layers + vocab projection) to the larger full-model drops.
