### PR TITLE
Use default hash for BinaryNg

### DIFF
--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -242,6 +242,28 @@ TEST(CanonicalKeyTest, DistinguishesVectorBool) {
     }
 }
 
+TEST(CanonicalKeyTest, ToHashTakesPrecedenceOverReflection) {
+    struct ReflectableWithToHash {
+        uint32_t reflected_value;
+        uint32_t hash_key;
+
+        hash_t to_hash() const { return hash_objects_with_default_seed(hash_key); }
+    };
+
+    static_assert(ttsl::concepts::Reflectable<ReflectableWithToHash>);
+    static_assert(ttsl::reflection::detail::supports_to_hash_v<ReflectableWithToHash>);
+
+    const ReflectableWithToHash same_hash_left{.reflected_value = 1, .hash_key = 7};
+    const ReflectableWithToHash same_hash_right{.reflected_value = 2, .hash_key = 7};
+    const ReflectableWithToHash different_hash{.reflected_value = 1, .hash_key = 8};
+
+    EXPECT_EQ(hash_objects_with_default_seed(same_hash_left), hash_objects_with_default_seed(same_hash_right));
+    EXPECT_EQ(canonical_key(same_hash_left), canonical_key(same_hash_right));
+
+    EXPECT_NE(hash_objects_with_default_seed(same_hash_left), hash_objects_with_default_seed(different_hash));
+    EXPECT_NE(canonical_key(same_hash_left), canonical_key(different_hash));
+}
+
 // Coverage over the same adversarial set used for the hash: the exact key must be injective here
 // (it is by construction, but pin it so a future encoding change can't silently regress).
 TEST(CanonicalKeyTest, NoCollisionsOverSmall4DShapes) {

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1557,7 +1557,7 @@ inline void append_canonical(std::string& out, const T& object) {
         append_bytes(out, &h, sizeof(h));
     } else if constexpr (ttsl::concepts::Reflectable<T>) {
         reflect::for_each([&out, &object](auto I) { append_canonical(out, reflect::get<I>(object)); }, object);
-    } else if constexpr (detail::is_std_hashable_v<T>) {
+    } else if constexpr (detail::is_std_hashable_v<T>) {  // order matters, is_std_hashable_v must be after Reflectable
         const std::size_t h = std::hash<T>{}(object);  // lossy fallback
         append_bytes(out, &h, sizeof(h));
     } else {

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1552,11 +1552,11 @@ inline void append_canonical(std::string& out, const T& object) {
             append_canonical(out, it->first);
             append_canonical(out, it->second);
         }
-    } else if constexpr (ttsl::concepts::Reflectable<T>) {
-        reflect::for_each([&out, &object](auto I) { append_canonical(out, reflect::get<I>(object)); }, object);
     } else if constexpr (ttsl::reflection::detail::supports_to_hash_v<T>) {
         const hash_t h = object.to_hash();  // lossy leaf (see note above)
         append_bytes(out, &h, sizeof(h));
+    } else if constexpr (ttsl::concepts::Reflectable<T>) {
+        reflect::for_each([&out, &object](auto I) { append_canonical(out, reflect::get<I>(object)); }, object);
     } else if constexpr (detail::is_std_hashable_v<T>) {
         const std::size_t h = std::hash<T>{}(object);  // lossy fallback
         append_bytes(out, &h, sizeof(h));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -9,7 +9,6 @@
 #include "ttnn/operations/eltwise/binary/common/binary_op_utils.hpp"
 #include "binary_ng_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
-#include "ttnn/tensor/tensor_utils.hpp"
 #include <cmath>
 
 using namespace tt::tt_metal;
@@ -223,30 +222,6 @@ SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint
     }
 
     TT_THROW("Invalid subtile broadcast type");
-}
-
-ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
-    // TODO: a more generalized way to skip the hashing of an EltwiseUnaryWithParam?
-    auto base_hash = ttsl::hash::hash_objects_with_default_seed(
-        binary_op_type,
-        lhs_activations,
-        rhs_activations,
-        (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
-        memory_config,
-        get_dtype(),
-        compute_kernel_config,
-        sub_core_grids,
-        subtile_broadcast_type,
-        is_sfpu,
-        is_quant_op,
-        is_where_op,
-        input_layout_a,
-        input_layout_b,
-        output_layout);
-    if (binary_op_type == BinaryOpType::ISCLOSE) {
-        base_hash = ttsl::hash::hash_objects(base_hash, equal_nan);
-    }
-    return base_hash;
 }
 
 DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
