### PR TITLE
[Feature] Dispatch telemetry SMC Control

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -5,18 +5,27 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cerrno>
 #include <chrono>
+#include <cstdlib>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <span>
+#include <string>
+#include <sys/wait.h>
 #include <thread>
+#include <unistd.h>
 #include <vector>
 
 #include <tt-metalium/experimental/dispatch_telemetry.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <umd/device/pcie/pci_device.hpp>
+#include <umd/device/tt_device/tt_device.hpp>
+#include <umd/device/types/core_coordinates.hpp>
 
 #include "command_queue_fixture.hpp"
 #include "multi_command_queue_fixture.hpp"
@@ -26,9 +35,12 @@
 #include "impl/dispatch/dispatch_mem_map.hpp"
 #include "impl/dispatch/dispatch_query_manager.hpp"
 #include "distributed/mesh_trace.hpp"
+#include "llrt/core_descriptor.hpp"
 
 namespace tt::tt_metal {
 namespace {
+
+constexpr const char* kObserverChildEnv = "TT_METAL_DISPATCH_TELEMETRY_OBSERVER_PCI_DEVICE_ID";
 
 template <typename TCoreType>
 Program create_blank_program(const TCoreType& core) {
@@ -52,11 +64,22 @@ void for_each_worker_core(const CoreRangeSet& worker_cores, Func func) {
     }
 }
 
+std::optional<std::string> smc_runtime_telemetry_unavailable_reason(tt::umd::TTDevice& tt_device) {
+    if (!tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_size().has_value()) {
+        return "SMC runtime telemetry buffer is unavailable";
+    }
+    if (!tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_address().has_value()) {
+        return "SMC runtime telemetry buffer address is unavailable or invalid";
+    }
+    return std::nullopt;
+}
+
 }  // namespace
 
 class DispatchTelemetryReadApiTest : public UnitMeshCQFixture {
 protected:
     void SetUp() override {
+        // Run setup early to instantiate mesh device
         UnitMeshCQFixture::SetUp();
         if (IsSkipped()) {
             return;
@@ -65,9 +88,17 @@ protected:
         if (MetalContext::instance().rtoptions().get_dispatch_telemetry_disabled()) {
             GTEST_SKIP() << "Dispatch telemetry is disabled";
         }
+
+        if (auto skip_reason = smc_runtime_telemetry_unavailable_reason(tt_device()); skip_reason.has_value()) {
+            GTEST_SKIP() << *skip_reason;
+        }
     }
 
     IDevice* device() const { return devices_.at(0)->get_devices().front(); }
+
+    tt::umd::TTDevice& tt_device() const {
+        return *MetalContext::instance().get_cluster().get_driver()->get_tt_device(device()->id());
+    }
 
     bool worker_dispatch_enabled() const {
         return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type() == CoreType::WORKER;
@@ -138,6 +169,7 @@ protected:
 class DispatchTelemetryMultiCQReadApiTest : public UnitMeshMultiCQSingleDeviceFixture {
 protected:
     void SetUp() override {
+        // Run setup early to instantiate mesh device
         UnitMeshMultiCQSingleDeviceFixture::SetUp();
         if (IsSkipped()) {
             return;
@@ -146,9 +178,17 @@ protected:
         if (MetalContext::instance().rtoptions().get_dispatch_telemetry_disabled()) {
             GTEST_SKIP() << "Dispatch telemetry is disabled";
         }
+
+        if (auto skip_reason = smc_runtime_telemetry_unavailable_reason(tt_device()); skip_reason.has_value()) {
+            GTEST_SKIP() << *skip_reason;
+        }
     }
 
     IDevice* device() const { return device_->get_devices().front(); }
+
+    tt::umd::TTDevice& tt_device() const {
+        return *MetalContext::instance().get_cluster().get_driver()->get_tt_device(device()->id());
+    }
 
     std::optional<CoreCoord> dispatch_s_virtual_core(uint8_t cq_id = 0) const {
         if (!MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
@@ -201,6 +241,10 @@ protected:
         }
 
         mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
+
+        if (auto skip_reason = smc_runtime_telemetry_unavailable_reason(tt_device()); skip_reason.has_value()) {
+            GTEST_SKIP() << *skip_reason;
+        }
     }
 
     void TearDown() override {
@@ -211,6 +255,10 @@ protected:
     }
 
     IDevice* device() const { return mesh_device_->get_devices().front(); }
+
+    tt::umd::TTDevice& tt_device() const {
+        return *MetalContext::instance().get_cluster().get_driver()->get_tt_device(device()->id());
+    }
 
     std::shared_ptr<distributed::MeshDevice> mesh_device_;
 };
@@ -225,6 +273,17 @@ protected:
 
         release_addr_ = devices_.at(0)->allocator()->get_base_allocator_addr(HalMemType::L1);
         started_addr_ = release_addr_ + sizeof(uint32_t);
+    }
+
+    void TearDown() override {
+        // Defensively release every compute core before tearing down so close() can always drain,
+        // regardless of how a test exited.
+        if (release_addr_ != 0 && !devices_.empty() && devices_.at(0) != nullptr) {
+            const CoreCoord grid_size = device()->compute_with_storage_grid_size();
+            const CoreRangeSet all_cores{CoreRange(CoreCoord{0, 0}, CoreCoord{grid_size.x - 1, grid_size.y - 1})};
+            release_worker(all_cores);
+        }
+        DispatchTelemetryReadApiTest::TearDown();
     }
 
     template <typename TCoreType>
@@ -315,16 +374,214 @@ protected:
     uint32_t started_addr_ = 0;
 };
 
+TEST_F(DispatchTelemetryReadApiTest, SMCControlIsInitialized) {
+    // Initialization of the mesh device should have written the default SMC control block to the device already
+    auto control = read_smc_dispatch_telemetry_control(tt_device());
+    ASSERT_TRUE(control.has_value());
+
+    auto expected_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+        CommandQueueDeviceAddrType::DISPATCH_TELEMETRY);
+    const uint32_t control_version = control->version;
+    const uint32_t control_signature = control->signature;
+    const uint8_t control_flags = control->flags;
+    const uint32_t dispatch_telemetry_addr = control->dispatch_telemetry_addr;
+    const uint8_t num_hw_cqs = control->num_hw_cqs;
+    EXPECT_EQ(control_version, dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION);
+    EXPECT_EQ(control_signature, dispatch_telemetry_types::SMC_TELEMETRY_SIGNATURE);
+    EXPECT_EQ(control_flags, 0);
+    EXPECT_EQ(dispatch_telemetry_addr, expected_addr);
+    EXPECT_EQ(num_hw_cqs, device()->num_hw_cqs());
+    ASSERT_LE(num_hw_cqs, dispatch_telemetry_types::RESERVED_CQ_SPACE);
+
+    {
+        auto& metal_context = MetalContext::instance();
+        auto& dcm = metal_context.get_dispatch_core_manager();
+        const ChipId chip = device()->id();
+        const uint16_t channel = metal_context.get_cluster().get_assigned_channel_for_device(chip);
+        const CoreType core_type = dcm.get_dispatch_core_type();
+
+        const auto dispatch_core_to_virtual_core = [&](const tt_cxy_pair& dispatch_core) {
+            return device()->virtual_core_from_logical_core(CoreCoord{dispatch_core.x, dispatch_core.y}, core_type);
+        };
+
+        const auto expect_smc_coord_matches_virtual_core = [&](uint32_t smc_xy, const CoreCoord& virtual_core) {
+            EXPECT_EQ(dispatch_telemetry_types::smc_dispatch_core_x(smc_xy), virtual_core.x);
+            EXPECT_EQ(dispatch_telemetry_types::smc_dispatch_core_y(smc_xy), virtual_core.y);
+        };
+
+        const auto expect_prefetch_coord = [&](uint32_t smc_xy, uint8_t cq_id) {
+            if (dcm.is_prefetcher_core_allocated(chip, channel, cq_id)) {
+                expect_smc_coord_matches_virtual_core(
+                    smc_xy, dispatch_core_to_virtual_core(dcm.prefetcher_core(chip, channel, cq_id)));
+            } else if (dcm.is_prefetcher_d_core_allocated(chip, channel, cq_id)) {
+                expect_smc_coord_matches_virtual_core(
+                    smc_xy, dispatch_core_to_virtual_core(dcm.prefetcher_d_core(chip, channel, cq_id)));
+            } else {
+                FAIL() << "Expected CQ " << static_cast<uint32_t>(cq_id) << " to have an allocated prefetch core";
+            }
+        };
+
+        const auto expect_dispatch_coord = [&](uint32_t smc_xy, uint8_t cq_id) {
+            if (dcm.is_dispatcher_core_allocated(chip, channel, cq_id)) {
+                expect_smc_coord_matches_virtual_core(
+                    smc_xy, dispatch_core_to_virtual_core(dcm.dispatcher_core(chip, channel, cq_id)));
+            } else if (dcm.is_dispatcher_d_core_allocated(chip, channel, cq_id)) {
+                expect_smc_coord_matches_virtual_core(
+                    smc_xy, dispatch_core_to_virtual_core(dcm.dispatcher_d_core(chip, channel, cq_id)));
+            } else {
+                FAIL() << "Expected CQ " << static_cast<uint32_t>(cq_id) << " to have an allocated dispatch core";
+            }
+        };
+
+        for (uint32_t cq = 0; cq < num_hw_cqs; ++cq) {
+            SCOPED_TRACE(cq);
+            const auto cq_id = static_cast<uint8_t>(cq);
+            const auto smc_coords = control->cq_dispatch_core_coords[cq];
+
+            expect_prefetch_coord(smc_coords.prefetch_xy, cq_id);
+            expect_dispatch_coord(smc_coords.dispatch_xy, cq_id);
+
+            if (dcm.is_dispatcher_s_core_allocated(chip, channel, cq_id)) {
+                expect_smc_coord_matches_virtual_core(
+                    smc_coords.dispatch_s_xy,
+                    dispatch_core_to_virtual_core(dcm.dispatcher_s_core(chip, channel, cq_id)));
+            } else {
+                const uint32_t dispatch_s_xy = smc_coords.dispatch_s_xy;
+                EXPECT_EQ(dispatch_s_xy, dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS);
+            }
+        }
+    }
+
+    // Validate cq_dispatch_core_coords for inactive CQs are invalid.
+    for (uint32_t cq = num_hw_cqs; cq < dispatch_telemetry_types::RESERVED_CQ_SPACE; ++cq) {
+        const auto smc_coords = control->cq_dispatch_core_coords[cq];
+        const uint32_t prefetch_xy = smc_coords.prefetch_xy;
+        const uint32_t dispatch_xy = smc_coords.dispatch_xy;
+        const uint32_t dispatch_s_xy = smc_coords.dispatch_s_xy;
+        EXPECT_EQ(prefetch_xy, dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS);
+        EXPECT_EQ(dispatch_xy, dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS);
+        EXPECT_EQ(dispatch_s_xy, dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS);
+    }
+}
+
+TEST_F(DispatchTelemetrySlowDispatchTest, SMCControlIsInitialized) {
+    auto control = read_smc_dispatch_telemetry_control(tt_device());
+    ASSERT_TRUE(control.has_value());
+
+    auto expected_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+        CommandQueueDeviceAddrType::DISPATCH_TELEMETRY);
+    const uint32_t control_version = control->version;
+    const uint32_t control_signature = control->signature;
+    const uint8_t control_flags = control->flags;
+    const uint32_t dispatch_telemetry_addr = control->dispatch_telemetry_addr;
+    const uint8_t num_hw_cqs = control->num_hw_cqs;
+    EXPECT_EQ(control_version, dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION);
+    EXPECT_EQ(control_signature, dispatch_telemetry_types::SMC_TELEMETRY_SIGNATURE);
+    EXPECT_TRUE(
+        control_flags &
+        static_cast<uint32_t>(dispatch_telemetry_types::SMCDispatchTelemetryFlags::SLOW_DISPATCH_ENABLED));
+    EXPECT_EQ(dispatch_telemetry_addr, expected_addr);
+    EXPECT_EQ(num_hw_cqs, device()->num_hw_cqs());
+    ASSERT_LE(num_hw_cqs, dispatch_telemetry_types::RESERVED_CQ_SPACE);
+
+    for (auto smc_coords : control->cq_dispatch_core_coords) {
+        const uint32_t prefetch_xy = smc_coords.prefetch_xy;
+        const uint32_t dispatch_xy = smc_coords.dispatch_xy;
+        const uint32_t dispatch_s_xy = smc_coords.dispatch_s_xy;
+        EXPECT_EQ(prefetch_xy, dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS);
+        EXPECT_EQ(dispatch_xy, dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS);
+        EXPECT_EQ(dispatch_s_xy, dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS);
+    }
+}
+
+// Only meant to be run as a child process within ReadInfoFromSeparateProcessWhileDeviceInUse
+TEST(DispatchTelemetryObserverChild, ReadInfoFromDeviceOwnedByAnotherProcess) {
+    const char* pci_device_id_env = std::getenv(kObserverChildEnv);
+    if (pci_device_id_env == nullptr) {
+        GTEST_SKIP() << "Observer child test only runs when " << kObserverChildEnv << " is set";
+    }
+
+    char* parse_end = nullptr;
+    const long pci_device_id = std::strtol(pci_device_id_env, &parse_end, 10);
+    ASSERT_NE(parse_end, pci_device_id_env);
+    ASSERT_EQ(*parse_end, '\0');
+    ASSERT_GE(pci_device_id, 0);
+
+    std::unique_ptr<tt::umd::TTDevice> tt_device = tt::umd::TTDevice::create(static_cast<int>(pci_device_id));
+    tt_device->init_tt_device();
+    if (auto skip_reason = smc_runtime_telemetry_unavailable_reason(*tt_device); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+    DispatchTelemetry telemetry(*tt_device);
+
+    EXPECT_EQ(telemetry.version(), dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION);
+    auto info = telemetry.read_info();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_FALSE(info->info_cqs.empty());
+}
+
+TEST_F(DispatchTelemetryHostL1WaitTest, ReadInfoFromSeparateProcessWhileDeviceInUse) {
+    constexpr const char* observerChildFilter =
+        "DispatchTelemetryObserverChild.ReadInfoFromDeviceOwnedByAnotherProcess";
+
+    auto* pci_device = tt_device().get_pci_device();
+    if (pci_device == nullptr) {
+        GTEST_SKIP() << "Requires a PCIe-backed TTDevice";
+    }
+    const int pci_device_num = pci_device->get_device_num();
+
+    auto& cq = devices_.at(0)->mesh_command_queue();
+    const CoreCoord worker_core{0, 0};
+    reset_worker_l1_state(worker_core);
+
+    distributed::MeshWorkload waiting_workload;
+    waiting_workload.add_program(device_range_, create_l1_wait_program(worker_core));
+    distributed::EnqueueMeshWorkload(cq, waiting_workload, false);
+
+    const bool worker_started = worker_reached_l1_wait(device(), worker_core);
+    if (!worker_started) {
+        release_core_and_finish(worker_core);
+    }
+    ASSERT_TRUE(worker_started);
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        const int fork_errno = errno;
+        release_core_and_finish(worker_core);
+        FAIL() << "fork() failed: " << std::strerror(fork_errno);
+    }
+
+    if (pid == 0) {
+        const std::string pci_device_id = std::to_string(pci_device_num);
+        if (setenv(kObserverChildEnv, pci_device_id.c_str(), 1) != 0) {
+            _exit(2);
+        }
+
+        const std::string filter_arg = std::string("--gtest_filter=") + observerChildFilter;
+        char* const args[] = {const_cast<char*>("/proc/self/exe"), const_cast<char*>(filter_arg.c_str()), nullptr};
+        execv("/proc/self/exe", args);
+        _exit(3);
+    }
+
+    int status = 0;
+    const pid_t wait_result = waitpid(pid, &status, 0);
+    release_core_and_finish(worker_core);
+
+    ASSERT_EQ(wait_result, pid) << "waitpid failed";
+    ASSERT_TRUE(WIFEXITED(status)) << "Child terminated abnormally";
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "Child exited with code " << WEXITSTATUS(status);
+}
+
 TEST_F(DispatchTelemetryReadApiTest, ReadDispatchCoreTelemetryFromWorkerL1) {
     const CoreCoord core{0, 0};
-    DispatchCoreTelemetry telemetry;
+    dispatch_telemetry_types::DispatchCoreTelemetry telemetry;
     telemetry.upstream_blocked_count = 17;
     telemetry.upstream_unblocked_count = 19;
     telemetry.program_count = 21;
     write_telemetry(CoreType::WORKER, core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(core, CoreType::WORKER);
-    auto actual = read_dispatch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_dispatch_core_telemetry(tt_device(), virtual_core);
 
     ASSERT_TRUE(actual.has_value());
     EXPECT_EQ(actual->upstream_blocked_count, telemetry.upstream_blocked_count);
@@ -338,14 +595,14 @@ TEST_F(DispatchTelemetryReadApiTest, ReadDispatchCoreTelemetryFromEthL1) {
         GTEST_SKIP() << "No ethernet cores available for L1 telemetry test";
     }
 
-    DispatchCoreTelemetry telemetry;
+    dispatch_telemetry_types::DispatchCoreTelemetry telemetry;
     telemetry.upstream_blocked_count = 17;
     telemetry.upstream_unblocked_count = 19;
     telemetry.program_count = 21;
     write_telemetry(CoreType::ETH, *core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(*core, CoreType::ETH);
-    auto actual = read_dispatch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_dispatch_core_telemetry(tt_device(), virtual_core);
 
     ASSERT_TRUE(actual.has_value());
     EXPECT_EQ(actual->upstream_blocked_count, telemetry.upstream_blocked_count);
@@ -355,38 +612,38 @@ TEST_F(DispatchTelemetryReadApiTest, ReadDispatchCoreTelemetryFromEthL1) {
 
 TEST_F(DispatchTelemetryReadApiTest, ReadDispatchCoreTelemetryRejectsBadSignature) {
     const CoreCoord core{0, 0};
-    DispatchCoreTelemetry telemetry;
-    telemetry.signature = INVALID_TELEMETRY_SIGNATURE;
+    dispatch_telemetry_types::DispatchCoreTelemetry telemetry;
+    telemetry.signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
     write_telemetry(CoreType::WORKER, core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(core, CoreType::WORKER);
-    auto actual = read_dispatch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_dispatch_core_telemetry(tt_device(), virtual_core);
 
     EXPECT_FALSE(actual.has_value());
 }
 
 TEST_F(DispatchTelemetryReadApiTest, ReadDispatchCoreTelemetryRejectsBadVersion) {
     const CoreCoord core{0, 0};
-    DispatchCoreTelemetry telemetry;
-    telemetry.version = DISPATCH_TELEMETRY_VERSION + 1;
+    dispatch_telemetry_types::DispatchCoreTelemetry telemetry;
+    telemetry.version = dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION + 1;
     write_telemetry(CoreType::WORKER, core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(core, CoreType::WORKER);
-    auto actual = read_dispatch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_dispatch_core_telemetry(tt_device(), virtual_core);
 
     EXPECT_FALSE(actual.has_value());
 }
 
 TEST_F(DispatchTelemetryReadApiTest, ReadPrefetchTelemetryFromWorkerL1) {
     const CoreCoord core{0, 0};
-    PrefetchCoreTelemetry telemetry;
+    dispatch_telemetry_types::PrefetchCoreTelemetry telemetry;
     telemetry.upstream_blocked_count = 23;
     telemetry.upstream_unblocked_count = 29;
     telemetry.command_count = 31;
     write_telemetry(CoreType::WORKER, core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(core, CoreType::WORKER);
-    auto actual = read_prefetch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_prefetch_core_telemetry(tt_device(), virtual_core);
 
     ASSERT_TRUE(actual.has_value());
     EXPECT_EQ(actual->upstream_blocked_count, telemetry.upstream_blocked_count);
@@ -400,14 +657,14 @@ TEST_F(DispatchTelemetryReadApiTest, ReadPrefetchTelemetryFromEthL1) {
         GTEST_SKIP() << "No ethernet cores available for L1 telemetry test";
     }
 
-    PrefetchCoreTelemetry telemetry;
+    dispatch_telemetry_types::PrefetchCoreTelemetry telemetry;
     telemetry.upstream_blocked_count = 17;
     telemetry.upstream_unblocked_count = 19;
     telemetry.command_count = 21;
     write_telemetry(CoreType::ETH, *core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(*core, CoreType::ETH);
-    auto actual = read_prefetch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_prefetch_core_telemetry(tt_device(), virtual_core);
 
     ASSERT_TRUE(actual.has_value());
     EXPECT_EQ(actual->upstream_blocked_count, telemetry.upstream_blocked_count);
@@ -417,39 +674,38 @@ TEST_F(DispatchTelemetryReadApiTest, ReadPrefetchTelemetryFromEthL1) {
 
 TEST_F(DispatchTelemetryReadApiTest, ReadPrefetchTelemetryRejectsBadSignature) {
     const CoreCoord core{0, 0};
-    PrefetchCoreTelemetry telemetry;
-    telemetry.signature = INVALID_TELEMETRY_SIGNATURE;
+    dispatch_telemetry_types::PrefetchCoreTelemetry telemetry;
+    telemetry.signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
     write_telemetry(CoreType::WORKER, core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(core, CoreType::WORKER);
-    auto actual = read_prefetch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_prefetch_core_telemetry(tt_device(), virtual_core);
 
     EXPECT_FALSE(actual.has_value());
 }
 
 TEST_F(DispatchTelemetryReadApiTest, ReadPrefetchTelemetryRejectsBadVersion) {
     const CoreCoord core{0, 0};
-    PrefetchCoreTelemetry telemetry;
-    telemetry.version = DISPATCH_TELEMETRY_VERSION + 1;
+    dispatch_telemetry_types::PrefetchCoreTelemetry telemetry;
+    telemetry.version = dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION + 1;
     write_telemetry(CoreType::WORKER, core, telemetry);
 
     const CoreCoord virtual_core = device()->virtual_core_from_logical_core(core, CoreType::WORKER);
-    auto actual = read_prefetch_core_telemetry(device()->id(), virtual_core);
+    auto actual = read_prefetch_core_telemetry(tt_device(), virtual_core);
 
     EXPECT_FALSE(actual.has_value());
 }
 
 TEST_F(DispatchTelemetrySlowDispatchTest, ReadInfoReturnsNulloptButVersionIsValid) {
-    DispatchTelemetry telemetry(*device());
+    DispatchTelemetry telemetry(tt_device());
 
     auto info = telemetry.read_info();
     EXPECT_FALSE(info.has_value());
 
-    EXPECT_EQ(telemetry.version(), DISPATCH_TELEMETRY_VERSION);
+    EXPECT_EQ(telemetry.version(), dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION);
 }
 
 TEST_F(DispatchTelemetryReadApiTest, DispatchCoreProgramCount) {
-    IDevice* device = this->device();
     auto& cq = devices_.at(0)->mesh_command_queue();
     constexpr size_t total_runs = 10;
     constexpr size_t num_blank_programs = 16;
@@ -457,7 +713,7 @@ TEST_F(DispatchTelemetryReadApiTest, DispatchCoreProgramCount) {
     // Verify it increments per program regardless of core count
     const CoreRangeSet worker_cores{CoreRange(CoreCoord{0, 0}, CoreCoord{1, 1})};
 
-    DispatchTelemetry telemetry(*device);
+    DispatchTelemetry telemetry(tt_device());
     auto initial = telemetry.read_info();
     ASSERT_TRUE(initial.has_value());
     ASSERT_FALSE(initial->info_cqs.empty());
@@ -494,13 +750,12 @@ TEST_F(DispatchTelemetryReadApiTest, DispatchCoreProgramCountForTraceReplay) {
         GTEST_SKIP() << "Requires dispatch_s to be enabled";
     }
 
-    IDevice* device = this->device();
     auto mesh_device = devices_.at(0);
     auto& cq = mesh_device->mesh_command_queue();
     int num_programs = 0;
     const CoreRangeSet worker_cores{CoreRange(CoreCoord{0, 0}, CoreCoord{1, 1})};
 
-    DispatchTelemetry telemetry(*device);
+    DispatchTelemetry telemetry(tt_device());
     auto initial = telemetry.read_info();
     ASSERT_TRUE(initial.has_value());
     ASSERT_FALSE(initial->info_cqs.empty());
@@ -542,12 +797,11 @@ TEST_F(DispatchTelemetryReadApiTest, DispatchCoreProgramCountForTraceReplay) {
 }
 
 TEST_F(DispatchTelemetryReadApiTest, PrefetchCommandCountIncrementsAfterProgramRuns) {
-    IDevice* device = this->device();
     auto& cq = devices_.at(0)->mesh_command_queue();
     constexpr size_t num_blank_programs = 4;
     const CoreRangeSet worker_cores{CoreRange(CoreCoord{0, 0}, CoreCoord{1, 1})};
 
-    DispatchTelemetry telemetry(*device);
+    DispatchTelemetry telemetry(tt_device());
     auto initial = telemetry.read_info();
     ASSERT_TRUE(initial.has_value());
     ASSERT_FALSE(initial->info_cqs.empty());
@@ -571,11 +825,10 @@ TEST_F(DispatchTelemetryReadApiTest, DispatchCoreEfficiencyIsNulloptWhenWorkerDi
     }
 
     // Create the device, single-core stream, blank program, and telemetry object.
-    IDevice* device = this->device();
     auto& cq = devices_.at(0)->mesh_command_queue();
     const CoreRangeSet worker_core{CoreRange(CoreCoord{0, 0})};
     Program program = create_blank_program(worker_core);
-    DispatchTelemetry telemetry(*device);
+    DispatchTelemetry telemetry(tt_device());
 
     // Run the blank program.
     distributed::MeshWorkload workload;
@@ -595,11 +848,10 @@ TEST_F(DispatchTelemetryReadApiTest, DispatchUtilizationIsEmptyWhenWorkerDispatc
     }
 
     // Create the device, single-core stream, blank program, and telemetry object.
-    IDevice* device = this->device();
     auto& cq = devices_.at(0)->mesh_command_queue();
     const CoreRangeSet worker_core{CoreRange(CoreCoord{0, 0})};
     Program program = create_blank_program(worker_core);
-    DispatchTelemetry telemetry(*device);
+    DispatchTelemetry telemetry(tt_device());
 
     // Run the blank program.
     distributed::MeshWorkload workload;
@@ -621,7 +873,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, WorkerWaitReportsUpstreamBlockedState) {
     const CoreCoord worker_core{0, 0};
     reset_worker_l1_state(worker_core);
 
-    DispatchTelemetry telemetry(*device);
+    DispatchTelemetry telemetry(tt_device());
     auto initial = telemetry.read_info();
     ASSERT_TRUE(initial.has_value());
     ASSERT_FALSE(initial->info_cqs.empty());
@@ -687,10 +939,10 @@ TEST_F(DispatchTelemetryReadApiTest, DispatchSTelemetryCurrentTimestampAdvances)
         GTEST_SKIP() << "Requires worker dispatch and dispatch_s to be enabled";
     }
 
-    auto first = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+    auto first = read_dispatch_core_telemetry(tt_device(), *dispatch_s_core);
     ASSERT_TRUE(first.has_value());
 
-    auto second = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+    auto second = read_dispatch_core_telemetry(tt_device(), *dispatch_s_core);
     ASSERT_TRUE(second.has_value());
     EXPECT_GT(second->current_timestamp, first->current_timestamp);
 }
@@ -716,7 +968,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryTracksWorkerRuntime) {
 
     EXPECT_TRUE(worker_reached_l1_wait(device(), worker_core));
     {
-        auto info = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+        auto info = read_dispatch_core_telemetry(tt_device(), *dispatch_s_core);
         ASSERT_TRUE(info.has_value());
         EXPECT_GT(info->workers_per_sub_device[0], 0);
         EXPECT_GT(info->current_timestamp, 0);
@@ -727,7 +979,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryTracksWorkerRuntime) {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     {
-        auto info = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+        auto info = read_dispatch_core_telemetry(tt_device(), *dispatch_s_core);
         ASSERT_TRUE(info.has_value());
         EXPECT_GT(info->workers_per_sub_device[0], 0);
         EXPECT_GT(info->current_timestamp, 0);
@@ -766,7 +1018,7 @@ TEST_F(DispatchTelemetryReadApiTest, DispatchTelemetryTracksWorkersPerSubDeviceC
     auto sub_device_manager = mesh_device->create_sub_device_manager({sub_devices[0], sub_devices[1]}, 3200);
     mesh_device->load_sub_device_manager(sub_device_manager);
 
-    auto info = read_dispatch_core_telemetry(device()->id(), *dispatch_telemetry_core);
+    auto info = read_dispatch_core_telemetry(tt_device(), *dispatch_telemetry_core);
     EXPECT_TRUE(info.has_value());
     if (info.has_value()) {
         for (size_t sub_device_index = 0; sub_device_index < num_sub_devices; ++sub_device_index) {
@@ -835,7 +1087,7 @@ TEST_F(DispatchTelemetryMultiCQReadApiTest, DispatchTelemetryTracksWorkersPerSub
         3200);
     mesh_device->load_sub_device_manager(sub_device_manager);
 
-    auto first_info = read_dispatch_core_telemetry(device()->id(), *first_dispatch_telemetry_core);
+    auto first_info = read_dispatch_core_telemetry(tt_device(), *first_dispatch_telemetry_core);
     EXPECT_TRUE(first_info.has_value());
     if (first_info.has_value()) {
         EXPECT_EQ(
@@ -846,7 +1098,7 @@ TEST_F(DispatchTelemetryMultiCQReadApiTest, DispatchTelemetryTracksWorkersPerSub
             sub_device_core_counts[cq_1_second_sub_device_index]);
     }
 
-    auto second_info = read_dispatch_core_telemetry(device()->id(), *second_dispatch_telemetry_core);
+    auto second_info = read_dispatch_core_telemetry(tt_device(), *second_dispatch_telemetry_core);
     EXPECT_TRUE(second_info.has_value());
     if (second_info.has_value()) {
         EXPECT_EQ(
@@ -862,18 +1114,18 @@ TEST_F(DispatchTelemetryMultiCQReadApiTest, DispatchTelemetryTracksWorkersPerSub
 }
 
 TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryDoesNotOvercountCompletionsOnStreamReset) {
-    if (!dispatch_s_virtual_core().has_value()) {
+    const auto dispatch_s_core = dispatch_s_virtual_core();
+    if (!worker_dispatch_enabled() || !dispatch_s_core.has_value()) {
         GTEST_SKIP() << "Requires dispatch_s to be enabled";
     }
 
     auto& cq = devices_.at(0)->mesh_command_queue();
     auto mesh_device = devices_.at(0);
     const CoreCoord worker_core{0, 0};
-    const auto dispatch_s_core = dispatch_s_virtual_core().value();
 
-    const auto completion_counts_are_bounded = [](const DispatchCoreTelemetry& telemetry) {
+    const auto completion_counts_are_bounded = [](const dispatch_telemetry_types::DispatchCoreTelemetry& telemetry) {
         bool has_active_sub_device = false;
-        for (size_t i = 0; i < MAX_SUB_DEVICES; ++i) {
+        for (size_t i = 0; i < dispatch_telemetry_types::MAX_SUB_DEVICES; ++i) {
             if (telemetry.workers_per_sub_device[i] == 0) {
                 continue;
             }
@@ -898,7 +1150,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryDoesNotOvercountComple
             return std::nullopt;
         }
 
-        auto while_working = read_dispatch_core_telemetry(device()->id(), dispatch_s_core);
+        auto while_working = read_dispatch_core_telemetry(tt_device(), dispatch_s_core.value());
         if (!while_working.has_value() || while_working->workers_per_sub_device[0] == 0 ||
             while_working->completion_count[0] >= while_working->workers_per_sub_device[0] ||
             while_working->last_work_launch_timestamp[0] == 0) {
@@ -924,7 +1176,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryDoesNotOvercountComple
     Finish(cq);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    auto after_reset = read_dispatch_core_telemetry(device()->id(), dispatch_s_core);
+    auto after_reset = read_dispatch_core_telemetry(tt_device(), dispatch_s_core.value());
     ASSERT_TRUE(after_reset.has_value()) << "Telemetry was not readable after reset";
     ASSERT_TRUE(completion_counts_are_bounded(*after_reset))
         << "Telemetry completion count exceeded worker semaphore count after reset";
@@ -937,7 +1189,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryDoesNotOvercountComple
     Finish(cq);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    auto after_second_batch = read_dispatch_core_telemetry(device()->id(), dispatch_s_core);
+    auto after_second_batch = read_dispatch_core_telemetry(tt_device(), dispatch_s_core.value());
     ASSERT_TRUE(after_second_batch.has_value()) << "Telemetry was not readable after the second batch of work";
     ASSERT_TRUE(completion_counts_are_bounded(*after_second_batch))
         << "Telemetry completion count exceeded worker semaphore count after the second batch of work";
@@ -979,7 +1231,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryTracksMultipleSubDevic
     }
     ASSERT_TRUE(first_started);
 
-    auto first_while_working = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+    auto first_while_working = read_dispatch_core_telemetry(tt_device(), dispatch_s_core.value());
 
     release_worker(first_worker);
     Finish(cq);
@@ -990,7 +1242,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryTracksMultipleSubDevic
     EXPECT_GT(first_while_working->last_work_launch_timestamp[0], 0);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    auto after_first_finish = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+    auto after_first_finish = read_dispatch_core_telemetry(tt_device(), dispatch_s_core.value());
     ASSERT_TRUE(after_first_finish.has_value());
     EXPECT_GT(after_first_finish->workers_per_sub_device[0], 0);
     EXPECT_EQ(after_first_finish->completion_count[0], after_first_finish->workers_per_sub_device[0]);
@@ -1007,7 +1259,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryTracksMultipleSubDevic
     }
     ASSERT_TRUE(second_started);
 
-    auto second_while_working = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+    auto second_while_working = read_dispatch_core_telemetry(tt_device(), dispatch_s_core.value());
 
     release_worker(second_worker);
     Finish(cq);
@@ -1018,7 +1270,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchSTelemetryTracksMultipleSubDevic
     EXPECT_GT(second_while_working->last_work_launch_timestamp[1], 0);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    auto after_second_finish = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+    auto after_second_finish = read_dispatch_core_telemetry(tt_device(), dispatch_s_core.value());
     ASSERT_TRUE(after_second_finish.has_value());
     EXPECT_GT(after_second_finish->workers_per_sub_device[0], 0);
     EXPECT_GT(after_second_finish->workers_per_sub_device[1], 0);
@@ -1069,7 +1321,7 @@ TEST_F(DispatchTelemetryReadApiTest, LastWorkLaunchTimestampIncrementsPerSubDevi
     }
 
     const auto read_timestamps = [&]() {
-        auto info = read_dispatch_core_telemetry(device()->id(), *dispatch_s_core);
+        auto info = read_dispatch_core_telemetry(tt_device(), *dispatch_s_core);
         EXPECT_TRUE(info.has_value());
         std::array<uint64_t, num_sub_devices> timestamps = {};
         if (info.has_value()) {
@@ -1175,7 +1427,7 @@ TEST_F(DispatchTelemetryReadApiTest, InactiveWorkersIncrementCompleteSem) {
     ASSERT_EQ(loaded_second_sub_device_cores.num_cores(), sub_device_core_count);
 
     const auto expect_completion_count_for_sub_device = [&](size_t sub_device_index, const char* case_name) {
-        auto info = read_dispatch_core_telemetry(device->id(), *dispatch_s_core);
+        auto info = read_dispatch_core_telemetry(tt_device(), *dispatch_s_core);
         ASSERT_TRUE(info.has_value());
         EXPECT_EQ(info->workers_per_sub_device[0], sub_device_core_count);
         EXPECT_EQ(info->workers_per_sub_device[1], sub_device_core_count);
@@ -1256,7 +1508,7 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchCoreEfficiencyAndUtilization) {
     const CoreRangeSet loaded_second_sub_device_cores =
         mesh_device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{1});
 
-    DispatchTelemetry telemetry(*device);
+    DispatchTelemetry telemetry(tt_device());
 
     EXPECT_EQ(
         loaded_first_sub_device_cores.num_cores() + loaded_second_sub_device_cores.num_cores(),

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -65,10 +65,14 @@ void for_each_worker_core(const CoreRangeSet& worker_cores, Func func) {
 }
 
 std::optional<std::string> smc_runtime_telemetry_unavailable_reason(tt::umd::TTDevice& tt_device) {
-    if (!tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_size().has_value()) {
+    auto* firmware_info_provider = tt_device.get_firmware_info_provider();
+    if (firmware_info_provider == nullptr) {
+        return "Firmware info provider is unavailable";
+    }
+    if (!firmware_info_provider->get_runtime_telemetry_buffer_size().has_value()) {
         return "SMC runtime telemetry buffer is unavailable";
     }
-    if (!tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_address().has_value()) {
+    if (!firmware_info_provider->get_runtime_telemetry_buffer_address().has_value()) {
         return "SMC runtime telemetry buffer address is unavailable or invalid";
     }
     return std::nullopt;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -65,10 +65,8 @@ void for_each_worker_core(const CoreRangeSet& worker_cores, Func func) {
 }
 
 std::optional<std::string> smc_runtime_telemetry_unavailable_reason(tt::umd::TTDevice& tt_device) {
-    // get_firmware_info_provider() THROWS (does not return null) when the device has no firmware info
-    // provider -- e.g. simulators -- so treat any failure as "unavailable" and let the fixture skip
-    // cleanly rather than error out in SetUp().
     try {
+        // Throws when the device has no firmware info provider (ex: simulators)
         auto* firmware_info_provider = tt_device.get_firmware_info_provider();
         if (!firmware_info_provider->get_runtime_telemetry_buffer_size().has_value()) {
             return "SMC runtime telemetry buffer is unavailable";

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -65,17 +65,21 @@ void for_each_worker_core(const CoreRangeSet& worker_cores, Func func) {
 }
 
 std::optional<std::string> smc_runtime_telemetry_unavailable_reason(tt::umd::TTDevice& tt_device) {
-    auto* firmware_info_provider = tt_device.get_firmware_info_provider();
-    if (firmware_info_provider == nullptr) {
-        return "Firmware info provider is unavailable";
+    // get_firmware_info_provider() THROWS (does not return null) when the device has no firmware info
+    // provider -- e.g. simulators -- so treat any failure as "unavailable" and let the fixture skip
+    // cleanly rather than error out in SetUp().
+    try {
+        auto* firmware_info_provider = tt_device.get_firmware_info_provider();
+        if (!firmware_info_provider->get_runtime_telemetry_buffer_size().has_value()) {
+            return "SMC runtime telemetry buffer is unavailable";
+        }
+        if (!firmware_info_provider->get_runtime_telemetry_buffer_address().has_value()) {
+            return "SMC runtime telemetry buffer address is unavailable or invalid";
+        }
+        return std::nullopt;
+    } catch (const std::exception& e) {
+        return std::string("Firmware info provider is unavailable: ") + e.what();
     }
-    if (!firmware_info_provider->get_runtime_telemetry_buffer_size().has_value()) {
-        return "SMC runtime telemetry buffer is unavailable";
-    }
-    if (!firmware_info_provider->get_runtime_telemetry_buffer_address().has_value()) {
-        return "SMC runtime telemetry buffer address is unavailable or invalid";
-    }
-    return std::nullopt;
 }
 
 }  // namespace

--- a/tt_metal/api/tt-metalium/experimental/dispatch_telemetry.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dispatch_telemetry.hpp
@@ -9,7 +9,9 @@
 #include <optional>
 #include <vector>
 
-#include <tt-metalium/device.hpp>
+namespace tt::umd {
+class TTDevice;
+}  // namespace tt::umd
 
 namespace tt::tt_metal {
 
@@ -47,7 +49,7 @@ struct DispatchTelemetryDeviceInfo {
 
 class DispatchTelemetry {
 public:
-    DispatchTelemetry(const IDevice& device);
+    DispatchTelemetry(tt::umd::TTDevice& device);
     ~DispatchTelemetry();
 
     /**

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -85,6 +85,9 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
     for (auto& cq : mesh_device_impl.mesh_command_queues_) {
         cq->finish();
     }
+    for (const auto& dev : active_devices) {
+        dev->set_smc_dispatch_telemetry_slow_dispatch_enabled(false);
+    }
     stashed_sd_queues_ = std::make_unique<StashedQueues>();
     for (auto& cq : mesh_device_impl.mesh_command_queues_) {
         stashed_sd_queues_->queues.push_back(std::move(cq));
@@ -120,7 +123,7 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
 
     ContextId context_id = extract_context_id(mesh_device);
     const auto& device_manager = MetalContext::instance(context_id).device_manager();
-    const auto& active_devices = device_manager->get_all_active_devices();
+    const auto& active_devices = device_manager->get_all_active_devices_impl();
 
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();
@@ -133,10 +136,13 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
         mesh_device_impl.mesh_command_queues_.push_back(std::move(cq));
     }
     stashed_sd_queues_.reset();
+    for (const auto& dev : active_devices) {
+        dev->set_smc_dispatch_telemetry_slow_dispatch_enabled(true);
+    }
 
     for (const auto& dev : active_devices) {
         for (int cq_id = 0; cq_id < dev->num_hw_cqs(); cq_id++) {
-            dynamic_cast<tt::tt_metal::Device*>(dev)->command_queues_[cq_id].get()->terminate();
+            dev->command_queues_[cq_id].get()->terminate();
         }
     }
 
@@ -147,7 +153,7 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
 
     // HWCommandQueue holds a reference to sysmem_manager_. Clear now so any future
     // init_command_queue_host call can safely replace sysmem_manager_ without dangling references
-    for (const auto& device : device_manager->get_all_active_devices_impl()) {
+    for (const auto& device : active_devices) {
         device->command_queue_programs_.clear();
         device->command_queues_.clear();
     }

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -52,7 +52,7 @@
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/tools/profiler/tt_metal_tracy.hpp"
 #include "tt_metal/impl/device/dispatch.hpp"
-#include <umd/device/types/xy_pair.hpp>
+#include "llrt/tt_cluster.hpp"
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt_stl/overloaded.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
@@ -110,6 +110,40 @@ void record_program_sub_device_for_range(
     TT_THROW("No local device found for range");
 }
 
+dispatch_telemetry_types::SMCDispatchCoreCoords build_smc_dispatch_core_coords(Device& device, uint8_t cq_id) {
+    auto& context = MetalContext::instance(device.get_context_id());
+
+    auto pack_logical_dispatch_core = [&](const tt_cxy_pair& logical_cxy) {
+        const CoreType core_type = context.get_dispatch_core_manager().get_dispatch_core_type();
+        const CoreCoord virtual_core =
+            device.virtual_core_from_logical_core(CoreCoord{logical_cxy.x, logical_cxy.y}, core_type);
+        return dispatch_telemetry_types::pack_smc_dispatch_core_xy(
+            static_cast<uint16_t>(virtual_core.x), static_cast<uint16_t>(virtual_core.y));
+    };
+
+    auto& dcm = context.get_dispatch_core_manager();
+    const uint16_t channel = context.get_cluster().get_assigned_channel_for_device(device.id());
+    const ChipId chip = device.id();
+
+    // dcm getters are not read only, they allocate new cores as a side effect. Verify that a core
+    // is allocated before retrieving its coordinates.
+    dispatch_telemetry_types::SMCDispatchCoreCoords coords;
+    if (dcm.is_prefetcher_core_allocated(chip, channel, cq_id)) {
+        coords.prefetch_xy = pack_logical_dispatch_core(dcm.prefetcher_core(chip, channel, cq_id));
+    } else if (dcm.is_prefetcher_d_core_allocated(chip, channel, cq_id)) {
+        coords.prefetch_xy = pack_logical_dispatch_core(dcm.prefetcher_d_core(chip, channel, cq_id));
+    }
+    if (dcm.is_dispatcher_core_allocated(chip, channel, cq_id)) {
+        coords.dispatch_xy = pack_logical_dispatch_core(dcm.dispatcher_core(chip, channel, cq_id));
+    } else if (dcm.is_dispatcher_d_core_allocated(chip, channel, cq_id)) {
+        coords.dispatch_xy = pack_logical_dispatch_core(dcm.dispatcher_d_core(chip, channel, cq_id));
+    }
+    coords.dispatch_s_xy = dcm.is_dispatcher_s_core_allocated(chip, channel, cq_id)
+                               ? pack_logical_dispatch_core(dcm.dispatcher_s_core(chip, channel, cq_id))
+                               : dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS;
+    return coords;
+}
+
 }  // namespace
 
 struct MeshReadEventDescriptor {
@@ -165,6 +199,14 @@ FDMeshCommandQueue::FDMeshCommandQueue(
         DispatchSettings::DISPATCH_MESSAGE_ENTRIES,
         mesh_device_->allocator_impl()->get_config().l1_unreserved_base);
     this->populate_virtual_program_dispatch_core();
+
+    for (auto* device : mesh_device_->get_devices()) {
+        if (auto* physical_device = dynamic_cast<Device*>(device)) {
+            physical_device->update_smc_dispatch_telemetry_for_fast_dispatch(
+                this->id_, build_smc_dispatch_core_coords(*physical_device, this->id_));
+        }
+    }
+
     this->populate_read_descriptor_queue();
     completion_queue_reader_thread_ = std::thread(&FDMeshCommandQueue::read_completion_queue, this);
 }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -937,6 +937,13 @@ bool MeshDeviceImpl::close_impl(MeshDevice* pimpl_wrapper) {
             }
         }
 
+        for (auto* device : view_->get_devices()) {
+            if (auto* physical_device = dynamic_cast<Device*>(device)) {
+                // Ensure slow dispatch is disabled regardless of current state
+                physical_device->set_smc_dispatch_telemetry_slow_dispatch_enabled(false);
+            }
+        }
+
         mesh_command_queues_.clear();
     }
 
@@ -1441,6 +1448,11 @@ bool MeshDeviceImpl::initialize_impl(
                 active_distributed_context_));
         }
     } else {
+        for (auto* device : this->get_devices()) {
+            if (auto* physical_device = dynamic_cast<Device*>(device)) {
+                physical_device->set_smc_dispatch_telemetry_slow_dispatch_enabled(true);
+            }
+        }
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
             mesh_command_queues_.push_back(std::make_unique<SDMeshCommandQueue>(
                 pimpl_wrapper, cq_id, std::bind(&MeshDeviceImpl::lock_api, this), active_distributed_context_));

--- a/tt_metal/hostdevcommon/api/hostdevcommon/common_values.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/common_values.hpp
@@ -16,3 +16,4 @@ constexpr static std::size_t DEFAULT_L1_SMALL_SIZE = 0;  //(1 << 15);  // 32KB
 constexpr static std::size_t DEFAULT_TRACE_REGION_SIZE = 0;
 constexpr static std::size_t DEFAULT_WORKER_L1_SIZE = 0;  // Size is dynamically determined based on the device type.
 constexpr static std::uint32_t DISPATCH_MAX_MESSAGE_ENTRIES = 8;
+constexpr static std::uint32_t MAX_NUM_HW_CQS = 2;

--- a/tt_metal/hostdevcommon/api/hostdevcommon/dispatch_telemetry_types.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dispatch_telemetry_types.hpp
@@ -18,12 +18,14 @@ constexpr uint32_t pack(const char (&s)[5]) {
 
 }  // namespace detail
 
+namespace dispatch_telemetry_types {
 // Increment only when breaking changes occur
 constexpr uint32_t DISPATCH_TELEMETRY_VERSION = 1;
 
 /**
  * @brief Expected signature for validating that a telemetry buffer contains dispatch telemetry data.
  */
+constexpr uint32_t SMC_TELEMETRY_SIGNATURE = detail::pack("SMC_");
 constexpr uint32_t DISPATCH_CORE_TELEMETRY_SIGNATURE = detail::pack("DISP");
 constexpr uint32_t PREFETCH_CORE_TELEMETRY_SIGNATURE = detail::pack("PREF");
 
@@ -109,4 +111,44 @@ struct __attribute__((packed, aligned(4))) DispatchTelemetryControl {
     uint32_t launched_work_start_stream_sem[RESERVED_SUB_DEVICE_SPACE] = {0};
 };
 
+constexpr uint32_t INVALID_SMC_DISPATCH_CORE_COORDS = UINT32_MAX;
+// Packed virtual dispatch-core coordinates. These are consumed by host telemetry readers and are not NOC coords.
+struct __attribute__((packed)) SMCDispatchCoreCoords {
+    uint32_t prefetch_xy = INVALID_SMC_DISPATCH_CORE_COORDS;
+    uint32_t dispatch_xy = INVALID_SMC_DISPATCH_CORE_COORDS;
+    uint32_t dispatch_s_xy = INVALID_SMC_DISPATCH_CORE_COORDS;
+};
+
+constexpr uint32_t smc_dispatch_core_x(uint32_t xy) { return xy >> 16; }
+
+constexpr uint32_t smc_dispatch_core_y(uint32_t xy) { return xy & 0xFFFF; }
+
+constexpr uint32_t pack_smc_dispatch_core_xy(uint16_t x, uint16_t y) {
+    return (static_cast<uint32_t>(x) << 16) | static_cast<uint32_t>(y);
+}
+
+constexpr uint32_t MAX_DISPATCH_CORES_PER_CQ = sizeof(SMCDispatchCoreCoords) / sizeof(uint32_t);
+constexpr uint32_t RESERVED_CQ_SPACE = 3;
+static_assert(MAX_NUM_HW_CQS <= RESERVED_CQ_SPACE, "Max number of hardware CQs exceeds reserved space");
+
+// flags enum
+enum class SMCDispatchTelemetryFlags : uint8_t {
+    NONE = 0,
+    SLOW_DISPATCH_ENABLED = 1 << 0,
+};
+
+// Stored on device but data is host read/write only, so types can be any size
+struct __attribute__((packed)) SMCDispatchTelemetryControl {
+    uint32_t version = DISPATCH_TELEMETRY_VERSION;
+    uint32_t signature = SMC_TELEMETRY_SIGNATURE;
+    uint8_t flags = 0;
+    uint32_t dispatch_telemetry_addr = 0;
+    uint8_t num_hw_cqs = RESERVED_CQ_SPACE;
+    SMCDispatchCoreCoords cq_dispatch_core_coords[RESERVED_CQ_SPACE];
+    struct __attribute__((packed)) SDTelemetry {
+        // Reserved for future use
+    } sd_telemetry[RESERVED_CQ_SPACE];
+};
+
+}  // namespace dispatch_telemetry_types
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -99,15 +99,25 @@ void Device::initialize_smc_dispatch_telemetry_control() {
     if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
         return;
     }
+    auto* tt_device = [&]() -> tt::umd::TTDevice* {
+        const auto& driver = context_->get_cluster().get_driver();
+        if (driver == nullptr) {
+            return nullptr;
+        }
+        auto* chip = driver->get_chip(this->id_);
+        if (chip == nullptr) {
+            return nullptr;
+        }
+        return chip->get_tt_device();
+    }();
+    if (tt_device == nullptr) {
+        return;
+    }
 
     smc_dispatch_telemetry_control_ = dispatch_telemetry_types::SMCDispatchTelemetryControl{};
     smc_dispatch_telemetry_control_.dispatch_telemetry_addr =
         context_->dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_TELEMETRY);
     smc_dispatch_telemetry_control_.num_hw_cqs = this->num_hw_cqs_;
-    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
-    if (tt_device == nullptr) {
-        return;
-    }
     write_smc_dispatch_telemetry_control(*tt_device, smc_dispatch_telemetry_control_);
 }
 
@@ -116,7 +126,17 @@ void Device::invalidate_smc_dispatch_telemetry_control() {
         return;
     }
 
-    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
+    auto* tt_device = [&]() -> tt::umd::TTDevice* {
+        const auto& driver = context_->get_cluster().get_driver();
+        if (driver == nullptr) {
+            return nullptr;
+        }
+        auto* chip = driver->get_chip(this->id_);
+        if (chip == nullptr) {
+            return nullptr;
+        }
+        return chip->get_tt_device();
+    }();
     if (tt_device == nullptr) {
         return;
     }
@@ -129,14 +149,25 @@ void Device::update_smc_dispatch_telemetry_for_fast_dispatch(
         return;
     }
 
+    auto* tt_device = [&]() -> tt::umd::TTDevice* {
+        const auto& driver = context_->get_cluster().get_driver();
+        if (driver == nullptr) {
+            return nullptr;
+        }
+        auto* chip = driver->get_chip(this->id_);
+        if (chip == nullptr) {
+            return nullptr;
+        }
+        return chip->get_tt_device();
+    }();
+    if (tt_device == nullptr) {
+        return;
+    }
+
     TT_FATAL(
         cq_id < dispatch_telemetry_types::RESERVED_CQ_SPACE,
         "CQ id {} exceeds reserved SMC dispatch telemetry CQ space",
         cq_id);
-    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
-    if (tt_device == nullptr) {
-        return;
-    }
 
     smc_dispatch_telemetry_control_.cq_dispatch_core_coords[cq_id] = coords;
     write_smc_dispatch_telemetry_control(*tt_device, smc_dispatch_telemetry_control_);
@@ -147,7 +178,17 @@ void Device::set_smc_dispatch_telemetry_slow_dispatch_enabled(bool enabled) {
         return;
     }
 
-    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
+    auto* tt_device = [&]() -> tt::umd::TTDevice* {
+        const auto& driver = context_->get_cluster().get_driver();
+        if (driver == nullptr) {
+            return nullptr;
+        }
+        auto* chip = driver->get_chip(this->id_);
+        if (chip == nullptr) {
+            return nullptr;
+        }
+        return chip->get_tt_device();
+    }();
     if (tt_device == nullptr) {
         return;
     }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -63,10 +63,12 @@
 #include "tt_metal/fabric/fabric_init.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <umd/device/coordinates/coordinate_manager.hpp>
+#include <umd/device/tt_device/tt_device.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <impl/debug/watcher_server.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <impl/dispatch/dispatch_telemetry.hpp>
 
 namespace tt::tt_metal {
 
@@ -91,6 +93,80 @@ Device::Device(
     TT_FATAL(env != nullptr, "env is nullptr");
     TT_FATAL(context != nullptr, "context is nullptr");
     this->initialize(num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap, minimal);
+}
+
+void Device::initialize_smc_dispatch_telemetry_control() {
+    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+        return;
+    }
+
+    smc_dispatch_telemetry_control_ = dispatch_telemetry_types::SMCDispatchTelemetryControl{};
+    smc_dispatch_telemetry_control_.dispatch_telemetry_addr =
+        context_->dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_TELEMETRY);
+    smc_dispatch_telemetry_control_.num_hw_cqs = this->num_hw_cqs_;
+    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
+    if (tt_device == nullptr) {
+        return;
+    }
+    write_smc_dispatch_telemetry_control(*tt_device, smc_dispatch_telemetry_control_);
+}
+
+void Device::invalidate_smc_dispatch_telemetry_control() {
+    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+        return;
+    }
+
+    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
+    if (tt_device == nullptr) {
+        return;
+    }
+    tt::tt_metal::invalidate_smc_dispatch_telemetry_control(*tt_device);
+}
+
+void Device::update_smc_dispatch_telemetry_for_fast_dispatch(
+    uint8_t cq_id, const dispatch_telemetry_types::SMCDispatchCoreCoords& coords) {
+    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+        return;
+    }
+
+    TT_FATAL(
+        cq_id < dispatch_telemetry_types::RESERVED_CQ_SPACE,
+        "CQ id {} exceeds reserved SMC dispatch telemetry CQ space",
+        cq_id);
+    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
+    if (tt_device == nullptr) {
+        return;
+    }
+
+    smc_dispatch_telemetry_control_.cq_dispatch_core_coords[cq_id] = coords;
+    write_smc_dispatch_telemetry_control(*tt_device, smc_dispatch_telemetry_control_);
+}
+
+void Device::set_smc_dispatch_telemetry_slow_dispatch_enabled(bool enabled) {
+    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+        return;
+    }
+
+    auto* tt_device = context_->get_cluster().get_driver()->get_chip(this->id_)->get_tt_device();
+    if (tt_device == nullptr) {
+        return;
+    }
+
+    bool slow_dispatch_currently_enabled =
+        (smc_dispatch_telemetry_control_.flags &
+         static_cast<uint32_t>(dispatch_telemetry_types::SMCDispatchTelemetryFlags::SLOW_DISPATCH_ENABLED)) != 0;
+    if (slow_dispatch_currently_enabled == enabled) {
+        return;
+    }
+
+    if (enabled) {
+        smc_dispatch_telemetry_control_.flags |=
+            static_cast<uint32_t>(dispatch_telemetry_types::SMCDispatchTelemetryFlags::SLOW_DISPATCH_ENABLED);
+    } else {
+        smc_dispatch_telemetry_control_.flags &=
+            ~static_cast<uint32_t>(dispatch_telemetry_types::SMCDispatchTelemetryFlags::SLOW_DISPATCH_ENABLED);
+    }
+    write_smc_dispatch_telemetry_control(*tt_device, smc_dispatch_telemetry_control_);
 }
 
 std::unordered_set<CoreCoord> Device::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
@@ -547,6 +623,7 @@ bool Device::initialize(
     }
 
     this->initialized_ = true;
+    this->initialize_smc_dispatch_telemetry_control();
 
     return true;
 }
@@ -556,6 +633,8 @@ bool Device::close() {
     if (not this->initialized_) {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
+
+    this->invalidate_smc_dispatch_telemetry_control();
 
     tt::tt_metal::MetalContext::instance().get_service_core_manager().impl().on_device_close(this->id_);
 

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/device.hpp>
 #include <hostdevcommon/common_values.hpp>
+#include <hostdevcommon/dispatch_telemetry_types.hpp>
 #include <hostdevcommon/kernel_structs.h>  // Leaked up to ttnn level from here
 #include <tt-metalium/hal_types.hpp>
 #include "context/metal_context.hpp"
@@ -150,6 +151,9 @@ public:
 
     bool compile_fabric();
     void configure_fabric();
+    void update_smc_dispatch_telemetry_for_fast_dispatch(
+        uint8_t cq_id, const dispatch_telemetry_types::SMCDispatchCoreCoords& coords);
+    void set_smc_dispatch_telemetry_slow_dispatch_enabled(bool enabled);
     // Puts device into reset
     bool close() override;
 
@@ -215,6 +219,9 @@ private:
 
     void configure_command_queue_programs(DispatchTopology* topology);
 
+    void initialize_smc_dispatch_telemetry_control();
+    void invalidate_smc_dispatch_telemetry_control();
+
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void mark_allocations_unsafe();
     // NOLINTNEXTLINE(readability-make-member-function-const)
@@ -231,6 +238,7 @@ private:
     std::vector<std::vector<ChipId>> tunnels_from_mmio_;
 
     bool initialized_ = false;
+    dispatch_telemetry_types::SMCDispatchTelemetryControl smc_dispatch_telemetry_control_;
 
     std::vector<std::unique_ptr<Program>> command_queue_programs_;
     bool using_fast_dispatch_ = false;

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -22,6 +22,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include <hostdevcommon/common_values.hpp>
 
 namespace tt::tt_metal {
 
@@ -69,7 +70,7 @@ public:
     /// @param dispatch_core_config specifies the core type that is designated for dispatch functionality
     dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env);
 
-    static constexpr uint8_t MAX_NUM_HW_CQS = 2;
+    static constexpr uint8_t MAX_NUM_HW_CQS = ::MAX_NUM_HW_CQS;
 
     /// @brief Gets the location of the kernel designated to read from the issue queue region from a particular command
     /// queue

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -94,9 +94,9 @@ DispatchMemMap::DispatchMemMap(
                 hal.get_realtime_profiler_msgs_factory(HalProgrammableCoreType::TENSIX)
                     .size_of<realtime_profiler_msgs::realtime_profiler_msg_t>();
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_TELEMETRY) {
-            device_cq_addr_sizes_[dev_addr_idx] = DISPATCH_TELEMETRY_SIZE;
+            device_cq_addr_sizes_[dev_addr_idx] = dispatch_telemetry_types::DISPATCH_TELEMETRY_SIZE;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_TELEMETRY_CONTROL) {
-            device_cq_addr_sizes_[dev_addr_idx] = sizeof(DispatchTelemetryControl);
+            device_cq_addr_sizes_[dev_addr_idx] = sizeof(dispatch_telemetry_types::DispatchTelemetryControl);
         } else if (dev_addr_type == CommandQueueDeviceAddrType::WORKER_COMPLETION_SEMAPHORES) {
             device_cq_addr_sizes_[dev_addr_idx] =
                 has_stream_registers_ ? 0 : DispatchSettings::DISPATCH_MESSAGE_ENTRIES * l1_alignment;

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -83,7 +83,7 @@ public:
     // Same as the one in cq_prefetch.cpp
     using prefetch_q_ptr_type = uint32_t;
 
-    static constexpr uint32_t MAX_NUM_HW_CQS = 2;
+    static constexpr uint32_t MAX_NUM_HW_CQS = ::MAX_NUM_HW_CQS;
 
     static constexpr uint32_t DISPATCH_MESSAGE_ENTRIES = ::DISPATCH_MAX_MESSAGE_ENTRIES;
 

--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -7,50 +7,94 @@
 #include <optional>
 #include <limits>
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 #include <tt-metalium/experimental/dispatch_telemetry.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
+#include <umd/device/tt_device/tt_device.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
-#include "device.hpp"
-#include "device_types.hpp"
-#include "dispatch/command_queue_common.hpp"
-#include "impl/context/metal_context.hpp"
-#include "impl/dispatch/dispatch_core_manager.hpp"
-#include "impl/dispatch/dispatch_mem_map.hpp"
 #include "impl/dispatch/dispatch_telemetry.hpp"
 #include <hostdevcommon/dispatch_telemetry_types.hpp>
 #include "llrt/tt_cluster.hpp"
 #include "umd/device/types/core_coordinates.hpp"
-#include "impl/context/metal_env_accessor.hpp"
-#include "llrt/core_descriptor.hpp"
 
 namespace tt::tt_metal {
 
 namespace {
 
-template <typename T>
-std::optional<T> read_telemetry_impl(ChipId chip, const CoreCoord& virtual_core, uint32_t signature, uint32_t version) {
-    // Telemetry lives at a fixed dispatch-core-local L1 offset assigned by DispatchMemMap.
-    // Prefetch and dispatch both use this section depending on which one is running on the core.
-    const auto& dispatch_mem_map = MetalContext::instance().dispatch_mem_map();
-    uint32_t addr = dispatch_mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_TELEMETRY);
+struct SMCRuntimeTelemetryBuffer {
+    tt_xy_pair arc_core;
+    uint32_t addr = 0;
+    uint32_t size = 0;
+};
 
-    // Make sure any in-flight kernel writes to L1 are visible before we sample.
-    const auto& cluster = MetalContext::instance().get_cluster();
-    cluster.l1_barrier(chip);
+std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control(tt::umd::TTDevice& tt_device) {
+    auto size = tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_size();
+    if (!size.has_value()) {
+        log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
+        return std::nullopt;
+    }
+    if (size.value() < sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl)) {
+        log_warning(
+            tt::LogMetal,
+            "Dispatch telemetry SMC buffer is too small: got {} bytes, expected at least {} bytes",
+            size.value(),
+            sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl));
+        return std::nullopt;
+    }
+
+    auto addr = tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_address();
+    if (!addr.has_value()) {
+        log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer address is unavailable or invalid");
+        return std::nullopt;
+    }
+
+    return SMCRuntimeTelemetryBuffer{.arc_core = tt_device.get_arc_core(), .addr = addr.value(), .size = size.value()};
+}
+
+template <typename T>
+std::optional<T> read_telemetry_impl(
+    tt::umd::TTDevice& tt_device, CoreCoord virtual_core, uint32_t signature, uint32_t version, uint32_t addr_offset) {
+    if (addr_offset == 0) {
+        log_warning(tt::LogMetal, "SMC dispatch telemetry control has no dispatch telemetry address");
+        return std::nullopt;
+    }
+
+    bool is_known_virtual_core = [&]() {
+        const auto& soc_desc = tt_device.get_soc_descriptor();
+        for (const tt::CoreType core_type : {tt::CoreType::TENSIX, tt::CoreType::ETH, tt::CoreType::DISPATCH}) {
+            for (const auto& core : soc_desc.get_cores(core_type, tt::CoordSystem::TRANSLATED)) {
+                if (core.x == virtual_core.x && core.y == virtual_core.y) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }();
+
+    if (!is_known_virtual_core) {
+        log_warning(
+            tt::LogMetal,
+            "Refusing dispatch telemetry read from unknown virtual core ({},{}); not a valid core in the SoC "
+            "descriptor",
+            virtual_core.x,
+            virtual_core.y);
+        return std::nullopt;
+    }
 
     T telemetry{};
-    cluster.read_core(&telemetry, sizeof(telemetry), tt_cxy_pair(chip, virtual_core), addr);
+    tt_device.read_from_device(&telemetry, virtual_core, addr_offset, sizeof(telemetry));
 
     if (telemetry.signature != signature) {
         // Copy to avoid taking a reference to a packed struct's member variable, which could be unaligned.
         uint32_t telemetry_signature = telemetry.signature;
         log_warning(
             tt::LogMetal,
-            "Signature mismatch on chip {} core ({},{}): got 0x{:x}, expected 0x{:x}",
-            chip,
+            "Signature mismatch on virtual core ({},{}): got 0x{:x}, expected 0x{:x}",
             virtual_core.x,
             virtual_core.y,
             telemetry_signature,
@@ -62,8 +106,7 @@ std::optional<T> read_telemetry_impl(ChipId chip, const CoreCoord& virtual_core,
         uint32_t telemetry_version = telemetry.version;
         log_warning(
             tt::LogMetal,
-            "Version mismatch on chip {} core ({},{}): got {}, expected {}",
-            chip,
+            "Version mismatch on virtual core ({},{}): got {}, expected {}",
             virtual_core.x,
             virtual_core.y,
             telemetry_version,
@@ -85,14 +128,96 @@ T calc_delta(T current, T last) {
 
 }  // namespace
 
-std::optional<DispatchCoreTelemetry> read_dispatch_core_telemetry(ChipId chip, const CoreCoord& virtual_core) {
-    return read_telemetry_impl<DispatchCoreTelemetry>(
-        chip, virtual_core, DISPATCH_CORE_TELEMETRY_SIGNATURE, DISPATCH_TELEMETRY_VERSION);
+std::optional<dispatch_telemetry_types::SMCDispatchTelemetryControl> read_smc_dispatch_telemetry_control(
+    tt::umd::TTDevice& tt_device) {
+    auto maybeSmcBufferInfo = discover_smc_dispatch_telemetry_control(tt_device);
+    if (!maybeSmcBufferInfo.has_value()) {
+        return std::nullopt;
+    }
+    const auto& smcBufferInfo = maybeSmcBufferInfo.value();
+
+    dispatch_telemetry_types::SMCDispatchTelemetryControl control{};
+    tt_device.read_from_device(&control, smcBufferInfo.arc_core, smcBufferInfo.addr, sizeof(control));
+
+    if (control.signature != dispatch_telemetry_types::SMC_TELEMETRY_SIGNATURE) {
+        uint32_t control_signature = control.signature;
+        log_warning(
+            tt::LogMetal,
+            "SMC dispatch telemetry signature mismatch: got 0x{:x}, expected 0x{:x}",
+            control_signature,
+            dispatch_telemetry_types::SMC_TELEMETRY_SIGNATURE);
+        return std::nullopt;
+    }
+    if (control.version != dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION) {
+        uint32_t control_version = control.version;
+        log_warning(
+            tt::LogMetal,
+            "SMC dispatch telemetry version mismatch: got {}, expected {}",
+            control_version,
+            dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION);
+        return std::nullopt;
+    }
+
+    return control;
 }
 
-std::optional<PrefetchCoreTelemetry> read_prefetch_core_telemetry(ChipId chip, const CoreCoord& virtual_core) {
-    return read_telemetry_impl<PrefetchCoreTelemetry>(
-        chip, virtual_core, PREFETCH_CORE_TELEMETRY_SIGNATURE, DISPATCH_TELEMETRY_VERSION);
+bool write_smc_dispatch_telemetry_control(
+    tt::umd::TTDevice& tt_device, const dispatch_telemetry_types::SMCDispatchTelemetryControl& control) {
+    auto maybeSmcBufferInfo = discover_smc_dispatch_telemetry_control(tt_device);
+    if (!maybeSmcBufferInfo.has_value()) {
+        return false;
+    }
+    const auto& smcBufferInfo = maybeSmcBufferInfo.value();
+    tt_device.write_to_device(&control, smcBufferInfo.arc_core, smcBufferInfo.addr, sizeof(control));
+    return true;
+}
+
+bool invalidate_smc_dispatch_telemetry_control(tt::umd::TTDevice& tt_device) {
+    auto maybeSmcBufferInfo = discover_smc_dispatch_telemetry_control(tt_device);
+    if (!maybeSmcBufferInfo.has_value()) {
+        return false;
+    }
+    const auto& smcBufferInfo = maybeSmcBufferInfo.value();
+
+    uint32_t invalid_signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
+    tt_device.write_to_device(
+        &invalid_signature,
+        smcBufferInfo.arc_core,
+        smcBufferInfo.addr + offsetof(dispatch_telemetry_types::SMCDispatchTelemetryControl, signature),
+        sizeof(invalid_signature));
+    return true;
+}
+
+std::optional<dispatch_telemetry_types::DispatchCoreTelemetry> read_dispatch_core_telemetry(
+    tt::umd::TTDevice& tt_device, CoreCoord virtual_core) {
+    auto control = read_smc_dispatch_telemetry_control(tt_device);
+    if (!control.has_value()) {
+        return std::nullopt;
+    }
+    uint32_t addr_offset = control->dispatch_telemetry_addr;
+
+    return read_telemetry_impl<dispatch_telemetry_types::DispatchCoreTelemetry>(
+        tt_device,
+        virtual_core,
+        dispatch_telemetry_types::DISPATCH_CORE_TELEMETRY_SIGNATURE,
+        dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION,
+        addr_offset);
+}
+
+std::optional<dispatch_telemetry_types::PrefetchCoreTelemetry> read_prefetch_core_telemetry(
+    tt::umd::TTDevice& tt_device, CoreCoord virtual_core) {
+    auto control = read_smc_dispatch_telemetry_control(tt_device);
+    if (!control.has_value()) {
+        return std::nullopt;
+    }
+    uint32_t addr_offset = control->dispatch_telemetry_addr;
+
+    return read_telemetry_impl<dispatch_telemetry_types::PrefetchCoreTelemetry>(
+        tt_device,
+        virtual_core,
+        dispatch_telemetry_types::PREFETCH_CORE_TELEMETRY_SIGNATURE,
+        dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION,
+        addr_offset);
 }
 
 class DispatchTelemetry::Impl {
@@ -108,116 +233,89 @@ private:
 
     struct CoreEntry {
         CoreRole role = CoreRole::INVALID;
-        CoreCoord virtual_core;  // read_core needs a virtual (noc-addressable) coord
-        uint8_t cq_id;
+        CoreCoord virtual_core;
+        uint8_t cq_id = 0;
     };
 
-    // TODO: replace with querying device without device instance or bake into telemetry
-    static uint32_t get_total_worker_and_active_eth_cores(const IDevice& device) {
-        auto& env = MetalEnvAccessor(tt::tt_metal::MetalContext::instance().get_env()).impl();
-        auto& dcm = MetalContext::instance().get_dispatch_core_manager();
-
-        const auto& compute_cores =
-            tt::get_logical_compute_cores(env, device.id(), device.num_hw_cqs(), dcm.get_dispatch_core_config());
-
-        uint32_t total_cores = compute_cores.size();
-        total_cores += device.get_active_ethernet_cores(/*skip_reserved_tunnel_cores=*/true).size();
+    static uint32_t get_total_worker_and_active_eth_cores(tt::umd::TTDevice& tt_device) {
+        const auto& soc_desc = tt_device.get_soc_descriptor();
+        uint32_t total_cores = soc_desc.get_cores(tt::CoreType::TENSIX, tt::CoordSystem::TRANSLATED).size();
+        total_cores += soc_desc.get_cores(tt::CoreType::ETH, tt::CoordSystem::TRANSLATED).size();
         return total_cores;
     }
 
-    std::vector<std::vector<CoreEntry>> collect_telemetry_cores(const IDevice& device) {
-        std::vector<std::vector<CoreEntry>> entries;
-
-        auto& dcm = MetalContext::instance().get_dispatch_core_manager();
-        const auto& cluster = MetalContext::instance().get_cluster();
-        const ChipId chip = device.id();
-        const uint16_t channel = cluster.get_assigned_channel_for_device(chip);
-        const uint8_t num_cqs = device.num_hw_cqs();
-        const CoreType core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-
-        for (uint8_t cq = 0; cq < num_cqs; ++cq) {
-            std::vector<CoreEntry> cq_entries;
-            if (dcm.is_prefetcher_core_allocated(chip, channel, cq)) {
-                CoreEntry entry{};
-                entry.role = CoreRole::PREFETCH;
-                tt_cxy_pair logical_cxy = dcm.prefetcher_core(chip, channel, cq);
-                entry.virtual_core =
-                    device.virtual_core_from_logical_core(CoreCoord{logical_cxy.x, logical_cxy.y}, core_type);
-                entry.cq_id = cq;
-                cq_entries.push_back(entry);
-            }
-            if (dcm.is_prefetcher_d_core_allocated(chip, channel, cq)) {
-                CoreEntry entry{};
-                entry.role = CoreRole::PREFETCH_D;
-                tt_cxy_pair logical_cxy = dcm.prefetcher_d_core(chip, channel, cq);
-                entry.virtual_core =
-                    device.virtual_core_from_logical_core(CoreCoord{logical_cxy.x, logical_cxy.y}, core_type);
-                entry.cq_id = cq;
-                cq_entries.push_back(entry);
-            }
-            if (dcm.is_dispatcher_core_allocated(chip, channel, cq)) {
-                CoreEntry entry{};
-                entry.role = CoreRole::DISPATCH;
-                tt_cxy_pair logical_cxy = dcm.dispatcher_core(chip, channel, cq);
-                entry.virtual_core =
-                    device.virtual_core_from_logical_core(CoreCoord{logical_cxy.x, logical_cxy.y}, core_type);
-                entry.cq_id = cq;
-                cq_entries.push_back(entry);
-            }
-            if (dcm.is_dispatcher_d_core_allocated(chip, channel, cq)) {
-                CoreEntry entry{};
-                entry.role = CoreRole::DISPATCH_D;
-                tt_cxy_pair logical_cxy = dcm.dispatcher_d_core(chip, channel, cq);
-                entry.virtual_core =
-                    device.virtual_core_from_logical_core(CoreCoord{logical_cxy.x, logical_cxy.y}, core_type);
-                entry.cq_id = cq;
-                cq_entries.push_back(entry);
-            }
-            if (dcm.is_dispatcher_s_core_allocated(chip, channel, cq)) {
-                CoreEntry entry{};
-                entry.role = CoreRole::DISPATCH_S;
-                tt_cxy_pair logical_cxy = dcm.dispatcher_s_core(chip, channel, cq);
-                entry.virtual_core =
-                    device.virtual_core_from_logical_core(CoreCoord{logical_cxy.x, logical_cxy.y}, core_type);
-                entry.cq_id = cq;
-                cq_entries.push_back(entry);
-            }
-            entries.push_back(cq_entries);
+    std::vector<std::vector<CoreEntry>> collect_telemetry_cores() {
+        auto control = read_smc_dispatch_telemetry_control(tt_device_);
+        if (!control.has_value() || control->num_hw_cqs > dispatch_telemetry_types::RESERVED_CQ_SPACE) {
+            return {};
         }
 
-        return entries;
+        std::vector<std::vector<CoreEntry>> entries_per_active_cq;
+        const uint8_t num_cqs = control->num_hw_cqs;
+
+        for (uint8_t cq = 0; cq < num_cqs; ++cq) {
+            const auto core_coords = control->cq_dispatch_core_coords[cq];
+            if (core_coords.prefetch_xy == dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS ||
+                core_coords.dispatch_xy == dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS) {
+                // Assumes valid CQ IDs are contiguous
+                break;
+            }
+
+            std::vector<CoreEntry> cq_entries;
+
+            auto smc_xy_to_virtual_core = [](uint32_t xy) {
+                return CoreCoord{
+                    dispatch_telemetry_types::smc_dispatch_core_x(xy),
+                    dispatch_telemetry_types::smc_dispatch_core_y(xy)};
+            };
+
+            cq_entries.push_back(CoreEntry{
+                .role = CoreRole::PREFETCH,
+                .virtual_core = smc_xy_to_virtual_core(core_coords.prefetch_xy),
+                .cq_id = cq});
+            cq_entries.push_back(CoreEntry{
+                .role = CoreRole::DISPATCH,
+                .virtual_core = smc_xy_to_virtual_core(core_coords.dispatch_xy),
+                .cq_id = cq});
+
+            if (core_coords.dispatch_s_xy != dispatch_telemetry_types::INVALID_SMC_DISPATCH_CORE_COORDS) {
+                // TODO: Handle dispatch_s telemetry once SMC-discovered dispatch_s data is consumed here.
+                cq_entries.push_back(CoreEntry{
+                    .role = CoreRole::DISPATCH_S,
+                    .virtual_core = smc_xy_to_virtual_core(core_coords.dispatch_s_xy),
+                    .cq_id = cq});
+            }
+
+            entries_per_active_cq.push_back(std::move(cq_entries));
+        }
+
+        return entries_per_active_cq;
     }
 
 public:
-    Impl(const IDevice& device) :
-        chip_(device.id()),
-        dispatch_core_type_(MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type()),
-        total_number_of_cores_(get_total_worker_and_active_eth_cores(device)),
-        // TODO: Note: current impl assumes cq count won't change during its object lifetime
-        telemetry_cores_per_cq_(collect_telemetry_cores(device)),
-        last_read_dispatch_core_telemetry_(telemetry_cores_per_cq_.size()),
-        last_read_prefetch_core_telemetry_(telemetry_cores_per_cq_.size()) {
-        TT_FATAL(!telemetry_cores_per_cq_.empty(), "No dispatch telemetry cores found on device\n");
+    Impl(tt::umd::TTDevice& device) :
+        tt_device_(device), total_number_of_cores_(get_total_worker_and_active_eth_cores(device)) {
         // Init private members to construction time
         (void)read_info();
     }
 
     ~Impl() = default;
 
-    uint32_t version() const { return DISPATCH_TELEMETRY_VERSION; }
+    uint32_t version() const { return dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION; }
 
     std::optional<float> get_normalized_utilization(
-        const DispatchCoreTelemetry& current_dispatch_core_telemetry,
-        const DispatchCoreTelemetry& last_read_dispatch_core_telemetry) {
+        const dispatch_telemetry_types::DispatchCoreTelemetry& current_dispatch_core_telemetry,
+        const dispatch_telemetry_types::DispatchCoreTelemetry& last_read_dispatch_core_telemetry) {
         auto current_utilization_work_runtime = current_dispatch_core_telemetry.utilization_work_runtime;
         auto last_utilization_work_runtime = last_read_dispatch_core_telemetry.utilization_work_runtime;
 
-        auto get_workers_in_flight_runtime = [](const DispatchCoreTelemetry& dispatch_core_telemetry) -> uint64_t {
+        auto get_workers_in_flight_runtime =
+            [](const dispatch_telemetry_types::DispatchCoreTelemetry& dispatch_core_telemetry) -> uint64_t {
             if (dispatch_core_telemetry.work_runtime_start == 0) {
                 return 0;
             }
 
-            for (size_t i = 0; i < MAX_SUB_DEVICES; ++i) {
+            for (size_t i = 0; i < dispatch_telemetry_types::MAX_SUB_DEVICES; ++i) {
                 if (dispatch_core_telemetry.workers_per_sub_device[i] == 0) {
                     continue;
                 }
@@ -249,19 +347,19 @@ public:
     }
 
     std::optional<float> get_normalized_core_efficiency(
-        const std::vector<DispatchCoreTelemetry>& current_dispatch_core_telemetry) {
+        const std::vector<dispatch_telemetry_types::DispatchCoreTelemetry>& current_dispatch_core_telemetry) {
         const uint32_t total_number_of_cores = total_number_of_cores_;
         TT_ASSERT(total_number_of_cores > 0, "Error in core detection, found 0 cores");
 
-        auto get_work_times = [&](const std::vector<DispatchCoreTelemetry>& dispatch_core_telemetry_per_cq,
-                                  // Cumulative of all work performed
-                                  double& total_work_runtime,
+        auto get_work_times = [&](const std::vector<dispatch_telemetry_types::DispatchCoreTelemetry>&
+                                      dispatch_core_telemetry_per_cq,
+                                  double& total_work_runtime,  // Cumulative of all work performed
                                   uint64_t& elapsed_device_time) {
             for (const auto& dispatch_telemetry : dispatch_core_telemetry_per_cq) {
                 // Uncompress the averaged work time
                 total_work_runtime += dispatch_telemetry.avg_work_runtime_per_worker * total_number_of_cores;
 
-                for (size_t i = 0; i < MAX_SUB_DEVICES; ++i) {
+                for (size_t i = 0; i < dispatch_telemetry_types::MAX_SUB_DEVICES; ++i) {
                     if (dispatch_telemetry.workers_per_sub_device[i] == 0) {
                         continue;
                     }
@@ -312,24 +410,19 @@ public:
         return std::clamp(core_efficiency, 0.0f, 1.0f);
     }
 
-    // Telemetry will be assembled in order according to its pre-calculated cq id.
-    // This id correlates to core coordinates, so it is static for the lifetime of the
-    // object.
     bool read_core_telemetry(
-        std::vector<DispatchCoreTelemetry>& current_dispatch_core_telemetry,
-        std::vector<PrefetchCoreTelemetry>& current_prefetch_core_telemetry) {
+        const std::vector<std::vector<CoreEntry>>& entries_per_active_cq,
+        std::vector<dispatch_telemetry_types::DispatchCoreTelemetry>& current_dispatch_core_telemetry,
+        std::vector<dispatch_telemetry_types::PrefetchCoreTelemetry>& current_prefetch_core_telemetry) {
         TT_ASSERT(
-            current_dispatch_core_telemetry.size() == telemetry_cores_per_cq_.size(),
-            "Invalid dispatch telemetry size");
+            current_dispatch_core_telemetry.size() == entries_per_active_cq.size(), "Invalid dispatch telemetry size");
         TT_ASSERT(
-            current_prefetch_core_telemetry.size() == telemetry_cores_per_cq_.size(),
-            "Invalid prefetch telemetry size");
+            current_prefetch_core_telemetry.size() == entries_per_active_cq.size(), "Invalid prefetch telemetry size");
 
-        for (size_t cq = 0; cq < telemetry_cores_per_cq_.size(); ++cq) {
-            const auto& cq_entries = telemetry_cores_per_cq_[cq];
+        for (size_t cq = 0; cq < entries_per_active_cq.size(); ++cq) {
+            const auto& cq_entries = entries_per_active_cq[cq];
             if (cq_entries.empty()) {
                 log_warning(tt::LogMetal, "No dispatch telemetry cores found for CQ {}", cq);
-                // TODO: does this trigger on slow dispatch?
                 return false;
             }
 
@@ -338,7 +431,7 @@ public:
 
             for (const auto& core : cq_entries) {
                 if (core.role == CoreRole::PREFETCH || core.role == CoreRole::PREFETCH_D) {
-                    auto telemetry = read_prefetch_core_telemetry(chip_, core.virtual_core);
+                    auto telemetry = read_prefetch_core_telemetry(tt_device_, core.virtual_core);
                     if (telemetry) {
                         TT_ASSERT(!found_prefetch_core, "Ensure only one prefetcher is found");
                         found_prefetch_core = true;
@@ -346,7 +439,7 @@ public:
                     }
                 }
                 if (core.role == CoreRole::DISPATCH || core.role == CoreRole::DISPATCH_D) {
-                    auto telemetry = read_dispatch_core_telemetry(chip_, core.virtual_core);
+                    auto telemetry = read_dispatch_core_telemetry(tt_device_, core.virtual_core);
                     if (telemetry) {
                         // TODO: for now
                         TT_ASSERT(!found_dispatch_core, "Ensure only worker dispatch is found");
@@ -367,11 +460,15 @@ public:
     }
 
     std::optional<DispatchTelemetryDeviceInfo> compute_telemetry_info(
-        const std::vector<DispatchCoreTelemetry>& current_dispatch_core_telemetry,
-        const std::vector<PrefetchCoreTelemetry>& current_prefetch_core_telemetry) {
+        const std::vector<std::vector<CoreEntry>>& entries_per_active_cq,
+        const std::vector<dispatch_telemetry_types::DispatchCoreTelemetry>& current_dispatch_core_telemetry,
+        const std::vector<dispatch_telemetry_types::PrefetchCoreTelemetry>& current_prefetch_core_telemetry) {
         TT_ASSERT(
             current_dispatch_core_telemetry.size() == current_prefetch_core_telemetry.size(),
             "Ensure there is one of each per cq");
+        TT_ASSERT(
+            entries_per_active_cq.size() == current_prefetch_core_telemetry.size(),
+            "Ensure telemetry and core entries are aligned");
         DispatchTelemetryDeviceInfo device_info;
         device_info.info_cqs.resize(current_prefetch_core_telemetry.size());
 
@@ -381,8 +478,9 @@ public:
         for (size_t cq = 0; cq < current_prefetch_core_telemetry.size(); ++cq) {
             auto& cq_info = device_info.info_cqs[cq];
             const auto& prefetch_telemetry = current_prefetch_core_telemetry[cq];
+            TT_ASSERT(!entries_per_active_cq[cq].empty(), "Missing dispatch telemetry core entry");
 
-            cq_info.cq_id = cq;
+            cq_info.cq_id = entries_per_active_cq[cq].front().cq_id;
             cq_info.prefetch_waiting_on_upstream =
                 (prefetch_telemetry.upstream_blocked_count != prefetch_telemetry.upstream_unblocked_count);
             cq_info.prefetch_blocked_count_since_last_read = calc_delta(
@@ -397,7 +495,7 @@ public:
             auto& cq_info = device_info.info_cqs[cq];
             const auto& dispatch_telemetry = current_dispatch_core_telemetry[cq];
 
-            TT_ASSERT(cq_info.cq_id == cq, "cq_id mismatch");
+            TT_ASSERT(cq_info.cq_id == entries_per_active_cq[cq].front().cq_id, "cq_id mismatch");
 
             cq_info.dispatch_waiting_on_upstream =
                 (dispatch_telemetry.upstream_blocked_count != dispatch_telemetry.upstream_unblocked_count);
@@ -416,26 +514,36 @@ public:
     }
 
     std::optional<DispatchTelemetryDeviceInfo> read_info() {
-        std::vector<DispatchCoreTelemetry> current_dispatch_core_telemetry(telemetry_cores_per_cq_.size());
-        std::vector<PrefetchCoreTelemetry> current_prefetch_core_telemetry(telemetry_cores_per_cq_.size());
-
-        if (!read_core_telemetry(current_dispatch_core_telemetry, current_prefetch_core_telemetry)) {
+        std::vector<std::vector<CoreEntry>> entries_per_active_cq = collect_telemetry_cores();
+        if (entries_per_active_cq.empty()) {
             return std::nullopt;
         }
 
-        return compute_telemetry_info(current_dispatch_core_telemetry, current_prefetch_core_telemetry);
+        std::vector<dispatch_telemetry_types::DispatchCoreTelemetry> current_dispatch_core_telemetry(
+            entries_per_active_cq.size());
+        std::vector<dispatch_telemetry_types::PrefetchCoreTelemetry> current_prefetch_core_telemetry(
+            entries_per_active_cq.size());
+
+        last_read_dispatch_core_telemetry_.resize(entries_per_active_cq.size());
+        last_read_prefetch_core_telemetry_.resize(entries_per_active_cq.size());
+
+        if (!read_core_telemetry(
+                entries_per_active_cq, current_dispatch_core_telemetry, current_prefetch_core_telemetry)) {
+            return std::nullopt;
+        }
+
+        return compute_telemetry_info(
+            entries_per_active_cq, current_dispatch_core_telemetry, current_prefetch_core_telemetry);
     }
 
 private:
-    ChipId chip_;
-    CoreType dispatch_core_type_;
+    tt::umd::TTDevice& tt_device_;
     uint32_t total_number_of_cores_;
-    std::vector<std::vector<CoreEntry>> telemetry_cores_per_cq_;
-    std::vector<DispatchCoreTelemetry> last_read_dispatch_core_telemetry_;
-    std::vector<PrefetchCoreTelemetry> last_read_prefetch_core_telemetry_;
+    std::vector<dispatch_telemetry_types::DispatchCoreTelemetry> last_read_dispatch_core_telemetry_;
+    std::vector<dispatch_telemetry_types::PrefetchCoreTelemetry> last_read_prefetch_core_telemetry_;
 };
 
-DispatchTelemetry::DispatchTelemetry(const IDevice& device) : impl_(std::make_unique<Impl>(device)) {}
+DispatchTelemetry::DispatchTelemetry(tt::umd::TTDevice& device) : impl_(std::make_unique<Impl>(device)) {}
 
 DispatchTelemetry::~DispatchTelemetry() = default;
 

--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -33,42 +33,44 @@ struct SMCRuntimeTelemetryBuffer {
 };
 
 std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control(tt::umd::TTDevice& tt_device) {
-    // Dispatch telemetry is best-effort: any failure to reach the SMC/firmware side must degrade to
-    // "unavailable" rather than propagate, otherwise it would break device init/close on devices that
-    // don't back a firmware info provider. Note get_firmware_info_provider() THROWS (does not return
-    // null) when uninitialized -- e.g. simulators (TtSimTTDevice has no firmware_info_provider) -- so
-    // this must be a try/catch, not a null check.
+    tt::umd::FirmwareInfoProvider* firmware_info_provider = nullptr;
     try {
-        auto* firmware_info_provider = tt_device.get_firmware_info_provider();
-        auto size = firmware_info_provider->get_runtime_telemetry_buffer_size();
-        if (!size.has_value()) {
-            log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
-            return std::nullopt;
-        }
-        if (size.value() < sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl)) {
-            log_warning(
-                tt::LogMetal,
-                "Dispatch telemetry SMC buffer is too small: got {} bytes, expected at least {} bytes",
-                size.value(),
-                sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl));
-            return std::nullopt;
-        }
-
-        auto addr = firmware_info_provider->get_runtime_telemetry_buffer_address();
-        if (!addr.has_value()) {
-            log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer address is unavailable or invalid");
-            return std::nullopt;
-        }
-
-        return SMCRuntimeTelemetryBuffer{
-            .arc_core = tt_device.get_arc_core(), .addr = addr.value(), .size = size.value()};
+        // Throws when the device has no firmware info provider (ex: simulators)
+        // Dispatch telemetry is best-effort: any failure to reach the SMC/firmware side must degrade to
+        // "unavailable" rather than propagate, otherwise it would break device init/close on devices that
+        // don't back a firmware info provider.
+        firmware_info_provider = tt_device.get_firmware_info_provider();
     } catch (const std::exception& e) {
         log_warning(
             tt::LogMetal,
             "Dispatch telemetry SMC buffer unavailable (no firmware info provider, e.g. simulator): {}",
             e.what());
+    }
+    if (firmware_info_provider == nullptr) {
         return std::nullopt;
     }
+
+    auto size = firmware_info_provider->get_runtime_telemetry_buffer_size();
+    if (!size.has_value()) {
+        log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
+        return std::nullopt;
+    }
+    if (size.value() < sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl)) {
+        log_warning(
+            tt::LogMetal,
+            "Dispatch telemetry SMC buffer is too small: got {} bytes, expected at least {} bytes",
+            size.value(),
+            sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl));
+        return std::nullopt;
+    }
+
+    auto addr = firmware_info_provider->get_runtime_telemetry_buffer_address();
+    if (!addr.has_value()) {
+        log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer address is unavailable or invalid");
+        return std::nullopt;
+    }
+
+    return SMCRuntimeTelemetryBuffer{.arc_core = tt_device.get_arc_core(), .addr = addr.value(), .size = size.value()};
 }
 
 template <typename T>

--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -33,32 +33,42 @@ struct SMCRuntimeTelemetryBuffer {
 };
 
 std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control(tt::umd::TTDevice& tt_device) {
-    auto* firmware_info_provider = tt_device.get_firmware_info_provider();
-    if (firmware_info_provider == nullptr) {
-        log_warning(tt::LogMetal, "Firmware info provider unavailable; skipping dispatch telemetry SMC buffer");
-        return std::nullopt;
-    }
-    auto size = firmware_info_provider->get_runtime_telemetry_buffer_size();
-    if (!size.has_value()) {
-        log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
-        return std::nullopt;
-    }
-    if (size.value() < sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl)) {
+    // Dispatch telemetry is best-effort: any failure to reach the SMC/firmware side must degrade to
+    // "unavailable" rather than propagate, otherwise it would break device init/close on devices that
+    // don't back a firmware info provider. Note get_firmware_info_provider() THROWS (does not return
+    // null) when uninitialized -- e.g. simulators (TtSimTTDevice has no firmware_info_provider) -- so
+    // this must be a try/catch, not a null check.
+    try {
+        auto* firmware_info_provider = tt_device.get_firmware_info_provider();
+        auto size = firmware_info_provider->get_runtime_telemetry_buffer_size();
+        if (!size.has_value()) {
+            log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
+            return std::nullopt;
+        }
+        if (size.value() < sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl)) {
+            log_warning(
+                tt::LogMetal,
+                "Dispatch telemetry SMC buffer is too small: got {} bytes, expected at least {} bytes",
+                size.value(),
+                sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl));
+            return std::nullopt;
+        }
+
+        auto addr = firmware_info_provider->get_runtime_telemetry_buffer_address();
+        if (!addr.has_value()) {
+            log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer address is unavailable or invalid");
+            return std::nullopt;
+        }
+
+        return SMCRuntimeTelemetryBuffer{
+            .arc_core = tt_device.get_arc_core(), .addr = addr.value(), .size = size.value()};
+    } catch (const std::exception& e) {
         log_warning(
             tt::LogMetal,
-            "Dispatch telemetry SMC buffer is too small: got {} bytes, expected at least {} bytes",
-            size.value(),
-            sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl));
+            "Dispatch telemetry SMC buffer unavailable (no firmware info provider, e.g. simulator): {}",
+            e.what());
         return std::nullopt;
     }
-
-    auto addr = firmware_info_provider->get_runtime_telemetry_buffer_address();
-    if (!addr.has_value()) {
-        log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer address is unavailable or invalid");
-        return std::nullopt;
-    }
-
-    return SMCRuntimeTelemetryBuffer{.arc_core = tt_device.get_arc_core(), .addr = addr.value(), .size = size.value()};
 }
 
 template <typename T>

--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -33,7 +33,12 @@ struct SMCRuntimeTelemetryBuffer {
 };
 
 std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control(tt::umd::TTDevice& tt_device) {
-    auto size = tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_size();
+    auto* firmware_info_provider = tt_device.get_firmware_info_provider();
+    if (firmware_info_provider == nullptr) {
+        log_warning(tt::LogMetal, "Firmware info provider unavailable; skipping dispatch telemetry SMC buffer");
+        return std::nullopt;
+    }
+    auto size = firmware_info_provider->get_runtime_telemetry_buffer_size();
     if (!size.has_value()) {
         log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
         return std::nullopt;
@@ -47,7 +52,7 @@ std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control
         return std::nullopt;
     }
 
-    auto addr = tt_device.get_firmware_info_provider()->get_runtime_telemetry_buffer_address();
+    auto addr = firmware_info_provider->get_runtime_telemetry_buffer_address();
     if (!addr.has_value()) {
         log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer address is unavailable or invalid");
         return std::nullopt;

--- a/tt_metal/impl/dispatch/dispatch_telemetry.hpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.hpp
@@ -7,30 +7,62 @@
 #include <optional>
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/device_types.hpp>
 
 #include <hostdevcommon/dispatch_telemetry_types.hpp>
+
+namespace tt::umd {
+class TTDevice;
+}
 
 namespace tt::tt_metal {
 
 /**
+ * @brief Read the SMC dispatch telemetry control block.
+ *
+ * @param tt_device Non-owning UMD device context.
+ * @return Control block on success, or std::nullopt if discovery or validation fails.
+ */
+std::optional<dispatch_telemetry_types::SMCDispatchTelemetryControl> read_smc_dispatch_telemetry_control(
+    tt::umd::TTDevice& tt_device);
+
+/**
+ * @brief Write the SMC dispatch telemetry control block.
+ *
+ * @param tt_device Non-owning UMD device context.
+ * @param control Control block to write.
+ * @return True if the write completed, false if the SMC buffer is unavailable.
+ */
+bool write_smc_dispatch_telemetry_control(
+    tt::umd::TTDevice& tt_device, const dispatch_telemetry_types::SMCDispatchTelemetryControl& control);
+
+/**
+ * @brief Invalidate the SMC dispatch telemetry control block signature.
+ *
+ * @param tt_device Non-owning UMD device context.
+ * @return True if the invalidation completed, false if the SMC buffer is unavailable.
+ */
+bool invalidate_smc_dispatch_telemetry_control(tt::umd::TTDevice& tt_device);
+
+/**
  * @brief Read the DispatchCoreTelemetry block from a dispatch core's L1.
  *
- * @param chip         Chip that owns the dispatch core.
- * @param virtual_core Virtual, NOC-addressable coord of the dispatch core to sample.
+ * @param tt_device Non-owning UMD device context.
+ * @param virtual_core Virtual coord of the dispatch core to sample.
  * @return Telemetry data on success, or std::nullopt if the buffer fails signature/version
  *         validation (a warning is logged in that case).
  */
-std::optional<DispatchCoreTelemetry> read_dispatch_core_telemetry(ChipId chip, const CoreCoord& virtual_core);
+std::optional<dispatch_telemetry_types::DispatchCoreTelemetry> read_dispatch_core_telemetry(
+    tt::umd::TTDevice& tt_device, CoreCoord virtual_core);
 
 /**
  * @brief Read the PrefetchCoreTelemetry block from a prefetch core's L1.
  *
- * @param chip         Chip that owns the prefetch core.
- * @param virtual_core Virtual, NOC-addressable coord of the prefetch core to sample.
+ * @param tt_device Non-owning UMD device context.
+ * @param virtual_core Virtual coord of the prefetch core to sample.
  * @return Telemetry data on success, or std::nullopt if the buffer fails signature/version
  *         validation (a warning is logged in that case).
  */
-std::optional<PrefetchCoreTelemetry> read_prefetch_core_telemetry(ChipId chip, const CoreCoord& virtual_core);
+std::optional<dispatch_telemetry_types::PrefetchCoreTelemetry> read_prefetch_core_telemetry(
+    tt::umd::TTDevice& tt_device, CoreCoord virtual_core);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -596,9 +596,9 @@ void DispatchKernel::CreateKernel() {
 void DispatchKernel::ConfigureCore() {
     TT_ASSERT(static_config_.dispatch_telemetry_addr.has_value());
     TT_ASSERT(static_config_.dispatch_telemetry_disabled.has_value());
-    DispatchCoreTelemetry zero_dispatch_telemetry{};
+    dispatch_telemetry_types::DispatchCoreTelemetry zero_dispatch_telemetry{};
     if (static_config_.dispatch_telemetry_disabled.value()) {
-        zero_dispatch_telemetry.signature = INVALID_TELEMETRY_SIGNATURE;
+        zero_dispatch_telemetry.signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
     }
     detail::WriteToDeviceL1(
         device_,

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -362,7 +362,7 @@ void DispatchSKernel::ConfigureCore() {
             static_config_.realtime_profiler_msg_addr.value());
 
         TT_ASSERT(static_config_.dispatch_telemetry_control_addr.has_value());
-        DispatchTelemetryControl zero_dispatch_telemetry_control{};
+        dispatch_telemetry_types::DispatchTelemetryControl zero_dispatch_telemetry_control{};
         detail::WriteToDeviceL1(
             device_,
             logical_core_,
@@ -377,9 +377,9 @@ void DispatchSKernel::ConfigureCore() {
         // Dispatch_s needs to init telemetry since it has a dedicated core
         TT_ASSERT(static_config_.dispatch_telemetry_addr.has_value());
         TT_ASSERT(static_config_.dispatch_telemetry_disabled.has_value());
-        DispatchCoreTelemetry zero_dispatch_telemetry{};
+        dispatch_telemetry_types::DispatchCoreTelemetry zero_dispatch_telemetry{};
         if (static_config_.dispatch_telemetry_disabled.value()) {
-            zero_dispatch_telemetry.signature = INVALID_TELEMETRY_SIGNATURE;
+            zero_dispatch_telemetry.signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
         }
         detail::WriteToDeviceL1(
             device_,

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -579,9 +579,9 @@ void PrefetchKernel::CreateKernel() {
 void PrefetchKernel::ConfigureCore() {
     TT_ASSERT(static_config_.dispatch_telemetry_addr.has_value());
     TT_ASSERT(static_config_.dispatch_telemetry_disabled.has_value());
-    PrefetchCoreTelemetry zero_prefetch_telemetry{};
+    dispatch_telemetry_types::PrefetchCoreTelemetry zero_prefetch_telemetry{};
     if (static_config_.dispatch_telemetry_disabled.value()) {
-        zero_prefetch_telemetry.signature = INVALID_TELEMETRY_SIGNATURE;
+        zero_prefetch_telemetry.signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
     }
     detail::WriteToDeviceL1(
         device_,

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -705,7 +705,8 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
         uint32_t worker_count = *(data_ptr++);
         workers_per_sub_device[i] = worker_count;
         if constexpr (telemetry_enabled) {
-            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchCoreTelemetry*>(dispatch_telemetry_base)
+            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
+                dispatch_telemetry_base)
                 ->workers_per_sub_device[i] = worker_count;
         }
 #if DEVICE_PRINT_DISPATCH_ENABLED
@@ -715,7 +716,8 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
     for (uint32_t i = num_sub_devices; i < max_num_worker_sems; ++i) {
         workers_per_sub_device[i] = 0;
         if constexpr (telemetry_enabled) {
-            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchCoreTelemetry*>(dispatch_telemetry_base)
+            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
+                dispatch_telemetry_base)
                 ->workers_per_sub_device[i] = 0;
         }
     }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -113,16 +113,19 @@ constexpr bool telemetry_enabled = !DISPATCH_TELEMETRY_DISABLED;
 constexpr uint32_t dispatch_telemetry_base = DISPATCH_TELEMETRY_ADDR;
 constexpr uintptr_t dispatch_telemetry_control_addr = DISPATCH_TELEMETRY_CONTROL_ADDR;
 constexpr uint32_t upstream_blocked_count_addr =
-    dispatch_telemetry_base + offsetof(tt::tt_metal::DispatchCoreTelemetry, upstream_blocked_count);
+    dispatch_telemetry_base +
+    offsetof(tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry, upstream_blocked_count);
 constexpr uint32_t upstream_unblocked_count_addr =
-    dispatch_telemetry_base + offsetof(tt::tt_metal::DispatchCoreTelemetry, upstream_unblocked_count);
+    dispatch_telemetry_base +
+    offsetof(tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry, upstream_unblocked_count);
 using DispatchTelemetryBlockGuard = TelemetryBlockGuard<
     upstream_blocked_count_addr,
     upstream_unblocked_count_addr,
     &upstream_blocked_counter,
     telemetry_enabled>;
-volatile tt_l1_ptr tt::tt_metal::DispatchTelemetryControl* dispatch_telemetry_control =
-    reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchTelemetryControl*>(dispatch_telemetry_control_addr);
+volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl* dispatch_telemetry_control =
+    reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl*>(
+        dispatch_telemetry_control_addr);
 
 constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
@@ -1358,7 +1361,8 @@ re_run_command:
             //              cmd->set_write_offset.offset2, cmd->set_write_offset.program_host_id);
             DeviceTimestampedData("runtime_host_id_dispatch", cmd->set_write_offset.program_host_id);
             if constexpr (telemetry_enabled) {
-                reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchCoreTelemetry*>(dispatch_telemetry_base)
+                reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
+                    dispatch_telemetry_base)
                     ->program_count = ++program_counter;
             }
             if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0 &&

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -54,8 +54,9 @@ constexpr uintptr_t dispatch_telemetry_base = DISPATCH_TELEMETRY_ADDR;
 constexpr uint32_t virtualize_unicast_cores = VIRTUALIZE_UNICAST_CORES;
 constexpr uint32_t num_virtual_unicast_cores = NUM_VIRTUAL_UNICAST_CORES;
 constexpr uint32_t num_physical_unicast_cores = NUM_PHYSICAL_UNICAST_CORES;
-volatile tt_l1_ptr tt::tt_metal::DispatchTelemetryControl* dispatch_telemetry_control =
-    reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchTelemetryControl*>(dispatch_telemetry_control_addr);
+volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl* dispatch_telemetry_control =
+    reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl*>(
+        dispatch_telemetry_control_addr);
 
 constexpr uint32_t worker_mcast_grid = WORKER_MCAST_GRID;
 constexpr uint32_t num_worker_cores_to_mcast = NUM_WORKER_CORES_TO_MCAST;
@@ -444,7 +445,8 @@ void process_go_signal_mcast_cmd() {
         const uint32_t stream_index = wait_stream - first_stream_used;
         ASSERT(stream_index < max_num_worker_sems);
         auto dispatch_telemetry =
-            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchCoreTelemetry*>(dispatch_telemetry_base);
+            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
+                dispatch_telemetry_base);
 
         dispatch_telemetry_control->launched_work_sequence_counter[stream_index] = ++local_launch_seq_counter;
         dispatch_telemetry->last_work_launch_timestamp[stream_index] = get_timestamp();

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -131,9 +131,11 @@ static uint32_t upstream_blocked_counter = 0;
 constexpr bool telemetry_enabled = !DISPATCH_TELEMETRY_DISABLED;
 constexpr uint32_t prefetch_telemetry_base = DISPATCH_TELEMETRY_ADDR;
 constexpr uint32_t upstream_blocked_count_addr =
-    prefetch_telemetry_base + offsetof(tt::tt_metal::PrefetchCoreTelemetry, upstream_blocked_count);
+    prefetch_telemetry_base +
+    offsetof(tt::tt_metal::dispatch_telemetry_types::PrefetchCoreTelemetry, upstream_blocked_count);
 constexpr uint32_t upstream_unblocked_count_addr =
-    prefetch_telemetry_base + offsetof(tt::tt_metal::PrefetchCoreTelemetry, upstream_unblocked_count);
+    prefetch_telemetry_base +
+    offsetof(tt::tt_metal::dispatch_telemetry_types::PrefetchCoreTelemetry, upstream_unblocked_count);
 using PrefetchTelemetryBlockGuard = TelemetryBlockGuard<
     upstream_blocked_count_addr,
     upstream_unblocked_count_addr,
@@ -2173,7 +2175,8 @@ bool process_cmd(
     }
 
     if constexpr (telemetry_enabled) {
-        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::PrefetchCoreTelemetry*>(prefetch_telemetry_base)
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::PrefetchCoreTelemetry*>(
+            prefetch_telemetry_base)
             ->command_count = ++command_counter;
     }
     return done;
@@ -2647,7 +2650,8 @@ void kernel_main_h() {
         }
 
         if constexpr (telemetry_enabled) {
-            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::PrefetchCoreTelemetry*>(prefetch_telemetry_base)
+            reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::PrefetchCoreTelemetry*>(
+                prefetch_telemetry_base)
                 ->command_count = ++command_counter;
         }
     }

--- a/tt_metal/impl/dispatch/kernels/cq_telemetry_dispatch_subordinate.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_telemetry_dispatch_subordinate.hpp
@@ -29,7 +29,8 @@ FORCE_INLINE void compress_work_runtime(
     avg_work_runtime_per_worker += current_sub_device_work_runtime / workers_per_sub_device;
     current_sub_device_work_runtime = 0;
     auto dispatch_telemetry =
-        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchCoreTelemetry*>(dispatch_telemetry_base);
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
+            dispatch_telemetry_base);
     dispatch_telemetry->avg_work_runtime_per_worker = avg_work_runtime_per_worker;
 }
 
@@ -61,9 +62,11 @@ FORCE_INLINE void dispatch_subordinate_telemetry() {
     }
 
     auto dispatch_telemetry =
-        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchCoreTelemetry*>(dispatch_telemetry_base);
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
+            dispatch_telemetry_base);
     auto dispatch_telemetry_control =
-        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::DispatchTelemetryControl*>(dispatch_telemetry_control_addr);
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl*>(
+            dispatch_telemetry_control_addr);
 
     // Start with all workers in the complete state until work is detected
     for (uint32_t i = 0; i < total_sub_devices; ++i) {

--- a/tt_metal/tools/dispatch_telemetry_dump/dispatch_telemetry_dump.cpp
+++ b/tt_metal/tools/dispatch_telemetry_dump/dispatch_telemetry_dump.cpp
@@ -1,190 +1,129 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-//
-// Verification and usage example of dispatch telemetry.
 
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
-#include <iostream>
+#include <cstddef>
+#include <chrono>
+#include <memory>
+#include <optional>
 #include <string>
-
-#include <sys/utsname.h>
+#include <string_view>
+#include <thread>
+#include <vector>
 
 #include <fmt/core.h>
 
-#include <hostdevcommon/common_values.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/dispatch_core_common.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/experimental/dispatch_telemetry.hpp>
-
-using namespace tt;
-using namespace tt::tt_metal;
+#include <umd/device/pcie/pci_device.hpp>
+#include <umd/device/tt_device/tt_device.hpp>
 
 namespace {
-struct KernelVersion {
-    unsigned major = 0;
-    unsigned minor = 0;
-    std::string release;
-};
 
-bool get_linux_kernel_version(KernelVersion& version) {
-    utsname info{};
-    if (uname(&info) != 0) {
-        return false;
+std::string format_optional_float(const std::optional<float>& value) {
+    if (!value.has_value()) {
+        return "n/a";
     }
-
-    version.release = info.release;
-    char* end = nullptr;
-    version.major = static_cast<unsigned>(std::strtoul(version.release.c_str(), &end, 10));
-    if (end == version.release.c_str() || *end != '.') {
-        return false;
-    }
-
-    const char* minor_start = end + 1;
-    version.minor = static_cast<unsigned>(std::strtoul(minor_start, &end, 10));
-    return end != minor_start;
+    return fmt::format("{:.6f}", value.value());
 }
 
-bool require_supported_kernel() {
-    KernelVersion version;
-    if (!get_linux_kernel_version(version)) {
-        fmt::print(stderr, "Unable to determine Linux kernel version; refusing to run dispatch_telemetry_dump.\n");
-        return false;
-    }
+std::string_view format_bool(bool value) { return value ? "yes" : "no"; }
 
-    if (version.major > 5 || (version.major == 5 && version.minor >= 15)) {
-        return true;
-    }
-
+void print_telemetry_info(
+    const tt::tt_metal::DispatchTelemetryDeviceInfo& info,
+    uint32_t device_index,
+    int pci_device_id,
+    uint32_t telemetry_version) {
     fmt::print(
-        stderr,
-        "dispatch_telemetry_dump requires Linux kernel 5.15 or newer; found {}.\n"
-        "tt-kmd memory.c::is_pin_pages_size_safe() documents that with IOMMU enabled on Linux 5.4,\n"
-        "large page pinnings can soft-lock during unpin in:\n"
-        "  tt_cdev_release/ioctl_unpin_pages -> unmap_sg -> __unmap_single -> iommu_unmap_page\n",
-        version.release);
-    return false;
-}
-
-bool print_snapshot(IDevice* device, DispatchTelemetry& telemetry) {
-    auto info = telemetry.read_info();
+        "dispatch_telemetry_dump device_index={} pci_device_id={} telemetry_api_version={}\n",
+        device_index,
+        pci_device_id,
+        telemetry_version);
     fmt::print(
-        "dispatch_telemetry_dump  chip={}  num_hw_cqs={}  telemetry_api_version={}  ts={}s\n",
-        device->id(),
-        device->num_hw_cqs(),
-        telemetry.version(),
-        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+        "device_core_efficiency_since_last_read: {}\n",
+        format_optional_float(info.device_core_efficiency_since_last_read));
 
-    if (!info.has_value()) {
-        fmt::print(stderr, "Failed to read dispatch telemetry info; see log warnings for validation details.\n");
-        return false;
+    for (const auto& cq_info : info.info_cqs) {
+        fmt::print("cq_id: {}\n", cq_info.cq_id);
+        fmt::print("prefetch_waiting_on_upstream: {}\n", format_bool(cq_info.prefetch_waiting_on_upstream));
+        fmt::print("dispatch_waiting_on_upstream: {}\n", format_bool(cq_info.dispatch_waiting_on_upstream));
+        fmt::print("program_count_since_last_read: {}\n", cq_info.program_count_since_last_read);
+        fmt::print("prefetch_blocked_count_since_last_read: {}\n", cq_info.prefetch_blocked_count_since_last_read);
+        fmt::print("dispatch_blocked_count_since_last_read: {}\n", cq_info.dispatch_blocked_count_since_last_read);
+        fmt::print("prefetch_command_count_since_last_read: {}\n", cq_info.prefetch_command_count_since_last_read);
+        fmt::print("utilization_since_last_read: {}\n", format_optional_float(cq_info.utilization_since_last_read));
     }
-
-    fmt::print(
-        "{:>3} {:<9} {:>8} {:>26} {:>24}\n",
-        "cq",
-        "component",
-        "waiting",
-        "blocked_since_last_read",
-        "work_since_last_read");
-    for (const auto& cq_info : info->info_cqs) {
-        fmt::print(
-            "{:>3} {:<9} {:>8} {:>26} {:>24}\n",
-            cq_info.cq_id,
-            "prefetch",
-            cq_info.prefetch_waiting_on_upstream ? "yes" : "no",
-            cq_info.prefetch_blocked_count_since_last_read,
-            cq_info.prefetch_command_count_since_last_read);
-        fmt::print(
-            "{:>3} {:<9} {:>8} {:>26} {:>24}\n",
-            cq_info.cq_id,
-            "dispatch",
-            cq_info.dispatch_waiting_on_upstream ? "yes" : "no",
-            cq_info.dispatch_blocked_count_since_last_read,
-            cq_info.program_count_since_last_read);
-    }
-    std::cout.flush();
-    return true;
-}
-
-Program create_blank_program(const CoreCoord& core) {
-    Program program = CreateProgram();
-    CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/blank.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-    return program;
-}
-
-void issue_workloads(distributed::MeshDevice* mesh_device, uint32_t num_programs) {
-    if (num_programs == 0) {
-        return;
-    }
-
-    auto& cq = mesh_device->mesh_command_queue();
-    const auto target_devices = distributed::MeshCoordinateRange(mesh_device->shape());
-    const CoreCoord worker_core{0, 0};
-
-    fmt::print("Issuing {} blank workload program(s).\n", num_programs);
-    for (uint32_t i = 0; i < num_programs; ++i) {
-        distributed::MeshWorkload workload;
-        workload.add_program(target_devices, create_blank_program(worker_core));
-        distributed::EnqueueMeshWorkload(cq, workload, false);
-    }
-    distributed::Finish(cq);
 }
 
 }  // namespace
 
 int main(int argc, char** argv) {
-    if (!require_supported_kernel()) {
-        return 1;
-    }
-
-    ChipId device_id = 0;
-    uint32_t num_programs = 4;
-
-    auto parse_u32 = [](const char* s) -> uint32_t {
-        const long value = std::atol(s);
-        return value > 0 ? static_cast<uint32_t>(value) : 0;
-    };
+    uint32_t device_index = 0;
+    bool list_devices = false;
+    bool monitor = false;
 
     for (int i = 1; i < argc; ++i) {
-        std::string a = argv[i];
-        if ((a == "--device" || a == "-d") && i + 1 < argc) {
-            device_id = std::atoi(argv[++i]);
-        } else if ((a == "--programs") && i + 1 < argc) {
-            num_programs = parse_u32(argv[++i]);
-        } else if (a == "--help" || a == "-h") {
-            fmt::print("Usage: {} [--device N] [--programs N]\n", argv[0]);
+        std::string arg = argv[i];
+        if ((arg == "--device" || arg == "-d") && i + 1 < argc) {
+            const long value = std::atol(argv[++i]);
+            if (value < 0) {
+                fmt::print(stderr, "Device index must be >= 0; got {}.\n", value);
+                return 1;
+            }
+            device_index = static_cast<uint32_t>(value);
+        } else if (arg == "--list-devices") {
+            list_devices = true;
+        } else if (arg == "--monitor") {
+            monitor = true;
+        } else if (arg == "--help" || arg == "-h") {
+            fmt::print("Usage: {} [--device INDEX] [--list-devices] [--monitor]\n", argv[0]);
             return 0;
         }
     }
 
-    auto mesh_device = distributed::MeshDevice::create_unit_mesh(
-        device_id, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreConfig{DispatchCoreType::WORKER});
-    IDevice* device = mesh_device->get_devices().front();
-
-    DispatchTelemetry telemetry(*device);
-    if (!telemetry.read_info().has_value()) {
-        fmt::print(
-            stderr, "Failed to read initial dispatch telemetry info; see log warnings for validation details.\n");
+    const std::vector<int> pci_device_ids = tt::umd::PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        fmt::print(stderr, "No PCIe devices found.\n");
         return 1;
     }
 
-    // TODO: Inspect device while it runs an independent workload instead of launching our own
-    //       once the SMC/ARC region supports sharing dispatch core locations.
-    issue_workloads(mesh_device.get(), num_programs);
+    if (list_devices) {
+        fmt::print("Enumerated UMD PCIe devices:\n");
+        for (size_t i = 0; i < pci_device_ids.size(); ++i) {
+            fmt::print("  index {} -> PCIe device id {}\n", i, pci_device_ids[i]);
+        }
+        return 0;
+    }
 
-    if (!print_snapshot(device, telemetry)) {
+    if (device_index >= pci_device_ids.size()) {
+        fmt::print(
+            stderr,
+            "Requested device index {} but only {} PCIe device(s) were found.\n",
+            device_index,
+            pci_device_ids.size());
         return 1;
+    }
+
+    const int pci_device_id = pci_device_ids.at(device_index);
+    std::unique_ptr<tt::umd::TTDevice> tt_device = tt::umd::TTDevice::create(pci_device_id);
+    tt_device->init_tt_device();
+
+    tt::tt_metal::DispatchTelemetry telemetry(*tt_device);
+    while (true) {
+        auto info = telemetry.read_info();
+        if (info.has_value()) {
+            print_telemetry_info(*info, device_index, pci_device_id, telemetry.version());
+        } else {
+            fmt::print(stderr, "Failed to read dispatch telemetry info; see log warnings for validation details.\n");
+        }
+
+        if (!monitor) {
+            break;
+        }
+
+        fmt::print("\n");
+        std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
     return 0;


### PR DESCRIPTION
### PR Category
Feature

### Summary
Relates to #43293 

* Bump UMD to 7dbc912
* Dispatch Telemetry API now only enabled on devices supported by firmware, currently Blackhole with firmware version >= v19.12.0
* Read SMC core for dispatch core location info and TTDevice for reference
* Passively read unowned devices using the TTDevice interface
* Added telemetry unit tests for SMC core info
* dispatch_telemetry_dump refactored to perform as a simple telemetry monitor

### Notes for reviewers
Requires UMD PR tenstorrent/tt-umd#2965 to merge first.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/dispatch-telemetry-SMC-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/dispatch-telemetry-SMC-buffer)