### PR TITLE
Fix #48796 - Add missing sub_core_grids exposed by test

### DIFF
--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -390,6 +390,7 @@ class Sampling1D(LightweightModule):
             topk_indices_int32,
             dtype=ttnn.int32,
             memory_config=cfg.sampling_memory_config,
+            sub_core_grids=cfg.sub_core_grids,
         )
         ttnn.deallocate(topk_indices_int32)
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #48796 

The test added in https://github.com/tenstorrent/tt-metal/pull/48458 runs sampling_1d.py with sub_core_grids. The PR didn't have a clean unit test run, as that was blocked by an unrelated failure causing early exit.
Apparently that path was not previously covered in the tests, and the new one exposed a preexisting bug where sub_core_grids was not passed correctly. 

### Notes for reviewers
-

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/48796)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/48796)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:tcheda/48796)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/48796)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/48796)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/48796)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/48796)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/48796)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/48796)