### PR TITLE
[indexer_score] mid-slab-boundary straddle

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1616,6 +1616,72 @@ def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_erro
         ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, cluster_axis=0, **kw)
 
 
+# ---- Mid-slab-boundary STRADDLE (drives the need for the straddle geometry, #48500 slice #2) ----
+# A NON-slab-aligned chunk_start makes each device's queries cross a cache-slab boundary, so the causal
+# diagonal must JUMP by (chunk_global - cl) at q-row (cl - offset). Scaled-down stand-in for the maxedge
+# iter2 case in test_mla (iters_isl=[2560,2592,5120] -> chunk_start 5152, offset 32): here sp=2,
+# chunk_global=1280, cl=640, chunk_start=704 (= cumulative 384+320) -> offset 64 (2 tiles), so q-tiles 18-19
+# straddle. The CURRENT op has no straddle (linear diagonal) -> this FAILS until the straddle is carved in.
+ST_CHUNK = 1280  # global chunk (tokens); per-shard cl = ST_CHUNK/sp
+ST_CS = 704  # mid-slab chunk_start (704 % 640 = 64 offset); the 384+320 cumulative of the maxedge stand-in
+ST_T = 3840  # cache length: whole chunks (3*1280) covering the fullest device's straddled window
+
+
+def _straddle_ref(q_g, k_nat, w_g, sp, chunk_global, chunk_start, t_len):
+    """Per-SP-rank straddled reference over natural-order K, mirroring the op's deduce_causal_geometry /
+    update_padded_kv_cache rotation. Device r's q-row 0 sits at base = chunk_start + r*Sq; with offset =
+    base % cl, rows >= (cl - offset) jump by (chunk_global - cl)."""
+    heads, gq = q_g.shape[1], q_g.shape[2]
+    sq = gq // sp  # per-device query rows
+    cl = chunk_global // sp
+    refs = []
+    for r in range(sp):
+        base = chunk_start + r * sq
+        offset = base % cl
+        straddle_row = cl - offset
+        sl = slice(r * sq, (r + 1) * sq)
+        qh, kh, wh = q_g[:, :, sl, :].float(), k_nat[:, 0].float(), w_g[:, :, sl, :].float()
+        score = torch.zeros(1, sq, t_len)
+        for h in range(heads):
+            score += torch.relu(qh[:, h] @ kh.transpose(-2, -1)) * wh[:, h]
+        s = torch.arange(sq)
+        pos = base + s + torch.where(s >= straddle_row, chunk_global - cl, 0)  # straddled natural position
+        future = torch.arange(t_len).unsqueeze(0) > pos.unsqueeze(1)
+        refs.append(score.masked_fill(future, float("-inf")).unsqueeze(1))
+    return torch.cat(refs, dim=2)
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 1)], ids=["sp2"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_straddle(mesh_device, case_id, heads):
+    """Mid-slab-boundary straddle on a REAL sp=2 mesh: block-cyclic K + a non-slab-aligned chunk_start (704,
+    offset 64) makes each device's queries straddle a slab boundary, so the causal diagonal must jump by
+    (chunk_global - cl) at q-row (cl - offset). This FAILS on the current op (linear diagonal, wrong -inf map);
+    the straddle geometry carved from #48500 makes it pass. Scaled stand-in for maxedge iter2 (test_mla)."""
+    sp = 2
+    q_g, k_nat, w_g = _global_inputs(heads, ST_CHUNK, ST_T, seed=42)
+    k_bc = _to_slab(k_nat, sp, ST_CHUNK)
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        chunk_start_idx=ST_CS,  # explicit, mid-slab -> offset 64
+        cluster_axis=0,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=ST_CHUNK // sp,
+        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
+    ref = _straddle_ref(q_g, k_nat, w_g, sp, ST_CHUNK, ST_CS, ST_T)
+    assert_indexer_match(out_t, ref, ST_CHUNK, ST_T, check_neg=True)
+
+
 @pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
 def test_indexer_score_qb_msa_block_cyclic(mesh_device):
     """MSA (raw dot, constant scale, num_groups=1) over a REAL SP=4 block-cyclic K cache: sp read from

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1625,6 +1625,7 @@ def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_erro
 ST_CHUNK = 1280  # global chunk (tokens); per-shard cl = ST_CHUNK/sp
 ST_CS = 704  # mid-slab chunk_start (704 % 640 = 64 offset); the 384+320 cumulative of the maxedge stand-in
 ST_T = 3840  # cache length: whole chunks (3*1280) covering the fullest device's straddled window
+ST_MSA_T = 5120  # block-pool straddle cache: 4*1280 whole chunks AND a whole number of k_chunk=1024 (bs=128)
 
 
 def _straddle_ref(q_g, k_nat, w_g, sp, chunk_global, chunk_start, t_len):
@@ -1648,6 +1649,35 @@ def _straddle_ref(q_g, k_nat, w_g, sp, chunk_global, chunk_start, t_len):
         pos = base + s + torch.where(s >= straddle_row, chunk_global - cl, 0)  # straddled natural position
         future = torch.arange(t_len).unsqueeze(0) > pos.unsqueeze(1)
         refs.append(score.masked_fill(future, float("-inf")).unsqueeze(1))
+    return torch.cat(refs, dim=2)
+
+
+def _straddle_msa_pooled_ref(q_g, k_nat, sp, chunk_global, chunk_start, t_len, scale, block_size):
+    """Per-SP-rank straddled MSA block-pool reference: raw dot (NO relu), constant `scale` gate, head-summed,
+    causal-masked over the STRADDLED natural position, then block-max-pooled with the forced-local +inf stamp
+    on each query's OWN (straddled) block. Mirrors _straddle_ref but for the block-pool path the writer's
+    forced-local straddle jump lives on -- concatenated per-SP-rank along seq. cl / chunk_global / block_size
+    are block-aligned, so a slab boundary is also a block boundary and the jump moves whole blocks."""
+    heads = q_g.shape[1]
+    sq = q_g.shape[2] // sp
+    cl = chunk_global // sp
+    nb = t_len // block_size
+    refs = []
+    for r in range(sp):
+        base = chunk_start + r * sq
+        offset = base % cl
+        straddle_row = cl - offset
+        sl = slice(r * sq, (r + 1) * sq)
+        qh, kh = q_g[:, :, sl, :].float(), k_nat[:, 0].float()
+        score = torch.zeros(1, sq, t_len)
+        for h in range(heads):
+            score += (qh[:, h] @ kh.transpose(-2, -1)) * scale  # MSA: raw dot, no relu
+        s = torch.arange(sq)
+        pos = base + s + torch.where(s >= straddle_row, chunk_global - cl, 0)  # straddled natural position
+        future = torch.arange(t_len).unsqueeze(0) > pos.unsqueeze(1)
+        pooled = score.masked_fill(future, float("-inf")).reshape(1, sq, nb, block_size).amax(dim=-1)
+        pooled[:, torch.arange(sq), pos // block_size] = float("inf")  # forced-local: own straddled block
+        refs.append(pooled.unsqueeze(1))
     return torch.cat(refs, dim=2)
 
 
@@ -1709,6 +1739,40 @@ def test_indexer_score_qb_msa_block_cyclic(mesh_device):
     out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
     ref = _msa_per_sp_ref(q_g, k_nat, QB_SP, QB_HISTORY)
     assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 1)], ids=["sp2"], indirect=True)
+def test_indexer_score_qb_msa_block_cyclic_straddle(mesh_device):
+    """Mid-slab-boundary straddle on the MSA BLOCK-POOL path (real sp=2 mesh): block-cyclic K + a non-slab-
+    aligned chunk_start (704, offset 64) makes each device's queries straddle a slab boundary. The DSA straddle
+    test above covers the compute-side causal diagonal (full-strip write); THIS pins the writer's block-pool
+    forced-local +inf stamp, which must jump to the query's OWN block ACROSS the boundary -- a path the DSA
+    (write_strip) test never exercises. Fails on the pre-straddle op (linear diagonal -> +inf stamped on the
+    wrong block)."""
+    sp = 2
+    bs = BLOCK_POOL_BS  # 128; cl (640) / chunk_global (1280) / bs all block-aligned -> jump moves whole blocks
+    q_g, k_nat, _ = _global_inputs(M3_QB_HEADS, ST_CHUNK, ST_MSA_T, seed=42)
+    k_bc = _to_slab(k_nat, sp, ST_CHUNK)
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        chunk_start_idx=ST_CS,  # explicit, mid-slab -> offset 64 -> straddle
+        cluster_axis=0,
+        scale=M3_QB_SCALE,
+        num_groups=1,
+        block_size=bs,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=ST_CHUNK // sp,
+        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
+    ref = _straddle_msa_pooled_ref(q_g, k_nat, sp, ST_CHUNK, ST_CS, ST_MSA_T, M3_QB_SCALE, bs)
+    assert_pooled_match(out_t, ref, 1, ST_CHUNK, ST_MSA_T // bs, pcc_floor=0.995)
 
 
 def test_indexer_score_rejects_partial_block_cyclic_args(device, expect_error):

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1628,7 +1628,7 @@ ST_T = 3840  # cache length: whole chunks (3*1280) covering the fullest device's
 
 
 def _straddle_ref(q_g, k_nat, w_g, sp, chunk_global, chunk_start, t_len):
-    """Per-SP-rank straddled reference over natural-order K, mirroring the op's deduce_causal_geometry /
+    """Per-SP-rank straddled reference over natural-order K, mirroring the op's device_causal_geometry /
     update_padded_kv_cache rotation. Device r's q-row 0 sits at base = chunk_start + r*Sq; with offset =
     base % cl, rows >= (cl - offset) jump by (chunk_global - cl)."""
     heads, gq = q_g.shape[1], q_g.shape[2]

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -52,13 +52,14 @@ constexpr uint32_t writer_straddle_jump_tiles = 1 + 9;
 
 // Per-device causal geometry for the block-cyclic slab layout, all in tiles. Each device scores Sq queries;
 // on a mesh device r's q-row 0 sits at chunk_start_idx + r*Sq. When those Sq queries cross a CACHE slab
-// boundary (a multiple of cl = the cache's per-shard width = chunk_size/ring_size), the post-boundary q-rows
-// live in the next slab, so the causal diagonal JUMPS by (chunk_size - cl) tiles at q-row (cl - offset).
-// offset == 0, or Sq fitting inside one slab (offset + Sq <= cl), leaves the diagonal linear -- the common
-// chunk-aligned case and any re-split where Sq divides cl. No slab -> plain linear, no straddle. sp is
-// derived from the mesh, so a slab implies a real mesh; the straddle is always evaluated when present
-// (validate_slab guarantees Sq <= cl, so a device crosses at most one boundary). Shared by create_at
-// (device_index from the coordinate) and override (stored device_index).
+// boundary (a multiple of cl = the cache's per-shard width = block_cyclic->chunk_local), the post-boundary
+// q-rows live in the next slab, so the causal diagonal JUMPS by (chunk_global - cl) tiles at q-row
+// (cl - offset), where chunk_global = sp * chunk_local. offset == 0, or Sq fitting inside one slab
+// (offset + Sq <= cl), leaves the diagonal linear -- the common chunk-aligned case and any re-split where Sq
+// divides cl. No block_cyclic -> plain linear, no straddle. sp is derived from the mesh, so a slab implies a
+// real mesh; the straddle is always evaluated when present (validate_block_cyclic guarantees Sq <= cl, so a
+// device crosses at most one boundary). Shared by create_at (device_index from the coordinate) and override
+// (stored device_index).
 struct DeviceCausalGeometry {
     uint32_t chunk_start_tiles;    // global position of this device's q-row 0 (tiles)
     uint32_t straddle_q_tile;      // q-tile-row at/after which the diagonal jumps (only when this device straddles)
@@ -68,11 +69,11 @@ inline DeviceCausalGeometry device_causal_geometry(
     const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
     const uint32_t TW = tt::constants::TILE_WIDTH;
     const uint32_t chunk_start = args.chunk_start_idx + device_index * Sq;
-    if (!args.slab.has_value()) {
+    if (!args.block_cyclic.has_value()) {
         return {chunk_start / TW, 0u, 0u};  // contiguous K -> linear diagonal, never straddles
     }
-    const uint32_t cl = args.slab->chunk_size / args.slab->ring_size;  // cache per-shard slab width (elements)
-    const uint32_t chunk_global = args.slab->chunk_size;
+    const uint32_t cl = args.block_cyclic->chunk_local;  // cache per-shard slab width (elements)
+    const uint32_t chunk_global = args.block_cyclic->sp * args.block_cyclic->chunk_local;
     const uint32_t offset = chunk_start % cl;  // position within the cache slab
     uint32_t straddle_q_tile = 0, straddle_jump_tiles = 0;
     if (offset != 0 && offset + Sq > cl) {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -34,6 +34,8 @@ constexpr uint32_t reader_q_addr = 0;
 constexpr uint32_t reader_k_addr = 1;
 constexpr uint32_t reader_w_addr = 2;
 constexpr uint32_t compute_chunk_start_tiles = 7;  // after 6 sched scalars + kv_len[6]
+constexpr uint32_t compute_straddle_q_tile = 8;    // mid-slab boundary-chip diagonal jump (q-tile-row)
+constexpr uint32_t compute_straddle_jump_tiles = 9;
 constexpr uint32_t writer_out_addr = 0;
 // Persistent-cache args, appended after each kernel's schedule/mcast args (hash-excluded, re-patched on a hit).
 constexpr uint32_t reader_num_scalars = 3 + 6;  // q/k/w addrs + schedule {row_group0..max_bands}
@@ -44,12 +46,40 @@ constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;             
 constexpr uint32_t compute_kv_len_tiles = 6;     // after the 6 schedule scalars {row_group0..max_bands}
 constexpr uint32_t writer_kv_len_tiles = 1 + 6;  // out_addr + the 6 schedule scalars {row_group0..max_bands}
 constexpr uint32_t writer_chunk_start_tiles = 1 + 7;  // after out_addr + 6 sched scalars + kv_len[7]; match writer
+constexpr uint32_t writer_straddle_q_tile = 1 + 8;    // mid-slab forced-local block jump (block-pool only)
+constexpr uint32_t writer_straddle_jump_tiles = 1 + 9;
 }  // namespace rt_arg
 
-// Per-device chunk_start (tiles): (base + rank*Sq) / TILE_WIDTH. Shared by create_at (device_index from
-// the coordinate) and override (stored device_index).
-inline uint32_t chunk_start_tiles_for(const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
-    return (args.chunk_start_idx + device_index * Sq) / tt::constants::TILE_WIDTH;
+// Per-device causal geometry for the block-cyclic slab layout, all in tiles. Each device scores Sq queries;
+// on a mesh device r's q-row 0 sits at chunk_start_idx + r*Sq. When those Sq queries cross a CACHE slab
+// boundary (a multiple of cl = the cache's per-shard width = chunk_size/ring_size), the post-boundary q-rows
+// live in the next slab, so the causal diagonal JUMPS by (chunk_size - cl) tiles at q-row (cl - offset).
+// offset == 0, or Sq fitting inside one slab (offset + Sq <= cl), leaves the diagonal linear -- the common
+// chunk-aligned case and any re-split where Sq divides cl. No slab -> plain linear, no straddle. sp is
+// derived from the mesh, so a slab implies a real mesh; the straddle is always evaluated when present
+// (validate_slab guarantees Sq <= cl, so a device crosses at most one boundary). Shared by create_at
+// (device_index from the coordinate) and override (stored device_index).
+struct DeviceCausalGeometry {
+    uint32_t chunk_start_tiles;    // global position of this device's q-row 0 (tiles)
+    uint32_t straddle_q_tile;      // q-tile-row at/after which the diagonal jumps (only when this device straddles)
+    uint32_t straddle_jump_tiles;  // diagonal jump in tiles (0 unless this device straddles)
+};
+inline DeviceCausalGeometry device_causal_geometry(
+    const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
+    const uint32_t TW = tt::constants::TILE_WIDTH;
+    const uint32_t chunk_start = args.chunk_start_idx + device_index * Sq;
+    if (!args.slab.has_value()) {
+        return {chunk_start / TW, 0u, 0u};  // contiguous K -> linear diagonal, never straddles
+    }
+    const uint32_t cl = args.slab->chunk_size / args.slab->ring_size;  // cache per-shard slab width (elements)
+    const uint32_t chunk_global = args.slab->chunk_size;
+    const uint32_t offset = chunk_start % cl;  // position within the cache slab
+    uint32_t straddle_q_tile = 0, straddle_jump_tiles = 0;
+    if (offset != 0 && offset + Sq > cl) {
+        straddle_q_tile = (cl - offset) / TW;
+        straddle_jump_tiles = (chunk_global - cl) / TW;
+    }
+    return {chunk_start / TW, straddle_q_tile, straddle_jump_tiles};
 }
 
 // This device's linearized SP-ring index; 0 on a single device (no coordinate lookup needed).
@@ -106,7 +136,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     // This device's SP-ring index and chunk_start (tiles), from the coordinate. chunk_t is a compute RUNTIME
     // arg, so the binary is identical across coords and steps.
     const uint32_t device_index = device_index_for(args, coord, q);
-    const uint32_t chunk_t = chunk_start_tiles_for(args, device_index, Sq);
+    const auto geom = device_causal_geometry(args, device_index, Sq);
+    const uint32_t chunk_t = geom.chunk_start_tiles;
 
     const uint32_t Sqt = Sq / tt::constants::TILE_HEIGHT;
     const uint32_t Tt = T / tt::constants::TILE_WIDTH;
@@ -484,15 +515,19 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
             reader_rt.push_back(k_batch_page_offset);
             reader_rt.push_back(kv_len_tiles);
             tt::tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
-            // compute: schedule[0-5], then kv_len_tiles[6] + chunk_start_tiles[7] (both hash-excluded runtime).
+            // compute: schedule[0-5], kv_len_tiles[6], chunk_start_tiles[7], straddle[8,9] (hash-excluded runtime).
             std::vector<uint32_t> compute_rt(sched.begin(), sched.end());
-            compute_rt.push_back(kv_len_tiles);  // slot [6]
-            compute_rt.push_back(chunk_t);       // slot [7]
+            compute_rt.push_back(kv_len_tiles);              // slot [6]
+            compute_rt.push_back(chunk_t);                   // slot [7]
+            compute_rt.push_back(geom.straddle_q_tile);      // slot [8], mid-slab boundary-chip diagonal jump
+            compute_rt.push_back(geom.straddle_jump_tiles);  // slot [9]
             tt::tt_metal::SetRuntimeArgs(program, compute_id, core, compute_rt);
             std::vector<uint32_t> writer_rt = {out.buffer()->address()};
             writer_rt.insert(writer_rt.end(), sched.begin(), sched.end());
-            writer_rt.push_back(kv_len_tiles);  // slot [7], after out_addr + the 6 schedule scalars
-            writer_rt.push_back(chunk_t);       // slot [8], per-device chunk-start (tiles); block-pool forced-local
+            writer_rt.push_back(kv_len_tiles);              // slot [7], after out_addr + the 6 schedule scalars
+            writer_rt.push_back(chunk_t);                   // slot [8], per-device chunk-start (tiles); forced-local
+            writer_rt.push_back(geom.straddle_q_tile);      // slot [9], mid-slab forced-local block jump (pool only)
+            writer_rt.push_back(geom.straddle_jump_tiles);  // slot [10]
             tt::tt_metal::SetRuntimeArgs(program, writer_id, core, writer_rt);
         }
     }
@@ -540,7 +575,8 @@ void IndexerScoreProgramFactory::override_runtime_arguments(
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, shared.reader_kernel);
         auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, shared.compute_kernel);
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, shared.writer_kernel);
-        const uint32_t chunk_t = chunk_start_tiles_for(args, shared.device_index, Sq);
+        const auto geom = device_causal_geometry(args, shared.device_index, Sq);
+        const uint32_t chunk_t = geom.chunk_start_tiles;
         for (const auto& core : shared.worker_cores) {
             auto& reader_rt = reader_args[core.x][core.y];
             patch_arg(reader_rt, rt_arg::reader_q_addr, tensors.q.buffer()->address(), "reader.q_addr");
@@ -550,9 +586,29 @@ void IndexerScoreProgramFactory::override_runtime_arguments(
             patch_arg(reader_rt, rt_arg::reader_kv_len_tiles, kv_len_tiles, "reader.kv_len_tiles");
             patch_arg(compute_args[core.x][core.y], rt_arg::compute_kv_len_tiles, kv_len_tiles, "compute.kv_len_tiles");
             patch_arg(compute_args[core.x][core.y], rt_arg::compute_chunk_start_tiles, chunk_t, "compute.chunk_start");
+            patch_arg(
+                compute_args[core.x][core.y],
+                rt_arg::compute_straddle_q_tile,
+                geom.straddle_q_tile,
+                "compute.straddle_q_tile");
+            patch_arg(
+                compute_args[core.x][core.y],
+                rt_arg::compute_straddle_jump_tiles,
+                geom.straddle_jump_tiles,
+                "compute.straddle_jump_tiles");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_out_addr, out.buffer()->address(), "writer.out_addr");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_kv_len_tiles, kv_len_tiles, "writer.kv_len_tiles");
             patch_arg(writer_args[core.x][core.y], rt_arg::writer_chunk_start_tiles, chunk_t, "writer.chunk_start");
+            patch_arg(
+                writer_args[core.x][core.y],
+                rt_arg::writer_straddle_q_tile,
+                geom.straddle_q_tile,
+                "writer.straddle_q_tile");
+            patch_arg(
+                writer_args[core.x][core.y],
+                rt_arg::writer_straddle_jump_tiles,
+                geom.straddle_jump_tiles,
+                "writer.straddle_jump_tiles");
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -395,16 +395,22 @@ inline void block_max_pool_batched(uint32_t unit_strip) {
     acc.pop_front(unit_strip);
 }
 
-/** Stamp the causal -inf mask onto row r's masked suffix [valid, KC) in place (empty when fully valid). */
+/** Stamp the causal -inf mask onto row r's masked suffix [valid, KC) in place (empty when fully valid).
+ *  straddle_* shift the diagonal on the mid-slab boundary chip (0 elsewhere); see causal_diag_tile. */
 inline void stamp_masked_suffix(
     const WorkUnitSpan& span,
     uint32_t q_row,
     uint32_t slot_base,
     uint32_t k_tiles_in_unit,
-    uint32_t chunk_start_tiles) {
+    uint32_t chunk_start_tiles,
+    uint32_t straddle_q_tile,
+    uint32_t straddle_jump_tiles) {
     const uint32_t k_tile0 = span.k_tile_start();
-    const uint32_t diag_tile = chunk_start_tiles + span.q_tile_start() + q_row;
-    const uint32_t valid = row_valid_prefix(span.q_tile_start() + q_row, k_tile0, k_tiles_in_unit, chunk_start_tiles);
+    const uint32_t q_row_abs = span.q_tile_start() + q_row;
+    const uint32_t diag_tile =
+        iscore::causal_diag_tile(q_row_abs, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
+    const uint32_t valid =
+        row_valid_prefix(q_row_abs, k_tile0, k_tiles_in_unit, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
     for (uint32_t k_col = valid; k_col < k_tiles_per_unit; ++k_col) {
         stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, k_tile0 + k_col, diag_tile);
     }
@@ -425,6 +431,10 @@ void kernel_main() {
     const uint32_t kv_len_tiles = get_arg_val<uint32_t>(6);
     // Per-device chunk-start offset (tiles); runtime so distinct values reuse one program.
     const uint32_t chunk_start_tiles = get_arg_val<uint32_t>(7);
+    // Mid-slab boundary-chip diagonal straddle (tiles): q-rows >= straddle_q_tile jump by straddle_jump_tiles.
+    // Both 0 on every non-boundary device and in the chunk-aligned case, leaving the diagonal linear.
+    const uint32_t straddle_q_tile = get_arg_val<uint32_t>(8);
+    const uint32_t straddle_jump_tiles = get_arg_val<uint32_t>(9);
     if (num_groups == 0 || num_bands == 0) {
         return;
     }
@@ -508,7 +518,14 @@ void kernel_main() {
                     // Matmul left srcA in k's format; the mask copies a bf16 -inf tile -> reconfig srcA to bf16.
                     reconfig_data_format_srca(cb_k, cb_mask);
                     for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-                        stamp_masked_suffix(span, r, r * k_tiles_per_unit, k_tiles_in_unit, chunk_start_tiles);
+                        stamp_masked_suffix(
+                            span,
+                            r,
+                            r * k_tiles_per_unit,
+                            k_tiles_in_unit,
+                            chunk_start_tiles,
+                            straddle_q_tile,
+                            straddle_jump_tiles);
                     }
                     acc.push_back(unit_strip);
                 } else {
@@ -536,7 +553,14 @@ void kernel_main() {
                             accumulate_row_streaming(q_row, slot_base);
                         }
 
-                        stamp_masked_suffix(span, q_row, slot_base, k_tiles_in_unit, chunk_start_tiles);
+                        stamp_masked_suffix(
+                            span,
+                            q_row,
+                            slot_base,
+                            k_tiles_in_unit,
+                            chunk_start_tiles,
+                            straddle_q_tile,
+                            straddle_jump_tiles);
                     }
                     acc.push_back(unit_strip);
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -70,10 +70,17 @@ constexpr uint32_t k_chunk_tiles = k_tiles_per_unit * head_dim_tiles;           
 
 // Thin wrapper binding the shared work-split formula to this kernel's CT dims: unmasked prefix
 // k-tiles of absolute q-tile-row q_row_abs in a unit. chunk_start_tiles is the per-device runtime
-// chunk-start offset (in tiles); the compute kernel reads it from a runtime arg.
+// chunk-start offset (in tiles); straddle_* carry the mid-slab boundary-chip diagonal jump (0 otherwise).
+// All three are compute-kernel runtime args.
 inline uint32_t row_valid_prefix(
-    uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit, uint32_t chunk_start_tiles) {
-    return iscore::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
+    uint32_t q_row_abs,
+    uint32_t k_tile_start,
+    uint32_t k_tiles_in_unit,
+    uint32_t chunk_start_tiles,
+    uint32_t straddle_q_tile,
+    uint32_t straddle_jump_tiles) {
+    return iscore::valid_prefix_tiles(
+        q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
 }
 
 /** (group, band) cell cursor. group = absolute q-row-group index; band = absolute k-band index; the

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
@@ -18,11 +18,25 @@ namespace ttnn::operations::experimental::indexer_score {
 // Future/diagonal tiles are computed and masked to -inf in-band (see valid_prefix_tiles); cost is
 // negligible at high sp_rank (~2x only near sp~0).
 
+/** This q-tile-row's causal diagonal tile (the k-tile holding key == query). Normally chunk_start_tiles +
+ *  q_row_abs, but on the mid-slab BOUNDARY chip the q-rows straddle a slab boundary: rows at/after
+ *  straddle_q_tile jump by straddle_jump_tiles (the global K gap between the two slabs the chip spans).
+ *  straddle_jump_tiles == 0 (every non-boundary device, and the chunk-aligned case) leaves it linear. */
+constexpr uint32_t causal_diag_tile(
+    uint32_t q_row_abs, uint32_t chunk_start_tiles, uint32_t straddle_q_tile, uint32_t straddle_jump_tiles) {
+    return chunk_start_tiles + q_row_abs + (q_row_abs >= straddle_q_tile ? straddle_jump_tiles : 0);
+}
+
 /** Unmasked prefix k-tiles of q-tile-row q_row_abs in a unit (start k_tile_start, k_tiles_in_unit
  *  valid). Tiles [0, this) are below the diagonal (no mask); diagonal and beyond are masked. */
 constexpr uint32_t valid_prefix_tiles(
-    uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit, uint32_t chunk_start_tiles) {
-    const uint32_t diag_tile = chunk_start_tiles + q_row_abs;
+    uint32_t q_row_abs,
+    uint32_t k_tile_start,
+    uint32_t k_tiles_in_unit,
+    uint32_t chunk_start_tiles,
+    uint32_t straddle_q_tile,
+    uint32_t straddle_jump_tiles) {
+    const uint32_t diag_tile = causal_diag_tile(q_row_abs, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
     const uint32_t v = diag_tile > k_tile_start ? diag_tile - k_tile_start : 0;
     return v < k_tiles_in_unit ? v : k_tiles_in_unit;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -66,7 +66,9 @@ inline void write_pooled_strip(
     uint32_t q_seq_row0,
     uint32_t col_off_blocks,
     uint32_t valid_blocks,
-    uint32_t chunk_start_keys) {
+    uint32_t chunk_start_keys,
+    uint32_t straddle_q_keys,
+    uint32_t straddle_jump_keys) {
     CircularBuffer cb(cb_out_strip);
     cb.wait_front(blocks_per_unit);
     volatile tt_l1_ptr uint16_t* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_read_ptr());
@@ -88,10 +90,13 @@ inline void write_pooled_strip(
     }
 
     // Forced-local block (sparse_local_block=1): force each query's own block to +inf so top-k always
-    // keeps it. Query (q_seq_row0 + rr)'s block = (chunk_start_keys + q_seq_row0 + rr) / POOL_BLOCK_KEYS;
-    // stamp only when it lands in this unit's [col_off_blocks, +valid).
+    // keeps it. Query (q_seq_row0 + rr)'s block = (q_pos) / POOL_BLOCK_KEYS, where q_pos =
+    // chunk_start_keys + q_seq_row0 + rr plus the mid-slab boundary-chip straddle jump (0 otherwise, so the
+    // common case is unchanged); stamp only when it lands in this unit's [col_off_blocks, +valid).
     for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
-        const uint32_t local_block = (chunk_start_keys + q_seq_row0 + rr) / POOL_BLOCK_KEYS;
+        const uint32_t q_seq = q_seq_row0 + rr;
+        const uint32_t q_pos = chunk_start_keys + q_seq + (q_seq >= straddle_q_keys ? straddle_jump_keys : 0);
+        const uint32_t local_block = q_pos / POOL_BLOCK_KEYS;
         if (local_block >= col_off_blocks && local_block < col_off_blocks + valid_blocks) {
             scratch[rr * valid_blocks + (local_block - col_off_blocks)] = POOL_POS_INF_BF16;
         }
@@ -124,6 +129,9 @@ void kernel_main() {
     // [8] per-device chunk-start (tiles); runtime so distinct values reuse one program. Only the block-pool
     // forced-local stamp uses it; always set.
     const uint32_t chunk_start_keys = get_arg_val<uint32_t>(8) * tt::constants::TILE_WIDTH;
+    // [9],[10] mid-slab boundary-chip forced-local block jump (keys); both 0 off the boundary chip.
+    const uint32_t straddle_q_keys = get_arg_val<uint32_t>(9) * tt::constants::TILE_WIDTH;
+    const uint32_t straddle_jump_keys = get_arg_val<uint32_t>(10) * tt::constants::TILE_WIDTH;
 
     constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 1>();
     const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
@@ -153,7 +161,15 @@ void kernel_main() {
                     const uint32_t page_row_start = plane_row0 + q_seq_row0;
                     if constexpr (block_pool) {
                         write_pooled_strip(
-                            noc, out_acc, page_row_start, q_seq_row0, col_off_blocks, valid_blocks, chunk_start_keys);
+                            noc,
+                            out_acc,
+                            page_row_start,
+                            q_seq_row0,
+                            col_off_blocks,
+                            valid_blocks,
+                            chunk_start_keys,
+                            straddle_q_keys,
+                            straddle_jump_keys);
                     } else {
                         write_strip(noc, out_acc, page_row_start, k_tile0, valid_w);
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -90,12 +90,13 @@ inline void write_pooled_strip(
     }
 
     // Forced-local block (sparse_local_block=1): force each query's own block to +inf so top-k always
-    // keeps it. Query (q_seq_row0 + rr)'s block = (q_pos) / POOL_BLOCK_KEYS, where q_pos =
-    // chunk_start_keys + q_seq_row0 + rr plus the mid-slab boundary-chip straddle jump (0 otherwise, so the
-    // common case is unchanged); stamp only when it lands in this unit's [col_off_blocks, +valid).
+    // keeps it. Query (q_seq_row0 + rr)'s block = q_pos / POOL_BLOCK_KEYS, where q_pos is the diagonal key
+    // position -- causal_diag_tile evaluated in KEYS (all args key units; the straddle jump is applied for
+    // the mid-slab boundary chip, 0 otherwise so the common case is unchanged). Stamp only when it lands in
+    // this unit's [col_off_blocks, +valid).
     for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
         const uint32_t q_seq = q_seq_row0 + rr;
-        const uint32_t q_pos = chunk_start_keys + q_seq + (q_seq >= straddle_q_keys ? straddle_jump_keys : 0);
+        const uint32_t q_pos = iscore::causal_diag_tile(q_seq, chunk_start_keys, straddle_q_keys, straddle_jump_keys);
         const uint32_t local_block = q_pos / POOL_BLOCK_KEYS;
         if (local_block >= col_off_blocks && local_block < col_off_blocks + valid_blocks) {
             scratch[rr * valid_blocks + (local_block - col_off_blocks)] = POOL_POS_INF_BF16;


### PR DESCRIPTION
## What

Adds the **mid-slab-boundary straddle** to `indexer_score` — the causal-diagonal jump for when a device's queries cross a cache-slab boundary because the block-cyclic K cache is scored from a **non-slab-aligned `chunk_start`**.

## Changes

- **`work_split.hpp`** — `causal_diag_tile()`: the diagonal jumps by `chunk_global − cl` at q-row `cl − offset`.
- **`compute` / `common` kernels** — thread `straddle_q_tile` / `straddle_jump_tiles` through the score compute.
- **`writer` kernel** — the block-pool forced-local stamp jumps by the straddle.
- **`program_factory`** — `device_causal_geometry` computes the offset / straddle when a slab is present. No `mid_slab_boundary` flag: sp is mesh-derived, so a slab implies a real mesh (single-chip has sp=1 → no slab). Contiguous / non-straddle path is byte-identical (straddle args 0 → linear diagonal).
- **Test** — `test_indexer_score_qb_straddle`: real sp=2 mesh, block-cyclic K, non-slab-aligned `chunk_start=704` (offset 64) so each device's queries straddle a slab boundary. Fails on the pre-straddle op (linear diagonal → wrong `-inf` map). Scaled stand-in for the `maxedge` iter2 case in `test_mla` (`iters_isl=[2560,2592,5120]` → `chunk_start 5152`, offset 32).

## Why

On power-of-2 meshes topology alone can't produce a straddle (`Sq | cl` always); the only trigger is a **non-slab-aligned `chunk_start`** — the padded multi-turn chunked-prefill case (old KV tile-aligned but not slab-aligned; new tokens rotated to the boundary chip), the GLM-5.1 target.

**Not included** (separate #48500 slices): sub-tile `kv_len`, the `mid_slab_boundary` param.

## Validation

8-chip BH, on the carved commits **before** the rebase onto merged #48772: `test_indexer_score_qb_straddle` PASS (glm5 + dsv32); regression `-k "indexer_score_qb or invp_math or partial_block_cyclic"` = 23 passed, 0 failed. Rebase onto merged #48772 was textually clean; re-verification against merged main is left to CI.

Related: #48500 (full feature), #48772 (block-cyclic interface, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/indexer-straddle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/indexer-straddle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/indexer-straddle) -> conv1d failing no correlation with indexer
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/indexer-straddle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/indexer-straddle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/indexer-straddle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/indexer-straddle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/indexer-straddle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/indexer-straddle)
