### PR TITLE
Fix real-time profiler not recording the last program

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -213,6 +213,54 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
     EXPECT_TRUE(mesh_device->close());
 }
 
+TEST(RealtimeProfilerSanity, LastProgramRecordDeliveredOnFinish) {
+    constexpr int kDeviceId = 0;
+
+    auto mesh_device = distributed::MeshDevice::create_unit_mesh(
+        kDeviceId, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreConfig{DispatchCoreType::WORKER});
+    ASSERT_NE(mesh_device, nullptr);
+
+    if (!IsProgramRealtimeProfilerActive()) {
+        mesh_device->close();
+        GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
+    }
+
+    std::mutex records_mu;
+    std::vector<ProgramRealtimeRecord> records;
+    ProgramRealtimeProfilerCallbackHandle handle =
+        RegisterProgramRealtimeProfilerCallback([&records_mu, &records](const ProgramRealtimeRecord& record) {
+            std::lock_guard<std::mutex> lk(records_mu);
+            records.push_back(record);
+        });
+
+    CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();
+    CoreRange all_cores(CoreCoord{0, 0}, CoreCoord{compute_grid.x - 1, compute_grid.y - 1});
+
+    for (uint32_t i = 0; i < kNumPrograms; ++i) {
+        enqueue_sanity_program(mesh_device, i + 1, all_cores);
+    }
+
+    distributed::Finish(mesh_device->mesh_command_queue());
+    UnregisterProgramRealtimeProfilerCallback(handle);
+
+    constexpr uint32_t last_runtime_id = kNumPrograms;
+    bool last_record_seen = false;
+    {
+        std::lock_guard<std::mutex> lk(records_mu);
+        for (const auto& rec : records) {
+            if (rec.runtime_id == last_runtime_id) {
+                last_record_seen = true;
+                break;
+            }
+        }
+    }
+
+    EXPECT_TRUE(last_record_seen) << "The final program's RT profiler record (runtime_id=" << last_runtime_id
+                                  << ") was not delivered; ensure that the finish-time RT-profiler flush is emitted";
+
+    EXPECT_TRUE(mesh_device->close());
+}
+
 TEST(RealtimeProfilerSanity, TraceReplayResolvesKernelSources) {
     constexpr int kDeviceId = 0;
     constexpr uint32_t kWarmupRuntimeId = 0x6001;

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -609,6 +609,15 @@ void FDMeshCommandQueue::finish_nolock(ttsl::Span<const SubDeviceId> sub_device_
         return;
     }
 
+    if (tt::IsProgramRealtimeProfilerActive()) {
+        for (const auto& sub_device_id : buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids)) {
+            const uint32_t wait_count = expected_num_workers_completed_[*sub_device_id];
+            for (auto* device : mesh_device_->get_devices()) {
+                write_rt_profiler_flush(id_, sub_device_id, device->sysmem_manager(), wait_count);
+            }
+        }
+    }
+
     auto event = this->enqueue_record_event_to_host_nolock(sub_device_ids);
 
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -98,4 +98,23 @@ void write_go_signal(
     sysmem_manager.fetch_queue_reserve_back(cq_id);
     sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
 }
+
+void write_rt_profiler_flush(
+    uint8_t cq_id, SubDeviceId sub_device_id, SystemMemoryManager& sysmem_manager, uint32_t wait_count) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_rt_profiler_flush();
+    uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+
+    void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+
+    HugepageDeviceCommand flush_cmd_sequence(cmd_region, cmd_sequence_sizeB);
+    const uint32_t wait_stream = MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(*sub_device_id);
+    flush_cmd_sequence.add_dispatch_rt_profiler_flush(wait_count, wait_stream);
+
+    TT_ASSERT(flush_cmd_sequence.size_bytes() == flush_cmd_sequence.write_offset_bytes());
+
+    sysmem_manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
+    sysmem_manager.fetch_queue_reserve_back(cq_id);
+    sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
+}
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_workload_utils.hpp
+++ b/tt_metal/distributed/mesh_workload_utils.hpp
@@ -32,4 +32,7 @@ void write_go_signal(
     bool send_unicasts,
     const program_dispatch::ProgramDispatchMetadata& dispatch_md);
 
