### PR TITLE
[skip ci] GPT-OSS 120B unit [bh_quietbox_2]: bump job timeout 10 -> 15 min

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -316,7 +316,7 @@ models:
     wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 20
-    bh_quietbox_2: 225
+    bh_quietbox_2: 230
     bh_galaxy: 70
   unit_tier2:
     wh_llmbox: 114

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -500,7 +500,10 @@
       tier: 1
     # Blackhole
     bh_quietbox_2:
-      timeout: 10
+      # 10 min was too tight: the suite runs to ~12 min and got wall-clock
+      # killed mid-"Full MLP Pipeline" on the prefill_4096 test_decoder while
+      # all components were still passing (PCC 0.96-0.99). Bump to 15.
+      timeout: 15
       tier: 1
     bh_galaxy:
       timeout: 10


### PR DESCRIPTION
## Summary

The **GPT-OSS 120B unit tests [bh_quietbox_2]** job (Tier 1 Unit) hit the GitHub **wall-clock job timeout** on the 2026-07-02 scheduled run ([run 28567509066](https://github.com/tenstorrent/tt-metal/actions/runs/28567509066)) — not a model bug.

## Investigation

Job ran 05:40:29 → 05:52:47 (~12m) then `##[error]The action has timed out.`. It was killed mid-**"Full MLP Pipeline"** on the second (`prefill_4096`) `test_decoder` parametrization, with **every component still passing**:

| component | PCC |
|---|---|
| rope vs HF | 0.9999 |
| Low-Latency Experts | 0.983 |
| Attention | 0.963 |
| RMS Norm | 0.9999 |
| Full Decoder Layer (decode-mode variant) | 0.988 |

The first (decode-mode) `test_decoder` completed fully (`✓ Tests completed successfully: all`); the suite was killed partway through the prefill variant. The **pytest timeout (1500s) was not the limiter** — the per-job **`timeout: 10` (minutes)** budget was.

## Change

`tests/pipeline_reorg/models_unit_tests.yaml` — GPT-OSS 120B, `bh_quietbox_2`: **`timeout: 10 → 15`**. Short (+50%) bump to clear the ~12-min runtime with headroom. Other SKUs unchanged (wh_llmbox 25, wh_galaxy 40, bh_galaxy 10).

## Validation

- [x] YAML parses; resolves to `timeout: 15` for gpt-oss-120b/bh_quietbox_2.
- [ ] Dispatch the GPT-OSS 120B unit job on bh_quietbox_2 to confirm the suite finishes within 15 min. *(No `bh_quietbox_2` dispatch input readily available; simplest confirmation is the next scheduled Tier 1 Unit run, or a targeted all-model-tests dispatch.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout)