### PR TITLE
Add fabric APIs for eager-compile model + control-plane bindings

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -75,6 +75,12 @@ enum class FabricApiType : uint8_t {
     Mesh = 1,
 };
 
+// Query the kernel defines required by the current fabric configuration and API type.
+// Pure query — no PD mutation, no side effects. Safe to call before kernel compilation.
+// Returns defines like {("FABRIC_2D", "1"), ("API_TYPE_Linear", "1")}.
+std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(
+    FabricApiType api_type = FabricApiType::Linear);
+
 std::vector<eth_chan_directions> get_neighbor_eth_directions(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
 
@@ -100,6 +106,21 @@ template <typename ProgramOrDescriptor>
 uint32_t append_routing_plane_connection_manager_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const std::vector<eth_chan_directions>& attempted_directions,
+    const std::vector<uint32_t>& connection_link_indices,
+    ProgramOrDescriptor& worker_program_or_desc,
+    tt::tt_metal::KernelHandle& kernel_id,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args,
+    FabricApiType api_type = FabricApiType::Linear,
+    CoreType core_type = CoreType::WORKER);
+
+// Like append_routing_plane_connection_manager_rt_args but does NOT inject kernel defines.
+// Use with get_fabric_kernel_defines() when defines must be set before kernel compilation
+// (e.g., blaze eager-compile model). Allocates semaphores and computes RT args only.
+template <typename ProgramOrDescriptor>
+void append_routing_plane_connection_rt_args_no_defines(
+    const FabricNodeId& src_fabric_node_id,
+    const std::vector<FabricNodeId>& dst_nodes,
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -81,6 +81,16 @@ enum class FabricApiType : uint8_t {
 std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(
     FabricApiType api_type = FabricApiType::Linear);
 
+// Compute fabric connection RT args without any PD mutation.
+// Pure computation — resolves routing + assembles RT args using caller-provided semaphore IDs.
+// Returns flat vector matching RoutingPlaneConnectionManager::build_from_args() layout.
+std::vector<uint32_t> compute_fabric_connection_rt_args(
+    const FabricNodeId& src_fabric_node_id,
+    const std::vector<FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    const std::vector<uint32_t>& teardown_sem_ids,
+    const std::vector<uint32_t>& buffer_index_sem_ids);
+
 std::vector<eth_chan_directions> get_neighbor_eth_directions(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -151,6 +151,11 @@ std::vector<chan_id_t> get_active_fabric_eth_routing_planes_in_direction(
 
 std::unordered_map<MeshId, tt::tt_metal::distributed::MeshShape> get_physical_mesh_shapes();
 
+// Returns all compute mesh ids known to the current mesh graph descriptor, including
+// peer meshes that are not visible via get_user_physical_mesh_ids() (which only
+// returns the local rank's meshes). Intended for inter-mesh topology discovery.
+std::vector<MeshId> get_all_fabric_mesh_ids();
+
 tt::tt_fabric::Topology get_fabric_topology();
 
 struct FabricEriscDatamoverKernelConfig {

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -75,22 +75,6 @@ enum class FabricApiType : uint8_t {
     Mesh = 1,
 };
 
-// Query the kernel defines required by the current fabric configuration and API type.
-// Pure query — no PD mutation, no side effects. Safe to call before kernel compilation.
-// Returns defines like {("FABRIC_2D", "1"), ("API_TYPE_Linear", "1")}.
-std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(
-    FabricApiType api_type = FabricApiType::Linear);
-
-// Compute fabric connection RT args without any PD mutation.
-// Pure computation — resolves routing + assembles RT args using caller-provided semaphore IDs.
-// Returns flat vector matching RoutingPlaneConnectionManager::build_from_args() layout.
-std::vector<uint32_t> compute_fabric_connection_rt_args(
-    const FabricNodeId& src_fabric_node_id,
-    const std::vector<FabricNodeId>& dst_nodes,
-    const std::vector<uint32_t>& connection_link_indices,
-    const std::vector<uint32_t>& teardown_sem_ids,
-    const std::vector<uint32_t>& buffer_index_sem_ids);
-
 std::vector<eth_chan_directions> get_neighbor_eth_directions(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
 
@@ -124,21 +108,6 @@ uint32_t append_routing_plane_connection_manager_rt_args(
     FabricApiType api_type = FabricApiType::Linear,
     CoreType core_type = CoreType::WORKER);
 
-// Like append_routing_plane_connection_manager_rt_args but does NOT inject kernel defines.
-// Use with get_fabric_kernel_defines() when defines must be set before kernel compilation
-// (e.g., blaze eager-compile model). Allocates semaphores and computes RT args only.
-template <typename ProgramOrDescriptor>
-void append_routing_plane_connection_rt_args_no_defines(
-    const FabricNodeId& src_fabric_node_id,
-    const std::vector<FabricNodeId>& dst_nodes,
-    const std::vector<uint32_t>& connection_link_indices,
-    ProgramOrDescriptor& worker_program_or_desc,
-    tt::tt_metal::KernelHandle& kernel_id,
-    const CoreCoord& worker_core,
-    std::vector<uint32_t>& worker_args,
-    FabricApiType api_type = FabricApiType::Linear,
-    CoreType core_type = CoreType::WORKER);
-
 // returns which links on a given src chip are available for forwarding the data to a dst chip
 // these link indices can then be used to establish connection with the fabric routers
 std::vector<uint32_t> get_forwarding_link_indices(
@@ -150,11 +119,6 @@ std::vector<chan_id_t> get_active_fabric_eth_routing_planes_in_direction(
     FabricNodeId fabric_node_id, RoutingDirection routing_direction);
 
 std::unordered_map<MeshId, tt::tt_metal::distributed::MeshShape> get_physical_mesh_shapes();
-
-// Returns all compute mesh ids known to the current mesh graph descriptor, including
-// peer meshes that are not visible via get_user_physical_mesh_ids() (which only
-// returns the local rank's meshes). Intended for inter-mesh topology discovery.
-std::vector<MeshId> get_all_fabric_mesh_ids();
 
 tt::tt_fabric::Topology get_fabric_topology();
 

--- a/tt_metal/api/tt-metalium/internal/fabric.hpp
+++ b/tt_metal/api/tt-metalium/internal/fabric.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <umd/device/types/core_coordinates.hpp>
+#include <vector>
+#include <unordered_map>
+#include <string>
+#include <cstdint>
+
+namespace tt::tt_metal {
+class Program;
+struct ProgramDescriptor;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::distributed {
+class MeshShape;
+}  // namespace tt::tt_metal::distributed
+
+namespace tt::tt_metal::internal {
+
+// EXPERIMENTAL / INTERNAL API. Not part of the stable public surface; signature may change.
+//
+// These APIs separate compile-time concerns (kernel defines) from runtime concerns (semaphores +
+// RT args), enabling an eager-compile model where defines are queried before kernel build and
+// connections are set up after build without post_build hooks.
+
+// Query the kernel defines required by the current fabric configuration and API type.
+// Pure query — no PD mutation, no side effects. Safe to call before kernel compilation.
+// Returns defines like {("FABRIC_2D", "1"), ("API_TYPE_Linear", "1")}.
+std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(
+    tt::tt_fabric::FabricApiType api_type = tt::tt_fabric::FabricApiType::Linear);
+
+// Compute fabric connection RT args without any PD mutation.
+// Pure computation — resolves routing + assembles RT args using caller-provided semaphore IDs.
+// Returns flat vector matching RoutingPlaneConnectionManager::build_from_args() layout.
+std::vector<uint32_t> compute_fabric_connection_rt_args(
+    const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
+    const std::vector<tt::tt_fabric::FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    const std::vector<uint32_t>& teardown_sem_ids,
+    const std::vector<uint32_t>& buffer_index_sem_ids);
+
+// Like append_routing_plane_connection_manager_rt_args but does NOT inject kernel defines.
+// Use with get_fabric_kernel_defines() when defines must be set before kernel compilation
+// (e.g., blaze eager-compile model). Allocates semaphores and computes RT args only.
+template <typename ProgramOrDescriptor>
+void append_routing_plane_connection_rt_args_no_defines(
+    const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
+    const std::vector<tt::tt_fabric::FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    ProgramOrDescriptor& worker_program_or_desc,
+    tt::tt_metal::KernelHandle& kernel_id,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args,
+    tt::tt_fabric::FabricApiType api_type = tt::tt_fabric::FabricApiType::Linear,
+    CoreType core_type = CoreType::WORKER);
+
+// Returns all compute mesh ids known to the current mesh graph descriptor, including
+// peer meshes that are not visible via get_user_physical_mesh_ids() (which only
+// returns the local rank's meshes). Intended for inter-mesh topology discovery.
+std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids();
+
+}  // namespace tt::tt_metal::internal

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -355,6 +355,85 @@ std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(Fabri
     return defines;
 }
 
+// Compute fabric connection RT args without any PD mutation.
+// Caller provides pre-allocated semaphore IDs (2 per connection: teardown + buffer_index).
+// Returns the flat RT args vector for RoutingPlaneConnectionManager::build_from_args().
+std::vector<uint32_t> compute_fabric_connection_rt_args(
+    const FabricNodeId& src_fabric_node_id,
+    const std::vector<FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    const std::vector<uint32_t>& teardown_sem_ids,
+    const std::vector<uint32_t>& buffer_index_sem_ids) {
+    TT_FATAL(
+        teardown_sem_ids.size() == dst_nodes.size(),
+        "teardown_sem_ids size ({}) must match dst_nodes size ({})",
+        teardown_sem_ids.size(),
+        dst_nodes.size());
+    TT_FATAL(
+        buffer_index_sem_ids.size() == dst_nodes.size(),
+        "buffer_index_sem_ids size ({}) must match dst_nodes size ({})",
+        buffer_index_sem_ids.size(),
+        dst_nodes.size());
+    TT_FATAL(
+        connection_link_indices.empty() ||
+            (connection_link_indices.size() == 1 || connection_link_indices.size() == dst_nodes.size()),
+        "connection_link_indices must be empty or have size 1 or the same size as dst_nodes");
+
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+
+    std::vector<uint32_t> worker_args;
+
+    for (size_t i = 0; i < dst_nodes.size(); i++) {
+        const auto& dst_node = dst_nodes[i];
+
+        // Direction tag
+        auto dir_opt = tt::tt_fabric::get_eth_forwarding_direction(src_fabric_node_id, dst_node);
+        TT_FATAL(
+            dir_opt.has_value(),
+            "Could not determine forwarding direction from src {} to first hop {}",
+            src_fabric_node_id,
+            dst_node);
+        worker_args.push_back(static_cast<uint32_t>(dir_opt.value()));
+
+        // ETH channel
+        uint32_t link_idx = 0;
+        if (!connection_link_indices.empty()) {
+            link_idx = (connection_link_indices.size() == 1) ? connection_link_indices[0] : connection_link_indices[i];
+        } else {
+            const auto links = get_forwarding_link_indices(src_fabric_node_id, dst_node);
+            TT_FATAL(!links.empty(), "No forwarding links available from {} to {}", src_fabric_node_id, dst_node);
+            link_idx = links[0];
+        }
+
+        auto forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_node);
+        const auto candidate_eth_chans =
+            control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
+        TT_FATAL(link_idx < candidate_eth_chans.size(), "Link index {} out of bounds", link_idx);
+        const auto fabric_router_channel = candidate_eth_chans[link_idx];
+
+        // Per-connection RT args: [eth_channel, teardown_sem, buffer_idx_sem]
+        worker_args.push_back(fabric_router_channel);
+        worker_args.push_back(teardown_sem_ids[i]);
+        worker_args.push_back(buffer_index_sem_ids[i]);
+    }
+
+    // 2D metadata
+    if (fabric_context.is_2D_routing_enabled()) {
+        auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+        worker_args.push_back(mesh_shape[1]);                     // ew_dim
+        worker_args.push_back(src_fabric_node_id.chip_id);        // my_chip_id
+        worker_args.push_back(src_fabric_node_id.mesh_id.get());  // my_mesh_id
+
+        for (const auto& dst_node : dst_nodes) {
+            worker_args.push_back(static_cast<uint16_t>(dst_node.chip_id));
+            worker_args.push_back(static_cast<uint16_t>(*dst_node.mesh_id));
+        }
+    }
+
+    return worker_args;
+}
+
 // Core implementation of routing plane connection setup.
 // When inject_defines is false, skips adding kernel defines to the PD (caller handles them separately).
 template <typename ProgramOrDescriptor>

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -337,9 +337,28 @@ uint32_t append_routing_plane_connection_manager_rt_args(
     return dst_nodes.size();
 }
 
-// append runtime parameter for RoutingPlaneConnectionManager
+// Query the kernel defines required by the current fabric configuration.
+// Pure query — no PD mutation, no side effects. Call before kernel compilation.
+std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(FabricApiType api_type) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+
+    std::vector<std::pair<std::string, std::string>> defines;
+    switch (api_type) {
+        case FabricApiType::Linear: defines.push_back({"API_TYPE_Linear", "1"}); break;
+        case FabricApiType::Mesh: defines.push_back({"API_TYPE_Mesh", "1"}); break;
+        default: TT_FATAL(false, "Unsupported FabricApiType: {}", static_cast<int>(api_type));
+    }
+    if (fabric_context.is_2D_routing_enabled()) {
+        defines.push_back({"FABRIC_2D", "1"});
+    }
+    return defines;
+}
+
+// Core implementation of routing plane connection setup.
+// When inject_defines is false, skips adding kernel defines to the PD (caller handles them separately).
 template <typename ProgramOrDescriptor>
-void append_routing_plane_connection_manager_rt_args(
+void append_routing_plane_connection_manager_rt_args_impl(
     const FabricNodeId& src_fabric_node_id,
     const std::vector<FabricNodeId>& dst_nodes,
     const std::vector<uint32_t>& connection_link_indices,
@@ -348,7 +367,8 @@ void append_routing_plane_connection_manager_rt_args(
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     FabricApiType api_type,
-    CoreType core_type) {
+    CoreType core_type,
+    bool inject_defines) {
     // 1) append tag (like direction) and fabric connection info for each route
     TT_FATAL(
         connection_link_indices.empty() ||
@@ -403,30 +423,35 @@ void append_routing_plane_connection_manager_rt_args(
             src_fabric_node_id, dst_node, link_idx, worker_program_or_desc, worker_core, worker_args, core_type);
     }
 
-    auto add_kernel_defines = [&, kernel_ref = [&]() {
-        if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
-            return &worker_program_or_desc.kernels[kernel_id];
-        } else {
-            return worker_program_or_desc.impl().get_kernel(kernel_id);
-        }
-    }()](std::initializer_list<std::pair<std::string, std::string>> defines) {
-        if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
-            for (const auto& define : defines) {
-                kernel_ref->defines.push_back(define);
+    if (inject_defines) {
+        auto add_kernel_defines = [&, kernel_ref = [&]() {
+            if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
+                return &worker_program_or_desc.kernels[kernel_id];
+            } else {
+                return worker_program_or_desc.impl().get_kernel(kernel_id);
             }
-        } else {
-            kernel_ref->add_defines(std::map<std::string, std::string>(defines.begin(), defines.end()));
-        }
-    };
+        }()](std::initializer_list<std::pair<std::string, std::string>> defines) {
+            if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
+                for (const auto& define : defines) {
+                    kernel_ref->defines.push_back(define);
+                }
+            } else {
+                kernel_ref->add_defines(std::map<std::string, std::string>(defines.begin(), defines.end()));
+            }
+        };
 
-    switch (api_type) {
-        case FabricApiType::Linear: add_kernel_defines({{"API_TYPE_Linear", "1"}}); break;
-        case FabricApiType::Mesh: add_kernel_defines({{"API_TYPE_Mesh", "1"}}); break;
-        default: TT_FATAL(false, "Unsupported FabricApiType: {}", static_cast<int>(api_type));
+        switch (api_type) {
+            case FabricApiType::Linear: add_kernel_defines({{"API_TYPE_Linear", "1"}}); break;
+            case FabricApiType::Mesh: add_kernel_defines({{"API_TYPE_Mesh", "1"}}); break;
+            default: TT_FATAL(false, "Unsupported FabricApiType: {}", static_cast<int>(api_type));
+        }
+        if (fabric_context.is_2D_routing_enabled()) {
+            add_kernel_defines({{"FABRIC_2D", "1"}});
+        }
     }
+
     // 2) Append additional info for 2D Mesh
     if (fabric_context.is_2D_routing_enabled()) {
-        add_kernel_defines({{"FABRIC_2D", "1"}});
         auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
         worker_args.push_back(mesh_shape[1]);                     // ew_dim
         worker_args.push_back(src_fabric_node_id.chip_id);        // my_chip_id
@@ -440,6 +465,58 @@ void append_routing_plane_connection_manager_rt_args(
             worker_args.push_back(static_cast<uint16_t>(*dst_node.mesh_id));
         }
     }
+}
+
+// append runtime parameter for RoutingPlaneConnectionManager
+// Original API — injects defines + semaphores + RT args into the PD.
+template <typename ProgramOrDescriptor>
+void append_routing_plane_connection_manager_rt_args(
+    const FabricNodeId& src_fabric_node_id,
+    const std::vector<FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    ProgramOrDescriptor& worker_program_or_desc,
+    tt::tt_metal::KernelHandle& kernel_id,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args,
+    FabricApiType api_type,
+    CoreType core_type) {
+    append_routing_plane_connection_manager_rt_args_impl(
+        src_fabric_node_id,
+        dst_nodes,
+        connection_link_indices,
+        worker_program_or_desc,
+        kernel_id,
+        worker_core,
+        worker_args,
+        api_type,
+        core_type,
+        /*inject_defines=*/true);
+}
+
+// No-defines variant: allocates semaphores + computes RT args, but does NOT inject kernel defines.
+// Use with get_fabric_kernel_defines() when defines must be set before kernel compilation.
+template <typename ProgramOrDescriptor>
+void append_routing_plane_connection_rt_args_no_defines(
+    const FabricNodeId& src_fabric_node_id,
+    const std::vector<FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    ProgramOrDescriptor& worker_program_or_desc,
+    tt::tt_metal::KernelHandle& kernel_id,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args,
+    FabricApiType api_type,
+    CoreType core_type) {
+    append_routing_plane_connection_manager_rt_args_impl(
+        src_fabric_node_id,
+        dst_nodes,
+        connection_link_indices,
+        worker_program_or_desc,
+        kernel_id,
+        worker_core,
+        worker_args,
+        api_type,
+        core_type,
+        /*inject_defines=*/false);
 }
 
 std::vector<uint32_t> get_forwarding_link_indices(
@@ -598,6 +675,28 @@ template void append_routing_plane_connection_manager_rt_args<tt::tt_metal::Prog
     CoreType);
 
 template void append_routing_plane_connection_manager_rt_args<tt::tt_metal::Program>(
+    const FabricNodeId&,
+    const std::vector<FabricNodeId>&,
+    const std::vector<uint32_t>&,
+    tt::tt_metal::Program&,
+    tt::tt_metal::KernelHandle&,
+    const CoreCoord&,
+    std::vector<uint32_t>&,
+    FabricApiType,
+    CoreType);
+
+template void append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::ProgramDescriptor>(
+    const FabricNodeId&,
+    const std::vector<FabricNodeId>&,
+    const std::vector<uint32_t>&,
+    tt::tt_metal::ProgramDescriptor&,
+    tt::tt_metal::KernelHandle&,
+    const CoreCoord&,
+    std::vector<uint32_t>&,
+    FabricApiType,
+    CoreType);
+
+template void append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::Program>(
     const FabricNodeId&,
     const std::vector<FabricNodeId>&,
     const std::vector<uint32_t>&,

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -100,6 +100,10 @@ std::unordered_map<MeshId, MeshShape> get_physical_mesh_shapes() {
 extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t wy, uint32_t dir, uint32_t neighbor);
 #endif
 
+std::vector<MeshId> get_all_fabric_mesh_ids() {
+    return tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph().get_mesh_ids();
+}
+
 template <typename ProgramOrDescriptor>
 void append_fabric_connection_rt_args(
     const FabricNodeId& src_fabric_node_id,

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -8,6 +8,7 @@
 #include "erisc_datamover_builder.hpp"
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/internal/fabric.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -100,9 +101,13 @@ std::unordered_map<MeshId, MeshShape> get_physical_mesh_shapes() {
 extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t wy, uint32_t dir, uint32_t neighbor);
 #endif
 
+namespace tt::tt_metal::internal {
+
 std::vector<MeshId> get_all_fabric_mesh_ids() {
     return tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph().get_mesh_ids();
 }
+
+}  // namespace tt::tt_metal::internal
 
 template <typename ProgramOrDescriptor>
 void append_fabric_connection_rt_args(
@@ -341,103 +346,6 @@ uint32_t append_routing_plane_connection_manager_rt_args(
     return dst_nodes.size();
 }
 
-// Query the kernel defines required by the current fabric configuration.
-// Pure query — no PD mutation, no side effects. Call before kernel compilation.
-std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(FabricApiType api_type) {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& fabric_context = control_plane.get_fabric_context();
-
-    std::vector<std::pair<std::string, std::string>> defines;
-    switch (api_type) {
-        case FabricApiType::Linear: defines.push_back({"API_TYPE_Linear", "1"}); break;
-        case FabricApiType::Mesh: defines.push_back({"API_TYPE_Mesh", "1"}); break;
-        default: TT_FATAL(false, "Unsupported FabricApiType: {}", static_cast<int>(api_type));
-    }
-    if (fabric_context.is_2D_routing_enabled()) {
-        defines.push_back({"FABRIC_2D", "1"});
-    }
-    return defines;
-}
-
-// Compute fabric connection RT args without any PD mutation.
-// Caller provides pre-allocated semaphore IDs (2 per connection: teardown + buffer_index).
-// Returns the flat RT args vector for RoutingPlaneConnectionManager::build_from_args().
-std::vector<uint32_t> compute_fabric_connection_rt_args(
-    const FabricNodeId& src_fabric_node_id,
-    const std::vector<FabricNodeId>& dst_nodes,
-    const std::vector<uint32_t>& connection_link_indices,
-    const std::vector<uint32_t>& teardown_sem_ids,
-    const std::vector<uint32_t>& buffer_index_sem_ids) {
-    TT_FATAL(
-        teardown_sem_ids.size() == dst_nodes.size(),
-        "teardown_sem_ids size ({}) must match dst_nodes size ({})",
-        teardown_sem_ids.size(),
-        dst_nodes.size());
-    TT_FATAL(
-        buffer_index_sem_ids.size() == dst_nodes.size(),
-        "buffer_index_sem_ids size ({}) must match dst_nodes size ({})",
-        buffer_index_sem_ids.size(),
-        dst_nodes.size());
-    TT_FATAL(
-        connection_link_indices.empty() ||
-            (connection_link_indices.size() == 1 || connection_link_indices.size() == dst_nodes.size()),
-        "connection_link_indices must be empty or have size 1 or the same size as dst_nodes");
-
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& fabric_context = control_plane.get_fabric_context();
-
-    std::vector<uint32_t> worker_args;
-
-    for (size_t i = 0; i < dst_nodes.size(); i++) {
-        const auto& dst_node = dst_nodes[i];
-
-        // Direction tag
-        auto dir_opt = tt::tt_fabric::get_eth_forwarding_direction(src_fabric_node_id, dst_node);
-        TT_FATAL(
-            dir_opt.has_value(),
-            "Could not determine forwarding direction from src {} to first hop {}",
-            src_fabric_node_id,
-            dst_node);
-        worker_args.push_back(static_cast<uint32_t>(dir_opt.value()));
-
-        // ETH channel
-        uint32_t link_idx = 0;
-        if (!connection_link_indices.empty()) {
-            link_idx = (connection_link_indices.size() == 1) ? connection_link_indices[0] : connection_link_indices[i];
-        } else {
-            const auto links = get_forwarding_link_indices(src_fabric_node_id, dst_node);
-            TT_FATAL(!links.empty(), "No forwarding links available from {} to {}", src_fabric_node_id, dst_node);
-            link_idx = links[0];
-        }
-
-        auto forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_node);
-        const auto candidate_eth_chans =
-            control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
-        TT_FATAL(link_idx < candidate_eth_chans.size(), "Link index {} out of bounds", link_idx);
-        const auto fabric_router_channel = candidate_eth_chans[link_idx];
-
-        // Per-connection RT args: [eth_channel, teardown_sem, buffer_idx_sem]
-        worker_args.push_back(fabric_router_channel);
-        worker_args.push_back(teardown_sem_ids[i]);
-        worker_args.push_back(buffer_index_sem_ids[i]);
-    }
-
-    // 2D metadata
-    if (fabric_context.is_2D_routing_enabled()) {
-        auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
-        worker_args.push_back(mesh_shape[1]);                     // ew_dim
-        worker_args.push_back(src_fabric_node_id.chip_id);        // my_chip_id
-        worker_args.push_back(src_fabric_node_id.mesh_id.get());  // my_mesh_id
-
-        for (const auto& dst_node : dst_nodes) {
-            worker_args.push_back(static_cast<uint16_t>(dst_node.chip_id));
-            worker_args.push_back(static_cast<uint16_t>(*dst_node.mesh_id));
-        }
-    }
-
-    return worker_args;
-}
-
 // Core implementation of routing plane connection setup.
 // When inject_defines is false, skips adding kernel defines to the PD (caller handles them separately).
 template <typename ProgramOrDescriptor>
@@ -574,32 +482,6 @@ void append_routing_plane_connection_manager_rt_args(
         api_type,
         core_type,
         /*inject_defines=*/true);
-}
-
-// No-defines variant: allocates semaphores + computes RT args, but does NOT inject kernel defines.
-// Use with get_fabric_kernel_defines() when defines must be set before kernel compilation.
-template <typename ProgramOrDescriptor>
-void append_routing_plane_connection_rt_args_no_defines(
-    const FabricNodeId& src_fabric_node_id,
-    const std::vector<FabricNodeId>& dst_nodes,
-    const std::vector<uint32_t>& connection_link_indices,
-    ProgramOrDescriptor& worker_program_or_desc,
-    tt::tt_metal::KernelHandle& kernel_id,
-    const CoreCoord& worker_core,
-    std::vector<uint32_t>& worker_args,
-    FabricApiType api_type,
-    CoreType core_type) {
-    append_routing_plane_connection_manager_rt_args_impl(
-        src_fabric_node_id,
-        dst_nodes,
-        connection_link_indices,
-        worker_program_or_desc,
-        kernel_id,
-        worker_core,
-        worker_args,
-        api_type,
-        core_type,
-        /*inject_defines=*/false);
 }
 
 std::vector<uint32_t> get_forwarding_link_indices(
@@ -768,26 +650,153 @@ template void append_routing_plane_connection_manager_rt_args<tt::tt_metal::Prog
     FabricApiType,
     CoreType);
 
+}  // namespace tt::tt_fabric
+
+namespace tt::tt_metal::internal {
+
+// Query the kernel defines required by the current fabric configuration.
+// Pure query — no PD mutation, no side effects. Call before kernel compilation.
+std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(tt::tt_fabric::FabricApiType api_type) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+
+    std::vector<std::pair<std::string, std::string>> defines;
+    switch (api_type) {
+        case tt::tt_fabric::FabricApiType::Linear: defines.push_back({"API_TYPE_Linear", "1"}); break;
+        case tt::tt_fabric::FabricApiType::Mesh: defines.push_back({"API_TYPE_Mesh", "1"}); break;
+        default: TT_FATAL(false, "Unsupported FabricApiType: {}", static_cast<int>(api_type));
+    }
+    if (fabric_context.is_2D_routing_enabled()) {
+        defines.push_back({"FABRIC_2D", "1"});
+    }
+    return defines;
+}
+
+// Compute fabric connection RT args without any PD mutation.
+// Caller provides pre-allocated semaphore IDs (2 per connection: teardown + buffer_index).
+// Returns the flat RT args vector for RoutingPlaneConnectionManager::build_from_args().
+std::vector<uint32_t> compute_fabric_connection_rt_args(
+    const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
+    const std::vector<tt::tt_fabric::FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    const std::vector<uint32_t>& teardown_sem_ids,
+    const std::vector<uint32_t>& buffer_index_sem_ids) {
+    TT_FATAL(
+        teardown_sem_ids.size() == dst_nodes.size(),
+        "teardown_sem_ids size ({}) must match dst_nodes size ({})",
+        teardown_sem_ids.size(),
+        dst_nodes.size());
+    TT_FATAL(
+        buffer_index_sem_ids.size() == dst_nodes.size(),
+        "buffer_index_sem_ids size ({}) must match dst_nodes size ({})",
+        buffer_index_sem_ids.size(),
+        dst_nodes.size());
+    TT_FATAL(
+        connection_link_indices.empty() ||
+            (connection_link_indices.size() == 1 || connection_link_indices.size() == dst_nodes.size()),
+        "connection_link_indices must be empty or have size 1 or the same size as dst_nodes");
+
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+
+    std::vector<uint32_t> worker_args;
+
+    for (size_t i = 0; i < dst_nodes.size(); i++) {
+        const auto& dst_node = dst_nodes[i];
+
+        // Direction tag
+        auto dir_opt = tt::tt_fabric::get_eth_forwarding_direction(src_fabric_node_id, dst_node);
+        TT_FATAL(
+            dir_opt.has_value(),
+            "Could not determine forwarding direction from src {} to first hop {}",
+            src_fabric_node_id,
+            dst_node);
+        worker_args.push_back(static_cast<uint32_t>(dir_opt.value()));
+
+        // ETH channel
+        uint32_t link_idx = 0;
+        if (!connection_link_indices.empty()) {
+            link_idx = (connection_link_indices.size() == 1) ? connection_link_indices[0] : connection_link_indices[i];
+        } else {
+            const auto links = tt::tt_fabric::get_forwarding_link_indices(src_fabric_node_id, dst_node);
+            TT_FATAL(!links.empty(), "No forwarding links available from {} to {}", src_fabric_node_id, dst_node);
+            link_idx = links[0];
+        }
+
+        auto forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_node);
+        const auto candidate_eth_chans =
+            control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
+        TT_FATAL(link_idx < candidate_eth_chans.size(), "Link index {} out of bounds", link_idx);
+        const auto fabric_router_channel = candidate_eth_chans[link_idx];
+
+        // Per-connection RT args: [eth_channel, teardown_sem, buffer_idx_sem]
+        worker_args.push_back(fabric_router_channel);
+        worker_args.push_back(teardown_sem_ids[i]);
+        worker_args.push_back(buffer_index_sem_ids[i]);
+    }
+
+    // 2D metadata
+    if (fabric_context.is_2D_routing_enabled()) {
+        auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+        worker_args.push_back(mesh_shape[1]);                     // ew_dim
+        worker_args.push_back(src_fabric_node_id.chip_id);        // my_chip_id
+        worker_args.push_back(src_fabric_node_id.mesh_id.get());  // my_mesh_id
+
+        for (const auto& dst_node : dst_nodes) {
+            worker_args.push_back(static_cast<uint16_t>(dst_node.chip_id));
+            worker_args.push_back(static_cast<uint16_t>(*dst_node.mesh_id));
+        }
+    }
+
+    return worker_args;
+}
+
+// No-defines variant: allocates semaphores + computes RT args, but does NOT inject kernel defines.
+// Use with get_fabric_kernel_defines() when defines must be set before kernel compilation.
+template <typename ProgramOrDescriptor>
+void append_routing_plane_connection_rt_args_no_defines(
+    const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
+    const std::vector<tt::tt_fabric::FabricNodeId>& dst_nodes,
+    const std::vector<uint32_t>& connection_link_indices,
+    ProgramOrDescriptor& worker_program_or_desc,
+    tt::tt_metal::KernelHandle& kernel_id,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args,
+    tt::tt_fabric::FabricApiType api_type,
+    CoreType core_type) {
+    tt::tt_fabric::append_routing_plane_connection_manager_rt_args_impl(
+        src_fabric_node_id,
+        dst_nodes,
+        connection_link_indices,
+        worker_program_or_desc,
+        kernel_id,
+        worker_core,
+        worker_args,
+        api_type,
+        core_type,
+        /*inject_defines=*/false);
+}
+
 template void append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::ProgramDescriptor>(
-    const FabricNodeId&,
-    const std::vector<FabricNodeId>&,
+    const tt::tt_fabric::FabricNodeId&,
+    const std::vector<tt::tt_fabric::FabricNodeId>&,
     const std::vector<uint32_t>&,
     tt::tt_metal::ProgramDescriptor&,
     tt::tt_metal::KernelHandle&,
     const CoreCoord&,
     std::vector<uint32_t>&,
-    FabricApiType,
+    tt::tt_fabric::FabricApiType,
     CoreType);
 
 template void append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::Program>(
-    const FabricNodeId&,
-    const std::vector<FabricNodeId>&,
+    const tt::tt_fabric::FabricNodeId&,
+    const std::vector<tt::tt_fabric::FabricNodeId>&,
     const std::vector<uint32_t>&,
     tt::tt_metal::Program&,
     tt::tt_metal::KernelHandle&,
     const CoreCoord&,
     std::vector<uint32_t>&,
-    FabricApiType,
+    tt::tt_fabric::FabricApiType,
     CoreType);
 
-}  // namespace tt::tt_fabric
+}  // namespace tt::tt_metal::internal

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -101,14 +101,6 @@ std::unordered_map<MeshId, MeshShape> get_physical_mesh_shapes() {
 extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t wy, uint32_t dir, uint32_t neighbor);
 #endif
 
-namespace tt::tt_metal::internal {
-
-std::vector<MeshId> get_all_fabric_mesh_ids() {
-    return tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph().get_mesh_ids();
-}
-
-}  // namespace tt::tt_metal::internal
-
 template <typename ProgramOrDescriptor>
 void append_fabric_connection_rt_args(
     const FabricNodeId& src_fabric_node_id,
@@ -346,20 +338,50 @@ uint32_t append_routing_plane_connection_manager_rt_args(
     return dst_nodes.size();
 }
 
-// Core implementation of routing plane connection setup.
-// When inject_defines is false, skips adding kernel defines to the PD (caller handles them separately).
+// Inject fabric kernel defines (API_TYPE_*, FABRIC_2D) onto the kernel identified by kernel_id.
+// Template: ProgramDescriptor appends to .defines vector; Program calls add_defines().
+template <typename ProgramOrDescriptor>
+void inject_fabric_kernel_defines(
+    ProgramOrDescriptor& worker_program_or_desc, tt::tt_metal::KernelHandle& kernel_id, FabricApiType api_type) {
+    const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+
+    auto add_kernel_defines = [&, kernel_ref = [&]() {
+        if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
+            return &worker_program_or_desc.kernels[kernel_id];
+        } else {
+            return worker_program_or_desc.impl().get_kernel(kernel_id);
+        }
+    }()](std::initializer_list<std::pair<std::string, std::string>> defines) {
+        if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
+            for (const auto& define : defines) {
+                kernel_ref->defines.push_back(define);
+            }
+        } else {
+            kernel_ref->add_defines(std::map<std::string, std::string>(defines.begin(), defines.end()));
+        }
+    };
+
+    switch (api_type) {
+        case FabricApiType::Linear: add_kernel_defines({{"API_TYPE_Linear", "1"}}); break;
+        case FabricApiType::Mesh: add_kernel_defines({{"API_TYPE_Mesh", "1"}}); break;
+        default: TT_FATAL(false, "Unsupported FabricApiType: {}", static_cast<int>(api_type));
+    }
+    if (fabric_context.is_2D_routing_enabled()) {
+        add_kernel_defines({{"FABRIC_2D", "1"}});
+    }
+}
+
+// Core: append connection manager RT args for one or more routes (no kernel defines).
+// Use inject_fabric_kernel_defines() separately when defines are needed on the kernel.
 template <typename ProgramOrDescriptor>
 void append_routing_plane_connection_manager_rt_args_impl(
     const FabricNodeId& src_fabric_node_id,
     const std::vector<FabricNodeId>& dst_nodes,
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
-    tt::tt_metal::KernelHandle& kernel_id,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
-    FabricApiType api_type,
-    CoreType core_type,
-    bool inject_defines) {
+    CoreType core_type) {
     // 1) append tag (like direction) and fabric connection info for each route
     TT_FATAL(
         connection_link_indices.empty() ||
@@ -414,33 +436,6 @@ void append_routing_plane_connection_manager_rt_args_impl(
             src_fabric_node_id, dst_node, link_idx, worker_program_or_desc, worker_core, worker_args, core_type);
     }
 
-    if (inject_defines) {
-        auto add_kernel_defines = [&, kernel_ref = [&]() {
-            if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
-                return &worker_program_or_desc.kernels[kernel_id];
-            } else {
-                return worker_program_or_desc.impl().get_kernel(kernel_id);
-            }
-        }()](std::initializer_list<std::pair<std::string, std::string>> defines) {
-            if constexpr (std::is_same_v<std::decay_t<ProgramOrDescriptor>, tt::tt_metal::ProgramDescriptor>) {
-                for (const auto& define : defines) {
-                    kernel_ref->defines.push_back(define);
-                }
-            } else {
-                kernel_ref->add_defines(std::map<std::string, std::string>(defines.begin(), defines.end()));
-            }
-        };
-
-        switch (api_type) {
-            case FabricApiType::Linear: add_kernel_defines({{"API_TYPE_Linear", "1"}}); break;
-            case FabricApiType::Mesh: add_kernel_defines({{"API_TYPE_Mesh", "1"}}); break;
-            default: TT_FATAL(false, "Unsupported FabricApiType: {}", static_cast<int>(api_type));
-        }
-        if (fabric_context.is_2D_routing_enabled()) {
-            add_kernel_defines({{"FABRIC_2D", "1"}});
-        }
-    }
-
     // 2) Append additional info for 2D Mesh
     if (fabric_context.is_2D_routing_enabled()) {
         auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
@@ -476,12 +471,10 @@ void append_routing_plane_connection_manager_rt_args(
         dst_nodes,
         connection_link_indices,
         worker_program_or_desc,
-        kernel_id,
         worker_core,
         worker_args,
-        api_type,
-        core_type,
-        /*inject_defines=*/true);
+        core_type);
+    inject_fabric_kernel_defines(worker_program_or_desc, kernel_id, api_type);
 }
 
 std::vector<uint32_t> get_forwarding_link_indices(
@@ -654,6 +647,10 @@ template void append_routing_plane_connection_manager_rt_args<tt::tt_metal::Prog
 
 namespace tt::tt_metal::internal {
 
+std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids() {
+    return tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph().get_mesh_ids();
+}
+
 // Query the kernel defines required by the current fabric configuration.
 // Pure query — no PD mutation, no side effects. Call before kernel compilation.
 std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(tt::tt_fabric::FabricApiType api_type) {
@@ -764,17 +761,16 @@ void append_routing_plane_connection_rt_args_no_defines(
     std::vector<uint32_t>& worker_args,
     tt::tt_fabric::FabricApiType api_type,
     CoreType core_type) {
+    (void)kernel_id;
+    (void)api_type;
     tt::tt_fabric::append_routing_plane_connection_manager_rt_args_impl(
         src_fabric_node_id,
         dst_nodes,
         connection_link_indices,
         worker_program_or_desc,
-        kernel_id,
         worker_core,
         worker_args,
-        api_type,
-        core_type,
-        /*inject_defines=*/false);
+        core_type);
 }
 
 template void append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::ProgramDescriptor>(

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -8,6 +8,8 @@
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
 #include <tt-metalium/core_coord.hpp>
@@ -216,6 +218,78 @@ void bind_fabric_api(nb::module_& mod) {
                 program_descriptor: ProgramDescriptor to add semaphores/defines to (mutated)
                 kernel_idx: Index of the kernel in the program descriptor
                 worker_core: Logical core coordinate of the worker
+        )");
+
+    mod.def(
+        "get_fabric_kernel_defines",
+        [](const std::string& api_type_str) {
+            tt::tt_fabric::FabricApiType api_type;
+            if (api_type_str == "Linear") {
+                api_type = tt::tt_fabric::FabricApiType::Linear;
+            } else if (api_type_str == "Mesh") {
+                api_type = tt::tt_fabric::FabricApiType::Mesh;
+            } else {
+                throw std::invalid_argument("api_type must be 'Linear' or 'Mesh', got: " + api_type_str);
+            }
+            return tt::tt_fabric::get_fabric_kernel_defines(api_type);
+        },
+        nb::arg("api_type") = "Linear",
+        R"(
+            Query the kernel defines required by the current fabric configuration.
+            Pure query — no PD mutation, no side effects. Safe to call before kernel compilation.
+
+            Args:
+                api_type: Fabric API type ("Linear" or "Mesh"). Defaults to "Linear".
+
+            Returns:
+                List of (name, value) tuples, e.g. [("FABRIC_2D", "1"), ("API_TYPE_Linear", "1")].
+        )");
+
+    mod.def(
+        "fabric_connection_rt_args",
+        [](const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
+           const std::vector<tt::tt_fabric::FabricNodeId>& dst_nodes,
+           const std::vector<uint32_t>& connection_link_indices,
+           tt::tt_metal::ProgramDescriptor& program_descriptor,
+           size_t kernel_idx,
+           tt::tt_metal::CoreCoord worker_core) {
+            std::vector<uint32_t> fabric_args;
+
+            tt::tt_metal::KernelHandle kernel_id = static_cast<tt::tt_metal::KernelHandle>(kernel_idx);
+            tt::tt_fabric::append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::ProgramDescriptor>(
+                src_fabric_node_id,
+                dst_nodes,
+                connection_link_indices,
+                program_descriptor,
+                kernel_id,
+                worker_core,
+                fabric_args);
+
+            return fabric_args;
+        },
+        nb::arg("src_fabric_node_id"),
+        nb::arg("dst_nodes"),
+        nb::arg("connection_link_indices"),
+        nb::arg("program_descriptor"),
+        nb::arg("kernel_idx"),
+        nb::arg("worker_core"),
+        R"(
+            Set up fabric connections: allocate semaphores and compute runtime args.
+            Does NOT inject kernel defines — use get_fabric_kernel_defines() for that.
+
+            Use this when kernel defines must be set before compilation (e.g., blaze
+            eager-compile model), and connection setup happens after compilation.
+
+            Args:
+                src_fabric_node_id: FabricNodeId of the source chip
+                dst_nodes: List of FabricNodeIds of destination chips (one per route)
+                connection_link_indices: List of link indices (empty for auto-select, size 1 for all routes, or per-route)
+                program_descriptor: ProgramDescriptor to add semaphores to (mutated)
+                kernel_idx: Index of the kernel in the program descriptor
+                worker_core: Logical core coordinate of the worker
+
+            Returns:
+                List of runtime args to extend into per-core NCRISC runtime args.
         )");
 
     mod.def(

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -348,6 +348,37 @@ void bind_fabric_api(nb::module_& mod) {
             this rank's local mesh(es). This is exactly the shape to pass to open_mesh_device, so it is
             safe to call before the device is opened (the control plane lazily inits from the MGD).
         )");
+
+    mod.def(
+        "get_eth_forwarding_direction",
+        [](const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
+           const tt::tt_fabric::FabricNodeId& dst_fabric_node_id) -> std::optional<int> {
+            auto dir = tt::tt_fabric::get_eth_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+            if (!dir.has_value()) {
+                return std::nullopt;
+            }
+            return static_cast<int>(*dir);
+        },
+        nb::arg("src_fabric_node_id"),
+        nb::arg("dst_fabric_node_id"),
+        R"(
+            Query the ethernet forwarding direction a fabric packet would take from src to dst.
+
+            Returns the raw eth_chan_directions enum value (EAST=0, WEST=1, NORTH=2, SOUTH=3, Z=4),
+            or None if no route exists between the two chips. The returned int matches the
+            per-connection `tag` stored in RoutingPlaneConnectionManager, so it can be used by
+            callers to dedup fabric connections by direction.
+        )");
+
+    mod.def(
+        "get_all_fabric_mesh_ids",
+        &tt::tt_fabric::get_all_fabric_mesh_ids,
+        R"(
+            Returns every compute mesh id declared in the active mesh graph descriptor.
+
+            Unlike get_user_physical_mesh_ids (which is scoped to the local rank's meshes),
+            this enumerates peer meshes as well, enabling multi-mesh topology discovery.
+        )");
 }
 
 }  // namespace ttnn::fabric

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -293,6 +293,30 @@ void bind_fabric_api(nb::module_& mod) {
         )");
 
     mod.def(
+        "compute_fabric_connection_rt_args",
+        &tt::tt_fabric::compute_fabric_connection_rt_args,
+        nb::arg("src_fabric_node_id"),
+        nb::arg("dst_nodes"),
+        nb::arg("connection_link_indices"),
+        nb::arg("teardown_sem_ids"),
+        nb::arg("buffer_index_sem_ids"),
+        R"(
+            Compute fabric connection RT args without any PD mutation.
+            Pure computation — resolves routing and assembles the flat RT args vector
+            using caller-provided semaphore IDs. No PD needed.
+
+            Args:
+                src_fabric_node_id: FabricNodeId of the source chip
+                dst_nodes: List of FabricNodeIds of destination chips
+                connection_link_indices: List of link indices (empty for auto-select)
+                teardown_sem_ids: Pre-allocated semaphore IDs (one per connection)
+                buffer_index_sem_ids: Pre-allocated semaphore IDs (one per connection)
+
+            Returns:
+                List of runtime args for RoutingPlaneConnectionManager::build_from_args().
+        )");
+
+    mod.def(
         "get_tt_fabric_packet_header_size_bytes",
         &tt::tt_fabric::get_tt_fabric_packet_header_size_bytes,
         R"(

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/internal/fabric.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 
@@ -231,7 +232,7 @@ void bind_fabric_api(nb::module_& mod) {
             } else {
                 throw std::invalid_argument("api_type must be 'Linear' or 'Mesh', got: " + api_type_str);
             }
-            return tt::tt_fabric::get_fabric_kernel_defines(api_type);
+            return tt::tt_metal::internal::get_fabric_kernel_defines(api_type);
         },
         nb::arg("api_type") = "Linear",
         R"(
@@ -256,7 +257,7 @@ void bind_fabric_api(nb::module_& mod) {
             std::vector<uint32_t> fabric_args;
 
             tt::tt_metal::KernelHandle kernel_id = static_cast<tt::tt_metal::KernelHandle>(kernel_idx);
-            tt::tt_fabric::append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::ProgramDescriptor>(
+            tt::tt_metal::internal::append_routing_plane_connection_rt_args_no_defines<tt::tt_metal::ProgramDescriptor>(
                 src_fabric_node_id,
                 dst_nodes,
                 connection_link_indices,
@@ -294,7 +295,7 @@ void bind_fabric_api(nb::module_& mod) {
 
     mod.def(
         "compute_fabric_connection_rt_args",
-        &tt::tt_fabric::compute_fabric_connection_rt_args,
+        &tt::tt_metal::internal::compute_fabric_connection_rt_args,
         nb::arg("src_fabric_node_id"),
         nb::arg("dst_nodes"),
         nb::arg("connection_link_indices"),
@@ -372,7 +373,7 @@ void bind_fabric_api(nb::module_& mod) {
 
     mod.def(
         "get_all_fabric_mesh_ids",
-        &tt::tt_fabric::get_all_fabric_mesh_ids,
+        &tt::tt_metal::internal::get_all_fabric_mesh_ids,
         R"(
             Returns every compute mesh id declared in the active mesh graph descriptor.
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -179,6 +179,8 @@ from ttnn._ttnn.fabric import (
     FabricNodeId,
     setup_fabric_connection,
     setup_routing_plane_connection,
+    get_fabric_kernel_defines,
+    fabric_connection_rt_args,
 )
 
 # Import cluster functions and types

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -181,6 +181,7 @@ from ttnn._ttnn.fabric import (
     setup_routing_plane_connection,
     get_fabric_kernel_defines,
     fabric_connection_rt_args,
+    compute_fabric_connection_rt_args,
 )
 
 # Import cluster functions and types

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -175,6 +175,8 @@ from ttnn._ttnn.fabric import (
     get_tt_fabric_packet_header_size_bytes,
     get_tt_fabric_max_payload_size_bytes,
     get_physical_mesh_shapes,
+    get_eth_forwarding_direction,
+    get_all_fabric_mesh_ids,
     MeshId,
     FabricNodeId,
     setup_fabric_connection,


### PR DESCRIPTION
## Summary

Adds Python-accessible fabric APIs that enable Blaze's eager-compile model, plus control-plane query bindings. Three commits:

- **Split fabric APIs** (`get_fabric_kernel_defines` + `fabric_connection_rt_args`): Separates compile-time concerns (kernel defines) from runtime concerns (semaphores + RT args). Enables querying defines before build, setting up connections after build. Original `setup_routing_plane_connection` unchanged (backward compatible).
- **`compute_fabric_connection_rt_args`**: Pure computation variant — caller provides pre-allocated semaphore IDs; function resolves routing and assembles flat RT args vector without mutating any ProgramDescriptor. Enables setting up fabric connections entirely in emit() without a post_build hook.
- **Fabric control-plane bindings** (`get_eth_forwarding_direction` + `get_all_fabric_mesh_ids`): Python access to ethernet forwarding direction query and full mesh-id enumeration (including peer meshes not visible via `get_user_physical_mesh_ids`).

## CI Runs

| Suite | Run | Notes |
|---|---|---|
| Sanity tests (ttsim + ttnn + runtime-sim) | [run 28613593438](https://github.com/tenstorrent/tt-metal/actions/runs/28613593438) | All green except pre-existing `Semaphore_Direct_Write_SanityCheck` death-test failure (sim_blackhole/sim_wormhole_b0) — unrelated to this PR |
| Merge Gate (fabric-unit-tests + static-checks + build) | [run 28659838756](https://github.com/tenstorrent/tt-metal/actions/runs/28659838756) | Manually dispatched — includes fabric hardware tests |
| Pre-commit hooks | [run 28618197620](https://github.com/tenstorrent/tt-metal/actions/runs/28618197620) | Green |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmalTT/fabric-apis-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmalTT/fabric-apis-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:esmalTT/fabric-apis-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmalTT/fabric-apis-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmalTT/fabric-apis-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmalTT/fabric-apis-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmalTT/fabric-apis-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmalTT/fabric-apis-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmalTT/fabric-apis-upstream)