### PR TITLE
[Cleanup] Align LocalTensorAccessor device API to its sister Scratchpad API

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
@@ -10,13 +10,14 @@
 // not define). LocalTensorAccessor carries no NOC machinery, so it compiles here.
 //
 // The accessor is constructed on all three TRISC threads (UNPACK/MATH/PACK) — the strongest compile
-// proof — and its full surface (get_bank_base_address / get_unsafe_ptr / operator[]) is exercised so
-// every method is instantiated. The PACK thread deposits the reported values into each output DFB
-// entry; a DM consumer carries them to DRAM for host verification.
+// proof — and its full surface (get_bank_base_address / local_mem / operator[]) is exercised so every
+// method is instantiated. The PACK thread deposits the reported values into each output DFB entry; a
+// DM consumer carries them to DRAM for host verification.
 //
 // The host checks that the reported base address equals the bound tensor's address — proving the
 // binding token reached the compute kernel and resolved to the correct local L1 shard address. The
-// get_unsafe_ptr / operator[] reports resolve to the same address (address-of avoids an actual load).
+// local_mem().get_unsafe_ptr() / operator[] reports resolve to the same address (address-of avoids an
+// actual load).
 
 #include <cstdint>
 
@@ -36,7 +37,8 @@ void kernel_main() {
     const uint32_t base_address = acc.get_bank_base_address();
     // Instantiate the element-access surface too, so it is compile-proven on TRISC. Both resolve to the
     // base address; address-of avoids an actual L1 load/store.
-    const uint32_t via_unsafe_ptr = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(acc.get_unsafe_ptr()));
+    const uint32_t via_unsafe_ptr =
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(acc.local_mem().get_unsafe_ptr()));
     const uint32_t via_subscript = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&acc[0]));
 
     // Also exercise the legacy (raw base-address) ctor: compile-proves it on TRISC and confirms it

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -12,16 +12,20 @@
 #include "api/tensor/tensor_binding_token.h"
 
 /**
- * @brief A minimal accessor for a tensor's node-local L1 shard.
- *
+ * @brief A minimal accessor for a tensor's node-local L1 region.
  * LocalTensorAccessor is the local-only counterpart to TensorAccessor.
  * Unlike TensorAccessor, it can be used on both data movement and compute kernels.
+ *
+ * "Node-local L1 region" is the part of the tensor that lives in this node's SRAM.
+ *  - For a sharded tensor, this is the local shard.
+ *  - For an interleaved tensor (in SRAM/L1), this is the contiguous local memory region
+ *    storing tensor data for this node (in physical layout-dictated order).
  *
  * To construct a LocalTensorAccessor:
  *  - Metal 2.0: use the token name your host code declared on the kernel's tensor binding
  *  - Legacy: construct from a raw L1 base address
  * @code
- *   // T is the element type of the local shard, chosen by the kernel author.
+ *   // T is the element type of the local region, chosen by the kernel author.
  *   LocalTensorAccessor<T> a(tensor::my_host_declared_accessor_name); // Metal 2.0
  *   LocalTensorAccessor<T> b(l1_base_address);                        // legacy
  *   auto& elem = a[0];                                                // read or write
@@ -30,11 +34,11 @@
  * Notes:
  *  - LocalTensorAccessor replaces the legacy "pinned CB as L1 pointer" pattern.
  *  - The current API is deliberately minimal; more features will be added as use cases arise.
- *  - Element access is currently NOT bounds-checked against the shard extent
+ *  - Element access is currently NOT bounds-checked against the region's extent
  *    (this should be added in the future).
  *
  * Template parameters:
- * @tparam T  Element type stored in the local shard.
+ * @tparam T  Element type stored in the local region.
  */
 template <typename T>
 class LocalTensorAccessor {
@@ -47,7 +51,7 @@ public:
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     [[nodiscard]] explicit LocalTensorAccessor(
         tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) noexcept :
-        // The shard's L1 base address is stored in the CRTA at the token-supplied offset.
+        // The region's L1 base address is stored in the CRTA at the token-supplied offset.
         // Delegates to the legacy constructor, which takes a raw L1 base address.
         LocalTensorAccessor(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))) {
         // ADDR_CRTA_OFFSET is a byte offset; dividing recovers the word index
@@ -65,18 +69,18 @@ public:
     /** @brief Access the element at the given index (read or write).
      *
      * Watcher validates the addresses in debug builds.
-     * Currently NOT bounds-checked against the shard extent.
+     * Currently NOT bounds-checked against the region's extent.
      *
-     * @param index Element index into the local shard.
+     * @param index Element index into the local region.
      * @return Reference to the element at the given index.
      */
     [[nodiscard]] T& operator[](uint32_t index) const { return mem_[index]; }
 
-    /** @brief L1 base address of the local shard, as a raw uint32_t byte address.
+    /** @brief L1 base address of the local region, as a raw uint32_t byte address.
      *
      * This is the form most kernel-side APIs consume (NOC transfers, CB/LLK configuration, ...).
      *
-     * @return the local shard's L1 base address (as uint32_t).
+     * @return the local region's L1 base address (as uint32_t).
      */
     [[nodiscard]] uint32_t get_bank_base_address() const noexcept {
         // static_cast narrows to uint32_t (uintptr_t is 64-bit on Gen2); an L1 address always fits.

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -7,63 +7,90 @@
 #include <cstdint>
 
 #include "api/core_local_mem.h"
+#include "api/debug/assert.h"
 #include "api/tensor/tensor_accessor_args.h"
 #include "api/tensor/tensor_binding_token.h"
-#include "internal/risc_attribs.h"  // tt_l1_ptr (named in get_unsafe_ptr's return type)
 
 /**
  * @brief A minimal accessor for a tensor's node-local L1 shard.
  *
- * LocalTensorAccessor is the local-only counterpart to TensorAccessor.
- * Unlike TensorAccessor, it can be used on both data movement and compute kernels.
+ * LocalTensorAccessor is the local-only counterpart to TensorAccessor. Unlike TensorAccessor it carries
+ * no NOC machinery, so it can be used on both data movement and compute kernels. It replaces the legacy
+ * "pinned CB as L1 pointer" pattern (get_pointer_to_cb_data<T>).
  *
- * USAGE:
- *   // The kernel author declares the element type T of the local shard
- *   auto a = LocalTensorAccessor<T>(tensor::my_host_declared_accessor_name); // Metal 2.0 ctor
- *   auto b = LocalTensorAccessor<T>(l1_base_address);                        // legacy ctor
- *   auto& lut = a[0];   // read or write
+ * Construct one from the accessor name your host code declared on the kernel's tensor binding, or from a
+ * raw L1 base address (legacy):
+ * @code
+ *   // T is the element type of the local shard, chosen by the kernel author.
+ *   LocalTensorAccessor<T> a(tensor::my_host_declared_accessor_name); // Metal 2.0
+ *   LocalTensorAccessor<T> b(l1_base_address);                        // legacy
+ *   auto& elem = a[0];                                                // read or write
+ * @endcode
  *
- * NOTE:
- *   LocalTensorAccessor replaces the "pinned CB as L1 pointer" legacy pattern (get_pointer_to_cb_data<T>).
+ * Element access is not bounds-checked against the shard extent: a LocalTensorAccessor is a view whose
+ * extent lives in tensor metadata and is not (currently) known here. (Its Program-scope sibling,
+ * Scratchpad, owns its extent and does bounds-check — see scratchpad.h.)
  *
- * FEATURES:
- *   Constructors are provided for both Metal 2.0 and legacy kernels.
- *   Read/write memory access via operator[] (and get_unsafe_ptr() / get_bank_base_address()).
- *
- *   This is a skeleton only; additional features will be added as needed.
+ * The surface is deliberately small — operator[], get_bank_base_address(), and local_mem() (the full
+ * CoreLocalMem<T> view, including the raw-pointer escape hatch); more will be added as use cases arise.
  *
  * @tparam T  Element type stored in the local shard.
+ * @see scratchpad.h (Scratchpad, the Program-scope sibling)
  */
 template <typename T>
 class LocalTensorAccessor {
 public:
-    // Construct from a Metal 2.0 binding token. The binding's base address is the first word of its
-    // CRTA section.
+    // Construct from the binding token your host code declared on the kernel's tensor binding (exposed as
+    // the tensor::<accessor_name> constant in the generated kernel_bindings_generated.h). Reads the
+    // shard's L1 base address from the binding's CRTA slot; delegates to the raw-address ctor below.
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
-    explicit LocalTensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
-        mem_(static_cast<uintptr_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
-        // ADDR_CRTA_OFFSET is a byte offset host codegen produces as crta_word_index * sizeof(u32), so
-        // it is word-aligned by construction; the /sizeof(u32) conversion would silently truncate otherwise.
+    [[nodiscard]] explicit LocalTensorAccessor(
+        tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) noexcept :
+        LocalTensorAccessor(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))) {
+        // ADDR_CRTA_OFFSET is a byte offset (codegen emits crta_word_index * sizeof(u32)); dividing
+        // recovers the word index, and would silently truncate a non-word-aligned value otherwise.
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
 
-    // Legacy constructor: from a raw node-local L1 base address. This is a byte address,
-    // typically the (legacy) Buffer's address passed into the kernel as a CRTA.
-    explicit LocalTensorAccessor(uint32_t bank_base_address) : mem_(static_cast<uintptr_t>(bank_base_address)) {}
+    // Legacy constructor: from a raw node-local L1 base address (a byte address) — typically a legacy
+    // Buffer's address passed into the kernel as a CRTA. Both constructors funnel through here, so this is
+    // the single point where the shard's base alignment is checked.
+    [[nodiscard]] explicit LocalTensorAccessor(uint32_t bank_base_address) noexcept :
+        mem_(static_cast<uintptr_t>(bank_base_address)) {
+        ASSERT(mem_.get_address() % alignof(T) == 0);
+    }
 
-    // Element access into the local shard (read and write), bounds-checked in debug builds.
-    T& operator[](uint32_t index) const { return mem_[index]; }
+    /** @brief Access the element at the given index (read or write).
+     *
+     * The target L1 address is sanitized in debug builds (see api/debug/assert.h for when that is
+     * active), but the index is NOT checked against the shard extent — a LocalTensorAccessor does not
+     * know its size (unlike Scratchpad).
+     *
+     * @param index Element index into the local shard.
+     * @return Reference to the element at the given index.
+     */
+    [[nodiscard]] T& operator[](uint32_t index) const { return mem_[index]; }
 
-    // Raw, directly-dereferenceable L1 pointer to the start of the local shard.
-    tt_l1_ptr T* get_unsafe_ptr() const { return mem_.get_unsafe_ptr(); }
+    /** @brief L1 base address of the local shard, as a raw uint32_t byte address.
+     *
+     * This is the form most kernel-side APIs consume (NOC transfers, CB/LLK configuration, ...).
+     *
+     * @return the local shard's L1 base address (as uint32_t).
+     */
+    [[nodiscard]] uint32_t get_bank_base_address() const noexcept {
+        // static_cast narrows uintptr_t -> uint32_t (uintptr_t is 64-bit on Gen2); an L1 address always fits.
+        return static_cast<uint32_t>(mem_.get_address());
+    }
 
-    // L1 base address of the local shard.
-    uint32_t get_bank_base_address() const { return static_cast<uint32_t>(mem_.get_address()); }
-
-    // The underlying typed L1 view, for callers wanting the full CoreLocalMem<T> surface
-    // (pointer arithmetic, scoped_lock, comparisons, ...).
-    const CoreLocalMem<T>& local_mem() const { return mem_; }
+    /** @brief The underlying typed L1 view, for callers wanting the full CoreLocalMem<T> surface
+     * (pointer arithmetic, scoped_lock, comparisons, ...).
+     *
+     * For element access, prefer operator[]; reach for this only when you need the raw underlying handle
+     * (e.g. local_mem().get_unsafe_ptr()).
+     */
+    // Returned by value: CoreLocalMem<T> is trivially copyable and pointer-sized.
+    [[nodiscard]] CoreLocalMem<T> local_mem() const noexcept { return mem_; }
 
 private:
     CoreLocalMem<T> mem_;

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -14,12 +14,12 @@
 /**
  * @brief A minimal accessor for a tensor's node-local L1 shard.
  *
- * LocalTensorAccessor is the local-only counterpart to TensorAccessor. Unlike TensorAccessor it carries
- * no NOC machinery, so it can be used on both data movement and compute kernels. It replaces the legacy
- * "pinned CB as L1 pointer" pattern (get_pointer_to_cb_data<T>).
+ * LocalTensorAccessor is the local-only counterpart to TensorAccessor.
+ * Unlike TensorAccessor, it can be used on both data movement and compute kernels.
  *
- * Construct one from the accessor name your host code declared on the kernel's tensor binding, or from a
- * raw L1 base address (legacy):
+ * To construct a LocalTensorAccessor:
+ *  - Metal 2.0: use the token name your host code declared on the kernel's tensor binding
+ *  - Legacy: construct from a raw L1 base address
  * @code
  *   // T is the element type of the local shard, chosen by the kernel author.
  *   LocalTensorAccessor<T> a(tensor::my_host_declared_accessor_name); // Metal 2.0
@@ -27,35 +27,36 @@
  *   auto& elem = a[0];                                                // read or write
  * @endcode
  *
- * Element access is not bounds-checked against the shard extent: a LocalTensorAccessor is a view whose
- * extent lives in tensor metadata and is not (currently) known here. (Its Program-scope sibling,
- * Scratchpad, owns its extent and does bounds-check — see scratchpad.h.)
+ * Notes:
+ *  - LocalTensorAccessor replaces the legacy "pinned CB as L1 pointer" pattern.
+ *  - The current API is deliberately minimal; more features will be added as use cases arise.
+ *  - Element access is currently NOT bounds-checked against the shard extent
+ *    (this should be added in the future).
  *
- * The surface is deliberately small — operator[], get_bank_base_address(), and local_mem() (the full
- * CoreLocalMem<T> view, including the raw-pointer escape hatch); more will be added as use cases arise.
- *
+ * Template parameters:
  * @tparam T  Element type stored in the local shard.
- * @see scratchpad.h (Scratchpad, the Program-scope sibling)
  */
 template <typename T>
 class LocalTensorAccessor {
 public:
-    // Construct from the binding token your host code declared on the kernel's tensor binding (exposed as
-    // the tensor::<accessor_name> constant in the generated kernel_bindings_generated.h). Reads the
-    // shard's L1 base address from the binding's CRTA slot; delegates to the raw-address ctor below.
+    // Construct from a Metal 2.0 binding token, from the host-declared accessor name.
+    // (tensor::<accessor_name> constant is in the generated, auto-included kernel_bindings_generated.h.)
+    // e.g.
+    // LocalTensorAccessor<T> my_local_accessor(tensor::my_host_declared_accessor_name);
+    //
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     [[nodiscard]] explicit LocalTensorAccessor(
         tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) noexcept :
+        // The shard's L1 base address is stored in the CRTA at the token-supplied offset.
+        // Delegates to the legacy constructor, which takes a raw L1 base address.
         LocalTensorAccessor(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))) {
-        // ADDR_CRTA_OFFSET is a byte offset (codegen emits crta_word_index * sizeof(u32)); dividing
-        // recovers the word index, and would silently truncate a non-word-aligned value otherwise.
+        // ADDR_CRTA_OFFSET is a byte offset; dividing recovers the word index
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
 
-    // Legacy constructor: from a raw node-local L1 base address (a byte address) — typically a legacy
-    // Buffer's address passed into the kernel as a CRTA. Both constructors funnel through here, so this is
-    // the single point where the shard's base alignment is checked.
+    // Legacy constructor: from a raw node-local L1 base address (a byte address).
+    // (Typically a legacy Buffer's address passed into the kernel as a CRTA.)
     [[nodiscard]] explicit LocalTensorAccessor(uint32_t bank_base_address) noexcept :
         mem_(static_cast<uintptr_t>(bank_base_address)) {
         ASSERT(mem_.get_address() % alignof(T) == 0);
@@ -63,9 +64,8 @@ public:
 
     /** @brief Access the element at the given index (read or write).
      *
-     * The target L1 address is sanitized in debug builds (see api/debug/assert.h for when that is
-     * active), but the index is NOT checked against the shard extent — a LocalTensorAccessor does not
-     * know its size (unlike Scratchpad).
+     * Watcher validates the addresses in debug builds.
+     * Currently NOT bounds-checked against the shard extent.
      *
      * @param index Element index into the local shard.
      * @return Reference to the element at the given index.
@@ -79,14 +79,14 @@ public:
      * @return the local shard's L1 base address (as uint32_t).
      */
     [[nodiscard]] uint32_t get_bank_base_address() const noexcept {
-        // static_cast narrows uintptr_t -> uint32_t (uintptr_t is 64-bit on Gen2); an L1 address always fits.
+        // static_cast narrows to uint32_t (uintptr_t is 64-bit on Gen2); an L1 address always fits.
         return static_cast<uint32_t>(mem_.get_address());
     }
 
     /** @brief The underlying typed L1 view, for callers wanting the full CoreLocalMem<T> surface
      * (pointer arithmetic, scoped_lock, comparisons, ...).
      *
-     * For element access, prefer operator[]; reach for this only when you need the raw underlying handle
+     * For element access, prefer operator[]; use this only when you need the raw underlying handle
      * (e.g. local_mem().get_unsafe_ptr()).
      */
     // Returned by value: CoreLocalMem<T> is trivially copyable and pointer-sized.


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Small cleanups to the new `LocalTensorAccessor` device API, to align it with review comments collected in https://github.com/tenstorrent/tt-metal/pull/48554.
 - Base-address alignment guard: Adds a watcher assert for the base address alignment.
 - Dropped `get_unsafe_ptr()`: Instead, obtain the base pointer as `local_mem().get_unsafe_ptr()`.
 - `local_mem()` returns by value instead of const&.
 - Add `[[nodiscard]]` and `noexcept` where appropriate.
 - Improve header comments

Existing tests are updated to match.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/align-local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/align-local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/align-local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/align-local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/align-local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/align-local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/align-local-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/align-local-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/align-local-tensor-accessor)