### PR TITLE
[skip ci] Temporarily skip SD3.5 T3K 2x4 perf test on Wormhole B0 due to regression

### DIFF
--- a/models/tt_dit/tests/models/sd35/test_performance_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_performance_sd35.py
@@ -8,7 +8,7 @@ import pytest
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 
 from ....parallel.config import DiTParallelConfig
@@ -107,6 +107,10 @@ def test_sd35_new_pipeline_performance(
                 ml_model_name="empty_run",
             )
         pytest.skip("4U is not supported for this test")
+
+    # Temporarily skip the 2x4 (T3K) Wormhole B0 configuration due to performance regression, refs #47937
+    if is_wormhole_b0() and tuple(mesh_device.shape) == (2, 4):
+        pytest.skip("Skipping 2x4 T3K Wormhole B0 perf test due to performance regression, refs #47937")
 
     logger.info(f"  Image size: {image_w}x{image_h}")
     logger.info(f"  Guidance scale: {guidance_scale}")


### PR DESCRIPTION
The test `test_sd35_new_pipeline_performance[wormhole_b0-device_params0-2x4cfg1sp0tp1-large-1024-1024-3.5-20]` has been failing for 7+ days on the T3000 perf job (`wh_llmbox_perf`). The denoising_steps_time regressed from an expected 12.5s to ~24.3s (nearly 2x), and total_time from 14.0s to ~26.0s. This PR adds a scoped `pytest.skip()` inside the test body, guarded by `is_wormhole_b0() and tuple(mesh_device.shape) == (2, 4)`, so only the failing T3K Wormhole B0 parametrization is skipped. The 4x8 Galaxy parametrization is unaffected. refs #47937

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47937)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47937)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47937)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47937)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47937)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47937)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47937)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47937)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47937)