### PR TITLE
#48660: comment out method outputs matmul warning

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -541,12 +541,12 @@ bool get_broadcast_batch(
 // currently advisory.
 // TODO(#44529): convert this back to TT_FATAL once all callers have been updated.
 void warn_if_allowed_worker_cores_missing(
-    const std::optional<operations::matmul::MatmulProgramConfig>& program_config, std::string_view entry_point) {
-    /* The following spammed CI logs too much and with AI details can be figured out.
-     * Leave in to convert to TT_FATAL in the future.
+    const std::optional<operations::matmul::MatmulProgramConfig>& program_config, std::string_view /*entry_point*/) {
     if (!program_config.has_value()) {
         return;
     }
+    /* The following spammed CI logs too much and with AI details can be figured out.
+     * Leave in to convert to TT_FATAL in the future.
     std::visit(
         [&](const auto& pc) {
             if constexpr (requires { pc.allowed_worker_cores; }) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -542,6 +542,8 @@ bool get_broadcast_batch(
 // TODO(#44529): convert this back to TT_FATAL once all callers have been updated.
 void warn_if_allowed_worker_cores_missing(
     const std::optional<operations::matmul::MatmulProgramConfig>& program_config, std::string_view entry_point) {
+    /* The following spammed CI logs too much and with AI details can be figured out.
+     * Leave in to convert to TT_FATAL in the future.
     if (!program_config.has_value()) {
         return;
     }
@@ -561,6 +563,7 @@ void warn_if_allowed_worker_cores_missing(
             }
         },
         program_config.value());
+        */
 }
 
 // Cross-validate a DRAM-sender global_cb's geometry against the matmul + weight shape.

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -541,12 +541,12 @@ bool get_broadcast_batch(
 // currently advisory.
 // TODO(#44529): convert this back to TT_FATAL once all callers have been updated.
 void warn_if_allowed_worker_cores_missing(
-    const std::optional<operations::matmul::MatmulProgramConfig>& program_config, std::string_view /*entry_point*/) {
+    const std::optional<operations::matmul::MatmulProgramConfig>& program_config,
+    [[maybe_unused]] std::string_view entry_point) {
     if (!program_config.has_value()) {
         return;
     }
-    /* The following spammed CI logs too much and with AI details can be figured out.
-     * Leave in to convert to TT_FATAL in the future.
+    /* The following spammed CI logs too much; leave it in place to convert to TT_FATAL in the future.
     std::visit(
         [&](const auto& pc) {
             if constexpr (requires { pc.allowed_worker_cores; }) {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Related to #48660 
Comment out method that has a warning that is supposed to be switched to fatal once models are updated. Leave the code in to make it easy to switch later on.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-48660_matmul_warn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-48660_matmul_warn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-48660_matmul_warn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-48660_matmul_warn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-48660_matmul_warn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-48660_matmul_warn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-48660_matmul_warn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-48660_matmul_warn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-48660_matmul_warn)