### PR TITLE
[Bugfix] Fix config/tokenizer resolution on read-only HF cache mounts

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -159,6 +159,10 @@ class PrefillModelAdapter(ABC):
     moe_pcc_threshold: float = 0.999
     mla_pcc_threshold: float = 0.999
     supports_pretrained: bool = True
+    # Whether the tokenizer needs trust_remote_code=True (custom tokenizer code shipped in the repo,
+    # e.g. Kimi's tiktoken-backed BBPE). DeepSeek-V3 uses a stock fast tokenizer, so it turns this off
+    # to avoid the flat-config trust_remote_code import path that otherwise breaks its load.
+    tokenizer_trust_remote_code: bool = True
     # Hand-built HF-attribute config factory (zero-arg callable) for models whose
     # ``model_type`` transformers can't load via AutoConfig (unregistered, e.g. DeepSeek-V3.2's
     # ``deepseek_v32`` / GLM's ``glm_moe_dsa``). None → resolve the config the normal way

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -163,6 +163,11 @@ class PrefillModelAdapter(ABC):
     # e.g. Kimi's tiktoken-backed BBPE). DeepSeek-V3 uses a stock fast tokenizer, so it turns this off
     # to avoid the flat-config trust_remote_code import path that otherwise breaks its load.
     tokenizer_trust_remote_code: bool = True
+    # Whether config/tokenizer resolution must copy the HF snapshot into a flat dir of real files.
+    # Only needed when loading with trust_remote_code=True (transformers resolves the remote module to
+    # its blobs/ realpath and then can't find relative-import siblings by name). Variants that load
+    # stock config/tokenizers (trust_remote_code=False) use the snapshot dir directly and set this off.
+    needs_flat_config_dir: bool = True
     # Hand-built HF-attribute config factory (zero-arg callable) for models whose
     # ``model_type`` transformers can't load via AutoConfig (unregistered, e.g. DeepSeek-V3.2's
     # ``deepseek_v32`` / GLM's ``glm_moe_dsa``). None → resolve the config the normal way

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -11,6 +11,7 @@ Automatically downloads weights from HuggingFace if not available locally.
 import json
 import os
 import shutil
+import tempfile
 from functools import lru_cache
 from pathlib import Path
 
@@ -194,17 +195,33 @@ def download_model_config_only(variant: TestVariant, cache_dir: Path) -> Path:
             ignore_patterns=["*.safetensors"],  # Don't download weight files
         )
 
+        # Variants that load config/tokenizer without trust_remote_code (e.g. DeepSeek-V3, stock fast
+        # tokenizer) can use the HF snapshot dir directly — no flat copy needed. Skipping it also avoids
+        # writing into a possibly read-only HF cache mount.
+        if not variant.needs_flat_config_dir:
+            logger.success(f"✓ Config files downloaded to: {model_dir}")
+            return Path(model_dir)
+
         # The HF cache stores files as symlinks into blobs/ (content-hash names). With
         # trust_remote_code=True, transformers resolves the remote module to its blob realpath
         # and then looks for its relative-import siblings (e.g. tool_declaration_ts.py) by name in
         # that same dir, which fails in blobs/. Copy into a flat dir of real files so relative
-        # imports resolve by name.
+        # imports resolve by name. The dir name is made dot-free (trust_remote_code can't import a
+        # dynamic module whose dir contains '.'). Weight shards are excluded so we never materialize
+        # the hundreds of GB the snapshot may hold from a prior weight download, and the flat dir lives
+        # in a writable temp location so a read-only HF cache mount doesn't break the copy.
         flat_dir = (
-            cache_dir
-            / "flat_config"
+            Path(tempfile.gettempdir())
+            / "ttnn_flat_config"
             / variant.hf_repo_id.replace("/", "__").replace(".", "_").replace("-", "_").replace("_", "-")
         )
-        shutil.copytree(model_dir, flat_dir, symlinks=False, dirs_exist_ok=True)
+        shutil.copytree(
+            model_dir,
+            flat_dir,
+            symlinks=False,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("*.safetensors"),
+        )
 
         logger.success(f"✓ Config files downloaded to: {model_dir} (flattened to: {flat_dir})")
         return flat_dir

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -477,6 +477,9 @@ def _resolve_state_dict(model_path_str: str):
 @lru_cache(maxsize=None)
 def _resolve_tokenizer(variant_name: str, padding_side: str):
     v = TEST_VARIANTS[variant_name]
+    # Only variants that ship custom tokenizer code (e.g. Kimi) need trust_remote_code; DeepSeek-V3
+    # uses a stock fast tokenizer and turns it off to avoid the flat-config custom-import path.
+    trust_remote_code = v.tokenizer_trust_remote_code
     candidates = [
         os.getenv(v.env_var),
         str(v.default_local_path) if v.default_local_path is not None else None,
@@ -488,7 +491,7 @@ def _resolve_tokenizer(variant_name: str, padding_side: str):
         p = Path(candidate)
         if p.exists() and any(p.glob("tokenizer*")):
             logger.info(f"Loading tokenizer from: {p}")
-            tok = AutoTokenizer.from_pretrained(str(p), use_fast=True, trust_remote_code=True)
+            tok = AutoTokenizer.from_pretrained(str(p), use_fast=True, trust_remote_code=trust_remote_code)
             tok.padding_side = padding_side
             return tok
 
@@ -496,7 +499,7 @@ def _resolve_tokenizer(variant_name: str, padding_side: str):
     cache_dir = Path(os.getenv("HF_HOME", Path.home() / ".cache" / "huggingface"))
     config_path = download_model_config_only(v, cache_dir)
     logger.info(f"Loading tokenizer from downloaded config: {config_path}")
-    tok = AutoTokenizer.from_pretrained(str(config_path), use_fast=True, trust_remote_code=True)
+    tok = AutoTokenizer.from_pretrained(str(config_path), use_fast=True, trust_remote_code=trust_remote_code)
     tok.padding_side = padding_side
     return tok
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/deepseek_v3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/deepseek_v3.py
@@ -34,6 +34,9 @@ class DeepSeekV3Adapter(MLAPrefillAdapter):
     prefill_trace_layout = "single_file"
     # Stock fast tokenizer — no custom tokenizer code to import, so skip trust_remote_code (Kimi keeps it).
     tokenizer_trust_remote_code = False
+    # No trust_remote_code, so config/tokenizer load fine from the HF snapshot dir — skip the flat copy
+    # (which is wasteful and fails on a read-only HF cache mount). Kimi keeps it (inherits True).
+    needs_flat_config_dir = False
 
     @property
     def reference_model_cls(self):

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/deepseek_v3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/deepseek_v3.py
@@ -32,6 +32,8 @@ class DeepSeekV3Adapter(MLAPrefillAdapter):
     mla_pcc_threshold = 0.996
     moe_pcc_threshold = 0.982
     prefill_trace_layout = "single_file"
+    # Stock fast tokenizer — no custom tokenizer code to import, so skip trust_remote_code (Kimi keeps it).
+    tokenizer_trust_remote_code = False
 
     @property
     def reference_model_cls(self):


### PR DESCRIPTION
### Summary
Problem: download_model_config_only unconditionally copied the entire HF snapshot into a flat_config/ dir under the HF cache. This failed on read-only cache mounts (/mnt/MLPerf, [Errno 30]) and needlessly tried to materialize hundreds of GB of weight shards left in the snapshot by the weight download.

Changes:

- Make trust_remote_code per-variant: DeepSeek-V3 uses a stock fast tokenizer (trust_remote_code=False); Kimi keeps trust_remote_code=True.
- Add a needs_flat_config_dir adapter flag. Variants that don't use trust_remote_code (DeepSeek-V3) load config/tokenizer straight from the HF snapshot dir — no copy.
- When the flat dir is needed (Kimi), copy into a writable temp dir and exclude *.safetensors, so it works on read-only caches and copies only a few MB.

### Checklist 
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:ddjekic/readonly_ci_fix) Relevant test passed
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ddjekic/readonly_ci_fix) galaxy tests fail due to some fabric related issues

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ddjekic/readonly_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ddjekic/readonly_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ddjekic/readonly_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ddjekic/readonly_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ddjekic/readonly_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ddjekic/readonly_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ddjekic/readonly_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ddjekic/readonly_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ddjekic/readonly_ci_fix)