### PR TITLE
#45832: update_padded_kv_cache — trace-safe per-element-tensor metadata overload (op + test, no trace)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -29,7 +29,9 @@ KVPE_HEAD_DIM = 576
 
 # (cache dtype, layout). bfloat8_b/bfloat4_b are block-float (TILE only); fp8_e4m3 is ROW_MAJOR only
 # (Blackhole); bf16 covers the row-major page math in a lossless dtype. The tests assert bit-exact
-# equality against the input read back, so no per-dtype tolerance is needed.
+# equality against the input read back, so no per-dtype tolerance is needed. Every case drives the
+# per-element-tensor (metadata) path via the _update_kv helper below -- it is layout-agnostic, since the
+# writer's page-row unit is a compile arg (TILE_HEIGHT for TILE, 1 for ROW_MAJOR).
 DTYPE_LAYOUT_CASES = [
     (ttnn.bfloat8_b, ttnn.TILE_LAYOUT),
     (ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT),
@@ -182,14 +184,16 @@ def test_update_padded_kv_cache_single_device(mesh_device, dtype, layout):
                 .to(torch.bfloat16)
                 .reshape(new_isl_global, KVPE_HEAD_DIM)
             )
-            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            _update_kv(
                 kv_cache,
                 tt_input,
                 slot_idx=u,
+                kv_actual_global=0,
                 layer_idx=l,
                 num_layers=num_layers,
-                kv_actual_global=0,
                 cluster_axis=sp_axis,
+                layout=layout,
+                mesh_device=mesh_device,
             )
 
     ttnn.synchronize_device(mesh_device)
@@ -210,6 +214,42 @@ def test_update_padded_kv_cache_single_device(mesh_device, dtype, layout):
                 f"(max abs diff {(written.float() - expected[(u, l)].float()).abs().max().item()})"
             )
             logger.info(f"  [{dtype}] user {u} layer {l}: exact match")
+
+
+def _make_scalar_tensor(mesh_device, value):
+    """Build one 1-element uint32 DRAM tensor ([1,1,1,1], ROW_MAJOR), replicated across the mesh.
+    The op's per-element-tensor (traceable) path reads element [0] of one such tensor for slot_idx
+    and another for kv_actual_global on-device (no host scalars)."""
+    payload = torch.tensor([value], dtype=torch.int64).reshape(1, 1, 1, 1)
+    return ttnn.from_torch(
+        payload,
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def _make_meta_tensors(mesh_device, kv_actual_global, slot_idx):
+    """Build the two per-element tensors (slot_idx, kv_actual_global) the traceable path consumes."""
+    return _make_scalar_tensor(mesh_device, slot_idx), _make_scalar_tensor(mesh_device, kv_actual_global)
+
+
+def _update_kv(
+    kv_cache, tt_input, *, slot_idx, kv_actual_global, layer_idx, num_layers, cluster_axis, layout, mesh_device
+):
+    """Drive update_padded_kv_cache through the per-element-tensor (metadata) path, which is the path
+    this PR adds and the one traced prefill uses. It is layout-agnostic (the writer's page-row unit is
+    a compile arg: TILE_HEIGHT for TILE, 1 for ROW_MAJOR), so every dtype/layout case runs on it. The
+    scalar path is covered against it by test_update_padded_kv_cache_metadata_matches_scalar."""
+    del layout  # both layouts drive the same (metadata) path; kept for call-site readability
+    slot_t, kv_t = _make_meta_tensors(mesh_device, kv_actual_global=kv_actual_global, slot_idx=slot_idx)
+    ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+        kv_cache, tt_input, slot_t, kv_t, layer_idx=layer_idx, num_layers=num_layers, cluster_axis=cluster_axis
+    )
+    ttnn.deallocate(slot_t)
+    ttnn.deallocate(kv_t)
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 4), (2, 4), (8, 4)], ids=["1x4", "2x4", "8x4"], indirect=True)
@@ -299,14 +339,16 @@ def test_update_padded_kv_cache_single_iteration_prefill(
             )
             # Exact reference: the input read back in natural order (same encode/decode as the cache).
             expected[(u, l)] = ttnn.to_torch(tt_input, mesh_composer=composer).to(torch.bfloat16)[0, 0]
-            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            _update_kv(
                 kv_cache,
                 tt_input,
                 slot_idx=u,
+                kv_actual_global=0,
                 layer_idx=l,
                 num_layers=num_layers,
-                kv_actual_global=0,
                 cluster_axis=sp_axis,
+                layout=layout,
+                mesh_device=mesh_device,
             )
 
     ttnn.synchronize_device(mesh_device)
@@ -508,14 +550,16 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
                 # scatter its valid rows into the natural-order reference.
                 inp_rb = ttnn.to_torch(tt_input, mesh_composer=composer).to(torch.bfloat16)[0, 0]
                 expected[(u, l)][flat_t[valid_rows]] = inp_rb[valid_rows]
-                ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                _update_kv(
                     kv_cache,
                     tt_input,
                     slot_idx=u,
+                    kv_actual_global=kv_actual,
                     layer_idx=l,
                     num_layers=num_layers,
-                    kv_actual_global=kv_actual,
                     cluster_axis=sp_axis,
+                    layout=layout,
+                    mesh_device=mesh_device,
                 )
         kv_actual = valid_end
 
@@ -554,3 +598,176 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
             logger.info(f"  user {u} layer {l}: exact match")
 
     logger.info(f"program cache entries: {mesh_device.num_program_cache_entries()}")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (8, 4),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("dtype, layout", DTYPE_LAYOUT_CASES, ids=DTYPE_LAYOUT_IDS)
