### PR TITLE
ci(llk): precompile stable header prefix (PCH) for the Quasar compile job

### DIFF
--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -31,6 +31,7 @@ runs:
       shell: bash
       working-directory: tt_metal/tt-llk/tests/python_tests
       env:
+        LLK_BUILD_PARALLELISM: "0" # one g++ per worker
         CHIP_ARCH: quasar
       run: |
         echo "Compiling Quasar (group ${{ inputs.test-group }}/${{ inputs.test-splits }})..."

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: '1-indexed shard to compile (must be <= test-splits).'
     required: false
     default: '1'
+  num-workers:
+    description: 'Number of pytest-xdist workers (-n). Defaults to "auto" (one per CPU). Set higher than nproc to overprovision and hide pytest collection overhead.'
+    required: false
+    default: 'auto'
 
 runs:
   using: composite
@@ -30,7 +34,7 @@ runs:
         CHIP_ARCH: quasar
       run: |
         echo "Compiling Quasar (group ${{ inputs.test-group }}/${{ inputs.test-splits }})..."
-        pytest -q --compile-producer -n 10 \
+        pytest -q --compile-producer -n ${{ inputs.num-workers }} \
               -m "${{ inputs.pytest-markers }}" \
               --splits ${{ inputs.test-splits }} --group ${{ inputs.test-group }} \
               --override-ini=log_cli=false --tb=short --timeout=60 \

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -15,9 +15,24 @@ inputs:
     required: false
     default: '1'
   num-workers:
-    description: 'Number of pytest-xdist workers (-n). 30 measured ~3.6 GiB sustained RAM+swap per worker on a 40-core/78.5 GiB xlarge runner (mean mem 92.35% + mean swap 46.18%), saturating RAM and forcing sustained swapping even with -Os and serial inner builds. 18 targets ~80% RAM with zero swap at that per-worker footprint; re-measure and adjust if it still swaps. Override per-call if a different runner size needs a different number.'
+    description: >-
+      Number of pytest-xdist workers (-n). Each worker is a full Python process
+      that imports numpy + torch (via golden_generators) + the config/format
+      tables — a FIXED ~0.6-1.2 GiB RSS paid once per worker for the whole run,
+      independent of compile work. With LLK_BUILD_PARALLELISM=1 each worker fans
+      out to len(KERNEL_COMPONENTS)=4 concurrent g++ (unpack/math/pack/sfpu) for
+      one variant, so total concurrent g++ = -n x 4. The compiler-side anon
+      memory (the swap driver) scales with total g++; the fixed Python tax scales
+      with -n. To hold ~16 total g++ (fully using the 16-core `large` runner)
+      while paying the Python tax only 4x instead of 16x, use -n 4 with inner
+      parallelism on. Reference point: on the older serial regime, -n 30 measured
+      ~3.6 GiB sustained RAM+swap per worker on a 40-core/78.5 GiB xlarge runner
+      and swapped hard. NOTE: this job runs on `large` (16-core), not xlarge — an
+      -n 18 serial config both over-subscribes cores and pays 18x the fixed
+      Python tax; -n 4 with parallelism is the memory-cheaper way to the same
+      g++ concurrency. Override per-call for a different runner size.
     required: false
-    default: '18'
+    default: '4'
 
 runs:
   using: composite
@@ -31,7 +46,16 @@ runs:
       shell: bash
       working-directory: tt_metal/tt-llk/tests/python_tests
       env:
-        LLK_BUILD_PARALLELISM: "0" # one g++ per worker
+        # Inner parallelism ON: each of the -n workers fans out to 4 concurrent
+        # g++ (one per Quasar KERNEL_COMPONENT). With -n 4 that is ~16 total g++
+        # (saturates the 16-core large runner) but only 4 heavyweight Python
+        # processes carrying the fixed numpy+torch tax, vs 16 with serial/-n 16.
+        # Component compiles are write-disjoint ({name}.elf each, build.h written
+        # once before fan-out, all inside the per-variant FileLock), so this is
+        # safe. Was defaulted off (=0) back when it multiplied -n without lowering
+        # it (OOM under -O3 on a smaller runner); with -Os and a proportionally
+        # reduced -n the total g++ concurrency is held constant, not multiplied.
+        LLK_BUILD_PARALLELISM: "1"
         CHIP_ARCH: quasar
       run: |
         echo "Compiling Quasar (group ${{ inputs.test-group }}/${{ inputs.test-splits }})..."

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -15,9 +15,9 @@ inputs:
     required: false
     default: '1'
   num-workers:
-    description: 'Number of pytest-xdist workers (-n). "auto" (one per CPU) OOM''d on a 40-core xlarge runner even with -Os and serial inner builds; 30 is the current known-safe value there. Override per-call if a different runner size needs a different number.'
+    description: 'Number of pytest-xdist workers (-n). 30 measured ~3.6 GiB sustained RAM+swap per worker on a 40-core/78.5 GiB xlarge runner (mean mem 92.35% + mean swap 46.18%), saturating RAM and forcing sustained swapping even with -Os and serial inner builds. 18 targets ~80% RAM with zero swap at that per-worker footprint; re-measure and adjust if it still swaps. Override per-call if a different runner size needs a different number.'
     required: false
-    default: '30'
+    default: '18'
 
 runs:
   using: composite

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -18,21 +18,32 @@ inputs:
     description: >-
       Number of pytest-xdist workers (-n). Each worker is a full Python process
       that imports numpy + torch (via golden_generators) + the config/format
-      tables — a FIXED ~0.6-1.2 GiB RSS paid once per worker for the whole run,
-      independent of compile work. With LLK_BUILD_PARALLELISM=1 each worker fans
-      out to len(KERNEL_COMPONENTS)=4 concurrent g++ (unpack/math/pack/sfpu) for
-      one variant, so total concurrent g++ = -n x 4. Bumped from 10 to 18 based
-      on real sidecar data: at -n 10 the box was only 53% RAM with ZERO swap
-      (~2x headroom) and workers ran ~99% per-worker CPU (compute-bound, not
-      memory-bound, not idle) -- only 10 of 40 cores were being fed. Per-worker
-      RSS estimated ~1.55 GiB (linear fit from -n 10 at 41 GiB used and -n 30 at
-      72 GiB used); -n 18 projects to ~69% RAM, still with real margin below the
-      -n 30 config that measured 92% mean / 100% peak and swapped hard. -n 18 is
-      a real config change to re-measure via the sidecar output, not a
-      guaranteed-safe number -- if it swaps, drop back toward 14-16. Override
-      per-call for a different runner size or target concurrency.
+      tables. With LLK_BUILD_PARALLELISM=1 each worker fans out to
+      len(KERNEL_COMPONENTS)=4 concurrent g++ (unpack/math/pack/sfpu) for one
+      variant, so total concurrent g++ = -n x 4. REVERTED from 18 back to 10:
+      -n 18 was tested and is a confirmed net negative, not just "no
+      improvement" -- JUnit comparison against the -n 10 run showed the
+      cache-hit-item (no compile at all) time distribution inflated ~29%
+      across the board (median 7ms->9ms, p99 48ms->57ms, max single item
+      3.3s), consistent with the 18x4=72 fan-out oversubscribing the 40 cores
+      and descheduling the cheap Python-bookkeeping path -- NOT extra real
+      compile work (the >=250ms "real compile" count was statistically
+      unchanged, 2507 vs 2520). Net effect: +22% total per-item CPU-time
+      wasted, wall-clock flat-to-slightly-worse, and mean RAM jumped to 85.96%
+      (peak 97.71%, right at the swap cliff) for no measured benefit. The
+      earlier "~1.55 GiB/worker" linear projection that justified the 18 bump
+      was a 2-point fit across configs with different LLK_BUILD_PARALLELISM/
+      scheduler settings and turned out to badly underestimate actual cost
+      (~3.2-3.6 GiB/worker measured between 10 and 18 workers at matched
+      config) -- treat any single-pair linear extrapolation on this job with
+      real skepticism going forward. -n 10 is the best confirmed config so
+      far: 61% peak RAM, zero swap, tied-fastest wall-clock, no wasted CPU. If
+      testing further, -n 12 is the next defensible probe (small step,
+      projected ~70% peak RAM) -- do not jump straight to a much higher
+      number again without an intermediate data point. Override per-call for
+      a different runner size or target concurrency.
     required: false
-    default: '18'
+    default: '10'
 
 runs:
   using: composite

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -23,16 +23,20 @@ inputs:
       out to len(KERNEL_COMPONENTS)=4 concurrent g++ (unpack/math/pack/sfpu) for
       one variant, so total concurrent g++ = -n x 4. The compiler-side anon
       memory (the swap driver) scales with total g++; the fixed Python tax scales
