### PR TITLE
Functional SFPU implementation for mean

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py
@@ -195,9 +195,8 @@ def test_mean_ulp_bf16(device, shape, dim, desc, distribution, keepdim, fp32_des
 # FP32 tests
 # ---------------------------------------------------------------------------
 
-# fp32_dest_acc_en=True is required for FP32 inputs.
-# Higher threshold requirement on WH compared to BH (800K, .001)
-_FP32_ULP_THRESHOLD = 1_800_000
+# ttnn.mean defaults to the accurate SFPU path, so this measures SFPU vs torch fp32 golden; the two fp32 orderings differ by at most a few hundred ULP here
+_FP32_ULP_THRESHOLD = 512
 _FP32_NEAR_ZERO_ATOL_FRACTION = 0.00125
 
 
@@ -238,7 +237,26 @@ def test_mean_ulp_fp32(device, shape, dim, desc, distribution, keepdim):
 # FP32 accurate (SFPU) vs fast (FPU) mode
 # ---------------------------------------------------------------------------
 
-# fast_and_approximate_mode: False (default) = accurate SFPU (full fp32); True = fast FPU (tf32).
+# fast_and_approximate_mode: False (default) = accurate SFPU (full fp32); True = fast FPU (tf32). Accuracy = max fp32 ULP vs an fp64 golden.
+_SFPU_ULP_MAX = 8  # accurate-path cap; observed peak is 2 ULP on this grid (4x headroom)
+
+
+def _fp32_input(distribution: str, shape, seed: int) -> torch.Tensor:
+    """FP32 test input. Distributions stress different accumulation regimes."""
+    torch.manual_seed(seed)
+    if distribution == "unit":
+        return torch.empty(shape, dtype=torch.float32).uniform_(1.0, 2.0)
+    if distribution == "large_offset":  # large shared exponent → catastrophic tf32 cancellation
+        return 1.0e4 + torch.empty(shape, dtype=torch.float32).uniform_(0.0, 1.0)
+    if distribution == "wide_range":  # many exponents in one reduction
+        return (
+            torch.empty(shape, dtype=torch.float32).uniform_(-1.0, 1.0)
+            * torch.pow(10.0, torch.empty(shape, dtype=torch.float32).uniform_(0.0, 5.0))
+            + 5.0e3
+        )
+    if distribution == "uniform_01":  # uniform [0, 1)
+        return torch.rand(shape, dtype=torch.float32)
+    raise ValueError(f"unknown distribution {distribution}")
 
 
 def _fp32_ulp_max(actual: torch.Tensor, reference: torch.Tensor) -> float:
@@ -251,43 +269,129 @@ def _fp32_ulp_max(actual: torch.Tensor, reference: torch.Tensor) -> float:
     return ulp.max().item()
 
 
-@pytest.mark.parametrize(
-    "shape, dim",
-    [
-        ((1, 22, 1536), -1),  # W reduce
-        ((1, 1, 32, 2048), -1),  # W reduce
-        ((2, 4, 512, 64), -2),  # H reduce
-        ((2, 3, 256, 256), [-2, -1]),  # HW reduce
-    ],
-    ids=["W1536", "W2048", "H512", "HW256x256"],
-)
-def test_mean_fp32_fast_and_approximate_mode(device, shape, dim):
-    """Accurate SFPU fp32 mean (fast_and_approximate_mode=False) must be no further from an fp64
-    reference than the fast FPU path; the log reports the actual gap. Mean-away-from-zero input
-    keeps ULP meaningful."""
-    torch.manual_seed(0)
-    x = torch.empty(shape, dtype=torch.float32).uniform_(1.0, 2.0)
-    ref = torch.mean(x.to(torch.float64), dim=dim, keepdim=True).to(torch.float32)  # high-precision golden
-    ckc = _make_mean_compute_kernel_config(device, fp32_dest_acc_en=True)
+def _mean_pair(device, x, dim, keepdim, fp32_dest_acc_en=True, input_memory_config=None, output_memory_config=None):
+    """Run ttnn.mean twice (fast FPU, accurate SFPU) on the same input; return (fpu, sfpu) as torch."""
+    ckc = _make_mean_compute_kernel_config(device, fp32_dest_acc_en)
+    tt_in = ttnn.from_torch(
+        x, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_memory_config
+    )
+    kw = dict(dim=dim, keepdim=keepdim, compute_kernel_config=ckc, memory_config=output_memory_config)
+    fpu = ttnn.to_torch(ttnn.mean(tt_in, fast_and_approximate_mode=True, **kw))
+    sfpu = ttnn.to_torch(ttnn.mean(tt_in, fast_and_approximate_mode=False, **kw))
+    return fpu, sfpu
 
-    tt_in = ttnn.from_torch(x, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    fpu = ttnn.to_torch(
-        ttnn.mean(tt_in, dim=dim, keepdim=True, fast_and_approximate_mode=True, compute_kernel_config=ckc)
-    ).reshape(ref.shape)
-    sfpu = ttnn.to_torch(
-        ttnn.mean(tt_in, dim=dim, keepdim=True, fast_and_approximate_mode=False, compute_kernel_config=ckc)
-    ).reshape(ref.shape)
 
+_ACCURATE_SHAPES = [
+    ((1, 22, 1536), -1, "W1536"),  # long W reduce
+    ((1, 1, 32, 2048), -1, "W2048"),
+    ((2, 4, 512, 64), -2, "H512"),  # H reduce
+    ((2, 3, 256, 256), [-2, -1], "HW256"),  # HW reduce
+    ((1, 1, 30, 1000), -1, "pad30x1000"),  # non-tile-aligned H and W (padding)
+]
+
+
+# Broad sweep — this test carries the distribution/keepdim/seed variation
+@pytest.mark.parametrize("distribution", ["unit", "large_offset", "wide_range"])
+@pytest.mark.parametrize("shape, dim, desc", _ACCURATE_SHAPES, ids=[c[2] for c in _ACCURATE_SHAPES])
+@pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim_false", "keepdim_true"])
+@pytest.mark.parametrize("seed", [0, 1234])
+def test_mean_fp32_accurate_vs_fast(device, distribution, shape, dim, desc, keepdim, seed):
+    """Accurate SFPU fp32 mean must be within the tight ULP cap of an fp64 golden; the FPU gap is logged."""
+    x = _fp32_input(distribution, shape, seed)
+    ref = torch.mean(x.to(torch.float64), dim=dim, keepdim=keepdim).to(torch.float32)
+    fpu, sfpu = _mean_pair(device, x, dim, keepdim)
     fpu_ulp = _fp32_ulp_max(fpu, ref)
     sfpu_ulp = _fp32_ulp_max(sfpu, ref)
     logger.info(
-        f"ttnn.mean fp32 accurate-vs-fast | shape={shape} dim={dim} | "
-        f"FPU max_abs={(fpu - ref).abs().max().item():.3e} ulp={fpu_ulp:.0f} | "
-        f"SFPU max_abs={(sfpu - ref).abs().max().item():.3e} ulp={sfpu_ulp:.0f}"
+        f"ttnn.mean fp32 accurate-vs-fast | {desc} {distribution} seed={seed} keepdim={keepdim} | "
+        f"FPU ulp={fpu_ulp:.0f} | SFPU ulp={sfpu_ulp:.0f}/{_SFPU_ULP_MAX}"
     )
+    assert sfpu_ulp <= _SFPU_ULP_MAX, f"SFPU ulp {sfpu_ulp:.0f} exceeds tight cap {_SFPU_ULP_MAX} (FPU={fpu_ulp:.0f})"
 
-    # The accurate (SFPU) path must be no further from the fp64 reference than the fast (FPU) path.
-    # The log above shows the actual magnitude of the improvement.
-    assert (
-        sfpu_ulp <= fpu_ulp
-    ), f"accurate path not better than fast path: SFPU={sfpu_ulp:.0f} ulp, FPU={fpu_ulp:.0f} ulp"
+
+def _mean_input_memory_config(mem_layout: str, shape):
+    """Input memory config for a 4D (1,1,H,W) shape whose H and W are divisible by 8 tiles."""
+    _, _, h, w = shape
+    if mem_layout == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    if mem_layout == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    if mem_layout == "l1_height_sharded":
+        return ttnn.create_sharded_memory_config(
+            shape=(h // 8, w),
+            core_grid=ttnn.CoreGrid(x=1, y=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            use_height_and_width_as_shard_shape=True,
+        )
+    if mem_layout == "l1_width_sharded":
+        return ttnn.create_sharded_memory_config(
+            shape=(h, w // 8),
+            core_grid=ttnn.CoreGrid(x=8, y=1),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ValueError(f"unknown mem_layout {mem_layout}")
+
+
+@pytest.mark.parametrize("mem_layout", ["dram_interleaved", "l1_interleaved", "l1_width_sharded", "l1_height_sharded"])
+@pytest.mark.parametrize("distribution", ["unit", "wide_range"])
+def test_mean_fp32_accurate_memory_layouts(device, mem_layout, distribution):
+    """Accurate SFPU path must hold the tight ULP cap across DRAM/L1 interleaved and L1 width/height sharded inputs."""
+    shape, dim = (1, 1, 256, 1024), -1
+    x = _fp32_input(distribution, shape, seed=0)
+    ref = torch.mean(x.to(torch.float64), dim=dim, keepdim=True).to(torch.float32)
+    _, sfpu = _mean_pair(
+        device,
+        x,
+        dim,
+        keepdim=True,
+        input_memory_config=_mean_input_memory_config(mem_layout, shape),
+        output_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    sfpu_ulp = _fp32_ulp_max(sfpu, ref)
+    logger.info(
+        f"ttnn.mean fp32 accurate | mem_layout={mem_layout} {distribution} | SFPU ulp={sfpu_ulp:.0f}/{_SFPU_ULP_MAX}"
+    )
+    assert sfpu_ulp <= _SFPU_ULP_MAX, f"SFPU ulp {sfpu_ulp:.0f} exceeds tight cap {_SFPU_ULP_MAX} for {mem_layout}"
+
+
+@pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim_false", "keepdim_true"])
+def test_mean_fp32_long_reduction_regression(device, keepdim):
+    """Regression: fp32 mean over a long W (uniform [0,1)) is thousands of ULP off on the FPU/tf32 path; accurate SFPU must be within a few ULP."""
+    shape, dim = (1, 22, 1536), -1
+    x = _fp32_input("uniform_01", shape, seed=404)
+    ref = torch.mean(x.to(torch.float64), dim=dim, keepdim=keepdim).to(torch.float32)
+    fpu, sfpu = _mean_pair(device, x, dim, keepdim)
+    fpu_ulp = _fp32_ulp_max(fpu, ref)
+    sfpu_ulp = _fp32_ulp_max(sfpu, ref)
+    logger.info(
+        f"fp32 mean long-W uniform keepdim={keepdim} | FPU ulp={fpu_ulp:.0f} | SFPU ulp={sfpu_ulp:.0f}/{_SFPU_ULP_MAX}"
+    )
+    assert sfpu_ulp <= _SFPU_ULP_MAX, f"SFPU ulp {sfpu_ulp:.0f} exceeds tight cap {_SFPU_ULP_MAX}"
+
+
+@pytest.mark.parametrize(
+    "shape, dim, desc",
+    [((1, 1, 4096, 8192), -1, "W8192_deep"), ((1, 1, 8192, 64), -2, "H8192_deep")],
+    ids=["W8192_deep", "H8192_deep"],
+)
+def test_mean_fp32_accurate_large_depth(device, shape, dim, desc):
+    """High accumulation depth (thousands of elements) is where the fast/tf32 path loses the most precision; accurate SFPU must still hold the tight cap."""
+    x = _fp32_input("large_offset", shape, seed=0)
+    ref = torch.mean(x.to(torch.float64), dim=dim, keepdim=True).to(torch.float32)
+    fpu, sfpu = _mean_pair(device, x, dim, keepdim=True)
+    fpu_ulp = _fp32_ulp_max(fpu, ref)
+    sfpu_ulp = _fp32_ulp_max(sfpu, ref)
+    logger.info(
+        f"ttnn.mean fp32 accurate large-depth | {desc} | FPU ulp={fpu_ulp:.0f} | SFPU ulp={sfpu_ulp:.0f}/{_SFPU_ULP_MAX}"
+    )
+    assert sfpu_ulp <= _SFPU_ULP_MAX, f"SFPU ulp {sfpu_ulp:.0f} exceeds tight cap {_SFPU_ULP_MAX}"
+
+
+@pytest.mark.parametrize("shape, dim", [((1, 1, 32, 2048), -1)])
+def test_mean_fp32_accurate_falls_back_without_fp32_dest_acc(device, shape, dim):
+    """Without fp32_dest_acc_en, accurate mode must fall back to the FPU (SFPU can't preserve fp32), giving results bit-identical to fast mode."""
+    torch.manual_seed(0)
+    x = 1.0e4 + torch.empty(shape, dtype=torch.float32).uniform_(0.0, 1.0)
+    fpu, sfpu = _mean_pair(device, x, dim, keepdim=True, fp32_dest_acc_en=False)
+    assert torch.equal(fpu, sfpu), "accurate path did not fall back to FPU when fp32_dest_acc_en=False"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py
@@ -232,3 +232,62 @@ def test_mean_ulp_fp32(device, shape, dim, desc, distribution, keepdim):
     if not passed:
         logger.info(f"  {msg}")
     assert passed, f"[FP32 {desc} {distribution} keepdim={keepdim}] {msg}"
+
+
+# ---------------------------------------------------------------------------
+# FP32 accurate (SFPU) vs fast (FPU) mode
+# ---------------------------------------------------------------------------
+
+# fast_and_approximate_mode: False (default) = accurate SFPU (full fp32); True = fast FPU (tf32).
+
+
+def _fp32_ulp_max(actual: torch.Tensor, reference: torch.Tensor) -> float:
+    """Max signed-magnitude fp32 ULP distance between two same-shape fp32 tensors."""
+    a = actual.reshape(reference.shape).to(torch.float32).contiguous().view(torch.int32).to(torch.int64)
+    r = reference.to(torch.float32).contiguous().view(torch.int32).to(torch.int64)
+    same = (a & 0x80000000) == (r & 0x80000000)
+    av, rv = a & 0x7FFFFFFF, r & 0x7FFFFFFF
+    ulp = torch.where(same, (av - rv).abs(), av.abs() + rv.abs())
+    return ulp.max().item()
+
+
+@pytest.mark.parametrize(
+    "shape, dim",
+    [
+        ((1, 22, 1536), -1),  # W reduce
+        ((1, 1, 32, 2048), -1),  # W reduce
+        ((2, 4, 512, 64), -2),  # H reduce
+        ((2, 3, 256, 256), [-2, -1]),  # HW reduce
+    ],
+    ids=["W1536", "W2048", "H512", "HW256x256"],
+)
+def test_mean_fp32_fast_and_approximate_mode(device, shape, dim):
+    """Accurate SFPU fp32 mean (fast_and_approximate_mode=False) must be no further from an fp64
+    reference than the fast FPU path; the log reports the actual gap. Mean-away-from-zero input
+    keeps ULP meaningful."""
+    torch.manual_seed(0)
+    x = torch.empty(shape, dtype=torch.float32).uniform_(1.0, 2.0)
+    ref = torch.mean(x.to(torch.float64), dim=dim, keepdim=True).to(torch.float32)  # high-precision golden
+    ckc = _make_mean_compute_kernel_config(device, fp32_dest_acc_en=True)
+
+    tt_in = ttnn.from_torch(x, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    fpu = ttnn.to_torch(
+        ttnn.mean(tt_in, dim=dim, keepdim=True, fast_and_approximate_mode=True, compute_kernel_config=ckc)
+    ).reshape(ref.shape)
+    sfpu = ttnn.to_torch(
+        ttnn.mean(tt_in, dim=dim, keepdim=True, fast_and_approximate_mode=False, compute_kernel_config=ckc)
+    ).reshape(ref.shape)
+
+    fpu_ulp = _fp32_ulp_max(fpu, ref)
+    sfpu_ulp = _fp32_ulp_max(sfpu, ref)
+    logger.info(
+        f"ttnn.mean fp32 accurate-vs-fast | shape={shape} dim={dim} | "
+        f"FPU max_abs={(fpu - ref).abs().max().item():.3e} ulp={fpu_ulp:.0f} | "
+        f"SFPU max_abs={(sfpu - ref).abs().max().item():.3e} ulp={sfpu_ulp:.0f}"
+    )
+
+    # The accurate (SFPU) path must be no further from the fp64 reference than the fast (FPU) path.
+    # The log above shows the actual magnitude of the improvement.
+    assert (
+        sfpu_ulp <= fpu_ulp
+    ), f"accurate path not better than fast path: SFPU={sfpu_ulp:.0f} ulp, FPU={fpu_ulp:.0f} ulp"

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -15,18 +15,32 @@ from models.common.utility_functions import torch_random
 TEST_PADDING_VALUE = -42
 
 
+def _skip_fp32_nc_reduce(dtype, dim):
+    # The accurate SFPU fp32 path covers H/W reductions only; batch/channel (dim 0/1) reductions use
+    # the NC path with a bf16-rounded 1/N scaler (~1e-3 error), so fp32 there is not ULP-exact.
+    axes = [dim] if isinstance(dim, int) else list(dim)
+    if dtype == ttnn.float32 and any(a in (0, 1) for a in axes):
+        pytest.skip("fp32 batch/channel-dim mean uses the bf16-scaler NC path; accurate SFPU covers H/W only")
+
+
 @pytest.mark.parametrize("batch_size", [1, 16])
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2])
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_mean(device, batch_size, h, w, dim, keepdim):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
+def test_mean(device, batch_size, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.bfloat16)
-    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch.bfloat16)
+    if dtype == ttnn.float32:
+        # FLOAT32 defaults to the accurate SFPU path, so it gets far tighter thresholds than the FPU BF16 path.
+        torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.float32)
+        torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim)
+    else:
+        torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.bfloat16)
+        torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch.bfloat16)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
 
     output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
@@ -34,27 +48,41 @@ def test_mean(device, batch_size, h, w, dim, keepdim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    assert_numeric_metrics(
-        torch_output_tensor,
-        output_tensor,
-        pcc_threshold=0.999,
-        rtol=0.118,
-        atol=0.002,
-        frobenius_threshold=0.005,
-        check_ulp=False if dim == -2 else True,
-    )
+    if dtype == ttnn.float32:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.9999,
+            rtol=0.01,
+            atol=1e-4,
+            frobenius_threshold=0.001,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.118,
+            atol=0.002,
+            frobenius_threshold=0.005,
+            check_ulp=False if dim == -2 else True,
+        )
 
 
 @pytest.mark.parametrize("shape", [(2, 3, 4, 5), (7, 17, 41, 31)])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, [0, 1], [2, 3], [0, 1, 2]])
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_mean_scaling(device, shape, dim, keepdim):
-    """Ones input → uniform mean; check exact bfloat16 result via ULP."""
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
+def test_mean_scaling(device, shape, dim, keepdim, dtype):
+    """Ones input → uniform mean; check the exact result via ULP (both dtypes)."""
+    _skip_fp32_nc_reduce(dtype, dim)
     torch.manual_seed(0)