+@pytest.mark.timeout(0)
+def test_update_padded_kv_cache_metadata_matches_scalar(mesh_device, dtype, layout):
+    """The per-element-tensor (traceable) path and the scalar path must produce bit-identical caches.
+
+    Drives the traceable path from two 1-element uint32 DRAM tensors (slot_idx, kv_actual_global)
+    that the writer reads on-device, and compares the written cache against the same write done via
+    the original scalar signature. Exact equality (the op is a pure copy and both paths run the
+    identical writer math) over a couple of (slot, start) chunks."""
+    if dtype == ttnn.fp8_e4m3 and not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
+
+    sp_axis, tp_axis = 0, 1
+    sp = mesh_device.shape[sp_axis]
+    tile = ttnn.TILE_SIZE
+
+    num_users, num_layers = 2, 2
+    new_isl_tiles_per_dev = 4
+    cache_tokens_per_dev = 512
+    chunk_local = new_isl_tiles_per_dev * tile  # per-device new tokens
+    chunk_global = chunk_local * sp  # one global chunk
+    cache_global = cache_tokens_per_dev * sp
+
+    input_shard_dims = [None, None]
+    input_shard_dims[sp_axis] = 2  # split the chunk across sp devices
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 1
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape)
+
+    mesh_device.enable_program_cache()
+
+    # (slot, layer, actual_start). Fix layer_idx=0 across cases so every metadata call hits — and must
+    # REUSE — the same cached program; vary (slot, start): two chunk-aligned starts plus one NON-slab-
+    # aligned start (chunk_global + one tile, so boundary chip 0 writes at a whole-tile offset while the
+    # other chips stay on the slab base — the boundary-straddling write otherwise only exercised on the
+    # scalar path). All fit the cache (4 chunks per slot). Program reuse is asserted after the loop.
+    cases = [(0, 0, 0), (1, 0, chunk_global), (0, 0, chunk_global + tile)]
+    entries_after_first = None
+
+    torch.manual_seed(0)
+    for slot_id, layer_idx, actual_start in cases:
+        # 1) The two per-element metadata tensors the traceable path reads on-device.
+        slot_t, kv_t = _make_meta_tensors(mesh_device, kv_actual_global=actual_start, slot_idx=slot_id)
+
+        # 2) One shared KV input slab, and two identical freshly-zeroed caches.
+        slab = torch.randn(chunk_global, KVPE_HEAD_DIM, dtype=torch.bfloat16).reshape(1, 1, chunk_global, KVPE_HEAD_DIM)
+        tt_input = _make_input(
+            slab,
+            dtype,
+            layout,
+            mesh_device,
+            ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims),
+        )
+
+        def _fresh_cache():
+            return init_kvpe_cache(
+                kvpe_cache_head_dim=KVPE_HEAD_DIM,
+                mesh_device=mesh_device,
+                seq_len=cache_global,
+                mesh_shape=list(mesh_device.shape),
+                sp_axis=sp_axis,
+                num_kvpe_cache_layers=num_users * num_layers,
+                dtype=dtype,
+                layout=layout,
+            )
+
+        cache_meta = _fresh_cache()
+        cache_scalar = _fresh_cache()
+
+        # 3) Per-element-tensor path: slot_idx/kv_actual_global read on-device from slot_t/kv_t.
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            cache_meta,
+            tt_input,
+            slot_t,
+            kv_t,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
+            cluster_axis=sp_axis,
+        )
+        # 4) Scalar path: original signature with host scalars.
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            cache_scalar,
+            tt_input,
+            slot_idx=slot_id,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
+            kv_actual_global=actual_start,
+            cluster_axis=sp_axis,
+        )
+        ttnn.synchronize_device(mesh_device)
+
+        # Compare only the VALID WRITTEN region (the chunk just written), not the whole cache: the
+        # unwritten / aligned ROW_MAJOR page-padding cells are uninitialized and read back as
+        # dtype-dependent garbage (e.g. NaN for bf16) that differs between the two separate cache
+        # allocations — exactly what the existing single/multi-iteration tests sidestep. Both paths
+        # run the identical writer with the same slot/offset, so the written region must byte-match.
+        batch_idx = slot_id * num_layers + layer_idx
+        # Per-chip write offset (tokens): chips before the boundary chip advance a full slab, the boundary
+        # chip advances by its whole-tile pad offset, chips after it stay on the slab base. Chunk-aligned
+        # starts make this uniform; the non-slab case makes it differ per chip (boundary chip straddles).
+        # Mirrors the writer's update_idxt so we extract exactly the cells that were written.
+        boundary_slab = actual_start // chunk_global
+        boundary_chip = (actual_start // chunk_local) % sp
+        boundary_offset = actual_start % chunk_local
+
+        def _local_start_row(c):
+            if c < boundary_chip:
+                return (boundary_slab + 1) * chunk_local
+            if c == boundary_chip:
+                return boundary_slab * chunk_local + boundary_offset
+            return boundary_slab * chunk_local
+
+        def _written_slab(cache):
+            host = ttnn.to_torch(cache, mesh_composer=composer).to(torch.float32)[:, :1, :, :]
+            return torch.cat(
+                [
+                    host[
+                        batch_idx,
+                        0,
+                        c * cache_tokens_per_dev
+                        + _local_start_row(c) : c * cache_tokens_per_dev
+                        + _local_start_row(c)
+                        + chunk_local,
+                        :,
+                    ]
+                    for c in range(sp)
+                ],
+                dim=0,
+            )
+
+        meta_slab = _written_slab(cache_meta)
+        scalar_slab = _written_slab(cache_scalar)
+        assert torch.equal(meta_slab, scalar_slab), (
+            f"slot {slot_id} layer {layer_idx} start {actual_start}: per-element-tensor-path written slab differs "
+            f"from scalar-path (max abs diff {(meta_slab - scalar_slab).abs().max().item()})"
+        )
+        logger.success(
+            f"[{dtype}] slot {slot_id} layer {layer_idx} start {actual_start}: "
+            f"per-element-tensor path == scalar path (bit-exact)"
+        )
+        # After the first case both programs (metadata + scalar, at layer 0) are compiled; capture the
+        # count so we can assert no further growth across the remaining (varied slot/start, same layer)
+        # cases — including the non-slab-aligned one.
+        if entries_after_first is None:
+            entries_after_first = mesh_device.num_program_cache_entries()
+        ttnn.deallocate(slot_t)
+        ttnn.deallocate(kv_t)
+        ttnn.deallocate(tt_input)
+
+    # The PR's core property: slot_idx / kv_actual_global are read on-device (never hashed), so successive
+    # metadata-tensor calls at the same layer — including the non-slab-aligned one — reuse the one cached
+    # metadata program (and the one scalar-path program) instead of recompiling per chunk.
+    assert mesh_device.num_program_cache_entries() == entries_after_first, (
+        f"program cache grew across metadata-tensor calls at a fixed layer — the metadata and scalar "
+        f"programs should each compile once and be reused: {entries_after_first} -> "
+        f"{mesh_device.num_program_cache_entries()}"
+    )
+    logger.info(f"program cache stable at {entries_after_first} entries across {len(cases)} metadata-path chunks")

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/reader_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/reader_update_padded_kv_cache.cpp
@@ -28,7 +28,13 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     const auto s = TensorAccessor(src_args, src_addr);
     Noc noc;
-    const uint32_t src_tile_bytes = cb_in0.get_tile_size();
+    // Page bytes must come from the CB's configured page size, NOT get_tile_size(): the op runs in
+    // ROW_MAJOR too, where a page is one token row (head_dim * element bytes) while get_tile_size()
+    // still reports the dtype's 32x32 tile size. Reading tile-size bytes into a row-major page slot
+    // over-reads the source page and overruns the CB in L1 (it scribbled the writer's metadata
+    // scratch, which sits directly after this CB, corrupting the on-device slot_idx /
+    // kv_actual_global read). The writer derives its page bytes the same way.
+    const uint32_t src_page_bytes = get_local_cb_interface(cb_id_in0).fifo_page_size;
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_tiles;
@@ -38,7 +44,7 @@ void kernel_main() {
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
         cb_in0.reserve_back(onetile);
-        noc.async_read(s, cb_in0, src_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        noc.async_read(s, cb_in0, src_page_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
         cb_in0.push_back(onetile);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
@@ -5,22 +5,38 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
 // CB -> cache writer for the per-chip-offset kv-cache update op.
 //
-// Reads the per-call `slot_idx` and `kv_actual_global` from common runtime args (patched on cache
-// hits by the op's MeshWorkloadFactory::override_runtime_arguments) and derives `start_id` from them
-// plus structural common rt-args. Those two values are omitted from the program hash — successive
-// users/chunks reuse one cached program (per layer). `layer_idx`, `num_layers` and `cluster_axis`
-// stay in the hash (structural).
-void kernel_main() {
+// The per-request `slot_idx` and `kv_actual_global` reach the kernel one of two ways, selected by the
+// `has_metadata` compile-time flag (the op sets it from whether the metadata tensors were supplied):
+//   - metadata path: read on-device from two 1-element uint32 DRAM tensors (raw addresses in common
+//     args 8 and 9) -> slot_idx = slot_idx tensor's element [0], kv_actual_global (tokens) =
+//     kv_actual_global tensor's element [0]. The values stay off the host dispatch path, so the op is
+//     traceable and one cached program per layer is reused across users/chunks.
+//   - scalar path: read from common runtime args 8/9 (patched on cache hits by the op's
+//     override_runtime_arguments). Kept out of the program hash the same way.
+// `layer_idx`, `num_layers` and `cluster_axis` stay in the hash (structural) in both paths.
+//
+// Compile args: [0]=cb_id_out, [1]=has_metadata, [2]=cb_id_meta, [3]=tile_height, [4..]=cache
+// accessor, then (metadata path only) ONE metadata accessor (the two 1-element tensors share an
+// identical layout, so the same accessor serves both reads). tile_height divides kv tokens into the
+// page-row unit (TILE_HEIGHT for TILE, 1 for ROW_MAJOR), so one kernel handles both layouts.
+//
+// The body lives in a template on `HasMeta` so the `if constexpr` below actually DISCARDS (does not
+// instantiate) the unused branch — `kernel_main` is not a template, so an `if constexpr` there would
+// still instantiate the metadata branch's TensorAccessor and fail to compile the scalar program.
+template <bool HasMeta>
+static void run_writer() {
     // Per-core runtime args (buffers arrive as Buffer* bindings -> addresses).
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t num_pages = get_arg_val<uint32_t>(1);
     const uint32_t core_blocks_written = get_arg_val<uint32_t>(2);
 
-    // Common runtime args (same for all cores on this chip): structural per cached program.
+    // Common runtime args (same for all cores on this chip). Indices 0-7 are structural; index 8 (and
+    // 9, scalar path) carry the per-request values resolved below.
     const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(0);
     const uint32_t sp_factor = get_common_arg_val<uint32_t>(1);
     const uint32_t chunk_local_t = get_common_arg_val<uint32_t>(2);
@@ -29,15 +45,57 @@ void kernel_main() {
     const uint32_t Wt = get_common_arg_val<uint32_t>(5);
     const uint32_t cache_HtWt = get_common_arg_val<uint32_t>(6);
     const uint32_t cache_CHtWt = get_common_arg_val<uint32_t>(7);
-    // Per-call values, patched on cache hits by override_runtime_arguments (not hashed).
-    const uint32_t slot_idx = get_common_arg_val<uint32_t>(8);
-    const uint32_t kv_actual_global = get_common_arg_val<uint32_t>(9);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t tile_height = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr uint32_t tile_height = get_compile_time_arg_val(3);
+    constexpr auto cache_args = TensorAccessorArgs<4>();
 
-    const uint32_t kv_actual_global_t = kv_actual_global / tile_height;
+    Noc noc;
+
+    // Resolve the two per-request values (slot_idx, and kv_actual_global already divided into the
+    // page-row unit) from whichever source this program was compiled for.
+    uint32_t slot_idx;
+    uint32_t kv_actual_global_t;
+    if constexpr (HasMeta) {
+        // Metadata path: NoC-read element [0] (page 0, 4 bytes) of each 1-element uint32 tensor into
+        // the L1-scratch CB. Each read targets dst offset 0 (DRAM-read dst-alignment: a 4-byte read into
+        // a non-16B-aligned dst offset lands wrong), so we read slot, barrier+extract, then overwrite the
+        // same slot with kv_actual_global. Single reserve_back/push_back (a second reserve_back on a
+        // single-page CB with no intervening pop would deadlock).
+        constexpr uint32_t cb_id_meta = get_compile_time_arg_val(2);
+        constexpr uint32_t kMetadataReadBytes = 4;
+        // ONE metadata accessor follows the cache accessor in the compile args; it serves both 1-element
+        // tensors (identical layout). Gate the offset on HasMeta so this TensorAccessorArgs<> is a
+        // *dependent* template-id: `if constexpr` only skips instantiation of the discarded branch's
+        // template-parameter-dependent constructs, so the scalar program (no metadata accessor) must
+        // not name a fixed out-of-range offset here.
+        constexpr uint32_t kMetaArgsOffset = HasMeta ? cache_args.next_compile_time_args_offset() : 0;
+        constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
+        const uint32_t slot_idx_addr = get_common_arg_val<uint32_t>(8);
+        const uint32_t kv_actual_global_addr = get_common_arg_val<uint32_t>(9);
+        CircularBuffer cb_meta(cb_id_meta);
+        cb_meta.reserve_back(1);
+
+        const auto s_slot = TensorAccessor(meta_args, slot_idx_addr);
+        noc.async_read(s_slot, cb_meta, kMetadataReadBytes, {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        // Metadata tensor is at a FIXED DRAM address reused every chunk; the RISC data cache may hold the
+        // prior chunk's value for this L1 line (barrier orders the DMA, volatile still reads cache). Force
+        // a refetch of the freshly-DMA'd value, else an intermittently stale read corrupts the write.
+        invalidate_l1_cache();
+        slot_idx = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+
+        const auto s_kv = TensorAccessor(meta_args, kv_actual_global_addr);
+        noc.async_read(s_kv, cb_meta, kMetadataReadBytes, {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        invalidate_l1_cache();  // same fresh-metadata refetch as above
+        kv_actual_global_t = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0] / tile_height;
+        cb_meta.push_back(1);
+    } else {
+        // Scalar path: per-call values arrive as common runtime args (patched on cache hits).
+        slot_idx = get_common_arg_val<uint32_t>(8);
+        kv_actual_global_t = get_common_arg_val<uint32_t>(9) / tile_height;
+    }
 
     // Cache linearization: users outer, layers inner.
     const uint32_t batch_idx = slot_idx * num_layers + layer_idx;
@@ -64,11 +122,11 @@ void kernel_main() {
         start_idx + (core_blocks_written / input_Ht) * cache_HtWt + (core_blocks_written % input_Ht) * Wt;
 
     const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
-    Noc noc;
     CircularBuffer cb(cb_id_out);
 
     constexpr uint32_t onepage = 1;
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    // `cache_args` and `noc` are declared above (shared with the optional metadata read).
+    const auto s = TensorAccessor(cache_args, dst_addr);
 
     const uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -78,4 +136,9 @@ void kernel_main() {
         cb.pop_front(onepage);
     }
     noc.async_write_barrier();
+}
+
+void kernel_main() {
+    constexpr bool has_metadata = get_compile_time_arg_val(1);
+    run_writer<has_metadata>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -23,11 +23,16 @@ using namespace tt::constants;
 namespace {
 
 // Reader kernel is reused from the kv_cache fill path — purely (src_addr, num_tiles, src_start) rt-args.
-// Writer is a forked variant that derives `start_id` on-device from the per-call `slot_idx` and
-// `kv_actual_global` (common runtime args patched on cache hits) plus structural common rt-args
-// (`my_sp_coord`/`sp_factor`/`layer_idx` etc.). The per-call scalars are patched by the op's
-// MeshWorkloadFactory::override_runtime_arguments, so the buffer-binding fast cache-hit path stays
-// correct while those values remain out of the program hash.
+// Writer is a forked variant that derives `start_id` on-device from the per-request `slot_idx` and
+// `kv_actual_global` plus the structural common rt-args (`my_sp_coord`/`sp_factor`/`layer_idx` etc.).
+// Those per-request values reach the writer one of two ways (chosen by whether the slot_idx /
+// kv_actual_global tensors are supplied; both keep them out of the program hash so one cached program
+// per layer is reused):
+//   - metadata path: read on-device from two 1-element uint32 DRAM tensors (raw addresses are common
+//     runtime args patched on cache hits) — off the host dispatch path, so the op is traceable.
+//   - scalar path: passed as common runtime args 8/9 and patched on cache hits.
+// MeshWorkloadFactory::override_runtime_arguments patches whichever applies so the buffer-binding fast
+// cache-hit path stays correct.
 constexpr auto kReaderKernelPath =
     "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/"
     "reader_update_padded_kv_cache.cpp";
@@ -37,38 +42,87 @@ constexpr auto kWriterKernelPath =
 
 constexpr uint32_t kSrcCbIndex = 0;
 constexpr uint32_t kNumInputPagesDoubleBuffered = 2;
+// L1-scratch CB the writer reads each 1-element metadata tensor into (element [0], 4 bytes). Both the
+// slot_idx and kv_actual_global tensors share this scratch slot (read sequentially): the writer reads
+// the slot_idx tensor's element [0] then the kv_actual_global tensor's element [0]. Sized to hold a
+// 4B uint32 page; rounded up to a 16B alignment-friendly slot.
+constexpr uint32_t kMetaCbIndex = 1;
+constexpr uint32_t kMetadataBytes = 16;
 
-// Per-call scalar checks shared by the cache-miss and cache-hit paths. slot_idx and kv_actual_global
-// are now host-side scalars (common runtime args patched on cache hits), so the value-range checks
-// dropped when they lived in device tensors can be enforced here again.
+// Runtime-arg checks shared by the cache-miss and cache-hit paths. The structural checks
+// (cluster_axis, layer_idx, 2D mesh) run on both paths. The slot_idx/kv_actual_global value checks
+// run only on the SCALAR path: there those are host values, so range/alignment/overflow can be
+// enforced; on the METADATA path they live in device tensors (can't be read host-side without a
+// device read-back) and are the caller's responsibility (host-side, where the payload is packed).
 void validate_runtime_args(
     const UpdatePaddedKvCacheDeviceOperation::operation_attributes_t& args,
     const UpdatePaddedKvCacheDeviceOperation::tensor_args_t& tensor_args) {
     TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
-    // The writer divides kv_actual_global by TILE_HEIGHT to get its tile offset, so it must be aligned.
     TT_FATAL(
-        args.kv_actual_global % TILE_HEIGHT == 0,
-        "kv_actual_global ({}) must be tile-aligned (a multiple of {})",
-        args.kv_actual_global,
-        TILE_HEIGHT);
+        args.layer_idx < args.num_layers,
+        "layer_idx {} out of range for num_layers {}",
+        args.layer_idx,
+        args.num_layers);
+    // The cache is sharded across a 2D mesh; the kernel derives sp_factor from the mesh extent.
     const auto& cache = tensor_args.cache;
-    const uint32_t num_slots = cache.padded_shape()[0] / args.num_layers;
-    TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
-
-    // This chunk is written at a per-chip offset derived from kv_actual_global; the prior valid KV
-    // plus this chunk must fit the global cache capacity (sp_factor slabs of cache_seq tokens each),
-    // else the write spills past the cache. sp_factor = mesh extent along cluster_axis.
     const auto& mesh_view = cache.device()->get_view();
     TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
-    const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
-    const uint32_t chunk_global_tokens = sp_factor * tensor_args.input.padded_shape()[-2];
-    const uint32_t global_cache_capacity = sp_factor * cache.padded_shape()[-2];
+
+    // Metadata-path invariant: the two per-request tensors are supplied together or not at all.
+    // The path is selected on `slot_idx.has_value()`, but create_descriptor / override_runtime_arguments
+    // dereference `kv_actual_global` unconditionally whenever slot_idx is set — a mismatched optional
+    // state would crash there, so reject it up front with a clear message.
     TT_FATAL(
-        args.kv_actual_global + chunk_global_tokens <= global_cache_capacity,
-        "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({})",
-        args.kv_actual_global,
-        chunk_global_tokens,
-        global_cache_capacity);
+        tensor_args.slot_idx.has_value() == tensor_args.kv_actual_global.has_value(),
+        "metadata tensors slot_idx and kv_actual_global must be supplied together (got slot_idx={}, "
+        "kv_actual_global={})",
+        tensor_args.slot_idx.has_value(),
+        tensor_args.kv_actual_global.has_value());
+    // Validate the structural properties the writer kernel assumes of each metadata tensor (device,
+    // UINT32, ROW_MAJOR, single-element, non-sharded) here, so a malformed tensor fails host-side with a
+    // clear message instead of a hard-to-debug device-side read. Values stay off the host dispatch path.
+    if (tensor_args.slot_idx.has_value()) {
+        auto validate_meta = [&cache](const Tensor& meta, const char* name) {
+            TT_FATAL(meta.storage_type() == StorageType::DEVICE, "metadata tensor {} must be on device", name);
+            TT_FATAL(meta.dtype() == DataType::UINT32, "metadata tensor {} must be UINT32", name);
+            TT_FATAL(meta.layout() == Layout::ROW_MAJOR, "metadata tensor {} must be ROW_MAJOR", name);
+            TT_FATAL(
+                meta.logical_volume() == 1,
+                "metadata tensor {} must be a single element (got {})",
+                name,
+                meta.logical_volume());
+            TT_FATAL(!meta.is_sharded(), "metadata tensor {} must not be sharded", name);
+            // The writer resolves meta.buffer()->address() against cache.device(); a tensor on a
+            // different mesh device would bake the wrong address and fail obscurely downstream.
+            TT_FATAL(meta.device() == cache.device(), "metadata tensor {} must be on the same device as cache", name);
+        };
+        validate_meta(tensor_args.slot_idx.value(), "slot_idx");
+        validate_meta(tensor_args.kv_actual_global.value(), "kv_actual_global");
+    }
+
+    if (!tensor_args.slot_idx.has_value()) {
+        // The writer divides kv_actual_global by TILE_HEIGHT to get its tile offset, so it must be aligned.
+        TT_FATAL(
+            args.kv_actual_global % TILE_HEIGHT == 0,
+            "kv_actual_global ({}) must be tile-aligned (a multiple of {})",
+            args.kv_actual_global,
+            TILE_HEIGHT);
+        const uint32_t num_slots = cache.padded_shape()[0] / args.num_layers;
+        TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
+
+        // This chunk is written at a per-chip offset derived from kv_actual_global; the prior valid KV
+        // plus this chunk must fit the global cache capacity (sp_factor slabs of cache_seq tokens each),
+        // else the write spills past the cache. sp_factor = mesh extent along cluster_axis.
+        const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+        const uint32_t chunk_global_tokens = sp_factor * tensor_args.input.padded_shape()[-2];
+        const uint32_t global_cache_capacity = sp_factor * cache.padded_shape()[-2];
+        TT_FATAL(
+            args.kv_actual_global + chunk_global_tokens <= global_cache_capacity,
+            "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({})",
+            args.kv_actual_global,
+            chunk_global_tokens,
+            global_cache_capacity);
+    }
 }
 
 }  // namespace
@@ -100,6 +154,9 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
     if (input.dtype() == DataType::FP8_E4M3) {
         TT_FATAL(input.layout() == Layout::ROW_MAJOR, "FP8_E4M3 requires ROW_MAJOR layout");
     }
+    // The per-element-tensor (metadata) path works in both layouts: the writer's page-row unit is the
+    // `writer_tile_height` compile arg (TILE_HEIGHT for TILE, 1 for ROW_MAJOR), so no layout guard is
+    // needed here.
 
     const auto& cache_shape = cache.padded_shape();
     const auto& input_shape = input.padded_shape();
@@ -123,23 +180,16 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
         "cache batch dim ({}) must be a multiple of num_layers ({})",
         cache_shape[0],
         args.num_layers);
-    // layer_idx is hashed (structural), so this is a miss-only check and stays valid for the cached
-    // program's lifetime. slot_idx / kv_actual_global value checks live in validate_runtime_args.
-    TT_FATAL(
-        args.layer_idx < args.num_layers,
-        "layer_idx {} out of range for num_layers {}",
-        args.layer_idx,
-        args.num_layers);
-
-    // The 2D-mesh requirement and the per-call value checks (kv tile-alignment, slot range, cache
-    // capacity) are enforced by validate_runtime_args, run on both the cache-miss and cache-hit paths.
+    // The 2D-mesh and cluster_axis/layer_idx structural checks are enforced by validate_runtime_args,
+    // run on both the cache-miss and cache-hit paths. slot_idx / kv_actual_global value checks (range,
+    // tile-alignment, capacity) now live in the metadata tensor and are the caller's responsibility.
     validate_runtime_args(args, tensor_args);
 }
 
 void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx and kv_actual_global are per-call scalars (not hashed) and can differ from the compiled
-    // program's call, so re-validate their ranges every hit. Structural constraints are hashed.
+    // Re-run the non-hashed structural checks on every hit. slot_idx and kv_actual_global are no longer
+    // host attributes — they live in the metadata tensor and are validated host-side by the caller.
     validate_runtime_args(args, tensor_args);
 }
 
@@ -157,18 +207,21 @@ UpdatePaddedKvCacheDeviceOperation::tensor_return_value_t UpdatePaddedKvCacheDev
 
 ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx and kv_actual_global are per-call scalars held in common runtime args and patched on
-    // cache hits, so they are intentionally NOT hashed and successive users/chunks reuse the cached
-    // program. layer_idx IS hashed: it takes only num_layers distinct values, so one program per layer
-    // is reused across users/chunks, and a hashed scalar stays correct on the fast cache-hit path.
-    // num_layers and cluster_axis stay IN: both are structural — they govern the cache slot
-    // linearization and which mesh dim is sp — not per-call data.
+    // slot_idx and kv_actual_global are NEVER hashed on either path (metadata: read on-device; scalar:
+    // common runtime args patched on cache hits), so successive users/chunks reuse the cached program.
+    // The metadata-vs-scalar choice DOES change the program (compile args, common args, which kernel
+    // path compiles), so `slot_idx.has_value()` is hashed to keep the two variants distinct (the
+    // slot_idx and kv_actual_global tensors are always present together).
+    // layer_idx IS hashed: it takes only num_layers distinct values, so one program per layer is reused
+    // across users/chunks. num_layers and cluster_axis stay IN: both are structural — they govern the
+    // cache slot linearization and which mesh dim is sp — not per-call data.
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
     // Hash the full padded shapes, not just their volumes: the descriptor derives Wt, input_Ht,
     // cache_HtWt/CHtWt and the work split from specific dimensions, so two differently-shaped
     // tensors that happen to share a volume must NOT collide onto the same cached program.
     return tt::tt_metal::operation::hash_operation<UpdatePaddedKvCacheDeviceOperation>(
+        tensor_args.slot_idx.has_value(),
         args.layer_idx,
         args.num_layers,
         args.cluster_axis,
@@ -193,6 +246,7 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
     auto* device = input.device();
+    const bool has_metadata = tensor_args.slot_idx.has_value();
 
     const auto& cache_shape = cache.padded_shape();
     const auto& input_shape = input.padded_shape();
@@ -232,6 +286,8 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     const auto& mesh_view = device->get_view();
     const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     const uint32_t my_sp_coord = ::ttnn::ccl::get_linearized_index_from_physical_coord(cache, coord, args.cluster_axis);
+    // On the metadata path slot_idx and kv_actual_global are not host values — the writer kernel reads
+    // element [0] of each per-element tensor and divides kv_actual_global by TILE_HEIGHT on-device.
 
     // Work split: one tile per "block". num_blocks_of_work = input_C * input_Ht (= num_heads * seq_tiles).
     const uint32_t num_blocks_of_work = input_shape[1] * input_Ht;
@@ -253,6 +309,20 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         }}},
     });
 
+    // L1-scratch CB the writer reads each metadata tensor's element into (reused for both reads).
+    // Metadata path only.
+    if (has_metadata) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = kMetadataBytes,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = kMetaCbIndex,
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = kMetadataBytes,
+            }}},
+        });
+    }
+
     // Reader kernel descriptor.
     KernelDescriptor::CompileTimeArgs reader_compile_args;
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_args);
@@ -264,10 +334,21 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     reader_kernel.compile_time_args = std::move(reader_compile_args);
     reader_kernel.config = ReaderConfigDescriptor{};
 
