### PR TITLE
[TTTv2] Pre-allocate on-device sampling buffers before trace capture

### DIFF
--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -478,6 +478,7 @@ class EagerLLMExecutor:
         prompt_lens: torch.Tensor | None = None,  # [batch_size], int64
         empty_slots: list[int] | None = None,
         start_pos: torch.Tensor | None = None,  # [batch_size], int64
+        sampling_params: SamplingParams | None = None,  # accepted for parity; eager path never traces
     ) -> torch.Tensor:  # [batch_size, 1, vocab_size], float32
         """Compile prefill for specific inputs. Returns logits from warmup run.
 
@@ -1084,6 +1085,7 @@ class TracedLLMExecutor:
         prompt_lens: torch.Tensor | None = None,  # [batch_size], int64
         empty_slots: list[int] | None = None,
         start_pos: torch.Tensor | None = None,  # [batch_size], int64
+        sampling_params: SamplingParams | None = None,
     ) -> torch.Tensor | None:  # [batch_size, 1, vocab_size] or None if already compiled
         """Compile prefill for specific inputs. Returns logits from warmup run.
 
@@ -1106,6 +1108,13 @@ class TracedLLMExecutor:
         trace_key = self._get_prefill_trace_key(tokens)
         if self.trace_id_prefill[trace_key] is not None:
             return None
