### PR TITLE
[indexer_score] slab-aware (block-cyclic) K addressing, sparse_sdpa-matched interface

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -122,6 +122,15 @@ def _extra_kwargs(program_config, compute_kernel_config):
     return kwargs
 
 
+def _slab_kwargs(slab_sp, sq):
+    """Build the explicit slab op-args from a simulated SP `slab_sp` and the q seq len. The slab layout is
+    PASSED, not derived: slab_sp = the SP the cache was gathered across, slab_chunk_size = slab_sp*sq (the
+    gathered chunk). None -> contiguous (no slab args)."""
+    if slab_sp is None:
+        return {}
+    return {"slab_sp": slab_sp, "slab_chunk_size": slab_sp * sq}
+
+
 def run_dsa(
     q,
     k,
@@ -132,16 +141,19 @@ def run_dsa(
     q_dtype=ttnn.bfloat16,
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
+    proxy_ring_size=None,
 ):
     """Run indexer_score_dsa (relu + learned gates + head-sum) and return the bf16 score as torch.
 
-    q (srcB) and k (srcA) may be bfp8_b; weights stay bf16.
+    q (srcB) and k (srcA) may be bfp8_b; weights stay bf16. proxy_ring_size simulates a ring_size-way slab K
+    layout on one chip (single-chip testing only).
     """
     out = ttnn.experimental.indexer_score_dsa(
         to_device(q, device, dtype=q_dtype),
         to_device(k, device, dtype=k_dtype),
         to_device(w, device),
         chunk_start_idx=chunk_start,
+        **_slab_kwargs(proxy_ring_size, q.shape[-2]),
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
@@ -159,10 +171,12 @@ def run_msa(
     q_dtype=ttnn.bfloat16,
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
+    proxy_ring_size=None,
 ):
     """Run indexer_score_msa (raw dot, constant `scale` gate, per-group planes) and return torch.
 
     No weights tensor: M3 has no learned gates, only `scale` (run as a constant gate in-op).
+    proxy_ring_size simulates a ring_size-way slab K layout on one chip (single-chip testing only).
     """
     out = ttnn.experimental.indexer_score_msa(
         to_device(q, device, dtype=q_dtype),
@@ -171,6 +185,7 @@ def run_msa(
         scale=scale,
         num_groups=num_groups,
         block_size=block_size,
+        **_slab_kwargs(proxy_ring_size, q.shape[-2]),
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
@@ -1483,3 +1498,129 @@ def test_indexer_score_block_pool_validation(device, expect_error, block_size, k
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=k_chunk_size, head_group_size=0)
     with expect_error(RuntimeError, match):
         run_msa(q, k, 512, device, num_groups=heads, block_size=block_size, program_config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# Slab (per-SP-shard) K layout. Chunked prefill packs each SP shard's per-chunk slab (slab_chunk_size/slab_sp
+# keys) back-to-back, so the gathered [B,1,T,D] k is in a PERMUTED physical order and the reader reads it back
+# in natural token order (invP per tile) -- scores (and the block-max-pool over token-contiguous blocks) come
+# out correct. The slab layout is PASSED EXPLICITLY (slab_sp = the SP the cache was gathered across,
+# slab_chunk_size = the global chunk), NOT derived. These tests pass slab_sp / slab_chunk_size = ring_size*Sq
+# via _slab_kwargs (proxy_ring_size) to exercise a real SP slab on one chip.
+# ---------------------------------------------------------------------------
+def _slab_positions(ring_size, chunk, t):
+    """P[r] = natural token position physically stored at slab row r. Physical row r (shard c = r//sll, local
+    row lr = r%sll) holds natural token (lr//cl)*chunk + c*cl + (lr%cl), where sll = T/ring_size (per-shard
+    local length), cl = chunk/ring_size (per-shard slab width). This is the layout the in-kernel invP inverts.
+    Canonical (production) version: models/demos/deepseek_v3_d_p/tt/mla/utils.py::blockcyclic_positions; kept
+    local here so this op unit test has no model dependency."""
+    sll, cl = t // ring_size, chunk // ring_size
+    c = torch.arange(ring_size).repeat_interleave(sll)
+    lr = torch.arange(sll).repeat(ring_size)
+    return (lr // cl) * chunk + c * cl + (lr % cl)
+
+
+def _to_slab(k_nat, ring_size, chunk):
+    """Permute a natural-order [1,1,T,D] k into its slab physical layout: k_slab[r] = k_nat[P[r]]."""
+    t = k_nat.shape[2]
+    P = _slab_positions(ring_size, chunk, t)
+    k_slab = k_nat.clone()
+    k_slab[0, 0] = k_nat[0, 0][P]
+    return k_slab
+
+
+# Simulated SP ring sizes; the chunk is derived per test as ring_size * Sq (so it divides T below).
+SLAB_RINGS = [4, 8]
+SLAB_IDS = ["ring4", "ring8"]
+
+
+@pytest.mark.parametrize("ring_size", SLAB_RINGS, ids=SLAB_IDS)
+@pytest.mark.parametrize("chunk_start", [0, 1024], ids=["cs0", "cs1024"])
+def test_indexer_score_dsa_slab(device, ring_size, chunk_start):
+    """DSA over a slab K cache, SINGLE CHIP: physical K is permuted; slab_sp / slab_chunk_size = ring_size*Sq
+    are passed explicitly to describe a real ring_size-way SP slab, so the reader presents K in natural token
+    order and the score matches the contiguous-K reference exactly (same -inf map + PCC >= 0.999)."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 2048
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)  # slab_chunk_size passed to the op = ring_size*Sq
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    out = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring_size)
+    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
+    assert_indexer_match(out, ref, sq, t, check_neg=True)
+
+
+@pytest.mark.parametrize("ring_size", SLAB_RINGS, ids=SLAB_IDS)
+@pytest.mark.parametrize("block_size", [0, BLOCK_POOL_BS], ids=["unpooled", "pooled"])
+def test_indexer_score_msa_slab(device, block_size, ring_size):
+    """MSA per-group scoring over a slab K cache, SINGLE CHIP. block_size=0 -> [1,G,Sq,T] planes; >0 ->
+    block-max-pool (the M3 crux: a pooled block is block_size CONTIGUOUS tokens, scattered across the physical
+    buffer, so only reading in natural order pools the right token range). Both match the contiguous-K ref."""
+    heads, dim, sq, t, chunk_start = 4, GLX_DIM, 128, 2048, 512
+    scale = dim**-0.5
+    q, k_nat, _ = make_inputs(heads, dim, sq, t)
+    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    out = run_msa(
+        q,
+        k_slab,
+        chunk_start,
+        device,
+        scale=scale,
+        num_groups=heads,
+        block_size=block_size,
+        program_config=cfg,
+        proxy_ring_size=ring_size,
+    )
+    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start, heads, block_size=block_size)
+    if block_size:
+        assert_pooled_match(out, ref, heads, sq, t // block_size, pcc_floor=0.995)
+    else:
+        assert_grouped_match(out, ref, heads, sq, t)
+
+
+def test_indexer_score_slab_remap_matters(device):
+    """The remap is load-bearing: with the proxy the permuted cache reads correctly; WITHOUT it the deduction
+    is the identity (one chip -> ring_size=1), so the permuted cache is read as-is and the scores are wrong (a
+    token permutation). Confirms the slab handling is not a no-op."""
+    ring_size = 8
+    heads, dim, sq, t, chunk_start = 64, GLX_DIM, 64, 2048, 1024
+    q, k_nat, w = make_inputs(heads, dim, sq, t)
+    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
+    masked = ref == float("-inf")
+    b = ref[~masked].flatten().float()
+
+    good = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring_size)
+    pcc_good = torch.corrcoef(torch.stack([good[~masked].flatten().float(), b]))[0, 1].item()
+    assert pcc_good >= 0.999, f"slab proxy PCC {pcc_good} < 0.999"
+
+    # No proxy on one chip -> ring_size=1 identity -> permuted cache read as-is. -inf map is positional
+    # (same), but the visible scores are permuted -> far below the floor.
+    bad = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg)
+    pcc_bad = torch.corrcoef(torch.stack([bad[~masked].flatten().float(), b]))[0, 1].item()
+    assert pcc_bad < 0.99, f"identity read of a permuted cache unexpectedly matched (PCC {pcc_bad})"
+
+
+def test_indexer_score_slab_rejects_bad_chunk(device, expect_error):
+    """A derived chunk (= ring_size*Sq) that does not divide T is rejected loudly so a bad layout can't
+    silently mis-address K. Here ring_size=5, Sq=64 -> chunk=320, which does not divide T=2048."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 2048
+    q, k, w = make_inputs(heads, dim, sq, t)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=256, head_group_size=0)
+    with expect_error(RuntimeError, "must divide T"):
+        run_dsa(q, k, w, 0, device, program_config=cfg, proxy_ring_size=5)
+
+
+def test_indexer_score_rejects_partial_slab_args(device, expect_error):
+    """slab_sp and slab_chunk_size define the cache's slab layout and must be passed TOGETHER -- passing only
+    one is a caller error (the per-shard width chunk/sp is undefined). Host-side guard, so a single chip
+    suffices."""
+    heads, dim, sq, t = 64, GLX_DIM, 64, 512
+    q, k, w = make_inputs(heads, dim, sq, t)
+    q_dev, k_dev, w_dev = to_device(q, device), to_device(k, device), to_device(w, device)
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+    for kwargs in [{"slab_sp": 4}, {"slab_chunk_size": 256}]:
+        with expect_error(RuntimeError, "together"):
+            ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=0, program_config=cfg, **kwargs)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -122,15 +122,6 @@ def _extra_kwargs(program_config, compute_kernel_config):
     return kwargs
 
 
-def _slab_kwargs(slab_sp, sq):
-    """Build the explicit slab op-args from a simulated SP `slab_sp` and the q seq len. The slab layout is
-    PASSED, not derived: slab_sp = the SP the cache was gathered across, slab_chunk_size = slab_sp*sq (the
-    gathered chunk). None -> contiguous (no slab args)."""
-    if slab_sp is None:
-        return {}
-    return {"slab_sp": slab_sp, "slab_chunk_size": slab_sp * sq}
-
-
 def run_dsa(
     q,
     k,
@@ -141,19 +132,17 @@ def run_dsa(
     q_dtype=ttnn.bfloat16,
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
-    proxy_ring_size=None,
 ):
     """Run indexer_score_dsa (relu + learned gates + head-sum) and return the bf16 score as torch.
 
-    q (srcB) and k (srcA) may be bfp8_b; weights stay bf16. proxy_ring_size simulates a ring_size-way slab K
-    layout on one chip (single-chip testing only).
+    q (srcB) and k (srcA) may be bfp8_b; weights stay bf16. (The block-cyclic K remap derives sp from the
+    mesh and so is exercised on a real SP mesh -- see the multidevice tests -- not simulated single-chip.)
     """
     out = ttnn.experimental.indexer_score_dsa(
         to_device(q, device, dtype=q_dtype),
         to_device(k, device, dtype=k_dtype),
         to_device(w, device),
         chunk_start_idx=chunk_start,
-        **_slab_kwargs(proxy_ring_size, q.shape[-2]),
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
@@ -171,12 +160,10 @@ def run_msa(
     q_dtype=ttnn.bfloat16,
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
-    proxy_ring_size=None,
 ):
     """Run indexer_score_msa (raw dot, constant `scale` gate, per-group planes) and return torch.
 
     No weights tensor: M3 has no learned gates, only `scale` (run as a constant gate in-op).
-    proxy_ring_size simulates a ring_size-way slab K layout on one chip (single-chip testing only).
     """
     out = ttnn.experimental.indexer_score_msa(
         to_device(q, device, dtype=q_dtype),
@@ -185,7 +172,6 @@ def run_msa(
         scale=scale,
         num_groups=num_groups,
         block_size=block_size,
-        **_slab_kwargs(proxy_ring_size, q.shape[-2]),
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
@@ -1167,7 +1153,7 @@ def _msa_per_sp_ref(q_g, k_g, sp_count, history):
 
 
 @pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
-def test_indexer_score_msa_qb_per_device_chunk_start(mesh_device):
+def test_indexer_score_qb_msa_per_device_chunk_start(mesh_device):
     """MSA over 4 BH devices (SP=4), each deriving its own chunk_start from its coordinate (cluster_axis
     unset -> linear order). Raw dot + constant scale, num_groups=1 -> one head-summed [1,1,Sq,T] plane."""
     q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
@@ -1187,7 +1173,7 @@ def test_indexer_score_msa_qb_per_device_chunk_start(mesh_device):
 
 
 @pytest.mark.parametrize("mesh_device", [(QB2_SP, QB2_TP)], ids=["2x2"], indirect=True)
-def test_indexer_score_msa_qb_sp2_tp2(mesh_device):
+def test_indexer_score_qb_msa_sp2_tp2(mesh_device):
     """MSA over a 2x2 mesh: chunk_start derived per-device along cluster_axis (SP), constant across TP; the
     M3 index heads split across TP. Each device head-sums its half (num_groups=1); the test sums the TP
     partials (the all-reduce) and validates per SP rank against its own raw-dot, own-chunk_start reference."""
@@ -1501,12 +1487,14 @@ def test_indexer_score_block_pool_validation(device, expect_error, block_size, k
 
 
 # ---------------------------------------------------------------------------
-# Slab (per-SP-shard) K layout. Chunked prefill packs each SP shard's per-chunk slab (slab_chunk_size/slab_sp
-# keys) back-to-back, so the gathered [B,1,T,D] k is in a PERMUTED physical order and the reader reads it back
-# in natural token order (invP per tile) -- scores (and the block-max-pool over token-contiguous blocks) come
-# out correct. The slab layout is PASSED EXPLICITLY (slab_sp = the SP the cache was gathered across,
-# slab_chunk_size = the global chunk), NOT derived. These tests pass slab_sp / slab_chunk_size = ring_size*Sq
-# via _slab_kwargs (proxy_ring_size) to exercise a real SP slab on one chip.
+# Block-cyclic (per-SP-shard slab) K layout. Chunked prefill packs each SP shard's per-chunk slab
+# (chunk_local = global_chunk/sp keys) back-to-back, so the SP-gathered [B,1,T,D] k is in a PERMUTED physical
+# order and the reader reads it back in natural token order (invP per tile) -- scores (and the block-max-pool
+# over token-contiguous blocks) come out correct. Interface matches ttnn.transformer.sparse_sdpa: the caller
+# names the MESH AXIS the cache was striped over (block_cyclic_sp_axis, sp DERIVED from the mesh) and passes
+# the per-shard chunk length (block_cyclic_chunk_local). The permutation is only non-trivial for sp > 1, so it
+# is exercised on a REAL SP mesh (below), NOT simulated on one chip; the pure invP tile-math is unit-tested
+# device-free.
 # ---------------------------------------------------------------------------
 def _slab_positions(ring_size, chunk, t):
     """P[r] = natural token position physically stored at slab row r. Physical row r (shard c = r//sll, local
@@ -1520,6 +1508,19 @@ def _slab_positions(ring_size, chunk, t):
     return (lr // cl) * chunk + c * cl + (lr % cl)
 
 
+def _slab_inv_positions(ring_size, chunk, t):
+    """invP[n] = physical slab row holding natural token n (inverse of _slab_positions). Row-granularity form
+    of the in-kernel per-tile SLAB_KTILE remap: slab = n//chunk, rem = n%chunk, c = rem//cl, off = rem%cl ->
+    r = c*sll + slab*cl + off (sll = t/ring_size, cl = chunk/ring_size)."""
+    sll, cl = t // ring_size, chunk // ring_size
+    n = torch.arange(t)
+    slab = n // chunk
+    rem = n - slab * chunk
+    c = rem // cl
+    off = rem - c * cl
+    return c * sll + slab * cl + off
+
+
 def _to_slab(k_nat, ring_size, chunk):
     """Permute a natural-order [1,1,T,D] k into its slab physical layout: k_slab[r] = k_nat[P[r]]."""
     t = k_nat.shape[2]
@@ -1529,98 +1530,93 @@ def _to_slab(k_nat, ring_size, chunk):
     return k_slab
 
 
-# Simulated SP ring sizes; the chunk is derived per test as ring_size * Sq (so it divides T below).
-SLAB_RINGS = [4, 8]
-SLAB_IDS = ["ring4", "ring8"]
+@pytest.mark.parametrize("ring_size", [2, 4, 8], ids=["sp2", "sp4", "sp8"])
+@pytest.mark.parametrize("chunk_local,t", [(32, 2048), (64, 4096), (128, 3072)], ids=["cl32", "cl64", "cl128"])
+def test_indexer_score_slab_invp_math(ring_size, chunk_local, t):
+    """Pure-function (device-free) check of the block-cyclic remap math the reader kernel bakes in: invP must
+    be the exact inverse of the block-cyclic layout P over the whole cache, for every legal (sp, chunk, T).
+    Locks the SLAB_KTILE arithmetic independent of any device; the end-to-end remap is validated on a real
+    SP mesh below. (Requires T a whole number of global chunks and chunk divisible by sp.)"""
+    chunk = ring_size * chunk_local  # global chunk = sp * per-shard chunk
+    if t % chunk or (t // ring_size) % chunk_local:
+        pytest.skip("layout must tile the cache evenly (whole global chunks, >=1 slab per shard)")
+    P = _slab_positions(ring_size, chunk, t)
+    invP = _slab_inv_positions(ring_size, chunk, t)
+    ident = torch.arange(t)
+    assert torch.equal(P[invP], ident), "P[invP(n)] != n -- invP is not the layout's inverse"
+    assert torch.equal(invP[P], ident), "invP[P(r)] != r -- not a bijection"
 
 
-@pytest.mark.parametrize("ring_size", SLAB_RINGS, ids=SLAB_IDS)
-@pytest.mark.parametrize("chunk_start", [0, 1024], ids=["cs0", "cs1024"])
-def test_indexer_score_dsa_slab(device, ring_size, chunk_start):
-    """DSA over a slab K cache, SINGLE CHIP: physical K is permuted; slab_sp / slab_chunk_size = ring_size*Sq
-    are passed explicitly to describe a real ring_size-way SP slab, so the reader presents K in natural token
-    order and the score matches the contiguous-K reference exactly (same -inf map + PCC >= 0.999)."""
-    heads, dim, sq, t = 64, GLX_DIM, 64, 2048
-    q, k_nat, w = make_inputs(heads, dim, sq, t)
-    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)  # slab_chunk_size passed to the op = ring_size*Sq
-    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
-    out = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring_size)
-    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
-    assert_indexer_match(out, ref, sq, t, check_neg=True)
+# ---- Real-mesh block-cyclic remap: sp DERIVED from block_cyclic_sp_axis on an (sp, 1) mesh ----
+# The remap is the identity at sp=1, so the natural->physical PERMUTATION arithmetic only runs on a real SP
+# mesh. K is stored block-cyclic and REPLICATED; q/w are SP-sharded on seq (per-chip chunk_local rows). The
+# reader remaps each logical K-tile so the score matches the contiguous-K, natural-order per-SP reference.
+# Reuses the QB constants (QB_HISTORY % (QB_SP*QB_SQ) == 0 -> T is a whole number of global chunks, and
+# T/QB_SP spans many slabs so the permutation is non-trivial).
+@pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
+    """DSA over a REAL SP=4 mesh with a block-cyclic K cache. sp is read from block_cyclic_sp_axis=0 (the mesh
+    rows); block_cyclic_chunk_local = QB_SQ (per-chip seq). chunk_start OMITTED -> the slab path deduces base =
+    T - global_chunk = QB_HISTORY, device r gets base + r*QB_SQ. Score must match the natural-order reference."""
+    q_g, k_nat, w_g = _global_inputs(heads, QB_CHUNK, QB_T, seed=42)
+    k_bc = _to_slab(k_nat, QB_SP, QB_CHUNK)  # global chunk = QB_SP * QB_SQ = QB_CHUNK
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))  # seq on SP axis, repl. axis 1
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
 
-
-@pytest.mark.parametrize("ring_size", SLAB_RINGS, ids=SLAB_IDS)
-@pytest.mark.parametrize("block_size", [0, BLOCK_POOL_BS], ids=["unpooled", "pooled"])
-def test_indexer_score_msa_slab(device, block_size, ring_size):
-    """MSA per-group scoring over a slab K cache, SINGLE CHIP. block_size=0 -> [1,G,Sq,T] planes; >0 ->
-    block-max-pool (the M3 crux: a pooled block is block_size CONTIGUOUS tokens, scattered across the physical
-    buffer, so only reading in natural order pools the right token range). Both match the contiguous-K ref."""
-    heads, dim, sq, t, chunk_start = 4, GLX_DIM, 128, 2048, 512
-    scale = dim**-0.5
-    q, k_nat, _ = make_inputs(heads, dim, sq, t)
-    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)
-    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
-    out = run_msa(
-        q,
-        k_slab,
-        chunk_start,
-        device,
-        scale=scale,
-        num_groups=heads,
-        block_size=block_size,
-        program_config=cfg,
-        proxy_ring_size=ring_size,
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        cluster_axis=0,  # SP axis (same axis the cache was striped over)
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=QB_SQ,
+        program_config=glx_config(heads),
     )
-    w_scale = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
-    ref = indexer_score_msa_ref(q, k_nat, w_scale, chunk_start, heads, block_size=block_size)
-    if block_size:
-        assert_pooled_match(out, ref, heads, sq, t // block_size, pcc_floor=0.995)
-    else:
-        assert_grouped_match(out, ref, heads, sq, t)
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
+    ref = _per_sp_ref(q_g, k_nat, w_g, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
 
 
-def test_indexer_score_slab_remap_matters(device):
-    """The remap is load-bearing: with the proxy the permuted cache reads correctly; WITHOUT it the deduction
-    is the identity (one chip -> ring_size=1), so the permuted cache is read as-is and the scores are wrong (a
-    token permutation). Confirms the slab handling is not a no-op."""
-    ring_size = 8
-    heads, dim, sq, t, chunk_start = 64, GLX_DIM, 64, 2048, 1024
-    q, k_nat, w = make_inputs(heads, dim, sq, t)
-    k_slab = _to_slab(k_nat, ring_size, ring_size * sq)
-    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
-    ref = indexer_score_dsa_ref(q, k_nat, w, chunk_start)
-    masked = ref == float("-inf")
-    b = ref[~masked].flatten().float()
+@pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
+def test_indexer_score_qb_msa_block_cyclic(mesh_device):
+    """MSA (raw dot, constant scale, num_groups=1) over a REAL SP=4 block-cyclic K cache: sp read from
+    block_cyclic_sp_axis=0, the reader remaps each logical K-tile so the head-summed per-SP score matches the
+    natural-order reference. The reader remap is block_size-independent (it presents natural-order K; pooling
+    then runs over that), so block-max-pool-over-block-cyclic is covered by composition of this remap test and
+    the single-chip contiguous pooled tests -- no separate pooled mesh case needed."""
+    q_g, k_nat, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
+    k_bc = _to_slab(k_nat, QB_SP, QB_CHUNK)
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
 
-    good = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg, proxy_ring_size=ring_size)
-    pcc_good = torch.corrcoef(torch.stack([good[~masked].flatten().float(), b]))[0, 1].item()
-    assert pcc_good >= 0.999, f"slab proxy PCC {pcc_good} < 0.999"
-
-    # No proxy on one chip -> ring_size=1 identity -> permuted cache read as-is. -inf map is positional
-    # (same), but the visible scores are permuted -> far below the floor.
-    bad = run_dsa(q, k_slab, w, chunk_start, device, program_config=cfg)
-    pcc_bad = torch.corrcoef(torch.stack([bad[~masked].flatten().float(), b]))[0, 1].item()
-    assert pcc_bad < 0.99, f"identity read of a permuted cache unexpectedly matched (PCC {pcc_bad})"
-
-
-def test_indexer_score_slab_rejects_bad_chunk(device, expect_error):
-    """A derived chunk (= ring_size*Sq) that does not divide T is rejected loudly so a bad layout can't
-    silently mis-address K. Here ring_size=5, Sq=64 -> chunk=320, which does not divide T=2048."""
-    heads, dim, sq, t = 64, GLX_DIM, 64, 2048
-    q, k, w = make_inputs(heads, dim, sq, t)
-    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=256, head_group_size=0)
-    with expect_error(RuntimeError, "must divide T"):
-        run_dsa(q, k, w, 0, device, program_config=cfg, proxy_ring_size=5)
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        cluster_axis=0,
+        scale=M3_QB_SCALE,
+        num_groups=1,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=QB_SQ,
+        program_config=glx_config(M3_QB_HEADS),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
+    ref = _msa_per_sp_ref(q_g, k_nat, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
 
 
-def test_indexer_score_rejects_partial_slab_args(device, expect_error):
-    """slab_sp and slab_chunk_size define the cache's slab layout and must be passed TOGETHER -- passing only
-    one is a caller error (the per-shard width chunk/sp is undefined). Host-side guard, so a single chip
-    suffices."""
+def test_indexer_score_rejects_partial_block_cyclic_args(device, expect_error):
+    """block_cyclic_sp_axis and block_cyclic_chunk_local define the cache's layout and must be passed TOGETHER
+    -- passing only one is a caller error (the per-shard width is undefined). Host-side guard, single chip."""
     heads, dim, sq, t = 64, GLX_DIM, 64, 512
     q, k, w = make_inputs(heads, dim, sq, t)
     q_dev, k_dev, w_dev = to_device(q, device), to_device(k, device), to_device(w, device)
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
-    for kwargs in [{"slab_sp": 4}, {"slab_chunk_size": 256}]:
-        with expect_error(RuntimeError, "together"):
+    for kwargs in [{"block_cyclic_sp_axis": 0}, {"block_cyclic_chunk_local": 256}]:
+        with expect_error(RuntimeError, "both be set or both unset"):
             ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=0, program_config=cfg, **kwargs)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1581,6 +1581,41 @@ def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
     assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
 
 
+# ---- Q sequence sharded across BOTH mesh axes via cluster_axis=None (block_cyclic_chunk_local == tp*q_isl) ----
+# On a 2x2 mesh with K block-cyclic over ONE axis (sp=2, tp=2), Q's sequence is split across all 4 devices.
+# cluster_axis=None ranks device (a,b) by its row-major position in the device list (a*B+b), so the flat
+# linearization IS a row-major nested 2D seq shard: device r's q-row 0 sits at base + r*Sq. For a slab-aligned
+# base every device stays inside its slab (no straddle), so the flat shard + block-cyclic remap reassembles to
+# a plain contiguous natural-order scoring of the whole chunk. A NAMED cluster_axis is rejected (its rank would
+# miss the second axis's offset).
+@pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["2x2"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_error):
+    """Q seq sharded across both axes (all 4 devices) with cluster_axis=None: chunk_local == tp*q_isl (tp=2),
+    which the guard allows only for cluster_axis=None. K block-cyclic over sp=2, aligned base -> no straddle,
+    so the reassembled score equals the contiguous natural-order reference. Also asserts a NAMED cluster_axis
+    (which would mis-rank) is still rejected."""
+    sp, chunk_global, t = 2, 256, 512  # cl=128, Sq per device = 256/4 = 64 (2 tiles); 2 chunks -> >1 slab/shard
+    q_g, k_nat, w_g = _global_inputs(heads, chunk_global, t, seed=42)
+    k_bc = _to_slab(k_nat, sp, chunk_global)
+    shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)  # flat row-major over all 4 devices == None's device order
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    kw = dict(block_cyclic_sp_axis=0, block_cyclic_chunk_local=chunk_global // sp, program_config=glx_config(heads))
+
+    # cluster_axis=None -> Q linearized row-major over all 4 devices (both axes). chunk_start OMITTED ->
+    # base = T - global_chunk = 256 (slab-aligned). Reassembled == contiguous natural scoring at base.
+    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, cluster_axis=None, **kw)
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+    ref = indexer_score_dsa_ref(q_g, k_nat, w_g, t - chunk_global)
+    assert_indexer_match(out_t, ref, chunk_global, t, check_neg=True)
+
+    # A NAMED cluster_axis with tp*q_isl is rejected (rank would miss the second axis's seq offset).
+    with expect_error(RuntimeError, "NAMED cluster_axis"):
+        ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, cluster_axis=0, **kw)
+
+
 @pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
 def test_indexer_score_qb_msa_block_cyclic(mesh_device):
     """MSA (raw dot, constant scale, num_groups=1) over a REAL SP=4 block-cyclic K cache: sp read from

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -123,6 +123,36 @@ void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args
             Sq);
     }
 }
+// Slab layout (slab_sp / slab_chunk_size, passed by the caller): ring_size/chunk are hashed and bake invP's
+// divisors into the reader, so the per-shard slab must be tile-aligned and tile the cache evenly -- miss-only
+// (a hit can't differ). Sq <= cl bounds a device's queries to at most one cache-slab crossing (one straddle).
+void validate_slab(const operation_attributes_t& attrs, const tensor_args_t& t) {
+    if (!attrs.slab.has_value()) {
+        return;
+    }
+    const uint32_t ring = attrs.slab->ring_size;
+    const uint32_t chunk = attrs.slab->chunk_size;
+    const uint32_t T = t.k.logical_shape()[2];
+    const uint32_t Sq = t.q.logical_shape()[2];
+    TT_FATAL(ring >= 1, "slab ring_size (slab_sp) must be >= 1 (got {})", ring);
+    TT_FATAL(chunk > 0 && chunk % ring == 0, "slab chunk_size {} must be > 0 and divisible by slab_sp {}", chunk, ring);
+    const uint32_t chunk_local = chunk / ring;
+    TT_FATAL(
+        chunk_local % tt::constants::TILE_WIDTH == 0,
+        "slab per-shard width chunk_size/slab_sp ({}) must be tile-aligned",
+        chunk_local);
+    TT_FATAL(
+        T % chunk == 0,
+        "slab chunk_size {} must divide T {} (the cache must be a whole number of global chunks)",
+        chunk,
+        T);
+    TT_FATAL(
+        Sq <= chunk_local,
+        "Sq ({}) must be <= the slab per-shard width chunk_size/slab_sp ({}); a device's queries may cross at "
+        "most one cache-slab boundary (one straddle). A coarser indexer SP (Sq > cl) is not yet supported.",
+        Sq,
+        chunk_local);
+}
 }  // namespace
 
 IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::select_program_factory(
@@ -148,6 +178,11 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         attrs.cluster_axis.value_or(0u),
         attrs.has_indexed_kv_cache(),
         attrs.has_runtime_kv_len(),
+        // The slab layout bakes invP divisors into the reader as compile-time defines, so ring_size/chunk
+        // must be hashed (a contiguous vs slab read, or a different slab shape, is a different binary).
+        attrs.has_slab(),
+        attrs.slab.has_value() ? attrs.slab->ring_size : 0u,
+        attrs.slab.has_value() ? attrs.slab->chunk_size : 0u,
         tensor_args);
 }
 
@@ -186,6 +221,7 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     // slot/kv_len runtime values are re-checked every dispatch.
     validate_static(attrs, tensor_args);
     validate_runtime_values(attrs, tensor_args);
+    validate_slab(attrs, tensor_args);
 
     // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
     TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4, "q, k must be rank 4");
@@ -393,7 +429,8 @@ IndexerScoreDeviceOperation::invoke(
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<SlabLayout> slab) {
     return {
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
@@ -406,7 +443,8 @@ IndexerScoreDeviceOperation::invoke(
             .program_config = program_config,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
-            .kv_len = kv_len},
+            .kv_len = kv_len,
+            .slab = slab},
         tensor_args_t{.q = q, .k = k, .weights = weights}};
 }
 
@@ -432,31 +470,62 @@ ttnn::Tensor launch_indexer_score(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> slab_sp,
+    std::optional<uint32_t> slab_chunk_size) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
+    using ttnn::operations::experimental::indexer_score::SlabLayout;
 
-    // base = rank 0's absolute chunk_start. Omit it on a mesh -> deduce base = T - sp_ring*Sq (assumes K is
-    // history + the full SP-gathered chunk). Caveats: the deduced window ends at T (incompatible with a
-    // growing kv_len < T -- pass chunk_start_idx there); omitting on one chip now gives base = T - Sq, not 0.
+    const uint32_t Sq = q.logical_shape()[2];
+
+    // The K-cache slab layout is PASSED, not derived: slab_sp = the SP the cache was gathered across (the
+    // cache's own SP, independent of how THIS op splits Q) and slab_chunk_size = the global chunk granularity.
+    // Both must be given together; slab_sp <= 1 (or unset) means contiguous K (no remap).
+    TT_FATAL(
+        slab_sp.has_value() == slab_chunk_size.has_value(),
+        "indexer_score: slab_sp and slab_chunk_size must be passed together (got slab_sp={}, slab_chunk_size={})",
+        slab_sp.has_value(),
+        slab_chunk_size.has_value());
+    const std::optional<SlabLayout> slab =
+        (slab_sp.has_value() && *slab_sp > 1)
+            ? std::optional<SlabLayout>{SlabLayout{.ring_size = *slab_sp, .chunk_size = *slab_chunk_size}}
+            : std::nullopt;
+
+    // base = the absolute chunk_start of this op's rank 0. Omit it -> deduce the start of the gathered chunk:
+    //   * slab set: the gathered chunk IS slab_chunk_size (the global chunk granularity) -> base = T - chunk.
+    //   * contiguous: the gathered chunk is sp_ring*Sq (each SP device contributes Sq) -> base = T - sp_ring*Sq,
+    //     the same deduction as before this feature (single chip: sp_ring = 1 -> base = T - Sq).
+    // The deduced window ends at T (incompatible with a growing kv_len < T -- pass chunk_start_idx there).
     uint32_t base = 0;
     if (chunk_start_idx.has_value()) {
         base = *chunk_start_idx;
     } else {
-        const uint32_t Sq = q.logical_shape()[2];
         const uint32_t T = k.logical_shape()[2];
-        // sp_ring = max_rank + 1 (get_linearized_index returns coord-min; get_topological_dimension would
-        // over-count on a nonzero-offset sub-mesh). max_linearized_rank is shared with the validated window.
-        const uint32_t sp_ring =
-            ttnn::operations::experimental::indexer_score::max_linearized_rank(q, cluster_axis) + 1;
-        TT_FATAL(
-            T >= sp_ring * Sq,
-            "indexer_score: cannot deduce chunk_start_idx -- T={} < sp_ring({})*Sq({}). Pass chunk_start_idx "
-            "explicitly if K does not equal history + the SP-gathered chunk.",
-            T,
-            sp_ring,
-            Sq);
-        base = T - sp_ring * Sq;
+        if (slab.has_value()) {
+            const uint32_t chunk = slab->chunk_size;
+            TT_FATAL(
+                T >= chunk,
+                "indexer_score: cannot deduce chunk_start_idx -- T={} < slab_chunk_size={}. Pass chunk_start_idx "
+                "explicitly if K does not equal history + the gathered chunk.",
+                T,
+                chunk);
+            base = T - chunk;
+        } else {
+            // sp_ring = max_rank + 1 (get_linearized_index returns coord-min; get_topological_dimension would
+            // over-count on a nonzero-offset sub-mesh). max_linearized_rank is shared with the validated window.
+            const uint32_t sp_ring =
+                ttnn::operations::experimental::indexer_score::max_linearized_rank(q, cluster_axis) + 1;
+            TT_FATAL(
+                T >= sp_ring * Sq,
+                "indexer_score: cannot deduce chunk_start_idx -- T={} < sp_ring({})*Sq({}). Pass chunk_start_idx "
+                "explicitly if K does not equal history + the SP-gathered chunk.",
+                T,
+                sp_ring,
+                Sq);
+            base = T - sp_ring * Sq;
+        }
     }
+
     // Default math_fidelity follows the matmul-input dtypes (both bfp8 -> LoFi, else HiFi2); a caller config
     // overrides per field. fp32-dest acc / full-sync default off (the only modes the custom LLK is validated for).
     const bool both_bfp8 = q.dtype() == DataType::BFLOAT8_B && k.dtype() == DataType::BFLOAT8_B;
@@ -482,7 +551,8 @@ ttnn::Tensor launch_indexer_score(
         resolved,
         cache_batch_idx,
         kv_len,
-        cluster_axis);
+        cluster_axis,
+        slab);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
@@ -497,7 +567,9 @@ ttnn::Tensor indexer_score_dsa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> slab_sp,
+    std::optional<uint32_t> slab_chunk_size) {
     // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling. Reads its real weights tensor.
     return launch_indexer_score(
         q,
@@ -513,7 +585,9 @@ ttnn::Tensor indexer_score_dsa(
         compute_kernel_config,
         cache_batch_idx,
         kv_len,
-        cluster_axis);
+        cluster_axis,
+        slab_sp,
+        slab_chunk_size);
 }
 
 ttnn::Tensor indexer_score_msa(
@@ -525,7 +599,9 @@ ttnn::Tensor indexer_score_msa(
     uint32_t block_size,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> slab_sp,
+    std::optional<uint32_t> slab_chunk_size) {
     // M3 has no learned gates, only a 1/sqrt(d) scale. Rather than materialize a constant [B,Hi,Sq,1] gate
     // tensor (an extra fill op dispatched every call), the reader fills cb_w with `scale` in L1 in-kernel
     // (synthesize_gate); q is passed as the unused weights placeholder so the op infra still has a valid
@@ -544,7 +620,9 @@ ttnn::Tensor indexer_score_msa(
         compute_kernel_config,
         /*cache_batch_idx=*/std::nullopt,
         /*kv_len=*/std::nullopt,
-        cluster_axis);
+        cluster_axis,
+        slab_sp,
+        slab_chunk_size);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -512,13 +512,17 @@ ttnn::Tensor launch_indexer_score(
             chunk_local,
             Sq,
             Sq * tp);
-        // Seq sharded across the TP axis too (chunk_local == tp*q_isl with tp > 1) needs the per-device
-        // chunk_start to fold in the TP-axis seq offset; indexer's chunk_start ranks only along cluster_axis,
-        // so guard that case rather than silently mis-masking. (Follow-up: SP-on-both-axes chunk_start.)
+        // Seq sharded across BOTH axes (chunk_local == tp*q_isl, tp > 1) is allowed ONLY with cluster_axis
+        // unset: then chunk_start ranks device (a,b) by its row-major position in the full device list
+        // (a*B+b), giving each its true position -- i.e. the flat linearization IS a row-major nested 2D seq
+        // shard, and the per-device offset/straddle come out correct. With a NAMED cluster_axis the rank is
+        // only that axis's coord, so it misses the other axis's seq offset and chunk_start would be wrong --
+        // reject that.
         TT_FATAL(
-            !(chunk_local == Sq * tp && tp > 1),
-            "indexer_score: block-cyclic with seq sharded across the TP axis (block_cyclic_chunk_local == "
-            "tp*q_isl, tp={}) is not yet supported -- chunk_start deduction handles only seq on the SP axis",
+            !(chunk_local == Sq * tp && tp > 1 && cluster_axis.has_value()),
+            "indexer_score: block_cyclic_chunk_local == tp*q_isl (tp={} > 1) with a NAMED cluster_axis is not "
+            "supported -- chunk_start would miss the second axis's seq offset. To seq-shard across both axes, "
+            "use cluster_axis=None (flat row-major linearization over all devices).",
             tp);
         // Internal layout keeps the GLOBAL chunk (sp*chunk_local) so the reader + factory stay byte-identical.
         if (sp > 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -10,6 +10,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/mesh_device.hpp>  // q.device()->get_view().shape() for block-cyclic sp derivation
 
 #include "kernels/indexer_score_work_split.hpp"  // banded grid mapping (banded_core_count)
 #include "ttnn/operations/ccl/ccl_common.hpp"    // get_linearized_index_from_physical_coord
@@ -123,9 +124,10 @@ void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args
             Sq);
     }
 }
