### PR TITLE
[Cleanup] Migrate data_movement roll/concat/scatter/fill_pad to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_writer_block_sharded_concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_writer_block_sharded_concat.cpp
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 // Dual-RISC block-sharded concat kernel.
 // Used as both reader (BRISC/NOC0) and writer (NCRISC/NOC1) with the host
@@ -20,6 +23,7 @@
 void kernel_main() {
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(0);
 
+    Noc noc;
     CircularBuffer output_cb(output_cb_id);
     uint32_t dst_base = output_cb.get_write_ptr();
 
@@ -39,15 +43,21 @@ void kernel_main() {
 
         CircularBuffer src_cb(src_cb_id);
         uint32_t src_l1_addr = src_cb.get_read_ptr() + src_l1_offset;
-        uint64_t src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, src_l1_addr);
         uint32_t dst_addr = dst_base + dst_offset;
 
+        UnicastEndpoint src;
         for (uint32_t row = 0; row < num_rows; row++) {
-            noc_async_read(src_noc_addr, dst_addr, copy_size);
-            src_noc_addr += src_stride;
+            CoreLocalMem<uint32_t> dst(dst_addr);
+            noc.async_read(
+                src,
+                dst,
+                copy_size,
+                {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = src_l1_addr},
+                {.offset_bytes = 0});
+            src_l1_addr += src_stride;
             dst_addr += dst_stride;
         }
     }
 
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp
@@ -49,17 +49,17 @@ void kernel_main() {
     const uint32_t num_work = get_arg_val<uint32_t>(3);
     const uint32_t local_right_col = get_arg_val<uint32_t>(4);
 
-    // get_noc_addr(addr) encodes the local core's physical NOC coordinates
-    // automatically — no need to call my_x[]/my_y[] directly.
+    // The UnicastEndpoint below carries this core's own physical NOC
+    // coordinates (my_x[]/my_y[]) so each read targets local L1.
 
     constexpr uint32_t row_stride_bytes = W_tiles * tile_bytes;
 
     Noc noc;
     CircularBuffer cb_data_in(cb_data_in_idx);
 
-    // Local-L1 self-read: no address-generator trait is applicable, so fall back
-    // to raw noc_async_read(get_noc_addr(addr), ...). CB reservations and the
-    // read barrier still go through the experimental API.
+    // Local-L1 self-read via the Noc wrapper's UnicastEndpoint form: no
+    // address-generator trait is applicable, so the endpoint carries explicit
+    // noc_x/noc_y/addr. CB reservations and the read barrier use the Device 2.0 API.
 
     if (has_bottom_pad_core) {
         // ---- Mode B: right non-corner tiles, then full bottom row ----

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
@@ -79,9 +79,9 @@ void kernel_main() {
     // ---- Phase 2: write-back loop ----
     // Tiles arrive in the same order as the reader and compute kernels.
     //
-    // Local-L1 self-write: no address-generator trait is applicable, so fall back
-    // to raw noc_async_write(..., get_noc_addr(addr), ...). CB wait/pop and the
-    // writes-flushed barrier still go through the experimental API.
+    // Local-L1 self-write via the Noc wrapper's UnicastEndpoint form: no
+    // address-generator trait is applicable, so the endpoint carries explicit
+    // noc_x/noc_y/addr. CB wait/pop and the writes-flushed barrier use the Device 2.0 API.
 
     if (has_bottom_pad_core) {
         // ---- Mode B ----

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp
@@ -4,7 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 // Native sharded roll copy kernel — supports both L1-sharded and DRAM-sharded tensors.
 //
@@ -60,6 +63,8 @@ void kernel_main() {
     CircularBuffer scratch_cb(scratch_cb_id);
     const uint32_t scratch_base = scratch_cb.get_write_ptr();
 
+    Noc noc;
+
     uint32_t arg_idx = 0;
 
     if constexpr (mode == 2) {
@@ -73,6 +78,8 @@ void kernel_main() {
         const uint32_t src_base[2] = {src_cbs[0].get_write_ptr(), src_cbs[1].get_write_ptr()};
         const uint32_t dst_base = dst_cb.get_write_ptr();
 
+        AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+
         const uint32_t dst_bank_id = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t dst_bank_base = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t num_src = get_arg_val<uint32_t>(arg_idx++);
@@ -80,9 +87,14 @@ void kernel_main() {
         for (uint32_t s = 0; s < num_src; s++) {
             const uint32_t bank_id = get_arg_val<uint32_t>(arg_idx++);
             const uint32_t bank_addr = get_arg_val<uint32_t>(arg_idx++);
-            noc_async_read(get_noc_addr_from_bank_id<true>(bank_id, bank_addr), src_base[s], shard_size);
+            noc.async_read(
+                dram_bank,
+                CoreLocalMem<uint32_t>(src_base[s]),
+                shard_size,
+                {.bank_id = bank_id, .addr = bank_addr},
+                {});
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
         for (uint32_t t = 0; t < num_transfers; t++) {
@@ -100,12 +112,19 @@ void kernel_main() {
             }
         }
 
-        noc_async_write(dst_base, get_noc_addr_from_bank_id<true>(dst_bank_id, dst_bank_base), shard_size);
-        noc_async_write_barrier();
+        noc.async_write(
+            CoreLocalMem<uint32_t>(dst_base),
+            dram_bank,
+            shard_size,
+            {},
+            {.bank_id = dst_bank_id, .addr = dst_bank_base});
+        noc.async_write_barrier();
 
     } else if constexpr (mode == 1) {
         // DRAM mode: source is a DRAM bank, destination is a DRAM bank.
         // Per-core header: dst_bank_id, dst_bank_base_addr.
+        AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+
         const uint32_t dst_bank_id = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t dst_bank_base = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
@@ -121,14 +140,22 @@ void kernel_main() {
 
             for (uint32_t row = 0; row < num_rows; row++) {
                 // Read tile-sized chunk from DRAM source into L1 scratch.
-                const uint64_t src_noc = get_noc_addr_from_bank_id<true>(src_bank_id, src_bank_addr);
-                noc_async_read(src_noc, scratch_base, copy_size);
-                noc_async_read_barrier();
+                noc.async_read(
+                    dram_bank,
+                    CoreLocalMem<uint32_t>(scratch_base),
+                    copy_size,
+                    {.bank_id = src_bank_id, .addr = src_bank_addr},
+                    {});
+                noc.async_read_barrier();
 
                 // Write from L1 scratch to DRAM destination.
-                const uint64_t dst_noc = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_bank_base + dst_offset);
-                noc_async_write(scratch_base, dst_noc, copy_size);
-                noc_async_write_barrier();
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(scratch_base),
+                    dram_bank,
+                    copy_size,
+                    {},
+                    {.bank_id = dst_bank_id, .addr = dst_bank_base + dst_offset});
+                noc.async_write_barrier();
 
                 src_bank_addr += src_stride;
                 dst_offset += dst_stride;
@@ -159,14 +186,18 @@ void kernel_main() {
                 const uint32_t pre_pad = off & (alignment - 1);
                 uint32_t read_size = pre_pad + copy_size;
                 read_size = (read_size + alignment - 1) & ~(alignment - 1);
-                const uint64_t noc_addr = get_noc_addr(src_noc_x, src_noc_y, src_cb_base + (off - pre_pad));
-                noc_async_read(noc_addr, half_base, read_size);
+                noc.async_read(
+                    UnicastEndpoint{},
+                    CoreLocalMem<uint32_t>(half_base),
+                    read_size,
+                    {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = src_cb_base + (off - pre_pad)},
+                    {});
                 return pre_pad;
             };
 
             uint32_t buf = 0;
             uint32_t pre = issue_read(src_l1_offset, scratch_base);
-            noc_async_read_barrier();
+            noc.async_read_barrier();
             for (uint32_t row = 0; row < num_rows; row++) {
                 const uint32_t cur_half = scratch_base + buf * scratch_half;
                 const bool has_next = (row + 1) < num_rows;
@@ -177,7 +208,7 @@ void kernel_main() {
                 }
                 local_copy(cur_half + pre, dst_base + dst_offset, copy_size);
                 if (has_next) {
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                 }
                 src_l1_offset += src_stride;
                 dst_offset += dst_stride;

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
@@ -39,21 +39,21 @@ FORCE_INLINE float perform_reduction(float input, uint16_t source_value, Scatter
 // performs scatter on data loaded to cb with load_to_cb
 template <typename index_type>
 FORCE_INLINE void scatter_along_chunk(
-    const uint32_t& input_cb,
-    const uint32_t& index_cb,
-    const uint32_t& source_cb,
-    const uint32_t& output_cb,
-    const uint32_t& fp32_temp_cb,
+    const CircularBuffer& input_cb,
+    const CircularBuffer& index_cb,
+    const CircularBuffer& source_cb,
+    const CircularBuffer& output_cb,
+    const CircularBuffer& fp32_temp_cb,
     const uint32_t& input_stick_size,
     const index_type& input_offset,
     const uint32_t& input_chunk_size,
     const uint32_t& index_chunk_size,
     const ScatterReductionType& scatter_reduction_type = ScatterReductionType::INVALID) {
-    const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
-    const uint32_t index_l1_read_addr = get_read_ptr(index_cb);
-    const uint32_t source_l1_read_addr = get_read_ptr(source_cb);
-    const uint32_t output_l1_write_addr = get_write_ptr(output_cb);
-    const uint32_t fp32_temp_l1_write_addr = get_write_ptr(fp32_temp_cb);
+    const uint32_t input_l1_read_addr = input_cb.get_read_ptr();
+    const uint32_t index_l1_read_addr = index_cb.get_read_ptr();
+    const uint32_t source_l1_read_addr = source_cb.get_read_ptr();
+    const uint32_t output_l1_write_addr = output_cb.get_write_ptr();
+    const uint32_t fp32_temp_l1_write_addr = fp32_temp_cb.get_write_ptr();
     volatile tt_l1_ptr uint16_t* input_l1_read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(input_l1_read_addr);
     volatile tt_l1_ptr index_type* index_l1_read_ptr =
         reinterpret_cast<volatile tt_l1_ptr index_type*>(index_l1_read_addr);
@@ -83,9 +83,10 @@ FORCE_INLINE void scatter_along_chunk(
 }
 
 // copies source stick to destination stick (first phase of scatter)
-FORCE_INLINE void copy_input_to_fp32_temp(uint32_t input_cb, uint32_t fp32_temp_cb, uint32_t input_chunk_size) {
-    const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
-    const uint32_t fp32_temp_l1_write_addr = get_write_ptr(fp32_temp_cb);
+FORCE_INLINE void copy_input_to_fp32_temp(
+    const CircularBuffer& input_cb, const CircularBuffer& fp32_temp_cb, uint32_t input_chunk_size) {
+    const uint32_t input_l1_read_addr = input_cb.get_read_ptr();
+    const uint32_t fp32_temp_l1_write_addr = fp32_temp_cb.get_write_ptr();
     volatile tt_l1_ptr uint16_t* input_l1_read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(input_l1_read_addr);
     volatile tt_l1_ptr float* fp32_temp_l1_write_ptr =
         reinterpret_cast<volatile tt_l1_ptr float*>(fp32_temp_l1_write_addr);
@@ -94,9 +95,10 @@ FORCE_INLINE void copy_input_to_fp32_temp(uint32_t input_cb, uint32_t fp32_temp_
     }
 }
 
-FORCE_INLINE void copy_fp32_temp_to_output(uint32_t fp32_temp_cb, uint32_t output_cb, uint32_t chunk_size) {
-    const uint32_t fp32_temp_l1_read_addr = get_read_ptr(fp32_temp_cb);
-    const uint32_t output_l1_write_addr = get_write_ptr(output_cb);
+FORCE_INLINE void copy_fp32_temp_to_output(
+    const CircularBuffer& fp32_temp_cb, const CircularBuffer& output_cb, uint32_t chunk_size) {
+    const uint32_t fp32_temp_l1_read_addr = fp32_temp_cb.get_read_ptr();
+    const uint32_t output_l1_write_addr = output_cb.get_write_ptr();
     volatile tt_l1_ptr float* fp32_temp_l1_read_ptr =
         reinterpret_cast<volatile tt_l1_ptr float*>(fp32_temp_l1_read_addr);
     volatile tt_l1_ptr uint16_t* output_l1_write_ptr =
@@ -167,7 +169,7 @@ void kernel_main() {
             input_cb.wait_front(ONE_PAGE);
             fp32_temp_cb.reserve_back(ONE_PAGE);
 
-            copy_input_to_fp32_temp(ctas.input_cb, ctas.fp32_temp_cb, input_chunk_length);
+            copy_input_to_fp32_temp(input_cb, fp32_temp_cb, input_chunk_length);
 
             if (in_bounds<N>(coord, index_dims)) {
                 const uint32_t index_stick_id = to_id<N>(coord, index_strides);
@@ -199,11 +201,11 @@ void kernel_main() {
                     index_cb.wait_front(ONE_PAGE);
                     source_cb.wait_front(ONE_PAGE);
                     scatter_along_chunk<index_std_type>(
-                        ctas.input_cb,
-                        ctas.index_cb,
-                        ctas.source_cb,
-                        ctas.output_cb,
-                        ctas.fp32_temp_cb,
+                        input_cb,
+                        index_cb,
+                        source_cb,
+                        output_cb,
+                        fp32_temp_cb,
                         ctas.input_stick_size,
                         input_offset,
                         input_chunk_length,
@@ -220,7 +222,7 @@ void kernel_main() {
             output_cb.reserve_back(ONE_PAGE);
 
             // third phase: push to the output cb with fp32->bf16 conversion
-            copy_fp32_temp_to_output(ctas.fp32_temp_cb, ctas.output_cb, input_chunk_length);
+            copy_fp32_temp_to_output(fp32_temp_cb, output_cb, input_chunk_length);
             fp32_temp_cb.pop_front(ONE_PAGE);
             output_cb.push_back(ONE_PAGE);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
@@ -14,9 +14,9 @@ namespace {
 // copies source stick to destination stick (first phase of scatter)
 template <typename number_type>
 FORCE_INLINE void copy_input_to_output(
-    const uint32_t& input_cb, const uint32_t& output_cb, const uint32_t& input_chunk_size) {
-    const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
-    const uint32_t output_l1_write_addr = get_write_ptr(output_cb);
+    const CircularBuffer& input_cb, const CircularBuffer& output_cb, const uint32_t& input_chunk_size) {
+    const uint32_t input_l1_read_addr = input_cb.get_read_ptr();
+    const uint32_t output_l1_write_addr = output_cb.get_write_ptr();
     volatile tt_l1_ptr number_type* input_l1_read_ptr =
         reinterpret_cast<volatile tt_l1_ptr number_type*>(input_l1_read_addr);
     volatile tt_l1_ptr number_type* output_l1_write_ptr =
@@ -54,19 +54,19 @@ FORCE_INLINE number_type perform_reduction(
 // performs scatter on data loaded to cb with load_to_cb
 template <typename number_type, typename index_type>
 FORCE_INLINE void scatter_along_chunk(
-    const uint32_t& input_cb,
-    const uint32_t& index_cb,
-    const uint32_t& source_cb,
-    const uint32_t& output_cb,
+    const CircularBuffer& input_cb,
+    const CircularBuffer& index_cb,
+    const CircularBuffer& source_cb,
+    const CircularBuffer& output_cb,
     const uint32_t& input_stick_size,
     const uint32_t& input_offset,
     const uint32_t& input_chunk_size,
     const uint32_t& index_chunk_size,
     const ScatterReductionType& scatter_reduction_type = ScatterReductionType::INVALID) {
-    const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
-    const uint32_t index_l1_read_addr = get_read_ptr(index_cb);
-    const uint32_t source_l1_read_addr = get_read_ptr(source_cb);
-    const uint32_t output_l1_write_addr = get_write_ptr(output_cb);
+    const uint32_t input_l1_read_addr = input_cb.get_read_ptr();
+    const uint32_t index_l1_read_addr = index_cb.get_read_ptr();
+    const uint32_t source_l1_read_addr = source_cb.get_read_ptr();
+    const uint32_t output_l1_write_addr = output_cb.get_write_ptr();
     volatile tt_l1_ptr number_type* input_l1_read_ptr =
         reinterpret_cast<volatile tt_l1_ptr number_type*>(input_l1_read_addr);
     volatile tt_l1_ptr index_type* index_l1_read_ptr =
@@ -90,7 +90,7 @@ FORCE_INLINE void scatter_along_chunk(
         volatile number_type& source_value = source_l1_read_ptr[index_in_index_chunk];
         const uint32_t& output_index = index_value - input_offset;
         output_l1_write_ptr[output_index] = perform_reduction<number_type>(
-            output_l1_write_ptr[output_index], source_value, scatter_reduction_type, get_dataformat(input_cb));
+            output_l1_write_ptr[output_index], source_value, scatter_reduction_type, input_cb.get_dataformat());
     }
 }
 
@@ -153,7 +153,7 @@ void kernel_main() {
             input_cb.wait_front(ONE_PAGE);
             output_cb.reserve_back(ONE_PAGE);
 
-            copy_input_to_output<input_std_type>(ctas.input_cb, ctas.output_cb, input_chunk_length);
+            copy_input_to_output<input_std_type>(input_cb, output_cb, input_chunk_length);
 
             if (in_bounds<N>(coord, index_dims)) {
                 const uint32_t index_stick_id = to_id<N>(coord, index_strides);
@@ -185,10 +185,10 @@ void kernel_main() {
                     index_cb.wait_front(ONE_PAGE);
                     source_cb.wait_front(ONE_PAGE);
                     scatter_along_chunk<input_std_type, index_std_type>(
-                        ctas.input_cb,
-                        ctas.index_cb,
-                        ctas.source_cb,
-                        ctas.output_cb,
+                        input_cb,
+                        index_cb,
+                        source_cb,
+                        output_cb,
                         ctas.input_stick_size,
                         input_offset,
                         input_chunk_length,


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to #45003. Second phase of the `data_movement` Device 2.0 kernel-API cleanup, follows the `common.hpp` shared-header migration in #47454.

Migrates four self-contained `data_movement` ops onto the Device 2.0 kernel data-movement API: `roll`, `concat`, `scatter`, `fill_pad` through a mechanical API swap. In `fill_pad` only stale doc comments that named the old free-fn API are refreshed.

### Notes for reviewers

- Kernel-side only; no host or op-infrastructure changes. 
- `roll` is the largest change: DRAM bank addressing moves to `AllocatorBank<...::DRAM>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/dm-phase2-device2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/dm-phase2-device2-cleanup)
