### PR TITLE
#48793: adjust firmware timeout for functional sim

### DIFF
--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -59,6 +59,11 @@ bool mock_firmware_sources_available_for(tt::ARCH arch) {
 }
 
 int firmware_wait_timeout_ms() {
+    // Default timeout for real silicon.
+    constexpr int kDefaultTimeoutMs = 10'000;
+    // Functional sim (.so) is slower than silicon; sometimes 10s is not enough, so use half a minute.
+    constexpr int kFunctionalSimTimeoutMs = 30'000;
+
     const auto& rtoptions = MetalContext::instance().rtoptions();
     if (rtoptions.get_simulator_enabled()) {
         // RTL sim directory backends are event-driven and much slower than functional ttsim (.so).
@@ -66,10 +71,9 @@ int firmware_wait_timeout_ms() {
         if (rtoptions.get_simulator_path().extension() != ".so") {
             return 0;
         }
-        // for functional sim, sometimes 10s is not enough, use half a minute.
-        return 30000;
+        return kFunctionalSimTimeoutMs;
     }
-    return 10000;
+    return kDefaultTimeoutMs;
 }
 
 }  // namespace

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -60,10 +60,14 @@ bool mock_firmware_sources_available_for(tt::ARCH arch) {
 
 int firmware_wait_timeout_ms() {
     const auto& rtoptions = MetalContext::instance().rtoptions();
-    // RTL sim directory backends are event-driven and much slower than functional ttsim (.so).
-    // llrt treats timeout_ms==0 on sim as infinite wait.
-    if (rtoptions.get_simulator_enabled() && rtoptions.get_simulator_path().extension() != ".so") {
-        return 0;
+    if (rtoptions.get_simulator_enabled()) {
+        // RTL sim directory backends are event-driven and much slower than functional ttsim (.so).
+        // llrt treats timeout_ms==0 on sim as infinite wait.
+        if (rtoptions.get_simulator_path().extension() != ".so") {
+            return 0;
+        }
+        // for functional sim, sometimes 10s is not enough, use half a minute.
+        return 30000;
     }
     return 10000;
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #48793 

Under some circumstances I had to wait 15s on funcitonal sim. Adjusted timeout to have 2x margin.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-48793_firmware_init_timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-48793_firmware_init_timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-48793_firmware_init_timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-48793_firmware_init_timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-48793_firmware_init_timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-48793_firmware_init_timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-48793_firmware_init_timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-48793_firmware_init_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-48793_firmware_init_timeout)