### PR TITLE
docs(exabox): make the validation/recover workflow agent-friendly and Confluence-sourced

### DIFF
--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -1,5 +1,7 @@
 # BH Galaxy Exabox Validation
 
+> **Important — for the latest recommendations and step-by-step guides, use Confluence: [Exabox DCAMP Bringup](https://tenstorrent.atlassian.net/wiki/spaces/Exabox/pages/2509373472).** Those pages are the source of truth and are kept current for the full workflow — preflight, validation, fabric tests, dispatch tests, `recover.sh`, and troubleshooting/escalation. This README is a summary and may lag.
+
 Scripts for validating Blackhole Galaxy Exabox clusters before running workloads.
 
 ## Quick Reference
@@ -211,33 +213,63 @@ If these tests fail, raise the issue in the `#exabox-infra` Slack channel and ta
 
 ## Quick Health Check (For Developers)
 
-For day-to-day use when you just need to verify a cluster is working.
+For day-to-day use when you just need to verify a cluster is working. `recover.sh` runs a distributed `tt-smi` reset, then cluster validation, then (on unrecoverable failure) auto-regenerates a degraded descriptor set — ~2 minutes end to end. Latest guidance: [Reference — Recover.sh](https://tenstorrent.atlassian.net/wiki/spaces/Exabox/pages/2509373523/Reference+Recover.sh+Quick+Reset+Validate) on Confluence.
 
-**Important: These scripts require a local build!**
+**Before you run (prerequisites):**
 
-Unlike the Docker-based qualification scripts above (`run_validation.sh`, `run_fabric_tests.sh`), the recovery scripts run binaries directly on the host and require you to build tt-metal first.
+- **Preflight must pass first** — chips visible (`tt-smi -l` shows 32 per host) and links up. Don't run `recover.sh` on a cluster that hasn't cleared preflight.
+- **Passwordless SSH to every host** via agent forwarding (see [SSH Setup](#ssh-setup)).
+- **MPI must reach all hosts.** Seed host keys and confirm reachability before running — this is the #1 cause of `recover.sh` hanging:
+  ```bash
+  export HOSTS=<comma-separated-hosts>
+  echo "$HOSTS" | tr ',' '\n' | xargs -I{} sh -c 'ssh-keyscan -H {} >> ~/.ssh/known_hosts 2>/dev/null'
+  mpirun --host "$HOSTS" hostname   # prints each hostname; if it hangs or prompts, fix SSH first
+  ```
 
-| Script Type | Requires Build? | Uses Docker? |
-|-------------|----------------|--------------|
-| `recover_*.sh` | **Yes** | No |
-| `run_validation.sh` | No | Yes |
-| `run_fabric_tests.sh` | No | Yes |
+**On Exabox, always run from the vetted pre-built path — no image, nothing to compile:**
+```bash
+cd /data/local-syseng-manual/tt-metal-recover
+./tools/scaleout/exabox/recover.sh --hosts <hosts> --mpi-if ens5f0np0
+# or for 8x16 configuration:
+./tools/scaleout/exabox/recover.sh --hosts <hosts> --config 8x16 --mpi-if ens5f0np0
+```
 
-**Build first:**
+This is the path everyone should use for a quick health check — it's already built and kept current, so you don't need to clone or build anything. (On another site the NIC name differs, so drop `--mpi-if` to auto-detect, or pin the right interface.)
+
+Look for `All Detected Links are healthy` in the output. No banner means it isn't done.
+
+**Rules — do / don't:**
+
+DO:
+- **Always run from the vetted path** `/data/local-syseng-manual/tt-metal-recover` — pre-built, no image needed.
+- **Pin the MPI interface** with `--mpi-if ens5f0np0` on Exabox (other sites: check `ip link`, or omit `--mpi-if` to auto-detect).
+- **If a run fails, power-cycle the affected hosts via `#bmc-bots` and re-run** before escalating — this clears most transient stalls and hangs.
+- **Confirm `All Detected Links are healthy`** before calling it done.
+
+DON'T:
+- **Don't run from your own checkout** (`/data/<user>/tt-metal`) unless you specifically need to test a local change — use the vetted path.
+- **Don't reach for image-based or hand-built runs** unless the vetted path can't do what you need.
+- **Don't flash or update firmware** on cluster machines — ever. They run debug FW (see [Do NOT Update Firmware on Cluster Machines](./TROUBLESHOOTING.md#do-not-update-firmware-on-cluster-machines)).
+- **Don't power-cycle on your own** — go through `#bmc-bots` (coordinate with the infra/cloud cluster managers).
+- **Don't combine `--skip-reset` with `--skip-validation`** — `recover.sh` fails fast with `Error: cannot use both --skip-reset and --skip-validation` (you must keep at least one of reset or validation).
+- **Don't declare success without the healthy-links banner.**
+
+**These scripts run a local build, not Docker.** Unlike the Docker-based qualification scripts above (`run_validation.sh`, `run_fabric_tests.sh`), the recovery scripts run binaries directly on the host, so a build has to exist somewhere. The vetted path above already provides one; only build tt-metal yourself if you're running from your own checkout (e.g. to test a local change) or on a site without the vetted path.
+
+| Script Type | Uses Docker? | Where the build comes from |
+|-------------|--------------|----------------------------|
+| `recover_*.sh` | No | Vetted pre-built path (Exabox), or your own `build_metal.sh` |
+| `run_validation.sh` | Yes | Docker image |
+| `run_fabric_tests.sh` | Yes | Docker image |
+
+**Building your own (only if not using the vetted path):**
 ```bash
 ./create_venv.sh
 source python_env/bin/activate
 ./build_metal.sh --build-metal-tests
 ```
 
-**Then run:**
-```bash
-./tools/scaleout/exabox/recover.sh --hosts <hosts>
-# or for 8x16 configuration:
-./tools/scaleout/exabox/recover.sh --hosts <hosts> --config 8x16
-```
-
-Look for `All Detected Links are healthy` in the output. If you see `could not access or execute an executable`, see [Recovery Script Fails](./TROUBLESHOOTING.md#recovery-script-fails-with-could-not-access-or-execute-an-executable).
+If you see `could not access or execute an executable`, the build is missing — use the vetted path or build first. See [Recovery Script Fails](./TROUBLESHOOTING.md#recovery-script-fails-with-could-not-access-or-execute-an-executable).
 
 **Tolerating missing cables:** by default, recovery fails if any expected cable is missing — either with `Encountered unrecoverable state` after 5 retrain attempts, or by early-exiting after a successful retrain without sending traffic. To validate the rest of the cluster when one or more cables are down, forward `--min-connections N` (relaxed mode, ASIC pair passes if it has at least N connections) via `--validation-args` and/or pass `--rerun-on-retrain` (rerun validation after a successful retrain so traffic actually runs).
 

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -235,14 +235,15 @@ Node: bh-glx-d01u08
 while attempting to start process rank 0.
 ```
 
-**Cause**: The `recover_*.sh` scripts run binaries directly on the host (not via Docker) and require a local build of tt-metal. Unlike the Docker-based scripts (`run_validation.sh`, `run_fabric_tests.sh`), they don't use containers.
+**Cause**: The `recover_*.sh` scripts run binaries directly on the host (not via Docker), so a local tt-metal build has to exist. This error means you ran from a checkout that hasn't been built. Unlike the Docker-based scripts (`run_validation.sh`, `run_fabric_tests.sh`), they don't use containers.
 
-**Solution**:
+**Solution** (simplest first):
 
-- **Build tt-metal first** - See [Quick Health Check](./README.md#quick-health-check-for-developers) for build instructions
-- **Or use Docker-based validation** - Run `./run_validation.sh --hosts <hosts> --image <docker-image>` which doesn't require a build
+- **On Exabox, run from the vetted pre-built path** - `cd /data/local-syseng-manual/tt-metal-recover` and run `recover.sh` from there. It's already built, so there's nothing to compile. This is the recommended path for a quick health check.
+- **Build tt-metal yourself** - only needed if you're running from your own checkout or on a site without the vetted path. See [Quick Health Check](./README.md#quick-health-check-for-developers) for build instructions.
+- **Or use Docker-based validation** - run `./run_validation.sh --hosts <hosts> --image <docker-image>`, which doesn't require a build.
 
-**Common confusion**: People often confuse the `recover_*.sh` scripts (developer tools, require build) with the `run_validation.sh` script (operator tool, uses Docker). For hardware qualification, use the Docker-based scripts.
+**Common confusion**: People often confuse the `recover_*.sh` scripts (run a local build directly on the host) with the `run_validation.sh` script (operator tool, uses Docker). For hardware qualification, use the Docker-based scripts.
 
 ---
 


### PR DESCRIPTION
## Summary
Repo docs told devs to build tt-metal before `recover.sh` and never mentioned the
vetted pre-built path — the opposite of the workflow we push in Confluence. This
aligns the docs and adds a fail-fast host guard.

should solve issues like these:
https://tenstorrent.atlassian.net/browse/DIIM-144?focusedCommentId=608376

## Changes
- **README/TROUBLESHOOTING**: lead with the vetted path (`/data/local-syseng-manual/tt-metal-recover`), demote build-your-own/image runs to fallbacks, add prerequisites + DO/DON'T, and point to [Confluence](https://tenstorrent.atlassian.net/wiki/spaces/Exabox/pages/2509373472) as source of truth.
- **Guard**: `check_duplicate_hosts` (new `utils/host_utils.sh`) wired into all four run scripts — `run_dispatch_tests.sh` was missing it. Rejects duplicate `--hosts` up front instead of corrupting MPI ranks and failing cryptically.

## Agent-friendly
One ordered path (prereqs → run → verify banner), explicit DON'Ts, and fail-fast errors agents/automation can act on.

## Testing

Given prompt to claude "how do i run recover.sh on my machine, research it" now I'm getting output of:
```
Always run from the pre-built vetted build. Nothing to clone or compile:

cd /data/local-syseng-manual/tt-metal-recover
./tools/scaleout/exabox/recover.sh --hosts "$HOSTS" --mpi-if ens5f0np0
```

Previously the same prompt did give output of
```
Build tt-metal (required for recover.sh):
./create_venv.sh
source python_env/bin/activate
./build_metal.sh --build-metal-tests
Running it
From the repo root, pass a comma-separated host list. Default config is 4x32:

./tools/scaleout/exabox/recover.sh --hosts <hosts>
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/exadocs_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/exadocs_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/exadocs_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/exadocs_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/exadocs_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/exadocs_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/exadocs_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/exadocs_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/exadocs_update)