### PR TITLE
log CHUNK_START with chunk metadata before the forward

### DIFF
--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -404,22 +404,27 @@ def _lease_reclaim(d2d_in, d2d_out) -> None:
 
 def _compute_and_send(runtime, kv_cache, rank: int, c: int, inp, meta: dict, d2d_out) -> float:
     """Run one chunk: prefill into the engine-owned kv_cache, forward the output downstream (non-last
-    rank) and grant the outbound sender so it ships over fabric, log CHUNK_START. Returns the
-    compute-start epoch (NTP-comparable)."""
+    rank) and grant the outbound sender so it ships over fabric. Returns the compute-start epoch
+    (NTP-comparable). CHUNK_START is logged BEFORE the forward, with this chunk's metadata, so the
+    slot/KV-range is visible per rank even if prefill_chunk hangs. The trailing metadata is kept after
+    compute_start so the c=/compute_start= fields stay parseable (plot_pipeline_trace.py)."""
     t_start = time.time()
+    logger.info(
+        f"[pp rank {rank}] CHUNK_START c={c} compute_start={t_start:.6f} "
+        f"slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})"
+    )
     out = runtime.prefill_chunk(
         inp, kv_cache, slot_id=meta["slot_id"], actual_start=meta["actual_start"], actual_end=meta["actual_end"]
     )
     if SYNC_PER_CHUNK:
-        # Block on device completion before the send so the delta is this rank's forward alone, not the
-        # downstream-start proxy. Serializes dispatch (no overlap) — measurement runs only.
+        # Block on device completion so the delta is this rank's forward alone, not the downstream-start
+        # proxy. Serializes dispatch (no overlap) — measurement runs only.
         ttnn.synchronize_device(runtime.mesh_device)
         logger.info(f"[pp rank {rank}] CHUNK_COMPUTE c={c} compute_ms={(time.time() - t_start) * 1000.0:.3f}")
     if not runtime.config.is_last_rank:
         _d2d_send(d2d_out, out, rank, meta)  # push + free; the grant below forwards it over fabric
     if d2d_out is not None:
         d2d_out.release_fabric_links()
-    logger.info(f"[pp rank {rank}] CHUNK_START c={c} compute_start={t_start:.6f}")
     return t_start
 
 


### PR DESCRIPTION
Every rank now logs its per-chunk slot + KV-range at chunk start, before prefill_chunk, so a hung forward still leaves the chunk's metadata in the log. Metadata trails compute_start so the c=/compute_start= fields stay parseable by plot_pipeline_trace.py.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-runner-chunk-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-runner-chunk-logging)