### PR TITLE
[LLK][BH] Fix reduce_tile REDUCE_ROW fp32-accumulation truncation with bf16 scaler

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -420,12 +420,28 @@ inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape)
  * @param tensor_shape: Tile shape describing tile dimensions.
  * @note Call @ref _llk_math_reduce_ with matching template args after this function,
  *       and @ref _llk_math_reduce_uninit_ after the last reduce to restore modified state.
+ * @note REDUCE_ROW SUM/AVG under fp32 dest accumulation forces the (swapped) scaler
+ *       operand in SrcA to be decoded as Tf32 so the MVMUL accumulation stays fp32-precise;
+ *       otherwise the unpacker-implied bf16 SrcA format truncates the reduction. Restored by
+ *       @ref _llk_math_reduce_uninit_.
  */
 template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void _llk_math_reduce_init_(const ckernel::TensorShape& tensor_shape)
 {
     reduce_configure_addrmod<type, dim, math_fidelity>(tensor_shape);
     reduce_configure_mop<type, dim, math_fidelity>(tensor_shape);
+
+    if constexpr (is_fp32_dest_acc_en && dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
+    {
+        // REDUCE_ROW SUM/AVG accumulates via MVMUL with the scaler swapped into SrcA. On Blackhole the
+        // unpacker-stamped implied SrcA format (bf16 for a bf16 scaler CB) would otherwise govern the MVMUL
+        // decode and quantize the within-face accumulation to bf16 (round-toward-zero) even with fp32 dest
+        // accumulation enabled. Disable implied-format inference and force SrcA to Tf32 so the reduction
+        // accumulates at fp32 precision; the scaler is represented at least as accurately in Tf32. This
+        // mirrors the fp32-scaler workaround and llk_math_transpose_dest.h; restored in _llk_math_reduce_uninit_.
+        TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
+    }
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
 
@@ -435,8 +451,14 @@ inline void _llk_math_reduce_init_(const ckernel::TensorShape& tensor_shape)
 /**
  * @brief Uninitialize after a reduce operation, undoing any init/execute-time workarounds.
  *
- * @note Reverses @ref _llk_math_reduce_init_
+ * @note Reverses @ref _llk_math_reduce_init_ by restoring implied SrcA-format inference
+ *       (DISABLE_IMPLIED_SRCA_FMT) to its hardware default, which @ref _llk_math_reduce_init_
+ *       disables to force the REDUCE_ROW SUM/AVG scaler to Tf32 under fp32 dest accumulation.
  */
 inline void _llk_math_reduce_uninit_()
 {
+    // Restore implied SrcA-format inference (hardware default). _llk_math_reduce_init_ disables it for
+    // REDUCE_ROW SUM/AVG under fp32 dest accumulation; reset unconditionally so subsequent ops are unaffected.
+    // Once implied inference is re-enabled it overrides ALU_FORMAT_SPEC_REG0_SrcA, so no format-register reset is needed.
+    TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
 }


### PR DESCRIPTION
## Summary

Fixes invalid (truncated) rounding in `reduce_tile<SUM/AVG, REDUCE_ROW>` on **Blackhole** when the reduced data is `Float32` with `fp32_dest_acc_en=true` and the scaler is `bfloat16`.

Reported in tenstorrent/tt-metal#17012 (customer example): inputs `1.265625, 1.7890625, 0.271484375, 1.671875` (all bf16-exact) have fp32 sum `4.998046875`, which should round to `5.0` on pack to bf16, but the device returned the round-toward-zero truncated value `4.96875`. The customer confirmed that switching the scaler circular buffer to `fp32` produced the correct result — pointing squarely at the scaler operand's format driving the accumulation precision.

> The issue is labeled **WH**; this PR fixes **Blackhole** (the reduce LLK is byte-for-byte the same MVMUL design on both). The Wormhole counterpart very likely needs the identical change — see *Follow-ups*. Referenced (not closed) because of the `do-not-close` label and the still-open WH scope.

## Root cause

For `REDUCE_ROW` SUM/AVG the reduce swaps operands so the **scaler lands in SrcA** and the data in SrcB, then accumulates via `MVMUL` (`llk_math_reduce.h`). On Blackhole the unpacker stamps an *implied SrcA format* (bf16, from a bf16 scaler CB) that `MVMUL` uses to decode SrcA, and that governs the within-face accumulation precision. So the reduction is effectively bf16-quantized (round-toward-zero) even though `ALU_ACC_CTRL_Fp32_enabled` is already set from `fp32_dest_acc_en`. The `is_fp32_dest_acc_en` template parameter was threaded into `_llk_math_reduce_`/`_llk_math_reduce_init_` but was **unused** — it is the natural hook for the fix.

## Fix

Math-side, self-contained in `tt_llk_blackhole/llk_lib/llk_math_reduce.h` — no metal-integration change is needed (`is_fp32_dest_acc_en` is already passed down from `llk_math_reduce_init` → `_llk_math_reduce_init_`):

- In `_llk_math_reduce_init_`, when `is_fp32_dest_acc_en && dim == REDUCE_ROW && type != MAX` (the MVMUL swap path only), disable implied-SrcA-format inference and force `ALU_FORMAT_SPEC_REG0_SrcA` to `Tf32`, so the accumulation stays fp32-precise. `Tf32` is the correct target — SrcA for MVMUL supports only `TF32/BF16/FP16` (no full-FP32 SrcA), and the scaler is represented at least as accurately in `Tf32`. No math-fidelity change.
- In `_llk_math_reduce_uninit_` (previously empty), restore implied-SrcA-format inference to its hardware default so subsequent ops are unaffected. `reduce_uninit()` is already mandated before the next non-reduce op, so restoration is guaranteed.

This mirrors the existing, proven `DISABLE_IMPLIED_SRCA_FMT_Base` + `ALU_FORMAT_SPEC_REG0_SrcA=Tf32` pattern in `llk_math_transpose_dest.h` / `llk_math_eltwise_unary_datacopy.h`, and reproduces the customer's verified fp32-scaler workaround. `REDUCE_COL`, `REDUCE_SCALAR`, and `MAX` (GAPOOL/GMPOOL, no operand swap — data stays in SrcA) are unaffected and untouched.

## Validation

Backend: `ttsim` (`libttsim_bh.so`), Blackhole.

- **No regression:** the 14 `Float32→Float32` `REDUCE_ROW` Sum/Average HiFi2 variants — which run with `is_fp32_dest_acc_en=true` and therefore execute the modified `if constexpr` branch — all pass (`14 passed`).
- **A/B isolation:** reverting *only* the LLK header and re-running the mixed-format case produced **byte-identical** device output to the fixed build, confirming the change is safe and side-effect-free on this backend.

### Why no bug-reproducing regression test is included

Two environment limitations, both independent of this fix (verified by the A/B):

1. **ttsim does not reproduce the bug.** Its functional model accumulates the reduce in fp32 regardless of the SrcA format (consistent with the tt-isa-documentation MVMUL model), so there is no pre-fix/post-fix delta to assert on ttsim.
2. **The tt-llk `reduce_test.cpp` harness cannot exercise distinct data/scaler formats.** It configures a single shared math format and tile size for both operands (`_llk_math_hw_configure_(formats.math, formats.math)`), so a `Float32`-data + `Float16_b`-scaler tile is read as overflow garbage regardless of the fix.

A targeted `fails-before / passes-after` regression test therefore requires either **silicon** or first extending the reduce harness to support mixed operand formats. Recommend validating on silicon via the customer's `ttnn` `moreh_softmax` reproduction.

## Follow-ups

- Apply the same fix to Wormhole (`tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h`) — identical MVMUL REDUCE_ROW design; the original issue was filed on WH.
- Add mixed data/scaler format support to the tt-llk reduce test harness, then a dedicated fp32-data + bf16-scaler `REDUCE_ROW` regression test.

---
🤖 Generated by the LLK issue-solver (codegen v1.1.0). Refs #17012.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-17012-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-17012-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-17012-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-17012-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-17012-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-17012-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-17012-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-17012-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-17012-v1)