### PR TITLE
fix(test): gate tt-emule ASAN sanitizer tests to the emule build

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -69,20 +69,31 @@ set(UNIT_TESTS_API_SOURCES
     test_duplicate_kernel.cpp
     test_core_local_mem_api.cpp
     test_zero_memory_api.cpp
-    test_alignment_writes.cpp
-    test_cb_leak.cpp
-    test_cb_pages.cpp
-    test_host_alignment.cpp
-    test_metadata_size.cpp
-    test_noc_without_barrier.cpp
-    test_padded_write.cpp
-    test_semaphore_write.cpp
-    test_tensor_bad_access.cpp
-    test_valid_mem_wrong_alloc.cpp
-    test_write_beyond_res_pages.cpp
-    test_write_outside_tensor.cpp
     disaggregation/test_kv_chunk_address_table.cpp
 )
+
+# tt-emule ASAN sanitizer tests. These EXPECT_DEATH tests assert on the emule
+# ASAN panic (e.g. "Illegal Semaphore Access") and JIT kernels that reference
+# emule-only defines/intrinsics (EMULE_SEM_BASE, __emule_local_l1_to_ptr). They
+# only build/pass under the emule backend; on ttsim/HW the kernels fail to
+# compile and the death tests fail. Gate them so they never enter the non-emule
+# unit_tests_api binary.
+if(TT_METAL_USE_EMULE)
+    list(APPEND UNIT_TESTS_API_SOURCES
+        test_alignment_writes.cpp
+        test_cb_leak.cpp
+        test_cb_pages.cpp
+        test_host_alignment.cpp
+        test_metadata_size.cpp
+        test_noc_without_barrier.cpp
+        test_padded_write.cpp
+        test_semaphore_write.cpp
+        test_tensor_bad_access.cpp
+        test_valid_mem_wrong_alloc.cpp
+        test_write_beyond_res_pages.cpp
+        test_write_outside_tensor.cpp
+    )
+endif()
 
 # Runtime tensor tests build into their own executable (unit_tests_tensor),
 # mirroring unit_tests_ttnn_tensor, so they stay out of the tt-metalium smoke binary.

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -79,7 +79,9 @@ set(UNIT_TESTS_API_SOURCES
 # compile and the death tests fail. Gate them so they never enter the non-emule
 # unit_tests_api binary.
 if(TT_METAL_USE_EMULE)
-    list(APPEND UNIT_TESTS_API_SOURCES
+    list(
+        APPEND
+        UNIT_TESTS_API_SOURCES
         test_alignment_writes.cpp
         test_cb_leak.cpp
         test_cb_pages.cpp


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The emule ASAN sanitizer tests (test_semaphore_write, test_cb_leak, and 11 siblings) were listed in the unconditional UNIT_TESTS_API_SOURCES, so they compiled into unit_tests_api for every backend. These EXPECT_DEATH tests assert on the emule ASAN panic (e.g. "Illegal Semaphore Access") and JIT kernels that reference emule-only defines/intrinsics (EMULE_SEM_BASE, __emule_local_l1_to_ptr), which exist only in the emule build.

Under the ttsim runtime-sanity job (runtime_sanity_tests.yaml runs unit_tests_api with a negative gtest filter that only excludes Quasar/HW fixtures), these ran on ttsim: the kernels fail to JIT-compile ('EMULE_SEM_BASE was not declared') or the process aborts / fails to die, crashing the binary. The break landed silently because push-triggered ttsim sanity had been disabled.

Move the 13 emule-only test files behind if(TT_METAL_USE_EMULE) so they never enter the non-emule unit_tests_api binary.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gate-emule-asan-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gate-emule-asan-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gate-emule-asan-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gate-emule-asan-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gate-emule-asan-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gate-emule-asan-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gate-emule-asan-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gate-emule-asan-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gate-emule-asan-tests)