### PR TITLE
[Gemma4] Add GEMMA4_MAX_TOKENS_ALL_USERS override for KV-cache pool size

### DIFF
--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -143,6 +143,21 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         # hybrid ``SlidingWindowSpec`` path.
         self._bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", "0") != "0"
 
+    @classmethod
+    def get_max_tokens_all_users(cls, model_name: str = "", **kwargs) -> int:
+        # The all-user KV-cache pool size is a per-device / per-model tuning knob,
+        # not a model constant: with hybrid KV groups disabled every layer
+        # allocates a full-length KV buffer, so the pool that fits in DRAM is
+        # hardware-specific (e.g. ~49K on QB2/P300x2 for 31B, ~131K for 12B).
+        # Keep that value OUT of the model code — set ``GEMMA4_MAX_TOKENS_ALL_USERS``
+        # from the tt-inference-server model spec's per-device ``env_vars`` block
+        # (gated there by device + model). This generic, value-free hook just
+        # honors that override and otherwise defers to the default.
+        override = os.environ.get("GEMMA4_MAX_TOKENS_ALL_USERS")
+        if override:
+            return int(override)
+        return super().get_max_tokens_all_users(model_name=model_name, **kwargs)
+
     def _maybe_disable_pli_prefill_trace(self, enable_trace: bool, batch_size: int = 1) -> bool:
         return maybe_disable_pli_prefill_trace(enable_trace, self.model[0], batch_size=batch_size)
 


### PR DESCRIPTION
## What

Adds a `get_max_tokens_all_users` hook to `Gemma4ForCausalLM` that honors a
`GEMMA4_MAX_TOKENS_ALL_USERS` environment override (set per-device from the
tt-inference-server model spec) and otherwise defers to the default. One file,
+15 lines.

## Why

Follow-up to #48283, which disabled the hybrid KV-cache groups
(`_HYBRID_KV_CACHE_GROUPS_ENABLED = False`, emit `FullAttentionSpec` for all
layers → a single KV group). That fix removed the ~1/6 pool-split ceiling, but
it also means **every layer now allocates a full-length KV buffer**, so the
all-user pool that fits in DRAM becomes hardware/model-specific and the default
`FALLBACK_MAX_TOKENS_ALL_USERS = 131072` no longer fits on smaller boards.

Concretely on QB2 (2× P300, P300X2) with **gemma-4-31b-it**:
- Per-token KV (60 layers × 16 KV heads × 256 head-dim × 2 (K+V) × bf16) ≈ 0.94 MiB.
- Default 131,072-token pool → ~120 GiB KV + ~58 GiB weights = ~178 GiB, which
  **exceeds the board's ~128 GB DRAM → OOM at KV allocation**.
- The env override lets the spec cap the pool (49,152 for 31B) without hardcoding
  a board-specific constant in model code. 12B fits the default (~131K), so it
  sets no override.

## Verified on QB2 (this change + #48283)

Booting gemma-4-31b-it with `GEMMA4_MAX_TOKENS_ALL_USERS=49152`:

```
Getting max_tokens_all_users=49152 ... from Gemma4ForCausalLM
Overriding num_gpu_blocks ... with num_gpu_blocks_override=769   (769 × 64 = 49,216)
GPU KV cache size: 49,216 tokens
Maximum concurrency for 49,152 tokens per request: 1.00x
```

Before (without disable+override): `GPU KV cache size: 23,168 tokens`,
`Maximum concurrency ... 0.51x` — a single full-length request could not be
admitted (32K input stayed at Running:0/Waiting:1 indefinitely). After: single
group, full 49,152-token pool, a full-length request is admittable.

## Notes / follow-up

- This is the DRAM-bounded ceiling for all-full-attention on QB2 (49K for 31B),
  not the 128K target. Restoring sliding-window savings to reach 128K needs
  vLLM token-chunked prefill + the metal-side `chunk_start_idx` path (tracked
  separately; see #48289).
- The override commit was originally authored on the #48283 branch after that PR
  merged, so it needs this dedicated PR to land on `main`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dwadhwani/gemma4-max-tokens-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dwadhwani/gemma4-max-tokens-override)