### PR TITLE
Fold extract into routed expert

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -118,6 +118,12 @@ void kernel_main() {
     // NoC 1 into cb_in1_up); both 0 = UP_WRITER_MCAST, reader skips up.
     constexpr uint32_t reader_reads_up = get_compile_time_arg_val(23);
     constexpr uint32_t reader_mcasts_up = get_compile_time_arg_val(24);
+    // fused_extract: 1 => x is the whole shared dispatched buffer and this
+    // expert's rows begin at start[global_id]/TILE tile-rows; the reader adds
+    // that offset to every x tile-row index (folding ttnn::extract). 0 =>
+    // legacy (x is the pre-extracted per-expert tensor, rows start at 0).
+    constexpr uint32_t fused_extract = get_compile_time_arg_val(25);
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(26);
     // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
@@ -128,7 +134,7 @@ void kernel_main() {
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t num_blocks_d = K_down_tiles_padded / in0_block_w_d;
 
-    constexpr uint32_t x_accessor_offset = 25;
+    constexpr uint32_t x_accessor_offset = 27;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
 
@@ -151,6 +157,15 @@ void kernel_main() {
     constexpr uint32_t idx_accessor_offset = counts_args.next_compile_time_args_offset();
     constexpr auto idx_args = TensorAccessorArgs<idx_accessor_offset>();
     const auto idx_acc = TensorAccessor(idx_args, idx_table_addr);
+
+    // `start` (expert_region_offsets) accessor — last in the CT accessor
+    // stream, matching the host append order. The base address is the last
+    // reader runtime arg (after the M-row NoC coord table). Used only when
+    // fused_extract; constructed unconditionally for CT-arg-layout stability.
+    const uint32_t start_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC);
+    constexpr uint32_t start_accessor_offset = idx_args.next_compile_time_args_offset();
+    constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
+    const auto start_acc = TensorAccessor(start_args, start_addr);
 
     // D2.0 NoC handles. `noc` uses default noc_index for mcasts/sem ops.
     // `noc_read` forces NoC 0 for DRAM weight/page reads — the kernel issues
@@ -204,6 +219,24 @@ void kernel_main() {
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
     const uint32_t global_expert_id = idx_ptr[local_expert_id];
     const uint32_t count_value = counts_ptr[global_expert_id];
+
+    // Fused-extract: this expert's tokens begin at start[global_id] (token row)
+    // within the shared dispatched buffer. Read the `start` page device-side
+    // and convert to tile rows; the in0 reader adds this to every x tile-row
+    // index. Mirrors the writer's direct-write offset so input slice and output
+    // slice line up on the same buffer region. 0 in legacy mode.
+    uint32_t region_offset_tiles = 0;
+    if constexpr (fused_extract != 0) {
+        CircularBuffer cb_start_scratch_obj(cb_start_scratch);
+        cb_start_scratch_obj.reserve_back(1);
+        const uint32_t start_l1 = cb_start_scratch_obj.get_write_ptr();
+        const uint32_t start_page_size = start_acc.get_aligned_page_size();
+        noc_read.async_read(start_acc, CoreLocalMem<uint32_t>(start_l1), start_page_size, {.page_id = 0}, {});
+        noc_read.async_read_barrier();
+        cb_start_scratch_obj.push_back(1);
+        const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
+        region_offset_tiles = start_ptr[global_expert_id] / 32;
+    }
     // count_value is in TOKEN rows. Convert to tile rows (ceil) then to chunks.
     // For count=0 the loop is empty (no chunks processed). For count > 0 we
     // process ceil(count_tiles / chunk_M_tiles) chunks; the remaining chunks
@@ -342,9 +375,14 @@ void kernel_main() {
                     // 0 * up = 0, 0 @ W_down = 0 (safe and free of NaN).
                     const bool row_valid = row < count_tiles;
                     if (row_valid) {
+                        // Fused-extract: x is the shared dispatched buffer, so
+                        // this expert's row `row` lives at absolute tile-row
+                        // (region_offset_tiles + row). region_offset_tiles is 0
+                        // in legacy mode (x already pre-extracted, rows at 0).
+                        const uint32_t abs_row = region_offset_tiles + row;
                         for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
                             const uint32_t col = kb * in0_block_w_gu + k;
-                            const uint32_t tile_idx = row * K_gate_tiles + col;
+                            const uint32_t tile_idx = abs_row * K_gate_tiles + col;
                             noc_read.async_read(
                                 x_acc, CoreLocalMem<uint32_t>(l1_x), x_tile_bytes, {.page_id = tile_idx}, {});
                             l1_x += x_tile_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -104,6 +104,26 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
     // Direct-write mode: expert_region_offsets present => the writer places
     // this expert's output into the SHARED optional_output buffer at the
     // expert's region offset (fusing ttnn::insert). Requires optional_output.
+    // Fused-extract mode: x is the whole shared dispatched buffer and the
+    // reader offsets its tile reads by this expert's region offset (read from
+    // expert_region_offsets device-side). fused_m_tiles is the per-expert
+    // allocated tile-row count; it must fit inside x. Always paired with
+    // direct-write (the writer places output back into the same shared buffer
+    // at the same region offset), so it requires expert_region_offsets +
+    // optional_output.
+    if (op.fused_m_tiles > 0) {
+        TT_FATAL(
+            t.expert_region_offsets.has_value(),
+            "fused-extract mode (fused_m_tiles > 0) requires expert_region_offsets");
+        TT_FATAL(t.optional_output.has_value(), "fused-extract mode (fused_m_tiles > 0) requires optional_output");
+        const uint32_t x_m_tiles = static_cast<uint32_t>(x_shape[-2]) / TILE;
+        TT_FATAL(
+            op.fused_m_tiles <= x_m_tiles,
+            "fused_m_tiles ({}) must be <= x's tile-row count ({})",
+            op.fused_m_tiles,
+            x_m_tiles);
+    }
+
     const bool direct_write = t.expert_region_offsets.has_value();
     if (direct_write) {
         const auto& start = *t.expert_region_offsets;
@@ -231,13 +251,15 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t chunk_M_tiles,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
-    const std::optional<ttnn::Tensor>& expert_region_offsets) {
+    const std::optional<ttnn::Tensor>& expert_region_offsets,
+    uint32_t fused_m_tiles) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::UnifiedRoutedExpertFfnDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .chunk_M_tiles = chunk_M_tiles,
             .local_expert_id = local_expert_id,
+            .fused_m_tiles = fused_m_tiles,
             .compute_kernel_config = compute_kernel_config},
         OperationType::tensor_args_t{
             .x = x,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
@@ -43,6 +43,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t chunk_M_tiles,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
-    const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt);
+    const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
+    uint32_t fused_m_tiles = 0);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -47,6 +47,11 @@ constexpr uint32_t CB_PARTIALS_UP = tt::CBIndex::c_13;
 // page in direct-write mode. Allocated unconditionally (negligible L1) so
 // the CB-index layout is stable across both write modes.
 constexpr uint32_t CB_START_SCRATCH = tt::CBIndex::c_14;
+// Reader-only scratch for the device-side `start` page in fused-extract mode.
+// Separate from the writer's CB_START_SCRATCH so reader (BRISC) and writer
+// (NCRISC) each fetch their own copy without a cross-RISC race. Allocated
+// unconditionally for CB-index-layout stability (negligible L1).
+constexpr uint32_t CB_START_SCRATCH_READER = tt::CBIndex::c_15;
 }  // namespace
 
 UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnProgramFactory::create(
@@ -59,7 +64,14 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const auto& gate_shape = t.gate_proj.padded_shape();
     const auto& down_shape = t.down_proj.padded_shape();
 
-    const uint32_t M_tiles_full = x_shape[-2] / TILE;
+    // Fused-extract mode: x is the whole shared dispatched buffer, so its
+    // row count is NOT the per-expert M. Use op.fused_m_tiles (= per-expert
+    // max_dispatched_tokens / TILE) as M_tiles_full for all chunk/loop math;
+    // the reader offsets its x reads by the expert's region offset. Legacy
+    // mode (fused_m_tiles == 0): x is the pre-extracted per-expert tensor and
+    // M_tiles_full comes from its shape.
+    const bool fused_extract = op.fused_m_tiles > 0;
+    const uint32_t M_tiles_full = fused_extract ? op.fused_m_tiles : (x_shape[-2] / TILE);
     const uint32_t K_gate_tiles = x_shape[-1] / TILE;            // = N_gate K = emb / TILE
     const uint32_t N_gate_tiles_full = gate_shape[-1] / TILE;    // = hidden / TILE
     const uint32_t K_down_tiles = down_shape[-2] / TILE;         // = hidden / TILE
@@ -469,6 +481,13 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             .set_page_size(CB_START_SCRATCH, start_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_cb_cfg);
 
+    // Reader's own copy of the `start` scratch (fused-extract mode). Same
+    // sizing as the writer's CB_START_SCRATCH.
+    tt::tt_metal::CircularBufferConfig start_reader_cb_cfg =
+        tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH_READER, tt::DataFormat::UInt32}})
+            .set_page_size(CB_START_SCRATCH_READER, start_scratch_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_reader_cb_cfg);
+
     // -------------------------- kernel build ------------------------------
     // Reader compile-time args. Order must exactly match the layout the reader
     // kernel reads via get_compile_time_arg_val(idx) and the TensorAccessor
