### PR TITLE
[Feature] Adding FD support to catch watcher test mode errors

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -25,6 +25,7 @@
 #include "buffer_types.hpp"
 #include "device.hpp"
 #include "impl/device/device_impl.hpp"
+#include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include "dispatch/dispatch_settings.hpp"
@@ -254,6 +255,47 @@ CoreCoord FDMeshCommandQueue::virtual_program_dispatch_core() const { return thi
 
 CoreType FDMeshCommandQueue::dispatch_core_type() const { return this->dispatch_core_type_; }
 
+bool FDMeshCommandQueue::record_watcher_error_in_test_mode(ChipId device_id) {
+    const auto error_message = tt::llrt::internal_::get_watcher_error_message_in_test_mode(device_id);
+    if (!error_message.has_value()) {
+        return false;
+    }
+
+    try {
+        TT_THROW("{}", *error_message);
+    } catch (...) {
+        {
+            std::lock_guard<std::mutex> exception_lock(exception_mutex_);
+            thread_exception_ptr_ = std::current_exception();
+            should_handle_exception_.store(true);
+        }
+
+        thread_exception_state_.store(true);
+        exit_condition_.store(true);
+        reads_processed_cv_.notify_all();
+        reader_thread_cv_.notify_all();
+        return true;
+    }
+}
+
+void FDMeshCommandQueue::wait_for_outstanding_reads(std::unique_lock<std::mutex>& reads_processed_lock) {
+    const auto predicate = [this] { return num_outstanding_reads_.load() == 0 || thread_exception_state_.load(); };
+
+    const auto& rtoptions = MetalContext::instance(mesh_device_->impl().get_context_id()).rtoptions();
+    if (rtoptions.get_watcher_enabled() && rtoptions.get_test_mode_enabled()) {
+        const ChipId device_id = mesh_device_->get_devices().at(0)->id();
+        constexpr auto poll_interval = std::chrono::milliseconds(100);
+        while (num_outstanding_reads_.load() != 0 && !thread_exception_state_.load()) {
+            if (record_watcher_error_in_test_mode(device_id)) {
+                return;
+            }
+            reads_processed_cv_.wait_for(reads_processed_lock, poll_interval, predicate);
+        }
+    } else {
+        reads_processed_cv_.wait(reads_processed_lock, predicate);
+    }
+}
+
 void FDMeshCommandQueue::clear_expected_num_workers_completed() {
     if (this->get_target_device_type() == tt::TargetDevice::Mock ||
         this->get_target_device_type() == tt::TargetDevice::Emule) {
@@ -289,8 +331,7 @@ void FDMeshCommandQueue::clear_expected_num_workers_completed() {
         std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range()));
     this->increment_num_entries_in_completion_queue();
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
-    reads_processed_cv_.wait(
-        lock, [this] { return num_outstanding_reads_.load() == 0 || thread_exception_state_.load(); });
+    this->wait_for_outstanding_reads(lock);
 }
 
 void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
@@ -612,8 +653,7 @@ void FDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId> sub_devi
     auto event = this->enqueue_record_event_to_host_nolock(sub_device_ids);
 
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
-    reads_processed_cv_.wait(
-        lock, [this] { return num_outstanding_reads_.load() == 0 || thread_exception_state_.load(); });
+    this->wait_for_outstanding_reads(lock);
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
     for (const auto& sub_device_id : buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids)) {
         sub_device_cq_owner[*sub_device_id].finished(this->id_);
@@ -627,6 +667,7 @@ void FDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId> sub_devi
             num_outstanding_reads_.store(0);
             reads_processed_cv_.notify_all();
             lock.unlock();
+            in_use_ = false;
             std::rethrow_exception(exception_ptr);
         }
     }
@@ -894,7 +935,7 @@ void FDMeshCommandQueue::read_completion_queue() {
         return;
     }
 