-    // Writer kernel descriptor. Compile args: src CB (read), tile_height (divides kv tokens into the
-    // page-row unit: TILE_HEIGHT for TILE, 1 for ROW_MAJOR), then the cache tensor accessor.
-    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, writer_tile_height};
+    // Writer kernel descriptor. Compile args (uniform leading layout so the kernel offsets are fixed):
+    // [0]=kSrcCbIndex, [1]=has_metadata, [2]=kMetaCbIndex (placeholder 0 on scalar path),
+    // [3]=writer_tile_height, [4..]=cache accessor, then (metadata path only) ONE metadata accessor
+    // (the slot_idx and kv_actual_global tensors share an identical 1-element uint32 replicated-DRAM
+    // layout, so the same TensorAccessorArgs serves both reads). writer_tile_height divides kv tokens
+    // into the page-row unit (TILE_HEIGHT for TILE, 1 for ROW_MAJOR). On the metadata path the writer
+    // reads slot_idx then kv_actual_global (each element [0]) via this accessor against the two raw
+    // addresses in common args 8/9; on the scalar path it reads them directly from common args 8/9.
+    KernelDescriptor::CompileTimeArgs writer_compile_args = {
+        kSrcCbIndex, static_cast<uint32_t>(has_metadata), has_metadata ? kMetaCbIndex : 0u, writer_tile_height};
     TensorAccessorArgs(cache.buffer()).append_to(writer_compile_args);
