### PR TITLE
fix(bge_m3): handle transformers 5.x bare-Tensor layer return in PCC test

### DIFF
--- a/models/demos/wormhole/bge_m3/tests/pcc/test_transformer_block.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/test_transformer_block.py
@@ -66,7 +66,11 @@ def test_transformer_block_vs_hf_first_layer(device, first_layer_artifacts, seq_
     hidden_states = torch.randn((BATCH_SIZE, seq_len, HIDDEN_SIZE), dtype=torch.bfloat16)
 
     with torch.no_grad():
-        reference_output = hf_layer(hidden_states=hidden_states, attention_mask=None)[0].unsqueeze(1).to(torch.float32)
+        hf_result = hf_layer(hidden_states=hidden_states, attention_mask=None)
+        # transformers < 5.0 returns a tuple[Tensor], while >= 5.0 returns a bare Tensor.
+        # Unwrap the tuple form without indexing into the batch dim of the bare Tensor.
+        hf_hidden_states = hf_result[0] if isinstance(hf_result, tuple) else hf_result
+        reference_output = hf_hidden_states.unsqueeze(1).to(torch.float32)
 
     tt_block = BgeM3TransformerBlock(
         args=args,


### PR DESCRIPTION
## Problem

Nightly N150 `bge_m3` (`test_ci_dispatch[bge_m3]`) fails at `test_transformer_block.py::test_transformer_block_vs_hf_first_layer[S128]`:

```
RuntimeError: output with shape [128, 1, 1024] doesn't match the broadcast shape [1, 128, 128, 1024]
```

The error is **host-side** in `comp_allclose` (`models/common/utility_functions.py`), not on device — the HF reference tensor and the TT output have incompatible shapes.

## Root cause

`transformers` **5.x** changed `XLMRobertaLayer.forward` to return a bare `torch.Tensor` instead of `tuple[Tensor]` (as in ≤4.57). The test unwrapped the result with `[0]`:

```python
reference_output = hf_layer(...)[0].unsqueeze(1)
```

- transformers ≤4.57 (tuple return): `[0]` unwraps the tuple → `(1,128,1024)` → unsqueeze → `[1,1,128,1024]` ✓ matches TT output
- transformers ≥5.0 (bare Tensor): `[0]` indexes **row 0**, dropping the batch dim → `(128,1024)` → unsqueeze → `[128,1,1024]` ✗

This is CI-environment drift: `tt_metal/python_env/requirements-dev.txt` pins `transformers==4.53.0`, but CI now runs transformers 5.x (its `utils/loading_report.py` "LOAD REPORT" log line, present only in 5.x, appears in the failing job; `models/demos/gemma4/requirements.txt` also pins `transformers==5.5.0`). The test passes locally on 4.57.x, which is why the failure is environment-dependent.

## Fix

Unwrap the layer output defensively so it produces `(1,1,128,1024)` under both return conventions:

```python
hf_result = hf_layer(hidden_states=hidden_states, attention_mask=None)
hf_hidden_states = hf_result[0] if isinstance(hf_result, tuple) else hf_result
reference_output = hf_hidden_states.unsqueeze(1).to(torch.float32)
```

Only this test used the fragile `[0]` slice; `test_model.py` uses `.last_hidden_state` and is unaffected.

## Verification

- Simulated the reference-extraction logic in isolated venvs for transformers **4.53.0** (tuple) and **5.5.0** (bare Tensor) — both yield `reference_output` shape `(1,1,128,1024)`.
- Ran the real on-device test locally: `test_transformer_block_vs_hf_first_layer[S128]` **passes**.

## Follow-up (not in this PR)

The transformers pin (`4.53.0` in `requirements-dev.txt`) is not what CI actually enforces (base image / `gemma4` pull in 5.x). Worth reconciling the pins so the test environment is deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/bge_m3_investigation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/bge_m3_investigation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rmillerTT/bge_m3_investigation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/bge_m3_investigation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/bge_m3_investigation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/bge_m3_investigation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/bge_m3_investigation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/bge_m3_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/bge_m3_investigation)