-    torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
-    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch.bfloat16)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch_input_tensor = torch.ones(shape, dtype=torch_dtype)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch_dtype)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
 
     output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
@@ -66,13 +94,16 @@ def test_mean_scaling(device, shape, dim, keepdim):
 @pytest.mark.parametrize("shape", [(2, 3, 4, 5), (7, 17, 41, 31)])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, [0, 1], [2, 3], [0, 1, 2]])
 @pytest.mark.parametrize("scalar", [2.0])
-def test_mean_scaling_factor(device, shape, dim, scalar):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
+def test_mean_scaling_factor(device, shape, dim, scalar, dtype):
+    _skip_fp32_nc_reduce(dtype, dim)
     torch.manual_seed(0)
-    torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
-    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, dtype=torch.bfloat16)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch_input_tensor = torch.ones(shape, dtype=torch_dtype)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, dtype=torch_dtype)
     torch_output_tensor = torch_output_tensor * scalar
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
 
     output_tensor = ttnn.mean(input_tensor, dim=dim, scalar=scalar)
@@ -83,14 +114,16 @@ def test_mean_scaling_factor(device, shape, dim, scalar):
 
 @pytest.mark.parametrize("mem_config", [None, ttnn.DRAM_MEMORY_CONFIG, "block", "height"])
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_mean_shard(device, mem_config, keepdim):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
+def test_mean_shard(device, mem_config, keepdim, dtype):
     torch.manual_seed(0)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
     if mem_config == "height":
         # Height 100 is intentionally non-tile-aligned (not a multiple of 32).
         # Physical height pads to 128, so shard height 32 across 4 cores is valid.
         # After reducing dim=-1 with keepdim=False the output shape is (1, 100),
         # which exercises reshape_tiled's shard spec recomputation for HEIGHT_SHARDED.