+    if (has_metadata) {
+        // One accessor reused for both 1-element tensors (identical layout).
+        TensorAccessorArgs(tensor_args.slot_idx->buffer()).append_to(writer_compile_args);
+    }
 
     KernelDescriptor writer_kernel;
     writer_kernel.kernel_source = kWriterKernelPath;
@@ -278,26 +359,46 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     // Common rt-args: per-chip kernel inputs for on-device update_idxt + start_id derivation. Indices
     // 0-7 are structural (constant for this cached program): my_sp_coord/sp_factor are this chip's mesh
-    // position, layer_idx is hashed. slot_idx (8) and kv_actual_global (9) are the per-call values
-    // patched on cache hits by override_runtime_arguments. The kernel composes
-    // batch_idx = slot_idx*num_layers + layer_idx.
-    writer_kernel.emplace_common_runtime_args({
-        my_sp_coord,
-        sp_factor,
-        input_Ht,
-        args.layer_idx,
-        args.num_layers,
-        Wt,
-        cache_HtWt,
-        cache_CHtWt,
-        args.slot_idx,
-        args.kv_actual_global,
-    });
+    // position, layer_idx is hashed. Indices 8 and 9 carry the per-call values that
+    // override_runtime_arguments patches on cache hits (the buffer-binding fast path leaves them
+    // stale otherwise): metadata path -> [8]=slot_idx tensor's raw DRAM address,
+    // [9]=kv_actual_global tensor's raw DRAM address; scalar path -> [8]=slot_idx, [9]=kv_actual_global.
+    // The kernel composes batch_idx = slot_idx*num_layers + layer_idx.
+    if (has_metadata) {
+        const uint32_t slot_idx_addr = tensor_args.slot_idx->buffer()->address();
+        const uint32_t kv_actual_global_addr = tensor_args.kv_actual_global->buffer()->address();
+        writer_kernel.emplace_common_runtime_args({
+            my_sp_coord,
+            sp_factor,
+            input_Ht,
+            args.layer_idx,
+            args.num_layers,
+            Wt,
+            cache_HtWt,
+            cache_CHtWt,
+            slot_idx_addr,          // smuggled-rta-ok: 1-element metadata tensor DRAM addr; the writer reads
+                                    // slot_idx on-device from it (trace-safe; value kept out of the program hash)
+            kv_actual_global_addr,  // smuggled-rta-ok: 1-element metadata tensor DRAM addr; read on-device
+        });
+    } else {
+        writer_kernel.emplace_common_runtime_args({
+            my_sp_coord,
+            sp_factor,
+            input_Ht,
+            args.layer_idx,
+            args.num_layers,
+            Wt,
+            cache_HtWt,
+            cache_CHtWt,
+            args.slot_idx,
+            args.kv_actual_global,
+        });
+    }
 
