### PR TITLE
[Cleanup] Replace inferred Gen1 DM Config with explicit factory function

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -106,9 +106,8 @@ inline KernelSpec MakeMinimalGen1DMKernel(
     };
 }
 
-// Helper to create a minimal valid KernelSpec for data movement that relies on a
-// Gen1 role hint (READER/WRITER) to fill in the hardware config, rather than
-// supplying an explicit Gen1Config (Gen1/WH/BH).
+// Helper to create a minimal valid KernelSpec for data movement whose Gen1 config is built
+// from a READER/WRITER role via Gen1Config::create_from_role (Gen1/WH/BH).
 inline KernelSpec MakeMinimalRoleDMKernel(const std::string& name, DataMovementRoleHint role) {
     return KernelSpec{
         .unique_id = KernelSpecName{name},
@@ -116,7 +115,7 @@ inline KernelSpec MakeMinimalRoleDMKernel(const std::string& name, DataMovementR
         .num_threads = 1,
         .hw_config =
             DataMovementHardwareConfig{
-                .role = role,
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(role),
             },
     };
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2854,14 +2854,14 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
 }
 
 TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
-    // On Gen1, a DM kernel that declares neither a role hint nor an explicit Gen1Config must be
-    // rejected: it has no way to resolve its processor/NOC placement.
+    // On Gen1, a DM kernel with no Gen1Config must be rejected: it has no way to resolve its
+    // processor/NOC placement.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.name = "test_program";
 
-    // MakeMinimalDMKernel produces a gen2 (Quasar) DM config (UNSPECIFIED role, no Gen1Config).
+    // MakeMinimalDMKernel produces a gen2 (Quasar) DM config (no Gen1Config).
     auto kernel = MakeMinimalDMKernel("dm_kernel");
 
     spec.kernels = {kernel};
@@ -2869,7 +2869,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("specifies neither a role hint")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("has no Gen1 config")));
 }
 
 TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
@@ -2925,27 +2925,6 @@ TEST_F(ProgramSpecTestGen1, TwoReaderRolesOnSameNodeConflict) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
-}
-
-TEST_F(ProgramSpecTestGen1, RoleHintWithExplicitGen1ConfigFails) {
-    // A role hint and an explicit Gen1Config are mutually exclusive: the hint already fills
-    // in the config, so supplying both is contradictory and must be rejected.
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "test_program";
-
-    auto kernel = MakeMinimalRoleDMKernel("dm_kernel", DataMovementRoleHint::READER);
-    auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-    dm_config.gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1};
-
-    spec.kernels = {kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("sets both a READER/WRITER role hint and an explicit Gen1 config")));
 }
 
 // WH N150 mock grid reference (wormhole_N150.yaml, harvest_mask=0x40 = 1 row harvested):

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2485,6 +2485,22 @@ static_assert(
     std::is_aggregate_v<CrossNodeDataflowBufferSpec>,
     "CrossNodeDataflowBufferSpec must remain an aggregate to support designated initializers");
 
