### PR TITLE
mla: sparse_sdpa multi-user read via cache_batch_idx (drop host slot-slice)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -169,6 +169,8 @@ def run_sparse_mla_accuracy_case(
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
     logger.info(f"[{variant.name}] sparse MLA accuracy: running TT inference")
@@ -242,6 +244,8 @@ def run_sparse_mla_determinism_case(
             mesh_shape=mesh_shape,
             sp_axis=sp_axis,
             num_kvpe_cache_layers=1,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
         )
         tt_output, _, _, shard_dims = run_mla_inference(
             config=config,
@@ -308,6 +312,8 @@ def run_sparse_mla_chunked_case(
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
     logger.debug(f"[{variant.name}] sparse MLA chunked: constructing TT module and indexed RoPE tensors")

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -85,6 +85,10 @@ def run_mla_inference(
         tp_axis=tp_axis,
         is_balanced=is_balanced,
         topology=topology,
+        # Match the single-layer test cache (num_kvpe_cache_layers=1): the sparse single-shot write now
+        # goes through update_padded_kv_cache, which asserts cache_batch % layer_num == 0. Dense is
+        # unaffected (its single-shot write uses fill_cache_for_user_, which ignores layer_num).
+        layer_num=1,
     )
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
     rope_tensors = rope_setup.get_rope_tensors(seq_len)

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -815,12 +815,15 @@ class ttMLA:
         kv_actual_isl: Optional[int],
         seq_len_local: int,
         return_kv_intermediates: bool,
-        keep_kvpe_bf16: bool,
-    ) -> tuple[ttnn.Tensor | None, ttnn.Tensor, ttnn.Tensor, dict | None]:
+        kvpe_cache: ttnn.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor, dict | None]:
         """Shared KV stem.
 
-        Returns bf16 kvpe only for sparse single-shot, where sparse attention consumes the
-        full latent prefix in bf16. All modes receive the bf8 kvpe written to the cache.
+        Returns tt_kvpe: the kvpe converted to the persistent cache's dtype/layout via
+        _to_cache_format (bf8/TILE for dense, bf16 or fp8/ROW_MAJOR for sparse). This single tensor
+        is BOTH written to the cache and consumed as the attention K input — dense ring SDPA takes it
+        as-is, and sparse_sdpa reads the uncompressed sparse cache format natively, so no separate
+        full-precision copy is needed. Also returns tt_kv_nope (dense V projection) + intermediates.
         """
         # NOTE: input is ideally L1 for chunked, but hidden states memory config is set outside the module
         tt_kv = ttnn.linear(
@@ -872,19 +875,19 @@ class ttMLA:
             kv_intermediates["tt_kv_rope"] = ttnn.clone(tt_kv_rope)
 
         # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
-        tt_kvpe = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
+        tt_kvpe_raw = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
         ttnn.deallocate(tt_kv_rope)
-        tt_kvpe_b8 = ttnn.typecast(tt_kvpe, dtype=ttnn.bfloat8_b)
+        # Match the persistent cache format: bf8/TILE (dense) OR bf16 or fp8/ROW_MAJOR (sparse). For the
+        # uncompressed sparse cache this is a layout-only change (no dtype typecast), so sparse_sdpa reads
+        # it natively with no bf8->bf16 round-trip.
+        tt_kvpe = self._to_cache_format(tt_kvpe_raw, kvpe_cache)
+        ttnn.deallocate(tt_kvpe_raw)
 
         if return_kv_intermediates:
-            # post-transform concat ([.., 576], bf8) -- what actually gets written to the cache.
-            kv_intermediates["tt_kvpe"] = ttnn.clone(tt_kvpe_b8)
+            # post-transform concat ([.., 576]) in the cache dtype -- what actually gets written.
+            kv_intermediates["tt_kvpe"] = ttnn.clone(tt_kvpe)
 
-        if not keep_kvpe_bf16:
-            ttnn.deallocate(tt_kvpe)
-            tt_kvpe = None
-
-        return tt_kvpe, tt_kvpe_b8, tt_kv_nope, kv_intermediates
+        return tt_kvpe, tt_kv_nope, kv_intermediates
 
     def _apply_wkv_b2(self, t: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
         return ttnn.linear(
@@ -894,10 +897,39 @@ class ttMLA:
             **self._get_mm_kwargs("wkv_b2", seq_len_local),
         )
 
-    def _write_kvpe(self, kvpe_cache: ttnn.Tensor, tt_kvpe_b8: ttnn.Tensor, cache_layer_idx: int) -> None:
-        """Single-shot cache fill: write this layer's whole kvpe slot (bf8). Chunked modes write
-        through _chunked_attn / update_padded_kv_cache instead."""
-        ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe_b8, cache_layer_idx)
+    def _to_cache_format(self, t: ttnn.Tensor, cache: ttnn.Tensor) -> ttnn.Tensor:
+        """Convert the freshly computed kvpe `t` (bf16, TILE) to the persistent cache's dtype+layout
+        for a write. The write ops require input dtype AND layout to match the cache:
+          - bf8/TILE cache (dense): typecast bf16->bfloat8_b, stays TILE.
+          - bf16 or fp8_e4m3 / ROW_MAJOR cache (sparse): retile TILE->ROW_MAJOR, and typecast only for
+            fp8 (bf16 needs none) — so sparse_sdpa reads the prefix natively, no bf8->bf16 round-trip.
+        LAYOUT is converted BEFORE dtype: fp8_e4m3 is ROW_MAJOR-only, so it must be produced by
+        typecasting an already-ROW_MAJOR tensor (never a TILE fp8 intermediate, which is unsupported) —
+        matching how init_kvpe_cache builds the fp8 cache. bf8 (block-float, TILE-only) is the reverse
+        case, but its layout already matches (both TILE) so the layout step is a no-op there.
+        Always returns a fresh tensor (clones if `t` already matches the cache format)."""
+        out = t
+        if out.layout != cache.layout:
+            out = ttnn.to_layout(out, cache.layout)
+        if out.dtype != cache.dtype:
+            relaid = ttnn.typecast(out, cache.dtype)
+            if out is not t:
+                ttnn.deallocate(out)
+            out = relaid
+        return ttnn.clone(t) if out is t else out
+
+    def _write_kvpe(self, kvpe_cache: ttnn.Tensor, tt_kvpe: ttnn.Tensor, cache_layer_idx: int) -> None:
+        """DENSE single-shot cache fill: write this layer's whole kvpe slot (bf8/TILE, already in the
+        cache's dtype/layout via _to_cache_format). Chunked modes (dense + sparse) and sparse single-shot
+        write through update_padded_kv_cache instead; only dense single-shot still uses this TILE-only
+        fill_cache_for_user_ primitive.
+
+        TODO: unify dense single-shot onto update_padded_kv_cache too (one write op model-wide, drop this
+        helper). Blocked on the single-chip case: test_prefill_block_loop[mesh-1x1] runs dense single-shot
+        on a (1,1) mesh, where fill_cache_for_user_ is mesh-agnostic but update_padded_kv_cache's SP
+        cluster_axis / block-cyclic / tile-aligned-kv_actual_global path is not yet validated. Confirm
+        update_padded handles 1x1 (and sp=1), then switch _dense_single_attn like _sparse_single_attn."""
+        ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, cache_layer_idx)
 
     def _o_proj_epilogue(self, attn_out: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
         """Shared nlp_concat_heads -> o_proj -> TP reduce-scatter epilogue."""
@@ -955,6 +987,18 @@ class ttMLA:
         kv_actual_isl = actual_start
         is_chunked = self.is_chunked
 
+        # Sparse attention (sparse_sdpa) reads the KVPE cache natively and only accepts bf16 / fp8_e4m3,
+        # ROW_MAJOR. Require the cache to already be in that op-wanted format so the whole path is a single
+        # kvpe tensor with NO compression round-trip (no bf8 typecast on write, no upcast on read-back).
+        if self._has_indexer:
+            assert kvpe_cache.dtype in (ttnn.bfloat16, ttnn.fp8_e4m3), (
+                f"sparse MLA requires an uncompressed KVPE cache (bf16 or fp8_e4m3) that sparse_sdpa reads "
+                f"natively, got {kvpe_cache.dtype}"
+            )
+            assert (
+                kvpe_cache.layout == ttnn.ROW_MAJOR_LAYOUT
+            ), f"sparse MLA requires a ROW_MAJOR KVPE cache, got {kvpe_cache.layout}"
+
         signpost(header="MLA_START")
 
         # q-norm output uses the tuned activation memory_config in every mode (dense and sparse);
@@ -973,20 +1017,18 @@ class ttMLA:
         indices = self._indexer.forward(hidden_states, qr, seq_len_local, start_pos=kv_actual_isl or 0)
 
         tt_q = self._q_stem(qr, rope_tensors, kv_actual_isl, seq_len_local)
-        keep_kvpe_bf16 = self._has_indexer and not is_chunked
-        tt_kvpe, tt_kvpe_b8, tt_kv_nope, kv_intermediates = self._kv_stem(
+        tt_kvpe, tt_kv_nope, kv_intermediates = self._kv_stem(
             hidden_states,
             rope_tensors,
             kv_actual_isl,
             seq_len_local,
             return_kv_intermediates,
-            keep_kvpe_bf16,
+            kvpe_cache,
         )
 
         attn_out = self._attention(
             tt_q=tt_q,
             tt_kvpe=tt_kvpe,
-            tt_kvpe_b8=tt_kvpe_b8,
             tt_kv_nope=tt_kv_nope,
             indices=indices,
             kvpe_cache=kvpe_cache,
@@ -1006,13 +1048,13 @@ class ttMLA:
     # All four share the forward() call signature and ignore the kwargs they don't need (**_), so the
     # bound name can be invoked uniformly. Bodies are the former mode-ladder branches, unchanged.
 
-    def _dense_single_attn(self, *, tt_q, tt_kvpe_b8, tt_kv_nope, kvpe_cache, cache_layer_idx, seq_len_local, **_):
+    def _dense_single_attn(self, *, tt_q, tt_kvpe, tt_kv_nope, kvpe_cache, cache_layer_idx, seq_len_local, **_):
         # Single-shot prefill: materialize V before causal ring SDPA.
-        self._write_kvpe(kvpe_cache, tt_kvpe_b8, cache_layer_idx)
+        self._write_kvpe(kvpe_cache, tt_kvpe, cache_layer_idx)
         tt_v_embedding = self._apply_wkv_b2(tt_kv_nope, seq_len_local)
         attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
             tt_q,
-            tt_kvpe_b8,
+            tt_kvpe,
             tt_v_embedding,
             self.joint_q,
             self.joint_kv,
@@ -1048,7 +1090,7 @@ class ttMLA:
         self,
         *,
         tt_q,
-        tt_kvpe_b8,
+        tt_kvpe,
         kvpe_cache,
         kv_actual_isl,
         cache_layer_idx,
@@ -1059,7 +1101,7 @@ class ttMLA:
         cache_batch_idx = self._cache_batch_idx(cache_user_id, cache_layer_idx)
         return self._chunked_attn(
             tt_q=tt_q,
-            tt_kvpe=tt_kvpe_b8,
+            tt_kvpe=tt_kvpe,
             kvpe_cache=kvpe_cache,
             kv_actual_isl=kv_actual_isl,
             cache_batch_idx=cache_batch_idx,
@@ -1069,22 +1111,29 @@ class ttMLA:
         )
 
     def _sparse_single_attn(
-        self, *, tt_q, tt_kvpe, tt_kvpe_b8, indices, kvpe_cache, cache_layer_idx, seq_len_local, **_
+        self, *, tt_q, tt_kvpe, indices, kvpe_cache, kv_actual_isl, cache_layer_idx, cache_user_id, seq_len_local, **_
     ):
         assert indices is not None, "sparse MLA forward requires indexer top-k indices"
-        # Single-shot: the live kvpe IS the whole sequence (natural order, contiguous SP shard).
-        assert tt_kvpe is not None
-        self._write_kvpe(kvpe_cache, tt_kvpe_b8, cache_layer_idx)
-        gathered = self._all_gather(tt_kvpe, dim=2, cluster_axis=self.sp_axis)  # [1,1,T,576] bf16 TILE, repl, natural
-        kvpe_dev = ttnn.to_layout(gathered, ttnn.ROW_MAJOR_LAYOUT)
-        if self.sp_factor > 1:
-            ttnn.deallocate(gathered)
-        ttnn.deallocate(tt_kvpe_b8)
-        ttnn.deallocate(tt_kvpe)
+        # Single-shot: write the cache via the SAME op as chunked (update_padded_kv_cache), so the sparse
+        # cache is uniformly bf16/fp8 ROW_MAJOR and the TILE-only fill_cache_for_user_ is avoided. The whole
+        # sequence is one chunk (kv_actual_global=0). The live kvpe IS the whole sequence (natural order,
+        # contiguous SP shard), already in the op's format, so attend on it directly — no cache read-back.
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            kvpe_cache,
+            tt_kvpe,
+            slot_idx=cache_user_id,
+            layer_idx=cache_layer_idx,
+            num_layers=self.layer_num,
+            kv_actual_global=kv_actual_isl or 0,
+            cluster_axis=self.sp_axis,
+        )
+        kvpe_dev = self._all_gather(tt_kvpe, dim=2, cluster_axis=self.sp_axis)  # [1,1,T,576] repl, natural
 
         # Sparse attention runs over latent V; project to v_head_dim afterwards.
         attn_out = self._sparse_mla(tt_q, kvpe_dev, indices)
-        ttnn.deallocate(kvpe_dev)
+        if kvpe_dev is not tt_kvpe:  # all_gather made a new buffer (sp>1); else it IS tt_kvpe itself
+            ttnn.deallocate(kvpe_dev)
+        ttnn.deallocate(tt_kvpe)
         ttnn.deallocate(tt_q)
         return self._apply_wkv_b2(attn_out, seq_len_local)
 
@@ -1092,7 +1141,7 @@ class ttMLA:
         self,
         *,
         tt_q,
-        tt_kvpe_b8,
+        tt_kvpe,
         indices,
         kvpe_cache,
         kv_actual_isl,
@@ -1111,7 +1160,7 @@ class ttMLA:
         # The whole multi-user cache is handed over; sparse_sdpa selects this slot via cache_batch_idx.
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
             kvpe_cache,
-            tt_kvpe_b8,
+            tt_kvpe,
             slot_idx=cache_user_id,
             layer_idx=cache_layer_idx,
             num_layers=self.layer_num,
@@ -1119,7 +1168,7 @@ class ttMLA:
             cluster_axis=self.sp_axis,
         )
         kvpe_dev = self._gather_kvpe_prefix(kvpe_cache)
-        ttnn.deallocate(tt_kvpe_b8)
+        ttnn.deallocate(tt_kvpe)
 
         # Sparse attention runs over latent V; project to v_head_dim afterwards.
         attn_out = self._sparse_mla(
@@ -1329,11 +1378,13 @@ class ttMLA:
 
     def _gather_kvpe_prefix(self, kvpe_cache):
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
-        bf8 / TILE / ND-sharded / block-cyclic across SP; sparse_sdpa consumes it bf16 / ROW_MAJOR /
-        replicated and remaps the natural-position indices to physical block-cyclic pages in-kernel
-        (invP), so the buffer is LEFT in block-cyclic order — no host reorder. Pipeline (all on
-        device): ND→interleaved, SP all-gather to full-T (no-op at sp==1), bf8→bf16, TILE→RM.
-        Returns the WHOLE multi-user cache [B, 1, seq_len_cache, 576] bf16 RM (block-cyclic, B =
+        ND-sharded / block-cyclic across SP, in the op's format (bf16 or fp8_e4m3, ROW_MAJOR — the
+        sparse cache is uncompressed). sparse_sdpa consumes it replicated and remaps the
+        natural-position indices to physical block-cyclic pages in-kernel (invP), so the buffer is
+        LEFT in block-cyclic order — no host reorder. Pipeline (all on device): ND→interleaved, SP
+        all-gather to full-T (no-op at sp==1). The cache is already in the op format, so there is NO
+        read-back dtype/layout conversion — the all-gather moves the native cache format directly.
+        Returns the WHOLE multi-user cache [B, 1, seq_len_cache, 576] (block-cyclic, B =
         num_users*num_layers user-major slots); sparse_sdpa selects this user/layer slot itself via
         cache_batch_idx (no host slot-slice). The unwritten suffix is never addressed since indices
         stay < populated."""
@@ -1343,8 +1394,4 @@ class ttMLA:
         )  # → [B,1,seq_len_cache,576] repl, block-cyclic
         if self.sp_factor > 1:
             ttnn.deallocate(cache_i)
-        full16 = ttnn.typecast(full, ttnn.bfloat16)
-        ttnn.deallocate(full)
-        full_rm = ttnn.to_layout(full16, ttnn.ROW_MAJOR_LAYOUT)
-        ttnn.deallocate(full16)
-        return full_rm
+        return full

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1037,6 +1037,13 @@ class ttMLA:
         )
         return attn_out
 
+    def _cache_batch_idx(self, cache_user_id: int, cache_layer_idx: int) -> int:
+        """Flat KVPE-cache slot for (user, layer). The cache batch dim is user-major: each user reserves
+        self.layer_num contiguous slots, so the flat slot is cache_user_id * layer_num + cache_layer_idx.
+        Shared by the dense (ring_mla) and sparse (sparse_sdpa) chunked paths."""
+        assert cache_user_id < self.slot_num, f"cache_user_id {cache_user_id} >= slot_num {self.slot_num}"
+        return cache_user_id * self.layer_num + cache_layer_idx
+
     def _dense_chunked_attn(
         self,
         *,
@@ -1049,10 +1056,7 @@ class ttMLA:
         seq_len_local,
         **_,
     ):
-        # Cache batch dim is user-major: each user reserves self.layer_num contiguous slots, so the
-        # flat slot is cache_user_id * layer_num + cache_layer_idx.
-        assert cache_user_id < self.slot_num, f"cache_user_id {cache_user_id} >= slot_num {self.slot_num}"
-        cache_batch_idx = cache_user_id * self.layer_num + cache_layer_idx
+        cache_batch_idx = self._cache_batch_idx(cache_user_id, cache_layer_idx)
         return self._chunked_attn(
             tt_q=tt_q,
             tt_kvpe=tt_kvpe_b8,
@@ -1099,9 +1103,12 @@ class ttMLA:
     ):
         assert indices is not None, "sparse MLA forward requires indexer top-k indices"
 
+        cache_batch_idx = self._cache_batch_idx(cache_user_id, cache_layer_idx)
+
         # Chunked: the prefix lives in the BLOCK-CYCLIC cache. Gather it on device and hand it to
         # sparse_sdpa still block-cyclic — the op remaps the natural top-k indices to physical pages
         # in-kernel (block_cyclic_chunk_local = per-shard chunk = seq_len_local), so no host reorder.
+        # The whole multi-user cache is handed over; sparse_sdpa selects this slot via cache_batch_idx.
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
             kvpe_cache,
             tt_kvpe_b8,
@@ -1111,11 +1118,13 @@ class ttMLA:
             kv_actual_global=kv_actual_isl,
             cluster_axis=self.sp_axis,
         )
-        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, cache_user_id, cache_layer_idx)
+        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache)
         ttnn.deallocate(tt_kvpe_b8)
 
         # Sparse attention runs over latent V; project to v_head_dim afterwards.
-        attn_out = self._sparse_mla(tt_q, kvpe_dev, indices, block_cyclic_chunk_local=seq_len_local)
+        attn_out = self._sparse_mla(
+            tt_q, kvpe_dev, indices, block_cyclic_chunk_local=seq_len_local, cache_batch_idx=cache_batch_idx
+        )
         ttnn.deallocate(kvpe_dev)
         ttnn.deallocate(tt_q)
         return self._apply_wkv_b2(attn_out, seq_len_local)
@@ -1229,7 +1238,12 @@ class ttMLA:
         return self.tp_factor > 1 and (heads_local < 32 or heads_local % 32 != 0)
 
     def _sparse_mla(
-        self, q: ttnn.Tensor, kvpe: ttnn.Tensor, indices: ttnn.Tensor, block_cyclic_chunk_local: Optional[int] = None
+        self,
+        q: ttnn.Tensor,
+        kvpe: ttnn.Tensor,
+        indices: ttnn.Tensor,
+        block_cyclic_chunk_local: Optional[int] = None,
+        cache_batch_idx: Optional[int] = None,
     ) -> ttnn.Tensor:
         """Absorbed MQA over the top-k selected latents (FlashMLA sparse contract: no causal mask —
         ``indices`` already encode it via the 0xFFFFFFFF sentinel). Invoked SPMD on the SP×TP mesh:
@@ -1243,7 +1257,12 @@ class ttMLA:
         block_cyclic_chunk_local: when set, ``kvpe`` is the KVPE cache in its native BLOCK-CYCLIC SP layout
         (not natural order) and ``indices`` are natural positions; sparse_sdpa remaps each index to its
         physical page in-kernel (invP) over the SP mesh axis, so the host reorder is eliminated. It is the
-        per-shard chunk length (chunk_size_global / sp). None → natural-order kvpe (single-shot path)."""
+        per-shard chunk length (chunk_size_global / sp). None → natural-order kvpe (single-shot path).
+
+        cache_batch_idx: when set, ``kvpe`` is the whole multi-user cache [B, 1, T, 576] (B =
+        num_users*num_layers user-major slots) and this selects the slot to attend — the op offsets its
+        gather page ids by cache_batch_idx * T in-kernel, so no host slot-slice. None → ``kvpe`` is a
+        single [1, 1, T, 576] slot (single-shot path)."""
         assert self.sp_axis == 0 and self.tp_axis == 1, "sparse_mla assumes sp_axis=0 (outer), tp_axis=1"
         sp = self.sp_factor
         seq_len_local = q.shape[2]  # per-chip query rows == S / sp
@@ -1291,6 +1310,7 @@ class ttMLA:
             k_chunk_size=k_chunk,
             block_cyclic_sp_axis=self.sp_axis if block_cyclic_chunk_local is not None else None,
             block_cyclic_chunk_local=block_cyclic_chunk_local,
+            cache_batch_idx=cache_batch_idx,
         )
         ttnn.deallocate(q_rm)
         if idx is not indices:
@@ -1307,25 +1327,22 @@ class ttMLA:
             ttnn.deallocate(out_all_heads)
         return ret
 
-    def _gather_kvpe_prefix(self, kvpe_cache, cache_user_id, cache_layer_idx):
+    def _gather_kvpe_prefix(self, kvpe_cache):
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
         bf8 / TILE / ND-sharded / block-cyclic across SP; sparse_sdpa consumes it bf16 / ROW_MAJOR /
         replicated and remaps the natural-position indices to physical block-cyclic pages in-kernel
         (invP), so the buffer is LEFT in block-cyclic order — no host reorder. Pipeline (all on
-        device): ND→interleaved, SP all-gather to full-T (no-op at sp==1), select this user/layer
-        slot, bf8→bf16, TILE→RM. Returns the whole preallocated cache [1, 1, seq_len_cache, 576] bf16
-        RM (block-cyclic); the unwritten suffix is never addressed since indices stay < populated."""
+        device): ND→interleaved, SP all-gather to full-T (no-op at sp==1), bf8→bf16, TILE→RM.
+        Returns the WHOLE multi-user cache [B, 1, seq_len_cache, 576] bf16 RM (block-cyclic, B =
+        num_users*num_layers user-major slots); sparse_sdpa selects this user/layer slot itself via
+        cache_batch_idx (no host slot-slice). The unwritten suffix is never addressed since indices
+        stay < populated."""
         cache_i = ttnn.to_memory_config(kvpe_cache, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
         full = self._all_gather(
             cache_i, dim=2, cluster_axis=self.sp_axis
         )  # → [B,1,seq_len_cache,576] repl, block-cyclic
         if self.sp_factor > 1:
             ttnn.deallocate(cache_i)
-        if full.shape[0] > 1:  # user-major slot select (no-op for the single-slot cache)
-            slot = cache_user_id * self.layer_num + cache_layer_idx
-            sel = ttnn.slice(full, [slot, 0, 0, 0], [slot + 1, 1, full.shape[2], full.shape[3]])
-            ttnn.deallocate(full)
-            full = sel
         full16 = ttnn.typecast(full, ttnn.bfloat16)
         ttnn.deallocate(full)
         full_rm = ttnn.to_layout(full16, ttnn.ROW_MAJOR_LAYOUT)


### PR DESCRIPTION
## What

Issue #48887. GLM-5.1 sparse MLA chunked prefill. Two related sparse-KVPE-cache changes:

### 1. `mla: sparse_sdpa multi-user read via cache_batch_idx (drop host slot-slice)`

The sparse chunked read (`_gather_kvpe_prefix` / `_sparse_mla`) host-sliced the per-user/layer slot out of the block-cyclic KVPE cache before calling `sparse_sdpa`. Since `sparse_sdpa` supports `cache_batch_idx` (offsets its gather page ids by `cache_batch_idx * T` in-kernel, and composes with the block-cyclic remap), hand it the whole `[B,1,T,576]` cache and let it select the slot — dropping the host slice, mirroring what `_dense_chunked_attn` (ring_mla) already does.

- `_gather_kvpe_prefix`: return the whole multi-user cache, no slot select.
- `_sparse_mla`: accept + forward `cache_batch_idx` to `sparse_sdpa`.
- `_sparse_chunked_attn`: compute `cache_batch_idx` and thread it through.
- `_cache_batch_idx`: extract the user-major slot formula + `slot_num` assert into one helper shared by the dense and sparse chunked paths.

### 2. `mla: uncompressed (bf16/fp8 RM) sparse KVPE cache — drop the bf8 round-trip`

`sparse_sdpa` reads the KVPE cache natively and only accepts **bf16 / fp8_e4m3, ROW_MAJOR**. The cache was **bf8 / TILE**, so every sparse path paid a compression round-trip: a `bf16->bf8` typecast on write and a `bf8->bf16` upcast on read-back in `_gather_kvpe_prefix`. Make the sparse cache uncompressed (the op-wanted format) so the whole path is a **single kvpe tensor with no dtype conversion**.

- `_to_cache_format(t, cache)`: convert the freshly computed kvpe to the cache's dtype+layout (bf8/TILE for dense, bf16 or fp8/ROW_MAJOR for sparse). Typecast only when dtypes differ; sparse is a layout-only change.
- `_kv_stem` returns a **single** `tt_kvpe` (dropped `keep_kvpe_bf16` + the bf16 side-tensor + the `_b8` naming). The one tensor is both written to the cache and used as the attention K input.
- `forward` asserts the sparse cache is **bf16/fp8 + ROW_MAJOR** (no bf8 for sparse).
- `_sparse_single_attn` unified onto `update_padded_kv_cache` (same write op as chunked): the whole sequence is one chunk, so block-cyclic reduces to natural order — this avoids `fill_cache_for_user_`, which is TILE-only and blocks RM. It then attends the live RM tensor directly (no cache read-back).
- `_gather_kvpe_prefix` does **zero** read-back casts (cache is already op-format). Note: the SP all-gather now moves bf16/RM instead of bf8/TILE, so `fp8_e4m3` (8-bit RM, also native) is the lower-bandwidth option if the gather cost matters.
- **Dense** single-shot stays on bf8/TILE via `fill_cache_for_user_` (no forcing function; `fill` is mesh-agnostic and must keep working on the 1×1 single-chip `test_prefill_block_loop`). TODO left to unify it once `update_padded` is validated on 1×1.

## Testing

`test_sparse_mla` (`glm_5_1`, `deepseek_v32`; 2x4, seq5120, chunk1024), fresh build (umd v0.9.7), **all pass**:

| variant | accuracy (single-shot) | chunked |
| --- | --- | --- |
| glm_5_1 | output 0.99667, cache kv/pe 0.99991/0.99992 | output 0.99639, kvpe prefix 0.99992 |
| deepseek_v32 | output 0.99628, cache kv/pe 0.99990/0.99991 | output 0.99617, kvpe prefix 0.99991 |

On par with the pre-change bf8 baseline (chunked glm `0.996377`) — the bf8 round-trip was not the precision bottleneck; this change removes it (and both casts) rather than improving accuracy.

**Not yet verified:** the actual `cache_batch_idx > 0` multi-user selection — the current tests are single-user/single-layer (B=1). Genuine multi-user validation also needs the indexer multi-user work (item 4) and a `num_users>1` chunked serving test (item 8).

## Stacking / base

Stacked on `ipotkonjak/mla-sparse-blockcyclic-in-kernel` (the in-kernel block-cyclic remap, #48733, currently in the merge queue). **Retarget to `main` once #48733 lands.**

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/sparse-sdpa-multiuser-cache-batch-idx)
