### PR TITLE
#45831: rotary_embedding_indexed — trace-safe per-element-tensor metadata overload (op + test, no trace)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
@@ -257,3 +257,127 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
         f"{entries_after_first} to {mesh_device.num_program_cache_entries()}"
     )
     logger.info(f"program cache entries: {mesh_device.num_program_cache_entries()}")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (8, 4),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.timeout(0)
+def test_rotary_embedding_indexed_metadata_matches_scalar(mesh_device):
+    """The per-element-tensor (traceable) path and the scalar path must produce bit-identical outputs.
+
+    Drives the traceable path from a 1-element uint32 DRAM tensor holding kv_actual_global (the reader
+    reads its element [0] on-device), and compares the rotated output against the same call done via
+    the original scalar kv_actual_global. Exact equality over chunk-0 and a mid-cache offset."""
+    sp_axis, tp_axis = 0, 1
+    sp = mesh_device.shape[sp_axis]
+    tile = ttnn.TILE_SIZE
+
+    n_heads = 1  # KV-rope shape (single head, SP-sharded)
+    new_isl_tiles_per_dev = 4
+    cache_tokens_per_dev = 512
+    C = new_isl_tiles_per_dev * tile  # per-device chunk (tokens)
+    chunk_global = C * sp
+    cache_global = cache_tokens_per_dev * sp
+
+    torch.manual_seed(0)
+    cos_full, sin_full = _make_cos_sin(cache_global, ROPE_HEAD_DIM)
+    cos_re = block_cyclic_reorder(cos_full, C, sp, seq_dim=2)
+    sin_re = block_cyclic_reorder(sin_full, C, sp, seq_dim=2)
+
+    shard_dims = [None, None]
+    shard_dims[sp_axis] = 2
+    from_torch_kwargs = dict(
+        device=mesh_device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    cos_tt = ttnn.from_torch(
+        cos_re,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+        **from_torch_kwargs,
+    )
+    sin_tt = ttnn.from_torch(
+        sin_re,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+        **from_torch_kwargs,
+    )
+    trans_tt = ttnn.from_torch(
+        get_rot_transformation_mat(), mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device), **from_torch_kwargs
+    )
+
+    input_shard_dims = [None, None]
+    input_shard_dims[sp_axis] = 2
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 1
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape)
+
+    # The traceable path reads kv_actual_global from element [0] of this 1-element uint32 DRAM tensor.
+    def _make_scalar_tensor(value):
+        return ttnn.from_torch(
+            torch.tensor([value], dtype=torch.int64).reshape(1, 1, 1, 1),
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+    mesh_device.enable_program_cache()
+    # Two slab-aligned offsets (boundary_chip == 0) plus one NON-slab-aligned offset (C + one tile:
+    # boundary_chip == 1 with a whole-tile boundary_offset), so the boundary chip's cos/sin read straddles
+    # a slab — the hard indexing case for this op — is exercised through the metadata path too, not just
+    # slab-aligned cases. kv_actual_global is a runtime arg (not hashed), so every case reuses the same
+    # cached program regardless of alignment (asserted after the loop).
+    cases = [0, chunk_global, C + tile]
+    entries_after_first = None
+
+    for kv_actual in cases:
+        torch_input = torch.randn(1, n_heads, chunk_global, ROPE_HEAD_DIM, dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(
+            torch_input,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims),
+            **from_torch_kwargs,
+        )
+
+        kv_t = _make_scalar_tensor(kv_actual)
+
+        out_scalar = ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
+            tt_input, cos_tt, sin_tt, trans_tt, kv_actual_global=kv_actual, cluster_axis=sp_axis
+        )
+        out_meta = ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
+            tt_input, cos_tt, sin_tt, trans_tt, kv_actual_global=kv_t, cluster_axis=sp_axis
+        )
+        ttnn.synchronize_device(mesh_device)
+
+        scalar_host = ttnn.to_torch(out_scalar, mesh_composer=composer).to(torch.float32)[:, :n_heads, :, :]
+        meta_host = ttnn.to_torch(out_meta, mesh_composer=composer).to(torch.float32)[:, :n_heads, :, :]
+        assert torch.equal(meta_host, scalar_host), (
+            f"kv_actual={kv_actual}: per-element-tensor-path output differs from scalar-path "
+            f"(max abs diff {(meta_host - scalar_host).abs().max().item()})"
+        )
+        logger.success(f"kv_actual={kv_actual}: per-element-tensor path == scalar path (bit-exact)")
+        # After the first chunk both programs (scalar + metadata, distinct by metadata.has_value()) are
+        # compiled; capture the count so we can assert no further growth across the remaining chunks.
+        if entries_after_first is None:
+            entries_after_first = mesh_device.num_program_cache_entries()
+        ttnn.deallocate(kv_t)
+        ttnn.deallocate(tt_input)
+
+    # The whole point of this path: kv_actual_global is a runtime arg (metadata address patched on cache
+    # hits), NOT part of the program hash, so successive chunks — including the non-slab-aligned one —
+    # must reuse the one cached metadata program rather than compile a new one each time.
+    assert mesh_device.num_program_cache_entries() == entries_after_first, (
+        f"program cache grew across chunks — the scalar+metadata programs should each compile once and be "
+        f"reused (kv_actual_global is a runtime arg, not hashed): {entries_after_first} -> "
+        f"{mesh_device.num_program_cache_entries()}"
+    )
+    logger.info(f"program cache stable at {entries_after_first} entries across {len(cases)} chunks")

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/kernels/dataflow/reader_rotary_embedding_indexed_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/kernels/dataflow/reader_rotary_embedding_indexed_interleaved_start_id.cpp
@@ -19,10 +19,18 @@
 // (older tokens finishing the current slab block, then newer tokens spilling into the next block)
 // is absorbed by the shard layout, so the read stays contiguous.
 //