-// Slab layout (slab_sp / slab_chunk_size, passed by the caller): ring_size/chunk are hashed and bake invP's
-// divisors into the reader, so the per-shard slab must be tile-aligned and tile the cache evenly -- miss-only
-// (a hit can't differ). Sq <= cl bounds a device's queries to at most one cache-slab crossing (one straddle).
+// Block-cyclic slab layout (sp derived from block_cyclic_sp_axis, global chunk = sp*block_cyclic_chunk_local):
+// ring_size/chunk are hashed and bake invP's divisors into the reader, so the per-shard slab must be
+// tile-aligned and tile the cache evenly -- miss-only (a hit can't differ). Sq <= cl bounds a device's queries
+// to at most one cache-slab crossing (one straddle).
 void validate_slab(const operation_attributes_t& attrs, const tensor_args_t& t) {
     if (!attrs.slab.has_value()) {
         return;
@@ -134,22 +136,22 @@ void validate_slab(const operation_attributes_t& attrs, const tensor_args_t& t) 
     const uint32_t chunk = attrs.slab->chunk_size;
     const uint32_t T = t.k.logical_shape()[2];
     const uint32_t Sq = t.q.logical_shape()[2];
-    TT_FATAL(ring >= 1, "slab ring_size (slab_sp) must be >= 1 (got {})", ring);
-    TT_FATAL(chunk > 0 && chunk % ring == 0, "slab chunk_size {} must be > 0 and divisible by slab_sp {}", chunk, ring);
+    TT_FATAL(ring >= 1, "block-cyclic sp must be >= 1 (got {})", ring);
+    TT_FATAL(chunk > 0 && chunk % ring == 0, "global chunk {} must be > 0 and divisible by sp {}", chunk, ring);
     const uint32_t chunk_local = chunk / ring;
     TT_FATAL(
         chunk_local % tt::constants::TILE_WIDTH == 0,
-        "slab per-shard width chunk_size/slab_sp ({}) must be tile-aligned",
+        "block_cyclic_chunk_local ({}) must be tile-aligned",
         chunk_local);
     TT_FATAL(
         T % chunk == 0,
-        "slab chunk_size {} must divide T {} (the cache must be a whole number of global chunks)",
+        "global chunk {} must divide T {} (the cache must be a whole number of global chunks)",
         chunk,
         T);
     TT_FATAL(
         Sq <= chunk_local,
-        "Sq ({}) must be <= the slab per-shard width chunk_size/slab_sp ({}); a device's queries may cross at "
-        "most one cache-slab boundary (one straddle). A coarser indexer SP (Sq > cl) is not yet supported.",
+        "Sq ({}) must be <= block_cyclic_chunk_local ({}); a device's queries may cross at most one cache-slab "
+        "boundary (one straddle). A coarser indexer SP (Sq > chunk_local) is not yet supported.",
         Sq,
         chunk_local);
 }
@@ -471,28 +473,61 @@ ttnn::Tensor launch_indexer_score(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis,
-    std::optional<uint32_t> slab_sp,
-    std::optional<uint32_t> slab_chunk_size) {
+    std::optional<uint32_t> block_cyclic_sp_axis,
+    std::optional<uint32_t> block_cyclic_chunk_local) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
     using ttnn::operations::experimental::indexer_score::SlabLayout;
 
     const uint32_t Sq = q.logical_shape()[2];
 
-    // The K-cache slab layout is PASSED, not derived: slab_sp = the SP the cache was gathered across (the
-    // cache's own SP, independent of how THIS op splits Q) and slab_chunk_size = the global chunk granularity.
-    // Both must be given together; slab_sp <= 1 (or unset) means contiguous K (no remap).
+    // Block-cyclic (per-SP-shard slab) K layout -- interface matches ttnn.transformer.sparse_sdpa: the caller
+    // names the MESH AXIS the cache was striped over (block_cyclic_sp_axis) and passes the per-shard chunk
+    // length (block_cyclic_chunk_local); `sp` is DERIVED from the mesh shape on that axis, so a caller cannot
+    // pass an sp that disagrees with the device. Both set together or neither. sp == 1 (single chip / size-1
+    // axis) is the identity permutation, represented as no slab.
     TT_FATAL(
-        slab_sp.has_value() == slab_chunk_size.has_value(),
-        "indexer_score: slab_sp and slab_chunk_size must be passed together (got slab_sp={}, slab_chunk_size={})",
-        slab_sp.has_value(),
-        slab_chunk_size.has_value());
-    const std::optional<SlabLayout> slab =
-        (slab_sp.has_value() && *slab_sp > 1)
-            ? std::optional<SlabLayout>{SlabLayout{.ring_size = *slab_sp, .chunk_size = *slab_chunk_size}}
-            : std::nullopt;
+        block_cyclic_sp_axis.has_value() == block_cyclic_chunk_local.has_value(),
+        "indexer_score: block_cyclic_sp_axis and block_cyclic_chunk_local must both be set or both unset "
+        "(got sp_axis={}, chunk_local={})",
+        block_cyclic_sp_axis.has_value(),
+        block_cyclic_chunk_local.has_value());
+    std::optional<SlabLayout> slab = std::nullopt;
+    if (block_cyclic_sp_axis.has_value()) {
+        const auto mesh_shape = q.device()->get_view().shape();
+        const uint32_t sp_axis = *block_cyclic_sp_axis;
+        TT_FATAL(
+            sp_axis < mesh_shape.dims(),
+            "indexer_score: block_cyclic_sp_axis ({}) out of range for mesh rank {}",
+            sp_axis,
+            mesh_shape.dims());
+        const uint32_t sp = mesh_shape[sp_axis];
+        const uint32_t tp = static_cast<uint32_t>(mesh_shape.mesh_size()) / sp;  // remaining (TP) device count
+        const uint32_t chunk_local = *block_cyclic_chunk_local;
+        // chunk_local is one of exactly two legal values (the cross-check sparse_sdpa also applies): q's
+        // per-chip seq length (seq sharded only on the SP axis) or tp*q_isl (seq also sliced across the TP
+        // axis, post-reshard). Anything else is a producer bug.
+        TT_FATAL(
+            chunk_local == Sq || chunk_local == Sq * tp,
+            "indexer_score: block_cyclic_chunk_local ({}) must be q_isl ({}) or tp*q_isl ({})",
+            chunk_local,
+            Sq,
+            Sq * tp);
+        // Seq sharded across the TP axis too (chunk_local == tp*q_isl with tp > 1) needs the per-device
+        // chunk_start to fold in the TP-axis seq offset; indexer's chunk_start ranks only along cluster_axis,
+        // so guard that case rather than silently mis-masking. (Follow-up: SP-on-both-axes chunk_start.)
+        TT_FATAL(
+            !(chunk_local == Sq * tp && tp > 1),
+            "indexer_score: block-cyclic with seq sharded across the TP axis (block_cyclic_chunk_local == "
+            "tp*q_isl, tp={}) is not yet supported -- chunk_start deduction handles only seq on the SP axis",
+            tp);
+        // Internal layout keeps the GLOBAL chunk (sp*chunk_local) so the reader + factory stay byte-identical.
+        if (sp > 1) {
+            slab = SlabLayout{.ring_size = sp, .chunk_size = sp * chunk_local};
+        }
+    }
 
     // base = the absolute chunk_start of this op's rank 0. Omit it -> deduce the start of the gathered chunk:
-    //   * slab set: the gathered chunk IS slab_chunk_size (the global chunk granularity) -> base = T - chunk.
+    //   * slab set: the gathered chunk IS the global chunk (sp*block_cyclic_chunk_local) -> base = T - chunk.
     //   * contiguous: the gathered chunk is sp_ring*Sq (each SP device contributes Sq) -> base = T - sp_ring*Sq,
     //     the same deduction as before this feature (single chip: sp_ring = 1 -> base = T - Sq).
     // The deduced window ends at T (incompatible with a growing kv_len < T -- pass chunk_start_idx there).
@@ -505,7 +540,7 @@ ttnn::Tensor launch_indexer_score(
             const uint32_t chunk = slab->chunk_size;
             TT_FATAL(
                 T >= chunk,
-                "indexer_score: cannot deduce chunk_start_idx -- T={} < slab_chunk_size={}. Pass chunk_start_idx "
+                "indexer_score: cannot deduce chunk_start_idx -- T={} < global chunk={}. Pass chunk_start_idx "
                 "explicitly if K does not equal history + the gathered chunk.",
                 T,
                 chunk);
@@ -568,8 +603,8 @@ ttnn::Tensor indexer_score_dsa(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis,
-    std::optional<uint32_t> slab_sp,
-    std::optional<uint32_t> slab_chunk_size) {
+    std::optional<uint32_t> block_cyclic_sp_axis,
+    std::optional<uint32_t> block_cyclic_chunk_local) {
     // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling. Reads its real weights tensor.
     return launch_indexer_score(
         q,
@@ -586,8 +621,8 @@ ttnn::Tensor indexer_score_dsa(
         cache_batch_idx,
         kv_len,
         cluster_axis,
-        slab_sp,
-        slab_chunk_size);
+        block_cyclic_sp_axis,
+        block_cyclic_chunk_local);
 }
 
 ttnn::Tensor indexer_score_msa(
@@ -600,8 +635,8 @@ ttnn::Tensor indexer_score_msa(
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cluster_axis,
-    std::optional<uint32_t> slab_sp,
-    std::optional<uint32_t> slab_chunk_size) {
+    std::optional<uint32_t> block_cyclic_sp_axis,
+    std::optional<uint32_t> block_cyclic_chunk_local) {
     // M3 has no learned gates, only a 1/sqrt(d) scale. Rather than materialize a constant [B,Hi,Sq,1] gate
     // tensor (an extra fill op dispatched every call), the reader fills cb_w with `scale` in L1 in-kernel
     // (synthesize_gate); q is passed as the unused weights placeholder so the op infra still has a valid
@@ -621,8 +656,8 @@ ttnn::Tensor indexer_score_msa(
         /*cache_batch_idx=*/std::nullopt,
         /*kv_len=*/std::nullopt,
         cluster_axis,
-        slab_sp,
-        slab_chunk_size);
+        block_cyclic_sp_axis,
+        block_cyclic_chunk_local);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -124,29 +124,28 @@ void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args
             Sq);
     }
 }