+
+        # Allocate persistent on-device sampling buffers BEFORE the prefill trace is captured
+        # (self.prefill_forward below). If they are first materialised during decode-trace capture
+        # (while this prefill trace is live), tt-metal places them unsafely and a decode-trace buffer
+        # clobbers the k tensor on replay -> corrupt k -> sampling-writer hang. See
+        # _prealloc_sampling_buffers.
+        self._prealloc_sampling_buffers(sampling_params)
 
         logits = self.prefill_forward(
             tokens,
@@ -1469,6 +1478,28 @@ class TracedLLMExecutor:
 
         return tt_output
 
+    def _prealloc_sampling_buffers(self, sampling_params) -> None:
+        """Materialise the *persistent* on-device sampling buffers before ANY trace is captured.
+
+        The k/p/temp param tensors and Sampling1D's device buffers were previously created lazily
+        inside ``_capture_decode_trace`` — i.e. AFTER the prefill trace is already live. tt-metal
+        flags this ("Allocating device buffers is unsafe due to the existence of an active trace",
+        allocator.cpp) and the buffers can land where a decode-trace buffer overlaps them; on replay
+        the trace clobbers the ``k`` tensor, the sampling writer reads a corrupt (huge) k and walks
+        its top-p loop out of L1 -> hard device hang (seen on perf batch-32 + perf_decode_tuning
+        "LoFi" on N300; LoFi shifts the decode-trace layout so the overlap lands on ``k``).
+        Allocating them here, with no trace active, gives them stable addresses that the prefill and
+        decode traces reserve around. Idempotent: the later capture-time calls reuse these caches.
+        """
+        if sampling_params is None or self.model.sampling is None:
+            return
+        # k/p/temp param tensors (cached on the eager engine; returns None for force-argmax models).
+        self._eager._get_decode_sampling_kpt(sampling_params)
+        # Sampling1D persistent device buffers (local indices / offsets / seeds / user ids).
+        if hasattr(self.model.sampling, "load_device_buffers"):
+            self.model.sampling.load_device_buffers()
+        logger.info("Pre-allocated on-device sampling buffers before trace capture")
+
     def _capture_decode_trace(self, tokens, start_pos, page_table, kv_cache, sampling_on_device, sampling_params=None):
         """Compile + capture decode trace."""
         self._eager.decode_forward(
@@ -1626,6 +1657,7 @@ def _compile_prefill_and_decode(
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     # todo)) check these against what is actually running in TTTv1 --> the prefill_forward may run sampling on device!

--- a/models/common/models/llama32_1b/model.py
+++ b/models/common/models/llama32_1b/model.py
@@ -1056,7 +1056,17 @@ class EagerLlama32_1BExecutor:
     def prepare_decode_inputs_device(self, tokens, current_pos, page_table):
         return self._engine.prepare_decode_inputs_device(tokens, current_pos, page_table)
 
-    def compile_prefill(self, *, tokens, page_table, kv_cache=None, prompt_lens=None, empty_slots=None, start_pos=None):
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
         return self._engine.compile_prefill(
             tokens=tokens,
             page_table=page_table,
@@ -1064,6 +1074,7 @@ class EagerLlama32_1BExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):
@@ -1163,7 +1174,17 @@ class TracedLlama32_1BExecutor:
     def warmup_model_prefill(self, seq_lens, make_tokens, make_page_table):
         return self._engine.warmup_model_prefill(seq_lens, make_tokens, make_page_table)
 
-    def compile_prefill(self, *, tokens, page_table, kv_cache=None, prompt_lens=None, empty_slots=None, start_pos=None):
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
         return self._engine.compile_prefill(
             tokens=tokens,
             page_table=page_table,
@@ -1171,6 +1192,7 @@ class TracedLlama32_1BExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):

--- a/models/common/models/llama32_3b/model.py
+++ b/models/common/models/llama32_3b/model.py
@@ -1047,7 +1047,17 @@ class EagerLlama32_3BExecutor:
     def prepare_decode_inputs_device(self, tokens, current_pos, page_table):
         return self._engine.prepare_decode_inputs_device(tokens, current_pos, page_table)
 
-    def compile_prefill(self, *, tokens, page_table, kv_cache=None, prompt_lens=None, empty_slots=None, start_pos=None):
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
         return self._engine.compile_prefill(
             tokens=tokens,
             page_table=page_table,
@@ -1055,6 +1065,7 @@ class EagerLlama32_3BExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):
@@ -1154,7 +1165,17 @@ class TracedLlama32_3BExecutor:
     def warmup_model_prefill(self, seq_lens, make_tokens, make_page_table):
         return self._engine.warmup_model_prefill(seq_lens, make_tokens, make_page_table)
 
-    def compile_prefill(self, *, tokens, page_table, kv_cache=None, prompt_lens=None, empty_slots=None, start_pos=None):
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
         return self._engine.compile_prefill(
             tokens=tokens,
             page_table=page_table,
@@ -1162,6 +1183,7 @@ class TracedLlama32_3BExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):

--- a/models/common/models/llama33_70b/model.py
+++ b/models/common/models/llama33_70b/model.py
@@ -1065,7 +1065,17 @@ class EagerLlama33_70BExecutor:
     def prepare_decode_inputs_device(self, tokens, current_pos, page_table):
         return self._engine.prepare_decode_inputs_device(tokens, current_pos, page_table)
 
-    def compile_prefill(self, *, tokens, page_table, kv_cache=None, prompt_lens=None, empty_slots=None, start_pos=None):
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
         return self._engine.compile_prefill(
             tokens=tokens,
             page_table=page_table,
@@ -1073,6 +1083,7 @@ class EagerLlama33_70BExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):
@@ -1172,7 +1183,17 @@ class TracedLlama33_70BExecutor:
     def warmup_model_prefill(self, seq_lens, make_tokens, make_page_table):
         return self._engine.warmup_model_prefill(seq_lens, make_tokens, make_page_table)
 
-    def compile_prefill(self, *, tokens, page_table, kv_cache=None, prompt_lens=None, empty_slots=None, start_pos=None):
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
         return self._engine.compile_prefill(
             tokens=tokens,
             page_table=page_table,
@@ -1180,6 +1201,7 @@ class TracedLlama33_70BExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):

--- a/models/common/models/llama3_8b/model.py
+++ b/models/common/models/llama3_8b/model.py
@@ -704,6 +704,7 @@ class EagerLlamaExecutor:
         prompt_lens=None,
         empty_slots=None,
         start_pos=None,
+        sampling_params=None,
     ):
         return self._engine.compile_prefill(
             tokens=tokens,
@@ -712,6 +713,7 @@ class EagerLlamaExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(
@@ -863,6 +865,7 @@ class TracedLlamaExecutor:
         prompt_lens=None,
         empty_slots=None,
         start_pos=None,
+        sampling_params=None,
     ):
         return self._engine.compile_prefill(
             tokens=tokens,
@@ -871,6 +874,7 @@ class TracedLlamaExecutor:
             prompt_lens=prompt_lens,
             empty_slots=empty_slots,
             start_pos=start_pos,
+            sampling_params=sampling_params,
         )
 
     def compile_decode(


### PR DESCRIPTION
## Summary

Fixes the hard device hang in the TTTv2 traced-decode path when on-device sampling is used at batch ≥ 16 (Qwen2.5-7B / Qwen2-7B, N300, `perf batch-32` + `on_device_topk`).

Closes #48822.

## Root cause

The persistent `k`/`p`/`temp` sampling param tensors and `Sampling1D`'s device buffers were materialised **lazily inside `_capture_decode_trace`** — i.e. *after* the prefill trace was already live. tt-metal flags allocating device buffers during an active trace as unsafe (`allocator.cpp`); the buffers can land where a decode-trace buffer overlaps them, so on replay the trace clobbers the tiny `k` tensor. The `ttnn.sampling` `writer_interleaved` kernel then reads a corrupt (huge) `k` and walks its top-p loop out of L1 → whole-device hang.

`perf_decode_tuning` (LoFi) only matters because it shifts the decode-trace layout so the overlap lands on `k` (the HiFi layout happens to miss it). The original hypotheses — the W1→DRAM spill and a CCL/all-gather deadlock — were both refuted on device (fabric/ERISC idle; the sole stuck workload was the sampling op with a frozen `writer_interleaved`).

## Fix

**Shared engine (`executor.py`):** add `TracedLLMExecutor._prealloc_sampling_buffers()` and call it from `compile_prefill` **before** the prefill trace is captured, giving the sampling buffers stable addresses that both the prefill and decode traces reserve around. `compile_prefill` gains a `sampling_params` kwarg (no-op for host sampling / non-sampling models; the eager override accepts it for parity), threaded through `_compile_prefill_and_decode`.

**Per-model wrappers:** `_compile_prefill_and_decode` now always forwards `sampling_params` to `executor.compile_prefill`. The Qwen wrappers delegate via `**kwargs` so they inherit this for free, but the Llama wrappers (`llama3_8b` / `llama32_1b` / `llama32_3b` / `llama33_70b`, both Eager and Traced) use **explicit** `compile_prefill` signatures — so they must accept and forward `sampling_params` too. Without this they would raise `TypeError` on the new kwarg **even on the default host path**. Updating them also enables the prealloc fix for those models (all build `Sampling1D` and support on-device sampling).

The shipping default (`SAMPLING_MODE=host`) path is a no-op change on every model.

## Verification (N300)

| Case | Result |
|---|---|
| Qwen2.5-7B, `on_device_topk`, full 28L, **perf batch-32** (original failing case) | **completes, no hang**, 14.8 t/s/u, coherent output |
| Qwen2.5-7B, `on_device_topk`, perf batch-1 / accuracy batch-32 | 14.6 / 13.6 t/s/u — unchanged |
| Llama-3.2-1B, **perf batch-32, host (default)** | **PASSED** (regression check on the shipping path) |
| Llama-3.2-1B, perf batch-32, `on_device_topk` | runs to completion — prealloc log confirmed, coherent output, no `TypeError`, no hang |

> Note: `on_device_topk` is a slower non-default path; its perf **gate** (calibrated for host) under-shoots on both Qwen and Llama. That is a pre-existing, separate gate issue — out of scope here and intentionally not touched.

## Scope / follow-ups

- The empty TTTv2 dirs (`mistral_7b`, `phi4`, `qwen25_72b`, `qwen25_coder_32b`) have no source on `main`; when they land, their wrappers must use `**kwargs` or forward `sampling_params`.
- Kernel hardening (bounding `k ≤ 2*FACE_WIDTH` in `writer_interleaved` + a host-side `ttnn.sampling` assert) is left as defense-in-depth; the root allocation fix removes the corruption.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apbernal/fix-tttv2-traced-decode-sampling-prealloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apbernal/fix-tttv2-traced-decode-sampling-prealloc)