@@ -506,6 +525,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         static_cast<uint32_t>(reader_reads_up),
         // reader_mcasts_up — 1 in LEGACY and UP_SPLIT (reader NoC-0 mcasts up).
         static_cast<uint32_t>(reader_mcasts_up),
+        // fused_extract — 1 => reader offsets x reads by start[global_id]/TILE
+        // (reads region from the shared dispatched buffer; folds ttnn::extract).
+        static_cast<uint32_t>(fused_extract),
+        // CB_START_SCRATCH_READER — reader's scratch for the device-side `start`
+        // page (fused-extract mode only).
+        CB_START_SCRATCH_READER,
     };
     tt::tt_metal::TensorAccessorArgs(x_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(gate_buffer).append_to(reader_ct_args);
@@ -513,6 +538,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     tt::tt_metal::TensorAccessorArgs(down_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(idx_buffer).append_to(reader_ct_args);
+    // `start` (expert_region_offsets in fused/direct mode; else x_buffer as a
+    // harmless stand-in for CT-arg layout stability). Read only when
+    // fused_extract. Mirrors the writer's start accessor.
+    tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(reader_ct_args);
 
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -770,6 +799,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             reader_args.push_back(static_cast<uint32_t>(noc.x));
             reader_args.push_back(static_cast<uint32_t>(noc.y));
         }
+        // `start` (expert_region_offsets) base address, appended last so it
+        // sits at a fixed trailing index the reader resolves from GRID_X_NOC.
+        // Read only in fused-extract mode.
+        reader_args.push_back(start_buffer->address());
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
 
         // Writer runtime arg layout (must match unified_routed_expert_ffn_writer.cpp):
@@ -829,6 +862,9 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
         reader_args[3] = down_addr;
         reader_args[4] = counts_addr;
         reader_args[5] = idx_addr;
+        // `start` base address is the last reader runtime arg (appended after
+        // the M-row NoC coord table in create()).
+        reader_args[reader_args.size() - 1] = start_addr;
 
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -42,10 +42,22 @@ struct UnifiedRoutedExpertFfnParams {
     // counts[global_id]).
     uint32_t local_expert_id = 0;
 
+    // Fused-extract mode. When > 0, `x` is NOT a pre-extracted per-expert
+    // tensor but the whole shared dispatched buffer; the reader offsets its x
+    // tile reads by this expert's region offset (start[global_id]/TILE, read
+    // device-side from `expert_region_offsets`) — folding what ttnn::extract
+    // used to do into the FFN reader. `fused_m_tiles` is the per-expert
+    // allocated tile-row count (= max_dispatched_tokens_per_expert / TILE) and
+    // replaces x.padded_shape()[-2]/TILE as M_tiles_full for all chunk/loop
+    // math. 0 = legacy mode (x is the pre-extracted per-expert tensor, reads
+    // start at row 0). Requires expert_region_offsets + optional_output set
+    // (always paired with direct-write).
+    uint32_t fused_m_tiles = 0;
+
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("chunk_M_tiles", "local_expert_id");
-    auto attribute_values() const { return std::forward_as_tuple(chunk_M_tiles, local_expert_id); }
+    static constexpr auto attribute_names = std::forward_as_tuple("chunk_M_tiles", "local_expert_id", "fused_m_tiles");
+    auto attribute_values() const { return std::forward_as_tuple(chunk_M_tiles, local_expert_id, fused_m_tiles); }
 };
 
 // Tensors fed into the op.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -5,12 +5,39 @@
 #include "unified_routed_expert_ffn.hpp"
 
 #include "device/unified_routed_expert_ffn_device_operation.hpp"
+#include "tt-metalium/constants.hpp"
 #include "tt-metalium/math.hpp"
 #include "ttnn/operations/creation/creation.hpp"
-#include "ttnn/operations/experimental/deepseek_prefill/extract/extract.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn {
+
+namespace {
+// Pick chunk_M_tiles for a given allocated M (tile rows). Factored out so both
+// the standalone wrapper (M from x's shape) and the fused MoE composite (M =
+// max_dispatched_tokens_per_expert / TILE, since x is the whole shared buffer)
+// share the exact same heuristic.
+uint32_t pick_chunk_m_tiles(uint32_t M_tiles_full) {
+    constexpr uint32_t kGridY = 8;
+    constexpr uint32_t kMinChunkMTiles = 16;  // per_core_M >= 2
+    constexpr uint32_t kMaxChunkMTiles = 64;  // per_core_M <= 8 (L1 cap)
+    uint32_t chunk_M_tiles = kMaxChunkMTiles;
+    uint32_t best_num_chunks = (M_tiles_full + kMinChunkMTiles - 1) / kMinChunkMTiles + 1;
+    uint32_t best_waste = kMaxChunkMTiles + 1;
+    for (uint32_t cand = kMinChunkMTiles; cand <= kMaxChunkMTiles; cand += kGridY) {
+        const uint32_t num_chunks = (M_tiles_full + cand - 1) / cand;
+        const uint32_t rem = M_tiles_full % cand;
+        const uint32_t waste = (rem == 0) ? 0 : (cand - rem);
+        const bool better = (num_chunks < best_num_chunks) || (num_chunks == best_num_chunks && waste < best_waste);
+        if (better) {
+            best_num_chunks = num_chunks;
+            best_waste = waste;
+            chunk_M_tiles = cand;
+        }
+    }
+    return chunk_M_tiles;
+}
+}  // namespace
 
 ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& x,
@@ -42,24 +69,8 @@ ttnn::Tensor unified_routed_expert_ffn(
     // (same num_chunks), prefers smaller waste = closer to-aligned. For
     // DS-V3 this picks 64 for nearly all sizes; 5k → 64 (3 chunks, was 40
     // with 4 chunks); 25k → 64 (13 chunks, was 40 with 20 chunks).
-    constexpr uint32_t kGridY = 8;
-    constexpr uint32_t kMinChunkMTiles = 16;  // per_core_M >= 2
-    constexpr uint32_t kMaxChunkMTiles = 64;  // per_core_M <= 8 (L1 cap)
     const uint32_t M_tiles_full = x.padded_shape()[-2] / 32;
-    uint32_t chunk_M_tiles = kMaxChunkMTiles;
-    uint32_t best_num_chunks = (M_tiles_full + kMinChunkMTiles - 1) / kMinChunkMTiles + 1;
-    uint32_t best_waste = kMaxChunkMTiles + 1;
-    for (uint32_t cand = kMinChunkMTiles; cand <= kMaxChunkMTiles; cand += kGridY) {
-        const uint32_t num_chunks = (M_tiles_full + cand - 1) / cand;
-        const uint32_t rem = M_tiles_full % cand;
-        const uint32_t waste = (rem == 0) ? 0 : (cand - rem);
-        const bool better = (num_chunks < best_num_chunks) || (num_chunks == best_num_chunks && waste < best_waste);
-        if (better) {
-            best_num_chunks = num_chunks;
-            best_waste = waste;
-            chunk_M_tiles = cand;
-        }
-    }
+    const uint32_t chunk_M_tiles = pick_chunk_m_tiles(M_tiles_full);
 
     return ttnn::prim::unified_routed_expert_ffn(
         x,
@@ -73,7 +84,8 @@ ttnn::Tensor unified_routed_expert_ffn(
         compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
                                           : std::nullopt,
         output,
-        expert_region_offsets);
+        expert_region_offsets,
+        /*fused_m_tiles=*/0);
 }
 
 ttnn::Tensor unified_routed_expert_moe(
@@ -95,56 +107,53 @@ ttnn::Tensor unified_routed_expert_moe(
     const uint32_t experts_per_chip = static_cast<uint32_t>(gate_projs.size());
     TT_FATAL(experts_per_chip > 0, "Need at least one expert per chip");
 
-    // Per-expert composite: extract this expert's tokens out of the dispatched
-    // buffer, run the unified FFN on them, and have the FFN's writer place the
-    // result DIRECTLY back into the SAME dispatched buffer at the expert's
-    // region offset (in-place direct-write mode). This fuses what used to be a
-    // separate ttnn::insert op into the FFN writer — the FFN no longer writes a
-    // per-expert temp buffer that insert then copies elsewhere; it writes the
-    // dispatched buffer in place once. Same loop applies regardless of
-    // `num_routed_experts`, and the (mutated) dispatched buffer is returned.
+    // Per-expert composite. The FFN runs in FUSED-EXTRACT + DIRECT-WRITE mode:
+    // its reader reads this expert's tokens DIRECTLY out of the shared
+    // dispatched buffer at the expert's region offset (folding what a separate
+    // ttnn::extract op used to do — no per-expert temp buffer, no extra
+    // DRAM round-trip), and its writer places the result back into the SAME
+    // dispatched buffer at the same region offset (folding ttnn::insert). One
+    // device program per expert; the (mutated) dispatched buffer is returned.
     //
-    // In-place is safe across the loop: extract for expert i copies region i out
-    // into a fresh `tokens` tensor before the FFN overwrites region i, and each
-    // expert only touches its own (non-overlapping) region, so a later expert's
-    // extract still reads its original dispatched rows.
-    //
-    // `tokens` from extract is a per-expert (max_dispatched_tokens_per_expert,
-    // emb) tensor with rows starting at 0. The FFN reads from row 0 of its
-    // inputs; passing expert_region_offsets makes the writer add
-    // expert_region_offsets[global_expert_id]/TILE tile-rows so the output lands
-    // back in this expert's slice of the dispatched buffer.
-    //
-    // No separate output allocation or zero-fill: because the FFN writes back
-    // into the existing dispatched buffer (instead of a freshly-allocated
-    // output), there is no per-call DRAM allocation and no up-front fill. Rows
-    // the FFN writer does not touch (tile-aligned slack within a region, regions
-    // of zero-count experts, and the tail of the buffer) retain their original
-    // dispatched-buffer contents, which are never read by downstream `combine`
+    // In-place read+write to the shared buffer is safe within and across the
+    // chunk loop: for a given chunk the reader reads x rows at the START of the
+    // chunk (gate/up matmul input) and the writer writes the SAME rows at the
+    // END (down matmul output), so the read always precedes the write by a
+    // compute data-dependency; each row is written exactly once, by its own
+    // chunk's writer, after its own chunk's read. Different experts touch
+    // disjoint (non-overlapping) regions. Rows the writer never touches
+    // (tile-aligned slack, zero-count experts, buffer tail) keep their original
+    // dispatched-buffer contents, which downstream `combine` never reads
     // (bounded per expert to [offset, offset + ceil_tile(count))).
+    //
+    // x is the whole shared dispatched buffer; the FFN's M_tiles_full (chunk /
+    // loop math) is driven by fused_m_tiles = max_dispatched_tokens_per_expert
+    // / TILE, NOT by x's (full-buffer) row count. The chunk_M_tiles heuristic
+    // therefore matches what the old per-expert (max_tokens, emb) tensor used.
+    constexpr uint32_t TILE = tt::constants::TILE_HEIGHT;
+    const uint32_t fused_m_tiles = (max_dispatched_tokens_per_expert + TILE - 1) / TILE;
+    const uint32_t chunk_M_tiles = pick_chunk_m_tiles(fused_m_tiles);
+    const std::optional<ttnn::DeviceComputeKernelConfig> ckc =
+        compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
+                                          : std::nullopt;
     for (uint32_t local_expert = 0; local_expert < experts_per_chip; ++local_expert) {
-        auto tokens = ttnn::extract(
+        // Fused-extract direct-write: x == output == dispatched_buffer, with
+        // expert_region_offsets so BOTH the reader (input slice) and the writer
+        // (output slice) offset into this expert's region of that same buffer.
+        // The op mutates dispatched_buffer in place; its return value is unused.
+        ttnn::prim::unified_routed_expert_ffn(
             dispatched_buffer,
-            expert_region_offsets,
-            expert_token_counts,
-            global_expert_idx_table,
-            local_expert,
-            max_dispatched_tokens_per_expert);
-        // In-place direct-write: output == dispatched_buffer, with
-        // expert_region_offsets so the writer offsets into this expert's region
-        // of that same buffer. The op mutates dispatched_buffer in place; its
-        // return value is unused (the composite returns dispatched_buffer below).
-        unified_routed_expert_ffn(
-            tokens,
             gate_projs[local_expert],
             up_projs[local_expert],
             down_projs[local_expert],
             expert_token_counts,
             global_expert_idx_table,
             local_expert,
-            compute_kernel_config,
+            chunk_M_tiles,
+            ckc,
             dispatched_buffer,
-            expert_region_offsets);
+            expert_region_offsets,
+            fused_m_tiles);
     }
     return dispatched_buffer;
 }


### PR DESCRIPTION
## Summary
On Blackhole, the routed-expert path launched a standalone `ttnn::extract` program per local expert (12 experts × 61 layers on Kimi) to copy each expert's token region into a temp tensor before the routed expert. This PR removes it. The routed expert's reader kernel now reads each expert's tokens directly from the shared dispatched buffer at its region offset. **Blackhole only**.

## Changes
- New fused-extract mode: the routed expert's reader kernel adds `start[global_id]/TILE` tile-rows to each x tile-row index (mirroring the writer's direct-write offset), so input and output line up on the same buffer.
- `unified_routed_expert_moe` no longer launches extract, drops the per-expert temp-buffer DRAM allocation and its write + re-read. In-place read + write is safe - reader reads before writer writes, each row written once, experts touch disjoint regions.

## Measurements

### Kimi Chunked Prefill (No-PCC) Per-Chunk Performance

**Configuration**
- Warm iterations: **1–9**
- Layer: **L61**
- Total iterations: **10**
- Mode: **nosvc**
- Build: **code_debug**
- Mesh: **8×4**
- Chunk size: **5120 tokens**
- ISL = `n_chunks × 5120`
- `-` = chunk absent at that ISL
- **base** = extract op present (baseline)
- **noext** = extract folded into FFN reader

| Chunk | Base (5k) | Noext (5k) | Base (25k) | Noext (25k) | Base (50k) | Noext (50k) | Base (100k) | Noext (100k) |
|------:|----------:|-----------:|-----------:|------------:|-----------:|------------:|------------:|-------------:|
| 0  | 1.394 | 1.331 | 1.483 | 1.359 | 1.438 | 1.361 | 1.440 | 1.387 |
| 1  | - | - | 1.481 | 1.360 | 1.434 | 1.367 | 1.455 | 1.391 |
| 2  | - | - | 1.481 | 1.363 | 1.433 | 1.368 | 1.458 | 1.381 |
| 3  | - | - | 1.466 | 1.355 | 1.441 | 1.358 | 1.447 | 1.389 |
| 4  | - | - | 1.483 | 1.372 | 1.446 | 1.356 | 1.449 | 1.381 |
| 5  | - | - | - | - | 1.434 | 1.364 | 1.445 | 1.385 |
| 6  | - | - | - | - | 1.442 | 1.362 | 1.448 | 1.382 |
| 7  | - | - | - | - | 1.443 | 1.366 | 1.430 | 1.383 |
| 8  | - | - | - | - | 1.453 | 1.365 | 1.454 | 1.390 |
| 9  | - | - | - | - | 1.446 | 1.368 | 1.445 | 1.382 |
| 10 | - | - | - | - | - | - | 1.442 | 1.387 |
| 11 | - | - | - | - | - | - | 1.463 | 1.421 |
| 12 | - | - | - | - | - | - | 1.449 | 1.431 |
| 13 | - | - | - | - | - | - | 1.483 | 1.460 |
| 14 | - | - | - | - | - | - | 1.512 | 1.494 |
| 15 | - | - | - | - | - | - | 1.558 | 1.538 |
| 16 | - | - | - | - | - | - | 1.609 | 1.590 |
| 17 | - | - | - | - | - | - | 1.627 | 1.609 |
| 18 | - | - | - | - | - | - | 1.707 | 1.686 |
| 19 | - | - | - | - | - | - | 1.742 | 1.720 |
| **Average** | **1.394** | **1.331** | **1.478** | **1.362** | **1.441** | **1.364** | **1.503** | **1.459** |
| **Improvement** | | **-4.6%** | | **-7.9%** | | **-5.4%** | | **-2.9%** |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/48706)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/48706)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kgrujcic/48706)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/48706)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/48706)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/48706)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/48706)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/48706)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/48706)