### PR TITLE
[Bug fix] Tolerate concurrent temp-file renames in kernel dir scan

### DIFF
--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -159,7 +159,18 @@ std::vector<tt::jit_build::GeneratedFile> read_directory_files(
             std::find(extensions.begin(), extensions.end(), entry.path().extension().string()) == extensions.end()) {
             continue;
         }
-        files.push_back({entry.path().filename().string(), read_file_bytes(entry.path().string())});
+        // Tolerate concurrent writers: another process compiling the same kernel into this
+        // shared cache dir may rename a FileRenamer temp file away between enumeration and read.
+        // Skip files that vanish or fail to read rather than aborting the whole upload.
+        try {
+            files.push_back({entry.path().filename().string(), read_file_bytes(entry.path().string())});
+        } catch (const std::runtime_error& e) {
+            log_debug(
+                tt::LogBuildKernels,
+                "Skipping file that could not be read during directory scan of {}: {}",
+                dir,
+                e.what());
+        }
     }
     return files;
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
When the JIT compile server runs with multiple processes sharing a cache dir, read_directory_files could enumerate a FileRenamer temp file and then fail to read it after another process renamed it to its target, throwing "Cannot read file". Skip files that fail to read during the scan instead of aborting the whole upload.

Fixes #48408

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/fix-jit-compile-server-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/fix-jit-compile-server-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ruizhang/fix-jit-compile-server-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/fix-jit-compile-server-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/fix-jit-compile-server-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/fix-jit-compile-server-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/fix-jit-compile-server-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/fix-jit-compile-server-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/fix-jit-compile-server-race)