-// `kv_actual_global` is a per-call scalar common runtime arg (NOT in the program hash). The op's
-// MeshWorkloadFactory::override_runtime_arguments patches it on cache hits, so successive chunks with
-// different prior KV lengths reuse one cached program while the value is always current.
-void kernel_main() {
+// The per-call `kv_actual_global` reaches the reader one of two ways, selected by the `has_metadata`
+// compile-time flag (set by the op from whether a metadata tensor was supplied; both keep the value out
+// of the program hash so one cached program is reused across chunks):
+//   - scalar path: common runtime arg 2 directly (patched on cache hits by override_runtime_arguments).
+//   - metadata path: common arg 2 is the metadata tensor's raw DRAM address; the reader NoC-reads
+//     kv_actual_global from element [0] of the dedicated 1-element uint32 tensor (4 bytes, no packed
+//     payload).
+// The body is a template on HasMeta so `if constexpr` truly discards the unused metadata branch (the
+// metadata TensorAccessorArgs offset is made dependent on HasMeta to avoid an out-of-range static_assert
+// on the scalar program).
+template <bool HasMeta>
+static void run_reader() {
     uint32_t argrt = 0;
     uint32_t src_addr = get_arg_val<uint32_t>(argrt++);
     uint32_t cos_addr = get_arg_val<uint32_t>(argrt++);
@@ -37,10 +45,9 @@ void kernel_main() {
     // the SP extent. Both are structural (per cached program / mesh coord), not per-call values.
     const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(0);
     const uint32_t sp_factor = get_common_arg_val<uint32_t>(1);
-    // kv_actual_global (prior valid global KV length in tokens) is the only per-call value. It is a
-    // common runtime arg patched on cache hits by MeshWorkloadFactory::override_runtime_arguments, so
-    // it is never stale and stays out of the program hash.
-    const uint32_t kv_actual_global = get_common_arg_val<uint32_t>(2);
+    // Common arg 2 is the per-call value: kv_actual_global (scalar path) or the metadata tensor's raw
+    // DRAM address (metadata path). Resolved to kv_actual_global below depending on HasMeta.
+    const uint32_t per_call_arg2 = get_common_arg_val<uint32_t>(2);
 
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t cos_cb_id = get_compile_time_arg_val(1);
@@ -54,7 +61,8 @@ void kernel_main() {
     constexpr uint32_t sin_Ht = get_compile_time_arg_val(9);
     constexpr uint32_t rotary_Ht = get_compile_time_arg_val(10);
     constexpr uint32_t tile_height = get_compile_time_arg_val(11);
-    constexpr auto input_args = TensorAccessorArgs<12>();
+    // [12]=has_metadata, [13]=metadata CB index. Operand accessors start at <14>.
+    constexpr auto input_args = TensorAccessorArgs<14>();
     constexpr auto cos_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto sin_args = TensorAccessorArgs<cos_args.next_compile_time_args_offset()>();
     constexpr auto trans_mat_args = TensorAccessorArgs<sin_args.next_compile_time_args_offset()>();
@@ -64,6 +72,39 @@ void kernel_main() {
     CircularBuffer cos_cb(cos_cb_id);
     CircularBuffer sin_cb(sin_cb_id);
     CircularBuffer trans_mat_cb(trans_mat_cb_id);
+
+    // Resolve kv_actual_global: scalar path takes common arg 2 directly; metadata path NoC-reads element
+    // [0] of the 1-element metadata tensor (address = common arg 2). Only that one uint32 (4 bytes) is
+    // read. The accessor offset is gated on HasMeta so the scalar program never instantiates this (would
+    // be an out-of-range compile-time arg).
+    uint32_t kv_actual_global;
+    if constexpr (HasMeta) {
+        // Per-element-tensor path: `kv_actual_global` is its OWN 1-element uint32 DRAM tensor (no packed
+        // metadata layout). Read element [0] directly (4 bytes). The tensor's raw DRAM address is common
+        // arg 2. Accessor offset gated on HasMeta so the scalar program never instantiates it.
+        constexpr uint32_t cb_id_meta = get_compile_time_arg_val(13);
+        constexpr uint32_t kMetaArgsOffset = HasMeta ? trans_mat_args.next_compile_time_args_offset() : 0;
+        constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
+        CircularBuffer cb_meta(cb_id_meta);
+        const auto s_meta = TensorAccessor(meta_args, per_call_arg2);
+        cb_meta.reserve_back(1);
+        noc.async_read(s_meta, cb_meta, 4, {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        // The metadata tensor lives at a FIXED DRAM address reused across every chunk/layer/rope call;
+        // the host updates its contents in place each chunk. After the NoC writes the fresh value into
+        // this core's cb_meta L1 page, the RISC data cache may still hold the PREVIOUS chunk's value for
+        // that L1 line: async_read_barrier orders the DMA but does NOT invalidate the RISC cache, and
+        // `volatile` forces a load but still reads the cached line. Whether the line was evicted is
+        // timing-dependent, so without this invalidate the read is intermittently STALE -> a wrong
+        // rotation offset that compounds (the L61 metadata KV-PCC run-to-run non-determinism).
+        // invalidate_l1_cache() forces a refetch of the freshly-DMA'd value.
+        invalidate_l1_cache();
+        CoreLocalMem<volatile uint32_t> meta(cb_meta.get_write_ptr());
+        kv_actual_global = meta[0];  // the 1-element tensor holds kv_actual_global directly
+        cb_meta.push_back(1);
+    } else {
+        kv_actual_global = per_call_arg2;
+    }
 
     // Convert the per-call kv_actual_global (tokens) to tiles.
     const uint32_t kv_actual_global_t = kv_actual_global / tile_height;
@@ -201,4 +242,9 @@ void kernel_main() {
             }
         }
     }
+}
+
+void kernel_main() {
+    constexpr bool has_metadata = get_compile_time_arg_val(12);
+    run_reader<has_metadata>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -37,23 +37,24 @@ constexpr auto kComputeKernelPath =
     "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/"
     "rotary_embedding_llama.cpp";
 
-// Structural + per-call checks shared by the cache-miss and cache-hit paths. kv_actual_global is now
-// a host-side scalar, so its tile-alignment can be enforced here again (it was unknown host-side when
-// it lived in a device tensor).
+// Metadata path only: L1-scratch CB the reader reads the metadata page into. The metadata tensor is a
+// dedicated 1-element uint32 tensor holding kv_actual_global directly at element [0]; the reader
+// NoC-reads only that one element (4 bytes). kMetadataBytes is the CB page size, kept at the 16-byte
+// L1 page-alignment floor -- the read itself is 4 bytes.
+constexpr uint8_t kMetaCbIndex = tt::CBIndex::c_4;
+constexpr uint32_t kMetadataBytes = 16;  // CB page size (16B L1 alignment floor); only 4B (element [0]) is read
+
+// Structural + per-call checks shared by the cache-miss and cache-hit paths. The structural checks
+// (cluster_axis, 2D mesh, chunk height) run on both paths; the kv_actual_global VALUE checks run only
+// on the SCALAR path — on the METADATA path kv_actual_global lives in the 1-element device tensor
+// (read on-device, so its value can't be checked host-side) and is the caller's responsibility. The
+// metadata TENSOR itself is still validated (storage/device/dtype/shape) on both paths below.
 void validate_runtime_args(
     const RotaryEmbeddingIndexedDeviceOperation::operation_attributes_t& args,
     const RotaryEmbeddingIndexedDeviceOperation::tensor_args_t& tensor_args) {
     // cluster_axis selects which mesh dim is the SP axis (num_rows vs num_cols); any other value
     // would silently pick the wrong extent and corrupt the per-device sharding math.
     TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
-
-    // The reader divides kv_actual_global by TILE_HEIGHT to get its tile offset into the cos/sin
-    // shard, so it must be tile-aligned.
-    TT_FATAL(
-        args.kv_actual_global % TILE_HEIGHT == 0,
-        "kv_actual_global ({}) must be tile-aligned (a multiple of {})",
-        args.kv_actual_global,
-        TILE_HEIGHT);
 
     const auto& input = tensor_args.input;
     const auto& cos = tensor_args.cos;
@@ -63,6 +64,36 @@ void validate_runtime_args(
     // chunk_local_t is the per-chip chunk height in tiles and is used by the reader as a
     // divisor/modulus to derive the boundary chip; a zero-height input chunk would divide by zero.
     TT_FATAL(chunk_local_t > 0, "input chunk seq dim ({}) must be at least one tile", input.padded_shape()[-2]);
+
+    if (tensor_args.metadata.has_value()) {
+        // Metadata path: kv_actual_global is read on-device from element [0] of the metadata tensor, so
+        // its VALUE is the caller's responsibility. But the tensor is dereferenced host-side
+        // (buffer()->address(), baked as a runtime arg) and read on-device as uint32, so validate the
+        // tensor itself here (runs on both cache miss and hit, since the metadata tensor can differ per
+        // call). dtype is NOT part of the program hash, so without this guard a uint32-then-bf16 sequence
+        // would silently reuse the cached program and misread the value.
+        const auto& metadata = tensor_args.metadata.value();
+        TT_FATAL(metadata.storage_type() == StorageType::DEVICE, "metadata must be on device");
+        TT_FATAL(metadata.buffer() != nullptr, "metadata must be allocated in a buffer on device");
+        TT_FATAL(metadata.device() == input.device(), "metadata must be on the same device as input");
+        TT_FATAL(
+            metadata.dtype() == DataType::UINT32,
+            "metadata must be uint32 (holds kv_actual_global, read on-device as uint32), got {}",
+            metadata.dtype());
+        TT_FATAL(
+            metadata.logical_shape().volume() == 1,
+            "metadata must be a single-element tensor (kv_actual_global at element [0]), got {} elements",
+            metadata.logical_shape().volume());
+        return;
+    }
+
+    // The reader divides kv_actual_global by TILE_HEIGHT to get its tile offset into the cos/sin
+    // shard, so it must be tile-aligned.
+    TT_FATAL(
+        args.kv_actual_global % TILE_HEIGHT == 0,
+        "kv_actual_global ({}) must be tile-aligned (a multiple of {})",
+        args.kv_actual_global,
+        TILE_HEIGHT);
 
     // Bound the largest update_idxt any chip reads from by the per-device cos/sin shard height.
     // Mirror the reader kernel's per-chip update_idxt exactly: each chip reads chunk_local_t tiles
@@ -180,7 +211,18 @@ ttsl::hash::hash_t RotaryEmbeddingIndexedDeviceOperation::compute_program_hash(
     // args.kv_actual_global (the per-call scalar) is intentionally NOT hashed -- it is a common
     // runtime arg patched on cache hits, so successive chunks with different KV lengths reuse one
     // cached program.
+    // The metadata-vs-scalar choice changes the program (compile args + which kernel branch compiles),
+    // so hash metadata.has_value() to keep the two variants distinct; kv_actual_global itself is never
+    // hashed on either path. Also hash the metadata tensor's memory_config: its TensorAccessorArgs are
+    // baked as compile-time args at program creation and only its address is patched on a cache hit, so
+    // two metadata-path calls that share this structural hash but pass metadata tensors with different
+    // memory layouts must not collide onto one cached program (the baked accessor would be wrong for the
+    // second). A default MemoryConfig stands in on the scalar path (already separated by has_value=false).
+    const MemoryConfig metadata_mem_config =
+        tensor_args.metadata.has_value() ? tensor_args.metadata->memory_config() : MemoryConfig{};
     return tt::tt_metal::operation::hash_operation<RotaryEmbeddingIndexedDeviceOperation>(
+        tensor_args.metadata.has_value(),
+        metadata_mem_config,
         args.cluster_axis,
         args.compute_kernel_config,
         input.dtype(),
@@ -205,6 +247,7 @@ tt::tt_metal::ProgramDescriptor RotaryEmbeddingIndexedDeviceOperation::ProgramFa
     const auto& cos = tensor_args.cos;
     const auto& sin = tensor_args.sin;
     const auto& trans_mat = tensor_args.trans_mat;
+    const bool has_metadata = tensor_args.metadata.has_value();
 
     const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -337,6 +380,15 @@ tt::tt_metal::ProgramDescriptor RotaryEmbeddingIndexedDeviceOperation::ProgramFa
             .data_format = output_cb_data_format,
             .page_size = output_single_tile_size}}},
     });
+    // Metadata path: L1-scratch CB the reader reads the metadata page into (one 16B page).
+    if (has_metadata) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = kMetadataBytes,
+            .core_ranges = CoreRangeSet(all_cores),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = kMetaCbIndex, .data_format = tt::DataFormat::UInt32, .page_size = kMetadataBytes}}},
+        });
+    }
 
     KernelDescriptor::Defines kernel_defines;
     kernel_defines.emplace_back("RELOAD_IMPL", use_reload_impl ? "1" : "0");