-// Block-cyclic slab layout (sp derived from block_cyclic_sp_axis, global chunk = sp*block_cyclic_chunk_local):
-// ring_size/chunk are hashed and bake invP's divisors into the reader, so the per-shard slab must be
-// tile-aligned and tile the cache evenly -- miss-only (a hit can't differ). Sq <= cl bounds a device's queries
-// to at most one cache-slab crossing (one straddle).
-void validate_slab(const operation_attributes_t& attrs, const tensor_args_t& t) {
-    if (!attrs.slab.has_value()) {
+// Block-cyclic layout (sp derived from block_cyclic_sp_axis, global chunk = sp*block_cyclic_chunk_local):
+// sp/chunk_local are hashed and bake invP's divisors into the reader, so the per-shard chunk must be
+// tile-aligned and tile the cache evenly -- miss-only (a hit can't differ). Sq <= chunk_local bounds a
+// device's queries to at most one cache-slab crossing (one straddle).
+void validate_block_cyclic(const operation_attributes_t& attrs, const tensor_args_t& t) {
+    if (!attrs.block_cyclic.has_value()) {
         return;
     }
-    const uint32_t ring = attrs.slab->ring_size;
-    const uint32_t chunk = attrs.slab->chunk_size;
+    const uint32_t sp = attrs.block_cyclic->sp;
+    const uint32_t chunk_local = attrs.block_cyclic->chunk_local;
+    const uint32_t chunk_global = sp * chunk_local;
     const uint32_t T = t.k.logical_shape()[2];
     const uint32_t Sq = t.q.logical_shape()[2];
-    TT_FATAL(ring >= 1, "block-cyclic sp must be >= 1 (got {})", ring);
-    TT_FATAL(chunk > 0 && chunk % ring == 0, "global chunk {} must be > 0 and divisible by sp {}", chunk, ring);
-    const uint32_t chunk_local = chunk / ring;
+    TT_FATAL(sp >= 1, "block-cyclic sp must be >= 1 (got {})", sp);
     TT_FATAL(
-        chunk_local % tt::constants::TILE_WIDTH == 0,
-        "block_cyclic_chunk_local ({}) must be tile-aligned",
+        chunk_local > 0 && chunk_local % tt::constants::TILE_WIDTH == 0,
+        "block_cyclic_chunk_local ({}) must be > 0 and tile-aligned",
         chunk_local);
     TT_FATAL(
-        T % chunk == 0,
-        "global chunk {} must divide T {} (the cache must be a whole number of global chunks)",
-        chunk,
+        T % chunk_global == 0,
+        "global chunk {} (= sp*chunk_local) must divide T {} (the cache must be a whole number of global chunks)",
+        chunk_global,
         T);
     TT_FATAL(
         Sq <= chunk_local,
@@ -180,11 +179,11 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         attrs.cluster_axis.value_or(0u),
         attrs.has_indexed_kv_cache(),
         attrs.has_runtime_kv_len(),
-        // The slab layout bakes invP divisors into the reader as compile-time defines, so ring_size/chunk
-        // must be hashed (a contiguous vs slab read, or a different slab shape, is a different binary).
-        attrs.has_slab(),
-        attrs.slab.has_value() ? attrs.slab->ring_size : 0u,
-        attrs.slab.has_value() ? attrs.slab->chunk_size : 0u,
+        // The block-cyclic layout bakes invP divisors into the reader as compile-time defines, so sp/chunk_local
+        // must be hashed (a contiguous vs block-cyclic read, or a different layout shape, is a different binary).
+        attrs.has_block_cyclic(),
+        attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
+        attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
         tensor_args);
 }
 
@@ -223,7 +222,7 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     // slot/kv_len runtime values are re-checked every dispatch.
     validate_static(attrs, tensor_args);
     validate_runtime_values(attrs, tensor_args);
-    validate_slab(attrs, tensor_args);
+    validate_block_cyclic(attrs, tensor_args);
 
     // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
     TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4, "q, k must be rank 4");
@@ -432,7 +431,7 @@ IndexerScoreDeviceOperation::invoke(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis,
-    std::optional<SlabLayout> slab) {
+    std::optional<BlockCyclicLayout> block_cyclic) {
     return {
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
@@ -446,7 +445,7 @@ IndexerScoreDeviceOperation::invoke(
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
             .kv_len = kv_len,
-            .slab = slab},
+            .block_cyclic = block_cyclic},
         tensor_args_t{.q = q, .k = k, .weights = weights}};
 }
 