+// DataMovementHardwareConfig::Gen1Config::create_from_role builds the conventional Gen1 placement
+// for a READER/WRITER kernel: READER -> NCRISC (RISCV_1) on NOC_0; WRITER -> BRISC (RISCV_0) on NOC_1.
+TEST(DataMovementHardwareConfig, Gen1ConfigCreateFromRole) {
+    using Gen1Config = DataMovementHardwareConfig::Gen1Config;
+
+    const auto reader = Gen1Config::create_from_role(DataMovementRoleHint::READER);
+    EXPECT_EQ(reader.processor, DataMovementProcessor::RISCV_1);
+    EXPECT_EQ(reader.noc, NOC::NOC_0);
+    EXPECT_EQ(reader.noc_mode, NOC_MODE::DM_DEDICATED_NOC);
+
+    const auto writer = Gen1Config::create_from_role(DataMovementRoleHint::WRITER);
+    EXPECT_EQ(writer.processor, DataMovementProcessor::RISCV_0);
+    EXPECT_EQ(writer.noc, NOC::NOC_1);
+    EXPECT_EQ(writer.noc_mode, NOC_MODE::DM_DEDICATED_NOC);
+}
+
 // These tests document the intended construction pattern using designated initializers.
 // They serve as living documentation and will fail to compile if aggregate status is broken.
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -663,7 +663,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .semaphore_bindings = {{.semaphore_spec_name = SemaphoreSpecName{"only_sem"}, .accessor_name = "signal"}},
         .hw_config =
             DataMovementHardwareConfig{
-                .role = DataMovementRoleHint::WRITER,
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER),
             },
     };
     KernelSpec consumer{
@@ -675,7 +675,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .semaphore_bindings = {{.semaphore_spec_name = SemaphoreSpecName{"only_sem"}, .accessor_name = "waiter"}},
         .hw_config =
             DataMovementHardwareConfig{
-                .role = DataMovementRoleHint::READER,
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER),
             },
     };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -25,10 +25,10 @@ namespace tt::tt_metal::experimental {
 // architecture, so architecture-agnostic host code may populate both.
 //
 // Gen1 DM config (i.e., which RISC and NOC a kernel uses) is performance-critical,
-// but the common case is handled for you: set the `role` hint to READER or WRITER
-// and the runtime fills in the conventional processor/NOC/NOC-mode. Power users
-// who want to override that convention can provide an explicit Gen1Config
-// (alongside RoleHint::UNSPECIFIED).
+// but the common case is handled for you: build the Gen1Config with
+// Gen1Config::create_from_role(READER/WRITER), which fills in the conventional
+// processor/NOC/NOC-mode. Power users who want to override that convention construct
+// a Gen1Config directly.
 //
 // Gen2 has a unified NOC and its DM kernel core selection is fully automated.
 // The gen2_config controls only whether the ISR-based DFB implicit sync is enabled.
@@ -37,22 +37,23 @@ namespace tt::tt_metal::experimental {
 // ============================================================================
 
 struct DataMovementHardwareConfig {
-    // Declares what the DM kernel does.
-    //  - If specified, the runtime will automatically fill in an omitted Gen1Config
-    //    with the standard optimal Gen1 DM config for a READER or WRITER kernel.
-    //  - If an explicit Gen1Config is provided, set the role hint to UNSPECIFIED.
-    //  - For Gen2, the role hint is ignored / informational.
-    enum class RoleHint { READER, WRITER, UNSPECIFIED };
-    RoleHint role = RoleHint::UNSPECIFIED;
+    // Names the common DM kernel roles, used only as an argument to
+    // Gen1Config::create_from_role() to build the conventional Gen1 placement.
+    enum class RoleHint { READER, WRITER };
 
     struct Gen1Config {
         tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
         tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
         tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
+
+        // Build the conventional Gen1 placement for a READER/WRITER kernel
+        // (mirrors the legacy Reader/WriterDataMovementConfig convention):
+        //   READER -> NCRISC (RISCV_1) on NOC_0;  WRITER -> BRISC (RISCV_0) on NOC_1
+        // Power users who need a non-conventional placement construct a Gen1Config directly.
+        static Gen1Config create_from_role(RoleHint role);
     };
-    // For a Gen1 DM kernel, specifying the Gen1Config is optional.
-    // If unspecified, the runtime infers the settings from the role hint (READER/WRITER).
-    // (A Gen1 DM kernel must provide either a role hint or an explicit Gen1Config.)
+    // For a Gen1 DM kernel (Wormhole / Blackhole), specify the Gen1Config — either built via
+    // Gen1Config::create_from_role(READER/WRITER) for the common case, or constructed directly.
     std::optional<Gen1Config> gen1_config = std::nullopt;
 
     struct Gen2Config {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -46,14 +46,12 @@ struct DataMovementHardwareConfig {
         tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
         tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
 
-        // Build the conventional Gen1 placement for a READER/WRITER kernel
-        // (mirrors the legacy Reader/WriterDataMovementConfig convention):
-        //   READER -> NCRISC (RISCV_1) on NOC_0;  WRITER -> BRISC (RISCV_0) on NOC_1
-        // Power users who need a non-conventional placement construct a Gen1Config directly.
+        // Create a generic Gen1 config based on the role of the kernel.
         static Gen1Config create_from_role(RoleHint role);
     };
-    // For a Gen1 DM kernel (Wormhole / Blackhole), specify the Gen1Config — either built via
-    // Gen1Config::create_from_role(READER/WRITER) for the common case, or constructed directly.
+    // For a Gen1 DM kernel (Wormhole / Blackhole), a Gen1Config must be provided.
+    // You can build a Gen1Config either via the convenient factory function `create_from_role`,
+    // or construct it directly.
     std::optional<Gen1Config> gen1_config = std::nullopt;
 
     struct Gen2Config {

--- a/tt_metal/impl/metal2_host_api/data_movement_hardware_config.cpp
+++ b/tt_metal/impl/metal2_host_api/data_movement_hardware_config.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp>
+
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// Build the conventional Gen1 placement for a READER/WRITER kernel, mirroring the legacy
+// Reader/WriterDataMovementConfig convention (see kernel_types.cpp):
+//   READER -> NCRISC (RISCV_1) on NOC_0;  WRITER -> BRISC (RISCV_0) on NOC_1
+// NOC mode is always DM_DEDICATED_NOC; DM_DYNAMIC_NOC is a power-user knob reached only by
+// constructing a Gen1Config directly.
+DataMovementHardwareConfig::Gen1Config DataMovementHardwareConfig::Gen1Config::create_from_role(RoleHint role) {
+    switch (role) {
+        case RoleHint::READER:
+            return Gen1Config{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::NOC::NOC_0,
+                .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC};
+        case RoleHint::WRITER:
+            return Gen1Config{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt::tt_metal::NOC::NOC_1,
+                .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC};
+    }
+    TT_THROW("Unhandled RoleHint in DataMovementHardwareConfig::Gen1Config::create_from_role");
+}
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -155,31 +155,6 @@ inline bool is_gen1_arch() {
     return arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE;
 }
 
-// Resolve the effective Gen1 hardware knobs (processor, NOC, NOC mode) for a DM kernel.
-// When the user supplies a READER/WRITER role hint, the runtime fills in the conventional
-// triple, mirroring the legacy ReaderDataMovementConfig / WriterDataMovementConfig
-// convention (see kernel_types.cpp):
-//   READER -> NCRISC (RISCV_1) on NOC_0
-//   WRITER -> BRISC  (RISCV_0) on NOC_1
-// NOC mode is always DM_DEDICATED_NOC; DM_DYNAMIC_NOC is a power-user knob reached only
-// via RoleHint::UNSPECIFIED + an explicit gen1_config, which is returned verbatim.
-//
-// Precondition (guaranteed by validation on Gen1): exactly one of {a READER/WRITER role,
-// an explicit gen1_config} is present.
-DataMovementHardwareConfig::Gen1Config ResolveGen1Config(const DataMovementHardwareConfig& dm_config) {
-    using Gen1Config = DataMovementHardwareConfig::Gen1Config;
-    switch (dm_config.role) {
-        case DataMovementRoleHint::READER:
-            return Gen1Config{
-                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_0, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
-        case DataMovementRoleHint::WRITER:
-            return Gen1Config{
-                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_1, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
-        case DataMovementRoleHint::UNSPECIFIED: return dm_config.gen1_config.value();
-    }
-    TT_THROW("Unhandled RoleHint in ResolveGen1Config");
-}
-
 NodeRangeSet to_node_range_set(const Nodes& nodes) {
     return std::visit(
         [](const auto& n) -> NodeRangeSet {
@@ -776,26 +751,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (kernel.is_data_movement_kernel()) {
             const auto& data_movement_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
 
-            // A role hint and an explicit Gen1 config are mutually exclusive: a READER/WRITER
-            // hint already fills in the Gen1 config, so also supplying one is contradictory.
-            TT_FATAL(
-                data_movement_config.role == DataMovementRoleHint::UNSPECIFIED ||
-                    !data_movement_config.gen1_config.has_value(),
-                "KernelSpec '{}' sets both a READER/WRITER role hint and an explicit Gen1 config. "
-                "A role hint fills the Gen1 config for you; either drop the explicit config, or use "
-                "RoleHint::UNSPECIFIED to take manual control.",
-                kernel.unique_id);
-
-            // On Gen1 (WH/BH), the kernel must declare its placement: either a READER/WRITER role
-            // hint (the runtime fills in processor/NOC/NOC-mode), or an explicit Gen1 config. There
-            // is no safe default for reader-vs-writer — it is op-specific. Gen2 is fully optional:
-            // absence is treated as "use defaults" (implicit sync left on for all bound DFBs).
+            // On Gen1 (WH/BH), the kernel must declare its placement via a Gen1 config — either built
+            // with Gen1Config::create_from_role(READER/WRITER) or constructed directly. There is no
+            // safe default for reader-vs-writer — it is op-specific. Gen2 is fully optional: absence is
+            // treated as "use defaults" (implicit sync left on for all bound DFBs).
             if (is_gen1_arch()) {
                 TT_FATAL(
-                    data_movement_config.role != DataMovementRoleHint::UNSPECIFIED ||
-                        data_movement_config.gen1_config.has_value(),
-                    "KernelSpec '{}' targets Gen1 (WH/BH) but specifies neither a role hint "
-                    "(READER/WRITER) nor an explicit Gen1 config. One is required.",
+                    data_movement_config.gen1_config.has_value(),
+                    "KernelSpec '{}' targets Gen1 (WH/BH) but has no Gen1 config. Supply a gen1_config "
+                    "(e.g. Gen1Config::create_from_role(READER/WRITER)).",
                     kernel.unique_id);
             }
         }
@@ -811,7 +775,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 continue;
             }
             const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-            const auto gen1 = ResolveGen1Config(dm_config);
+            const auto gen1 = dm_config.gen1_config.value();
             const NodeRangeSet& nodes = collected.kernel_node_set.at(kernel.unique_id);
             for (const auto& range : nodes.ranges()) {
                 for (const auto& node : range) {
@@ -1936,9 +1900,8 @@ KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const Collec
     return result;
 }
 
-// Gen1 (WH/BH) processor assignment: read the effective processor (explicit, or derived
-// from the role hint via ResolveGen1Config) and return a KernelRiscMaskMap using the Gen1
-// bit encoding (RISCV_0: bit 0, RISCV_1: bit 1, compute: bit 2).
+// Gen1 (WH/BH) processor assignment: read the kernel's gen1_config processor and return a
+// KernelRiscMaskMap using the Gen1 bit encoding (RISCV_0: bit 0, RISCV_1: bit 1, compute: bit 2).
 KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
     static constexpr uint8_t GEN1_COMPUTE_RISC_BIT = 2;
 
@@ -1946,7 +1909,7 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
     for (const KernelSpec& kernel : spec.kernels) {
         if (kernel.is_data_movement_kernel()) {
             const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-            const auto gen1 = ResolveGen1Config(dm_config);
+            const auto gen1 = dm_config.gen1_config.value();
             result[&kernel] = static_cast<uint16_t>(1u << static_cast<uint8_t>(gen1.processor));
         } else {
             result[&kernel] = static_cast<uint16_t>(1u << GEN1_COMPUTE_RISC_BIT);
@@ -2372,7 +2335,7 @@ std::map<std::string, std::string> to_defines_map(const KernelSpec::CompilerOpti
 DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_data_movement_kernel(), "Expected a DM kernel");
     const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel_spec.hw_config);
-    const auto gen1 = ResolveGen1Config(dm_config);
+    const auto gen1 = dm_config.gen1_config.value();
 
     return DataMovementConfig{
         .processor = gen1.processor,

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -56,6 +56,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dataflow_buffer/dataflow_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_run_args.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/data_movement_hardware_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocator/algorithms/free_list_opt.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -117,7 +117,9 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         .compile_time_args =
             {{"tiles_per_channel_dim", tiles_per_channel_dim}, {"tiles_per_width_dim", tiles_per_width_dim}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block_id", "num_blocks"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer kernel (SRC1 -> DRAM) ----
@@ -140,7 +142,9 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
              {"element_size", datum_size(out_cb_data_format)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_block_id", "num_blocks", "patch_height_offset", "output_offset"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute kernels (untilize SRC0 -> SRC1) ----
@@ -354,7 +358,9 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .compile_time_args = std::move(reader_cta),
         .runtime_arg_schema = {.runtime_arg_names = {"src_index", "curr_src_row_index"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer kernel (SRC0 [+ SRC1 scratch] -> DRAM) ----
@@ -366,7 +372,9 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = std::move(writer_cta),
         .runtime_arg_schema = {.runtime_arg_names = {"dst_index"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
     // SRC0 is consumed by the writer.
     writer.dfb_bindings.push_back(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_program_factory.cpp
@@ -119,7 +119,9 @@ ttnn::device_operation::ProgramArtifacts Fold::MultiCore::create_program_artifac
                 DFBBinding{.dfb_spec_name = DST0, .accessor_name = "dst0", .endpoint_type = DFBEndpointType::PRODUCER},
             },
         .compile_time_args = make_cta(/*is_reader=*/1),
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     KernelSpec reader{
@@ -132,7 +134,9 @@ ttnn::device_operation::ProgramArtifacts Fold::MultiCore::create_program_artifac
                 DFBBinding{.dfb_spec_name = DST0, .accessor_name = "dst0", .endpoint_type = DFBEndpointType::CONSUMER},
             },
         .compile_time_args = make_cta(/*is_reader=*/0),
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Assemble the spec ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
@@ -407,7 +407,6 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithHaloProgramFactory::create_
             .source = std::filesystem::path(kReaderKernelPath),
             .hw_config =
                 DataMovementHardwareConfig{
-                    .role = DataMovementRoleHint::UNSPECIFIED,
                     .gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = processor, .noc = noc},
                 },
         };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -195,7 +195,9 @@ ttnn::device_operation::ProgramArtifacts InterleavedToShardedProgramFactory::cre
     KernelSpec reader{
         .unique_id = I2S_READER,
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = I2S_INPUT, .accessor_name = "src"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
     if (is_tile) {
         reader.source =
@@ -244,7 +246,9 @@ ttnn::device_operation::ProgramArtifacts InterleavedToShardedProgramFactory::cre
     // Writer kernel.
     KernelSpec writer{
         .unique_id = I2S_WRITER,
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
     if (dst_is_dram) {
         writer.dfb_bindings = {ConsumerOf(I2S_OUTPUT_DFB, "out")};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -181,7 +181,9 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
                      "num_output_tiles",
                      "MtNt"},
             },
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer kernel ----
@@ -203,7 +205,9 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
             {
                 .runtime_arg_names = {"num_pages", "start_id"},
             },
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute kernel(s) — one KernelSpec per core group, preserving the per-group tile-count CTA ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -6829,7 +6829,10 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
                          "last_block_h",
                          "sparsity_addr",
                      }},
-            .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+            .hw_config =
+                m2::DataMovementHardwareConfig{
+                    .gen1_config =
+                        m2::DataMovementHardwareConfig::Gen1Config::create_from_role(m2::DataMovementRoleHint::READER)},
         });
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -410,7 +410,9 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseOptimizedProgramFac
             {
                 .runtime_arg_names = {"in0_tensor_start_tile_id", "batch"},
             },
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Reader/Writer kernel (reads in1, writes output) ----
@@ -457,7 +459,9 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseOptimizedProgramFac
             {
                 .runtime_arg_names = {"in1_tensor_start_tile_id", "batch", "out_tensor_start_tile_id"},
             },
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     ComputeHardwareConfig compute_hw_config{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
@@ -165,7 +165,10 @@ ttnn::device_operation::ProgramArtifacts MoveOverlapProgramFactory::create_progr
             {
                 m2::TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"},
             },
-        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+        .hw_config =
+            m2::DataMovementHardwareConfig{
+                .gen1_config =
+                    m2::DataMovementHardwareConfig::Gen1Config::create_from_role(m2::DataMovementRoleHint::READER)},
     };
 
     // Named CTA: the stick-layout kernel needs the (unaligned) page size at compile time.
@@ -208,7 +211,10 @@ ttnn::device_operation::ProgramArtifacts MoveOverlapProgramFactory::create_progr
             {
                 m2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"},
             },
-        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+        .hw_config =
+            m2::DataMovementHardwareConfig{
+                .gen1_config =
+                    m2::DataMovementHardwareConfig::Gen1Config::create_from_role(m2::DataMovementRoleHint::WRITER)},
     };
 
     // The stick-layout writer needs the (unaligned) page size at compile time, like its reader.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
@@ -98,11 +98,9 @@ ttnn::device_operation::ProgramArtifacts MoveShardedProgramFactory::create_progr
                 m2::TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"},
                 m2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"},
             },
-        // Preserve the legacy processor/NOC selection (RISCV_1 / NOC_1) via an explicit Gen1Config;
-        // the role hint is set UNSPECIFIED when an explicit Gen1Config is provided.
+        // Preserve the legacy processor/NOC selection (RISCV_1 / NOC_1) via an explicit Gen1Config.
         .hw_config =
             m2::DataMovementHardwareConfig{
-                .role = m2::DataMovementRoleHint::UNSPECIFIED,
                 .gen1_config =
                     m2::DataMovementHardwareConfig::Gen1Config{
                         .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}},

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -221,7 +221,9 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgra
                   "start_dim_h",
                   "start_dim_c",
                   "start_dim_n"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
     if (has_pad_align) {
         reader_spec.compiler_options.defines = {{"HAS_PAD_ALIGN", "1"}};
@@ -245,7 +247,9 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgra
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .compile_time_args = writer_cta,
         .runtime_arg_schema = {.runtime_arg_names = {"num_sticks_per_core", "num_sticks_per_barrier", "start_page_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -325,7 +325,9 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactor
                   "num_local_unpadded_Y",
                   "full_unpadded_X_nbytes",
                   "num_local_W"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ------------------------------------------------------------------------
@@ -351,7 +353,9 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactor
                   "full_padded_X_nbytes",
                   "dst_stick_offset",
                   "num_local_W"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     log_debug(tt::LogOp, "ncores: {}", ncores);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -169,7 +169,9 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create
                   "num_local_unpadded_Y",
                   "full_unpadded_X_nbytes",
                   "num_local_W"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ------------------------------------------------------------------------
@@ -195,7 +197,9 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create
                   "full_padded_X_nbytes",
                   "dst_stick_offset",
                   "num_local_W"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -326,7 +326,9 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
              {"row_major_min_bytes", row_major_min_bytes},
              {"num_sticks_padded_read", static_cast<uint32_t>(stick_size_padded / row_major_min_bytes)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_cores_read"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ------------------------------------------------------------------------
@@ -356,7 +358,9 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
                   "start_dim_h",
                   "start_dim_c",
                   "start_dim_n"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -145,7 +145,9 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
              {"W_front_pad_bytes", W_padding_front_bytes},
              {"unpadded_stick_step", unpadded_stick_step},
              {"padded_stick_step", padded_stick_step}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer_spec{
@@ -160,7 +162,9 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
              {"padded_shard_height", shard_height_padded},
              {"padding_value_as_u32", padding_value_as_u32},
              {"padding_value_num_bytes", static_cast<uint32_t>(output.element_size())}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     KernelRunArgs reader_run{.kernel = READER_KERNEL};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.cpp
@@ -133,7 +133,9 @@ ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
         .compile_time_args = {{"num_dims", num_dims}, {"page_size", page_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
     reader_spec.advanced_options.num_runtime_varargs = 4 * num_dims;
 
@@ -152,7 +154,9 @@ ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_
              {"pad_value", packed_pad_value},
              {"element_size", static_cast<uint32_t>(output.element_size())}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
     writer_spec.advanced_options.num_runtime_varargs = 4 * num_dims;
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
@@ -118,7 +118,9 @@ ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_progr
                 TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // -------- Writer KernelSpec (consumes SRC0, fills PAD scratch, writes output) --------
@@ -162,7 +164,9 @@ ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_progr
                   "num_padded_Yt",
                   "num_unpadded_Xt",
                   "num_padded_Xt"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -1019,7 +1019,9 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         .tensor_bindings = make_reader_tensor_bindings(false),
         .compile_time_args = reader_cta,
         .runtime_arg_schema = {.runtime_arg_names = reader_rta_names},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     std::optional<KernelSpec> reader1;
@@ -1032,7 +1034,10 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
             .tensor_bindings = make_reader_tensor_bindings(true),
             .compile_time_args = reader1_cta,
             .runtime_arg_schema = {.runtime_arg_names = reader_rta_names},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
         };
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -146,7 +146,9 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
         .compile_time_args =
             {{"Ht", Ht}, {"Wt", Wt}, {"HtWt", HtWt}, {"scaler_bits", scaler_bits}, {"use_welford", 0u}},
         .runtime_arg_schema = {.runtime_arg_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -156,7 +158,9 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     auto make_compute = [&](const KernelSpecName& id, uint32_t compute_Wt) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -151,7 +151,9 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .compile_time_args = {{"scaler_bits", std::bit_cast<uint32_t>(scaler)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -161,7 +163,9 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute (reduce, or negate/MIN variant with INTRA self-loop acc/ineg) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -132,7 +132,6 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyLocalShardFactory<local_is
         // Preserve the legacy explicit RISCV_0 / NOC RISCV_0_default placement.
         .hw_config =
             DataMovementHardwareConfig{
-                .role = DataMovementRoleHint::UNSPECIFIED,
                 .gen1_config =
                     DataMovementHardwareConfig::Gen1Config{
                         .processor = DataMovementProcessor::RISCV_0,
@@ -150,7 +149,6 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyLocalShardFactory<local_is
         // Preserve the legacy explicit RISCV_1 / NOC RISCV_1_default placement.
         .hw_config =
             DataMovementHardwareConfig{
-                .role = DataMovementRoleHint::UNSPECIFIED,
                 .gen1_config =
                     DataMovementHardwareConfig::Gen1Config{
                         .processor = DataMovementProcessor::RISCV_1,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -86,7 +86,9 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_progr
                 {"page_size", aligned_page_size},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"start_page", "end_page"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -107,7 +109,9 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_progr
                 {"page_size", aligned_page_size},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"start_page", "end_page"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // Work split: per-core page ranges.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
@@ -790,7 +790,9 @@ ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_a
         KernelSpec k{
             .unique_id = KernelSpecName{name},
             .source = std::filesystem::path(kernel_source),
-            .hw_config = DataMovementHardwareConfig{.role = role},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(role)},
         };
         k.tensor_bindings.push_back(TensorBinding{
             .tensor_parameter_name = TensorParamName{kGenInputTensorParam}, .accessor_name = kGenInputTensorParam});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.cpp
@@ -109,7 +109,9 @@ ttnn::device_operation::ProgramArtifacts ReshardSameHeightFactory<local_is_outpu
         KernelSpec k{
             .unique_id = KernelSpecName{name},
             .source = std::filesystem::path(kernel_path),
-            .hw_config = DataMovementHardwareConfig{.role = role},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(role)},
         };
         k.tensor_bindings.push_back(TensorBinding{
             .tensor_parameter_name = TensorParamName{kSHRemoteTensorParam}, .accessor_name = kSHRemoteTensorParam});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.cpp
@@ -174,7 +174,9 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
         KernelSpec k{
             .unique_id = KernelSpecName{name},
             .source = std::filesystem::path(kernel_path),
-            .hw_config = DataMovementHardwareConfig{.role = role},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(role)},
         };
         k.tensor_bindings.push_back(TensorBinding{
             .tensor_parameter_name = TensorParamName{kSWRemoteTensorParam}, .accessor_name = kSWRemoteTensorParam});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -165,7 +165,9 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
     // Reader kernel: produces the resident input shard into the borrowed INPUT DFB (fake-push).
     KernelSpec reader{
         .unique_id = S2I_READER,
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
     reader.source =
         "ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/kernels/dataflow/"
@@ -177,7 +179,9 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
     KernelSpec writer{
         .unique_id = S2I_WRITER,
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = S2I_OUTPUT, .accessor_name = "dst"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
     writer.dfb_bindings = {ConsumerOf(writer_in_dfb, "out")};
     if (is_tile) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
@@ -296,7 +296,9 @@ ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_a
                  {"start_id", "num_sticks_per_core", "num_sticks_per_core_read", "num_read_per_barrier"},
              .common_runtime_arg_names =
                  {"addr_offset", "padded_stick_size", "unpadded_stick_size", "stick_size_offset", "misalignment"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         .advanced_options = {.num_runtime_varargs = num_dims, .num_common_runtime_varargs = 2 * num_dims},
     };
 
@@ -319,7 +321,9 @@ ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_a
                   "num_read_per_barrier",
                   "start_id",
                   "page_size_override"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // --- Per-core runtime args ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
@@ -273,7 +273,9 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedProgramFactory::create_pr
         .compile_time_args =
             {{"stick_size_padded", static_cast<uint32_t>(stick_size_padded)},
              {"stick_size_unpadded", static_cast<uint32_t>(stick_size_unpadded)}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         .advanced_options = {.num_runtime_varargs = max_varargs},
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.cpp
@@ -90,7 +90,8 @@ ttnn::device_operation::ProgramArtifacts SliceRmStrideProgramFactory::create_pro
     reader.dfb_bindings = {
         DFBBinding{.dfb_spec_name = C0, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::PRODUCER}};
     reader.tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "in"}};
-    reader.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER};
+    reader.hw_config = DataMovementHardwareConfig{
+        .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)};
 
     KernelSpec writer;
     writer.unique_id = WRITER;
@@ -98,7 +99,8 @@ ttnn::device_operation::ProgramArtifacts SliceRmStrideProgramFactory::create_pro
     writer.dfb_bindings = {
         DFBBinding{.dfb_spec_name = C0, .accessor_name = "cb_in", .endpoint_type = DFBEndpointType::CONSUMER}};
     writer.tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "out"}};
-    writer.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER};
+    writer.hw_config = DataMovementHardwareConfig{
+        .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)};
 
     const auto& slice_start = args.slice_start;
     const auto& slice_end = args.slice_end;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.cpp
@@ -104,7 +104,9 @@ ttnn::device_operation::ProgramArtifacts SliceTileProgramFactory::create_program
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "in"}},
         .compile_time_args = {{"num_dims", num_dims}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         .advanced_options = {.num_runtime_varargs = num_dims, .num_common_runtime_varargs = 2 * num_dims},
     };
 
@@ -119,7 +121,9 @@ ttnn::device_operation::ProgramArtifacts SliceTileProgramFactory::create_program
             .dfb_spec_name = C0, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "out"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // --- Per-core runtime args ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -128,7 +128,9 @@ ttnn::device_operation::ProgramArtifacts SliceTileTensorArgsProgramFactory::crea
              TensorBinding{.tensor_parameter_name = END, .accessor_name = "end"}},
         .compile_time_args = {{"num_dims", num_dims}, {"tile_width", tile_width}, {"tile_height", tile_height}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         .advanced_options = {.num_runtime_varargs = num_dims, .num_common_runtime_varargs = 3 * num_dims},
     };
 
@@ -143,7 +145,9 @@ ttnn::device_operation::ProgramArtifacts SliceTileTensorArgsProgramFactory::crea
             .dfb_spec_name = C0, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "out"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // --- Per-core runtime args ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -241,7 +241,10 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
                       "single_block_size_col_arg",
                       "sub_block_width_size",
                       "single_sub_block_size_row_arg"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         });
 
         // Writer: consumes c_16 (out); writes output tensor.
@@ -257,7 +260,10 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
                  {"total_tiles_per_row", total_tiles_per_row}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
         });
 
         // Compute: consumes c_0 (in), produces c_16 (out).

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.cpp
@@ -113,7 +113,9 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreDefaultProgramFactory::c
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_rows", "num_tiles_per_block", "block_width_size", "num_full_blocks_in_row", "start_page_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // -- Writer kernel (spans all_cores) --
@@ -129,7 +131,9 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreDefaultProgramFactory::c
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = MC_OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // -- Compute kernels (preserved multiplicity: per-group CTAs) --

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -79,7 +79,9 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreShardedProgramFactory::c
             .endpoint_type = DFBEndpointType::PRODUCER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // -- Writer kernel --
@@ -93,7 +95,9 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreShardedProgramFactory::c
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // -- Compute kernel --

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
@@ -79,7 +79,9 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreWidthShardedProgramFacto
             .endpoint_type = DFBEndpointType::PRODUCER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // -- Writer kernel --
@@ -93,7 +95,9 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreWidthShardedProgramFacto
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // -- Compute kernel --

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.cpp
@@ -117,7 +117,9 @@ ttnn::device_operation::ProgramArtifacts TilizeSingleCoreProgramFactory::create_
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_block", "block_width_size", "num_full_blocks_in_row", "start_stick_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // -- Writer kernel --
@@ -133,7 +135,9 @@ ttnn::device_operation::ProgramArtifacts TilizeSingleCoreProgramFactory::create_
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SC_OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // -- Compute kernel --

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
@@ -114,7 +114,9 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreDefaultFac
              {"page_size", page_size},
              {"size_of_valid_data_in_last_page_in_row", size_of_valid_data_in_last_page_in_row}},
         .runtime_arg_schema = {.runtime_arg_names = {"padded_X_size", "pad_value", "start_page_id", "n_block_reps"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer (Metal 2.0 fork) ----
@@ -127,7 +129,9 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreDefaultFac
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute (Metal 2.0 fork; full + cliff) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
@@ -158,7 +158,9 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingSingleCoreFactory::
                   "num_blocks_w_diff",
                   "block_row_size",
                   "block_row_leftover_size"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer (Metal 2.0 fork of writer_unary_interleaved_start_id) ----
@@ -171,7 +173,9 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingSingleCoreFactory::
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute (Metal 2.0 fork of tilize) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
@@ -128,7 +128,9 @@ ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_progr
             },
         .runtime_arg_schema =
             {.runtime_arg_names = {"N", "C", "HtWt", "batch_step", "channel_step", "num_pages", "start_id", "hw", "n"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // Writer KernelSpec.
@@ -152,7 +154,9 @@ ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_progr
                 {"write_size", stick_size},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     spec.kernels.push_back(std::move(reader));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -112,7 +112,9 @@ ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_pro
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks_per_core_read", "num_read_per_barrier", "start_id", "curr_c", "curr_h", "curr_n"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ------------------------------------------------------------------------
@@ -126,7 +128,9 @@ ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_pro
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .compile_time_args = {{"W_size_bytes", stick_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_sticks_per_core_read", "num_read_per_barrier", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -417,7 +417,10 @@ ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::creat
                       "num_sticks_per_shard_core",
                       "num_cores_read",
                       "read_stick_stride"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         };
         reader_spec.compiler_options.defines = {{"USE_SPECIAL_CASE", "1"}};
         reader_spec.advanced_options.num_runtime_varargs = max_reader_varargs;
@@ -436,7 +439,10 @@ ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::creat
                       "read_stick_stride",
                       "src_read_stick_offset",
                       "dst_write_stick_offset"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
         };
         writer_spec.advanced_options.num_runtime_varargs = max_writer_varargs;
 
@@ -500,7 +506,10 @@ ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::creat
                  {"num_cores_y", num_cores_y}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"num_sticks_per_core", "start_id", "curr_c", "curr_h", "curr_n"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         };
         reader_spec.advanced_options.num_runtime_varargs = num_cores_x + num_cores_y;
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -169,7 +169,9 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFacto
                 {"tile_width", 1u},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // Writer DFB bindings (SRC_CB consumer; PAD_CB consumer when padding).
@@ -205,7 +207,9 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFacto
             },
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_tile_idx", "end_tile_idx", "start_padding_tile_idx", "end_padding_tile_idx"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     spec.kernels.push_back(std::move(reader));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -155,7 +155,9 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_
                   "ct",
                   "ctoffs",
                   "wt"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ------------------------------------------------------------------------
@@ -169,7 +171,9 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .compile_time_args = {{"page_size", single_tile_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -152,7 +152,10 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
                  {"W_size_bytes", W * input_tensor.element_size()},
                  {"l1_write_offset_bytes", wt * input_tensor.element_size() * TILE_WIDTH}},
             .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_hw_blocks"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         };
 
         KernelSpec writer_spec{
@@ -173,7 +176,10 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
                  {"H_size_bytes", H * output_tensor.element_size()},
                  {"l1_read_offset_bytes", ht * output_tensor.element_size() * TILE_HEIGHT}},
             .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_hw_blocks"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
         };
 
         ComputeHardwareConfig compute_cfg{.fp32_dest_acc_en = fp32_dest_acc_en};
@@ -249,7 +255,10 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
             .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"num_tiles", "start_id", "start_ht", "start_wt", "Ht", "Wt", "HtWt"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
         };
 
         KernelSpec writer_spec{
@@ -262,7 +271,10 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
             .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
             .compile_time_args = {{"page_size", dst_single_tile_size}},
             .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
         };
 
         ComputeHardwareConfig compute_cfg{.fp32_dest_acc_en = fp32_dest_acc_en};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -120,7 +120,9 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::creat
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = CB_IN0, .accessor_name = "cb_in0", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer_spec{
@@ -131,7 +133,9 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::creat
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = CB_OUT0, .accessor_name = "cb_out0", .endpoint_type = DFBEndpointType::CONSUMER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     ComputeHardwareConfig compute_cfg{.fp32_dest_acc_en = fp32_dest_acc_en};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -161,7 +161,9 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
              {"Wt", wt},
              {"W_size_bytes", stick_size_bytes},
              {"l1_write_offset_bytes", wt * input_tensor.element_size() * TILE_WIDTH}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     ComputeHardwareConfig compute_cfg{.fp32_dest_acc_en = fp32_dest_acc_en};
@@ -234,7 +236,10 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
                  {"W_per_tile_last", W_per_tile_last},
                  {"H_size_bytes", H * output_tensor.element_size()},
                  {"l1_read_offset_bytes", ht * output_tensor.element_size() * TILE_HEIGHT}},
-            .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .gen1_config =
+                        DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
         };
         kernels.push_back(std::move(writer_spec));
         wu_kernels.push_back(WRITER_KERNEL);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -206,7 +206,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreBlockProgramFactory::c
              {"total_tiles_per_row", total_tiles_per_row}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -232,7 +234,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreBlockProgramFactory::c
                   "single_block_size_col_arg",
                   "sub_block_width_size",
                   "single_sub_block_size_row_arg"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -95,7 +95,9 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -104,7 +106,9 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -86,7 +86,9 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -95,7 +97,9 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -137,7 +137,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
              {"num_shards", num_shards},
              {"num_cores", num_compute_cores}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -162,7 +164,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
              {"output_tensor_width", output_tensor_width},
              {"output_tensor_height", output_tensor_height}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -110,7 +110,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
             .dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer (Metal 2.0 fork of writer_..._interleaved_parallel_columns) ----
@@ -125,7 +127,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_core", "tile_width_size", "start_stick_id", "offset_within_stick"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute (Metal 2.0 fork of untilize; full + cliff) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -168,7 +168,8 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
     reader.unique_id = READER;
     reader.dfb_bindings = {
         DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}};
-    reader.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER};
+    reader.hw_config = DataMovementHardwareConfig{
+        .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)};
     if (use_block_reader) {
         reader.source = kdir / "reader_unary_sharded_blocks_metal2.cpp";
         reader.tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}};
@@ -206,7 +207,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
                   "num_unpadded_cols_per_input_block",
                   "width_wise_output_block_start_index",
                   "num_cols_already_processed_in_first_output_block"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute KernelSpec(s) (common; full + optional interleaved cliff) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -107,7 +107,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
             .dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer (Metal 2.0 fork of writer_..._interleaved_parallel_columns) ----
@@ -122,7 +124,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_core", "tile_width_size", "start_stick_id", "offset_within_stick"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute (Metal 2.0 fork of untilize; uniform across all sub-core-grid cores) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -124,7 +124,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
             .dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_page_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer ----
@@ -142,7 +144,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
              {"num_blocks_per_output_column_row", num_blocks_per_column_row},
              {"num_tiles_per_output_block", num_tiles_per_block},
              {"output_single_block_width_size", output_single_block_width_size}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute (Metal 2.0 fork of untilize) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -195,7 +195,9 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_program_art
              {"total_tiles_per_row", total_tiles_per_row}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     KernelSpec writer{
@@ -220,7 +222,9 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_program_art
                   "single_block_size_col_arg",
                   "sub_block_width_size",
                   "single_sub_block_size_row_arg"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -116,7 +116,9 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_program_artif
              {"third_dim", third_dim},
              {"number_blocks_per_core", nblocks_per_core}},
         .runtime_arg_schema = {.runtime_arg_names = {"core_number", "tiles_per_row", "num_blocks"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer kernel ----
@@ -136,7 +138,9 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_program_artif
              {"unpadded_X_size", unpadded_row_size_bytes}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"core_number", "size_per_row_per_block", "blocks_per_core", "width_size"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute kernel (full + cliff) ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -101,7 +101,9 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_program_artifact
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer kernel ----
@@ -119,7 +121,8 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_program_artifact
             {{"float32_dtype", static_cast<uint32_t>(float32_dtype)}, {"unpadded_X_size", unpadded_row_size_bytes}},
         .runtime_arg_schema = {.runtime_arg_names = {"padded_X_size", "start_stick_id", "n_block_reps"}},
     };
-    writer.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER};
+    writer.hw_config = DataMovementHardwareConfig{
+        .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)};
 
     // ---- Compute kernels (full + cliff) ----
     KernelSpec::CompilerOptions::Defines compute_defines;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -125,7 +125,9 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_program_artifacts(
              {"num_shards", num_shards},
              {"num_cores", num_compute_cores}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ------------------------------------------------------------------------
@@ -185,7 +187,9 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_program_artifacts(
              {"output_tensor_height", output_tensor_height},
              {"tensor_rank", static_cast<uint32_t>(input.padded_shape().rank())}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
         .advanced_options =
             KernelAdvancedOptions{
                 .num_common_runtime_varargs = static_cast<uint32_t>(writer_common_runtime_args.size())},

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -145,7 +145,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreShardedPr
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ------------------------------------------------------------------------
@@ -156,7 +158,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreShardedPr
     // ------------------------------------------------------------------------
     KernelSpec writer{
         .unique_id = WRITER,
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
     if (out_sharded) {
         // Both out-sharded writers consume OUT (untilized tiles) and produce the resident OUT_SHARDED

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -137,7 +137,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingSingleCoreProgramF
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::READER)},
     };
 
     // ---- Writer kernel ----
@@ -166,7 +168,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingSingleCoreProgramF
                   "num_blocks_w_diff",
                   "block_row_size",
                   "block_row_leftover_size"}},
-        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .gen1_config = DataMovementHardwareConfig::Gen1Config::create_from_role(DataMovementRoleHint::WRITER)},
     };
 
     // ---- Compute kernel ----


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
`RoleHint` used to be a way to *infer* a `Gen1Config` when one wasn't set — a READER/WRITER hint that the runtime silently expanded into the conventional processor/NOC placement. This makes that convenience explicit instead of implicit: a `Gen1Config` is now mandatory, and the READER/WRITER shorthand becomes a plain factory, `Gen1Config::create_from_role(role)`, that the caller invokes up front. Same ergonomics for the common case, but the config is always concrete rather than something the runtime has to resolve later.

### Notes for reviewers
This is a prerequisite for type-erasing the hardware config across generations (`std::variant<Gen1Config, Gen2Config>`): a stored `role` that implicitly stands in for a `Gen1Config` has no home in a one-of-N config, so it had to become a way to *construct* a `Gen1Config` rather than a field on it.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/dmhc-role-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/dmhc-role-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/dmhc-role-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/dmhc-role-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/dmhc-role-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/dmhc-role-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/dmhc-role-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/dmhc-role-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/dmhc-role-factory)