@@ -360,11 +412,19 @@ tt::tt_metal::ProgramDescriptor RotaryEmbeddingIndexedDeviceOperation::ProgramFa
         (uint32_t)sin_seq_len_t,
         (uint32_t)rotary_seq_len_t,
         (uint32_t)TILE_HEIGHT,  // reader divides kv_actual_global (tokens) into tiles
+        // [12] has_metadata, [13] metadata CB index (placeholder 0 on the scalar path). The metadata
+        // accessor (when present) is appended after the four operand accessors below, so the reader's
+        // operand-accessor offsets stay fixed at <14>.
+        (uint32_t)has_metadata,
+        (uint32_t)(has_metadata ? kMetaCbIndex : 0),
     };
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*cos_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*sin_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*trans_mat_buffer).append_to(reader_compile_time_args);
+    if (has_metadata) {
+        TensorAccessorArgs(*tensor_args.metadata->buffer()).append_to(reader_compile_time_args);
+    }
 
     KernelDescriptor::CompileTimeArgs writer_compile_time_args = {
         (uint32_t)output_cb_index,
@@ -379,11 +439,14 @@ tt::tt_metal::ProgramDescriptor RotaryEmbeddingIndexedDeviceOperation::ProgramFa
     // Per-chip cos/sin shard offset inputs. These are structural (per cached program / mesh coord):
     // sp_factor is the mesh extent along the cluster axis and my_sp_coord is this chip's index along
     // it, so they are constant across calls and safe to bake once even on the binding fast path.
-    // kv_actual_global is the only per-call value; it is a common runtime arg (index 2) that
-    // MeshWorkloadFactory::override_runtime_arguments patches on cache hits, so it is never stale.
+    // Reader common arg index 2 is the per-call value patched on cache hits by
+    // MeshWorkloadFactory::override_runtime_arguments: the metadata tensor's raw DRAM address (metadata
+    // path) or kv_actual_global (scalar path).
     const auto& mesh_view = device->get_view();
     const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     const uint32_t my_sp_coord = ::ttnn::ccl::get_linearized_index_from_physical_coord(cos, coord, args.cluster_axis);
+    const uint32_t reader_per_call_arg =
+        has_metadata ? static_cast<uint32_t>(tensor_args.metadata->buffer()->address()) : args.kv_actual_global;
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = kReaderKernelPath;
@@ -392,7 +455,7 @@ tt::tt_metal::ProgramDescriptor RotaryEmbeddingIndexedDeviceOperation::ProgramFa
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.defines = kernel_defines;
     reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.emplace_common_runtime_args({my_sp_coord, sp_factor, args.kv_actual_global});
+    reader_desc.emplace_common_runtime_args({my_sp_coord, sp_factor, reader_per_call_arg});
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source = kWriterKernelPath;
@@ -488,16 +551,20 @@ void RotaryEmbeddingIndexedDeviceOperation::MeshWorkloadFactory::override_runtim
     tensor_return_value_t& output) {
     // Default adapter behaviour: patch operand buffer-binding addresses on cache hits.
     descriptor_adapter_t::apply_descriptor(cached_workload, args, tensor_args, output);
-    // Reader common runtime arg 2 holds kv_actual_global -- the per-call value the buffer-binding fast
-    // path would otherwise leave stale. Patch it on every cached program (one per mesh coordinate).
+    // Reader common runtime arg 2 holds the per-call value the buffer-binding fast path would otherwise
+    // leave stale: the metadata tensor's raw DRAM address (metadata path) or kv_actual_global (scalar
+    // path). Patch it on every cached program (one per mesh coordinate).
     constexpr uint32_t kReaderKernelHandle = 0;  // reader is pushed first in create_descriptor
-    constexpr uint32_t kKvActualGlobalCommonArgIdx = 2;
+    constexpr uint32_t kPerCallCommonArgIdx = 2;
+    const uint32_t per_call_arg = tensor_args.metadata.has_value()
+                                      ? static_cast<uint32_t>(tensor_args.metadata->buffer()->address())
+                                      : args.kv_actual_global;
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& reader_common = GetCommonRuntimeArgs(program, kReaderKernelHandle);
         TT_FATAL(
-            kKvActualGlobalCommonArgIdx < reader_common.size(),
-            "rotary_embedding_indexed reader is missing the kv_actual_global common runtime arg");
-        reader_common[kKvActualGlobalCommonArgIdx] = args.kv_actual_global;
+            kPerCallCommonArgIdx < reader_common.size(),
+            "rotary_embedding_indexed reader is missing its per-call common runtime arg");
+        reader_common[kPerCallCommonArgIdx] = per_call_arg;
     }
 }
 