-    // Per-core runtime args. Buffers are passed as Buffer* bindings (not raw addresses) so cache hits
-    // take the fast path that patches addresses and skips create_descriptor. The per-call scalars
-    // (slot_idx, kv_actual_global) are common args patched by override_runtime_arguments, so no per-core
-    // scalar goes stale.
+    // Per-core runtime args. The input/cache buffers are passed as Buffer* bindings (not raw
+    // addresses) so cache hits take the fast path that patches addresses and skips create_descriptor.
+    // The metadata buffers' raw addresses are common args patched by override_runtime_arguments (the
+    // fast path does not refresh raw-address common args), so no per-core scalar goes stale.
     auto* src_buffer = input.buffer();
     auto* dst_buffer = cache.buffer();
     const uint32_t g1_numcores = core_group_1.num_cores();
@@ -315,7 +416,7 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         reader_kernel.emplace_runtime_args(core, {src_buffer, num_blocks_per_core * Wt, num_blocks_written * Wt});
 
         // Writer: (dst_addr, num_pages, core_blocks_written) — kernel derives update_idxt + head
-        // offset from the slot_idx/kv_actual_global common args.
+        // offset from the slot_idx/kv_actual_global it reads from the metadata tensors.
         writer_kernel.emplace_runtime_args(core, {dst_buffer, num_blocks_per_core * Wt, num_blocks_written});
 
         num_blocks_written += num_blocks_per_core;