@@ -476,22 +475,22 @@ ttnn::Tensor launch_indexer_score(
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
-    using ttnn::operations::experimental::indexer_score::SlabLayout;
+    using ttnn::operations::experimental::indexer_score::BlockCyclicLayout;
 
     const uint32_t Sq = q.logical_shape()[2];
 
-    // Block-cyclic (per-SP-shard slab) K layout -- interface matches ttnn.transformer.sparse_sdpa: the caller
+    // Block-cyclic (per-SP-shard) K layout -- interface matches ttnn.transformer.sparse_sdpa: the caller
     // names the MESH AXIS the cache was striped over (block_cyclic_sp_axis) and passes the per-shard chunk
     // length (block_cyclic_chunk_local); `sp` is DERIVED from the mesh shape on that axis, so a caller cannot
     // pass an sp that disagrees with the device. Both set together or neither. sp == 1 (single chip / size-1
-    // axis) is the identity permutation, represented as no slab.
+    // axis) is the identity permutation, represented as no block-cyclic layout.
     TT_FATAL(
         block_cyclic_sp_axis.has_value() == block_cyclic_chunk_local.has_value(),
         "indexer_score: block_cyclic_sp_axis and block_cyclic_chunk_local must both be set or both unset "
         "(got sp_axis={}, chunk_local={})",
         block_cyclic_sp_axis.has_value(),
         block_cyclic_chunk_local.has_value());
-    std::optional<SlabLayout> slab = std::nullopt;
+    std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
     if (block_cyclic_sp_axis.has_value()) {
         const auto mesh_shape = q.device()->get_view().shape();
         const uint32_t sp_axis = *block_cyclic_sp_axis;
@@ -524,14 +523,15 @@ ttnn::Tensor launch_indexer_score(
             "supported -- chunk_start would miss the second axis's seq offset. To seq-shard across both axes, "
             "use cluster_axis=None (flat row-major linearization over all devices).",
             tp);
-        // Internal layout keeps the GLOBAL chunk (sp*chunk_local) so the reader + factory stay byte-identical.
+        // Store {sp, chunk_local} (matching sparse_sdpa's BlockCyclicLayout); the factory derives the global
+        // chunk (sp*chunk_local) and the invP tile divisors from these.
         if (sp > 1) {
-            slab = SlabLayout{.ring_size = sp, .chunk_size = sp * chunk_local};
+            block_cyclic = BlockCyclicLayout{.sp = sp, .chunk_local = chunk_local};
         }
     }
 
     // base = the absolute chunk_start of this op's rank 0. Omit it -> deduce the start of the gathered chunk:
-    //   * slab set: the gathered chunk IS the global chunk (sp*block_cyclic_chunk_local) -> base = T - chunk.
+    //   * block-cyclic: the gathered chunk IS the global chunk (sp*chunk_local) -> base = T - chunk.
     //   * contiguous: the gathered chunk is sp_ring*Sq (each SP device contributes Sq) -> base = T - sp_ring*Sq,
     //     the same deduction as before this feature (single chip: sp_ring = 1 -> base = T - Sq).
     // The deduced window ends at T (incompatible with a growing kv_len < T -- pass chunk_start_idx there).
@@ -540,8 +540,8 @@ ttnn::Tensor launch_indexer_score(
         base = *chunk_start_idx;
     } else {
         const uint32_t T = k.logical_shape()[2];
-        if (slab.has_value()) {
-            const uint32_t chunk = slab->chunk_size;
+        if (block_cyclic.has_value()) {
+            const uint32_t chunk = block_cyclic->sp * block_cyclic->chunk_local;
             TT_FATAL(
                 T >= chunk,
                 "indexer_score: cannot deduce chunk_start_idx -- T={} < global chunk={}. Pass chunk_start_idx "
@@ -591,7 +591,7 @@ ttnn::Tensor launch_indexer_score(
         cache_batch_idx,
         kv_len,
         cluster_axis,
-        slab);
+        block_cyclic);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -53,7 +53,8 @@ struct IndexerScoreDeviceOperation {
         const DeviceComputeKernelConfig& compute_kernel_config,
         std::optional<uint32_t> cache_batch_idx,
         std::optional<uint32_t> kv_len,
-        std::optional<uint32_t> cluster_axis);
+        std::optional<uint32_t> cluster_axis,
+        std::optional<SlabLayout> slab);
 };
 
 }  // namespace ttnn::operations::experimental::indexer_score
@@ -63,6 +64,12 @@ namespace ttnn::experimental {
 // Two public frontends over one shared device op: the lightning indexer's two flavours differ only in
 // fixed knobs, so each gets its own callable. Both share the program factory + 3 kernels (flavour = compile-
 // time args) and produce a row-major bf16 score. Causality: key t visible to query s iff t <= chunk_start + s.
+//
+// SLAB K LAYOUT: the gathered K cache is a per-SP-shard slab (chunked prefill + SP all-gather), so the reader
+// reads it back in natural token order via an invP remap. The layout is PASSED EXPLICITLY -- slab_sp (the SP
+// the cache was gathered across) and slab_chunk_size (the global chunk granularity) -- because the cache's
+// slab is independent of how THIS op splits Q (e.g. an SP=8 cache scored by an SP=32 indexer). Both unset (or
+// slab_sp==1) = contiguous K (no remap).
 
 // DeepSeek-V3.2 DSA / GLM-5 (ttnn.experimental.indexer_score_dsa):
 //   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
@@ -78,7 +85,9 @@ ttnn::Tensor indexer_score_dsa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_len = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt);
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<uint32_t> slab_sp = std::nullopt,
+    std::optional<uint32_t> slab_chunk_size = std::nullopt);
 
 // MiniMax-M3 MSA (ttnn.experimental.indexer_score_msa):
 //   score[b, g, s, t] = sum_{h in group g} (q[b,h,s,:] . k[b,t,:]) * scale