@@ -510,6 +577,7 @@ ttnn::Tensor rotary_embedding_indexed(
     const ttnn::Tensor& cos,
     const ttnn::Tensor& sin,
     const ttnn::Tensor& trans_mat,
+    const std::optional<ttnn::Tensor>& metadata,
     uint32_t kv_actual_global,
     uint32_t cluster_axis,
     const std::optional<MemoryConfig>& memory_config,
@@ -535,7 +603,8 @@ ttnn::Tensor rotary_embedding_indexed(
         .output_mem_config = out_mem_config,
         .compute_kernel_config = kernel_config_val,
     };
-    auto tensor_args = OperationType::tensor_args_t{.input = input, .cos = cos, .sin = sin, .trans_mat = trans_mat};
+    auto tensor_args = OperationType::tensor_args_t{
+        .input = input, .cos = cos, .sin = sin, .trans_mat = trans_mat, .metadata = metadata};
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.hpp
@@ -22,11 +22,13 @@ namespace ttnn::operations::experimental::deepseek_prefill::rotary_embedding_ind
 struct RotaryEmbeddingIndexedDeviceOperation {
     struct operation_attributes_t {
         uint32_t cluster_axis;  // mesh axis the cos/sin caches are SP-sharded along.
-        // Prior valid global KV length in tokens. A per-call scalar that is intentionally NOT hashed:
-        // it lives in a common runtime arg and is patched on cache hits by
-        // MeshWorkloadFactory::override_runtime_arguments, so one cached program is reused across
-        // chunks while the value stays current.
-        uint32_t kv_actual_global;  // TODO: move to metadata
+        // Prior valid global KV length in tokens. Used only on the SCALAR path (when no `metadata`
+        // tensor is supplied): a per-call scalar intentionally NOT hashed — it lives in a common
+        // runtime arg patched on cache hits by MeshWorkloadFactory::override_runtime_arguments, so one
+        // cached program is reused across chunks while the value stays current. On the METADATA path it
+        // is unused (0); the reader reads kv_actual_global on-device from element [0] of the 1-element
+        // `metadata` tensor.
+        uint32_t kv_actual_global;  // scalar path only
         MemoryConfig output_mem_config;
         ttnn::DeviceComputeKernelConfig compute_kernel_config;
     };
@@ -36,6 +38,12 @@ struct RotaryEmbeddingIndexedDeviceOperation {
         const Tensor& cos;
         const Tensor& sin;
         const Tensor& trans_mat;
+        // Optional. When set: a dedicated 1-element uint32 DRAM tensor, replicated across the mesh,
+        // holding kv_actual_global (tokens, tile-aligned) directly at element [0]. The reader NoC-reads
+        // that one element on-device (traceable path), so a captured ttnn trace advances the value per
+        // chunk via an in-place host update of this tensor. When empty, the op uses the scalar
+        // `kv_actual_global` attribute.
+        std::optional<Tensor> metadata;
     };
 
     using spec_return_value_t = tt::tt_metal::TensorSpec;
@@ -92,11 +100,15 @@ struct RotaryEmbeddingIndexedDeviceOperation {
 
 namespace ttnn::prim {
 
+// Unified primitive. `metadata` selects the path: set -> traceable on-device read of kv_actual_global
+// (from element [0] of the 1-element metadata tensor; the scalar arg is ignored, pass 0); empty ->
+// scalar path using the kv_actual_global attribute.
 ttnn::Tensor rotary_embedding_indexed(
     const ttnn::Tensor& input,
     const ttnn::Tensor& cos,
     const ttnn::Tensor& sin,
     const ttnn::Tensor& trans_mat,
+    const std::optional<ttnn::Tensor>& metadata,
     uint32_t kv_actual_global,
     uint32_t cluster_axis,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed.cpp
@@ -8,6 +8,7 @@
 
 namespace ttnn::operations::experimental::deepseek_prefill::rotary_embedding_indexed {
 
+// Scalar form: no metadata tensor; kv_actual_global is a host scalar.
 ttnn::Tensor rotary_embedding_indexed(
     const ttnn::Tensor& input,
     const ttnn::Tensor& cos,
@@ -18,7 +19,38 @@ ttnn::Tensor rotary_embedding_indexed(
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
     return ttnn::prim::rotary_embedding_indexed(
-        input, cos, sin, trans_mat, kv_actual_global, cluster_axis, memory_config, compute_kernel_config);
+        input,
+        cos,
+        sin,
+        trans_mat,
+        /*metadata=*/std::nullopt,
+        kv_actual_global,
+        cluster_axis,
+        memory_config,
+        compute_kernel_config);
+}
+
+// Tensor form: kv_actual_global is a 1-element uint32 DRAM tensor read on-device (element [0]); the
+// scalar attr is unused on this path.
+ttnn::Tensor rotary_embedding_indexed(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& cos,
+    const ttnn::Tensor& sin,
+    const ttnn::Tensor& trans_mat,
+    const ttnn::Tensor& kv_actual_global,
+    uint32_t cluster_axis,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
+    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    return ttnn::prim::rotary_embedding_indexed(
+        input,
+        cos,
+        sin,
+        trans_mat,
+        /*metadata=*/kv_actual_global,
+        /*kv_actual_global=*/0,
+        cluster_axis,
+        memory_config,
+        compute_kernel_config);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::rotary_embedding_indexed

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed.hpp
@@ -23,15 +23,31 @@ namespace ttnn::operations::experimental::deepseek_prefill::rotary_embedding_ind
 // shard the same way the per-chip kv-cache writer derives its `update_idxt`, so the boundary chip's
 // older-then-wrap token layout is read with a single contiguous offset.
 //
-// `kv_actual_global` is a per-call scalar (tokens, tile-aligned) held in a common runtime arg and
-// patched on cache hits, so its value is out of the program hash and successive chunks reuse one
-// cached program. Returns a new tensor with the same spec as `input`.
+// `kv_actual_global` (tokens, tile-aligned) stays out of the program hash, so successive chunks reuse
+// one cached program. Returns a new tensor with the same spec as `input`. Two call forms (identical
+// results):
+
+// (1) Scalar form: `kv_actual_global` is a host scalar held in a common runtime arg, patched on cache
+//     hits.
 ttnn::Tensor rotary_embedding_indexed(
     const ttnn::Tensor& input,
     const ttnn::Tensor& cos,
     const ttnn::Tensor& sin,
     const ttnn::Tensor& trans_mat,
     uint32_t kv_actual_global,
+    uint32_t cluster_axis,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+
+// (2) Tensor form (traceable): `kv_actual_global` is its OWN 1-element uint32 DRAM tensor that the reader
+//     reads on-device (element [0]). Off the host dispatch path, so one captured program replays across
+//     chunks (the host updates the 1-element tensor in place per chunk).
+ttnn::Tensor rotary_embedding_indexed(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& cos,
+    const ttnn::Tensor& sin,
+    const ttnn::Tensor& trans_mat,
+    const ttnn::Tensor& kv_actual_global,
     uint32_t cluster_axis,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed_nanobind.cpp
@@ -15,6 +15,10 @@
 namespace ttnn::operations::experimental::deepseek_prefill::rotary_embedding_indexed::detail {
 
 void bind_rotary_embedding_indexed(nb::module_& mod) {
+    using ttnn::Tensor;
+    using ttnn::operations::experimental::deepseek_prefill::rotary_embedding_indexed::rotary_embedding_indexed;
+    using MemCfg = std::optional<tt::tt_metal::MemoryConfig>;
+    using KCfg = std::optional<const ttnn::DeviceComputeKernelConfig>;
     ttnn::bind_function<"rotary_embedding_indexed", "ttnn.experimental.deepseek_prefill.">(
         mod,
         R"doc(
@@ -24,10 +28,18 @@ void bind_rotary_embedding_indexed(nb::module_& mod) {
             caches at a per-device offset derived on-device from a single global valid-KV length
             (`kv_actual_global`) and the device's coordinate along `cluster_axis`. The boundary
             chip's older-then-wrap token layout is read with a single contiguous offset because the
-            wrap is absorbed by the block-cyclic cos/sin shard layout.
+            wrap is absorbed by the block-cyclic cos/sin shard layout. `kv_actual_global` stays out of
+            the program hash, so successive chunks reuse one cached program.
 
-            `kv_actual_global` is a per-call scalar held in a common runtime arg and patched on cache
-            hits, so its value is out of the program hash and successive chunks reuse one cached program.
+            Two call forms (identical results):
+              - scalar: ``(input, cos, sin, trans_mat, kv_actual_global, cluster_axis, ...)`` — host
+                scalar patched on cache hits.
+              - metadata: ``(input, cos, sin, trans_mat, kv_actual_global, cluster_axis, ...)`` where the
+                ``kv_actual_global`` argument is a 1-element uint32 tensor instead of an int — the reader
+                reads the value on-device from element [0] of that tensor, so it never touches the host
+                dispatch path. This form is trace-safe. Both overloads bind this 5th argument as
+                ``kv_actual_global`` (pass an int for the scalar form, a 1-element uint32 tensor for the
+                metadata form).
 
             Args:
                 input (ttnn.Tensor): 4D per-chip input chunk on device, TILE layout
@@ -36,21 +48,54 @@ void bind_rotary_embedding_indexed(nb::module_& mod) {
                     `cluster_axis` in block-cyclic order keyed by `chunk_local`.
                 sin (ttnn.Tensor): 4D sin cache, same layout/shape as `cos`.
                 trans_mat (ttnn.Tensor): rotation transformation matrix (one tile), replicated.
-                kv_actual_global (int): prior valid global KV length in tokens (tile-aligned).
+                kv_actual_global (int | ttnn.Tensor): prior valid global KV length in tokens
+                    (tile-aligned). Scalar form: an int. Metadata (trace-safe) form: a dedicated
+                    1-element uint32 DRAM tensor, replicated across the mesh, holding the value directly
+                    at element [0]; the reader reads it on-device. Same argument name/position in both
+                    forms.
                 cluster_axis (int): mesh axis the cos/sin caches are SP-sharded along (0 or 1).
 
             Returns:
                 ttnn.Tensor: a new tensor with the same spec as `input`, rotary-embedded.
         )doc",
-        &ttnn::operations::experimental::deepseek_prefill::rotary_embedding_indexed::rotary_embedding_indexed,
-        nb::arg("input").noconvert(),
-        nb::arg("cos").noconvert(),
-        nb::arg("sin").noconvert(),
-        nb::arg("trans_mat").noconvert(),
-        nb::arg("kv_actual_global"),
-        nb::arg("cluster_axis"),
-        nb::arg("memory_config") = std::nullopt,
-        nb::arg("compute_kernel_config") = std::nullopt);
+        // Scalar form.
+        ttnn::overload_t(
+            nb::overload_cast<
+                const Tensor&,
+                const Tensor&,
+                const Tensor&,
+                const Tensor&,
+                uint32_t,
+                uint32_t,
+                const MemCfg&,
+                const KCfg&>(&rotary_embedding_indexed),
+            nb::arg("input").noconvert(),
+            nb::arg("cos").noconvert(),
+            nb::arg("sin").noconvert(),
+            nb::arg("trans_mat").noconvert(),
+            nb::arg("kv_actual_global"),
+            nb::arg("cluster_axis"),
+            nb::arg("memory_config") = std::nullopt,
+            nb::arg("compute_kernel_config") = std::nullopt),
+        // Metadata form (traceable).
+        ttnn::overload_t(
+            nb::overload_cast<
+                const Tensor&,
+                const Tensor&,
+                const Tensor&,
+                const Tensor&,
+                const Tensor&,
+                uint32_t,
+                const MemCfg&,
+                const KCfg&>(&rotary_embedding_indexed),
+            nb::arg("input").noconvert(),
+            nb::arg("cos").noconvert(),
+            nb::arg("sin").noconvert(),
+            nb::arg("trans_mat").noconvert(),
+            nb::arg("kv_actual_global").noconvert(),
+            nb::arg("cluster_axis"),
+            nb::arg("memory_config") = std::nullopt,
+            nb::arg("compute_kernel_config") = std::nullopt));
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::rotary_embedding_indexed::detail


### PR DESCRIPTION

Per-element-tensor overload: per-chunk scalars (slot_id / kv_actual_global / valid_global) can be passed as 1-element uint32 DRAM tensors read on-device, so a captured ttnn trace advances them per chunk via an in-place host update. Scalar overload unchanged. Includes the op-equivalence unit test (no trace, no model plumbing). Extracted from the validated rebased branch ppopovic/trace_rebased_on_main.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ppopovic/metadata_rotary_embedding_indexed)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ppopovic/metadata_rotary_embedding_indexed)
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ppopovic/metadata_rotary_embedding_indexed)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ppopovic/metadata_rotary_embedding_indexed)
Unrelated failures on CI