### PR TITLE
Use float literals 0.0f, 1.0f, -1.0f 2/2

### DIFF
--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -184,8 +184,8 @@ The ``my_smoothstep_tiles`` function uses the layered abstraction pattern shown 
         for (size_t i = 0; i < vectors_per_face; i++) {
             sfpi::vFloat x = sfpi::dst_reg[i];
             sfpi::vFloat t = (x - edge0) * inv_delta;
-            v_if(t < sfpi::vConst0) { t = sfpi::vConst0; }
-            v_elseif(t > sfpi::vConst1) { t = sfpi::vConst1; }
+            v_if(t < 0.0f) { t = 0.0f; }
+            v_elseif(t > 1.0f) { t = 1.0f; }
             v_endif;
             sfpi::vFloat result = t * t * (3.0f - 2.0f * t);
             sfpi::dst_reg[i] = result;
@@ -231,13 +231,11 @@ The clamping of the intermediate value ``t`` to the [0, 1] range is implemented 
 
 .. code-block:: cpp
 
-    v_if(t < sfpi::vConst0) { t = sfpi::vConst0; }
-    v_elseif(t > sfpi::vConst1) { t = sfpi::vConst1; }
+    v_if(t < 0.0f) { t = 0.0f; }
+    v_elseif(t > 1.0f) { t = 1.0f; }
     v_endif;
 
 The ``v_if`` and ``v_elseif`` instructions perform element-wise conditional assignments on the ``vFloat`` vector ``t``. Each lane of the SIMD vector is evaluated independently. A ``v_endif`` is required to terminate the conditional block.
-
-The SFPI constants ``sfpi::vConst0`` and ``sfpi::vConst1`` are vectors with all 32 lanes set to 0.0f and 1.0f, respectively. These constants are hardware-defined, readily available for SFPI programs, and do not require manual initialization. Using these pre-defined constants is more efficient than using literal values because the SFPU operates on vectors. Literal values would require broadcasting to a vector, which adds instructions and overhead.
 
 This is analogous to conditional execution in other parallel programming models, where a mask is used to control which processing elements are active.
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sampling.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sampling.h
@@ -50,16 +50,16 @@ inline void calculate_sampling_binary_comp_first_column(
     for (int d = 0; d < ITERATIONS_FIRST_COLUMN; d++) {
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vFloat result = sfpi::vConst0;
+        sfpi::vFloat result = 0.0f;
 
         if constexpr (OP == SfpuType::le) {
-            v_if(in0 <= in1) { result = sfpi::vConst1; }
+            v_if(in0 <= in1) { result = 1.0f; }
             v_endif;
         } else if constexpr (OP == SfpuType::lt) {
-            v_if(in0 < in1) { result = sfpi::vConst1; }
+            v_if(in0 < in1) { result = 1.0f; }
             v_endif;
         } else {
-            v_if(in0 >= in1) { result = sfpi::vConst1; }
+            v_if(in0 >= in1) { result = 1.0f; }
             v_endif;
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -54,7 +54,7 @@ sfpi_inline sfpi::vFloat _swiglu_sigmoid_(sfpi::vFloat x) {
     } else {
         exp_neg_x = _sfpu_exp_21f_bf16_<true>(-x);
     }
-    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
+    sfpi::vFloat denominator = 1.0f + exp_neg_x;
     if constexpr (is_fp32_dest_acc_en) {
         return sfpu_reciprocal_iter<2>(denominator);
     } else {
@@ -87,7 +87,7 @@ inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, c
         v_endif;
 
         // up = up + 1
-        up = up + sfpi::vConst1;
+        up = up + 1.0f;
 
         // sigmoid(alpha * gate)
         sfpi::vFloat alpha_gate = gate * alpha;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This is the set of outlier files of https://github.com/tenstorrent/tt-metal/pull/48728

We can just use float literals these days

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/consts2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/consts2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsidwell/consts2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/consts2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/consts2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/consts2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/consts2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/consts2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/consts2)