### PR TITLE
[Bug fix] test_cbrt: make coverage RNG-version-independent (exhaustive bf16 vs fp64 golden) 

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -629,7 +629,11 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     if not within_threshold:
         ulp_index = torch.argmax(ulp_tensor)
         ulp_index_tuple = tuple(int(idx) for idx in torch.unravel_index(ulp_index, golden.shape))
-        message += f" @ {list(ulp_index_tuple)} = |{calculated[ulp_index_tuple]} - {golden[ulp_index_tuple]}| / {ulp_value[ulp_index_tuple]}"
+        message += (
+            f" @ {list(ulp_index_tuple)} = "
+            f"|calculated {calculated[ulp_index_tuple]} - golden {golden[ulp_index_tuple]}| "
+            f"/ ULP(golden) {ulp_value[ulp_index_tuple]}"
+        )
     return (within_threshold, message)
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -159,10 +159,25 @@ def test_rad2deg(device, h, w):
     run_math_unary_test(device, h, w, ttnn.rad2deg, ulp=1)
 
 
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-def test_cbrt(device, h, w):
-    run_math_unary_test(device, h, w, ttnn.cbrt, ulp=1)
+def test_cbrt(device):
+    # Exhaustive over every bf16 value so coverage can't drift with the torch RNG version.
+    # Evaluate the registered golden in fp64 by upcasting the input: it is sgn(x)*pow(|x|,1/3),
+    # and in bf16 the non-representable 1/3 rounds the reference up to 2 ULP short of the true
+    # cube root while the kernel is correct. Subnormal bf16 inputs are flushed to zero on device,
+    # so flush the reference input to match.
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor[torch.isfinite(input_tensor.to(torch.float32))]
+    input_tensor = torch.where(
+        input_tensor.to(torch.float32).abs() < 2.0**-126, torch.zeros_like(input_tensor), input_tensor
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.cbrt)
+    golden = golden_function(input_tensor.to(torch.float64))
+
+    tt_in = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    result = ttnn.to_torch(ttnn.cbrt(tt_in))
+    assert_with_ulp(golden, result, 1)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -160,11 +160,10 @@ def test_rad2deg(device, h, w):
 
 
 def test_cbrt(device):
-    # Exhaustive over every bf16 value so coverage can't drift with the torch RNG version.
-    # Evaluate the registered golden in fp64 by upcasting the input: it is sgn(x)*pow(|x|,1/3),
-    # and in bf16 the non-representable 1/3 rounds the reference up to 2 ULP short of the true
-    # cube root while the kernel is correct. Subnormal bf16 inputs are flushed to zero on device,
-    # so flush the reference input to match.
+    # Exhaustive over every bf16 value.
+    # Evaluate the registered golden in fp64 by upcasting the input,
+    # in bf16 the non-representable 1/3 was rounding the reference up to 2 ULP short of the true
+    # cube root while the kernel was correct. Subnormal bf16 inputs are flushed to zero on device.
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
     input_tensor = input_tensor[torch.isfinite(input_tensor.to(torch.float32))]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1771,33 +1771,6 @@ def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
         assert_allclose(ttnn.to_torch(output_tensor), golden_tensor, rtol=1e-05, atol=atol)
 
 
-def test_cbrt_arange(device):
-    # Generate all possible bit patterns for bf16
-    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32)
-
-    input_tensor = all_bitpatterns.to(torch.uint16).view(torch.bfloat16)
-    input_tensor = input_tensor.to(torch.float32)
-
-    # Mask subnormals (they get flushed to zero) and NaN (converted to inf for bf16)
-    mask = (((all_bitpatterns >> 7) & 0xFF) == 0) | ((all_bitpatterns & 0x7F) != 0) | torch.isnan(input_tensor)
-    input_tensor[mask] = 1.0
-
-    tt_in = ttnn.from_torch(
-        input_tensor,
-        dtype=ttnn.bfloat16,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    golden_function = ttnn.get_golden_function(ttnn.cbrt)
-    golden = golden_function(input_tensor, device=device)
-
-    tt_result = ttnn.cbrt(tt_in)
-    result = ttnn.to_torch(tt_result)
-    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
-
-
 @pytest.mark.parametrize("ttnn_op", [ttnn.isinf, ttnn.isnan, ttnn.isposinf, ttnn.isneginf, ttnn.isfinite])
 @pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype",

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -177,10 +177,15 @@ def assert_with_ulp(
 
     The error is measured using the following formula:
     ``
-        | expected - actual | / ULP(expected)
+        | actual - expected | / ULP(expected)
     ``
 
     Where ULP(expected) returns, for each element, the length of a single Unit of Least Precision (ULP).
+
+    ``expected_result`` is the reference (golden) tensor and ``actual_result`` is the tensor under test.
+    On failure the message reports the worst element as ``|calculated <actual> - golden <expected>| /
+    ULP(golden)``, i.e. the first printed operand is ``actual_result`` and the divisor is the ULP of
+    ``expected_result``.
 
 
     Args:


### PR DESCRIPTION
### PR Category
Bug fix (test-side)

### Summary
Fixes #48568.

`test_cbrt` failed on `wh_n300_civ2` with a 2-ULP delta after the PyTorch 2.11 → 2.12.1 bump
(#47800). The failure was **test fragility, not a kernel regression**: the old test drew its input
with `torch.manual_seed(0)` + `torch.rand`, so the 2.12.1 RNG change made it sample a value it had
never covered before — `2^-12 = 0.000244140625`, whose true `cbrt` is exactly `2^-4 = 0.0625`.

Two things went wrong there, both in the *test*, not the SFPU kernel:
- `run_math_unary_test` evaluates the golden as `golden_function(bf16_input)`, so the reference cube
  root ran in **bf16**. `1/3` is not representable, so `torch.pow(x, 1/3)` rounds low — the golden was
  up to **2 ULP short of the true cube root** while the device answer (`0.0625`) was exactly correct.
- Coverage depended on the RNG algorithm version, so which inputs get tested drifts silently with the
  torch pin.

An exhaustive bf16 sweep on this branch measures the kernel at **max 0.507 ULP** across all 65536
values — the kernel is accurate; the golden was the problem.

**Fix:** rewrite `test_cbrt` to enumerate every finite bf16 value (mirrors the existing
`test_exp_arange_masking` pattern) and compare against the op's own registered golden
(`ttnn.get_golden_function(ttnn.cbrt)`) evaluated on an **fp64 upcast** of the input, so coverage
can't drift with the torch version, the reference is correctly rounded, and the golden formula stays
a single source of truth shared with the rest of the ttnn test suite. Non-finite inputs are masked and
bf16 subnormals are flushed to zero to match device FTZ behaviour. Asserted at ≤1 ULP.

Also clarifies the `comp_ulp` failure message and `assert_with_ulp` docstring: the message now labels
its operands (`|calculated <actual> - golden <expected>| / ULP(golden)`) and the docstring states the
formula as `| actual - expected | / ULP(expected)` and which operand is printed first. The previous
`|expected - actual|` wording had operands transposed relative to what the code prints, which sent an
earlier triage down the wrong path (blaming the device instead of the golden).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mmoscickiTT/48568_cbrt_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mmoscickiTT/48568_cbrt_test_fix)