@@ -342,18 +443,23 @@ void UpdatePaddedKvCacheDeviceOperation::MeshWorkloadFactory::override_runtime_a
     tensor_return_value_t& output) {
     // Default adapter behaviour: patch operand buffer-binding addresses on cache hits.
     descriptor_adapter_t::apply_descriptor(cached_workload, args, tensor_args, output);
-    // The writer's common runtime args 8/9 hold slot_idx/kv_actual_global -- the per-call values the
-    // buffer-binding fast path would otherwise leave stale. Patch them on every cached program.
+    // The writer's per-call common runtime args are raw scalars (not Buffer* bindings), so the
+    // buffer-binding fast path would leave them stale across calls. Patch BOTH on every cached
+    // program: metadata path -> arg 8 = slot_idx tensor's raw DRAM address, arg 9 = kv_actual_global
+    // tensor's raw DRAM address (kernel reads element [0] of each on-device); scalar path ->
+    // arg 8 = slot_idx, arg 9 = kv_actual_global.
     constexpr uint32_t kWriterKernelHandle = 1;  // writer is pushed second in create_descriptor
-    constexpr uint32_t kSlotIdxCommonArgIdx = 8;
-    constexpr uint32_t kKvActualGlobalCommonArgIdx = 9;
+    constexpr uint32_t kArg8 = 8;
+    constexpr uint32_t kArg9 = 9;
+    const bool has_metadata = tensor_args.slot_idx.has_value();
+    const uint32_t arg8 = has_metadata ? tensor_args.slot_idx->buffer()->address() : args.slot_idx;
+    const uint32_t arg9 = has_metadata ? tensor_args.kv_actual_global->buffer()->address() : args.kv_actual_global;
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& writer_common = GetCommonRuntimeArgs(program, kWriterKernelHandle);
         TT_FATAL(
-            kKvActualGlobalCommonArgIdx < writer_common.size(),
-            "update_padded_kv_cache writer is missing the slot_idx/kv_actual_global common args");
-        writer_common[kSlotIdxCommonArgIdx] = args.slot_idx;
-        writer_common[kKvActualGlobalCommonArgIdx] = args.kv_actual_global;
+            kArg9 < writer_common.size(), "update_padded_kv_cache writer is missing its per-call common runtime args");
+        writer_common[kArg8] = arg8;
+        writer_common[kArg9] = arg9;
     }
 }
 