-    while (!thread_exception_state_.load()) {
+    while (!thread_exception_state_.load() && !exit_condition_.load()) {
         try {
             {
                 std::unique_lock<std::mutex> lock(reader_thread_cv_mutex_);
@@ -906,6 +947,9 @@ void FDMeshCommandQueue::read_completion_queue() {
 
             uint32_t num_reads = num_outstanding_reads_.load();
             for (uint32_t i = 0; i < num_reads; i++) {
+                if (thread_exception_state_.load() || exit_condition_.load()) {
+                    return;
+                }
                 auto mesh_read_descriptor = *(completion_queue_reads_.pop());
                 std::visit(
                     [&](auto&& mesh_read_descriptor) {
@@ -919,6 +963,9 @@ void FDMeshCommandQueue::read_completion_queue() {
                         }
                     },
                     mesh_read_descriptor);
+            }
+            if (thread_exception_state_.load() || exit_condition_.load()) {
+                return;
             }
             std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
             num_outstanding_reads_.fetch_sub(num_reads);
@@ -1002,6 +1049,9 @@ void FDMeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& re
                                .get_assigned_channel_for_device(device->id());
         device->sysmem_manager().completion_queue_wait_front(id_, exit_condition_);
 
+        if (exit_condition_.load()) {
+            return;
+        }
         event_dispatch::read_events_from_completion_queue(
             read_event_descriptor.single_device_descriptor,
             mmio_device_id,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -170,6 +170,12 @@ private:
     // so the main thread can handle the exception
     std::atomic<bool> thread_exception_state_ = false;
 
+    // Poll completion-queue reads, aborting early if watcher trips in test mode.
+    void wait_for_outstanding_reads(std::unique_lock<std::mutex>& reads_processed_lock);
+
+    // Route watcher faults through the same exception path as the completion-queue reader thread.
+    bool record_watcher_error_in_test_mode(ChipId device_id);
+
     // Distributed context used to synchronize operations done by all active ranks on the given mesh device.
     std::shared_ptr<distributed::multihost::DistributedContext> active_distributed_context_;
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -59,7 +59,8 @@ void loop_and_wait_with_timeout(
     const FuncWait& wait_condition,
     const OnTimeout& on_timeout,
     std::chrono::duration<float> timeout_duration,
-    const GetProgress& get_progress) {
+    const GetProgress& get_progress,
+    std::atomic<bool>* exit_condition = nullptr) {
     if (timeout_duration.count() > 0.0f) {
         auto last_progress_time = std::chrono::high_resolution_clock::now();
         uint32_t last_progress_value = 0;
@@ -70,6 +71,10 @@ void loop_and_wait_with_timeout(
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_progress_update_ms());
 
         while (true) {
+            if (exit_condition != nullptr && exit_condition->load(std::memory_order_acquire)) {
+                break;
+            }
+
             func_body();
 
             // Check if operation is finished
@@ -101,6 +106,9 @@ void loop_and_wait_with_timeout(
         }
     } else {
         do {
+            if (exit_condition != nullptr && exit_condition->load(std::memory_order_acquire)) {
+                break;
+            }
             func_body();
         } while (wait_condition());
     }
@@ -767,7 +775,8 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
         wait_condition,
         on_timeout,
         tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations(),
-        get_dispatch_progress);
+        get_dispatch_progress,
+        &exit_condition);
 
     return write_ptr_and_toggle;
 }

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -352,7 +352,7 @@ std::optional<std::string> get_watcher_error_message_in_test_mode(ChipId device_
         auto& watcher = *tt::tt_metal::MetalContext::instance().watcher_server();
         if (watcher.killed_due_to_error() || !watcher.exception_message().empty()) {
             return fmt::format(
-                "Device {}: Aborting wait for physical cores to finish due to watcher error: {}",
+                "Device {}: Aborting wait due to watcher error: {}",
                 device_id,
                 watcher.exception_message());
         }

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -345,6 +345,27 @@ void print_aerisc_training_status(tt::ChipId device_id, const CoreCoord& virtual
 
 }  // namespace
 
+std::optional<std::string> get_watcher_error_message_in_test_mode(ChipId device_id) {
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    if (rtoptions.get_watcher_enabled() && rtoptions.get_test_mode_enabled() &&
+        tt::tt_metal::MetalContext::instance().watcher_server()) {
+        auto& watcher = *tt::tt_metal::MetalContext::instance().watcher_server();
+        if (watcher.killed_due_to_error() || !watcher.exception_message().empty()) {
+            return fmt::format(
+                "Device {}: Aborting wait for physical cores to finish due to watcher error: {}",
+                device_id,
+                watcher.exception_message());
+        }
+    }
+    return std::nullopt;
+}
+
+void throw_if_watcher_tripped_in_test_mode(ChipId device_id) {
+    if (auto error_message = get_watcher_error_message_in_test_mode(device_id)) {
+        TT_THROW("{}", *error_message);
+    }
+}
+
 void wait_until_cores_done(
     tt::ChipId device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms) {
     // poll the cores until the set of not done cores is empty
@@ -360,19 +381,7 @@ void wait_until_cores_done(
                 .count();
     }
     while (!not_done_phys_cores.empty()) {
-        // In tests, when rtoptions.get_test_mode_enabled() is true, watcher
-        // will stop but will not kill the program. This section detects watcher
-        // stopping and reports a fatal error so Finish() can return and the test process can tear down.
-        if (rtoptions.get_watcher_enabled() && rtoptions.get_test_mode_enabled() &&
-            tt::tt_metal::MetalContext::instance().watcher_server()) {
-            auto& watcher = *tt::tt_metal::MetalContext::instance().watcher_server();
-            if (watcher.killed_due_to_error() || !watcher.exception_message().empty()) {
-                TT_THROW(
-                    "Device {}: Aborting wait for physical cores to finish due to watcher error: {}",
-                    device_id,
-                    watcher.exception_message());
-            }
-        }
+        throw_if_watcher_tripped_in_test_mode(device_id);
 
         if (timeout_ms > 0) {
             auto now = std::chrono::high_resolution_clock::now();

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -67,6 +69,12 @@ void wait_until_cores_done(
     ChipId device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms = 0);
 
 void wait_for_idle(ChipId device_id, const std::vector<std::vector<CoreCoord>>& logical_cores);
+
+// In test mode, return a watcher fault message if one was recorded, so host waits can unwind.
+std::optional<std::string> get_watcher_error_message_in_test_mode(ChipId device_id);
+
+// In test mode, throw if watcher detected a device-side fault so host waits can unwind.
+void throw_if_watcher_tripped_in_test_mode(ChipId device_id);
 
 // Send a message to the ethernet firmware mailbox, if supported
 // Possible message types can be queried from the Hal. See tt::tt_metal::FWMailboxMsg


### PR DESCRIPTION
### PR Category
Feature: #48833 

### Summary
This change enables fast dispatch "waits" to catch when watcher + watcher test mode are enabled and a watcher error occurs. Without this change, it will wait forever for the next operation.

With the change, the existing behaviour is unchanged (wait until next operation), but when watcher + watcher test mode are enabled, every 100ms the "wait" will check if a watcher error has occurred. When watcher test mode is enabled this will cause some unnecessary spinning on the host side, but given that watcher + watcher test mode is a debug feature and rarely used, I think this is a reasonable trade-off.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_48833)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_48833)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kstevens/issue_48833)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_48833)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_48833)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_48833)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_48833)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_48833)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_48833)