@@ -512,32 +487,6 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor_a = tensor_args.input_tensor_a;
-    const auto& input_tensor_b = tensor_args.input_tensor_b;
-
-    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
-
-    if (input_tensor_b.has_value()) {
-        TT_FATAL(is_device_tensor(*input_tensor_b), "Unexpected Tensor type {}", input_tensor_b->storage_type());
-
-        const auto shard_volumes = get_shard_volumes(
-            input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), compute_output_specs(attributes, tensor_args));
-
-        return operation::hash_operation<BinaryNgDeviceOperation>(
-            attributes,
-            input_tensor_a.dtype(),
-            input_tensor_a.memory_config(),
-            input_tensor_b->dtype(),
-            input_tensor_b->memory_config(),
-            shard_volumes);
-    }
-
-    return operation::hash_operation<BinaryNgDeviceOperation>(
-        attributes, input_tensor_a.dtype(), input_tensor_a.memory_config());
-}
-
 bool BinaryNgDeviceOperation::skip_launch(
     const operation_attributes_t& /*attributes*/,
     const tensor_args_t& /*tensor_args*/,
@@ -694,9 +643,21 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         equal_nan,
         input_tensor_a.layout(),
         input_tensor_b.layout(),
-        output_layout};
+        output_layout,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt};
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
+    const auto shard_volumes = ttnn::operations::binary_ng::get_shard_volumes(
+        input_tensor_a.tensor_spec(),
+        input_tensor_b.tensor_spec(),
+        OperationType::compute_output_specs(operation_attributes, tensor_args));
+    if (shard_volumes.has_value()) {
+        operation_attributes.a_shard_volume = shard_volumes->a_shard_volume;
+        operation_attributes.b_shard_volume = shard_volumes->b_shard_volume;
+        operation_attributes.c_shard_volume = shard_volumes->c_shard_volume;
+    }
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
@@ -769,7 +730,10 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         /*equal_nan=*/false,
         input_tensor_a.layout(),
         Layout::INVALID,
-        output_layout};
+        output_layout,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt};
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <tuple>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/eltwise/binary_ng/types.hpp"
@@ -55,15 +58,71 @@ struct BinaryNgDeviceOperation {
         Layout input_layout_a = Layout::TILE;
         Layout input_layout_b = Layout::TILE;
         Layout output_layout = Layout::TILE;
+        std::optional<std::uint32_t> a_shard_volume;
+        std::optional<std::uint32_t> b_shard_volume;
+        std::optional<std::uint32_t> c_shard_volume;
 
-        ttsl::hash::hash_t to_hash() const;
         DataType get_dtype() const;
+
+        // Program-cache attributes. Runtime scalar/tolerance values are excluded; they are patched as runtime args.
+        static constexpr auto attribute_names = std::make_tuple(
+            "binary_op_type",
+            "lhs_activations",
+            "rhs_activations",
+            "post_activations",
+            "memory_config",
+            "dtype",
+            "compute_kernel_config",
+            "sub_core_grids",
+            "subtile_broadcast_type",
+            "is_sfpu",
+            "is_quant_op",
+            "is_where_op",
+            "input_layout_a",
+            "input_layout_b",
+            "output_layout",
+            "equal_nan",
+            "a_shard_volume",
+            "b_shard_volume",
+            "c_shard_volume");
+
+        auto attribute_values() const {
+            return std::make_tuple(
+                binary_op_type,
+                lhs_activations,
+                rhs_activations,
+                (is_where_op || is_quant_op) ? ttnn::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
+                memory_config,
+                get_dtype(),
+                compute_kernel_config,
+                sub_core_grids,
+                subtile_broadcast_type,
+                is_sfpu,
+                is_quant_op,
+                is_where_op,
+                input_layout_a,
+                input_layout_b,
+                output_layout,
+                binary_op_type == BinaryOpType::ISCLOSE ? equal_nan : false,
+                a_shard_volume,
+                b_shard_volume,
+                c_shard_volume);
+        }
     };
 
     struct tensor_args_t {
         const Tensor& input_tensor_a;
         std::optional<Tensor> input_tensor_b;
         std::optional<Tensor> output_tensor;
+
+        ttsl::hash::hash_t to_hash() const {
+            return ttsl::hash::hash_objects_with_default_seed(
+                input_tensor_a.dtype(),
+                input_tensor_a.memory_config(),
+                input_tensor_b.has_value() ? std::optional<DataType>{input_tensor_b->dtype()} : std::nullopt,
+                input_tensor_b.has_value() ? std::optional<MemoryConfig>{input_tensor_b->memory_config()}
+                                           : std::nullopt);
+        }
     };
 
     struct ProgramFactory {
@@ -78,7 +137,6 @@ struct BinaryNgDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     // Re-apply ALL per-dispatch state to the cached program on every program-cache hit — the


### PR DESCRIPTION
### PR Category
Maintenance

### Summary
Replace custom hash by the default one for BinaryNg.
In `reflection.hpp`, canonical encoding currently checks Reflectable before to_hash(), while hash_object() checks to_hash() first. Align canonical encoding with the hash order so tensor_args_t::to_hash() affects both sides of the cache key.

### Local tests, that passed

```bash
pytest \
  tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py \
  tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py \
  tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_bcast_fp32_dest_acc.py \
  tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py \
  tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py \
  tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py \
  tests/ttnn/unit_tests/operations/eltwise/test_binary_dtype_validation.py \
  -v

# POWER op via binary_ng
pytest tests/ttnn/unit_tests/operations/eltwise/test_pow.py -k binary_ng -v

# isclose / relational binary_ng coverage
pytest tests/ttnn/unit_tests/operations/eltwise/test_relational.py -k isclose -v
```



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/binary-ng-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vlad/binary-ng-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vlad/binary-ng-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/binary-ng-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vlad/binary-ng-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/binary-ng-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/binary-ng-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/binary-ng-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/binary-ng-hash)