@@ -364,10 +470,12 @@ namespace ttnn::prim {
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
+    const std::optional<ttnn::Tensor>& slot_idx_tensor,
+    const std::optional<ttnn::Tensor>& kv_actual_global_tensor,
     uint32_t slot_idx,
+    uint32_t kv_actual_global,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
     uint32_t cluster_axis) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::UpdatePaddedKvCacheDeviceOperation;
@@ -378,7 +486,12 @@ ttnn::Tensor update_padded_kv_cache(
         .num_layers = num_layers,
         .cluster_axis = cluster_axis,
     };
-    auto tensor_args = OperationType::tensor_args_t{.cache = cache, .input = input};
+    auto tensor_args = OperationType::tensor_args_t{
+        .cache = cache,
+        .input = input,
+        .slot_idx = slot_idx_tensor,
+        .kv_actual_global = kv_actual_global_tensor,
+    };
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
@@ -23,11 +23,16 @@ struct UpdatePaddedKvCacheDeviceOperation {
         // Cache slot is linearized as users-outer, layers-inner:
         //   batch_idx = slot_idx * num_layers + layer_idx
         // layer_idx is hashed (structural): it takes only num_layers distinct values, so one cached
-        // program per layer is reused across users and chunks. slot_idx and kv_actual_global are
-        // per-call scalars held in common runtime args and patched on cache hits by
-        // MeshWorkloadFactory::override_runtime_arguments, so they stay out of the program hash.
-        uint32_t slot_idx;          // TODO: move to metadata
-        uint32_t kv_actual_global;  // TODO: move to metadata
+        // program per layer is reused across users and chunks.
+        //
+        // `slot_idx` and `kv_actual_global` are the per-call values for the SCALAR path (used only
+        // when `tensor_args.slot_idx`/`kv_actual_global` are empty). They are common runtime args
+        // patched on cache hits, so they stay out of the program hash. On the METADATA path they are
+        // unused (left 0) and the writer kernel reads them on-device from the per-element metadata
+        // tensors instead — keeping the per-request values off the host dispatch path so the op is
+        // traceable.
+        uint32_t slot_idx;          // scalar path only
+        uint32_t kv_actual_global;  // scalar path only
         uint32_t layer_idx;
         uint32_t num_layers;
         uint32_t cluster_axis;
@@ -36,6 +41,13 @@ struct UpdatePaddedKvCacheDeviceOperation {
     struct tensor_args_t {
         const Tensor& cache;
         const Tensor& input;
+        // Optional, present together on the METADATA path: two 1-element uint32 DRAM tensors,
+        // replicated across the mesh ([1,1,1,1], ROW_MAJOR). `slot_idx` holds the user slot;
+        // `kv_actual_global` holds the prior valid global KV length in tokens (tile-aligned). The
+        // writer kernel reads element [0] of each on-device (traceable path). When both are empty, the
+        // op uses the scalar `slot_idx`/`kv_actual_global` attributes instead.
+        std::optional<Tensor> slot_idx;
+        std::optional<Tensor> kv_actual_global;
     };
 
     using spec_return_value_t = tt::tt_metal::TensorSpec;
@@ -58,8 +70,9 @@ struct UpdatePaddedKvCacheDeviceOperation {
     };
 
     // Wraps the ProgramDescriptor factory so the default adapter patches buffer bindings on cache
-    // hits, and override_runtime_arguments additionally patches the per-call slot_idx/kv_actual_global
-    // scalars (common runtime args) -- the values the buffer-binding fast path would leave stale.
+    // hits, and override_runtime_arguments additionally patches the per-call common runtime args the
+    // buffer-binding fast path would leave stale: the slot_idx/kv_actual_global tensors' raw DRAM
+    // addresses (metadata path) or slot_idx/kv_actual_global scalars (scalar path).
     struct MeshWorkloadFactory {
         using descriptor_adapter_t = ttnn::device_operation::MeshDeviceOperationAdapter<
             DescriptorAdapterOperation>::DescriptorMeshWorkloadAdapter<ProgramFactory>;
@@ -92,13 +105,18 @@ struct UpdatePaddedKvCacheDeviceOperation {
 
 namespace ttnn::prim {
 
+// Unified primitive. The tensor operands select the path: both set -> traceable on-device read
+// (slot_idx/kv_actual_global scalars ignored, pass 0); both empty -> scalar path using the
+// slot_idx/kv_actual_global scalars.
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
+    const std::optional<ttnn::Tensor>& slot_idx_tensor,
+    const std::optional<ttnn::Tensor>& kv_actual_global_tensor,
     uint32_t slot_idx,
+    uint32_t kv_actual_global,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
@@ -3,10 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "update_padded_kv_cache.hpp"
+
+#include <optional>
+
 #include "device/update_padded_kv_cache_device_operation.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache {
 
+// Scalar form: no metadata tensors; slot_idx/kv_actual_global are host scalars.
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
@@ -16,7 +20,37 @@ ttnn::Tensor update_padded_kv_cache(
     uint32_t kv_actual_global,
     uint32_t cluster_axis) {
     return ttnn::prim::update_padded_kv_cache(
-        cache, input, slot_idx, layer_idx, num_layers, kv_actual_global, cluster_axis);
+        cache,
+        input,
+        /*slot_idx_tensor=*/std::nullopt,
+        /*kv_actual_global_tensor=*/std::nullopt,
+        slot_idx,
+        kv_actual_global,
+        layer_idx,
+        num_layers,
+        cluster_axis);
+}
+
+// Per-element-tensor form: slot_idx/kv_actual_global read on-device from the two 1-element tensors
+// (the scalar attrs are unused).
+ttnn::Tensor update_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& slot_idx,
+    const ttnn::Tensor& kv_actual_global,
+    uint32_t layer_idx,
+    uint32_t num_layers,
+    uint32_t cluster_axis) {
+    return ttnn::prim::update_padded_kv_cache(
+        cache,
+        input,
+        slot_idx,
+        kv_actual_global,
+        /*slot_idx=*/0,
+        /*kv_actual_global=*/0,
+        layer_idx,
+        num_layers,
+        cluster_axis);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
@@ -18,18 +18,18 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 // cache before spilling into the next slab.
 //
 // Cache slot is addressed with users-outer, layers-inner linearization — the op composes
-// `batch_idx = slot_idx * num_layers + layer_idx`. For a single-user prefill workload, callers
-// pass `slot_idx = 0` and the desired `layer_idx`.
-//
-// `slot_idx` and `kv_actual_global` are per-call scalars held in common runtime args and patched on
-// cache hits, so their values stay out of the program hash and successive users/chunks reuse one
-// cached program (per layer).
+// `batch_idx = slot_idx * num_layers + layer_idx`. `slot_idx` and `kv_actual_global` (tokens,
+// tile-aligned) stay out of the program hash either way, so successive users/chunks reuse one cached
+// program (per layer).
 //
 // Supports TILE and ROW_MAJOR layouts (the op is a pure page copy; the per-chip offset math is
 // expressed in 32-row-aligned page units, identical for both). `cache` and `input` must share
 // layout and dtype: block-float (bfloat8_b/bfloat4_b) is TILE-only; FP8_E4M3 is ROW_MAJOR-only.
 //
-// In-place: returns a handle to `cache`.
+// In-place: returns a handle to `cache`. Two call forms (identical results):
+
+// (1) Scalar form (original): per-call `slot_idx`/`kv_actual_global` are host values, passed as
+//     common runtime args and patched on cache hits.
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
@@ -37,6 +37,21 @@ ttnn::Tensor update_padded_kv_cache(
     uint32_t layer_idx,
     uint32_t num_layers,
     uint32_t kv_actual_global,
+    uint32_t cluster_axis);
+
+// (2) Per-element-tensor form (traceable): `slot_idx`/`kv_actual_global` are read on-device by the
+//     writer kernel from two 1-element uint32 DRAM tensors ([1,1,1,1], ROW_MAJOR, replicated across
+//     the mesh) — `slot_idx` holds the user slot, `kv_actual_global` holds the prior valid global KV
+//     length in tokens (tile-aligned). The writer reads element [0] of each. Because they never touch
+//     the host dispatch path, this form is trace-safe (one captured program replays across
+//     chunks/users).
+ttnn::Tensor update_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& slot_idx,
+    const ttnn::Tensor& kv_actual_global,
+    uint32_t layer_idx,
+    uint32_t num_layers,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -14,6 +14,8 @@
 namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::detail {
 
 void bind_update_padded_kv_cache(nb::module_& mod) {
+    using ttnn::Tensor;
+    using ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::update_padded_kv_cache;
     ttnn::bind_function<"update_padded_kv_cache", "ttnn.experimental.deepseek_prefill.">(
         mod,
         R"doc(
@@ -29,12 +31,18 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
             In place: returns a handle to `cache`.
 
             Cache slot is linearized users-outer, layers-inner — internally the op composes
-            ``batch_idx = slot_idx * num_layers + layer_idx``. Single-user prefill callers
-            pass ``slot_idx = 0`` and the desired ``layer_idx``.
+            ``batch_idx = slot_idx * num_layers + layer_idx``. ``slot_idx`` and ``kv_actual_global``
+            stay out of the program hash, so successive users/chunks reuse one cached program (per
+            layer).
 
-            ``slot_idx`` and ``kv_actual_global`` are per-call scalars held in common runtime args
-            and patched on cache hits, so their values stay out of the program hash and successive
-            users/chunks reuse one cached program (per layer).
+            Two call forms (identical results):
+              - scalar: ``(cache, input, slot_idx, layer_idx, num_layers, kv_actual_global,
+                cluster_axis)`` — the per-call values are host scalars patched on cache hits.
+              - per-element-tensor: ``(cache, input, slot_idx, kv_actual_global, layer_idx,
+                num_layers, cluster_axis)`` — ``slot_idx`` and ``kv_actual_global`` are 1-element
+                uint32 tensors; the writer kernel reads element [0] of each on-device, so they never
+                touch the host dispatch path. This form is trace-safe (one captured program replays
+                across chunks/users).
 
             Args:
                 cache (ttnn.Tensor): 4D KV cache tensor on device, TILE or ROW_MAJOR layout. Sharded
@@ -44,25 +52,44 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                     Seq dims stay 32-aligned in both layouts.
                 input (ttnn.Tensor): 4D input slab on device, same layout, dtype and head dim as
                     cache. Per-chip seq length = chunk_local.
-                slot_idx (int): user slot in the batched prefill cache.
+                slot_idx (int | ttnn.Tensor): scalar form: user slot in the batched prefill cache.
+                    per-element-tensor form: a 1-element uint32 DRAM tensor ([1,1,1,1], ROW_MAJOR,
+                    replicated across the mesh) whose element [0] is the user slot; read on-device.
+                kv_actual_global (int | ttnn.Tensor): scalar form: prior valid global KV length in
+                    tokens (tile-aligned). per-element-tensor form: a 1-element uint32 DRAM tensor
+                    (same layout as ``slot_idx``) whose element [0] is that length; read on-device.
+                    The caller packs valid values for the tensor form (host-side validation).
                 layer_idx (int): Transformer layer index for this call. Structural (hashed): one
                     cached program per layer is reused across users and chunks.
                 num_layers (int): Total layers folded into the cache batch dim. Structural —
                     fixed for the lifetime of the workload.
-                kv_actual_global (int): prior valid global KV length in tokens. Tile-aligned.
                 cluster_axis (int): Cluster axis along which the cache is sharded (0 or 1).
 
             Returns:
                 ttnn.Tensor: handle to `cache` with the new slab written in place.
         )doc",
-        &ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::update_padded_kv_cache,
-        nb::arg("cache").noconvert(),
-        nb::arg("input").noconvert(),
-        nb::arg("slot_idx"),
-        nb::arg("layer_idx"),
-        nb::arg("num_layers"),
-        nb::arg("kv_actual_global"),
-        nb::arg("cluster_axis"));
+        // Scalar form (original signature preserved).
+        ttnn::overload_t(
+            nb::overload_cast<const Tensor&, const Tensor&, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t>(
+                &update_padded_kv_cache),
+            nb::arg("cache").noconvert(),
+            nb::arg("input").noconvert(),
+            nb::arg("slot_idx"),
+            nb::arg("layer_idx"),
+            nb::arg("num_layers"),
+            nb::arg("kv_actual_global"),
+            nb::arg("cluster_axis")),
+        // Per-element-tensor form (traceable).
+        ttnn::overload_t(
+            nb::overload_cast<const Tensor&, const Tensor&, const Tensor&, const Tensor&, uint32_t, uint32_t, uint32_t>(
+                &update_padded_kv_cache),
+            nb::arg("cache").noconvert(),
+            nb::arg("input").noconvert(),
+            nb::arg("slot_idx").noconvert(),
+            nb::arg("kv_actual_global").noconvert(),
+            nb::arg("layer_idx"),
+            nb::arg("num_layers"),
+            nb::arg("cluster_axis")));
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::detail


### PR DESCRIPTION

Per-element-tensor overload: per-chunk scalars (slot_id / kv_actual_global / valid_global) can be passed as 1-element uint32 DRAM tensors read on-device, so a captured ttnn trace advances them per chunk via an in-place host update. Scalar overload unchanged. Includes the op-equivalence unit test (no trace, no model plumbing). Extracted from the validated rebased branch ppopovic/trace_rebased_on_main.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ppopovic/metadata_update_padded_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ppopovic/metadata_update_padded_kv_cache)
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ppopovic/metadata_update_padded_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ppopovic/metadata_update_padded_kv_cache)

(Random failures on CI)