### PR TITLE
Fix: Raise runtime_llk BH timeout from 8 to 12 minutes

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -222,7 +222,7 @@ runtime:
   unit:
     wh_n150_civ2: 226
     wh_n300_civ2: 74
-    bh_p150b_civ2: 210
+    bh_p150b_civ2: 214
     bh_p150b_civ2_viommu: 5
     bh_p100a_civ2_viommu: 74
     bh_loudbox: 20

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -92,10 +92,6 @@
   team: runtime
 
 # --- LLK + SFPI Tests ---
-# WH timeout raised from 8→12 min: full LLK+SFPI suite exceeds 8 min wall clock on wh_n150_civ2.
-# BH timeout raised from 8→12 min: #48778 - runtime_llk [bh_p150b_civ2] intermittently
-# times out at 8 min with no test failure; testing whether it's a wall-clock budget
-# issue (like the WH case above) rather than a real device hang.
 - name: runtime_llk
   # 4 tests disabled by #44767.
   disabled_llk_filter: &disabled_llk 'LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3:MeshDeviceFixture.Top32RmDevPipelineCompletes'

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -93,6 +93,9 @@
 
 # --- LLK + SFPI Tests ---
 # WH timeout raised from 8→12 min: full LLK+SFPI suite exceeds 8 min wall clock on wh_n150_civ2.
+# BH timeout raised from 8→12 min: #48778 - runtime_llk [bh_p150b_civ2] intermittently
+# times out at 8 min with no test failure; testing whether it's a wall-clock budget
+# issue (like the WH case above) rather than a real device hang.
 - name: runtime_llk
   # 4 tests disabled by #44767.
   disabled_llk_filter: &disabled_llk 'LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3:MeshDeviceFixture.Top32RmDevPipelineCompletes'
@@ -103,7 +106,7 @@
     wh_n150_civ2:
       timeout: 12
     bh_p150b_civ2:
-      timeout: 8
+      timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 


### PR DESCRIPTION
## Summary

`runtime_llk [bh_p150b_civ2]` has been intermittently timing out after 8 minutes mid-run (#48778), with no test failure and no fixed hang point — the last-running sub-test index moves between runs (index 31 in one CI run, index 38 in another). That's the signature of a marginal wall-clock budget, not a deterministic state leak or device hang: a real leak would reproducibly hang at the same test every time.

This mirrors the WH `runtime_llk` timeout raise in #46561, which hit the same symptom on `wh_n150_civ2` and was fixed the same way.

- Raise `runtime_llk` timeout for `bh_p150b_civ2` from 8 to 12 minutes.
- Bump the `runtime: unit: bh_p150b_civ2` budget in `.github/time_budget.yaml` from 210 → 214 to stay consistent with the per-job timeouts in `runtime_unit_tests.yaml`.

## Test plan

- [x] Ran `runtime-unit-tests.yaml` via `workflow_dispatch` on this branch (Blackhole only): `runtime_llk [bh_p150b_civ2]` completed successfully in ~12 minutes (previously killed at the 8-minute mark) — https://github.com/tenstorrent/tt-metal/actions/runs/28582841442

Fixes #48778

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/bump-bh-runtime-llk-timeout-12min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/bump-bh-runtime-llk-timeout-12min)