### PR TITLE
feat: optimize llk test build process by tracking built variant IDss

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -177,6 +177,10 @@ class TestConfig:
     SKIP_JUST_FOR_COMPILE_MARKER: ClassVar[str] = "SKIPPED_JUST_FOR_COMPILE"
     SKIP_JUST_FOR_STIMULI_MARKER: ClassVar[str] = "SKIPPED_JUST_FOR_STIMULI"
     _BUILD_DIRS_CREATED: ClassVar[bool] = False
+    # variant_ids this process has already built (or seen already built on disk).
+    # Variants that differ only in runtime args / formats / stimuli collapse to the
+    # same variant_id. Per-process: each xdist worker keeps its own.
+    _BUILT_VARIANT_IDS: ClassVar[set[str]] = set()
     SPEED_OF_LIGHT: ClassVar[bool] = (
         False  # Should everything be converted to compile-time arguments?
     )
@@ -1195,19 +1199,31 @@ class TestConfig:
     def build_elfs(self):
 
         VARIANT_DIR = TestConfig.ARTEFACTS_DIR / self.test_name / self.variant_id
-        if not self.skip_build_header:
-            header_content = self.generate_build_header()
         done_marker = VARIANT_DIR / ".build_complete"
 
         if TestConfig.INFRA_TESTING:
             return
 
+        # In-process fast path: this worker already built (or saw built) this
+        # variant_id, so there is nothing to compile and nothing to stat. This is
+        # the cheapest exit and collapses runtime-only-differing variants.
+        if self.variant_id in TestConfig._BUILT_VARIANT_IDS:
+            return
+
         self.build_shared_artefacts()
 
-        # Fast path: if build is already complete, skip entirely
+        # Fast path: if build is already complete on disk (e.g. produced by
+        # another xdist worker), skip entirely.
         if done_marker.exists():
             logger.debug("Build already complete for {}", self.variant_id[:12])
+            TestConfig._BUILT_VARIANT_IDS.add(self.variant_id)
             return
+
+        # The build header is only needed for variants we actually compile, so
+        # generate it after the fast-path checks above rather than for every
+        # collected test (the vast majority of which hit a fast path).
+        if not self.skip_build_header:
+            header_content = self.generate_build_header()
 
         # Acquire lock for this variant to prevent concurrent builds
         lock_file = TestConfig.SYNC_DIR / f"{self.variant_id}.lock"
@@ -1216,6 +1232,7 @@ class TestConfig:
         with lock:
             # Check again inside lock in case another process just finished
             if done_marker.exists():
+                TestConfig._BUILT_VARIANT_IDS.add(self.variant_id)
                 return
 
             VARIANT_OBJ_DIR = VARIANT_DIR / "obj"
@@ -1327,6 +1344,8 @@ class TestConfig:
 
             # Mark build as complete so other processes know they can use the artefacts
             done_marker.touch()
+
+        TestConfig._BUILT_VARIANT_IDS.add(self.variant_id)
 
     def read_coverage_data_from_device(self):
         VARIANT_DIR = TestConfig.ARTEFACTS_DIR / self.test_name / self.variant_id


### PR DESCRIPTION
### PR Category
Performance. Test only.

### Summary
`build_elfs` reworked into a fast-path ladder (cheapest to most expensive):

1. In-process cache check first: if this worker already built/saw this variant_id, return immediately with zero filesystem stats and no header generation.
2. `build_shared_artefacts()` only for variants that get past the cache.
3. On-disk `done_marker` check (variant built by another xdist worker) now also populates the in-process cache so subsequent hits take path 1.
4. Build-header generation moved down to just before the lock: it now only runs for variants actually compiled, instead of for every collected item (the vast majority of which hit a fast path).
5. Cache is populated inside the lock's re-check and after a successful build.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranicTT/cache-test-variant-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranicTT/cache-test-variant-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fvranicTT/cache-test-variant-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranicTT/cache-test-variant-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranicTT/cache-test-variant-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranicTT/cache-test-variant-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranicTT/cache-test-variant-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranicTT/cache-test-variant-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranicTT/cache-test-variant-ids)