@@ -98,6 +107,8 @@ ttnn::Tensor indexer_score_msa(
     uint32_t block_size = 0,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt);
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<uint32_t> slab_sp = std::nullopt,
+    std::optional<uint32_t> slab_chunk_size = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -54,7 +54,7 @@ struct IndexerScoreDeviceOperation {
         std::optional<uint32_t> cache_batch_idx,
         std::optional<uint32_t> kv_len,
         std::optional<uint32_t> cluster_axis,
-        std::optional<SlabLayout> slab);
+        std::optional<BlockCyclicLayout> block_cyclic);
 };
 
 }  // namespace ttnn::operations::experimental::indexer_score

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -71,8 +71,10 @@ namespace ttnn::experimental {
 // (block_cyclic_sp_axis) and passes the per-shard chunk length (block_cyclic_chunk_local); `sp` is DERIVED
 // from the mesh shape on that axis, so a caller cannot pass an sp that disagrees with the device.
 // block_cyclic_chunk_local must be q_isl (seq sharded only on the SP axis) or tp*q_isl (tp = mesh/sp). Both
-// set together, or neither = contiguous K (no remap); sp==1 is the identity. NOTE: seq sharded across the TP
-// axis too (chunk_local == tp*q_isl, tp>1) is not yet supported.
+// set together, or neither = contiguous K (no remap); sp==1 is the identity. Seq sharded across BOTH axes
+// (chunk_local == tp*q_isl, tp>1) is allowed ONLY with cluster_axis=None (flat row-major linearization over
+// all devices == a row-major nested 2D seq shard); with a NAMED cluster_axis it is rejected (chunk_start
+// would miss the second axis's seq offset).
 
 // DeepSeek-V3.2 DSA / GLM-5 (ttnn.experimental.indexer_score_dsa):
 //   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -65,11 +65,14 @@ namespace ttnn::experimental {
 // fixed knobs, so each gets its own callable. Both share the program factory + 3 kernels (flavour = compile-
 // time args) and produce a row-major bf16 score. Causality: key t visible to query s iff t <= chunk_start + s.
 //
-// SLAB K LAYOUT: the gathered K cache is a per-SP-shard slab (chunked prefill + SP all-gather), so the reader
-// reads it back in natural token order via an invP remap. The layout is PASSED EXPLICITLY -- slab_sp (the SP
-// the cache was gathered across) and slab_chunk_size (the global chunk granularity) -- because the cache's
-// slab is independent of how THIS op splits Q (e.g. an SP=8 cache scored by an SP=32 indexer). Both unset (or
-// slab_sp==1) = contiguous K (no remap).
+// BLOCK-CYCLIC K LAYOUT: the gathered K cache is a per-SP-shard slab (chunked prefill + SP all-gather), so the
+// reader reads it back in natural token order via an invP remap. The interface matches
+// ttnn.transformer.sparse_sdpa: the caller names the MESH AXIS the cache was striped over
+// (block_cyclic_sp_axis) and passes the per-shard chunk length (block_cyclic_chunk_local); `sp` is DERIVED
+// from the mesh shape on that axis, so a caller cannot pass an sp that disagrees with the device.
+// block_cyclic_chunk_local must be q_isl (seq sharded only on the SP axis) or tp*q_isl (tp = mesh/sp). Both
+// set together, or neither = contiguous K (no remap); sp==1 is the identity. NOTE: seq sharded across the TP
+// axis too (chunk_local == tp*q_isl, tp>1) is not yet supported.
 
 // DeepSeek-V3.2 DSA / GLM-5 (ttnn.experimental.indexer_score_dsa):
 //   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
@@ -86,8 +89,8 @@ ttnn::Tensor indexer_score_dsa(
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_len = std::nullopt,
     std::optional<uint32_t> cluster_axis = std::nullopt,
-    std::optional<uint32_t> slab_sp = std::nullopt,
-    std::optional<uint32_t> slab_chunk_size = std::nullopt);
+    std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
+    std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);
 
 // MiniMax-M3 MSA (ttnn.experimental.indexer_score_msa):
 //   score[b, g, s, t] = sum_{h in group g} (q[b,h,s,:] . k[b,t,:]) * scale
@@ -108,7 +111,7 @@ ttnn::Tensor indexer_score_msa(
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cluster_axis = std::nullopt,
-    std::optional<uint32_t> slab_sp = std::nullopt,
-    std::optional<uint32_t> slab_chunk_size = std::nullopt);
+    std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
+    std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -27,20 +27,19 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
     return cfg.head_group_size == 0 ? Hi : static_cast<uint32_t>(cfg.head_group_size);
 }
 