+void write_rt_profiler_flush(
+    uint8_t cq_id, SubDeviceId sub_device_id, SystemMemoryManager& sysmem_manager, uint32_t wait_count);
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -259,6 +259,7 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
             case CQ_DISPATCH_CMD_SEND_GO_SIGNAL:
             case CQ_DISPATCH_NOTIFY_SUBORDINATE_GO_SIGNAL:
             case CQ_DISPATCH_CMD_TERMINATE:
+            case CQ_DISPATCH_CMD_RT_PROFILER_FLUSH:
             case CQ_DISPATCH_CMD_SET_WRITE_OFFSET: break;
             default: TT_THROW("Unrecognized dispatch command: {}", cmd_id); break;
         }

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -552,6 +552,26 @@ void DeviceCommand<hugepage_write>::add_dispatch_go_signal_mcast(
 }
 
 template <bool hugepage_write>
+void DeviceCommand<hugepage_write>::add_dispatch_rt_profiler_flush(uint32_t wait_count, uint32_t wait_stream) {
+    this->add_prefetch_relay_inline(true, sizeof(CQDispatchCmd), DispatcherSelect::DISPATCH_SUBORDINATE);
+    auto initialize_flush_cmd = [&](CQDispatchCmd* flush_cmd) {
+        *flush_cmd = {};
+        flush_cmd->base.cmd_id = CQ_DISPATCH_CMD_RT_PROFILER_FLUSH;
+        flush_cmd->rt_profiler_flush.wait_count = wait_count;
+        flush_cmd->rt_profiler_flush.wait_stream = wait_stream;
+    };
+    CQDispatchCmd* flush_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    if constexpr (hugepage_write) {
+        alignas(MEMCPY_ALIGNMENT) CQDispatchCmd flush_cmd{};
+        initialize_flush_cmd(&flush_cmd);
+        this->memcpy(flush_cmd_dst, &flush_cmd, sizeof(CQDispatchCmd));
+    } else {
+        initialize_flush_cmd(flush_cmd_dst);
+    }
+    this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+}
+
+template <bool hugepage_write>
 void DeviceCommand<hugepage_write>::add_notify_dispatch_s_go_signal_cmd(uint8_t wait, uint16_t index_bitmask) {
     // Command to have dispatch_master send a notification to dispatch_subordinate
     this->add_prefetch_relay_inline(true, sizeof(CQDispatchCmd), DispatcherSelect::DISPATCH_MASTER);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -125,6 +125,8 @@ public:
 
     void add_notify_dispatch_s_go_signal_cmd(uint8_t wait, uint16_t index_bitmask);
 
+    void add_dispatch_rt_profiler_flush(uint32_t wait_count, uint32_t wait_stream);
+
     template <bool inline_data = false>
     void add_dispatch_write_paged(
         bool flush_prefetch,

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -121,6 +121,12 @@ public:
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
+    void add_dispatch_rt_profiler_flush() {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
     void add_dispatch_set_sub_device_worker_counts(uint32_t num_sub_devices) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd) + num_sub_devices * sizeof(uint32_t);

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -60,7 +60,8 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA = 17,
     CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST = 18,  // unicast packed large write with uint32_t length
     CQ_DISPATCH_SET_SUB_DEVICE_WORKER_COUNTS = 19,
-    CQ_DISPATCH_CMD_MAX_COUNT,  // for checking legal IDs
+    CQ_DISPATCH_CMD_RT_PROFILER_FLUSH = 20,  // dispatch_s: wait on the last program and signal its profiler record
+    CQ_DISPATCH_CMD_MAX_COUNT,               // for checking legal IDs
 };
 
 enum GoSignalMcastSettings : uint8_t {
@@ -411,6 +412,11 @@ struct CQDispatchNotifySubordinateGoSignalCmd {
     uint32_t pad3;
 } __attribute__((packed));
 
+struct CQDispatchRtProfilerFlushCmd {
+    uint32_t wait_count;   // worker completion count to wait on
+    uint32_t wait_stream;  // stream index to wait on
+} __attribute__((packed));
+
 struct CQDispatchSetNumWorkerSemsCmd {
     uint8_t pad1;
     uint16_t pad2;
@@ -448,6 +454,7 @@ struct CQDispatchCmd {
         CQDispatchSetNumWorkerSemsCmd set_num_worker_sems;
         CQDispatchSetGoSignalNocDataCmd set_go_signal_noc_data;
         CQDispatchSetSubDeviceWorkerCountsCmd set_sub_device_worker_counts;
+        CQDispatchRtProfilerFlushCmd rt_profiler_flush;
     } __attribute__((packed));
 };
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -593,10 +593,11 @@ void kernel_main() {
         volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
         DeviceTimestampedData("process_cmd_d_dispatch_subordinate", (uint32_t)cmd->base.cmd_id);
         if (rt_profiler_enabled) {
-            uint32_t buffer_id = (cmd->base.cmd_id == CQ_DISPATCH_CMD_SEND_GO_SIGNAL)
-                                     ? popped_pid
-                                     : static_cast<uint32_t>(REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID);
-            write_buffer_id(rt_profiler_msg, buffer_id);
+            const bool is_profiled_cmd = cmd->base.cmd_id == CQ_DISPATCH_CMD_SEND_GO_SIGNAL ||
+                                         cmd->base.cmd_id == CQ_DISPATCH_CMD_RT_PROFILER_FLUSH;
+            write_buffer_id(
+                rt_profiler_msg,
+                is_profiled_cmd ? popped_pid : static_cast<uint32_t>(REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID));
         }
         switch (cmd->base.cmd_id) {
             case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: process_go_signal_mcast_cmd(); break;
@@ -610,6 +611,10 @@ void kernel_main() {
                     dispatch_telemetry_base);
                 break;
             case CQ_DISPATCH_CMD_WAIT: process_dispatch_s_wait_cmd(); break;
+            case CQ_DISPATCH_CMD_RT_PROFILER_FLUSH:
+                wait_for_workers(cmd->rt_profiler_flush.wait_count, cmd->rt_profiler_flush.wait_stream);
+                cmd_ptr += sizeof(CQDispatchCmd);
+                break;
             case CQ_DISPATCH_CMD_TERMINATE:
                 if (rt_profiler_enabled) {
                     signal_realtime_profiler_and_switch(rt_profiler_msg);

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -289,7 +289,11 @@ void device_module(nb::module_& m_device) {
         nb::arg("DispatchCoreConfig") = nb::none(),
         nb::kw_only(),
         nb::arg("worker_l1_size") = DEFAULT_WORKER_L1_SIZE);
-    m_device.def("CloseDevice", [](MeshDevice* device) { device->close(); }, R"doc(
+    m_device.def(
+        "CloseDevice",
+        [](MeshDevice* device) { device->close(); },
+        nb::call_guard<nb::gil_scoped_release>(),
+        R"doc(
         Reset an instance of TT accelerator device to default state and relinquish connection to device.
 
         +------------------+------------------------+-----------------------+-------------+----------+
@@ -305,6 +309,7 @@ void device_module(nb::module_& m_device) {
                 device_entry.second->close();
             }
         },
+        nb::call_guard<nb::gil_scoped_release>(),
         R"doc(
         Reset an instance of TT accelerator device to default state and relinquish connection to device.
 
@@ -716,7 +721,10 @@ void device_module(nb::module_& m_device) {
     m_device.def(
         "UnregisterProgramRealtimeProfilerCallback",
         [](uint64_t handle) {
-            tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback(handle);
+            {
+                nb::gil_scoped_release release;
+                tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback(handle);
+            }
             auto it = python_realtime_callback_refs.find(handle);
             if (it != python_realtime_callback_refs.end()) {
                 Py_DECREF(it->second);
@@ -724,7 +732,6 @@ void device_module(nb::module_& m_device) {
             }
         },
         nb::arg("handle"),
-        nb::call_guard<nb::gil_scoped_release>(),
         R"doc(
             Unregister a previously registered real-time profiler callback.
             This call waits for any in-flight invocations of the callback to finish.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The RT profiler ships a program's record on the dispatch_s command *following* its go-signal, so records lag by one command. The last program before the command queue finishes has no following command, so its record isn't delivered.

Adds `CQ_DISPATCH_CMD_RT_PROFILER_FLUSH`, which the finish path enqueues to dispatch_s. It waits on the last program's workers and delivers the final record.

Also fixes GIL deadlocks in the RT-profiler Python bindings.

Closes #48131.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml/badge.svg?branch=yusuf/fix-rt-profiler-last-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml?query=branch:yusuf/fix-rt-profiler-last-program)