-        torch_input_tensor = torch.randn(1, 100, 160, dtype=torch.bfloat16)
+        torch_input_tensor = torch.randn(1, 100, 160, dtype=torch_dtype)
         sharded_config = ttnn.create_sharded_memory_config(
             shape=(32, 160),
             core_grid=ttnn.CoreGrid(x=1, y=4),
@@ -98,7 +131,7 @@ def test_mean_shard(device, mem_config, keepdim):
             use_height_and_width_as_shard_shape=True,
         )
     else:
-        torch_input_tensor = torch.randn(1, 1024, 160, dtype=torch.bfloat16)
+        torch_input_tensor = torch.randn(1, 1024, 160, dtype=torch_dtype)
         sharded_config = ttnn.create_sharded_memory_config(
             shape=(1, 1024, 160),
             core_grid=ttnn.CoreGrid(x=5, y=8),
@@ -108,7 +141,7 @@ def test_mean_shard(device, mem_config, keepdim):
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
-        dtype=ttnn.bfloat16,
+        dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=sharded_config,
@@ -127,13 +160,13 @@ def test_mean_shard(device, mem_config, keepdim):
     )
     tt_output_torch = ttnn.to_torch(output_tensor)
     torch_output = torch.mean(torch_input_tensor, -1, keepdim)
-    # test for equivalance
+    # test for equivalance; FLOAT32 runs the accurate SFPU path, so its abs tolerance is far tighter.
     assert_numeric_metrics(
         torch_output,
         tt_output_torch,
         pcc_threshold=0.999,
         rtol=0.610,
-        atol=0.002,
+        atol=1e-4 if dtype == ttnn.float32 else 0.002,
         frobenius_threshold=0.0055,
     )
 

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -14,23 +14,24 @@
  * Int32 HW reduce into a W-then-H two-step (see reduce_op.cpp use_two_step_hw_sfpu_reduce).
  * MIN is pre-lowered to MAX + negate and dispatched via reduce_{h,w}_neg.
  *
- * Float32 SUM additionally opts into the SFPU path when the host defines REDUCE_SFPU_FP32
- * (for accurate ttnn.mean)
+ * Float32 SUM additionally opts into the SFPU path when the caller passes enable_fp32_sfpu=true
+ * (accurate ttnn.mean); the host threads that flag in from the kernel's compile-time args.
  */
