### PR TITLE
[skip ci] Skip test_transformer_block_vs_hf_first_layer[S128] on N150 (refs #48010)

### DIFF
--- a/models/demos/wormhole/bge_m3/tests/pcc/test_transformer_block.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/test_transformer_block.py
@@ -58,6 +58,8 @@ def first_layer_artifacts(model_location_generator):
 @pytest.mark.slow
 @pytest.mark.parametrize("seq_len", SEQUENCE_LENGTHS, ids=[f"S{seq_len}" for seq_len in SEQUENCE_LENGTHS])
 def test_transformer_block_vs_hf_first_layer(device, first_layer_artifacts, seq_len):
+    if seq_len == 128:
+        pytest.skip("Skipping S128 due to known failure on N150, refs #48010")
     require_single_device(device)
     hf_layer, state_dict, args = first_layer_artifacts
     args.grid_size = device.compute_with_storage_grid_size()


### PR DESCRIPTION
The parametrized test `test_transformer_block_vs_hf_first_layer[S128]` has been failing on the Nightly N150 bge_m3 CI job for 7+ days (since at least 2026-06-24, commit ae414c18e46f). The `test_ci_dispatch[bge_m3]` wrapper also fails as a downstream consequence because it runs the transformer block tests with `-x`.

This PR adds a minimal in-body `pytest.skip()` guarded on `seq_len == 128` so that only the failing S128 parametrization is skipped; all other seq_len values (1024, 2048, 4096, 8192) continue to run.

refs #48010

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-48010)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-48010)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:lifecycle/disable-issue-48010)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-48010)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-48010)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-48010)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-48010)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-48010)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-48010)