### PR TITLE
#46577: zero_padded_kv_cache — trace-safe per-element-tensor metadata overload (op + test, no trace)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
@@ -359,3 +359,157 @@ def test_zero_padded_kv_cache_layers_users(
     assert pad.max() < 0.1, f"target pad [{valid_global},{ceil_v}) not zeroed (max={pad.max()})"
     assert rest.min() > 0.9, f"target rows past window touched (min={rest.min()})"
     logger.success(f"layers={num_layers} users={num_users} slot={slot_idx} layer={layer_idx} PASSED")
+
+
+# (slot_idx, valid_global): a single-tile partial (740), a 3-tile window (2600), a full-tile window
+# with row_start=0 (4512), and a non-zero slot.
+_EQUIV_CASES = [(0, 740), (0, 2600), (0, 4512), (1, 2600)]
+_EQUIV_IDS = [f"slot{s}_v{v}" for (s, v) in _EQUIV_CASES]
+
+
+def _make_scalar_tensor(mesh_device, value):
+    """A 1-element uint32 tensor [1,1,1,1], ROW_MAJOR, DRAM, replicated across the mesh -- the
+    per-element view the tensor-path overload reads element 0 from."""
+    t = torch.tensor([[[[value]]]], dtype=torch.int32)  # ttnn maps int32->uint32 storage
+    return ttnn.from_torch(
+        t,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("slot_idx,valid_global", _EQUIV_CASES, ids=_EQUIV_IDS)
+@pytest.mark.timeout(0)
+def test_zero_padded_kv_cache_tensor_matches_scalar(mesh_device, slot_idx, valid_global):
+    """The per-element-tensor path and the scalar path must produce bit-identical caches.
+
+    Builds two 1-element uint32 replicated-DRAM tensors (slot_idx, valid_global), hands them to the
+    tensor-path overload (the reader/writer read element 0 of each on-device), and compares the zeroed
+    cache against the same call done via the original scalar signature, per device, bit-exact."""
+    mesh_shape = list(mesh_device.shape)
+    sp_axis = 0
+    sp = mesh_shape[sp_axis]
+    kvpe = 64
+    chunk_size_global = 5120
+    seq_len_cache = 5120
+    seq_len_local = seq_len_cache // sp
+    num_users, num_layers = 2, 1
+
+    def _make_seeded_cache():
+        c = init_kvpe_cache(
+            kvpe, mesh_device, seq_len_cache, mesh_shape, sp_axis, num_kvpe_cache_layers=num_layers, num_users=num_users
+        )
+        ones = torch.ones(1, 1, seq_len_local, kvpe, dtype=torch.bfloat16)
+        tt_ones = ttnn.from_torch(
+            ones,
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        for b in range(num_users * num_layers):
+            ttnn.fill_cache(c, tt_ones, b, update_idx=0)
+        return c
+
+    mesh_device.enable_program_cache()
+    cache_scalar = _make_seeded_cache()
+    cache_tensor = _make_seeded_cache()
+    ttnn.synchronize_device(mesh_device)
+
+    # 1-element uint32 tensors: slot_idx and valid_global, each read element 0 on-device.
+    tt_slot_idx = _make_scalar_tensor(mesh_device, slot_idx)
+    tt_valid_global = _make_scalar_tensor(mesh_device, valid_global)
+
+    # Scalar path and per-element-tensor path on identical seeded caches.
+    ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+        cache_scalar, slot_idx, 0, num_layers, valid_global, chunk_size_global, sp_axis, 128
+    )
+    ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+        cache_tensor, tt_slot_idx, tt_valid_global, 0, num_layers, chunk_size_global, sp_axis, 128
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    scalar_devs = [ttnn.to_torch(d).float() for d in ttnn.get_device_tensors(cache_scalar)]
+    tensor_devs = [ttnn.to_torch(d).float() for d in ttnn.get_device_tensors(cache_tensor)]
+    for di, (a, b) in enumerate(zip(tensor_devs, scalar_devs)):
+        assert torch.equal(a, b), (
+            f"slot {slot_idx} v {valid_global} device {di}: tensor-path cache differs from scalar-path "
+            f"(max abs diff {(a - b).abs().max().item()})"
+        )
+    logger.success(f"slot={slot_idx} valid_global={valid_global}: tensor path == scalar path (bit-exact)")
+    ttnn.deallocate(tt_slot_idx)
+    ttnn.deallocate(tt_valid_global)
+
+
+@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.timeout(0)
+def test_zero_padded_kv_cache_tensor_program_reuse(mesh_device):
+    """Cache-HIT coverage of the tensor path: two successive tensor-overload calls with DIFFERENT
+    1-element metadata tensors (distinct DRAM addresses) must reuse ONE cached program, and the second
+    call must zero ITS OWN window -- proving override_runtime_arguments patches the metadata tensor
+    addresses (common args 10/11) on the cache hit rather than reusing the first call's tensors. (The
+    tensor path is TILE-only, so this uses a TILE cache.)"""
+    sp_axis = 0
+    kvpe = 64
+    chunk_size_global = 5120
+    seq_len_cache = 5120
+    num_users, num_layers = 2, 1
+
+    cache = _init_cache_filled_with_ones(
+        mesh_device,
+        head_dim=kvpe,
+        seq_len_cache=seq_len_cache,
+        chunk_size_global=chunk_size_global,
+        sp_axis=sp_axis,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        num_layers=num_layers,
+        num_users=num_users,
+    )
+    mesh_device.enable_program_cache()
+
+    # Two DISTINCT (slot, valid_global) pairs, each via its OWN metadata tensors (distinct DRAM addresses).
+    slot_a, va = 0, 740
+    slot_b, vb = 1, 2600
+    ceil128 = lambda v: math.ceil(v / 128) * 128  # noqa: E731
+
+    slot_ta, valid_ta = _make_scalar_tensor(mesh_device, slot_a), _make_scalar_tensor(mesh_device, va)
+    # First tensor-overload call: program-cache MISS (compiles the tensor program).
+    ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+        cache, slot_ta, valid_ta, 0, num_layers, chunk_size_global, sp_axis, 128
+    )
+    ttnn.synchronize_device(mesh_device)
+    entries_after_first = mesh_device.num_program_cache_entries()
+
+    slot_tb, valid_tb = _make_scalar_tensor(mesh_device, slot_b), _make_scalar_tensor(mesh_device, vb)
+    # Second call with DIFFERENT tensors -> program-cache HIT; the override must patch the new DRAM
+    # addresses (common args 10/11) so the kernel reads slot_b/vb, not the first call's slot_a/va.
+    ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+        cache, slot_tb, valid_tb, 0, num_layers, chunk_size_global, sp_axis, 128
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    assert mesh_device.num_program_cache_entries() == entries_after_first, (
+        f"tensor-path program was recompiled on the second call instead of reused "
+        f"({entries_after_first} -> {mesh_device.num_program_cache_entries()}) -- successive chunks must "
+        f"reuse one cached program via the patched metadata addresses"
+    )
+    # Both windows zeroed, every other element still one: proves the SECOND (cache-hit) call read the NEW
+    # tensors' values (slot_b/vb) via the patched addresses. If patching had failed it would have re-zeroed
+    # slot_a/va and slot_b's window would still be all ones -> this assertion would fail.
+    _assert_cache_windows(
+        cache,
+        mesh_device,
+        chunk_size_global=chunk_size_global,
+        seq_len_cache=seq_len_cache,
+        sp_axis=sp_axis,
+        num_layers=num_layers,
+        windows={(slot_a, 0): (va, ceil128(va)), (slot_b, 0): (vb, ceil128(vb))},
+    )
+    logger.success("tensor-path program reused across chunks; second (cache-hit) call zeroed its own window")
+    for t in (slot_ta, valid_ta, slot_tb, valid_tb):
+        ttnn.deallocate(t)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/compute/zero_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/compute/zero_padded_kv_cache.cpp
@@ -9,18 +9,19 @@
 #include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp"
 
-// Multiplies the boundary (partial) pad tile by the row-mask, zeroing the pad rows while preserving
-// the real rows. Only runs on the chip that owns the partial tile. The mask is a single tile reused
-// across all Wt width-tiles (the mask depends only on the row).
+// Multiplies one (partial) tile by the row-mask for each of the Wt width-tiles, zeroing the pad rows
+// while preserving the real rows. The reader and writer drive an UNCONDITIONAL src/mask/out CB
+// protocol -- the reader always pushes src+mask and the writer always pops the out tiles (discarding
+// the result on a chip with no partial pad work) -- so this kernel needs NO per-call scalar: it always
+// processes exactly Wt tiles. Wt is a structural common arg (index 7) readable by all three compute
+// threads, so no reader->compute handoff (control CB / mailbox) is required, and the kernel is
+// identical on the scalar and metadata paths.
 void kernel_main() {
     constexpr uint32_t src_cb = get_compile_time_arg_val(0);
     constexpr uint32_t mask_cb = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb = get_compile_time_arg_val(2);
 
-    const ZeroPadChipWork w = zero_pad_compute_chip_work();
-    if (w.count == 0 || w.first_partial == 0) {
-        return;
-    }
+    const uint32_t Wt = get_common_arg_val<uint32_t>(7);  // structural; same on both paths
 
     CircularBuffer src(src_cb);
     CircularBuffer mask(mask_cb);
@@ -30,9 +31,9 @@ void kernel_main() {
     mul_tiles_init(src_cb, mask_cb);
 
     mask.wait_front(1);
-    src.wait_front(w.Wt);
-    out.reserve_back(w.Wt);
-    for (uint32_t i = 0; i < w.Wt; ++i) {
+    src.wait_front(Wt);
+    out.reserve_back(Wt);
+    for (uint32_t i = 0; i < Wt; ++i) {
         tile_regs_acquire();
         mul_tiles(src_cb, mask_cb, i, 0, 0);
         tile_regs_commit();
@@ -40,7 +41,7 @@ void kernel_main() {
         pack_tile(0, out_cb);
         tile_regs_release();
     }
-    out.push_back(w.Wt);
-    src.pop_front(w.Wt);
+    out.push_back(Wt);
+    src.pop_front(Wt);
     mask.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/reader_zero_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/reader_zero_padded_kv_cache.cpp
@@ -10,29 +10,65 @@
 #include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp"
 
-// Reads the boundary (partial) pad tile from the cache into the src CB, and builds the bf16 row-mask
-// tile (rows [0,row_start) = 1.0, rows [row_start,32) = 0.0) into the mask CB. Only runs on the chip
-// that owns the partial tile; chips with only full pad tiles do nothing here.
-void kernel_main() {
+// Reads this chip's boundary seq-tile from the cache into the src CB and builds the bf16 row-mask tile
+// (rows [0,row_start) = 1.0, rest = 0.0) into the mask CB. UNCONDITIONALLY pushes src+mask every call
+// (even on a chip with no pad work, where it reads the slot's base tile and an all-zero mask): the
+// compute kernel always consumes Wt src tiles and the writer always pops the out tiles, so the CB
+// protocol is balanced without any reader->compute control handoff. The writer decides what (if
+// anything) actually gets written back.
+//
+// The per-call slot_idx / valid_global reach the kernel one of two ways (HasMeta compile flag):
+//   - scalar path: common runtime args 9 / 3 (patched on cache hits).
+//   - tensor path: NoC-read on-device, each from its own 1-element uint32 tensor -- slot_idx from the
+//     tensor at common arg 10, valid_global (= actual_end) from the tensor at common arg 11 (element 0
+//     of each). One TensorAccessorArgs is reused for both (identical layout).
+// The body is a template on HasMeta so `if constexpr` discards the metadata branch on the scalar
+// program (the metadata TensorAccessorArgs offset is made dependent on HasMeta to stay in range).
+template <bool HasMeta>
+static void run_reader() {
     constexpr uint32_t src_cb = get_compile_time_arg_val(0);
     constexpr uint32_t mask_cb = get_compile_time_arg_val(1);
     constexpr uint32_t cache_tile_bytes = get_compile_time_arg_val(2);
-    constexpr auto cache_args = TensorAccessorArgs<3>();
+    // [3] = has_metadata, [4] = metadata CB index. Cache accessor starts at <5>; the metadata accessor
+    // (metadata path only) is appended after it.
+    constexpr uint32_t meta_cb = get_compile_time_arg_val(4);
+    constexpr auto cache_args = TensorAccessorArgs<5>();
 
     const uint32_t cache_addr = get_arg_val<uint32_t>(0);
 
-    const ZeroPadChipWork w = zero_pad_compute_chip_work();
-    if (w.count == 0 || w.first_partial == 0) {
-        return;  // this chip has no partial tile to mask
+    Noc noc;
+
+    ZeroPadChipWork w;
+    if constexpr (HasMeta) {
+        // NoC-read slot_idx and valid_global, each element 0 of its own 1-element uint32 tensor:
+        // slot_idx tensor address = common arg 10, valid_global tensor address = common arg 11. One
+        // accessor (kMetaArgsOffset) is reused for both reads (identical layout).
+        constexpr uint32_t kMetaArgsOffset = HasMeta ? cache_args.next_compile_time_args_offset() : 0;
+        constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
+        const uint32_t slot_idx_addr = get_common_arg_val<uint32_t>(10);
+        const uint32_t valid_global_addr = get_common_arg_val<uint32_t>(11);
+        CircularBuffer cb_meta(meta_cb);
+        cb_meta.reserve_back(1);
+        const auto s_slot = TensorAccessor(meta_args, slot_idx_addr);
+        noc.async_read(s_slot, cb_meta, 4, {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        const uint32_t slot = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+        const auto s_valid = TensorAccessor(meta_args, valid_global_addr);
+        noc.async_read(s_valid, cb_meta, 4, {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        const uint32_t valid_global = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+        cb_meta.push_back(1);
+        w = zero_pad_compute_chip_work(slot, valid_global);
+    } else {
+        w = zero_pad_compute_chip_work();
     }
 
     const auto s = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
     const uint32_t base_page = w.batch_page_base + w.base_local_tile * w.Wt;
 
-    Noc noc;
+    // Read the Wt width-tiles of this chip's boundary seq-tile into the src CB. When this chip has no
+    // pad work (count==0 -> base_local_tile==0) this reads the slot's base tile; the writer discards it.
     CircularBuffer src(src_cb);
-
-    // Read the Wt width-tiles of the boundary seq-tile into the src CB.
     src.reserve_back(w.Wt);
     for (uint32_t i = 0; i < w.Wt; ++i) {
         noc.async_read(s, src, cache_tile_bytes, {.page_id = base_page + i}, {.offset_bytes = i * cache_tile_bytes});
@@ -40,7 +76,8 @@ void kernel_main() {
     noc.async_read_barrier();
     src.push_back(w.Wt);
 
-    // Build the bf16 row-mask tile in L1 (face layout: 4x 16x16 faces, order TL,TR,BL,BR).
+    // Build the bf16 row-mask tile in L1 (face layout: 4x 16x16 faces, order TL,TR,BL,BR). When there
+    // is no partial (row_start==0) the mask is all-zero, which is harmless: the writer discards it.
     constexpr uint16_t kBf16One = 0x3F80;  // 1.0
     CircularBuffer mask(mask_cb);
     mask.reserve_back(1);
@@ -56,4 +93,9 @@ void kernel_main() {
         }
     }
     mask.push_back(1);
+}
+
+void kernel_main() {
+    constexpr bool has_metadata = get_compile_time_arg_val(3);
+    run_reader<has_metadata>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/writer_zero_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/writer_zero_padded_kv_cache.cpp
@@ -6,46 +6,77 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp"
 
 // Writes this chip's share of the pad window back to the cache: the masked partial tile (from the
-// compute out CB) goes back to the boundary seq-tile, and every fully-pad seq-tile is zeroed in
-// place. The owned tiles are contiguous-local, so the full tiles form a contiguous page range.
-void kernel_main() {
+// compute out CB) goes back to the boundary seq-tile, and every fully-pad seq-tile is zeroed in place.
+//
+// The compute kernel pushes Wt out tiles UNCONDITIONALLY (the CB protocol is balanced without a
+// reader->compute handoff), so this writer always pops them; it just discards the result on a chip
+// with no partial tile. The per-call slot_idx / valid_global come from common args (scalar path) or
+// are NoC-read each from its own 1-element uint32 tensor (tensor path: slot_idx tensor at common arg
+// 10, valid_global tensor at common arg 11), selected by the HasMeta compile flag.
+template <bool HasMeta>
+static void run_writer() {
     constexpr uint32_t out_cb = get_compile_time_arg_val(0);
     constexpr uint32_t zero_cb = get_compile_time_arg_val(1);
     constexpr uint32_t cache_tile_bytes = get_compile_time_arg_val(2);
-    constexpr auto cache_args = TensorAccessorArgs<3>();
+    // [3] = has_metadata, [4] = metadata CB index. Cache accessor at <5>; metadata accessor after it.
+    constexpr uint32_t meta_cb = get_compile_time_arg_val(4);
+    constexpr auto cache_args = TensorAccessorArgs<5>();
 
     const uint32_t cache_addr = get_arg_val<uint32_t>(0);
 
-    const ZeroPadChipWork w = zero_pad_compute_chip_work();
-    if (w.count == 0) {
-        return;  // nothing on this chip
+    Noc noc;
+
+    ZeroPadChipWork w;
+    if constexpr (HasMeta) {
+        // NoC-read slot_idx and valid_global, each element 0 of its own 1-element uint32 tensor:
+        // slot_idx tensor address = common arg 10, valid_global tensor address = common arg 11. One
+        // accessor (kMetaArgsOffset) is reused for both reads (identical layout).
+        constexpr uint32_t kMetaArgsOffset = HasMeta ? cache_args.next_compile_time_args_offset() : 0;
+        constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
+        const uint32_t slot_idx_addr = get_common_arg_val<uint32_t>(10);
+        const uint32_t valid_global_addr = get_common_arg_val<uint32_t>(11);
+        CircularBuffer cb_meta(meta_cb);
+        cb_meta.reserve_back(1);
+        const auto s_slot = TensorAccessor(meta_args, slot_idx_addr);
+        noc.async_read(s_slot, cb_meta, 4, {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        const uint32_t slot = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+        const auto s_valid = TensorAccessor(meta_args, valid_global_addr);
+        noc.async_read(s_valid, cb_meta, 4, {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        const uint32_t valid_global = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+        cb_meta.push_back(1);
+        w = zero_pad_compute_chip_work(slot, valid_global);
+    } else {
+        w = zero_pad_compute_chip_work();
     }
 
     const auto s = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
     const uint32_t base_page = w.batch_page_base + w.base_local_tile * w.Wt;
 
-    Noc noc;
-
-    uint32_t first_full_tile = 0;
-    if (w.first_partial) {
-        // Write the masked partial seq-tile (Wt width-tiles) back to the boundary tile.
-        CircularBuffer out(out_cb);
-        out.wait_front(w.Wt);
+    // UNCONDITIONAL: compute always pushes Wt out tiles -> always consume them. Write the masked
+    // partial back only on the chip that owns it; otherwise the tiles are discarded.
+    CircularBuffer out(out_cb);
+    out.wait_front(w.Wt);
+    if (w.count != 0 && w.first_partial != 0) {
         for (uint32_t i = 0; i < w.Wt; ++i) {
             noc.async_write(
                 out, s, cache_tile_bytes, {.offset_bytes = i * cache_tile_bytes}, {.page_id = base_page + i});
         }
         noc.async_write_barrier();
-        out.pop_front(w.Wt);
-        first_full_tile = 1;
     }
+    out.pop_front(w.Wt);
 
+    // Zero the fully-pad seq-tiles (those after an optional leading partial). Contiguous-local, so a
+    // contiguous page range.
+    const uint32_t first_full_tile = w.first_partial ? 1u : 0u;
     if (first_full_tile >= w.count) {
-        return;  // only a partial tile on this chip, no full pad tiles
+        return;  // nothing to zero (count==0, or only the partial tile on this chip)
     }
 
     // Zero a one-tile L1 scratch, then stream it to every full pad page. The scratch is never
@@ -61,4 +92,9 @@ void kernel_main() {
         noc.async_write_zeros(s, cache_tile_bytes, {.page_id = page}, zero);
     }
     noc.write_zeros_dram_barrier();
+}
+
+void kernel_main() {
+    constexpr bool has_metadata = get_compile_time_arg_val(3);
+    run_writer<has_metadata>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp
@@ -20,11 +20,10 @@ struct ZeroPadTokenRange {
 // Validation guarantees that [valid_global, ceil_pad(valid_global)) remains in one block-cyclic slab.
 // Intersect that window with this chip's contiguous slice of the slab, then map the intersection to the
 // chip-local cache rows. Both TILE and ROW_MAJOR paths derive their native page ranges from this result.
-inline ZeroPadTokenRange zero_pad_compute_token_range() {
+inline ZeroPadTokenRange zero_pad_compute_token_range(uint32_t valid_global) {
     const uint32_t my = get_common_arg_val<uint32_t>(0);
     const uint32_t sp = get_common_arg_val<uint32_t>(1);
     const uint32_t chunk_local = get_common_arg_val<uint32_t>(2);
-    const uint32_t valid_global = get_common_arg_val<uint32_t>(3);
     const uint32_t pad_align = get_common_arg_val<uint32_t>(4);
 
     const uint32_t pad_end = ((valid_global + pad_align - 1) / pad_align) * pad_align;
@@ -54,15 +53,18 @@ struct ZeroPadChipWork {
     uint32_t batch_page_base;  // page offset of this (slot,layer) batch slot in the cache
 };
 
-inline ZeroPadChipWork zero_pad_compute_chip_work() {
+// Core derivation, taking the two per-call values (slot_idx, valid_global=v) as parameters. The
+// metadata path reads them on-device from the metadata tensor and calls this; the scalar path reads
+// common args 9/3 via the no-arg overload below. All other inputs (incl valid_global for the window
+// math, via zero_pad_compute_token_range) are structural common args.
+inline ZeroPadChipWork zero_pad_compute_chip_work(uint32_t slot, uint32_t v) {
     const uint32_t layer = get_common_arg_val<uint32_t>(5);
     const uint32_t num_layers = get_common_arg_val<uint32_t>(6);
     const uint32_t Wt = get_common_arg_val<uint32_t>(7);
     const uint32_t cache_CHtWt = get_common_arg_val<uint32_t>(8);
-    const uint32_t slot = get_common_arg_val<uint32_t>(9);
 
     ZeroPadChipWork w{0, 0, 0, 0, Wt, (slot * num_layers + layer) * cache_CHtWt};
-    const ZeroPadTokenRange range = zero_pad_compute_token_range();
+    const ZeroPadTokenRange range = zero_pad_compute_token_range(v);
     if (range.count == 0) {
         return w;
     }
@@ -75,10 +77,16 @@ inline ZeroPadChipWork zero_pad_compute_chip_work() {
     return w;
 }
 
+// Scalar path (TILE): read the two per-call values from common args (slot_idx = 9, valid_global = 3).
+// The metadata (per-element-tensor) path is TILE-only; ROW_MAJOR uses the scalar signature.
+inline ZeroPadChipWork zero_pad_compute_chip_work() {
+    return zero_pad_compute_chip_work(get_common_arg_val<uint32_t>(9), get_common_arg_val<uint32_t>(3));
+}
+
 // ROW_MAJOR counterpart: one page is one token row, so the exact window [valid_global, pad_end) can
 // be zeroed without reading or masking a boundary tile. Validation keeps the window within one
 // block-cyclic slab; therefore each chip's owned rows form one contiguous local page range even when
-// the global window crosses a chip boundary.
+// the global window crosses a chip boundary. ROW_MAJOR is scalar-only: valid_global is common arg 3.
 struct ZeroPadRowMajorChipWork {
     uint32_t count;
     uint32_t base_local_row;
@@ -91,6 +99,6 @@ inline ZeroPadRowMajorChipWork zero_pad_compute_row_major_chip_work() {
     const uint32_t cache_CH_pages = get_common_arg_val<uint32_t>(8);
     const uint32_t slot = get_common_arg_val<uint32_t>(9);
 
-    const ZeroPadTokenRange range = zero_pad_compute_token_range();
+    const ZeroPadTokenRange range = zero_pad_compute_token_range(get_common_arg_val<uint32_t>(3));
     return {range.count, range.base_local_token, (slot * num_layers + layer) * cache_CH_pages};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -44,11 +44,23 @@ constexpr uint32_t kSrcCbIndex = 0;   // partial tile read from cache (cache dty
 constexpr uint32_t kMaskCbIndex = 1;  // row-mask tile built in the reader (bf16)
 constexpr uint32_t kOutCbIndex = 2;   // masked partial tile from compute (cache dtype)
 constexpr uint32_t kZeroCbIndex = 3;  // pre-zeroed scratch for full-tile writes (cache dtype)
+// Tensor path only: L1 scratch each kernel reads the 1-element uint32 metadata tensor page into (reused
+// within a kernel for its two sequential slot_idx/valid_global reads -- identical layout). The reader
+// (BRISC) and writer (NCRISC) run on the SAME core, so they MUST use SEPARATE CBs: a shared CB is one L1
+// page both kernels NoC-read into concurrently, and a skew across the slot->valid read transition could
+// let one kernel observe the other's value (wrong pad window -> silent cache corruption).
+constexpr uint32_t kMetaCbIndex = 4;        // reader's metadata scratch
+constexpr uint32_t kMetaCbIndexWriter = 5;  // writer's metadata scratch (disjoint from the reader's)
+constexpr uint32_t kMetadataBytes = 16;
 
-// Common runtime arg layout shared by the reader and writer (the compute reads a subset). Index 3 is
-// valid_global and index 9 is slot_idx -- the per-call scalars patched by override_runtime_arguments.
+// Common runtime arg layout. Index 3 is valid_global and index 9 is slot_idx -- the per-call scalars
+// patched by override_runtime_arguments on the SCALAR path. On the TENSOR path index 10 is the
+// slot_idx tensor's raw DRAM address and index 11 is the valid_global tensor's, both patched there (the
+// reader/writer read element 0 of each).
 constexpr uint32_t kValidGlobalCommonArgIdx = 3;
 constexpr uint32_t kSlotIdxCommonArgIdx = 9;
+constexpr uint32_t kSlotIdxAddrCommonArgIdx = 10;
+constexpr uint32_t kValidGlobalAddrCommonArgIdx = 11;
 
 // Per-call scalar checks shared by the cache-miss and cache-hit paths.
 void validate_runtime_args(
@@ -56,8 +68,39 @@ void validate_runtime_args(
     const ZeroPaddedKvCacheDeviceOperation::tensor_args_t& tensor_args) {
     TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
     const auto& cache = tensor_args.cache;
-    const uint32_t num_slots = cache.padded_shape()[0] / args.num_layers;
-    TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
+
+    // Metadata-path invariant + tensor validation. The path is selected on slot_idx.has_value(), but the
+    // factory dereferences valid_global->buffer() whenever slot_idx is set, so a mismatched optional would
+    // null-deref -- reject it up front. Then validate each metadata tensor's structural properties (device,
+    // UINT32, ROW_MAJOR, single-element) the reader/writer assume, so a malformed tensor fails host-side
+    // with a clear message instead of a silent 4-byte on-device misread. Values stay off the dispatch path.
+    TT_FATAL(
+        tensor_args.slot_idx.has_value() == tensor_args.valid_global.has_value(),
+        "metadata tensors slot_idx and valid_global must be supplied together (got slot_idx={}, valid_global={})",
+        tensor_args.slot_idx.has_value(),
+        tensor_args.valid_global.has_value());
+    if (tensor_args.slot_idx.has_value()) {
+        auto validate_meta = [&cache](const Tensor& meta, const char* name) {
+            TT_FATAL(meta.storage_type() == StorageType::DEVICE, "metadata tensor {} must be on device", name);
+            TT_FATAL(meta.dtype() == DataType::UINT32, "metadata tensor {} must be UINT32", name);
+            TT_FATAL(meta.layout() == Layout::ROW_MAJOR, "metadata tensor {} must be ROW_MAJOR", name);
+            TT_FATAL(
+                meta.logical_volume() == 1,
+                "metadata tensor {} must be a single element (got {})",
+                name,
+                meta.logical_volume());
+            TT_FATAL(meta.device() == cache.device(), "metadata tensor {} must be on the same device as cache", name);
+        };
+        validate_meta(tensor_args.slot_idx.value(), "slot_idx");
+        validate_meta(tensor_args.valid_global.value(), "valid_global");
+    }
+
+    // slot_idx is a host value only on the scalar path; on the tensor path it lives in the device
+    // tensor (read on-device) and is the caller's responsibility.
+    if (!tensor_args.slot_idx.has_value()) {
+        const uint32_t num_slots = cache.padded_shape()[0] / args.num_layers;
+        TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
+    }
 
     const auto& mesh_view = cache.device()->get_view();
     TT_FATAL(mesh_view.is_mesh_2d(), "zero_padded_kv_cache requires a 2D mesh");
@@ -91,11 +134,14 @@ void validate_runtime_args(
         "global cache capacity ({}) must be a multiple of pad_align ({})",
         global_capacity,
         args.pad_align);
-    TT_FATAL(
-        args.valid_global <= global_capacity,
-        "valid_global ({}) exceeds cache capacity ({})",
-        args.valid_global,
-        global_capacity);
+    // valid_global is a host value only on the scalar path.
+    if (!tensor_args.valid_global.has_value()) {
+        TT_FATAL(
+            args.valid_global <= global_capacity,
+            "valid_global ({}) exceeds cache capacity ({})",
+            args.valid_global,
+            global_capacity);
+    }
 }
 
 }  // namespace
@@ -121,6 +167,15 @@ void ZeroPaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
     }
     if (cache.dtype() == DataType::FP8_E4M3) {
         TT_FATAL(cache.layout() == Layout::ROW_MAJOR, "fp8_e4m3 cache must be ROW_MAJOR");
+    }
+    // The per-element-tensor (metadata) path is TILE-only: it patches the reader/writer kernels (0/2),
+    // which only exist for TILE (ROW_MAJOR is a dataflow-only single writer). ROW_MAJOR must use the
+    // scalar signature. (Guard added when rebasing the metadata overload onto main's ROW_MAJOR support.)
+    if (tensor_args.slot_idx.has_value()) {
+        TT_FATAL(
+            cache.layout() == Layout::TILE,
+            "zero_padded_kv_cache per-element-tensor (metadata) path supports TILE layout only; use the "
+            "scalar signature for ROW_MAJOR");
     }
     const auto& cache_shape = cache.padded_shape();
     TT_FATAL(cache_shape.rank() == 4, "cache must be 4D (got rank {})", cache_shape.rank());
@@ -159,7 +214,11 @@ ttsl::hash::hash_t ZeroPaddedKvCacheDeviceOperation::compute_program_hash(
     // slot_idx and valid_global are per-call scalars (patched, NOT hashed). layer_idx, num_layers,
     // cluster_axis, chunk_size_global and pad_align are structural (hashed). Hash the full cache shape.
     const auto& cache = tensor_args.cache;
+    // The tensor-vs-scalar choice changes the reader/writer programs (compile args + which kernel
+    // branch compiles), so hash slot_idx.has_value() to keep the two variants distinct; slot_idx and
+    // valid_global themselves are never hashed on either path.
     return tt::tt_metal::operation::hash_operation<ZeroPaddedKvCacheDeviceOperation>(
+        tensor_args.slot_idx.has_value(),
         args.layer_idx,
         args.num_layers,
         args.cluster_axis,
@@ -182,6 +241,10 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     const auto& cache = tensor_args.cache;
     auto* device = cache.device();
     const auto& cache_shape = cache.padded_shape();
+    const bool has_metadata = tensor_args.slot_idx.has_value();
+    const uint32_t slot_idx_addr = has_metadata ? static_cast<uint32_t>(tensor_args.slot_idx->buffer()->address()) : 0u;
+    const uint32_t valid_global_addr =
+        has_metadata ? static_cast<uint32_t>(tensor_args.valid_global->buffer()->address()) : 0u;
 
     const tt::DataFormat cache_format = datatype_to_dataformat_converter(cache.dtype());
     const bool is_row_major = cache.layout() == Layout::ROW_MAJOR;
@@ -201,6 +264,12 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
 
     // Keep one common-argument layout for both descriptors. Page units are native to the layout:
     // width-tiles for TILE, one complete token row for ROW_MAJOR.
+    // Layout: 0 my_sp_coord, 1 sp_factor, 2 chunk_local(tokens), 3 valid_global, 4 pad_align,
+    //         5 layer_idx, 6 num_layers, 7 Wt, 8 cache_CH_pages (== cache_CHtWt for TILE), 9 slot_idx,
+    //         10 slot_idx_addr, 11 valid_global_addr.
+    // Indices 3/9 are the scalar-path per-call values; 10/11 are the slot_idx/valid_global tensors' raw
+    // DRAM addresses (metadata path, 0 on the scalar path). override_runtime_arguments patches whichever
+    // applies. The metadata (per-element-tensor) path is TILE-only; ROW_MAJOR uses the scalar values.
     const std::vector<uint32_t> common_runtime_args = {
         my_sp_coord,
         sp_factor,
@@ -212,6 +281,8 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
         Wt,
         cache_CH_pages,
         args.slot_idx,
+        slot_idx_addr,
+        valid_global_addr,
     };
 
     if (is_row_major) {
@@ -257,14 +328,33 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     add_cb(kMaskCbIndex, mask_format, mask_tile_size, 1);
     add_cb(kOutCbIndex, cache_format, cache_tile_size, Wt);
     add_cb(kZeroCbIndex, cache_format, cache_tile_size, 1);
+    if (has_metadata) {
+        // Metadata read scratch: a SEPARATE L1 page per kernel. The reader and writer run on the same
+        // core, so sharing one CB would race their concurrent NoC reads (see kMetaCbIndex/...Writer).
+        add_cb(kMetaCbIndex, tt::DataFormat::UInt32, kMetadataBytes, 1);
+        add_cb(kMetaCbIndexWriter, tt::DataFormat::UInt32, kMetadataBytes, 1);
+    }
 
     // Reader: reads cache (TensorAccessor) + builds mask.
     KernelDescriptor reader;
     reader.kernel_source = kReaderKernelPath;
     reader.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader.core_ranges = all_cores;
-    reader.compile_time_args = {kSrcCbIndex, kMaskCbIndex, cache_tile_size};
+    // [3]=has_metadata, [4]=metadata CB index (placeholder 0 on the scalar path). Cache accessor at
+    // <5>; the metadata accessor (when present) is appended after it so the cache-accessor offset is
+    // fixed at <5> for both paths.
+    reader.compile_time_args = {
+        kSrcCbIndex,
+        kMaskCbIndex,
+        cache_tile_size,
+        static_cast<uint32_t>(has_metadata),
+        has_metadata ? kMetaCbIndex : 0u};
     TensorAccessorArgs(cache.buffer()).append_to(reader.compile_time_args);
+    if (has_metadata) {
+        // One metadata accessor, reused for both 1-element tensors (identical layout); the kernel reads
+        // each from its own DRAM address (common args 10/11).
+        TensorAccessorArgs(tensor_args.slot_idx->buffer()).append_to(reader.compile_time_args);
+    }
     reader.config = ReaderConfigDescriptor{};
     reader.common_runtime_args = common_runtime_args;
     reader.emplace_runtime_args(CoreCoord{0, 0}, {cache.buffer()});
@@ -284,8 +374,20 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     writer.kernel_source = kWriterKernelPath;
     writer.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer.core_ranges = all_cores;
-    writer.compile_time_args = {kOutCbIndex, kZeroCbIndex, cache_tile_size};
+    // Same leading layout as the reader: [3]=has_metadata, [4]=metadata CB index, cache accessor at
+    // <5>, then the metadata accessor when present.
+    writer.compile_time_args = {
+        kOutCbIndex,
+        kZeroCbIndex,
+        cache_tile_size,
+        static_cast<uint32_t>(has_metadata),
+        has_metadata ? kMetaCbIndexWriter : 0u};  // writer's OWN metadata CB (disjoint from the reader's)
     TensorAccessorArgs(cache.buffer()).append_to(writer.compile_time_args);
+    if (has_metadata) {
+        // One metadata accessor, reused for both 1-element tensors (identical layout); the kernel reads
+        // each from its own DRAM address (common args 10/11).
+        TensorAccessorArgs(tensor_args.slot_idx->buffer()).append_to(writer.compile_time_args);
+    }
     writer.config = WriterConfigDescriptor{};
     writer.common_runtime_args = common_runtime_args;
     writer.emplace_runtime_args(CoreCoord{0, 0}, {cache.buffer()});
@@ -310,15 +412,35 @@ void ZeroPaddedKvCacheDeviceOperation::MeshWorkloadFactory::override_runtime_arg
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     descriptor_adapter_t::apply_descriptor(cached_workload, args, tensor_args, output);
-    // TILE has reader/compute/writer; ROW_MAJOR is a dataflow-only writer. Patch every kernel in the
-    // selected descriptor without assuming one fixed kernel count.
-    const uint32_t num_kernels = tensor_args.cache.layout() == Layout::ROW_MAJOR ? 1u : 3u;
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        for (uint32_t kernel_handle = 0; kernel_handle < num_kernels; ++kernel_handle) {
-            auto& common = GetCommonRuntimeArgs(program, kernel_handle);
-            TT_FATAL(kSlotIdxCommonArgIdx < common.size(), "zero_padded_kv_cache kernel missing per-call common args");
-            common[kValidGlobalCommonArgIdx] = args.valid_global;
-            common[kSlotIdxCommonArgIdx] = args.slot_idx;
+    // Patch the per-call common args the buffer-binding fast path would otherwise leave stale.
+    //   - metadata (tensor) path [TILE-only]: reader (0) and writer (2) read slot_idx/valid_global
+    //     on-device from the two 1-element tensors, so only their raw DRAM addresses (indices 10/11)
+    //     need patching; compute (1) reads only structural args.
+    //   - scalar path: every kernel reads slot_idx (9)/valid_global (3). TILE has reader/compute/writer
+    //     (3 kernels); ROW_MAJOR is a dataflow-only writer (1 kernel).
+    if (tensor_args.slot_idx.has_value()) {
+        const uint32_t slot_idx_addr = static_cast<uint32_t>(tensor_args.slot_idx->buffer()->address());
+        const uint32_t valid_global_addr = static_cast<uint32_t>(tensor_args.valid_global->buffer()->address());
+        for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+            for (uint32_t kernel_handle : {0u, 2u}) {  // reader, writer (metadata path is TILE-only)
+                auto& common = GetCommonRuntimeArgs(program, kernel_handle);
+                TT_FATAL(
+                    kValidGlobalAddrCommonArgIdx < common.size(),
+                    "zero_padded_kv_cache kernel missing the metadata-tensor addr common args");
+                common[kSlotIdxAddrCommonArgIdx] = slot_idx_addr;
+                common[kValidGlobalAddrCommonArgIdx] = valid_global_addr;
+            }
+        }
+    } else {
+        const uint32_t num_kernels = tensor_args.cache.layout() == Layout::ROW_MAJOR ? 1u : 3u;
+        for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+            for (uint32_t kernel_handle = 0; kernel_handle < num_kernels; ++kernel_handle) {
+                auto& common = GetCommonRuntimeArgs(program, kernel_handle);
+                TT_FATAL(
+                    kSlotIdxCommonArgIdx < common.size(), "zero_padded_kv_cache kernel missing per-call common args");
+                common[kValidGlobalCommonArgIdx] = args.valid_global;
+                common[kSlotIdxCommonArgIdx] = args.slot_idx;
+            }
         }
     }
 }
@@ -329,6 +451,8 @@ namespace ttnn::prim {
 
 ttnn::Tensor zero_padded_kv_cache(
     const ttnn::Tensor& cache,
+    const std::optional<ttnn::Tensor>& slot_idx_tensor,
+    const std::optional<ttnn::Tensor>& valid_global_tensor,
     uint32_t slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
@@ -347,7 +471,8 @@ ttnn::Tensor zero_padded_kv_cache(
         .num_layers = num_layers,
         .cluster_axis = cluster_axis,
     };
-    auto tensor_args = OperationType::tensor_args_t{.cache = cache};
+    auto tensor_args =
+        OperationType::tensor_args_t{.cache = cache, .slot_idx = slot_idx_tensor, .valid_global = valid_global_tensor};
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.hpp
@@ -28,10 +28,12 @@ struct ZeroPaddedKvCacheDeviceOperation {
         //
         // Cache slot is linearized as users-outer, layers-inner: batch_idx = slot_idx*num_layers + layer_idx.
         // layer_idx is hashed (structural): one cached program per layer, reused across users/chunks.
-        // slot_idx and valid_global are per-call scalars held in common runtime args and patched on
-        // cache hits by override_runtime_arguments, so they stay out of the program hash.
-        uint32_t slot_idx;           // per-call (patched, not hashed)
-        uint32_t valid_global;       // per-call (patched, not hashed): # real tokens; window starts here
+        // slot_idx and valid_global are the per-call values for the SCALAR path (used only when no
+        // `metadata` tensor is supplied): common runtime args patched on cache hits, out of the program
+        // hash. On the METADATA path they are unused (0); the reader/writer read slot_idx (= metadata
+        // index 0) and valid_global (= actual_end = metadata index 2) on-device.
+        uint32_t slot_idx;           // scalar path only
+        uint32_t valid_global;       // scalar path only: # real tokens; window starts here
         uint32_t chunk_size_global;  // structural: block-cyclic chunk size (= sp_factor * chunk_local)
         uint32_t pad_align;          // structural: migration read alignment (128); window end = ceil
         uint32_t layer_idx;          // hashed (structural)
@@ -43,6 +45,14 @@ struct ZeroPaddedKvCacheDeviceOperation {
         // In-place: the op reads the boundary tile from the cache, masks it, and writes it back; the
         // full pad tiles are written from the L1 zeros buffer. No separate input tensor.
         const Tensor& cache;
+        // Optional traceable path. When set: two 1-element uint32 DRAM tensors (each replicated across
+        // the mesh, identical [1,1,1,1] layout) — the un-packed per-element views of the runner's
+        // h2d_socket_sync payload [slot_id, actual_start, actual_end]. `slot_idx` holds element 0 and
+        // `valid_global` holds element 2 (= actual_end). The reader/writer read element 0 of each
+        // tensor on-device (traceable path). When empty, the op uses the scalar `slot_idx`/`valid_global`
+        // attributes. Both are set together or both empty.
+        std::optional<Tensor> slot_idx;
+        std::optional<Tensor> valid_global;
     };
 
     using spec_return_value_t = tt::tt_metal::TensorSpec;
@@ -99,8 +109,13 @@ struct ZeroPaddedKvCacheDeviceOperation {
 
 namespace ttnn::prim {
 
+// Unified primitive. The tensors select the path: when both `slot_idx_tensor` and
+// `valid_global_tensor` are set -> traceable on-device read of element 0 of each (the scalar args are
+// ignored, pass 0). Both empty -> scalar path using slot_idx/valid_global.
 ttnn::Tensor zero_padded_kv_cache(
     const ttnn::Tensor& cache,
+    const std::optional<ttnn::Tensor>& slot_idx_tensor,
+    const std::optional<ttnn::Tensor>& valid_global_tensor,
     uint32_t slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache.cpp
@@ -3,10 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "zero_padded_kv_cache.hpp"
+
+#include <optional>
+
 #include "device/zero_padded_kv_cache_device_operation.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache {
 
+// Scalar form: no per-element tensors; slot_idx/valid_global are host scalars.
 ttnn::Tensor zero_padded_kv_cache(
     const ttnn::Tensor& cache,
     uint32_t slot_idx,
@@ -17,7 +21,40 @@ ttnn::Tensor zero_padded_kv_cache(
     uint32_t cluster_axis,
     uint32_t pad_align) {
     return ttnn::prim::zero_padded_kv_cache(
-        cache, slot_idx, layer_idx, num_layers, valid_global, chunk_size_global, cluster_axis, pad_align);
+        cache,
+        /*slot_idx_tensor=*/std::nullopt,
+        /*valid_global_tensor=*/std::nullopt,
+        slot_idx,
+        layer_idx,
+        num_layers,
+        valid_global,
+        chunk_size_global,
+        cluster_axis,
+        pad_align);
+}
+
+// Tensor form: slot_idx/valid_global read on-device from two 1-element uint32 tensors (the scalar
+// attrs are unused).
+ttnn::Tensor zero_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& slot_idx,
+    const ttnn::Tensor& valid_global,
+    uint32_t layer_idx,
+    uint32_t num_layers,
+    uint32_t chunk_size_global,
+    uint32_t cluster_axis,
+    uint32_t pad_align) {
+    return ttnn::prim::zero_padded_kv_cache(
+        cache,
+        slot_idx,
+        valid_global,
+        /*slot_idx=*/0,
+        layer_idx,
+        num_layers,
+        /*valid_global=*/0,
+        chunk_size_global,
+        cluster_axis,
+        pad_align);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
 
@@ -24,15 +25,32 @@ namespace ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache
 // unpack/compute engine.
 //
 // Cache slot is addressed users-outer, layers-inner: batch_idx = slot_idx * num_layers + layer_idx.
-// valid_global and slot_idx are per-call scalars (patched on cache hits, out of the program hash).
-//
-// In-place: returns a handle to `cache`.
+// valid_global and slot_idx stay out of the program hash, so successive chunks reuse one cached
+// program. In-place: returns a handle to `cache`. Two call forms (identical results):
+
+// (1) Scalar form: per-call slot_idx/valid_global are host values (common runtime args, patched on
+//     cache hits).
 ttnn::Tensor zero_padded_kv_cache(
     const ttnn::Tensor& cache,
     uint32_t slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
     uint32_t valid_global,
+    uint32_t chunk_size_global,
+    uint32_t cluster_axis,
+    uint32_t pad_align = 128);
+
+// (2) Tensor form (traceable): the reader/writer read slot_idx and valid_global (= actual_end)
+//     on-device, each from its own 1-element uint32 DRAM tensor (replicated across the mesh). These are
+//     the un-packed per-element views of the runner's h2d_socket_sync payload [slot_id, actual_start,
+//     actual_end] (slot_idx = element 0, valid_global = element 2). Off the host dispatch path, so one
+//     captured program replays across chunks.
+ttnn::Tensor zero_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& slot_idx,
+    const ttnn::Tensor& valid_global,
+    uint32_t layer_idx,
+    uint32_t num_layers,
     uint32_t chunk_size_global,
     uint32_t cluster_axis,
     uint32_t pad_align = 128);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
@@ -14,6 +14,8 @@
 namespace ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache::detail {
 
 void bind_zero_padded_kv_cache(nb::module_& mod) {
+    using ttnn::Tensor;
+    using ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache::zero_padded_kv_cache;
     ttnn::bind_function<"zero_padded_kv_cache", "ttnn.experimental.deepseek_prefill.">(
         mod,
         R"doc(
@@ -32,16 +34,30 @@ void bind_zero_padded_kv_cache(nb::module_& mod) {
             token rows directly, so the payload never enters the unpack/compute engine.
 
             Cache slot is linearized users-outer, layers-inner: batch_idx = slot_idx*num_layers
-            + layer_idx. ``valid_global`` and ``slot_idx`` are per-call scalars patched on cache
-            hits, out of the program hash.
+            + layer_idx. ``valid_global`` and ``slot_idx`` stay out of the program hash, so
+            successive chunks reuse one cached program.
+
+            Two call forms (identical results):
+              - scalar: ``(cache, slot_idx, layer_idx, num_layers, valid_global, chunk_size_global,
+                cluster_axis, pad_align)`` -- host scalars patched on cache hits.
+              - tensor: ``(cache, slot_idx, valid_global, layer_idx, num_layers, chunk_size_global,
+                cluster_axis, pad_align)`` -- ``slot_idx`` and ``valid_global`` are 1-element uint32
+                tensors; the reader/writer read element 0 of each on-device, so they never touch the
+                host dispatch path. This form is trace-safe.
 
             Args:
                 cache (ttnn.Tensor): 4D, DRAM-backed KV cache tensor with head dim 1. Supports
-                    TILE layout, or ROW_MAJOR layout with BF16 or FP8_E4M3 dtype.
-                slot_idx (int): user slot in the batched prefill cache.
+                    TILE layout, or ROW_MAJOR layout with BF16 or FP8_E4M3 dtype. The per-element-tensor
+                    (metadata) form of slot_idx/valid_global below is TILE-only; ROW_MAJOR uses scalars.
+                slot_idx (int, scalar form / ttnn.Tensor, tensor form): user slot in the batched prefill
+                    cache. As a tensor: a 1-element uint32 DRAM tensor (replicated across the mesh, the
+                    runner's h2d_socket_sync payload element 0 [slot_id]); read on-device from element 0.
+                valid_global (int, scalar form / ttnn.Tensor, tensor form): number of real (non-pad)
+                    global tokens; window starts here. As a tensor: a 1-element uint32 DRAM tensor
+                    (replicated across the mesh, the runner's payload element 2 [actual_end]); read
+                    on-device from element 0.
                 layer_idx (int): Transformer layer index for this call (hashed/structural).
                 num_layers (int): Total layers folded into the cache batch dim (structural).
-                valid_global (int): number of real (non-pad) global tokens; window starts here.
                 chunk_size_global (int): block-cyclic chunk size (= sp_factor * chunk_local).
                 cluster_axis (int): Cluster axis along which the cache is sharded (0 or 1).
                 pad_align (int): migration read alignment; window ends at ceil_pad_align (default 128).
@@ -49,15 +65,37 @@ void bind_zero_padded_kv_cache(nb::module_& mod) {
             Returns:
                 ttnn.Tensor: handle to `cache`, pad window zeroed in place.
         )doc",
-        &ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache::zero_padded_kv_cache,
-        nb::arg("cache").noconvert(),
-        nb::arg("slot_idx"),
-        nb::arg("layer_idx"),
-        nb::arg("num_layers"),
-        nb::arg("valid_global"),
-        nb::arg("chunk_size_global"),
-        nb::arg("cluster_axis"),
-        nb::arg("pad_align") = 128);
+        // Scalar form (original signature preserved).
+        ttnn::overload_t(
+            nb::overload_cast<const Tensor&, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t>(
+                &zero_padded_kv_cache),
+            nb::arg("cache").noconvert(),
+            nb::arg("slot_idx"),
+            nb::arg("layer_idx"),
+            nb::arg("num_layers"),
+            nb::arg("valid_global"),
+            nb::arg("chunk_size_global"),
+            nb::arg("cluster_axis"),
+            nb::arg("pad_align") = 128),
+        // Tensor form (traceable): slot_idx + valid_global as 1-element uint32 tensors.
+        ttnn::overload_t(
+            nb::overload_cast<
+                const Tensor&,
+                const Tensor&,
+                const Tensor&,
+                uint32_t,
+                uint32_t,
+                uint32_t,
+                uint32_t,
+                uint32_t>(&zero_padded_kv_cache),
+            nb::arg("cache").noconvert(),
+            nb::arg("slot_idx").noconvert(),
+            nb::arg("valid_global").noconvert(),
+            nb::arg("layer_idx"),
+            nb::arg("num_layers"),
+            nb::arg("chunk_size_global"),
+            nb::arg("cluster_axis"),
+            nb::arg("pad_align") = 128));
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache::detail


### PR DESCRIPTION
Per-element-tensor overload: per-chunk scalars (slot_id / kv_actual_global / valid_global) can be passed as 1-element uint32 DRAM tensors read on-device, so a captured ttnn trace advances them per chunk via an in-place host update. Scalar overload unchanged. Includes the op-equivalence unit test (no trace, no model plumbing). Extracted from the validated rebased branch ppopovic/trace_rebased_on_main.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ppopovic/metadata_zero_padded_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=bppopovic/metadata_zero_padded_kv_cache)
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ppopovic/metadata_zero_padded_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ppopovic/metadata_zero_padded_kv_cache)