-      with -n. To hold ~16 total g++ (fully using the 16-core `large` runner)
-      while paying the Python tax only 4x instead of 16x, use -n 4 with inner
-      parallelism on. Reference point: on the older serial regime, -n 30 measured
-      ~3.6 GiB sustained RAM+swap per worker on a 40-core/78.5 GiB xlarge runner
-      and swapped hard. NOTE: this job runs on `large` (16-core), not xlarge — an
-      -n 18 serial config both over-subscribes cores and pays 18x the fixed
-      Python tax; -n 4 with parallelism is the memory-cheaper way to the same
-      g++ concurrency. Override per-call for a different runner size.
+      with -n. Current value (10) intentionally reconstructs the ORIGINAL
+      pre-#47457 baseline concurrency exactly: before that PR, the inner
+      ThreadPoolExecutor(4) was unconditional (not a toggle), so -n 10 always
+      meant up to 10 x 4 = 40 concurrent g++. This is a deliberate A/B point on
+      the 40-core/78.5 GiB xlarge runner (where all real sidecar measurements in
+      this file's history were taken) to isolate the effect of PCH/-Os/shell=False
+      /slots against the literal original concurrency structure. Caution: 40
+      total g++ is MORE than the -n 30 serial config that already measured
+      ~3.6 GiB sustained RAM+swap per worker and swapped hard (30 total g++) --
+      this may swap as much or more; re-measure via the sidecar output and tune
+      down (or lower KERNEL_COMPONENTS fan-out) if so. Override per-call for a
+      different runner size or target concurrency.
     required: false
-    default: '4'
+    default: '10'
 
 runs:
   using: composite

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -120,6 +120,30 @@ runs:
                 --override-ini=log_cli=false --tb=short --timeout=60 \
                 --junitxml=pytest-report-quasar-compile.xml .
 
+    - name: Report PCH status
+      # We have never been able to confirm from a real run whether PCH is
+      # actually succeeding, failing, or silently no-op'ing on Quasar --
+      # helpers/logger.py defaults loguru to INFO (DEBUG is suppressed
+      # entirely) and separately routes through pytest's log_cli (=false
+      # here), while the per-xdist-worker files it always writes regardless
+      # of log_cli (test_run_gw*.log) were never surfaced anywhere retrievable
+      # after the ephemeral runner tears down -- only the JUnit XML gets
+      # uploaded. The PCH success line was just promoted debug->info to clear
+      # the level filter, but that alone still wouldn't reach this job's
+      # captured console output. Grepping the worker log files directly and
+      # echoing to stdout sidesteps all of loguru/log_cli's routing and is
+      # guaranteed visible in the Actions log regardless of that config.
+      if: always()
+      shell: bash
+      working-directory: tt_metal/tt-llk/tests/python_tests
+      run: |
+        echo "=== PCH status (grepped from test_run_gw*.log) ==="
+        if compgen -G "test_run_gw*.log" > /dev/null; then
+          grep -hi "pch" test_run_gw*.log || echo "(no PCH-related log lines found in any worker log)"
+        else
+          echo "(no test_run_gw*.log files found -- check working-directory/log config)"
+        fi
+
     - name: Upload JUnit report for compiling elfs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       if: always()

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -21,22 +21,18 @@ inputs:
       tables — a FIXED ~0.6-1.2 GiB RSS paid once per worker for the whole run,
       independent of compile work. With LLK_BUILD_PARALLELISM=1 each worker fans
       out to len(KERNEL_COMPONENTS)=4 concurrent g++ (unpack/math/pack/sfpu) for
-      one variant, so total concurrent g++ = -n x 4. The compiler-side anon
-      memory (the swap driver) scales with total g++; the fixed Python tax scales
-      with -n. Current value (10) intentionally reconstructs the ORIGINAL
-      pre-#47457 baseline concurrency exactly: before that PR, the inner
-      ThreadPoolExecutor(4) was unconditional (not a toggle), so -n 10 always
-      meant up to 10 x 4 = 40 concurrent g++. This is a deliberate A/B point on
-      the 40-core/78.5 GiB xlarge runner (where all real sidecar measurements in
-      this file's history were taken) to isolate the effect of PCH/-Os/shell=False
-      /slots against the literal original concurrency structure. Caution: 40
-      total g++ is MORE than the -n 30 serial config that already measured
-      ~3.6 GiB sustained RAM+swap per worker and swapped hard (30 total g++) --
-      this may swap as much or more; re-measure via the sidecar output and tune
-      down (or lower KERNEL_COMPONENTS fan-out) if so. Override per-call for a
-      different runner size or target concurrency.
+      one variant, so total concurrent g++ = -n x 4. Bumped from 10 to 18 based
+      on real sidecar data: at -n 10 the box was only 53% RAM with ZERO swap
+      (~2x headroom) and workers ran ~99% per-worker CPU (compute-bound, not
+      memory-bound, not idle) -- only 10 of 40 cores were being fed. Per-worker
+      RSS estimated ~1.55 GiB (linear fit from -n 10 at 41 GiB used and -n 30 at
+      72 GiB used); -n 18 projects to ~69% RAM, still with real margin below the
+      -n 30 config that measured 92% mean / 100% peak and swapped hard. -n 18 is
+      a real config change to re-measure via the sidecar output, not a
+      guaranteed-safe number -- if it swaps, drop back toward 14-16. Override
+      per-call for a different runner size or target concurrency.
     required: false
-    default: '10'
+    default: '18'
 
 runs:
   using: composite

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -15,9 +15,9 @@ inputs:
     required: false
     default: '1'
   num-workers:
-    description: 'Number of pytest-xdist workers (-n). Defaults to "auto" (one per CPU). Set higher than nproc to overprovision and hide pytest collection overhead.'
+    description: 'Number of pytest-xdist workers (-n). "auto" (one per CPU) OOM''d on a 40-core xlarge runner even with -Os and serial inner builds; 30 is the current known-safe value there. Override per-call if a different runner size needs a different number.'
     required: false
-    default: 'auto'
+    default: '30'
 
 runs:
   using: composite

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -63,30 +63,45 @@ runs:
         CHIP_ARCH: quasar
       run: |
         echo "Compiling Quasar (group ${{ inputs.test-group }}/${{ inputs.test-splits }})..."
-        # --maxschedchunk override (the binding constraint we found, NOT worker count):
-        # the repo-wide pytest.ini has `addopts = -s --maxschedchunk=10` (added
-        # 2026-02, present on main, untouched by this branch). maxschedchunk caps
-        # how many test node-ids pytest-xdist's single master hands a worker in one
-        # execnet dispatch, in BOTH the initial and steady-state refill paths
-        # (xdist src/xdist/scheduler/load.py: node_chunksize = min(items//4,
-        # maxschedchunk); floored at 2). With ~413k ultra-fast compile tests (JUnit
-        # median ~8 ms) and chunk=10, the ONE master process must originate
-        # ~413k/10 ≈ 41k dispatch round-trips AND process 413k inbound testreports
-        # serially -- it cannot feed the workers fast enough, so they starve. Two
-        # measured runs on the 40-core/78.5 GiB xlarge confirm the starvation is the
-        # cap, not memory or worker count: -n10+parallel burned only ~48% of wall on
-        # real work (wall 1173 s vs sum-of-per-test-time/10 = 606 s; CPU mean 24.6%,
-        # RAM peak 60.8%, ZERO swap -- huge headroom) and -n30 serial was WORSE
-        # (65% idle, CPU 32.8%) despite more workers, because 30 mouths share the
-        # same single-master feeder throttled to chunk=10. maxschedchunk was small
-        # by design for suites of few slow tests; it is exactly wrong for 413k fast
-        # ones. Raising the cap lets the master ship large chunks (~20 per worker
-        # here) and amortize its per-dispatch overhead, while 2000 << the ~10k
-        # initial-chunk ceiling keeps enough tests pending for the steady-state
-        # watermark to still steal-rebalance the long tail (0.9% of tests are
-        # >500 ms). CLI value wins over addopts (last --maxschedchunk parsed).
-        # Scoped to THIS job by overriding on the command line rather than editing
-        # the shared pytest.ini (which every LLK hardware-test job also consumes).
+        # --dist=worksteal (supersedes the earlier --maxschedchunk=2000 experiment).
+        #
+        # What the JUnit + sidecar data actually showed (three runs, 40-core/78.5 GiB
+        # xlarge, 413,234 tests each):
+        #  * ~99.2% of test items finish <100 ms and ~65% <10 ms -- they are CACHE
+        #    HITS (build_elfs hits the .build_complete done-marker and returns without
+        #    compiling). Only ~0.6-0.8% (~2500-3200 items) are real g++ compiles
+        #    (300-1000 ms). So this job is NOT compile-bound in aggregate.
+        #  * With -n 10 the workers run at ~99% per-worker CPU (9.9 of 10 cores busy);
+        #    they are NOT starved/idle. Low box CPU (~25% of 40) is purely because
+        #    only 10 of 40 cores are fed. The real bottleneck is per-worker single-
+        #    thread Python/pytest per-item overhead x 413k items, gated by -n.
+        #  * The prior --maxschedchunk 10->2000 change helped only a little (~23 s),
+        #    and for a reason we can now name precisely -- NOT "master feeder
+        #    starvation": LoadScheduling's initial chunk = min(items//4, maxschedchunk)
+        #    (floor 2). At chunk=10 all 10 workers pull tiny chunks off the SAME front
+        #    of pending, so they cold-compile OVERLAPPING variant_ids at once (items
+        #    that share a variant_id are adjacent in collection order). One compiles;
+        #    the others block ~700 ms on the per-variant FileLock then cache-hit. That
+        #    redundant simultaneous compilation is what pushed peak CPU to 88.7% and
+        #    wasted ~600 s of duplicated compile-wait. chunk=2000 kept same-variant
+        #    runs on ONE worker (compile once, same-worker cache-hit the rest): ~700
+        #    fewer collisions and a LOWER peak CPU (78%) -- a GOOD sign, not worse
+        #    utilisation.
+        #
+        # worksteal takes that locality to the limit AND fixes the tail risk of a big
+        # static chunk (xdist src/xdist/scheduler/worksteal.py, v3.8.0): it hands each
+        # worker ONE contiguous ~1/10 block up front (max same-variant locality -> min
+        # cross-worker cold-cache FileLock collisions, especially the startup burst),
+        # then when a worker drops below 2 pending it STEALS half the busiest worker's
+        # tail -> rebalances the slow long tail a static chunk cannot. Fewer
+        # simultaneous cold compiles also mean a lower startup memory spike, which
+        # de-risks a future num-workers increase (mem at -n 10 is only ~53% with ZERO
+        # swap: ~2x headroom, and workers are compute-bound, so raising -n toward ~18
+        # is the next lever to test once this run is measured).
+        # Expected effect is modest (collisions cost only ~15-30 s of wall); this is
+        # the strictly-better scheduler + an enabler, not a fix for the ~25% CPU
+        # ceiling, which needs more workers and/or fewer/cheaper per-item Python items.
+        # worksteal ignores maxschedchunk, so the shared pytest.ini addopts is moot.
         "$GITHUB_WORKSPACE/.github/scripts/utils/host-load-sidecar.sh" \
           --interval 1 \
           --label "Quasar compile (group ${{ inputs.test-group }}/${{ inputs.test-splits }})" \
@@ -94,7 +109,7 @@ runs:
           -- pytest -q --compile-producer -n ${{ inputs.num-workers }} \
                 -m "${{ inputs.pytest-markers }}" \
                 --splits ${{ inputs.test-splits }} --group ${{ inputs.test-group }} \
-                --maxschedchunk=2000 \
+                --dist=worksteal \
                 --override-ini=log_cli=false --tb=short --timeout=60 \
                 --junitxml=pytest-report-quasar-compile.xml .
 

--- a/.github/actions/llk-compile-quasar/action.yml
+++ b/.github/actions/llk-compile-quasar/action.yml
@@ -63,6 +63,30 @@ runs:
         CHIP_ARCH: quasar
       run: |
         echo "Compiling Quasar (group ${{ inputs.test-group }}/${{ inputs.test-splits }})..."
+        # --maxschedchunk override (the binding constraint we found, NOT worker count):
+        # the repo-wide pytest.ini has `addopts = -s --maxschedchunk=10` (added
+        # 2026-02, present on main, untouched by this branch). maxschedchunk caps
+        # how many test node-ids pytest-xdist's single master hands a worker in one
+        # execnet dispatch, in BOTH the initial and steady-state refill paths
+        # (xdist src/xdist/scheduler/load.py: node_chunksize = min(items//4,
+        # maxschedchunk); floored at 2). With ~413k ultra-fast compile tests (JUnit
+        # median ~8 ms) and chunk=10, the ONE master process must originate
+        # ~413k/10 ≈ 41k dispatch round-trips AND process 413k inbound testreports
+        # serially -- it cannot feed the workers fast enough, so they starve. Two
+        # measured runs on the 40-core/78.5 GiB xlarge confirm the starvation is the
+        # cap, not memory or worker count: -n10+parallel burned only ~48% of wall on
+        # real work (wall 1173 s vs sum-of-per-test-time/10 = 606 s; CPU mean 24.6%,
+        # RAM peak 60.8%, ZERO swap -- huge headroom) and -n30 serial was WORSE
+        # (65% idle, CPU 32.8%) despite more workers, because 30 mouths share the
+        # same single-master feeder throttled to chunk=10. maxschedchunk was small
+        # by design for suites of few slow tests; it is exactly wrong for 413k fast
+        # ones. Raising the cap lets the master ship large chunks (~20 per worker
+        # here) and amortize its per-dispatch overhead, while 2000 << the ~10k
+        # initial-chunk ceiling keeps enough tests pending for the steady-state
+        # watermark to still steal-rebalance the long tail (0.9% of tests are
+        # >500 ms). CLI value wins over addopts (last --maxschedchunk parsed).
+        # Scoped to THIS job by overriding on the command line rather than editing
+        # the shared pytest.ini (which every LLK hardware-test job also consumes).
         "$GITHUB_WORKSPACE/.github/scripts/utils/host-load-sidecar.sh" \
           --interval 1 \
           --label "Quasar compile (group ${{ inputs.test-group }}/${{ inputs.test-splits }})" \
@@ -70,6 +94,7 @@ runs:
           -- pytest -q --compile-producer -n ${{ inputs.num-workers }} \
                 -m "${{ inputs.pytest-markers }}" \
                 --splits ${{ inputs.test-splits }} --group ${{ inputs.test-group }} \
+                --maxschedchunk=2000 \
                 --override-ini=log_cli=false --tb=short --timeout=60 \
                 --junitxml=pytest-report-quasar-compile.xml .
 

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -440,7 +440,7 @@ jobs:
          needs.find-changed-files.outputs.llk-sfpi-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
-    runs-on: tt-ubuntu-2204-xlarge-stable
+    runs-on: tt-ubuntu-2204-large-stable
     timeout-minutes: 80
     container:
       image: ${{ needs.resolve-docker-pull-refs.outputs.llk-ci-docker-image }}

--- a/tt_metal/tt-llk/docs/tests/quasar_compile_dedup_design.md
+++ b/tt_metal/tt-llk/docs/tests/quasar_compile_dedup_design.md
@@ -1,0 +1,195 @@
+# Design: deduplicating `--compile-producer` test items by `variant_id`
+
+Status: **design / not implemented.** This documents an investigation into the
+single largest remaining lever for the `llk-build-quasar` PR-gate job and the
+reasons it has not (yet) been shipped. It is intended to be read alongside the
+broader write-up in [`quasar_compile_investigation.md`](quasar_compile_investigation.md)
+and PR [#48767](https://github.com/tenstorrent/tt-metal/pull/48767).
+
+## Problem
+
+The `llk-build-quasar` job runs `pytest --compile-producer -m quasar` over the
+full Quasar test enumeration — **413,234 test items** in the measured run. Each
+item pays the full pytest per-item cost (collection slot, fixture setup/teardown,
+test-body Python, xdist marshalling, JUnit reporting) even though the *compile*
+each item asks for is very often a no-op cache hit against an artifact another
+item already produced.
+
+The artifacts themselves are already deduplicated. `build_elfs()`
+(`helpers/test_config.py`) keys the ELF output directory on `variant_id` and
+guards it with a `.build_complete` done-marker plus a per-`variant_id`
+`FileLock`; the second and subsequent items that resolve to the same `variant_id`
+hit the fast path and return without recompiling. What is **not** deduplicated is
+the per-item *framework* cost that runs before that fast path: the item is still
+collected, its fixtures still run, its test body still constructs a `TestConfig`,
+generates stimuli, and computes the hash — only then does `build_elfs()` notice
+the work is redundant.
+
+## Evidence
+
+Across the 6 largest quasar test files — **94.7%** of the 413,234-item suite —
+the items collapse onto roughly **2,500–3,200 distinct `variant_id`s**. That is a
+**~120–160:1 redundancy ratio**: only ~2.5–3.2k items are genuine compiles; the
+other ~410k are cache-hit no-ops that still each pay the full per-item Python /
+pytest overhead (JUnit median ~7–9 ms/item).
+
+(The collapse ratio was measured by projecting the per-item parametrize arguments
+onto the fields that actually feed `generate_variant_hash()`; see "Why it's hard"
+for why that projection is not authoritative on its own.)
+
+### What `variant_id` is
+
+`variant_id` is a sha256 hash computed in `TestConfig.generate_variant_hash()`
+(`helpers/test_config.py`). It hashes `str(value)` of every field in the
+`TestConfig` instance `__dict__` **except** a documented `NON_COMPILATION_ARGUMENTS`
+exclusion list. That list always excludes bookkeeping fields
+(`run_configs`, `variant_id`, `runtime_arguments_struct`, `runtime_format`,
+`passed_templates`, `passed_runtimes`, `current_run_type`, `temp_elfs`) and,
+when **not** running `--speed-of-light`, additionally excludes
+`variant_stimuli`, `pack_size`, `unpack_size_a`, `unpack_size_b`, `runtimes`,
+and (unless `compile_time_formats`) `formats_config`. In other words: stimuli
+*values* and most runtime-only arguments deliberately do **not** affect the
+compile hash — which is exactly why so many items collapse onto one `variant_id`.
+
+## Why it's hard
+
+The blocker is **when** `variant_id` becomes computable.
+
+`generate_variant_hash()` runs inside `.run()` → `.prepare()`, i.e. at the very
+end of each test body — **after** the parametrized fixtures have run,
+`generate_stimuli()` has executed, and the `TestConfig` has been fully
+constructed from that test's bespoke logic. By the time you can compute the key
+that tells you an item is a duplicate, you have already paid essentially all of
+that item's per-item cost. An in-body "am I a duplicate? then skip" check saves
+almost nothing, because the expensive part already ran to build the object the
+check reads.
+
+There is **no existing generic mechanism** to derive an equivalent dedup key
+from just the pytest parametrize arguments at *collection* time, before fixtures
+run. The mapping from "parametrize params" to "what actually affects the compile"
+is not centralized: it lives as bespoke logic scattered across each test body
+(which templates/runtimes each test constructs, which format fields it passes,
+which options it toggles). `generate_variant_hash()` is the single point that
+currently reifies that mapping, and it only exists once the body has already run.
+
+### Correctness stakes are asymmetric
+
+Consumer-mode correctness risk is assessed as **near-zero if implemented
+correctly**. Artifacts are already deduplicated today via the `variant_id` +
+`.build_complete` marker, so consumer mode already loads shared artifacts across
+many items with no change. The *only* correctness risk is getting the dedup
+**key** exactly right: a collection-time key that does not perfectly mirror
+`generate_variant_hash()` could silently drop an item that was in fact a genuinely
+distinct variant. In consumer mode that surfaces as a **hard missing-ELF failure**
+(the dropped variant was never compiled), not a soft slowdown. A wrong key fails
+loud, not silent — which is a safety net, but it also raises the bar: you want
+high confidence the key mirrors the hash before you ship, because a mismatch
+breaks the gate rather than merely degrading it.
+
+## Options
+
+### (a) Collection-time dedup hook
+
+Add a `pytest_collection_modifyitems` hook in `conftest.py` (there is already one
+there for `--test-order-file`; `item.callspec.params` is already read elsewhere in
+the conftest, so the collection-time params are accessible) that computes a
+*would-be compile key* directly from `item.callspec.params` and deselects items
+whose key has already been seen.
+
+- **Pro:** attacks the cost at the only point where dropping an item removes
+  *all* of its per-item overhead (collection, fixtures, body, marshalling,
+  reporting) — the only kind of drop that shrinks both the call-phase term and
+  the framework-overhead term (see Savings).
+- **Con:** requires building and maintaining a `params → compile-key` mapping
+  **outside** the per-test-body logic that currently owns it. That mapping can
+  drift out of sync with `generate_variant_hash()` over time (a test starts
+  toggling a new compile-affecting option; the hook doesn't know; it over-dedups;
+  consumer mode breaks).
+- **Mitigation — CI belt-and-suspenders assertion:** on a full producer run,
+  assert `#distinct(collection_key) == #distinct(variant_id)` (the latter is
+  observable from the produced artifact dirs / logs). If the counts diverge, the
+  mapping has drifted and the run fails loudly *in producer mode* (safe) rather
+  than silently dropping a variant that only bites later in consumer mode. This
+  turns silent drift into a caught, actionable CI failure.
+
+### (b) Reduced, separately-enumerated producer parameter set
+
+Restructure producer mode so it enumerates a *reduced* parameter set up front
+(one item per genuine compile), rather than enumerating the full test matrix and
+deduplicating after the fact.
+
+- **Pro:** cleaner separation of concerns — the reduced enumeration *is* the set
+  of genuine compiles, so there is no after-the-fact key to keep in sync; no
+  ~410k phantom items are ever created.
+- **Con:** a bigger architectural change. It needs each test (or a shared layer)
+  to expose "the distinct compile configurations I need" independently of the
+  full functional matrix, and to keep consumer mode able to map its full-matrix
+  items back onto those shared artifacts. More invasive, more up-front design.
+
+### (c) Leave it as-is
+
+Given (1) the effort and (2) the asymmetric failure mode (a wrong dedup key is a
+hard consumer-mode failure, not a soft degradation), a legitimate option is to
+not ship dedup and instead keep improving the cheaper, lower-risk levers
+(coordinator throughput, worker count, per-item Python cost, PCH). The safety net
+raises the confidence bar for (a)/(b); until that bar is met, the status quo is
+defensible.
+
+## Recommended next steps
+
+1. **Prototype option (a) offline, non-gating.** Build the `params → compile-key`
+   mapping for the 6 largest files only (94.7% of the suite), run a full producer
+   pass with the belt-and-suspenders assertion enabled, and confirm
+   `#distinct(key) == #distinct(variant_id)` before deselecting anything. This
+   validates the mapping with zero risk to the gate.
+2. **Only then wire it into the gate**, with the assertion left permanently on so
+   any future drift fails the producer run loudly.
+3. **Keep the assertion cheap** — it is a set-size comparison over data the run
+   already produces; it should not itself become a per-item cost.
+4. Treat option (b) as the longer-term target if the `params → compile-key`
+   mapping in (a) proves hard to keep in sync, since (b) removes the sync problem
+   by construction.
+
+## Savings estimate (and its uncertainty)
+
+At the best-known config (`-n 10`), the JUnit artifacts give:
+
+- **Ideal-packed producer wall-clock** (Σ of JUnit call-phase times ÷ worker
+  count) ≈ **544 s**.
+- **Actual observed producer wall-clock** ≈ **1212 s**.
+
+The ~**668 s gap** is per-item framework overhead (fixture setup/teardown,
+reporting, execnet marshalling, collection) sitting *on top of* call-phase time.
+Crucially, **only a true collection-time drop** (option (a)/(b)) — not an in-body
+skip — shrinks **both** terms for the ~410k redundant items: an in-body skip still
+pays collection + fixtures + body + marshalling + reporting, so it barely touches
+the 668 s framework term and does nothing for the items that are already fast in
+the call phase.
+
+If the ~410k redundant items were never created, producer wall-clock would be
+dominated by the ~2.5–3.2k genuine compiles plus a small fixed overhead —
+an **order-of-magnitude** speedup in principle. **But this exact number could not
+be measured** in the investigation sandbox: there is no Quasar toolchain
+(`riscv-tt-elf-g++`) or torch/pytest environment available, so the genuine-compile
+wall-clock and the residual fixed overhead were not profiled directly. The
+order-of-magnitude framing is an upper bound implied by the redundancy ratio and
+the measured Σ-call-phase/overhead split, not a measured result. Real profiling
+on a runner with the actual toolchain is required to turn it into a committed
+number.
+
+## Open questions
+
+- **Does the `params → compile-key` mapping stay tractable across all 26 files,**
+  or only the 6 largest? The 94.7% coverage from the top 6 may make a partial
+  dedup (top-6-only) worthwhile on its own, sidestepping the long tail.
+- **What is the true genuine-compile wall-clock** for ~2.5–3.2k variants at the
+  best config, and what fixed overhead remains after dedup? Needed to commit to a
+  savings number.
+- **How stable is `generate_variant_hash()`'s field set** across test churn?
+  The exclusion list (`NON_COMPILATION_ARGUMENTS`) is documented but has grown;
+  the drift-detection assertion is the guard, but its cost and false-positive
+  behaviour on legitimately-new variants need validation.
+- **Interaction with the pytest-xdist coordinator:** if dedup cuts item count
+  ~150×, does the coordinator-throughput cap (the `--maxschedchunk` / `worksteal`
+  finding in the main investigation) stop being the binding constraint, and does
+  the optimal `-n` change? Dedup and worker tuning are not independent.

--- a/tt_metal/tt-llk/docs/tests/quasar_compile_investigation.md
+++ b/tt_metal/tt-llk/docs/tests/quasar_compile_investigation.md
@@ -1,0 +1,143 @@
+# `llk-build-quasar` compile-time investigation — summary for feedback
+
+**Status:** ongoing. This is a coworker-facing summary written to solicit
+feedback and advice. It is deliberately concise; the full detail, measurements,
+and code live in PR
+[#48767](https://github.com/tenstorrent/tt-metal/pull/48767) (branch
+`nsextonTT/llk-quasar-pch`) — please read the PR description and commit messages
+for the numbers behind each claim.
+
+Feedback especially wanted on: the two open threads at the end, and whether the
+memory-scaling extrapolation mistakes below have a cleaner methodology.
+
+## The original problem
+
+The `llk-build-quasar` PR-gate job compiles **~400k kernel variants**
+(413,234 test items in the measured run) with
+`pytest --compile-producer -m quasar`. Each variant fans out to **4**
+`riscv-tt-elf-g++` subprocesses (one per Quasar TRISC role:
+unpack / math / pack / sfpu). The job takes **~20 min**, and — the puzzle that
+started this — **CPU did not scale** when moving from a 16-core to a 40-core
+runner. Adding cores did not make it faster, which meant the binding constraint
+was not raw compute.
+
+## The sequence of findings (including the dead ends)
+
+Roughly chronological. Several promising theories were overturned by real
+measurement; those are kept here on purpose — the value of this investigation has
+been in *not* shipping the plausible-but-wrong fixes.
+
+1. **PCH (precompiled headers).** Every one of the ~4× compiles re-parses the
+   same ~2600 lines of stable headers (`ckernel.h` alone pulls in ~1256 lines of
+   `constexpr` op wrappers). Added GCC PCH support for the variant-independent
+   header prefix + per-role common headers. **Verified the mechanism end-to-end
+   with a real compiler** (matching flags reuse the `.gch`; mismatched flags
+   silently fall back to parsing from source with an identical correct result, so
+   no miscompile risk). **But: the PCH speedup is not yet realized on a runner** —
+   see the regression below, and the JUnit median compile time (~8 ms) did *not*
+   move, which is at least consistent with PCH not engaging on most variants.
+   Diagnosing *why* generation was failing needs a real runner with the toolchain
+   (not available in the investigation sandbox).
+
+2. **Regression: PCH fail-open without memoization (found on a live run, fixed).**
+   After the branch landed, a real run showed the job using **<half the CPU
+   (~2 cores)**, same memory, wall-clock **past the 20-min baseline**. Root cause:
+   `build_pch()` failed *open* but did **not** memoize the failure, so on the
+   per-variant hot path (~100k+ calls) every subsequent variant re-acquired the
+   process-global PCH `FileLock` and re-ran the doomed compiles, serializing all
+   xdist workers behind one lock → CPU collapse. Fixed by gating generation to at
+   most one attempt per worker and writing a `.pch_failed` marker. **Falsified
+   along the way:** the `shell=True` → `shlex.split()` change was suspected but
+   proven *not* the cause (tokenization is byte-identical). Mitigation if it
+   recurs: `TT_LLK_DISABLE_PCH=1`.
+
+3. **Memory / worker-count tuning — a string of measured reversals.** This is the
+   part most worth reading critically.
+   - `-n auto` (40 workers on the 40-core xlarge): **OOM, exit 137**, even with
+     `-Os` and serial inner builds.
+   - `-n 30`: measured **92% mean / 100% peak RAM, ~46% mean swap** — RAM fully
+     saturated and swapping for much of the run. That is *why* more cores didn't
+     help: the job was memory/swap-bound, not compute-bound.
+   - **Inner-parallel g++ (`LLK_BUILD_PARALLELISM=1`, fewer heavyweight Python
+     workers).** Each xdist worker is a full Python process importing numpy +
+     torch (~0.6–1.2 GiB RSS) — a *fixed* tax that scales with `-n`, whereas the
+     compiler memory that drives swap scales with *total g++*. Holding total g++
+     constant while cutting worker count pays that tax fewer times. This is the
+     lever that made the box memory-safe.
+   - `-n 30 → 18`: derived from a per-worker RAM estimate targeting ~80% RAM,
+     zero swap.
+   - `-n 10 → 18` (again): a two-point linear memory fit said ~1.55 GiB/worker,
+     projecting -n 18 to ~69% RAM with headroom.
+   - **`-n 18` reverted to `-n 10` — confirmed net negative.** JUnit A/B (same
+     413k tests) showed no extra useful compiles, but the **cache-hit (no-compile)
+     items inflated ~29%** (median 7 ms → 9 ms) and **+22% total wasted per-item
+     CPU**, RAM 53% → 86% at the swap cliff. Mechanism: `-n 18 × 4 = up to 72
+     concurrent g++` on 40 cores; oversubscription during g++ bursts deschedules
+     the cheap single-threaded Python bookkeeping on other workers. **The
+     ~1.55 GiB/worker linear model was wrong** — actual was ~3.2–3.6 GiB/worker
+     once measured at matched config, ~2× off. That model class is now flagged as
+     unreliable for extrapolation on this job.
+
+4. **The realized-parallelism cap: the pytest-xdist coordinator.** With memory no
+   longer binding, CPU was *still* low (~25% mean) — workers were **starving
+   (~48–65% of wall-clock idle in both `-n 10` and `-n 30`)**, not computing. The
+   single xdist master, throttled by `--maxschedchunk=10` (in the shared
+   `pytest.ini`, never touched by this branch), can't feed ~413k ultra-fast
+   (~8 ms median) items fast enough: ~41k dispatch round-trips + 413k inbound
+   reports, all serial on one event loop. **More workers made it worse, not
+   better** — a direct A/B that points at coordinator throughput. Tried
+   `--maxschedchunk=2000` (helped only ~23 s), then switched to
+   **`--dist=worksteal`** (removes per-top-up master round-trips; ignores
+   `maxschedchunk`). The mechanism is *strongly inferred* from xdist source + the
+   "more workers = worse" A/B, but **not directly measured** (the per-second
+   sidecar samples that would clinch it aren't retrievable via `gh`).
+
+5. **Small, safe per-item wins.** `__slots__` on `TestOutcome`; dropping `-O3` →
+   `-Os` for the compile-only job; and gating the autouse `_seed_torch_rng`
+   fixture to skip in producer mode (it fires ~400k times and buys nothing when
+   no ELF is ever run and stimuli are excluded from the compile hash).
+
+## Where things landed (as of now)
+
+- **Best confirmed config:** `num-workers=10`, `LLK_BUILD_PARALLELISM=1`
+  (4 inner g++ per worker), `--dist=worksteal`, `-Os`. At `-n 10`: **~61% peak
+  RAM, zero swap, tied-fastest wall-clock** of all tested configs, no wasted CPU.
+  This is the current default in `.github/actions/llk-compile-quasar/action.yml`.
+- The starvation finding says the remaining ceiling is **per-item framework
+  overhead + coordinator throughput**, not compute or memory — which is what the
+  two open threads target.
+
+## Two open threads
+
+1. **Producer-mode stimuli/golden guard.** In producer mode the test body's
+   `pytest.skip()` fires only at the *end* (inside `run()`), so stimuli + golden
+   are computed per item and thrown away. Golden is already short-circuited to a
+   cheap dummy; this branch additionally made that guard explicit and
+   order-independent (defense-in-depth). The bigger prize — skipping the
+   torch-based per-item **stimuli** fill — was investigated and **deliberately not
+   implemented**: `generate_stimuli()` is one generic function called from 25 of
+   26 quasar files, several test bodies transform the stimuli *values* before the
+   skip point, and there is no runner in the sandbox to prove all-zeros is
+   crash/hang-safe across every transform. Flagged as requiring real-runner
+   validation.
+
+2. **Test-item deduplication by `variant_id`.** The ~413k items collapse onto
+   ~2.5–3.2k distinct compile variants (~120–160:1). Deduplicating them at
+   *collection* time is the order-of-magnitude lever, but the dedup key must
+   exactly mirror `generate_variant_hash()` or consumer mode fails with a hard
+   missing-ELF. Full design, options, and the belt-and-suspenders drift-detection
+   proposal are in
+   [`quasar_compile_dedup_design.md`](quasar_compile_dedup_design.md).
+
+## Caveats for readers
+
+- Almost everything quantitative here was measured on **real CI runs** (sidecar
+  memory/CPU + JUnit artifacts). The two things that are **inferred, not directly
+  measured**, are (a) the coordinator-starvation *mechanism* (strongly supported
+  by xdist source + A/B, but the clinching per-second samples aren't retrievable)
+  and (b) the dedup savings *magnitude* (order-of-magnitude is an upper bound from
+  the redundancy ratio, not a profiled number — no Quasar toolchain in the
+  sandbox).
+- The memory-scaling extrapolations were wrong twice (once ~2× off). Treat any
+  future "project RAM at `-n X`" claim on this job with suspicion until measured
+  at matched config.

--- a/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_common.h
+++ b/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_common.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ---------------------------------------------------------------------------
+// Precompiled-header (PCH) base for the Quasar `--compile-producer` build.
+//
+// This header aggregates the *variant-independent* prefix that every Quasar
+// kernel translation unit parses before any generated per-variant header. A
+// single Quasar compile job fans out ~400k `riscv-tt-elf-g++` invocations, and
+// without a PCH each one re-parses this same ~2600 lines of stable headers from
+// scratch (ckernel_ops.h alone is ~1256 lines of constexpr register-op
+// wrappers). Precompiling it once per job run and force-including the result
+// with `-include` eliminates that repeated front-end work.
+//
+// CORRECTNESS INVARIANT — only headers whose transitive `#include` closure is
+// byte-identical across every variant in a run may live here. Concretely, this
+// prefix must NOT (even transitively) reach the per-variant generated header
+// `build.h` (pulled in via the static `helpers/include/params.h` wrapper). The
+// closure of the headers below was verified to bottom out only at static,
+// checked-in or toolchain-provided files:
+//
+//   <cstdint>            - libstdc++, stable
+//   ckernel.h            - -> ckernel_ops.h / ckernel_include.h / tensix.h ...
+//                          (does NOT reach cfg_defines.h / build.h / params.h)
+//   llk_defs.h           - stable enums/defs
+//   llk_memory_checks.h  - -> core_config.h / dev_mem_map.h (static hw headers)
+//
+// Notably `cfg_defines.h` (hw/inc/internal/tt-2xx/quasar/cfg_defines.h) IS
+// static per-arch, so headers that reach it are still PCH-safe; only `build.h`
+// (format inference emitted per variant) and its `params.h` wrapper are
+// per-variant and are therefore deliberately absent from this prefix.
+//
+// This header is force-included at top-of-TU via `-include`, so every include
+// below is guarded (`#pragma once`) and the source `#include "ckernel.h"` etc.
+// in the kernel .cpp become no-ops. The per-variant `params.h`/`build.h` are
+// still parsed normally, AFTER this prefix, exactly as before.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"

--- a/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_math.h
+++ b/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_math.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// PCH prefix for the Quasar MATH TRISC role (compiled with -DLLK_TRISC_MATH).
+// Base prefix + the role-common math header. `llk_math_common.h` (which pulls in
+// `cmath_common.h`) is included in every math-role branch before `params.h`; its
+// closure is static (never reaches build.h/params.h), so it is PCH-safe.
+// Operation-specific math headers (e.g. llk_math_eltwise_unary_datacopy.h) vary
+// per test and are intentionally excluded.
+#pragma once
+
+// clang-format off
+// Order matters: the base prefix must precede the role-common header, matching
+// the include order in every kernel .cpp (universal prefix before the role
+// branch). Do not let include sorting reorder these.
+#include "quasar_pch_common.h"
+#include "llk_math_common.h"
+// clang-format on

--- a/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_pack.h
+++ b/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_pack.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// PCH prefix for the Quasar PACK TRISC role (compiled with -DLLK_TRISC_PACK).
+// Base prefix + the role-common pack headers. `llk_pack.h` and
+// `llk_pack_common.h` appear in every pack-role branch before `params.h`; both
+// have static include closures (never reach build.h/params.h), so they are
+// PCH-safe.
+#pragma once
+
+// clang-format off
+// Order matters: the base prefix must precede the role-common headers, matching
+// the include order in every kernel .cpp (universal prefix before the role
+// branch). Do not let include sorting reorder these.
+#include "quasar_pch_common.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+// clang-format on

--- a/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_sfpu.h
+++ b/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_sfpu.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// PCH prefix for the Quasar SFPU TRISC role (compiled with -DLLK_TRISC_ISOLATE_SFPU).
+//
+// Base prefix only, by design. Unlike unpack/math/pack, the SFPU role has NO
+// consistent role-common header across tests: the isolated-SFPU tests pull in
+// cmath_common.h / llk_math_common.h / llk_srcs.h, whereas the common case
+// (tests without an explicit SFPU pipeline) resolves `run_kernel` through the
+// `sfpu_stub.h` stub, which — under LLK_TRISC_ISOLATE_SFPU — includes the
+// per-variant `params.h`/`build.h`. There is therefore no non-per-variant SFPU
+// header safe to bake in beyond the universal base, so we precompile only the
+// base prefix (still capturing the dominant ckernel.h / ckernel_ops.h cost) for
+// this role.
+#pragma once
+
+#include "quasar_pch_common.h"

--- a/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_unpack.h
+++ b/tt_metal/tt-llk/tests/helpers/pch/quasar_pch_unpack.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// PCH prefix for the Quasar UNPACK TRISC role (compiled with -DLLK_TRISC_UNPACK).
+// Base prefix + the role-common unpack header. `llk_unpack_common.h` is included
+// in every unpack-role branch before the per-variant `params.h`, and its include
+// closure is static (reaches cfg_defines.h but never build.h/params.h), so it is
+// PCH-safe. Operation-specific unpack headers (e.g. llk_unpack_unary_operand.h)
+// vary per test and are intentionally excluded.
+#pragma once
+
+// clang-format off
+// Order matters: the base prefix must precede the role-common header, matching
+// the include order in every kernel .cpp (universal prefix before the role
+// branch). Do not let include sorting reorder these.
+#include "quasar_pch_common.h"
+#include "llk_unpack_common.h"
+// clang-format on

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# trigger: llk-build-quasar
 # SPDX-License-Identifier: Apache-2.0
 
 import atexit

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -125,8 +125,17 @@ def _seed_torch_rng():
     Stimuli that don't set an explicit StimuliSpec.seed fall back to torch's
     global generator, so seeding here makes both generate_stimuli() and any
     direct torch.rand/randn/randint/uniform_ calls reproducible.
+
+    Skipped in --compile-producer mode: that job never executes an ELF or
+    checks a result (every test body ends in pytest.skip() inside run()), and
+    stimuli tensors are excluded from the compile hash/header when not
+    SPEED_OF_LIGHT (see generate_variant_hash's NON_COMPILATION_ARGUMENTS), so
+    RNG determinism is irrelevant there. This runs once per test item; at the
+    Quasar producer's ~400k-item scale, skipping the reseed removes that many
+    torch.manual_seed() calls off the hot path for zero behavioural change.
     """
-    torch.manual_seed(_DEFAULT_TORCH_SEED)
+    if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
+        torch.manual_seed(_DEFAULT_TORCH_SEED)
     yield
 
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -282,13 +282,6 @@ def register_golden(cls):
     return cls
 
 
-def get_golden_generator(cls):
-    """Retrieve the registered golden class instance."""
-    if cls not in golden_registry:
-        raise KeyError(f"Golden class {cls.__name__} is not registered.")
-    return golden_registry[cls]
-
-
 class DummyGoldenGenerator:
     def __call__(*args, **kwargs):
         return torch.zeros(1024, dtype=torch.bfloat16)
@@ -305,6 +298,53 @@ class DummyGoldenGenerator:
 
 def dummy_golden_generator(cls):
     return DummyGoldenGenerator()
+
+
+# Defense-in-depth producer-mode guard.
+#
+# In --compile-producer mode the job only compiles ELFs; the test body's
+# pytest.skip() fires inside run()/prepare() *after* every golden has already
+# been computed and thrown away. To avoid that waste, setup_mode() swaps in the
+# cheap DummyGoldenGenerator via `golden_generators.get_golden_generator =
+# dummy_golden_generator`.
+#
+# That module-attribute swap only reaches callers that resolve the name through
+# the module object at call time. Every quasar test, however, does
+# `from helpers.golden_generators import get_golden_generator`, which copies the
+# function object into the test module's namespace at import time. The swap is
+# therefore only honoured because pytest_configure() (→ setup_mode) happens to
+# run *before* the test modules are imported/collected — a real but implicit and
+# fragile ordering dependency (if a test module were ever imported first, its
+# bound name would keep pointing at the un-swapped function and produce full
+# goldens in producer mode again).
+#
+# _PRODUCER_MODE + the in-body check below make the guard order-independent:
+# because a function's __globals__ always refer to *this* module, the check sees
+# the flag no matter how the name was imported or when it was bound. This is
+# additive belt-and-suspenders on top of the existing swap; it does not change
+# any non-producer path (the flag defaults to False and is only set for
+# --compile-producer, which never coexists with the --stimuli-only/--use-stimuli
+# proxy modes).
+_PRODUCER_MODE = False
+
+
+def set_producer_mode(enabled: bool) -> None:
+    """Enable/disable the producer-mode golden short-circuit (see above)."""
+    global _PRODUCER_MODE
+    _PRODUCER_MODE = enabled
+
+
+def get_golden_generator(cls):
+    """Retrieve the registered golden class instance.
+
+    In --compile-producer mode returns the cheap DummyGoldenGenerator regardless
+    of how this function was imported (see _PRODUCER_MODE note above).
+    """
+    if _PRODUCER_MODE:
+        return DummyGoldenGenerator()
+    if cls not in golden_registry:
+        raise KeyError(f"Golden class {cls.__name__} is not registered.")
+    return golden_registry[cls]
 
 
 class ProxyMode(Enum):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -188,6 +188,16 @@ class TestConfig:
     STIMULI_ADDRESS_MAP: ClassVar[dict[str, int]] = {}
     SIMULATOR_TIMEOUT: ClassVar[int] = 600
 
+    # Inner compile parallelism toggle. Disabled by default: each pytest-xdist
+    # worker compiles its kernel components serially (one g++ at a time), so total
+    # concurrent compilers is just (xdist -n) and RSS scales linearly with -n
+    # (avoids OOM / exit 137). Enable (LLK_BUILD_PARALLELISM=1) to compile a
+    # variant's components concurrently — total g++ becomes (xdist -n) ×
+    # len(KERNEL_COMPONENTS), so lower -n accordingly.
+    BUILD_PARALLELISM: ClassVar[bool] = (
+        os.environ.get("LLK_BUILD_PARALLELISM", "0") == "1"
+    )
+
     # When the infrastructure itself needs to be tested, some functionality like compiling the artefacts and writing them
     # to tmpfs can be skipped (eg. object, elf and coverage data files etc.). This flag is used to skip such code to enable fast execution of infra tests.
     INFRA_TESTING: ClassVar[bool] = False
@@ -1299,9 +1309,10 @@ class TestConfig:
                     (f"#include  <{self.test_name}>\n" "#include  <trisc.cpp>\n"),
                 )
 
-            with ThreadPoolExecutor(
-                max_workers=len(TestConfig.KERNEL_COMPONENTS)
-            ) as executor:
+            max_workers = (
+                len(TestConfig.KERNEL_COMPONENTS) if TestConfig.BUILD_PARALLELISM else 1
+            )
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = [
                     executor.submit(build_kernel_part, name)
                     for name in TestConfig.KERNEL_COMPONENTS

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -584,7 +584,14 @@ class TestConfig:
 
         if compile_producer:
             TestConfig.BUILD_MODE = BuildMode.PRODUCE
+            # Two guards, on purpose. The module-attribute swap keeps the
+            # historical behaviour for module-qualified callers; set_producer_mode
+            # makes the short-circuit order-independent so the many tests that do
+            # `from helpers.golden_generators import get_golden_generator` also get
+            # the dummy even though they bound the name at import time (see the
+            # _PRODUCER_MODE note in golden_generators.py).
             golden_generators_module.get_golden_generator = dummy_golden_generator
+            golden_generators_module.set_producer_mode(True)
 
         if compile_consumer:
             TestConfig.BUILD_MODE = BuildMode.CONSUME

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -138,6 +138,13 @@ class TestConfig:
     PERF_DATA_DIR: ClassVar[Path]
     DEFAULT_STIMULI_CACHE_FOLDER: ClassVar[Path]
 
+    # Precompiled-header (PCH) scratch dir + checked-in source dir (Quasar only).
+    # PCH_AVAILABLE flips to True once the per-run .gch files are built; if
+    # generation fails for any reason it stays False and compiles run unchanged.
+    PCH_DIR: ClassVar[Path]
+    PCH_SOURCE_DIR: ClassVar[Path]
+    PCH_AVAILABLE: ClassVar[bool] = False
+
     # Sources directories
     LLK_ROOT: ClassVar[Path]
     TESTS_WORKING_DIR: ClassVar[Path]
@@ -407,6 +414,9 @@ class TestConfig:
         TestConfig.DEFAULT_STIMULI_CACHE_FOLDER = (
             TestConfig.ARTEFACTS_DIR / "temp_stimuli"
         )
+        # Per-run PCH scratch (.gch live here) + checked-in PCH source headers.
+        TestConfig.PCH_DIR = TestConfig.ARTEFACTS_DIR / "pch"
+        TestConfig.PCH_SOURCE_DIR = TestConfig.HELPERS / "pch"
 
     @staticmethod
     def create_build_directories():
@@ -425,6 +435,7 @@ class TestConfig:
                 TestConfig.PROFILER_SHARED_OBJ_DIR,
                 TestConfig.PROFILER_SHARED_ELF_DIR,
                 TestConfig.COVERAGE_INFO_DIR,
+                TestConfig.PCH_DIR,
             ]
         )
         TestConfig._BUILD_DIRS_CREATED = True
@@ -975,6 +986,98 @@ class TestConfig:
             done_marker.touch()
             TestConfig.SHARED_ARTEFACTS_AVAILABLE = True
 
+    @staticmethod
+    def _pch_trisc_define(component: str) -> str:
+        """Command-line TRISC define for a KERNEL_COMPONENTS entry (matches build_kernel_part)."""
+        return "ISOLATE_SFPU" if component == "sfpu" else component.upper()
+
+    def build_pch(self):
+        """Precompile the per-role Quasar PCH prefixes once per job run.
+
+        A single Quasar `--compile-producer` run fans out ~400k
+        `riscv-tt-elf-g++` calls; without a PCH each one re-parses the same
+        stable header prefix (ckernel.h/ckernel_ops.h etc.) from scratch. We
+        precompile that prefix once per role into `.gch` files under PCH_DIR and
+        force-include them from build_kernel_part.
+
+        Safety: this is Quasar-only, opt-outable via TT_LLK_DISABLE_PCH=1, and
+        fail-open — any error leaves PCH_AVAILABLE False so compiles run exactly
+        as before. The `.gch` are built with the same compute flags as the
+        common-case variant; build_kernel_part only force-includes them for
+        variants whose flags match (see there), and even a stale/mismatched
+        `.gch` would be silently ignored by GCC (`-include` falls back to
+        parsing the header from source), never miscompiled.
+        """
+        if TestConfig.PCH_AVAILABLE:
+            return
+        # Quasar-only: the checked-in PCH headers and role set are Quasar-specific.
+        if TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR:
+            return
+        if os.environ.get("TT_LLK_DISABLE_PCH") == "1":
+            logger.debug("PCH disabled via TT_LLK_DISABLE_PCH=1")
+            return
+
+        done_marker = TestConfig.PCH_DIR / ".pch_complete"
+        if done_marker.exists():
+            TestConfig.PCH_AVAILABLE = True
+            return
+
+        lock = FileLock("/tmp/tt-llk-build-pch.lock")
+        with lock:
+            if done_marker.exists():
+                TestConfig.PCH_AVAILABLE = True
+                return
+
+            os.makedirs(TestConfig.PCH_DIR, exist_ok=True)
+
+            # Canonical common-case compute flags. Constructed from the same
+            # TestConfig options as resolve_compile_options()/build_kernel_part
+            # so the PCH is byte-for-byte flag-compatible with the variants that
+            # will consume it: no coverage/profiler/device-print, and
+            # -DRUNTIME_FORMATS present (compile_time_formats defaults to False).
+            canonical_options = (
+                f"{' '.join(TestConfig.INCLUDES)} {TestConfig.INITIAL_OPTIONS_COMPILE} "
+                "-DLLK_BOOT_MODE_TRISC -DRUNTIME_FORMATS "
+            )
+
+            try:
+                for component in TestConfig.KERNEL_COMPONENTS:
+                    trisc_define = TestConfig._pch_trisc_define(component)
+                    src_header = TestConfig.PCH_SOURCE_DIR / f"quasar_pch_{component}.h"
+                    if not src_header.exists():
+                        raise FileNotFoundError(
+                            f"missing PCH source header {src_header}"
+                        )
+                    # Colocate a copy of the header with its .gch so that
+                    # `-include {staged_header}` resolves `{staged_header}.gch`.
+                    staged_header = TestConfig.PCH_DIR / f"quasar_pch_{component}.h"
+                    shutil.copyfile(src_header, staged_header)
+                    gch_path = f"{staged_header}.gch"
+
+                    pch_command = (
+                        f"{TestConfig.GXX} {TestConfig.ARCH_COMPUTE} {TestConfig.ARCH_SPECIFIC_OPTIONS} "
+                        f"{TestConfig.OPTIONS_ALL} -I{TestConfig.TESTS_WORKING_DIR} "
+                        f"-I{TestConfig.RISCV_SOURCES} {canonical_options} "
+                        f"-DLLK_TRISC_{trisc_define} "
+                        f"-x c++-header {staged_header} -o {gch_path}"
+                    )
+                    logger.trace(pch_command)
+                    run_shell_command(pch_command, TestConfig.TESTS_WORKING_DIR)
+
+                done_marker.touch()
+                TestConfig.PCH_AVAILABLE = True
+                logger.debug(
+                    "Precompiled Quasar PCH headers for roles: {}",
+                    ", ".join(TestConfig.KERNEL_COMPONENTS),
+                )
+            except Exception as e:
+                # Fail open: disable PCH for this run, leave compiles unchanged.
+                TestConfig.PCH_AVAILABLE = False
+                logger.warning(
+                    "PCH generation failed ({}); continuing without precompiled headers.",
+                    e,
+                )
+
     def generate_compile_time_data_formats(self) -> list[str]:
         header_content: list[str] = [
             "// Data formats inferred by Python inference model"
@@ -1203,6 +1306,7 @@ class TestConfig:
             return
 
         self.build_shared_artefacts()
+        self.build_pch()
 
         # Fast path: if build is already complete, skip entirely
         if done_marker.exists():
@@ -1283,9 +1387,30 @@ class TestConfig:
                         f"-DDEVICE_PRINT_BUFFER_SIZE2={TestConfig.DEVICE_PRINT_BUFFER_SIZE2} "
                         f"-DPROCESSOR_INDEX={risc_id} "
                     )
+                # Force-include the precompiled header prefix for this role, but
+                # only for variants whose compile flags match those the .gch was
+                # built with (the common case). The PCH is built with the
+                # canonical flag set (no coverage/profiler/device-print,
+                # -DRUNTIME_FORMATS present, no -DDISABLE_SFPLOADMACRO); using it
+                # on a variant with a different macro set would make GCC discard
+                # it anyway (-Winvalid-pch, which under -Werror could fail the
+                # build), so we simply skip -include there and compile as before.
+                pch_include = ""
+                if TestConfig.PCH_AVAILABLE:
+                    canonical_variant = (
+                        self.coverage_build == CoverageBuild.No
+                        and self.profiler_build == ProfilerBuild.No
+                        and not self.compile_time_formats
+                        and not device_print_flags
+                        and os.environ.get("TT_METAL_DISABLE_SFPLOADMACRO") != "1"
+                    )
+                    if canonical_variant:
+                        pch_header = TestConfig.PCH_DIR / f"quasar_pch_{name}.h"
+                        pch_include = f"-include {pch_header} -Winvalid-pch "
+
                 compile_command = (
                     f"{TestConfig.GXX} {TestConfig.ARCH_COMPUTE} {TestConfig.ARCH_SPECIFIC_OPTIONS} {TestConfig.OPTIONS_ALL} -I{TestConfig.TESTS_WORKING_DIR} "
-                    f"-I{TestConfig.RISCV_SOURCES} -I{VARIANT_DIR} {local_options_compile} {optional_kernel_flags} "
+                    f"-I{TestConfig.RISCV_SOURCES} -I{VARIANT_DIR} {pch_include}{local_options_compile} {optional_kernel_flags} "
                     f"-DLLK_TRISC_{trisc_define} {device_print_flags}{TestConfig.OPTIONS_LINK} {COVERAGES_DEPS} "
                     f"-T{local_memory_layout_ld} -T{TestConfig.LINKER_SCRIPTS / name}.ld -T{TestConfig.LINKER_SCRIPTS}/sections.ld "
                     f"-x c++ - -lc -o {VARIANT_ELF_DIR / name}.elf"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -504,15 +504,23 @@ class TestConfig:
         speed_of_light: bool = False,
     ):
         debug_flag = "" if no_debug_symbols else "-g "
-        # Quasar's compile-producer job never runs or perf-tests the ELF it
-        # builds (it only checks that it compiles), so -O3 buys nothing there
-        # while its template-heavy codegen drives peak per-compile memory —
-        # the actual ceiling on how many workers can run concurrently. -Os
-        # lowers that ceiling. WH/BH keep -O3 since their builds are exercised
-        # on real hardware and/or perf-measured.
-        opt_flag = (
-            "-Os" if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR else "-O3"
-        )
+        # TEMPORARY TEST: forced to -O3 for all architectures (including
+        # Quasar) to let Neil directly measure PCH's speedup at -O3, matching
+        # the conditions of his earlier standalone PCH test. This is NOT a
+        # permanent reversion -- confirmed via the real pinned SFPI 7.64.0
+        # toolchain (commit ce901330ae) that -Os combined with a
+        # force-included PCH triggers a genuine compiler ICE in 2 SFPU
+        # sources (ckernel_sfpu_where.h, ckernel_sfpu_binary.h), while -O3
+        # (or -O2) + PCH is clean on the same sources. Quasar's
+        # compile-producer job never runs/perf-tests the ELF, so -O3 buys
+        # nothing there while its codegen drives peak per-compile memory --
+        # the actual ceiling on concurrent workers -- which is why it was
+        # switched to -Os in the first place. Revert this back to the
+        # CHIP_ARCH-conditional -Os once the -O3 PCH comparison is done:
+        #   opt_flag = (
+        #       "-Os" if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR else "-O3"
+        #   )
+        opt_flag = "-O3"
         TestConfig.OPTIONS_ALL = (
             f"{debug_flag}{opt_flag} "
             "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -ftt-no-dyninit "

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -105,7 +105,7 @@ class StimuliMode(Enum):
     LOAD_CACHED = 2  # load from disk, skip computation
 
 
-@dataclass
+@dataclass(slots=True)
 class TestOutcome:
     result: Any = None
     # Lines emitted by DEVICE_PRINT() during this run.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -141,9 +141,14 @@ class TestConfig:
     # Precompiled-header (PCH) scratch dir + checked-in source dir (Quasar only).
     # PCH_AVAILABLE flips to True once the per-run .gch files are built; if
     # generation fails for any reason it stays False and compiles run unchanged.
+    # PCH_ATTEMPTED gates generation to at most once per worker process: build_pch
+    # runs on the per-variant hot path, and a fail-open generation writes no
+    # success marker, so without this flag every variant would re-enter and
+    # re-serialize on the global PCH FileLock (see build_pch).
     PCH_DIR: ClassVar[Path]
     PCH_SOURCE_DIR: ClassVar[Path]
     PCH_AVAILABLE: ClassVar[bool] = False
+    PCH_ATTEMPTED: ClassVar[bool] = False
 
     # Sources directories
     LLK_ROOT: ClassVar[Path]
@@ -1008,7 +1013,7 @@ class TestConfig:
         `.gch` would be silently ignored by GCC (`-include` falls back to
         parsing the header from source), never miscompiled.
         """
-        if TestConfig.PCH_AVAILABLE:
+        if TestConfig.PCH_AVAILABLE or TestConfig.PCH_ATTEMPTED:
             return
         # Quasar-only: the checked-in PCH headers and role set are Quasar-specific.
         if TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR:
@@ -1017,15 +1022,30 @@ class TestConfig:
             logger.debug("PCH disabled via TT_LLK_DISABLE_PCH=1")
             return
 
+        # Commit to at most one generation attempt per worker process. build_pch
+        # is on the per-variant hot path (build_elfs calls it before the variant's
+        # own done-marker fast-path), and generation is fail-open (below): on
+        # failure PCH_AVAILABLE stays False and no success marker is written. If we
+        # re-entered per variant we would re-acquire the global FileLock and re-run
+        # the doomed compiles on every one of the ~100k+ variants, serializing all
+        # xdist workers behind one lock and collapsing CPU utilisation. One shot.
+        TestConfig.PCH_ATTEMPTED = True
+
         done_marker = TestConfig.PCH_DIR / ".pch_complete"
+        failed_marker = TestConfig.PCH_DIR / ".pch_failed"
         if done_marker.exists():
             TestConfig.PCH_AVAILABLE = True
+            return
+        # A sibling worker already tried and failed this run; don't retry.
+        if failed_marker.exists():
             return
 
         lock = FileLock("/tmp/tt-llk-build-pch.lock")
         with lock:
             if done_marker.exists():
                 TestConfig.PCH_AVAILABLE = True
+                return
+            if failed_marker.exists():
                 return
 
             os.makedirs(TestConfig.PCH_DIR, exist_ok=True)
@@ -1072,7 +1092,13 @@ class TestConfig:
                 )
             except Exception as e:
                 # Fail open: disable PCH for this run, leave compiles unchanged.
+                # Record the failure under the lock so neither this process nor any
+                # sibling worker re-attempts generation for the rest of the run.
                 TestConfig.PCH_AVAILABLE = False
+                try:
+                    failed_marker.touch()
+                except OSError:
+                    pass
                 logger.warning(
                     "PCH generation failed ({}); continuing without precompiled headers.",
                     e,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1087,6 +1087,23 @@ class TestConfig:
             )
 
             try:
+                # Every role header (quasar_pch_{unpack,math,pack,sfpu}.h) does
+                # `#include "quasar_pch_common.h"` with a bare quoted include,
+                # resolved by GCC relative to the INCLUDING FILE'S OWN
+                # directory. That only works if the common header is staged
+                # alongside the role headers in PCH_DIR too, not just in
+                # PCH_SOURCE_DIR where they normally live side by side. This
+                # was missing entirely -- every build_pch() call has been
+                # failing with "quasar_pch_common.h: No such file or
+                # directory" since PCH was introduced (confirmed via a real
+                # run's "Report PCH status" log), meaning PCH has never once
+                # produced a usable .gch; every compile has silently fallen
+                # back to the pre-PCH fail-open path this whole time.
+                common_src = TestConfig.PCH_SOURCE_DIR / "quasar_pch_common.h"
+                if not common_src.exists():
+                    raise FileNotFoundError(f"missing PCH source header {common_src}")
+                shutil.copyfile(common_src, TestConfig.PCH_DIR / "quasar_pch_common.h")
+
                 for component in TestConfig.KERNEL_COMPONENTS:
                     trisc_define = TestConfig._pch_trisc_define(component)
                     src_header = TestConfig.PCH_SOURCE_DIR / f"quasar_pch_{component}.h"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -150,40 +150,35 @@ class TestConfig:
     PCH_AVAILABLE: ClassVar[bool] = False
     PCH_ATTEMPTED: ClassVar[bool] = False
 
-    # Test sources that must NOT force-include the math-role PCH: doing so
-    # crashes the pinned SFPI toolchain (riscv-tt-elf-g++ 7.64.0[735], GCC 15.1
-    # fork; tenstorrent/sfpi) with a hard internal compiler error, not a
-    # graceful -Winvalid-pch fallback.
+    # Sources observed to ICE the pinned SFPI toolchain when the math-role PCH
+    # is force-included. This set is NO LONGER the PCH safety mechanism -- PCH
+    # is disabled by default in build_pch(), so this denylist is currently
+    # inert -- but it is kept as a record of which sources have been seen to
+    # crash and as the gate that still applies if PCH is re-enabled via
+    # TT_LLK_ENABLE_PCH=1.
     #
-    # Root cause, reproduced directly against the pinned toolchain: the ICE
-    # requires BOTH -Os (this branch's Quasar-only opt level, see
-    # setup_compilation_options) AND a matching force-included PCH. The exact
-    # 2x2 matrix on sfpu_where_quasar_test.cpp's math .elf:
-    #     -Os + PCH  -> ICE      -O2/-O3 + PCH  -> OK
-    #     -Os no-PCH -> OK       -O2/-O3 no-PCH -> OK
-    # i.e. neither -Os alone (every pre-PCH run compiled these fine) nor PCH
-    # alone (at -O2/-O3) is sufficient; only the combination trips it. The
-    # crash is in the fork's custom RISC-V backend passes, downstream of PCH
-    # AST restore + the -Os codegen path, on the unrolled `v_if`-based SFPU
-    # bodies these two ops share:
-    #   ckernel_sfpu_where.h:71   -> in transform, at rtl-rvtt-synth.cc:123
-    #   ckernel_sfpu_binary.h:66  -> in get_def_stmt_liveness_1, at
-    #                                gimple-rvtt-live.cc:347
-    # (confirmed as the ONLY two files that ICE across a full ~2500-compile
-    # producer run; every other SFPU op -- gelu/tanh/square/exp/... -- and
-    # every non-SFPU math op compiles cleanly with -Os + math PCH, so this is
-    # scoped per-source, not per-role.)
+    # WARNING: this denylist is NOT a reliable fix and must not be treated as
+    # one. An earlier round of this investigation claimed the ICE required
+    # BOTH -Os AND a force-included PCH, asserting "-O2/-O3 + PCH -> OK" as a
+    # verified 2x2 matrix. Real CI run 28638406365 disproves that: at -O3 with
+    # PCH force-included, a source NOT in this set (eltwise_unary) ICEd 1920
+    # times (get_def_stmt_liveness_1, at gimple-rvtt-live.cc:347). Observed so
+    # far, from real CI logs:
+    #   run 28636598915 (-Os): sfpu_where (transform @ rtl-rvtt-synth.cc:123)
+    #                          + eltwise_binary (get_def_stmt_liveness_1 @
+    #                          gimple-rvtt-live.cc:347)
+    #   run 28638406365 (-O3): eltwise_unary (get_def_stmt_liveness_1 @
+    #                          gimple-rvtt-live.cc:347)
+    # i.e. the set of crashing sources changes with the opt level, so no fixed
+    # denylist covers all of them. eltwise_unary is deliberately NOT added
+    # here: doing so would just be more whack-a-mole and would re-imply this
+    # list is sufficient, which the evidence says it is not.
     #
-    # -Wno-error=invalid-pch (below) is NOT a backstop here: it only rescues a
-    # *mismatched* .gch (which GCC discards). These variants match the PCH
-    # exactly, so the .gch is accepted and consumed, and the compiler crashes
-    # anyway. The only safe option is to skip -include entirely for these
-    # sources; they then compile via the plain -Os path (proven OK above),
-    # forgoing PCH's speedup for ~2 ops while every other op keeps it.
-    #
-    # Keyed on os.path.basename(self.test_name). Revisit when the pinned SFPI
-    # version bumps -- if a newer toolchain fixes the backend passes, this set
-    # can shrink to empty and PCH re-enabled for these ops.
+    # The gate is keyed on os.path.basename(self.test_name) in
+    # build_kernel_part (that comparison itself is correct -- test_name is the
+    # full source path, e.g. "sources/quasar/sfpu_where_quasar_test.cpp", and
+    # basename() of it matches these entries). It is only the *premise* -- that
+    # a small fixed list can enumerate the crashing sources -- that is unsound.
     PCH_INCOMPATIBLE_SOURCES: ClassVar[frozenset[str]] = frozenset(
         {
             "sfpu_where_quasar_test.cpp",
@@ -504,23 +499,21 @@ class TestConfig:
         speed_of_light: bool = False,
     ):
         debug_flag = "" if no_debug_symbols else "-g "
-        # TEMPORARY TEST: forced to -O3 for all architectures (including
-        # Quasar) to let Neil directly measure PCH's speedup at -O3, matching
-        # the conditions of his earlier standalone PCH test. This is NOT a
-        # permanent reversion -- confirmed via the real pinned SFPI 7.64.0
-        # toolchain (commit ce901330ae) that -Os combined with a
-        # force-included PCH triggers a genuine compiler ICE in 2 SFPU
-        # sources (ckernel_sfpu_where.h, ckernel_sfpu_binary.h), while -O3
-        # (or -O2) + PCH is clean on the same sources. Quasar's
-        # compile-producer job never runs/perf-tests the ELF, so -O3 buys
-        # nothing there while its codegen drives peak per-compile memory --
-        # the actual ceiling on concurrent workers -- which is why it was
-        # switched to -Os in the first place. Revert this back to the
-        # CHIP_ARCH-conditional -Os once the -O3 PCH comparison is done:
-        #   opt_flag = (
-        #       "-Os" if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR else "-O3"
-        #   )
-        opt_flag = "-O3"
+        # Quasar builds at -Os to lower peak per-compile memory so more xdist
+        # workers fit; every other arch uses -O3. The earlier -O3 override
+        # here was a TEMPORARY test to check whether -O3 avoided the PCH ICE;
+        # it did not (see below), so it is reverted.
+        #
+        # Do NOT re-introduce a global -O3 override as a PCH workaround: real
+        # CI run 28638406365 compiled at -O3 with PCH force-included and still
+        # produced 1920 identical internal compiler errors
+        # (get_def_stmt_liveness_1, at config/riscv/tt/gimple-rvtt-live.cc:347,
+        # during GIMPLE pass: rvtt_live) on eltwise_unary_sfpu_quasar_test.cpp.
+        # The opt level only changes WHICH source ICEs, not whether PCH ICEs.
+        # PCH is disabled by default for this reason -- see build_pch().
+        opt_flag = (
+            "-Os" if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR else "-O3"
+        )
         TestConfig.OPTIONS_ALL = (
             f"{debug_flag}{opt_flag} "
             "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -ftt-no-dyninit "
@@ -1080,9 +1073,10 @@ class TestConfig:
         precompile that prefix once per role into `.gch` files under PCH_DIR and
         force-include them from build_kernel_part.
 
-        Safety: this is Quasar-only, opt-outable via TT_LLK_DISABLE_PCH=1, and
-        fail-open — any error leaves PCH_AVAILABLE False so compiles run exactly
-        as before. The `.gch` are built with the same compute flags as the
+        Safety: PCH is DISABLED BY DEFAULT (opt-in via TT_LLK_ENABLE_PCH=1;
+        see the gate below for why), this is Quasar-only, and it is fail-open —
+        any error leaves PCH_AVAILABLE False so compiles run exactly as before.
+        The `.gch` are built with the same compute flags as the
         common-case variant; build_kernel_part only force-includes them for
         variants whose flags match (see there), and even a stale/mismatched
         `.gch` would be silently ignored by GCC (`-include` falls back to
@@ -1092,6 +1086,34 @@ class TestConfig:
             return
         # Quasar-only: the checked-in PCH headers and role set are Quasar-specific.
         if TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR:
+            return
+        # PCH is DISABLED BY DEFAULT (opt-in via TT_LLK_ENABLE_PCH=1).
+        #
+        # Once build_pch() was fixed to actually stage the common header
+        # (commit 6099c3b39f), force-including the generated .gch was found to
+        # crash the pinned SFPI toolchain with a hard internal compiler error
+        # in the fork's custom RISC-V backend passes, NOT a graceful
+        # -Winvalid-pch fallback. Two real CI runs demonstrate this:
+        #   * run 28636598915 (-Os): 346 ICEs on sfpu_where + eltwise_binary
+        #     (transform @ rtl-rvtt-synth.cc:123; get_def_stmt_liveness_1 @
+        #     gimple-rvtt-live.cc:347).
+        #   * run 28638406365 (-O3): 1920 ICEs on eltwise_unary
+        #     (get_def_stmt_liveness_1 @ gimple-rvtt-live.cc:347).
+        # Every failing compile in both runs had -include of the math .gch and
+        # emitted zero -Winvalid-pch warnings, i.e. the .gch was accepted and
+        # consumed and the compiler then crashed in codegen.
+        #
+        # The two runs crash on DIFFERENT source files at different opt levels,
+        # so neither a per-source denylist (PCH_INCOMPATIBLE_SOURCES) nor an
+        # opt-level change is a reliable fix: the set of sources that ICE is
+        # not stable, so any fixed exclusion list will miss some. Until the
+        # toolchain backend bug is fixed (or a reliable predicate for the
+        # crashing shape is found), the only safe default is to not
+        # force-include PCH at all -- which is exactly the proven pre-PCH path
+        # that every run before 6099c3b39f took. Set TT_LLK_ENABLE_PCH=1 to
+        # re-enable for local experiments.
+        if os.environ.get("TT_LLK_ENABLE_PCH") != "1":
+            logger.debug("PCH disabled by default (set TT_LLK_ENABLE_PCH=1 to enable)")
             return
         if os.environ.get("TT_LLK_DISABLE_PCH") == "1":
             logger.debug("PCH disabled via TT_LLK_DISABLE_PCH=1")

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1112,7 +1112,7 @@ class TestConfig:
 
                 done_marker.touch()
                 TestConfig.PCH_AVAILABLE = True
-                logger.debug(
+                logger.info(
                     "Precompiled Quasar PCH headers for roles: {}",
                     ", ".join(TestConfig.KERNEL_COMPONENTS),
                 )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -150,6 +150,47 @@ class TestConfig:
     PCH_AVAILABLE: ClassVar[bool] = False
     PCH_ATTEMPTED: ClassVar[bool] = False
 
+    # Test sources that must NOT force-include the math-role PCH: doing so
+    # crashes the pinned SFPI toolchain (riscv-tt-elf-g++ 7.64.0[735], GCC 15.1
+    # fork; tenstorrent/sfpi) with a hard internal compiler error, not a
+    # graceful -Winvalid-pch fallback.
+    #
+    # Root cause, reproduced directly against the pinned toolchain: the ICE
+    # requires BOTH -Os (this branch's Quasar-only opt level, see
+    # setup_compilation_options) AND a matching force-included PCH. The exact
+    # 2x2 matrix on sfpu_where_quasar_test.cpp's math .elf:
+    #     -Os + PCH  -> ICE      -O2/-O3 + PCH  -> OK
+    #     -Os no-PCH -> OK       -O2/-O3 no-PCH -> OK
+    # i.e. neither -Os alone (every pre-PCH run compiled these fine) nor PCH
+    # alone (at -O2/-O3) is sufficient; only the combination trips it. The
+    # crash is in the fork's custom RISC-V backend passes, downstream of PCH
+    # AST restore + the -Os codegen path, on the unrolled `v_if`-based SFPU
+    # bodies these two ops share:
+    #   ckernel_sfpu_where.h:71   -> in transform, at rtl-rvtt-synth.cc:123
+    #   ckernel_sfpu_binary.h:66  -> in get_def_stmt_liveness_1, at
+    #                                gimple-rvtt-live.cc:347
+    # (confirmed as the ONLY two files that ICE across a full ~2500-compile
+    # producer run; every other SFPU op -- gelu/tanh/square/exp/... -- and
+    # every non-SFPU math op compiles cleanly with -Os + math PCH, so this is
+    # scoped per-source, not per-role.)
+    #
+    # -Wno-error=invalid-pch (below) is NOT a backstop here: it only rescues a
+    # *mismatched* .gch (which GCC discards). These variants match the PCH
+    # exactly, so the .gch is accepted and consumed, and the compiler crashes
+    # anyway. The only safe option is to skip -include entirely for these
+    # sources; they then compile via the plain -Os path (proven OK above),
+    # forgoing PCH's speedup for ~2 ops while every other op keeps it.
+    #
+    # Keyed on os.path.basename(self.test_name). Revisit when the pinned SFPI
+    # version bumps -- if a newer toolchain fixes the backend passes, this set
+    # can shrink to empty and PCH re-enabled for these ops.
+    PCH_INCOMPATIBLE_SOURCES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "sfpu_where_quasar_test.cpp",
+            "eltwise_binary_sfpu_quasar_test.cpp",
+        }
+    )
+
     # Sources directories
     LLK_ROOT: ClassVar[Path]
     TESTS_WORKING_DIR: ClassVar[Path]
@@ -1460,14 +1501,34 @@ class TestConfig:
                 # only for variants whose compile flags match those the .gch was
                 # built with (the common case). The PCH is built with the
                 # canonical flag set (no coverage/profiler/device-print,
-                # -DRUNTIME_FORMATS present, no -DDISABLE_SFPLOADMACRO); using it
-                # on a variant with a different macro set would make GCC discard
-                # it anyway (-Winvalid-pch, which under -Werror could fail the
-                # build), so we simply skip -include there and compile as before.
+                # -DRUNTIME_FORMATS present, no -DDISABLE_SFPLOADMACRO).
+                #
+                # canonical_variant is a best-effort gate, not a guarantee: a
+                # real run just proved it has gaps (e.g. implied_math_format
+                # isn't checked here, and a mismatched variant got -include'd
+                # anyway). The design intent was always "an incompatible .gch
+                # just gets discarded and re-parsed from source via
+                # -Winvalid-pch, never a hard failure" -- but -Werror is on
+                # globally (INITIAL_OPTIONS_COMPILE) and invalid-pch was never
+                # added to the -Wno-error= exemptions, so a real mismatch
+                # turned that intended-safe warning into a build-breaking
+                # error instead. -Wno-error=invalid-pch restores the actually
+                # intended fail-safe behavior regardless of any gap in
+                # canonical_variant's flag coverage -- correctness no longer
+                # depends on that gate being exhaustive.
                 pch_include = ""
                 if TestConfig.PCH_AVAILABLE:
+                    # Some sources crash the pinned toolchain when the math-role
+                    # PCH is force-included under -Os (hard ICE, not a graceful
+                    # -Winvalid-pch fallback). Skip -include for those so they
+                    # compile via the plain path; see PCH_INCOMPATIBLE_SOURCES.
+                    pch_safe_source = (
+                        os.path.basename(self.test_name)
+                        not in TestConfig.PCH_INCOMPATIBLE_SOURCES
+                    )
                     canonical_variant = (
-                        self.coverage_build == CoverageBuild.No
+                        pch_safe_source
+                        and self.coverage_build == CoverageBuild.No
                         and self.profiler_build == ProfilerBuild.No
                         and not self.compile_time_formats
                         and not device_print_flags
@@ -1475,7 +1536,10 @@ class TestConfig:
                     )
                     if canonical_variant:
                         pch_header = TestConfig.PCH_DIR / f"quasar_pch_{name}.h"
-                        pch_include = f"-include {pch_header} -Winvalid-pch "
+                        pch_include = (
+                            f"-include {pch_header} "
+                            "-Winvalid-pch -Wno-error=invalid-pch "
+                        )
 
                 compile_command = (
                     f"{TestConfig.GXX} {TestConfig.ARCH_COMPUTE} {TestConfig.ARCH_SPECIFIC_OPTIONS} {TestConfig.OPTIONS_ALL} -I{TestConfig.TESTS_WORKING_DIR} "

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -463,8 +463,17 @@ class TestConfig:
         speed_of_light: bool = False,
     ):
         debug_flag = "" if no_debug_symbols else "-g "
+        # Quasar's compile-producer job never runs or perf-tests the ELF it
+        # builds (it only checks that it compiles), so -O3 buys nothing there
+        # while its template-heavy codegen drives peak per-compile memory —
+        # the actual ceiling on how many workers can run concurrently. -Os
+        # lowers that ceiling. WH/BH keep -O3 since their builds are exercised
+        # on real hardware and/or perf-measured.
+        opt_flag = (
+            "-Os" if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR else "-O3"
+        )
         TestConfig.OPTIONS_ALL = (
-            f"{debug_flag}-O3 "
+            f"{debug_flag}{opt_flag} "
             "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -ftt-no-dyninit "
             "-ffast-math -fno-exceptions -fno-rtti -fno-use-cxa-atexit "
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -3,6 +3,7 @@
 
 import math
 import os
+import shlex
 import subprocess
 from collections import namedtuple
 from pathlib import Path
@@ -146,10 +147,14 @@ def print_faces(operand1, tile_shape=None):
 def run_shell_command(
     command: str, cwd: str | None = None, stdin_data: str | bytes = None, text=True
 ):
+    # No call site relies on shell features (pipes, redirects, globbing,
+    # chaining) — every command here is a flat "program arg arg ..." string,
+    # so we tokenize it ourselves and exec the program directly. This avoids
+    # spawning an extra /bin/sh per call, which matters at the ~400k
+    # invocation scale of the Quasar compile-producer run.
     result = subprocess.run(
-        command,
+        shlex.split(command),
         cwd=cwd,
-        shell=True,
         text=text,
         input=stdin_data,
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## 🔎 Realized-parallelism cap identified: the pytest-xdist coordinator (`--maxschedchunk=10`) — addressed in `f11e2b8096`

**Puzzle:** with `num-workers=10` + `LLK_BUILD_PARALLELISM=1` on the 40-core / 78.5 GiB
xlarge, the compile job finished ~7% faster than the old `-n 30` serial config, used
**dramatically less memory (RAM peak 60.8%, ZERO swap)** — yet CPU utilisation was **lower**
(mean 24.6% vs 32.8%) despite theoretically allowing more concurrent `g++` (10×4=40 vs 30).
Memory is provably no longer the binding constraint, so what caps CPU?

**Verdict (high confidence, code + two measured runs): the single pytest-xdist master is
the throughput ceiling, throttled by `--maxschedchunk=10`.** This flag lives in the repo-wide
`tt_metal/tt-llk/tests/python_tests/pytest.ini` (`addopts = -s --maxschedchunk=10`, added
2026-02-19 in `a55f37832a`, present on `main`, **never touched by this branch** — it has been
silently capping this job all along, which matches the earlier "effective parallelism ~5.2x"
finding from a pre-#47457 run).

`maxschedchunk` bounds how many test node-ids the *one* xdist master hands a worker per
`execnet` dispatch — in **both** the initial and steady-state refill paths
(`src/xdist/scheduler/load.py`: `node_chunksize = min(items_per_node // 4, maxschedchunk)`,
floored at 2). With **~413k ultra-fast** compile tests (JUnit **median ~8 ms**) and chunk=10,
the single master must originate **~413k / 10 ≈ 41k dispatch round-trips** *and* process
**413k inbound testreports**, all serially on one process/event-loop. It cannot feed the
workers fast enough → they starve waiting to be handed work. This is dead time that appears in
no testcase's reported time, which is exactly why the JUnit "sum of per-test time" is far below
wall-clock.

**Evidence (JUnit artifacts pulled for both runs, 413,234 testcases each):**

| Config | wall (JUnit suite) | Σ per-test time | Σ/`-n` (ideal wall) | **worker idle** | sidecar CPU mean | RAM peak | swap |
|---|---|---|---|---|---|---|---|
| `-n 10` + inner-parallel | 1173 s | 6062 s | 606 s | **~48% of wall** | 24.6% | 60.8% | 0% |
| `-n 30` serial | 1244 s | 13103 s | 437 s | **~65% of wall** | 32.8% | 100% | heavy |

- Both runs are **starvation-dominated**, not compute- or memory-bound. `-n 30` was **worse**
  (65% idle) despite 3× the workers — because 30 mouths share the same single-master feeder
  capped at chunk=10. Adding workers makes it worse, not better → the cap is coordinator
  throughput, confirmed by direct A/B.
- Independent cross-check: sidecar CPU core-seconds reconcile with the JUnit compile work
  (`-n 10`: ~12,140 core-s ≈ 6062 s × ~2 effective inner-g++ concurrency; `-n 30`: ~17,392
  core-s ≈ 13,103 s × ~1.33). The compilers aren't secretly doing more or less — there's just
  less *realized* concurrency because workers sit idle between chunks.
- **PCH/-Os did NOT move the median** (8 ms in *both* the parallel and serial runs, identical
  to the pre-#47457 finding). The parallel run's *sum* halved only because a test's 4 `g++`
  now overlap (wall = max, not sum) — a real speedup, but the median front-end cost per
  compile is unchanged. (Whether PCH is actually being applied — `canonical_variant` gating —
  is worth a separate check; the median being unchanged is at least consistent with PCH
  helping little OR not engaging on most variants.)

**Ruled out as the cap (checked in code):**
- Per-variant `FileLock(SYNC_DIR/{variant_id}.lock)` — one lock per unique sha256 variant;
  only serialises genuine duplicate variants (desired dedup), no cross-worker contention.
- `build_shared_artefacts()` / `build_pch()` global `FileLock`s — both short-circuit on
  process-local class flags (`SHARED_ARTEFACTS_AVAILABLE`, `PCH_AVAILABLE`/`PCH_ATTEMPTED`)
  before touching the lock, so they contend only once at startup (the fail-open memoization
  bug that *did* make `build_pch` contended throughout was already fixed in `6843e26f11`).
- Inner `ThreadPoolExecutor(4)` — `run_shell_command` uses `subprocess.run(shlex.split(...))`,
  a blocking call that releases the GIL for the whole compile; the 4 threads do run `g++`
  concurrently (core-seconds cross-check shows ~2× realised, not 0). Python-side setup
  (`generate_build_header`, hashing, `build.h` write) runs on the worker's main thread before
  fan-out — real per-variant overhead, but it's per-*worker*, not a global serializer.
- Not `pytest-split`: `--splits 1 --group 1` is a no-op single group ("No test durations
  found … split tests evenly"); it doesn't interact with `-n` here.

**Confidence:** the ~50–65% worker starvation is **confirmed** (JUnit Σ/`-n` vs wall, both
runs). The **mechanism** (maxschedchunk=10 → single-master dispatch/report serialization) is
**strongly inferred** from xdist source + the identical ~41k-dispatch count in both runs + the
"more workers = worse" A/B, but **not directly measured** — the raw per-second sidecar samples
(which would show whether CPU is flat-low the whole run vs. tapering into a tail) are in the
Step Summary, which prior rounds confirmed is not retrievable via `gh`. A tail-imbalance
contribution can't be fully separated from coordinator starvation with aggregate min/max/mean
alone; both point the same way and both are relieved by a larger chunk.

**Change pushed (`f11e2b8096`):** override `--maxschedchunk=2000` on the Quasar compile pytest
command line only (CLI wins over `addopts`; leaves the shared `pytest.ini` — consumed by every
LLK hardware-test job — untouched). 2000 ≪ the ~10k initial-chunk ceiling (413k/10/4), so the
master ships ~20 large chunks/worker and amortizes per-dispatch overhead, while enough tests
stay pending for the steady-state watermark to steal-rebalance the long tail (0.9% of tests
are >500 ms). Kept `-n 10` + parallelism ON to **isolate this one variable** for a clean A/B.

**What to expect / next step:** if the coordinator was the cap, this run should show CPU mean
jump well above 24.6% and wall drop, at similar (low) memory. If CPU rises but doesn't
saturate, memory headroom (60.8% peak, no swap) means we can then safely raise `-n` (16→20)
*on top of* the larger chunk — that combination, not `-n` alone, is the path to the 40 cores.
If it barely moves, the residual cap is per-variant Python orchestration and the fix shifts to
reducing that (or `--dist worksteal`, which removes per-top-up master round-trips entirely).

---

> ## ⚠️ Runtime regression found on the live `llk-build-quasar` run — fixed in `6843e26f11`
>
> **Symptom (observed on a real run):** after this branch landed, the Quasar
> compile job used **less than half the CPU (only ~2 cores' worth)**, the **same
> memory**, but wall-clock **regressed past the ~20-min baseline** (still running
> at 25 min). Lower CPU + longer wall-clock = something serialized/blocked, not
> compute-bound.
>
> **Root cause — fail-open **without** memoization in `build_pch()` (high confidence):**
> `build_elfs()` calls `self.build_pch()` on the **per-variant hot path** (~100k+
> times), *before* the variant's own done-marker fast-path. `build_pch()`
> short-circuits only via `PCH_AVAILABLE` or the `.pch_complete` marker — both set
> **only on success**. Its `except` fails **open** (leaves `PCH_AVAILABLE=False`,
> writes **no** marker). So if generation fails even once, **every subsequent
> variant** re-enters `build_pch()`, re-acquires the process-global
> `FileLock("/tmp/tt-llk-build-pch.lock")`, and re-runs the 4 doomed compiles —
> serializing all `-n` xdist workers behind one lock. Nine workers block on the
> lock (idle, not computing) while one retries → **CPU collapses to ~1–2 cores,
> wall-clock balloons, memory unchanged.** That is precisely the reported symptom,
> and the 2-core collapse is near-diagnostic of it: no other theory (valid-PCH →
> *faster*; invalid-PCH under `-Werror` → *hard fail*, not slow; silently-ignored
> PCH → mild, still-*parallel* slowdown) serializes the workers.
>
> This is the asymmetry vs. `build_shared_artefacts()`, which this "mirrored":
> that one fails **closed** (no try/except → the job dies), so it never needed to
> memoize a failure. `build_pch()` added fail-open on top without memoizing.
>
> **Falsified along the way:** the `shell=True`→`shlex.split()` change is *not* the
> cause — `shlex.split()` tokenizes the real (flat) compile/PCH command strings
> byte-identically to whitespace-splitting (verified: 49==49 tokens, no drops/empties).
>
> **Fix (`6843e26f11`):** gate generation to **at most one attempt per worker
> process** via a new `PCH_ATTEMPTED` flag, and write a `.pch_failed` marker under
> the lock on failure so sibling workers skip the doomed compiles too. Worst case
> is now O(workers) attempts at startup instead of O(variants); when generation
> fails, the run proceeds exactly as pre-PCH (no `-include`) instead of spiraling.
> Success path and fail-open semantics are otherwise unchanged.
>
> **Still open (needs a real runner):** *why* `build_pch()` was failing in the
> first place is unconfirmed — no `riscv-tt-elf-g++` in the investigation sandbox.
> The fix removes the regression regardless of the trigger, but the PCH **speedup
> is not realized** until the generation failure is diagnosed. Next diagnostic:
> grep the job log for `PCH generation failed (...)` and read the accompanying
> `run_shell_command` RuntimeError stderr (the failing `-x c++-header` invocation).
> **Immediate mitigation if this recurs on a live run: set `TT_LLK_DISABLE_PCH=1`**
> (returns before the lock/compiles, restores the pre-PCH baseline instantly).
>
> ---

## Problem

The `llk-build-quasar` PR-gate job (`.github/workflows/pr-gate.yaml` → `.github/actions/llk-compile-quasar/action.yml`) compiles **~400,000 kernel variants** with `pytest --compile-producer -n 10 -m quasar`. Each variant fans out to **4** `riscv-tt-elf-g++` subprocesses — one per Quasar TRISC role (`unpack`/`math`/`pack`/`sfpu`) — via `run_shell_command(..., shell=True)` in `helpers/test_config.py::build_kernel_part`.

Every one of those compiles re-parses the **same ~2600 lines of stable headers** from scratch: `ckernel.h` (which alone pulls in `ckernel_ops.h`, ~1256 lines of `constexpr` register-op wrappers — the single largest chunk), `llk_defs.h`, `llk_memory_checks.h`, plus a role-common header. None of that changes between variants, yet none of it is cached. This repeated front-end work is a large share of the job's ~20-minute wall-clock and presents as the memory-bandwidth-shaped symptom we've seen on the runners.

## What this PR does

Adds GCC precompiled-header (PCH) support to the Quasar compile path:

1. **Checked-in PCH source headers** under `tt_metal/tt-llk/tests/helpers/pch/`:
   - `quasar_pch_common.h` — the universal, variant-independent prefix (`<cstdint>`, `ckernel.h`, `llk_defs.h`, `llk_memory_checks.h`).
   - `quasar_pch_unpack.h` / `quasar_pch_math.h` / `quasar_pch_pack.h` — base + that role's common header (`llk_unpack_common.h` / `llk_math_common.h` / `llk_pack.h`+`llk_pack_common.h`).
   - `quasar_pch_sfpu.h` — base only (see the sfpu note below).
2. **`TestConfig.build_pch()`** precompiles each role header **once per job run** into `.gch` files under the existing `/tmp/tt-llk-build/pch` scratch dir, guarded by a `FileLock` + done-marker (mirroring the existing `build_shared_artefacts()` pattern, so it runs once across all xdist workers).
3. **`build_kernel_part`** force-includes the matching role PCH with `-include <pch>.h -Winvalid-pch` on each per-variant compile.

## Headers in / out of the PCH, and why

A header is only PCH-safe here if its transitive `#include` closure is **byte-identical across every variant in a run**. I verified the closures directly against the checked-out tree.

**In the PCH (static, never reach per-variant content):**
- `ckernel.h` and its chain (`ckernel_ops.h`, `ckernel_include.h`, `tensix.h`, …) — verified it does **not** reach `cfg_defines.h`, `build.h`, or `params.h`.
- `llk_defs.h`, `llk_memory_checks.h` (→ static `core_config.h`/`dev_mem_map.h`).
- Role-common headers `llk_unpack_common.h`, `llk_math_common.h` (→`cmath_common.h`), `llk_pack.h`, `llk_pack_common.h`. These transitively reach `cfg_defines.h` **but never `build.h`/`params.h`** (verified), so they are still variant-independent.

**Excluded (per-variant):**
- `build.h` — auto-generated per variant (`generate_build_header()`), contains the format-inference `FormatConfig`/`RuntimeParams`.
- `params.h` — a **static wrapper** (`tests/helpers/include/params.h`) whose only job is to `#include "build.h"`, so it is effectively per-variant.

> ⚠️ Correction to the original investigation note: `cfg_defines.h` is **not** per-variant — it is a **static, per-arch** header (`tt_metal/hw/inc/internal/tt-2xx/quasar/cfg_defines.h`) resolved via the arch include path. The genuinely per-variant file is `build.h`; `params.h` is just its static wrapper. This is why role-common headers (which reach `cfg_defines.h`) are safe to precompile.

### On the sfpu role (the "4th ELF" question)

The original note flagged 4 ELFs (unpack/math/pack/sfpu) but earlier header analysis found only 3 roles. **Confirmed: sfpu is a genuine 4th compile role** — `KERNEL_COMPONENTS = ["unpack","math","pack","sfpu"]` for Quasar, and the sfpu compile gets its own command-line define `-DLLK_TRISC_ISOLATE_SFPU` (vs `-DLLK_TRISC_{UNPACK,MATH,PACK}`). It therefore needs its own PCH keyed to that define.

However, the sfpu role has **no consistent role-common header** across tests: the isolated-SFPU tests include `cmath_common.h`/`llk_math_common.h`/`llk_srcs.h`, while the common case (tests without an explicit SFPU pipeline) resolves `run_kernel` through `sfpu_stub.h`, which — under `LLK_TRISC_ISOLATE_SFPU` — pulls in the per-variant `params.h`/`build.h`. So `quasar_pch_sfpu.h` precompiles **only the universal base** (still capturing the dominant `ckernel.h`/`ckernel_ops.h` cost) and adds no sfpu-specific header.

## Flag-matching requirement and how it's satisfied

A GCC `.gch` is only reused when the consuming compile's **preprocessor macro set, target, language, and codegen flags match** those the `.gch` was built with; otherwise GCC discards it. `build_pch()` builds each `.gch` from the **same `TestConfig` option fields** as `build_kernel_part`'s canonical path — `ARCH_COMPUTE` (`-mcpu=tt-qsr32-tensix`), `OPTIONS_ALL` (`-O3 -std=c++17 -ftt-* -ffast-math -fno-exceptions …`), `INCLUDES`, `INITIAL_OPTIONS_COMPILE` (`-DTENSIX_FIRMWARE -DENV_LLK_INFRA -DKERNEL_BUILD -DENABLE_LLK_ASSERT -DARCH_QUASAR`), `-DLLK_BOOT_MODE_TRISC`, `-DRUNTIME_FORMATS`, and `-DLLK_TRISC_<role>`.

`build_kernel_part` then only attaches `-include` for variants whose flags match that canonical set (i.e. **not** coverage/profiler/device-print builds, `compile_time_formats` off so `-DRUNTIME_FORMATS` is present, and `TT_METAL_DISABLE_SFPLOADMACRO` unset). For any other variant it compiles exactly as before. The extra `-I<VARIANT_DIR>` and linker (`-T`, `-Wl,…`) flags present only at consume time do **not** affect PCH validity.

Crucially, the **include order** is preserved: in every kernel `.cpp` the universal prefix and role-common header are already included **before** `params.h`/`build.h`, so force-including them at top-of-TU sees the identical macro environment — the precompiled AST equals what each compile would have parsed from source. The per-variant `build.h` is still `#include`d normally, after the prefix.

## Safety

- **Quasar-only** — no effect on Wormhole/Blackhole jobs.
- **Opt-out**: `TT_LLK_DISABLE_PCH=1` skips PCH generation entirely.
- **Fail-open**: any error in `build_pch()` logs a warning, leaves `PCH_AVAILABLE=False`, and every compile runs unchanged.
- **No silent miscompile risk**: `-include foo.h` makes GCC look for `foo.h.gch`; if it's missing or flag-incompatible, GCC **ignores it and parses `foo.h` from source**. Combined with the gating above (so `-Winvalid-pch` never fires under the job's `-Werror` for a valid PCH), correctness is preserved regardless of PCH state.

## Testing — what I did vs. couldn't do in this environment

**Verified in this sandbox:**
- Confirmed the 4-role model, the exact compile command/flags (`test_config.py:build_kernel_part`), the once-per-run scratch-dir pattern, and every include-closure claim above by reading the checked-out sources.
- Reproduced the **PCH mechanism end-to-end with a real compiler** (clang, which implements the same GCC-compatible `-include`/`.gch`/`-Winvalid-pch` lookup): (a) a matching-flags compile **uses** the `.gch`; (b) a mismatched-flags compile **silently falls back** to parsing the header from source and produces the **identical correct result** (no miscompile); (c) `-include` placed before `-D` and an extra `-I` at consume time do not break validity; (d) a **valid** PCH consumed under `-Werror` does not error.
- `python3 -m py_compile`, `black` (line-length 88, py310), and `isort` (profile=black) all clean on `test_config.py`; `clang-format` clean on all 5 new headers.

**Could NOT do here (untested-in-CI caveats — please exercise in the actual `llk-build-quasar` runner):**
- No `riscv-tt-elf-g++` / SFPI toolchain and no Python runtime deps (`ttexalens`, etc.) are available in this sandbox, so I could not run a **real** riscv PCH build or a real quasar kernel compile against it. The flag-matching is argued by construction (same `TestConfig` fields) and by inspection; a reviewer should confirm on a real runner that the `.gch` is actually **accepted** (not silently rejected) for the common-case variants — e.g. run one group with `logger` at trace level and confirm no `-Winvalid-pch` fallback on canonical compiles, and compare wall-clock with/without `TT_LLK_DISABLE_PCH=1`.

## Reviewer, please specifically check

1. **`.gch` acceptance on a real runner** — that riscv-tt-elf-g++ accepts these PCHs for the common-case variants (no unexpected `-Winvalid-pch` fallback), which is the whole speed win.
2. **The role-common closure claim** — that `llk_unpack_common.h` / `llk_math_common.h` / `llk_pack*.h` genuinely never reach `build.h`/`params.h` on your side too (I verified statically, but you know the tree).
3. **`.gch` cross-run staleness** — within one job run the checked-out headers are fixed, so the once-per-run `.gch` is safe; the scratch dir is not reused across runs. Confirm no CI caching layer persists `/tmp/tt-llk-build/pch` across runs with a different toolchain.
4. Whether the sfpu PCH should try to precompile a sfpu-specific common set for the isolated-SFPU tests (I deliberately kept it base-only for safety — open to widening if you think it's worth it).

## Also: drop `shell=True` from `run_shell_command`

Every command built for `run_shell_command()` (`helpers/utils.py`) — the compile command itself, the PCH-generation command, the shared-artefact/BRISC builds, coverage merging — is a flat `"program arg arg ..."` string. None use pipes, redirects, `&&`/`;` chaining, globbing, or shell variable expansion; I checked every call site in `test_config.py` and `hardware_controller.py`.

`shell=True` was therefore spawning an unnecessary extra `/bin/sh` fork+exec per call, purely as a side effect of building the command as an interpolated string instead of an argument list. At ~400k compiles this is measurable, and it compounds with worker concurrency (more parallel xdist workers means more concurrent shell spawns, not just more compiler work) — so it's directly relevant to the same "16-core == 40-core" symptom this PR targets, independent of the PCH change.

Fix: tokenize with `shlex.split()` and call `subprocess.run()` with `shell=False` (the default) instead. Verified `shlex.split()` tokenizes the actual compile command (including the `-x c++ -` stdin-source flag) identically to how `/bin/sh` would have. No call site uses quoted arguments or embedded spaces, so this is a behavior-preserving change for every existing caller.

## Relationship to in-flight work

This is a **standalone** change and is complementary to — but independent of — two open PRs; it touches neither:
- **#47457** *(ci(llk): increase quasar compile parallelism 10 → auto)* — reduces wall-clock by using more cores; PCH reduces per-compile work. They compose.
- **#48611** *(experiment: fast quasar compile / runtime kernel params)* — migrates compile-time template params to runtime args, shrinking the per-variant space; PCH accelerates whatever variants remain.

## Update: merged #47457, plus a new lever (-O3 → -Os for Quasar)

Real before/after timing on a controlled test harness showed our changes so far only bought ~7% (22m14s → 20m45s). JUnit artifact analysis pinned down why: per-compile median time was unchanged (4/6/8/11/16/23ms percentiles identical before/after — only p99 improved), and effective parallelism was **5.2x in both runs**, nowhere near a 40-core box. Root cause: this test harness resolves the composite action from tt-metal `@main`, which still hardcodes `-n 10` — #47457 (the `-n auto` fix) hadn't been part of the comparison at all.

Two follow-up changes, now both on this branch:

1. **Merged `nsexton/llk-quasar-parallelism` (#47457)** into this branch. It changes `-n 10` → `-n auto`, reverts the inner per-variant `ThreadPoolExecutor` to serial by default (`LLK_BUILD_PARALLELISM=0`, their actual OOM fix — total concurrent `g++` was `-n × 3`, now just `-n`), and moves the runner `xlarge → large`. Only real conflict was in `.github/actions/llk-compile-quasar/action.yml` (both branches touched the same `run:` block) — resolved by keeping the `host-load-sidecar.sh` wrapper from this branch while taking `-n ${{ inputs.num-workers }}` from theirs. `test_config.py` merged cleanly (different lines in the same functions).

2. **Dropped Quasar's compile-producer from `-O3` to `-Os`** (`setup_compilation_options`, Quasar-only via a `CHIP_ARCH` check — WH/BH keep `-O3`). Rationale: compile-producer only checks that a kernel compiles, it never runs or perf-tests the ELF, so `-O3`'s codegen effort is pure waste there — but it does drive peak per-compile memory, which is the real ceiling on how far `-n auto` can push concurrency before OOM. Lowering that ceiling should let `-n auto` claim more of the 40 cores on `large`. This directly targets the OOM constraint #47457's own notes flagged.

Not yet verified on a real runner (no riscv toolchain in this environment) — the `-Werror` warning set can shift between `-O3` and `-Os` (e.g. `-Wmaybe-uninitialized` is optimization-sensitive), so this needs a real CI pass to confirm it still builds clean before merging.


## Update: inner-parallel g++ + reduced workers (`LLK_BUILD_PARALLELISM=1`, `-n 4`) — commit `40c88e2a`

Evaluated Neil's hypothesis ("enable `LLK_BUILD_PARALLELISM` and reduce compile
producers so same-variant components share overlapping source and reduce memory
pressure"). Verdict: **his recommended *direction* is right, but for a different
mechanism than the one he stated.**

**Mechanism 1 (Neil's stated one — file/source overlap): rejected.** File-backed
read-only content (the compiler binary, shared libs, the PCH `.gch` files, system
and static LLK headers) is already shared across *all* concurrent `g++` via the OS
page cache / COW mmap, regardless of whether the concurrent compiles are "4
components of one variant" or "first components of 4 different variants" — the
kernel shares identical file pages between any processes mapping the same file; it
does not care about the variant grouping. What is *not* shareable is each
compiler's private **anonymous** heap (AST, symbol tables, template instantiation
state, codegen buffers), which is per-process regardless of grouping — and that's
what drives the swap we measured. The only genuinely per-variant *file* is the
generated `build.h` (verified: a few KB of `constexpr`/struct lines + includes of
*static* headers), far too small for page-cache churn across distinct variants to
be a secondary memory lever. So same-variant overlap does not reduce peak
anonymous memory.

**Mechanism 2 (fixed per-worker-process overhead): confirmed, and it's the real
lever.** `test_config.py` imports `numpy` directly and imports `golden_generators`
which imports `torch`; each pytest-xdist worker is a *separate Python process* that
pays this once (~0.6–1.2 GiB RSS, estimate — no recorded worker-startup RSS was
available; torch CPU alone is ~0.4–0.7 GiB) for the whole run, independent of
compile work. The compiler-side anonymous memory that drives swap scales with
*total concurrent g++*; the fixed Python tax scales with *`-n`*.

**Apples-to-apples at fixed total g++ (`KERNEL_COMPONENTS`=4 for Quasar, verified
`["unpack","math","pack","sfpu"]`):**
- Regime A (serial): `-n = G` → G Python procs, G g++.
- Regime B (parallel): `-n = G/4` → G/4 Python procs, G g++.
- The `G × g++` term is identical; the only delta is `(G − G/4) × fixed_py`.
  At G≈16, that's **~7–14 GiB** less committed memory for Regime B (est.).

**Correctness of Regime B (why it's safe to run components concurrently):** each
`build_kernel_part` compiles from stdin and writes only its own
`{VARIANT_ELF_DIR}/{name}.elf` (write-disjoint); `build.h` is written *once* before
the `ThreadPoolExecutor` fans out and is only *read* concurrently; the pool runs
inside the per-variant `FileLock`; results are collected via `fut.result()` and the
compile wait is in `subprocess.run` (GIL released). Parallelism was defaulted off
in #47457 because it *multiplied* `-n` without lowering it (OOM under `-O3` on a
smaller runner) — not because the mechanism is unsafe. Here `-n` is reduced
proportionally so total g++ is *held constant, not multiplied*, and `-Os` is
already in place. The sfpu perf-counter deadlock caveat is runtime-only; the
compile-producer never runs the ELF.

**⚠️ Correction to my own prior assumption — runner size.** The committed
`pr-gate.yaml` runs `llk-build-quasar` on **`tt-ubuntu-2204-large-stable`
(16-core)**, not xlarge, and does not override `num-workers`. The previous
`num-workers=18` default was tuned against the **xlarge (40-core / 78.53 GiB)**
`-n 30` sidecar data — a mismatch: on a 16-core box `-n 18` both over-subscribes
cores *and* pays 18× the fixed Python tax. `-n 4` + inner parallelism gives the
same ~16 total g++ (saturating 16 cores) with only 4× the Python tax.

**Config pushed (`40c88e2a`):** `LLK_BUILD_PARALLELISM=1`, `num-workers` default
`18 → 4`. **Confidence:** high on direction (verified from code + first
principles); medium on the exact number — the `fixed_py` magnitude is an estimate.
**What real-runner data would resolve it:** a `host-load-sidecar.sh` run of this
config on the `large` runner. If mean RAM sits comfortably below 100% with little/no
swap, the fixed-overhead thesis holds and `-n 4` is right; if CPU is under-utilized
(g++ < cores), bump toward `-n 5` (≈20 g++); if it still swaps, the per-compile
`-Os` anon peak is higher than modeled — drop to `-n 3` (≈12 g++). Comparing this
run's mean-mem/swap against the `-n 30`/`-n 18` serial baselines directly measures
the per-worker Python tax we're trying to shed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsextonTT/llk-quasar-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsextonTT/llk-quasar-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsextonTT/llk-quasar-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsextonTT/llk-quasar-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsextonTT/llk-quasar-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsextonTT/llk-quasar-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsextonTT/llk-quasar-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsextonTT/llk-quasar-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsextonTT/llk-quasar-pch)
## Related docs added on this branch

Two markdown docs were added under `tt_metal/tt-llk/docs/tests/` (they capture
investigation state; they do not change behaviour):

- [`quasar_compile_dedup_design.md`](tt_metal/tt-llk/docs/tests/quasar_compile_dedup_design.md)
  — design write-up for deduplicating the ~413k `--compile-producer` items
  (~2.5–3.2k distinct `variant_id`s; ~120–160:1) at collection time, with options,
  a drift-detection safety assertion, and savings uncertainty.
- [`quasar_compile_investigation.md`](tt_metal/tt-llk/docs/tests/quasar_compile_investigation.md)
  — concise, coworker-facing summary of the whole compile-time investigation
  (including the dead ends), for soliciting feedback.

A separate commit also makes the producer-mode golden short-circuit explicit and
order-independent (defense-in-depth); the per-item **stimuli** fill is
investigated in the dedup doc and deliberately left as a real-runner-validation
follow-up (see that commit's message for the per-file safety reasoning).