-template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim, DataFormat data_format>
+template <
+    ckernel::PoolType pool_type,
+    ckernel::ReduceDim reduce_dim,
+    DataFormat data_format,
+    bool enable_fp32_sfpu = false>
 constexpr bool is_sfpu_reduce_path() {
     if constexpr (pool_type != ckernel::PoolType::MAX && pool_type != ckernel::PoolType::SUM) {
         return false;
     }
     if constexpr (data_format != DataFormat::Int32) {
-#ifdef REDUCE_SFPU_FP32
-        // Opt-in accurate fp32 path: only Float32 SUM (mean is SUM + 1/N post-mul on the host).
-        if constexpr (data_format != DataFormat::Float32 || pool_type != ckernel::PoolType::SUM) {
+        // Float32 opts into the SFPU path only when enabled, and only for SUM (accurate ttnn.mean,
+        // which the host lowers to SUM + a 1/N post-mul). Everything else non-Int32 stays on the FPU.
+        if constexpr (!enable_fp32_sfpu || data_format != DataFormat::Float32 || pool_type != ckernel::PoolType::SUM) {
             return false;
         }
-#else
-        return false;
-#endif
     }
     if constexpr (reduce_dim == ckernel::ReduceDim::REDUCE_SCALAR) {
         return false;

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -13,6 +13,9 @@
  * Int32 REDUCE_SCALAR is unsupported (no SFPU scalar primitive); the host decomposes an
  * Int32 HW reduce into a W-then-H two-step (see reduce_op.cpp use_two_step_hw_sfpu_reduce).
  * MIN is pre-lowered to MAX + negate and dispatched via reduce_{h,w}_neg.
+ *
+ * Float32 SUM additionally opts into the SFPU path when the host defines REDUCE_SFPU_FP32
+ * (for accurate ttnn.mean)
  */
 template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim, DataFormat data_format>
 constexpr bool is_sfpu_reduce_path() {
@@ -20,7 +23,14 @@ constexpr bool is_sfpu_reduce_path() {
         return false;
     }
     if constexpr (data_format != DataFormat::Int32) {
+#ifdef REDUCE_SFPU_FP32
+        // Opt-in accurate fp32 path: only Float32 SUM (mean is SUM + 1/N post-mul on the host).
+        if constexpr (data_format != DataFormat::Float32 || pool_type != ckernel::PoolType::SUM) {
+            return false;
+        }
+#else
         return false;
+#endif
     }
     if constexpr (reduce_dim == ckernel::ReduceDim::REDUCE_SCALAR) {
         return false;

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -4,7 +4,18 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "llk_defs.h"
+
+/**
+ * @brief Float32 reduce precision mode.
+ *
+ * Fast keeps fp32 on the FPU/GMPOOL path (inputs truncated to tf32 — faster, lossy); Accurate
+ * routes fp32 SUM through the SFPU for full-fp32 accumulation (accurate ttnn.mean). Only affects
+ * Float32 SUM; Int32 always uses the SFPU regardless of this mode.
+ */
+enum class ReduceFp32Mode : uint8_t { Fast, Accurate };
 
 /**
  * @brief Determines whether a reduce operation should use the SFPU path.
@@ -14,22 +25,24 @@
  * Int32 HW reduce into a W-then-H two-step (see reduce_op.cpp use_two_step_hw_sfpu_reduce).
  * MIN is pre-lowered to MAX + negate and dispatched via reduce_{h,w}_neg.
  *
- * Float32 SUM additionally opts into the SFPU path when the caller passes enable_fp32_sfpu=true
- * (accurate ttnn.mean); the host threads that flag in from the kernel's compile-time args.
+ * Float32 SUM additionally opts into the SFPU path when the caller passes ReduceFp32Mode::Accurate
+ * (accurate ttnn.mean); the host threads that mode in from the kernel's compile-time args.
  */
 template <
     ckernel::PoolType pool_type,
     ckernel::ReduceDim reduce_dim,
     DataFormat data_format,
-    bool enable_fp32_sfpu = false>
+    ReduceFp32Mode fp32_mode = ReduceFp32Mode::Fast>
 constexpr bool is_sfpu_reduce_path() {
     if constexpr (pool_type != ckernel::PoolType::MAX && pool_type != ckernel::PoolType::SUM) {
         return false;
     }
     if constexpr (data_format != DataFormat::Int32) {
-        // Float32 opts into the SFPU path only when enabled, and only for SUM (accurate ttnn.mean,
+        // Float32 opts into the SFPU path only in Accurate mode, and only for SUM (accurate ttnn.mean,
         // which the host lowers to SUM + a 1/N post-mul). Everything else non-Int32 stays on the FPU.
-        if constexpr (!enable_fp32_sfpu || data_format != DataFormat::Float32 || pool_type != ckernel::PoolType::SUM) {
+        if constexpr (
+            fp32_mode != ReduceFp32Mode::Accurate || data_format != DataFormat::Float32 ||
+            pool_type != ckernel::PoolType::SUM) {
             return false;
         }
     }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 
 #include "api/compute/reduce.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 /**
  * @file reduce_helpers_compute.hpp
  * @brief Single unified reduce function with automatic dispatch
@@ -298,6 +299,8 @@ struct NoOp {
  *                       SFPU; MIN dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
  * @tparam input_policy Input handling policy (default: WaitAndPopPerTile - streaming mode)
  * @tparam reconfig_mode Data format reconfiguration mode (default: INPUT_AND_OUTPUT)
+ * @tparam fp32_mode Float32 precision mode (default: Fast). Accurate routes Float32 SUM through
+ *                   the SFPU for full-fp32 accumulation; see ReduceFp32Mode.
  *
  * @param input_block_shape Tile grid dimensions (rows x cols x batches)
  *              Use ReduceInputBlockShape::of(r, c, b), ::row(c), ::col(r), or ::single()
@@ -383,6 +386,7 @@ template <
     uint32_t output_dfb_id,
     ReduceInputPolicy input_policy = ReduceInputPolicy::WaitAndPopPerTile,
     ReduceDataFormatReconfigMode reconfig_mode = ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
+    ReduceFp32Mode fp32_mode = ReduceFp32Mode::Fast,
     typename AccumulateT = NoAccumulation,
     typename PostReduceOp = NoOp>
 ALWI void reduce(

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -6,6 +6,7 @@
 // Do not include directly - include reduce_helpers_compute.hpp instead
 
 #include "api/compute/add_int_sfpu.h"
+#include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/binary_max_min.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
@@ -37,18 +38,33 @@ ALWI void sfpu_reduce_max_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
     binary_max_int32_tile(a, b, out);
 }
 
-// SFPU SUM fold (Int32 cross-tile add). add_int_tile is exact 2's-complement and wraps on
-// overflow, matching torch's Int32 sum semantics.
+// SFPU cross-tile add. Int32 uses add_int_tile; Float32 uses add_binary_tile for
+// accurate fp32 accumulation. add_binary_tile is unavailable on Quasar, so guard
+// it with ARCH_QUASAR to avoid template lookup failures.
 template <DataFormat format>
 ALWI void sfpu_reduce_sum_fold_init() {
-    static_assert(format == DataFormat::Int32, "SFPU reduce SUM fold: Int32 only");
-    add_int_tile_init();
+    if constexpr (format == DataFormat::Int32) {
+        add_int_tile_init();
+    } else {
+#ifndef ARCH_QUASAR
+        add_binary_tile_init();
+#else
+        static_assert(format == DataFormat::Int32, "Accurate fp32 SFPU mean is not supported on Quasar");
+#endif
+    }
 }
 
 template <DataFormat format>
 ALWI void sfpu_reduce_sum_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
-    static_assert(format == DataFormat::Int32, "SFPU reduce SUM fold: Int32 only");
-    add_int_tile<format>(a, b, out);
+    if constexpr (format == DataFormat::Int32) {
+        add_int_tile<format>(a, b, out);
+    } else {
+#ifndef ARCH_QUASAR
+        add_binary_tile(a, b, out);
+#else
+        static_assert(format == DataFormat::Int32, "Accurate fp32 SFPU mean is not supported on Quasar");
+#endif
+    }
 }
 
 // Pool-type dispatched cross-tile fold init (MAX -> binary_max, SUM -> add_int).

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -264,7 +264,7 @@ template <
     uint32_t output_dfb_id,
     ReduceInputPolicy input_policy,
     ReduceDataFormatReconfigMode reconfig_mode,
-    bool enable_fp32_sfpu = false,
+    ReduceFp32Mode fp32_mode,
     typename AccumulateT,
     typename PostReduceOp>
 ALWI void reduce(
@@ -332,7 +332,7 @@ ALWI void reduce(
     const uint32_t Wt = input_block_shape.cols;
     const uint32_t num_batches = input_block_shape.batches;
 
-    constexpr bool is_sfpu = is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format, enable_fp32_sfpu>();
+    constexpr bool is_sfpu = is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format, fp32_mode>();
 
     DataflowBuffer input_dfb(input_dfb_id);
     DataflowBuffer scaler_dfb(scaler_dfb_id);

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -264,6 +264,7 @@ template <
     uint32_t output_dfb_id,
     ReduceInputPolicy input_policy,
     ReduceDataFormatReconfigMode reconfig_mode,
+    bool enable_fp32_sfpu = false,
     typename AccumulateT,
     typename PostReduceOp>
 ALWI void reduce(
@@ -331,7 +332,7 @@ ALWI void reduce(
     const uint32_t Wt = input_block_shape.cols;
     const uint32_t num_batches = input_block_shape.batches;
 
-    constexpr bool is_sfpu = is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format>();
+    constexpr bool is_sfpu = is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format, enable_fp32_sfpu>();
 
     DataflowBuffer input_dfb(input_dfb_id);
     DataflowBuffer scaler_dfb(scaler_dfb_id);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -51,19 +51,37 @@ inline uint32_t dense_rm_padding_identity_bits(tt::DataFormat df, tt::tt_metal::
     return static_cast<uint32_t>(bf16);
 }
 
-// True when the reduce uses the Int32 SFPU path (FPU GMPOOL/matmul have no Int32 support).
-// Int32 MAX/SUM only; MIN is lowered to MAX + negate on the host before reaching the factories.
-inline bool use_sfpu_reduce_path(tt::tt_metal::DataType dtype, tt::tt_metal::ReduceOpMath math_op) {
+// True when the reduce uses the SFPU path instead of the FPU GMPOOL/matmul path.
+// Int32 MAX/SUM always use SFPU (FPU has no Int32 support); MIN is lowered to MAX + negate on the
+// host before reaching the factories. Float32 SUM opts into SFPU only when the host requests the
+// accurate ttnn.mean path (`use_sfpu_reduce`): the FPU path truncates fp32 to tf32,
+// so accumulating register-to-register in the SFPU preserves full fp32. mean is lowered to SUM +
+// a 1/N post-mul before this is consulted, so only SUM (never AVG) is checked for fp32.
+inline bool use_sfpu_reduce_path(
+    tt::tt_metal::DataType dtype, tt::tt_metal::ReduceOpMath math_op, bool use_sfpu_reduce = false) {
     using tt::tt_metal::ReduceOpMath;
-    return dtype == tt::tt_metal::DataType::INT32 && (math_op == ReduceOpMath::MAX || math_op == ReduceOpMath::SUM);
+    if (dtype == tt::tt_metal::DataType::INT32) {
+        return math_op == ReduceOpMath::MAX || math_op == ReduceOpMath::SUM;
+    }
+    return use_sfpu_reduce && dtype == tt::tt_metal::DataType::FLOAT32 && math_op == ReduceOpMath::SUM;
 }
 
-// True when a non-unity scalar must be applied as a post-reduce multiply instead of via the scaler
-// CB (MAX/MIN keep only its exponent; the Int32 SFPU path ignores the CB). Float/bf16 SUM use the CB.
-inline bool requires_post_mul(tt::tt_metal::ReduceOpMath math_op, tt::tt_metal::DataType dtype, float scaler) {
+// True when a non-unity scalar must be a post-reduce multiply instead of via the scaler CB: MAX/MIN,
+// the Int32 SFPU path, and the accurate fp32 SFPU mean all ignore the scaler CB (fp32 matches AVG/SUM).
+inline bool requires_post_mul(
+    tt::tt_metal::ReduceOpMath math_op, tt::tt_metal::DataType dtype, float scaler, bool use_sfpu_reduce = false) {
     using tt::tt_metal::ReduceOpMath;
-    return scaler != 1.0f &&
-           (math_op == ReduceOpMath::MAX || (math_op == ReduceOpMath::SUM && dtype == tt::tt_metal::DataType::INT32));
+    if (scaler == 1.0f) {
+        return false;
+    }
+    if (math_op == ReduceOpMath::MAX) {
+        return true;
+    }
+    if (math_op == ReduceOpMath::SUM && dtype == tt::tt_metal::DataType::INT32) {
+        return true;
+    }
+    return use_sfpu_reduce && dtype == tt::tt_metal::DataType::FLOAT32 &&
+           (math_op == ReduceOpMath::SUM || math_op == ReduceOpMath::AVG);
 }
 
 // All RM-path locals derived from the input shape, tile geometry, and math op.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -15,7 +15,8 @@ void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
-    constexpr bool enable_fp32_sfpu = get_compile_time_arg_val(4) != 0;
+    // Accurate fp32 mean: host sets CT arg 4 to route Float32 SUM through the SFPU (full fp32) vs the FPU (tf32).
+    constexpr auto fp32_mode = get_compile_time_arg_val(4) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
@@ -27,7 +28,7 @@ void kernel_main() {
         tt::CBIndex::c_3,
         compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
         compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT,
-        enable_fp32_sfpu>(
+        fp32_mode>(
         compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC),
         compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
         compute_kernel_lib::NoAccumulation{},

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -15,6 +15,7 @@ void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
+    constexpr bool enable_fp32_sfpu = get_compile_time_arg_val(4) != 0;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
@@ -25,7 +26,8 @@ void kernel_main() {
         tt::CBIndex::c_2,
         tt::CBIndex::c_3,
         compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
+        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT,
+        enable_fp32_sfpu>(
         compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC),
         compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
         compute_kernel_lib::NoAccumulation{},

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -33,8 +33,10 @@ void kernel_main() {
     // unified reduce compute kernel (row_chunk = DEST_AUTO_LIMIT). For shard_Wt=1 this
     // degenerates to one column per chunk; for shard_Wt>1 it interleaves columns.
     // Int32 SFPU max reserves one DST for the binary-fold work tile (DEST_AUTO_LIMIT - 1).
+    // Accurate fp32 mean: host sets this to 1 so SFPU chunk sizing here matches the compute kernel.
+    constexpr bool enable_fp32_sfpu = get_compile_time_arg_val(4) != 0;
     constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
-    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>();
+    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format, enable_fp32_sfpu>();
     constexpr uint32_t row_chunk =
         use_sfpu_reduce_path ? (compute_kernel_lib::DEST_AUTO_LIMIT - 1) : compute_kernel_lib::DEST_AUTO_LIMIT;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -33,10 +33,10 @@ void kernel_main() {
     // unified reduce compute kernel (row_chunk = DEST_AUTO_LIMIT). For shard_Wt=1 this
     // degenerates to one column per chunk; for shard_Wt>1 it interleaves columns.
     // Int32 SFPU max reserves one DST for the binary-fold work tile (DEST_AUTO_LIMIT - 1).
-    // Accurate fp32 mean: host sets this to 1 so SFPU chunk sizing here matches the compute kernel.
-    constexpr bool enable_fp32_sfpu = get_compile_time_arg_val(4) != 0;
+    // Accurate fp32 mean: host sets CT arg 4 to 1 so SFPU chunk sizing here matches the compute kernel.
+    constexpr auto fp32_mode = get_compile_time_arg_val(4) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
     constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
-    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format, enable_fp32_sfpu>();
+    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format, fp32_mode>();
     constexpr uint32_t row_chunk =
         use_sfpu_reduce_path ? (compute_kernel_lib::DEST_AUTO_LIMIT - 1) : compute_kernel_lib::DEST_AUTO_LIMIT;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
 
     constexpr uint32_t scaler_bits = get_compile_time_arg_val(3);
     constexpr bool use_welford = get_compile_time_arg_val(4) != 0;
-    constexpr bool enable_fp32_sfpu = get_compile_time_arg_val(5) != 0;
+    constexpr auto fp32_mode = get_compile_time_arg_val(5) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
 
@@ -33,7 +33,7 @@ void kernel_main() {
     // per chunk, which would feed the Welford kernel tiles from the wrong columns.
     // Int32 SFPU max keeps one acc DST per column plus one shared work DST (DEST_AUTO_LIMIT - 1).
     constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
-    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format, enable_fp32_sfpu>();
+    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format, fp32_mode>();
     constexpr uint32_t row_chunk = use_welford ? 1
                                                : (use_sfpu_reduce_path ? (compute_kernel_lib::DEST_AUTO_LIMIT - 1)
                                                                        : compute_kernel_lib::DEST_AUTO_LIMIT);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -24,6 +24,7 @@ void kernel_main() {
 
     constexpr uint32_t scaler_bits = get_compile_time_arg_val(3);
     constexpr bool use_welford = get_compile_time_arg_val(4) != 0;
+    constexpr bool enable_fp32_sfpu = get_compile_time_arg_val(5) != 0;
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
 
@@ -32,7 +33,7 @@ void kernel_main() {
     // per chunk, which would feed the Welford kernel tiles from the wrong columns.
     // Int32 SFPU max keeps one acc DST per column plus one shared work DST (DEST_AUTO_LIMIT - 1).
     constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
-    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>();
+    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format, enable_fp32_sfpu>();
     constexpr uint32_t row_chunk = use_welford ? 1
                                                : (use_sfpu_reduce_path ? (compute_kernel_lib::DEST_AUTO_LIMIT - 1)
                                                                        : compute_kernel_lib::DEST_AUTO_LIMIT);
@@ -44,7 +45,7 @@ void kernel_main() {
     float scaler_f = __builtin_bit_cast(float, scaler_bits);
     dataflow_kernel_lib::prepare_reduce_scaler<cb_id_in2, REDUCE_OP, REDUCE_DIM>(scaler_f);
 
-    constexpr auto tensor_args = TensorAccessorArgs<5>();
+    constexpr auto tensor_args = TensorAccessorArgs<6>();
     auto tensor_accessor = TensorAccessor(tensor_args, src_addr);
 
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -84,7 +84,8 @@ Tensor reduce(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
     bool negate,
-    bool use_row_major_support) {
+    bool use_row_major_support,
+    bool fast_and_approximate_mode) {
     if (reduce_math == tt::tt_metal::ReduceOpMath::MIN) {
         return reduce_min(input_tensor, reduce_dim, scaler, output_mem_config, compute_kernel_config, sub_core_grids);
     }
@@ -102,6 +103,14 @@ Tensor reduce(
     // fp32_dest_acc_en defaults to True here, so always use HiFi3 as default on Wormhole B0.
     const auto arch = input_tensor.device()->arch();
     const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+
+    // Accurate fp32 mean: run fp32 AVG on the SFPU (full fp32), lowered to SUM + 1/N post-mul below.
+    // fast_and_approximate_mode=false (the ttnn-convention default) selects this accurate path. Quasar
+    // lacks the SFPU fp32 binary add (add_binary_tile), so fall back to the FPU there instead of
+    // tripping the kernel static_assert.
+    const bool use_sfpu_fp32_mean = !fast_and_approximate_mode &&
+                                    input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
+                                    reduce_math == tt::tt_metal::ReduceOpMath::AVG && arch != tt::ARCH::QUASAR;
     ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(ttnn::init_device_compute_kernel_config(
         arch,
         std::nullopt,
@@ -140,8 +149,10 @@ Tensor reduce(
     // row-major W/H path we tilize one logical row at a time from a narrow RM page; AVG applies an extra normalization
     // for full tile faces that does not match torch.mean together with partial-row tilize. Use SUM + the same scaler.
     // SUM and MAX pass through unchanged.
+    // The accurate fp32 SFPU mean path also lowers AVG to SUM: the SFPU folds tiles with a plain
+    // add (add_binary_tile) and normalizes via the 1/N post-mul below, so it needs SUM semantics.
     tt::tt_metal::ReduceOpMath prim_reduce_math = reduce_math;
-    if (use_rm_dense && reduce_math == tt::tt_metal::ReduceOpMath::AVG) {
+    if ((use_rm_dense || use_sfpu_fp32_mean) && reduce_math == tt::tt_metal::ReduceOpMath::AVG) {
         prim_reduce_math = tt::tt_metal::ReduceOpMath::SUM;
     }
 
@@ -156,7 +167,9 @@ Tensor reduce(
     // A non-unity scalar is applied after the reduction (see requires_post_mul() in common.hpp):
     // GMPOOL keeps only the scaler's exponent for MAX/MIN, and the Int32 SFPU path ignores the
     // scaler CB. Int32 post-mul rounds through fp32, so it is lossy for |result| > 2^24.
-    const bool use_post_mul = ttnn::prim::requires_post_mul(reduce_math, tilized_input.dtype(), scaler);
+    // The accurate fp32 SFPU mean also post-muls (SFPU ignores the scaler CB), applying the 1/N here.
+    const bool use_post_mul =
+        ttnn::prim::requires_post_mul(reduce_math, tilized_input.dtype(), scaler, use_sfpu_fp32_mean);
     const float reduce_scaler = use_post_mul ? 1.0f : scaler;
     const float post_mul = use_post_mul ? scaler : 1.0f;
 
@@ -194,9 +207,13 @@ Tensor reduce(
     // INT32 SFPU reduce has no REDUCE_SCALAR primitive (ROW/COL only), so Int32 HW always uses
     // W-then-H. Float32 max HW can use single-core REDUCE_SCALAR (FPU) when num_tiles == 1;
     // multi-tile HW still uses W-then-H via is_multicore_hw. Applies to MAX/SUM and MIN (MIN via negate).
+    // The accurate fp32 SFPU mean (AVG) likewise has no SFPU REDUCE_SCALAR, so it must decompose HW
+    // into W-then-H regardless of tile count; forcing the two-step keeps it off the single-core path.
     const bool use_two_step_hw_sfpu_reduce =
-        (reduce_dim == tt::tt_metal::ReduceOpDim::HW) && (tilized_input.dtype() == tt::tt_metal::DataType::INT32) &&
-        (reduce_math == tt::tt_metal::ReduceOpMath::MAX || reduce_math == tt::tt_metal::ReduceOpMath::SUM);
+        (reduce_dim == tt::tt_metal::ReduceOpDim::HW) &&
+        ((tilized_input.dtype() == tt::tt_metal::DataType::INT32 &&
+          (reduce_math == tt::tt_metal::ReduceOpMath::MAX || reduce_math == tt::tt_metal::ReduceOpMath::SUM)) ||
+         use_sfpu_fp32_mean);
 
     if (is_multicore_hw || use_two_step_hw_sfpu_reduce ||
         (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {
@@ -218,7 +235,7 @@ Tensor reduce(
 
         const Tensor output_tensor = ttnn::prim::reduce(
             tilized_input,
-            reduce_math,
+            prim_reduce_math,
             tt::tt_metal::ReduceOpDim::W,
             1.0f,
             output_mem_config,
@@ -228,7 +245,8 @@ Tensor reduce(
             negate,
             /*post_mul_scaler=*/1.0f,
             /*row_major_w_dense_path=*/false,
-            /*row_major_h_dense_path=*/false);
+            /*row_major_h_dense_path=*/false,
+            /*use_sfpu_reduce=*/use_sfpu_fp32_mean);
 
         if (negate && !ttnn::prim::h_reduce_negate_fits_in_l1(output_tensor, sub_core_grids)) {
             return h_reduce_with_external_negate(output_tensor, reduce_scaler, post_mul, out_final_dtype);
@@ -236,7 +254,7 @@ Tensor reduce(
 
         return ttnn::prim::reduce(
             output_tensor,
-            reduce_math,
+            prim_reduce_math,
             tt::tt_metal::ReduceOpDim::H,
             reduce_scaler,
             output_mem_config,
@@ -246,7 +264,8 @@ Tensor reduce(
             negate,
             /*post_mul_scaler=*/post_mul,
             /*row_major_w_dense_path=*/false,
-            /*row_major_h_dense_path=*/false);
+            /*row_major_h_dense_path=*/false,
+            /*use_sfpu_reduce=*/use_sfpu_fp32_mean);
     }
 
     if (negate && reduce_dim == tt::tt_metal::ReduceOpDim::H &&
@@ -267,7 +286,8 @@ Tensor reduce(
         negate,
         /*post_mul_scaler=*/post_mul,
         /*row_major_w_dense_path=*/use_rm_dense_w,
-        /*row_major_h_dense_path=*/use_rm_dense_h);
+        /*row_major_h_dense_path=*/use_rm_dense_h,
+        /*use_sfpu_reduce=*/use_sfpu_fp32_mean);
 }
 
 }  // namespace ttnn::operations::reduction::generic::detail

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -104,13 +104,6 @@ Tensor reduce(
     const auto arch = input_tensor.device()->arch();
     const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
 
-    // Accurate fp32 mean: run fp32 AVG on the SFPU (full fp32), lowered to SUM + 1/N post-mul below.
-    // fast_and_approximate_mode=false (the ttnn-convention default) selects this accurate path. Quasar
-    // lacks the SFPU fp32 binary add (add_binary_tile), so fall back to the FPU there instead of
-    // tripping the kernel static_assert.
-    const bool use_sfpu_fp32_mean = !fast_and_approximate_mode &&
-                                    input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
-                                    reduce_math == tt::tt_metal::ReduceOpMath::AVG && arch != tt::ARCH::QUASAR;
     ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(ttnn::init_device_compute_kernel_config(
         arch,
         std::nullopt,
@@ -118,6 +111,11 @@ Tensor reduce(
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true));
     ttnn::verify_numerical_configuration(arch, compute_kernel_config);
+
+    // Accurate fp32 mean: SFPU AVG (lowered to SUM + 1/N below); FPU fallback without fp32_dest_acc_en or on Quasar.
+    const bool use_sfpu_fp32_mean =
+        !fast_and_approximate_mode && input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
+        reduce_math == tt::tt_metal::ReduceOpMath::AVG && arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en;
 
     // Dense row-major reduce: a fast path that consumes ROW_MAJOR input directly (no host tilize)
     // and is currently restricted to mean (AVG) / sum (SUM) on 4D BF16/FLOAT32 tensors with

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
@@ -28,7 +28,10 @@ Tensor reduce(
     // row-major fast path. When false (default), the op always tilizes and uses the classic
     // tile-reduce kernels. Default-off pending fixes to the dense RM path (perf regression +
     // multi-H-tile hang); see reduce_op.cpp for the eligibility constraints.
-    bool use_row_major_support = false);
+    bool use_row_major_support = false,
+    // When false (default), fp32 mean runs on the accurate SFPU path (full fp32); true selects the FPU. Ignored for
+    // non-fp32/non-AVG.
+    bool fast_and_approximate_mode = false);
 
 }  // namespace ttnn::operations::reduction::generic::detail
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -219,7 +219,8 @@ ttnn::Tensor reduce(
     bool negate,
     float post_mul_scaler,
     bool row_major_w_dense_path,
-    bool row_major_h_dense_path) {
+    bool row_major_h_dense_path,
+    bool use_sfpu_reduce) {
     return ttnn::device_operation::launch<ReduceDeviceOperation>(
         ReduceParams{
             reduce_math,
@@ -232,7 +233,8 @@ ttnn::Tensor reduce(
             negate,
             post_mul_scaler,
             row_major_w_dense_path,
-            row_major_h_dense_path},
+            row_major_h_dense_path,
+            use_sfpu_reduce},
         input_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -70,6 +70,7 @@ ttnn::Tensor reduce(
     bool negate = false,
     float post_mul_scaler = 1.0f,
     bool row_major_w_dense_path = false,
-    bool row_major_h_dense_path = false);
+    bool row_major_h_dense_path = false,
+    bool use_sfpu_reduce = false);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
@@ -34,6 +34,9 @@ struct ReduceParams {
     // may be set at a time (validated in validate_on_program_cache_miss).
     bool row_major_w_dense_path{false};
     bool row_major_h_dense_path{false};
+    // Accurate fp32 mean: route Float32 SUM through the SFPU (full fp32); set from
+    // ttnn.mean(fast_and_approximate_mode=False).
+    bool use_sfpu_reduce{false};
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -353,11 +353,8 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     if (use_post_mul) {
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
-    // Accurate fp32 mean: define REDUCE_SFPU_FP32 to route Float32 SUM through the SFPU (needs 32-bit DEST).
+    // Accurate fp32 mean: route Float32 SUM through the SFPU (needs 32-bit DEST)
     const bool fp32_sfpu_reduce = is_sfpu_reduce && a.dtype() == DataType::FLOAT32 && fp32_dest_acc_en;
-    if (fp32_sfpu_reduce) {
-        reduce_defines["REDUCE_SFPU_FP32"] = "1";
-    }
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     // UnpackToDestFp32 unpacks c_0 straight into the fp32 DEST, bypassing the SrcA tf32 truncation.
@@ -380,7 +377,8 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         reader_desc.compile_time_args = reader_compile_time_args;
         reader_desc.defines = {reduce_defines.begin(), reduce_defines.end()};
     } else if (use_width_sharding) {
-        std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, src1_cb_index, scaler_cb_index, scaler_bits};
+        std::vector<uint32_t> reader_compile_time_args = {
+            src0_cb_index, src1_cb_index, scaler_cb_index, scaler_bits, fp32_sfpu_reduce ? 1u : 0u};
         std::map<std::string, std::string> reader_defines;
         reader_defines["REDUCE_SCALER"] = "1";
         // Pass DEST config so reader can compute DEST_AUTO_LIMIT
@@ -393,7 +391,8 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         reader_desc.compile_time_args = reader_compile_time_args;
         reader_desc.defines = {reader_defines.begin(), reader_defines.end()};
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, scaler_bits, /*use_welford=*/0};
+        std::vector<uint32_t> reader_compile_time_args = {
+            Ht, Wt, HtWt, scaler_bits, /*use_welford=*/0, fp32_sfpu_reduce ? 1u : 0u};
         TensorAccessorArgs(a).append_to(reader_compile_time_args);
 
         // Pass DEST config so reader can compute DEST_AUTO_LIMIT
@@ -449,10 +448,11 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         compute_kernel_args_group_1 = build_rm_compute_ct_args(plan, plan.Ht_rm, post_mul_scaler_bits);
     } else {
         compute_kernel_args_group_1 = {
-            Ht,                    // Ht
-            compute_Wt,            // Wt
-            compute_NC,            // NC
-            post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+            Ht,                          // Ht
+            compute_Wt,                  // Wt
+            compute_NC,                  // NC
+            post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+            fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
         };
     }
 
@@ -486,10 +486,11 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
                 use_width_sharding ? (num_cols_per_core_group_2 / NC) : num_cols_per_core_group_2;
             uint32_t compute_NC_group_2 = use_width_sharding ? NC : 1;
             compute_kernel_args_group_2 = {
-                Ht,                    // Ht
-                compute_Wt_group_2,    // Wt
-                compute_NC_group_2,    // NC
-                post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+                Ht,                          // Ht
+                compute_Wt_group_2,          // Wt
+                compute_NC_group_2,          // NC
+                post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+                fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
             };
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -83,9 +83,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     // reduction via SFPU mul_unary_tile inside the compute kernel.
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
 
-    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support); see
-    // use_sfpu_reduce_path() in common.hpp. SUM never negates, so use_fpu_negate is unaffected.
-    const bool is_sfpu_reduce = use_sfpu_reduce_path(a.dtype(), operation_attributes.math_op);
+    // Int32 max/min/sum use the SFPU reduce path; fp32 SUM only for the accurate mean opt-in.
+    const bool is_sfpu_reduce =
+        use_sfpu_reduce_path(a.dtype(), operation_attributes.math_op, operation_attributes.use_sfpu_reduce);
     const bool use_fpu_negate = operation_attributes.negate && !is_sfpu_reduce;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -353,8 +353,17 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     if (use_post_mul) {
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
+    // Accurate fp32 mean: define REDUCE_SFPU_FP32 to route Float32 SUM through the SFPU (needs 32-bit DEST).
+    const bool fp32_sfpu_reduce = is_sfpu_reduce && a.dtype() == DataType::FLOAT32 && fp32_dest_acc_en;
+    if (fp32_sfpu_reduce) {
+        reduce_defines["REDUCE_SFPU_FP32"] = "1";
+    }
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    // UnpackToDestFp32 unpacks c_0 straight into the fp32 DEST, bypassing the SrcA tf32 truncation.
+    if (fp32_sfpu_reduce) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
 
     KernelDescriptor reader_desc;
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -176,9 +176,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
-    // Int32 max/min/sum use the SFPU reduce path (GMPOOL has no Int32 support); see
-    // use_sfpu_reduce_path() in common.hpp. SUM never negates, so use_fpu_negate is unaffected.
-    const bool is_sfpu_reduce = use_sfpu_reduce_path(a.dtype(), operation_attributes.math_op);
+    // Int32 max/min/sum use the SFPU reduce path; fp32 SUM only for the accurate mean opt-in.
+    const bool is_sfpu_reduce =
+        use_sfpu_reduce_path(a.dtype(), operation_attributes.math_op, operation_attributes.use_sfpu_reduce);
     const bool use_fpu_negate = operation_attributes.negate && !is_sfpu_reduce;
 
     std::vector<uint32_t> reader_compile_time_args;
@@ -229,8 +229,17 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     if (use_post_mul) {
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
+    // Accurate fp32 mean: define REDUCE_SFPU_FP32 to route Float32 SUM through the SFPU (needs 32-bit DEST).
+    const bool fp32_sfpu_reduce = is_sfpu_reduce && a.dtype() == DataType::FLOAT32 && fp32_dest_acc_en;
+    if (fp32_sfpu_reduce) {
+        reduce_defines["REDUCE_SFPU_FP32"] = "1";
+    }
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    // UnpackToDestFp32 unpacks c_0 straight into the fp32 DEST, bypassing the SrcA tf32 truncation.
+    if (fp32_sfpu_reduce) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -229,11 +229,8 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     if (use_post_mul) {
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
-    // Accurate fp32 mean: define REDUCE_SFPU_FP32 to route Float32 SUM through the SFPU (needs 32-bit DEST).
+    // Accurate fp32 mean: route Float32 SUM through the SFPU (needs 32-bit DEST)
     const bool fp32_sfpu_reduce = is_sfpu_reduce && a.dtype() == DataType::FLOAT32 && fp32_dest_acc_en;
-    if (fp32_sfpu_reduce) {
-        reduce_defines["REDUCE_SFPU_FP32"] = "1";
-    }
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     // UnpackToDestFp32 unpacks c_0 straight into the fp32 DEST, bypassing the SrcA tf32 truncation.
@@ -278,10 +275,11 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         compute_kernel_args_group_1 = build_rm_compute_ct_args(plan, ht_per_core_group_1, post_mul_scaler_bits);
     } else {
         compute_kernel_args_group_1 = {
-            ht_per_core_group_1,   // Ht
-            Wt,                    // Wt
-            1,                     // NC
-            post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+            ht_per_core_group_1,         // Ht
+            Wt,                          // Wt
+            1,                           // NC
+            post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+            fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
         };
     }
 
@@ -310,10 +308,11 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
             compute_kernel_args_group_2 = build_rm_compute_ct_args(plan, ht_per_core_group_2, post_mul_scaler_bits);
         } else {
             compute_kernel_args_group_2 = {
-                ht_per_core_group_2,   // Ht
-                Wt,                    // Wt
-                1,                     // NC
-                post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+                ht_per_core_group_2,         // Ht
+                Wt,                          // Wt
+                1,                           // NC
+                post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+                fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
             };
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -182,6 +182,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
         Wt,                    // Wt
         NC,                    // NC
         post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
+        0u,                    // enable_fp32_sfpu: always 0 (fp32 mean HW is forced to the two-step W-then-H path)
     };
 
     const std::string compute_kernel =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -321,7 +321,10 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         // Welford processes one column at a time (SFPU can only track one running
         // mean/M2 state), so the reader must deliver tiles in strict column-major
         // order: all Ht tiles of column 0, then all Ht tiles of column 1, etc.
-        std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, scaler_bits, /*use_welford=*/1};
+        // enable_fp32_sfpu=0: Welford never uses the fp32-SFPU reduce path (use_welford=1 forces
+        // row_chunk=1). The slot keeps this reader's CT-arg layout in lockstep with the reduce factories.
+        std::vector<uint32_t> reader_compile_time_args = {
+            Ht, Wt, HtWt, scaler_bits, /*use_welford=*/1, /*enable_fp32_sfpu=*/0u};
         TensorAccessorArgs(input).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -37,7 +37,8 @@ Tensor reduce(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    bool fast_and_approximate_mode = false);
 
 // input_shape has original shape while output_shape has reduction applied and last 2 dims padded.
 // Need to get slice parameters based on the minimum of the two shapes.
@@ -136,7 +137,8 @@ static Tensor reduce_impl(
     // Sum precision chain: when active, intermediate stages stay FP32 and only
     // the stage with is_last_in_chain=true packs the final bf16 result.
     bool chain_active = false,
-    bool is_last_in_chain = false) {
+    bool is_last_in_chain = false,
+    bool fast_and_approximate_mode = false) {
     auto input_shape = input_tensor_arg.logical_shape();
     auto rank = input_shape.rank();
     auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
@@ -186,6 +188,9 @@ static Tensor reduce_impl(
                     // Only the smallest-axis sub-step ends the chain; earlier sub-steps stay in fp32.
                     const bool sub_is_last = chain_active && is_last_in_chain && (i_dim == min_reduce_axis);
                     if (use_reduce_type) {
+                        // Multi-axis / non-H·W single-axis means reduce via transpose-to-H here; the accurate
+                        // SFPU mean is scoped to natural W/H/HW, so keep these sub-steps on the FPU (fast/
+                        // approximate) path to preserve behavior.
                         output_tensor = reduce_impl<reduce_type>(
                             output_tensor,
                             {reduce_dim},
@@ -196,7 +201,8 @@ static Tensor reduce_impl(
                             non_height_width_dims,
                             sub_core_grids,
                             chain_active,
-                            sub_is_last);
+                            sub_is_last,
+                            /*fast_and_approximate_mode=*/true);
                     } else {
                         output_tensor = reduce_impl<reduction_common::ReduceType::Sum>(
                             output_tensor,
@@ -278,7 +284,10 @@ static Tensor reduce_impl(
                 memory_config,
                 std::nullopt,
                 compute_kernel_config,
-                sub_core_grids);
+                sub_core_grids,
+                /*negate=*/false,
+                /*use_row_major_support=*/false,
+                /*fast_and_approximate_mode=*/fast_and_approximate_mode);
         } else if constexpr (reduce_type == reduction_common::ReduceType::Max) {
             output_tensor = ttnn::operations::reduction::generic::detail::reduce(
                 input_tensor,
@@ -500,7 +509,8 @@ Tensor reduce(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool fast_and_approximate_mode) {
     // ttnn.mean does not support integer inputs. Remove once integer AVG is implemented.
     if constexpr (reduce_type == reduction_common::ReduceType::Mean) {
         const auto dt = input_tensor_arg.dtype();
@@ -598,7 +608,8 @@ Tensor reduce(
         non_height_width_dims,
         sub_core_grids,
         /*chain_active=*/chain_active,
-        /*is_last_in_chain=*/chain_active);
+        /*is_last_in_chain=*/chain_active,
+        /*fast_and_approximate_mode=*/fast_and_approximate_mode);
 }
 
 Tensor pool_sum(
@@ -650,7 +661,8 @@ Tensor mean(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool fast_and_approximate_mode) {
     return operations::reduction::reduce<reduction_common::ReduceType::Mean>(
         input_tensor_arg,
         dim_arg,
@@ -659,7 +671,8 @@ Tensor mean(
         compute_kernel_config,
         scalar,
         correction,
-        sub_core_grids);
+        sub_core_grids,
+        fast_and_approximate_mode);
 }
 
 Tensor max(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -46,7 +46,10 @@ Tensor mean(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    // When false (default), fp32 mean reduces on the accurate SFPU path (full fp32); true selects the faster tf32 FPU
+    // path.
+    bool fast_and_approximate_mode = false);
 
 Tensor max(
     const Tensor& input_tensor_arg,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -19,13 +19,18 @@ namespace ttnn::operations::reduction::detail {
 
 namespace nb = nanobind;
 
-inline std::string get_generic_reduction_doc(const char* op_name, const char* qualified_name, bool int32_supported) {
+inline std::string get_generic_reduction_doc(
+    const char* op_name, const char* qualified_name, bool int32_supported, bool has_fast_approximate_mode = false) {
     // INT32 (TILE only) is supported for sum/min/max via the SFPU reduce path, but not for mean:
     // the average (sum / N) is usually fractional, so there is no canonical INT32 result to return.
     const char* int32_row = int32_supported ? R"doc(
                 * - INT32
                   - TILE)doc"
                                             : "";
+    // Only ttnn.mean exposes fast_and_approximate_mode.
+    const char* fast_approx_kwarg = has_fast_approximate_mode ? R"doc(
+            fast_and_approximate_mode (bool, optional): FLOAT32 only. `False` (default) uses the accurate SFPU path (full float32 accumulation); `True` uses the faster FPU path (inputs truncated to TF32, higher ULP error). The accurate path requires a compute_kernel_config with `fp32_dest_acc_en=True` and is unavailable on Quasar; in those cases it falls back to the FPU. No effect for non-FLOAT32 inputs.)doc"
+                                                              : "";
     return fmt::format(
         R"doc(
         Computes the {0} of the input tensor :attr:`input_tensor` along the specified dimension(s) :attr:`dim`.
@@ -41,7 +46,7 @@ inline std::string get_generic_reduction_doc(const char* op_name, const char* qu
             compute_kernel_config (ttnn.ComputeKernelConfig, optional): Compute kernel configuration for the operation. Defaults to `None`.
             scalar (float, optional): A scaling factor to be applied to the input tensor. Defaults to `1.0`.
             correction (bool, optional): **Deprecated.** This parameter is deprecated and will be removed in a future release. It has no impact on the result.
-            sub_core_grids (ttnn.CoreRangeSet, optional): Subcore grids to use for the operation. Defaults to `None`, which will use all cores.
+            sub_core_grids (ttnn.CoreRangeSet, optional): Subcore grids to use for the operation. Defaults to `None`, which will use all cores.{3}
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -72,7 +77,8 @@ inline std::string get_generic_reduction_doc(const char* op_name, const char* qu
         )doc",
         op_name,
         qualified_name,
-        int32_row);
+        int32_row,
+        fast_approx_kwarg);
 }
 
 // Wrapper that detects explicit use of the deprecated 'correction' parameter and
@@ -160,7 +166,8 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("correction") = nb::none(),
         nb::arg("sub_core_grids") = nb::none());
 
-    const auto mean_doc = get_generic_reduction_doc("mean", "ttnn.mean", /*int32_supported=*/false);
+    const auto mean_doc =
+        get_generic_reduction_doc("mean", "ttnn.mean", /*int32_supported=*/false, /*has_fast_approximate_mode=*/true);
     ttnn::bind_function<"mean">(
         mod,
         mean_doc.c_str(),

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -112,6 +112,38 @@ Tensor generic_reduction_with_deprecated_correction(
         sub_core_grids);
 }
 
+// mean exposes an extra 'fast_and_approximate_mode' opt-in that sum/min/max do not, so it needs its
+// own wrapper instead of the shared generic_reduction_with_deprecated_correction<>. Same deprecated-
+// correction handling, plus the trailing accurate flag forwarded to ttnn::mean.
+inline Tensor mean_with_deprecated_correction(
+    const Tensor& input_tensor,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
+    bool keepdim,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    float scalar,
+    std::optional<bool> correction,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool fast_and_approximate_mode) {
+    if (correction.has_value()) {
+        nb::gil_scoped_acquire acquire;
+        PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "The 'correction' parameter is deprecated and will be removed in a future release.",
+            1);
+    }
+    return ttnn::mean(
+        input_tensor,
+        dim,
+        keepdim,
+        memory_config,
+        compute_kernel_config,
+        scalar,
+        correction.value_or(true),
+        sub_core_grids,
+        fast_and_approximate_mode);
+}
+
 inline void bind_generic_reductions(nb::module_& mod) {
     const auto sum_doc = get_generic_reduction_doc("sum", "ttnn.sum", /*int32_supported=*/true);
     ttnn::bind_function<"sum">(
@@ -132,7 +164,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
     ttnn::bind_function<"mean">(
         mod,
         mean_doc.c_str(),
-        &generic_reduction_with_deprecated_correction<&ttnn::mean>,
+        &mean_with_deprecated_correction,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -141,7 +173,10 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("scalar") = 1.0f,
         nb::arg("correction") = nb::none(),
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        // fast_and_approximate_mode=false (default) selects the accurate fp32 SFPU reduce; true selects the FPU. No
+        // effect for non-fp32.
+        nb::arg("fast_and_approximate_mode") = false);
 
     const auto max_doc = get_generic_reduction_doc("max", "ttnn.max", /*int32_supported=*/true);
     ttnn::bind_function<"max">(


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

This PR fixes high ULP errors in `ttnn.mean` for `FLOAT32` reductions by introducing an accurate FP32 reduction path using the SFPU.

Previously, `FLOAT32` mean reductions used the FPU reduction path, which internally truncates FP32 inputs to TF32, resulting in large ULP errors for models such as LLaMA and DeepSeek.

This change:
- Routes `FLOAT32` mean through the SFPU reduction path for full FP32 accumulation.
- Lowers `mean` to `sum + 1/N` while preserving FP32 accuracy.
- Reuses the existing SFPU reduction infrastructure with architecture guards for Quasar.
- Updates the host post-processing path to correctly handle block-float (`BFLOAT8_B`/`BFLOAT4_B`) outputs.
- Preserves existing behavior for other reduction operations and data types.

Fixes #25779.

### Notes for reviewers


- **Scope**: Accurate FP32 mean only — `ttnn.mean` with `fast_and_approximate_mode=False` (the default). Other FP32 reductions (`sum`, `max`, etc.) stay on the existing FPU path.
- **Mechanism**: Host lowers AVG → SUM and applies `1/N` via post-mul; device runs FP32 SUM on the SFPU with `add_binary_tile` cross-tile accumulation and `UnpackToDestFp32` to avoid TF32 truncation.
- **Opt-out**: `fast_and_approximate_mode=True` restores the prior FPU (TF32) behavior for users who prefer speed over accuracy.
- **Limits**:
  - Quasar lacks `add_binary_tile`; host falls back to FPU and the kernel is guarded with `ARCH_QUASAR`.
- **Touch points**: `reduce_op.cpp` (routing/lowering), `common.hpp` (`use_sfpu_reduce_path` / `requires_post_mul`), W/H program factories (`REDUCE_SFPU_FP32`, `UnpackToDestFp32`), `reduce_helpers_compute.inl` (`add_binary_tile`), nanobind (`fast_and_approximate_mode` on `mean` only).
- **Tests**: `tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py` — `test_mean_fp32_fast_and_approximate_mode` compares accurate vs fast path ULP against an FP64 reference.

### Perf and Accuracy Comparison

## Performance Results

The new SFPU-based `FLOAT32` mean path significantly improves numerical accuracy by avoiding the TF32 truncation present in the existing FPU reduction path. Across all evaluated configurations, the maximum ULP error is reduced from **4K–10K ULP** to **1–2 ULP**.

The performance impact depends on the reduction dimension and memory layout. For DRAM and L1 interleaved layouts, the overhead is generally **1–20%**, while some sharded configurations incur a higher overhead (up to ~46%) due to the SFPU reduction implementation.

| S.No | Shape | Dim | MemLayout | FPU (ns) | SFPU (ns) | Diff % (+ = SFPU slower) | ULP (FPU) | ULP (SFPU) |
|-----:|-------|:---:|-----------|---------:|----------:|-------------------------:|----------:|-----------:|
| 1 | (1, 1, 32, 128) | -1 | DRAM-Interleaved | 4178 | 4823 | 15.5 | 4679 | 1 |
| 2 | (1, 1, 32, 128) | -1 | L1-Interleaved | 3496 | 4205 | 20.3 | 4679 | 1 |
| 3 | (1, 1, 32, 128) | -1 | L1-Shard(H,1c) | 2554 | 3578 | 40.1 | 4679 | 1 |
| 4 | (1, 1, 32, 128) | -2 | DRAM-Interleaved | 2891 | 3285 | 13.6 | 10520 | 1 |
| 5 | (1, 1, 32, 128) | -2 | L1-Interleaved | 2421 | 2818 | 16.4 | 10520 | 1 |
| 6 | (1, 1, 32, 128) | -2 | L1-Shard(W,4c) | 1688 | 2092 | 24.0 | 10520 | 1 |
| 7 | (1, 1, 128, 32) | -1 | DRAM-Interleaved | 2943 | 3453 | 17.3 | 5037 | 1 |
| 8 | (1, 1, 128, 32) | -1 | L1-Interleaved | 2444 | 2899 | 18.6 | 5037 | 1 |
| 9 | (1, 1, 128, 32) | -1 | L1-Shard(H,4c) | 2582 | 3074 | 19.1 | 5037 | 1 |
| 10 | (1, 1, 128, 32) | -2 | DRAM-Interleaved | 4257 | 4922 | 15.6 | 8994 | 1 |
| 11 | (1, 1, 128, 32) | -2 | L1-Interleaved | 3564 | 4189 | 17.5 | 8994 | 1 |
| 12 | (1, 1, 128, 32) | -2 | L1-Shard(W,1c) | 2321 | 3250 | 40.0 | 8994 | 1 |
| 13 | (1, 1, 1024, 1024) | -1 | DRAM-Interleaved | 32312 | 32927 | 1.9 | 4320 | 2 |
| 14 | (1, 1, 1024, 1024) | -1 | L1-Interleaved | 31629 | 33024 | 4.4 | 4320 | 2 |
| 15 | (1, 1, 1024, 1024) | -1 | L1-Shard(H,32c) | 31745 | 32512 | 2.4 | 4320 | 2 |
| 16 | (1, 1, 1024, 1024) | -2 | DRAM-Interleaved | 29651 | 30471 | 2.8 | 8651 | 1 |
| 17 | (1, 1, 1024, 1024) | -2 | L1-Interleaved | 27786 | 28064 | 1.0 | 8651 | 1 |
| 18 | (1, 1, 1024, 1024) | -2 | L1-Shard(W,32c) | 9342 | 13464 | 44.1 | 8651 | 1 |
| 19 | (1, 1, 4096, 256) | -1 | DRAM-Interleaved | 32693 | 33702 | 3.1 | 4654 | 1 |
| 20 | (1, 1, 4096, 256) | -1 | L1-Interleaved | 21427 | 22546 | 5.2 | 4654 | 1 |
| 21 | (1, 1, 4096, 256) | -1 | L1-Shard(H,64c) | 17512 | 18663 | 6.6 | 4654 | 1 |
| 22 | (1, 1, 4096, 256) | -2 | DRAM-Interleaved | 99909 | 99688 | -0.2 | 8411 | 2 |
| 23 | (1, 1, 4096, 256) | -2 | L1-Interleaved | 88922 | 89226 | 0.3 | 8411 | 2 |
| 24 | (1, 1, 4096, 256) | -2 | L1-Shard(W,8c) | 32877 | 47823 | 45.5 | 8411 | 2 |
| 25 | (1, 1, 256, 4096) | -1 | DRAM-Interleaved | 101848 | 101354 | -0.5 | 4195 | 2 |
| 26 | (1, 1, 256, 4096) | -1 | L1-Interleaved | 90664 | 91325 | 0.7 | 4195 | 2 |
| 27 | (1, 1, 256, 4096) | -1 | L1-Shard(H,8c) | 120450 | 119429 | -0.8 | 4195 | 2 |
| 28 | (1, 1, 256, 4096) | -2 | DRAM-Interleaved | 25798 | 26402 | 2.3 | 9238 | 1 |
| 29 | (1, 1, 256, 4096) | -2 | L1-Interleaved | 16106 | 17306 | 7.5 | 9238 | 1 |
| 30 | (1, 1, 256, 4096) | -2 | L1-Shard(W,64c) | 5558 | 8130 | 46.3 | 9238 | 1 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/reduce_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/reduce_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/reduce_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/reduce_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/reduce_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/reduce_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/reduce_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/reduce_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/reduce_mean)