-// Slab (per-SP-shard) K cache layout. Chunked prefill stores each of `ring_size` SP shards' per-chunk slab
-// (chunk_size/ring_size keys) back-to-back in its local cache, so after the SP all-gather the [B,1,T,D] k
-// holds keys in a PERMUTED physical order: physical row r holds the natural token at
-// P[r] = (lr/cl)*chunk_size + c*cl + (lr%cl), where c = r/sll, lr = r%sll, sll = T/ring_size,
-// cl = chunk_size/ring_size. The reader reads K back in LOGICAL token order (invP per tile), so the causal
-// mask and block-max-pool -- both keyed on the logical column -- stay byte-identical and the score columns
-// come out in natural token order. RESOLVED at the ttnn entry (interface matches sparse_sdpa): the caller
-// names the mesh axis the cache was striped over (block_cyclic_sp_axis) and passes the per-shard chunk length
-// (block_cyclic_chunk_local); ring_size = the mesh extent on that axis (DERIVED, not free), chunk_size =
-// ring_size * block_cyclic_chunk_local. Hashed (it shapes the reader binary). ring_size == 1 is the identity,
-// represented as no slab at all.
-struct SlabLayout {
-    uint32_t ring_size;   // SP shard count the cache was gathered across (derived from the mesh sp axis)
-    uint32_t chunk_size;  // global prefill chunk granularity (elements); per-shard slab = chunk_size/ring_size
+// Block-cyclic (per-SP-shard) K cache layout. Chunked prefill stores each of `sp` SP shards' per-chunk slab
+// (chunk_local keys) back-to-back in its local cache, so after the SP all-gather the [B,1,T,D] k holds keys in
+// a PERMUTED physical order: physical row r holds the natural token at
+// P[r] = (lr/chunk_local)*chunk_global + c*chunk_local + (lr%chunk_local), where c = r/sll, lr = r%sll,
+// sll = T/sp, chunk_global = sp*chunk_local. The reader reads K back in LOGICAL token order (invP per tile),
+// so the causal mask and block-max-pool -- both keyed on the logical column -- stay byte-identical and the
+// score columns come out in natural token order. RESOLVED at the ttnn entry (interface + naming match
+// sparse_sdpa): the caller names the mesh axis the cache was striped over (block_cyclic_sp_axis) and passes
+// the per-shard chunk length (block_cyclic_chunk_local); sp = the mesh extent on that axis (DERIVED, not
+// free). Hashed (it shapes the reader binary). sp == 1 is the identity, represented as no block_cyclic at all.
+struct BlockCyclicLayout {
+    uint32_t sp;           // SP shard count the cache was gathered across (derived from the mesh sp axis)
+    uint32_t chunk_local;  // per-shard chunk length (elements); == chunk_size_global / sp == per-chip seq_len
 };
 
 struct operation_attributes_t {
@@ -78,12 +77,12 @@ struct operation_attributes_t {
     // reuses ONE program. grid/work-split/output width stay keyed on the hashed T. nullopt == T.
     std::optional<uint32_t> kv_len{std::nullopt};
     bool has_runtime_kv_len() const { return kv_len.has_value(); }
-    // Resolved slab (per-SP-shard) K layout. When set, the reader remaps each logical k-tile to its physical
-    // (permuted) tile, presenting K in natural token order. HASHED (ring_size/chunk_size shape the reader
+    // Resolved block-cyclic (per-SP-shard) K layout. When set, the reader remaps each logical k-tile to its
+    // physical (permuted) tile, presenting K in natural token order. HASHED (sp/chunk_local shape the reader
     // binary via compile-time defines, so the contiguous path stays byte-identical). nullopt == contiguous K
-    // (which is also what ring_size == 1 resolves to, since that is the identity permutation).
-    std::optional<SlabLayout> slab{std::nullopt};
-    bool has_slab() const { return slab.has_value(); }
+    // (which is also what sp == 1 resolves to, since that is the identity permutation).
+    std::optional<BlockCyclicLayout> block_cyclic{std::nullopt};
+    bool has_block_cyclic() const { return block_cyclic.has_value(); }
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -27,6 +27,21 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
     return cfg.head_group_size == 0 ? Hi : static_cast<uint32_t>(cfg.head_group_size);
 }
 
+// Slab (per-SP-shard) K cache layout. Chunked prefill stores each of `ring_size` SP shards' per-chunk slab
+// (chunk_size/ring_size keys) back-to-back in its local cache, so after the SP all-gather the [B,1,T,D] k
+// holds keys in a PERMUTED physical order: physical row r holds the natural token at
+// P[r] = (lr/cl)*chunk_size + c*cl + (lr%cl), where c = r/sll, lr = r%sll, sll = T/ring_size,
+// cl = chunk_size/ring_size. The reader reads K back in LOGICAL token order (invP per tile), so the causal
+// mask and block-max-pool -- both keyed on the logical column -- stay byte-identical and the score columns
+// come out in natural token order. PASSED EXPLICITLY by the caller (slab_sp / slab_chunk_size), NOT derived
+// from the mesh: the cache's slab layout (how K was gathered) is independent of how THIS op splits Q -- e.g.
+// a cache gathered with SP=8 (chunk_size/8 per shard) may be scored by an SP=32 indexer with a smaller Sq.
+// Hashed (it shapes the reader binary). ring_size == 1 is the identity, represented as no slab at all.
+struct SlabLayout {
+    uint32_t ring_size;   // SP shard count the cache was gathered across (the cache's SP, NOT this op's SP)
+    uint32_t chunk_size;  // global prefill chunk granularity (elements); per-shard slab = chunk_size/ring_size
+};
+
 struct operation_attributes_t {
     // Absolute chunk_start of rank 0. Rank r uses chunk_start_idx + r*Sq; the per-device value is derived
     // host-side and passed to compute as a RUNTIME arg (hash-excluded), so distinct values reuse one program.
@@ -62,6 +77,12 @@ struct operation_attributes_t {
     // reuses ONE program. grid/work-split/output width stay keyed on the hashed T. nullopt == T.
     std::optional<uint32_t> kv_len{std::nullopt};
     bool has_runtime_kv_len() const { return kv_len.has_value(); }
+    // Resolved slab (per-SP-shard) K layout. When set, the reader remaps each logical k-tile to its physical
+    // (permuted) tile, presenting K in natural token order. HASHED (ring_size/chunk_size shape the reader
+    // binary via compile-time defines, so the contiguous path stays byte-identical). nullopt == contiguous K
+    // (which is also what ring_size == 1 resolves to, since that is the identity permutation).
+    std::optional<SlabLayout> slab{std::nullopt};
+    bool has_slab() const { return slab.has_value(); }
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -33,12 +33,13 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
 // P[r] = (lr/cl)*chunk_size + c*cl + (lr%cl), where c = r/sll, lr = r%sll, sll = T/ring_size,
 // cl = chunk_size/ring_size. The reader reads K back in LOGICAL token order (invP per tile), so the causal
 // mask and block-max-pool -- both keyed on the logical column -- stay byte-identical and the score columns
-// come out in natural token order. PASSED EXPLICITLY by the caller (slab_sp / slab_chunk_size), NOT derived
-// from the mesh: the cache's slab layout (how K was gathered) is independent of how THIS op splits Q -- e.g.
-// a cache gathered with SP=8 (chunk_size/8 per shard) may be scored by an SP=32 indexer with a smaller Sq.
-// Hashed (it shapes the reader binary). ring_size == 1 is the identity, represented as no slab at all.
+// come out in natural token order. RESOLVED at the ttnn entry (interface matches sparse_sdpa): the caller
+// names the mesh axis the cache was striped over (block_cyclic_sp_axis) and passes the per-shard chunk length
+// (block_cyclic_chunk_local); ring_size = the mesh extent on that axis (DERIVED, not free), chunk_size =
+// ring_size * block_cyclic_chunk_local. Hashed (it shapes the reader binary). ring_size == 1 is the identity,
+// represented as no slab at all.
 struct SlabLayout {
-    uint32_t ring_size;   // SP shard count the cache was gathered across (the cache's SP, NOT this op's SP)
+    uint32_t ring_size;   // SP shard count the cache was gathered across (derived from the mesh sp axis)
     uint32_t chunk_size;  // global prefill chunk granularity (elements); per-shard slab = chunk_size/ring_size
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -353,20 +353,20 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     reader_ct.push_back(args.synthesize_gate ? 1u : 0u);  // fill cb_w with gate_scale in L1 vs read DRAM
     reader_ct.push_back(gate_scale_bits);                 // bf16 pair, the in-kernel gate fill value
 
-    // Slab (per-SP-shard) K: bake invP's divisors as reader defines (only when a slab layout is present, so
-    // the contiguous path emits no defines -> byte-identical reader binary). cl_t = (chunk/ring)/TILE_WIDTH
-    // per-shard slab in tiles; the kernel maps logical tile L -> L + c*SLAB_DELTA_T - shard*SLAB_K_T.
-    // ring_size/chunk/T are all hashed, so SLAB_DELTA_T is a pure compile-time constant (no per-dispatch arg).
+    // Block-cyclic (per-SP-shard) K: bake invP's divisors as reader defines (only when a block-cyclic layout
+    // is present, so the contiguous path emits no defines -> byte-identical reader binary). cl_t = per-shard
+    // chunk in tiles; the kernel maps logical tile L -> L + shard*BC_SHARD_STRIDE_GAP - slab*BC_SLAB_STRIDE_GAP.
+    // sp/chunk_local/T are all hashed, so the gaps are pure compile-time constants (no per-dispatch arg).
     std::map<std::string, std::string> reader_defines;
-    if (args.has_slab()) {
-        const uint32_t ring = args.slab->ring_size;
-        const uint32_t chunk_tiles = args.slab->chunk_size / tt::constants::TILE_WIDTH;
-        const uint32_t cl_t = chunk_tiles / ring;  // per-shard slab width in tiles
-        reader_defines["SLAB_ENABLE"] = "1";
-        reader_defines["SLAB_RING"] = std::to_string(ring);
-        reader_defines["SLAB_CHUNK_LOCAL_T"] = std::to_string(cl_t);
-        reader_defines["SLAB_K_T"] = std::to_string(cl_t * (ring - 1));
-        reader_defines["SLAB_DELTA_T"] = std::to_string((Tt - chunk_tiles) / ring);
+    if (args.has_block_cyclic()) {
+        const uint32_t sp = args.block_cyclic->sp;
+        const uint32_t cl_t = args.block_cyclic->chunk_local / tt::constants::TILE_WIDTH;  // per-shard chunk (tiles)
+        const uint32_t chunk_tiles = sp * cl_t;                                            // global chunk (tiles)
+        reader_defines["BC_ENABLE"] = "1";
+        reader_defines["BC_SP"] = std::to_string(sp);
+        reader_defines["BC_CHUNK_LOCAL_T"] = std::to_string(cl_t);
+        reader_defines["BC_SLAB_STRIDE_GAP"] = std::to_string(cl_t * (sp - 1));
+        reader_defines["BC_SHARD_STRIDE_GAP"] = std::to_string((Tt - chunk_tiles) / sp);
     }
 
     std::vector<uint32_t> writer_ct = common_ct;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <array>
+#include <map>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -351,6 +353,22 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     reader_ct.push_back(args.synthesize_gate ? 1u : 0u);  // fill cb_w with gate_scale in L1 vs read DRAM
     reader_ct.push_back(gate_scale_bits);                 // bf16 pair, the in-kernel gate fill value
 
+    // Slab (per-SP-shard) K: bake invP's divisors as reader defines (only when a slab layout is present, so
+    // the contiguous path emits no defines -> byte-identical reader binary). cl_t = (chunk/ring)/TILE_WIDTH
+    // per-shard slab in tiles; the kernel maps logical tile L -> L + c*SLAB_DELTA_T - shard*SLAB_K_T.
+    // ring_size/chunk/T are all hashed, so SLAB_DELTA_T is a pure compile-time constant (no per-dispatch arg).
+    std::map<std::string, std::string> reader_defines;
+    if (args.has_slab()) {
+        const uint32_t ring = args.slab->ring_size;
+        const uint32_t chunk_tiles = args.slab->chunk_size / tt::constants::TILE_WIDTH;
+        const uint32_t cl_t = chunk_tiles / ring;  // per-shard slab width in tiles
+        reader_defines["SLAB_ENABLE"] = "1";
+        reader_defines["SLAB_RING"] = std::to_string(ring);
+        reader_defines["SLAB_CHUNK_LOCAL_T"] = std::to_string(cl_t);
+        reader_defines["SLAB_K_T"] = std::to_string(cl_t * (ring - 1));
+        reader_defines["SLAB_DELTA_T"] = std::to_string((Tt - chunk_tiles) / ring);
+    }
+
     std::vector<uint32_t> writer_ct = common_ct;
     const uint32_t out_elem_bytes = out.element_size();  // bf16 today
     // row-major page = one output row: T scores, or nblocks block-scores when pooling.
@@ -370,7 +388,10 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     auto reader_id = tt::tt_metal::CreateKernel(
-        program, kdir + "reader_indexer_score.cpp", core_ranges, tt::tt_metal::ReaderDataMovementConfig(reader_ct));
+        program,
+        kdir + "reader_indexer_score.cpp",
+        core_ranges,
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct, reader_defines));
     auto writer_id = tt::tt_metal::CreateKernel(
         program, kdir + "writer_indexer_score.cpp", core_ranges, tt::tt_metal::WriterDataMovementConfig(writer_ct));
     auto compute_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -49,6 +49,25 @@ constexpr uint32_t fused_stream_k = get_compile_time_arg_val(mc_ct_base + 9);
 constexpr uint32_t synthesize_gate = get_compile_time_arg_val(mc_ct_base + 10);
 constexpr uint32_t gate_scale_bits = get_compile_time_arg_val(mc_ct_base + 11);  // bf16 pair (two per word)
 
+// Slab (per-SP-shard) K layout: the gathered cache stores each SP shard's per-chunk slab back-to-back, so
+// logical token tile L physically lives at invP(L). invP, in tiles, is page = L + c*SLAB_DELTA_T - g*SLAB_K_T,
+// with q = L/SLAB_CHUNK_LOCAL_T (= g*ring + c), g = q/SLAB_RING, c = q%SLAB_RING. The factory bakes the
+// divisors as compile-time defines (SLAB_CHUNK_LOCAL_T / SLAB_RING / SLAB_K_T / SLAB_DELTA_T) only when a slab
+// layout is present (ring_size > 1), so the contiguous path emits no defines and SLAB_KTILE is the identity
+// -> byte-identical reader binary. Reading K in logical order keeps the causal mask + block-max-pool (both
+// keyed on the logical column) unchanged and yields score columns in natural token order.
+#ifdef SLAB_ENABLE
+inline uint32_t slab_logical_to_physical_ktile(uint32_t logical_ktile) {
+    const uint32_t q = logical_ktile / SLAB_CHUNK_LOCAL_T;
+    const uint32_t shard = q / SLAB_RING;
+    const uint32_t c = q - shard * SLAB_RING;
+    return logical_ktile + c * SLAB_DELTA_T - shard * SLAB_K_T;
+}
+#define SLAB_KTILE(L) slab_logical_to_physical_ktile(L)
+#else
+#define SLAB_KTILE(L) (L)
+#endif
+
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
 struct McastDir {
     uint32_t role;            // McastRole: none (DRAM read), sender (read + mcast), receiver (wait for mcast)
@@ -243,12 +262,14 @@ inline void read_k_chunk(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
             for (uint32_t k_col = 0; k_col < k_tiles_in_unit; ++k_col) {
+                // SLAB_KTILE: identity for contiguous K; invP(logical seq tile) for the per-SP-shard slab layout.
+                const uint32_t seq_tile = SLAB_KTILE(k_tile_start + k_col);
                 for (uint32_t dim_tile = 0; dim_tile < head_dim_tiles; ++dim_tile) {
                     noc.async_read(
                         k_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         k_tile_bytes,
-                        {.page_id = k_batch_page_offset + (k_tile_start + k_col) * head_dim_tiles + dim_tile},
+                        {.page_id = k_batch_page_offset + seq_tile * head_dim_tiles + dim_tile},
                         {});
                     ptr += k_tile_bytes;
                 }
@@ -269,12 +290,13 @@ inline void read_k_chunk_streaming(Noc noc, const KAcc& k_acc, uint32_t k_tile_s
         uint32_t ptr = cb.get_write_ptr();
         for (uint32_t c = cbase; c < c_end; ++c) {
             if (c < k_tiles_in_unit) {
+                const uint32_t seq_tile = SLAB_KTILE(k_tile_start + c);  // identity unless slab layout
                 for (uint32_t d = 0; d < head_dim_tiles; ++d) {
                     noc.async_read(
                         k_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         k_tile_bytes,
-                        {.page_id = (k_tile_start + c) * head_dim_tiles + d},
+                        {.page_id = seq_tile * head_dim_tiles + d},
                         {});
                     ptr += k_tile_bytes;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -49,23 +49,27 @@ constexpr uint32_t fused_stream_k = get_compile_time_arg_val(mc_ct_base + 9);
 constexpr uint32_t synthesize_gate = get_compile_time_arg_val(mc_ct_base + 10);
 constexpr uint32_t gate_scale_bits = get_compile_time_arg_val(mc_ct_base + 11);  // bf16 pair (two per word)
 
-// Slab (per-SP-shard) K layout: the gathered cache stores each SP shard's per-chunk slab back-to-back, so
-// logical token tile L physically lives at invP(L). invP, in tiles, is page = L + c*SLAB_DELTA_T - g*SLAB_K_T,
-// with q = L/SLAB_CHUNK_LOCAL_T (= g*ring + c), g = q/SLAB_RING, c = q%SLAB_RING. The factory bakes the
-// divisors as compile-time defines (SLAB_CHUNK_LOCAL_T / SLAB_RING / SLAB_K_T / SLAB_DELTA_T) only when a slab
-// layout is present (ring_size > 1), so the contiguous path emits no defines and SLAB_KTILE is the identity
-// -> byte-identical reader binary. Reading K in logical order keeps the causal mask + block-max-pool (both
-// keyed on the logical column) unchanged and yields score columns in natural token order.
-#ifdef SLAB_ENABLE
-inline uint32_t slab_logical_to_physical_ktile(uint32_t logical_ktile) {
-    const uint32_t q = logical_ktile / SLAB_CHUNK_LOCAL_T;
-    const uint32_t shard = q / SLAB_RING;
-    const uint32_t c = q - shard * SLAB_RING;
-    return logical_ktile + c * SLAB_DELTA_T - shard * SLAB_K_T;
+// Block-cyclic (per-SP-shard) K layout: the gathered cache stores each SP shard's per-chunk slab back-to-back,
+// so logical token tile L physically lives at invP(L). invP, in tiles, is
+// page = L + shard*BC_SHARD_STRIDE_GAP - slab*BC_SLAB_STRIDE_GAP, with block_idx = L/BC_CHUNK_LOCAL_T,
+// slab = block_idx/BC_SP (which global chunk), shard = block_idx%BC_SP (which SP shard). The factory bakes the
+// divisors as compile-time defines (BC_CHUNK_LOCAL_T / BC_SP / BC_SHARD_STRIDE_GAP / BC_SLAB_STRIDE_GAP) only
+// when a block-cyclic layout is present (sp > 1), so the contiguous path emits no defines and BC_KTILE is the
+// identity -> byte-identical reader binary. Reading K in logical order keeps the causal mask + block-max-pool
+// (both keyed on the logical column) unchanged and yields score columns in natural token order.
+#ifdef BC_ENABLE
+// TODO: unify with ttnn.transformer.sparse_sdpa's logical_to_chunked_physical (sparse_sdpa_gather.hpp) -- same
+// block-cyclic invP; share via a common header later (units differ: tiles here, rows there).
+inline uint32_t logical_to_chunked_physical(
+    uint32_t logical, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
+    const uint32_t block_idx = logical / chunk_local;
+    const uint32_t slab = block_idx / sp;          // which global chunk (high part)
+    const uint32_t shard = block_idx - slab * sp;  // which SP shard within the chunk (low part)
+    return logical + shard * shard_stride_gap - slab * slab_stride_gap;
 }
-#define SLAB_KTILE(L) slab_logical_to_physical_ktile(L)
+#define BC_KTILE(L) logical_to_chunked_physical(L, BC_CHUNK_LOCAL_T, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP)
 #else
-#define SLAB_KTILE(L) (L)
+#define BC_KTILE(L) (L)
 #endif
 
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
@@ -262,8 +266,8 @@ inline void read_k_chunk(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
             for (uint32_t k_col = 0; k_col < k_tiles_in_unit; ++k_col) {
-                // SLAB_KTILE: identity for contiguous K; invP(logical seq tile) for the per-SP-shard slab layout.
-                const uint32_t seq_tile = SLAB_KTILE(k_tile_start + k_col);
+                // BC_KTILE: identity for contiguous K; invP(logical seq tile) for the per-SP-shard block-cyclic layout.
+                const uint32_t seq_tile = BC_KTILE(k_tile_start + k_col);
                 for (uint32_t dim_tile = 0; dim_tile < head_dim_tiles; ++dim_tile) {
                     noc.async_read(
                         k_acc,
@@ -290,7 +294,7 @@ inline void read_k_chunk_streaming(Noc noc, const KAcc& k_acc, uint32_t k_tile_s
         uint32_t ptr = cb.get_write_ptr();
         for (uint32_t c = cbase; c < c_end; ++c) {
             if (c < k_tiles_in_unit) {
-                const uint32_t seq_tile = SLAB_KTILE(k_tile_start + c);  // identity unless slab layout
+                const uint32_t seq_tile = BC_KTILE(k_tile_start + c);  // identity unless block-cyclic layout
                 for (uint32_t d = 0; d < head_dim_tiles; ++d) {
                     noc.async_read(
                         k_acc,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -62,6 +62,19 @@ void bind_indexer_score(nb::module_& mod) {
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis (Sq = q seq len). None = linear device order
                 (1 on a single device, so chunk_start_idx is used as-is).
+            slab_sp: optional int. The SP the K cache slab was gathered across --
+                i.e. the cache's OWN sequence-parallel degree, independent of how
+                this op splits Q. The gathered [B,1,T,D] k is then in per-SP-shard
+                slab (block-cyclic) physical order, and the reader reads it back in
+                natural token order (invP per tile) so scores come out token-ordered
+                and the causal mask/pool stay exact. Unset (or 1) = contiguous K (no
+                remap). Pair with slab_chunk_size. NOT derived from the mesh -- the
+                cache's slab is decoupled from this op's parallelization (e.g. an
+                SP=8 cache, slab_sp=8, scored by an SP=32 indexer with a smaller Sq).
+            slab_chunk_size: optional int, REQUIRED with slab_sp. The global prefill
+                chunk granularity in tokens (e.g. 5120); the cache's per-shard slab
+                width is slab_chunk_size / slab_sp. Must be divisible by slab_sp with
+                a tile-aligned per-shard width, divide T, and be >= Sq.
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
@@ -75,7 +88,9 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cache_batch_idx") = std::nullopt,
         nb::arg("kv_len") = std::nullopt,
-        nb::arg("cluster_axis") = std::nullopt);
+        nb::arg("cluster_axis") = std::nullopt,
+        nb::arg("slab_sp") = std::nullopt,
+        nb::arg("slab_chunk_size") = std::nullopt);
 
     ttnn::bind_function<"indexer_score_msa", "ttnn.experimental.">(
         mod,
@@ -118,6 +133,13 @@ void bind_indexer_score(nb::module_& mod) {
             cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis. None = linear device order.
+            slab_sp / slab_chunk_size: same semantics as indexer_score_dsa. slab_sp
+                = the SP the K cache slab was gathered across (the cache's own SP,
+                decoupled from this op's split) and slab_chunk_size = the global
+                chunk granularity; the reader reads the permuted cache back in
+                natural token order so the per-group scores (and the block-max-pool,
+                which pools token-contiguous blocks) come out correct. Unset =
+                contiguous K.
 
         Returns: score [B, num_groups, Sq, T_out] bf16 row-major (T_out = T, or
             T/block_size when block-max-pooling); future/pad columns/blocks -inf.
@@ -132,7 +154,9 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("block_size") = 0,
         nb::arg("program_config") = IndexerScoreProgramConfig{},
         nb::arg("compute_kernel_config") = std::nullopt,
-        nb::arg("cluster_axis") = std::nullopt);
+        nb::arg("cluster_axis") = std::nullopt,
+        nb::arg("slab_sp") = std::nullopt,
+        nb::arg("slab_chunk_size") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::indexer_score::detail

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -73,8 +73,9 @@ void bind_indexer_score(nb::module_& mod) {
             block_cyclic_chunk_local: optional int, REQUIRED with block_cyclic_sp_axis.
                 The per-shard chunk length (chunk_size_global / sp). Cross-checked
                 against q: must equal q_isl (Sq, seq sharded only on the SP axis) or
-                tp*q_isl (tp = mesh_size/sp). NOTE: the tp*q_isl case with tp>1 (seq
-                also sharded across the TP axis) is not yet supported.
+                tp*q_isl (tp = mesh_size/sp). The tp*q_isl case with tp>1 (seq sharded
+                across BOTH axes) is allowed only with cluster_axis=None (flat row-major
+                linearization over all devices); with a named cluster_axis it is rejected.
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -62,19 +62,19 @@ void bind_indexer_score(nb::module_& mod) {
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis (Sq = q seq len). None = linear device order
                 (1 on a single device, so chunk_start_idx is used as-is).
-            slab_sp: optional int. The SP the K cache slab was gathered across --
-                i.e. the cache's OWN sequence-parallel degree, independent of how
-                this op splits Q. The gathered [B,1,T,D] k is then in per-SP-shard
-                slab (block-cyclic) physical order, and the reader reads it back in
-                natural token order (invP per tile) so scores come out token-ordered
-                and the causal mask/pool stay exact. Unset (or 1) = contiguous K (no
-                remap). Pair with slab_chunk_size. NOT derived from the mesh -- the
-                cache's slab is decoupled from this op's parallelization (e.g. an
-                SP=8 cache, slab_sp=8, scored by an SP=32 indexer with a smaller Sq).
-            slab_chunk_size: optional int, REQUIRED with slab_sp. The global prefill
-                chunk granularity in tokens (e.g. 5120); the cache's per-shard slab
-                width is slab_chunk_size / slab_sp. Must be divisible by slab_sp with
-                a tile-aligned per-shard width, divide T, and be >= Sq.
+            block_cyclic_sp_axis: optional int. The MESH AXIS the K cache was striped
+                over (chunked prefill + SP all-gather leaves [B,1,T,D] k in per-SP-shard
+                slab / block-cyclic physical order). ``sp`` is DERIVED from the mesh
+                shape on that axis, so a caller cannot pass an sp that disagrees with
+                the device. The reader reads the permuted cache back in natural token
+                order (invP per tile) so scores come out token-ordered and the causal
+                mask/pool stay exact. Unset (or sp==1) = contiguous K (no remap). Pair
+                with block_cyclic_chunk_local. Interface matches ttnn.transformer.sparse_sdpa.
+            block_cyclic_chunk_local: optional int, REQUIRED with block_cyclic_sp_axis.
+                The per-shard chunk length (chunk_size_global / sp). Cross-checked
+                against q: must equal q_isl (Sq, seq sharded only on the SP axis) or
+                tp*q_isl (tp = mesh_size/sp). NOTE: the tp*q_isl case with tp>1 (seq
+                also sharded across the TP axis) is not yet supported.
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
@@ -89,8 +89,8 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("cache_batch_idx") = std::nullopt,
         nb::arg("kv_len") = std::nullopt,
         nb::arg("cluster_axis") = std::nullopt,
-        nb::arg("slab_sp") = std::nullopt,
-        nb::arg("slab_chunk_size") = std::nullopt);
+        nb::arg("block_cyclic_sp_axis") = std::nullopt,
+        nb::arg("block_cyclic_chunk_local") = std::nullopt);
 
     ttnn::bind_function<"indexer_score_msa", "ttnn.experimental.">(
         mod,
@@ -133,13 +133,13 @@ void bind_indexer_score(nb::module_& mod) {
             cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis. None = linear device order.
-            slab_sp / slab_chunk_size: same semantics as indexer_score_dsa. slab_sp
-                = the SP the K cache slab was gathered across (the cache's own SP,
-                decoupled from this op's split) and slab_chunk_size = the global
-                chunk granularity; the reader reads the permuted cache back in
-                natural token order so the per-group scores (and the block-max-pool,
-                which pools token-contiguous blocks) come out correct. Unset =
-                contiguous K.
+            block_cyclic_sp_axis / block_cyclic_chunk_local: same semantics as
+                indexer_score_dsa. block_cyclic_sp_axis = the MESH AXIS the K cache
+                was striped over (sp derived from the mesh shape on that axis) and
+                block_cyclic_chunk_local = the per-shard chunk length; the reader
+                reads the permuted cache back in natural token order so the per-group
+                scores (and the block-max-pool, which pools token-contiguous blocks)
+                come out correct. Unset = contiguous K.
 
         Returns: score [B, num_groups, Sq, T_out] bf16 row-major (T_out = T, or
             T/block_size when block-max-pooling); future/pad columns/blocks -inf.
@@ -155,8 +155,8 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("program_config") = IndexerScoreProgramConfig{},
         nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cluster_axis") = std::nullopt,
-        nb::arg("slab_sp") = std::nullopt,
-        nb::arg("slab_chunk_size") = std::nullopt);
+        nb::arg("block_cyclic_sp_axis") = std::nullopt,
+        nb::arg("block_cyclic_chunk_local") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::indexer_score::detail


### PR DESCRIPTION
## What

`indexer_score` slab-aware (per-SP-shard **block-cyclic**) K addressing for chunked prefill, with the public interface aligned to the merged `ttnn.transformer.sparse_sdpa` remap op.

Two commits:

1. **slab-aware K addressing** — a slice of #48500 (owner's full feature = slab + sub-tile kv_len + mid-slab straddle); this contains ONLY the slab (per-SP-shard block-cyclic) K addressing. Chunked prefill + SP all-gather leaves the `[B,1,T,D]` K in per-SP-shard block-cyclic physical order; the reader remaps each logical K-tile to its physical tile in-kernel (`invP` / `SLAB_KTILE`), presenting K in natural token order so the causal mask, banded multicast, and block-max-pool stay byte-identical. Reader-side address remap + host plumbing only — compute/writer/cb/work_split untouched.

2. **match sparse_sdpa's interface** (this is the follow-up work) — replace `slab_sp` + `slab_chunk_size` with **`block_cyclic_sp_axis`** + **`block_cyclic_chunk_local`**, mirroring the merged `sparse_sdpa` remap op (#48428). `sp` is **derived from the mesh** shape on the named axis (a caller cannot pass an `sp` that disagrees with the device); `chunk_local` (per-shard) is cross-checked against q (`q_isl` or `tp*q_isl`, `tp = mesh/sp`). The decoupled-SP path is dropped to match sparse_sdpa (no caller needs it). The seq-sharded-across-TP-axis case (`chunk_local == tp*q_isl, tp>1`) is guarded as not-yet-supported (indexer computes per-device `chunk_start`, which sparse_sdpa does not). Host-only: internal layout keeps the global chunk, so the reader kernel + program factory are byte-identical.

## Tests

Single-chip tests are genuinely single-chip (no faked mesh via a proxy `sp`): device-free pure-function invP-math test + real-mesh block-cyclic remap tests (DSA + MSA on an `(sp,1)` mesh, `sp` read from `block_cyclic_sp_axis`). MSA mesh tests renamed `*_msa_qb_*` → `*_qb_msa_*` so the existing multi-card CI selector `-k indexer_score_qb` collects them.

## Validation

8-chip BH box: invP math 9/9; DSA + MSA block-cyclic mesh pass; all contiguous-mesh regression tests pass; host build clean.

## Notes for reviewers

- Interface deliberately matches #48428 (`sparse_sdpa`) so the two ops that consume the same DeepSeek block-cyclic KVPE cache read identically to callers.
- Related: #48500 (owner's full feature), #48428 (`sparse_sdpa` block-cyclic remap, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/indexer-slab-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/indexer-slab-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/indexer-slab-aware)