### PR TITLE
#45830: ring_mla — trace-safe per-element-tensor metadata overload (op + test, no trace)

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -492,7 +492,7 @@ class RingJointSDPARuntime:
     compute_kernel_config: object
 
 
-def open_ring_joint_sdpa_runtime(mesh_config, *, fp32_dest_acc_en: bool = False):
+def open_ring_joint_sdpa_runtime(mesh_config, *, fp32_dest_acc_en: bool = False, trace_region_size: int = 0):
     use_ring = mesh_config.sp_size > 2
     fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
     topology = Topology.Ring if use_ring else Topology.Linear
@@ -516,7 +516,9 @@ def open_ring_joint_sdpa_runtime(mesh_config, *, fp32_dest_acc_en: bool = False)
         )
 
         mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
-        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+        # trace_region_size defaults to 0 (no trace region), leaving every existing caller unchanged; only
+        # the trace-replay test asks for one.
+        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, trace_region_size=trace_region_size)
 
         full_compute_grid = mesh_device.compute_with_storage_grid_size()
         ccl_sub_device_crs = ttnn.CoreRangeSet(
@@ -3070,10 +3072,11 @@ def _make_ring_mla_scalar_tensor(mesh_device, value):
     )
 
 
-def _make_ring_mla_metadata(mesh_device, slot_id, actual_start, actual_end):
+def _make_ring_mla_metadata(mesh_device, slot_id, actual_start):
     """Build the two 1-element uint32 DRAM tensors the trace-safe ring_mla reads on-device: slot_id
-    (was metadata[0]) and kv_actual_isl == actual_start (was metadata[1]). actual_end is unused by the
-    op (logical_n is still passed as a host arg). Returns (slot_id_tensor, kv_actual_isl_tensor)."""
+    (was metadata[0]) and kv_actual_isl == actual_start (was metadata[1]). Returns
+    (slot_id_tensor, kv_actual_isl_tensor). The runner's canonical h2d payload also carries actual_end,
+    but this op never reads it (logical_n stays a host arg), so it is not a parameter here."""
     return (
         _make_ring_mla_scalar_tensor(mesh_device, slot_id),
         _make_ring_mla_scalar_tensor(mesh_device, actual_start),
@@ -3142,20 +3145,23 @@ def test_ring_mla_metadata_matches_scalar_indexed(kv_cache_batch_idx):
             device=mesh_device,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_shard_dims),
         )
-        persistent_output_buffer_kv = ttnn.from_torch(
-            torch.zeros(cache_batch, nhk, sq, d_k),
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_shard_dims
-            ),
-        )
 
-        # No rotation here: the whole sq is valid, so actual_start=0, actual_end=logical_n=sq.
-        tt_slot_id, tt_kv_actual_isl = _make_ring_mla_metadata(
-            mesh_device, slot_id=kv_cache_batch_idx, actual_start=0, actual_end=sq
-        )
+        # ring_mla writes into the persistent gather buffer, so each run gets its OWN freshly-zeroed
+        # instance: sharing one across the two runs would let the scalar run's leftovers stand in for
+        # anything the metadata run fails to gather, and the comparison could pass on stale data.
+        def make_persistent_output_buffer_kv():
+            return ttnn.from_torch(
+                torch.zeros(cache_batch, nhk, sq, d_k),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_shard_dims
+                ),
+            )
+
+        # No rotation here: the whole sq is valid, so actual_start=0.
+        tt_slot_id, tt_kv_actual_isl = _make_ring_mla_metadata(mesh_device, slot_id=kv_cache_batch_idx, actual_start=0)
 
         main_row_dim = q_shard_dims[0] if q_shard_dims[0] is not None else -1
         main_col_dim = q_shard_dims[1] if q_shard_dims[1] is not None else -1
@@ -3168,7 +3174,7 @@ def test_ring_mla_metadata_matches_scalar_indexed(kv_cache_batch_idx):
             tt_out, _ = ttnn.transformer.ring_mla(
                 tt_Q,
                 tt_KV,
-                persistent_output_buffer_kv=persistent_output_buffer_kv,
+                persistent_output_buffer_kv=make_persistent_output_buffer_kv(),
                 head_dim_v=d_v,
                 logical_n=sq,
                 is_balanced=False,
@@ -3260,15 +3266,19 @@ def test_ring_mla_metadata_matches_scalar_rotation(kv_actual_isl):
             device=mesh_device,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_shard_dims),
         )
-        persistent_output_buffer_kv = ttnn.from_torch(
-            torch.zeros(b, nhk, sp_size * cache_seq_per_dev, d_k),
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_shard_dims
-            ),
-        )
+
+        # Own instance per run -- ring_mla writes this buffer, so sharing it between the two runs would let
+        # the scalar run's leftovers stand in for anything the metadata run fails to gather.
+        def make_persistent_output_buffer_kv():
+            return ttnn.from_torch(
+                torch.zeros(b, nhk, sp_size * cache_seq_per_dev, d_k),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_shard_dims
+                ),
+            )
 
         program_config = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=runtime.sdpa_compute_grid,
@@ -3276,10 +3286,8 @@ def test_ring_mla_metadata_matches_scalar_rotation(kv_actual_isl):
             k_chunk_size=32,
             exp_approx_mode=False,
         )
-        # metadata tensors: slot_id=0, kv_actual_isl tensor = kv_actual_isl (actual_end=logical_n unused).
-        tt_slot_id, tt_kv_actual_isl = _make_ring_mla_metadata(
-            mesh_device, slot_id=0, actual_start=kv_actual_isl, actual_end=logical_n
-        )
+        # metadata tensors: slot_id=0, kv_actual_isl tensor = kv_actual_isl.
+        tt_slot_id, tt_kv_actual_isl = _make_ring_mla_metadata(mesh_device, slot_id=0, actual_start=kv_actual_isl)
 
         main_row_dim = q_shard_dims[0] if q_shard_dims[0] is not None else -1
         main_col_dim = q_shard_dims[1] if q_shard_dims[1] is not None else -1
@@ -3289,7 +3297,7 @@ def test_ring_mla_metadata_matches_scalar_rotation(kv_actual_isl):
             tt_out, _ = ttnn.transformer.ring_mla(
                 tt_q,
                 tt_kv,
-                persistent_output_buffer_kv=persistent_output_buffer_kv,
+                persistent_output_buffer_kv=make_persistent_output_buffer_kv(),
                 head_dim_v=d_v,
                 logical_n=logical_n,
                 is_balanced=False,
@@ -3321,6 +3329,267 @@ def test_ring_mla_metadata_matches_scalar_rotation(kv_actual_isl):
         )
         logger.success(f"ring_mla rotation kv_actual_isl={kv_actual_isl}: metadata path == scalar path (bit-exact)")
     finally:
+        close_ring_joint_sdpa_runtime(runtime)
+
+
+def _ring_mla_host_scalar_tensor(mesh_device, value):
+    """HOST-side twin of _make_ring_mla_scalar_tensor, for refreshing a metadata tensor in place with
+    ttnn.copy_host_to_device_tensor (the specs must match exactly). Mirrors the runner's own update path."""
+    return ttnn.from_torch(
+        torch.tensor([value], dtype=torch.int64).reshape(1, 1, 1, 1),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+# One captured ring_mla is small; 4 MB is ample headroom for the segment plus its runtime args.
+RING_MLA_TRACE_REGION_SIZE = 4 * 1024 * 1024
+
+
+@pytest.mark.parametrize("num_chunks", [4], ids=["chunks4"])
+def test_ring_mla_metadata_trace_replay_matches_scalar(num_chunks):
+    """ONE captured trace, replayed once per chunk with only the metadata tensors refreshed in place,
+    must match the scalar path chunk-for-chunk.
+
+    This is the coverage the single-dispatch metadata tests structurally cannot provide, and it is the
+    whole point of the metadata path. Both hazards the kernels work around are multi-dispatch phenomena:
+
+      * the op-start NoC drop-to-zero on a reader's FIRST read recurs on every dispatch, so it can appear
+        on replay 3 having been absent on replays 0-2;
+      * the metadata tensors sit at FIXED DRAM addresses that the host rewrites between replays, so a
+        missing invalidate_l1_cache() surfaces as a replay computing from the PRIOR chunk's slot /
+        kv_actual_isl.
+
+    Neither is a small numeric drift: a chunk that replays the previous chunk's kv_actual_isl gathers the
+    wrong KV prefix and mis-maps Q, so a bit-exact comparison fails loudly rather than degrading.
+
+    What makes this discriminating is where the per-chunk geometry comes from. The metadata path is driven
+    exactly as the model drives it (mla.py: `ring_logical_n = global cache capacity` when metadata is
+    set): the host `logical_n` is a CONSTANT placeholder -- full capacity, identical for every chunk --
+    because logical_n is excluded from the program hash and runtime-patched
+    (compute_program_hash: cache_key_logical_n = 0 when rotation is on), and a captured trace freezes
+    runtime args. So the only thing that distinguishes one replay from the next is the metadata tensors,
+    and a replay is correct ONLY IF logical_nt, the q-mapping and the ring masks are truly re-derived
+    on-device from kv_actual_isl. The scalar reference, by contrast, gets the real per-chunk logical_n."""
+    mesh_config = MESH_CONFIG
+    sp_size = mesh_config.sp_size
+    if sp_size < 2:
+        pytest.skip(f"ring_mla requires at least 2 devices in ring, got SP={sp_size}")
+
+    tile_height = 32
+    chunk_size_local = 32
+    chunk_size_global = chunk_size_local * sp_size
+    # Chunk starts drift across cache-slab boundaries (not slab-aligned), so consecutive chunks exercise
+    # different rotation geometry -- a stale kv_actual_isl cannot accidentally produce the right answer.
+    new_actual_isl = chunk_size_global // 2 + tile_height
+    assert new_actual_isl % tile_height == 0 and new_actual_isl <= chunk_size_global
+    total_seq = new_actual_isl * num_chunks
+
+    b, local_heads, nhk = 1, 4, 1
+    nhq = local_heads * mesh_config.tp_size
+    d_q, d_k, d_v = 64, 64, 32
+    cache_batch = 2
+    slot_id = 1  # non-zero: a dropped/stale slot read lands on the garbage slot, not silently on ours
+
+    # Fixed max-sized allocations, exactly as the model does: the buffers are sized for the longest chunk
+    # and only kv_actual_isl grows, so shapes stay constant and a single capture is legitimate.
+    max_cache_slabs = max(2, math.ceil(total_seq / chunk_size_global) + 1)
+    persistent_seq_len = sp_size * max_cache_slabs * chunk_size_local
+    max_input_cache_slabs = max(
+        max(2, math.ceil(((i + 1) * new_actual_isl) / chunk_size_global)) for i in range(num_chunks)
+    )
+    stable_kv_input_seq_len = sp_size * max_input_cache_slabs * chunk_size_local
+    stable_cache_seq_per_dev = stable_kv_input_seq_len // sp_size
+
+    torch.manual_seed(CHUNKED_PREFILL_SEED)
+    q_full = fa_rand(b, nhq, total_seq, d_q)
+    kv_full = fa_rand(b, nhk, total_seq, d_k)
+
+    # Per-chunk host inputs, built up front so both paths see byte-identical device inputs.
+    chunks = []
+    for i in range(num_chunks):
+        kv_actual_isl = i * new_actual_isl
+        logical_n = kv_actual_isl + new_actual_isl
+        q_host, kv_host, valid_rows, kv_valid_per_dev, _ = build_kv_pad_rotation_mla_inputs(
+            kv_full[:, :, :kv_actual_isl, :],
+            q_full[:, :, kv_actual_isl:logical_n, :].contiguous(),
+            kv_full[:, :, kv_actual_isl:logical_n, :].contiguous(),
+            kv_actual_isl,
+            sp_size,
+            chunk_size_local,
+        )
+        cache_seq_per_dev = kv_host.shape[2] // sp_size
+        assert stable_kv_input_seq_len >= kv_host.shape[2] and persistent_seq_len > kv_host.shape[2]
+        # Embed this chunk's rotated KV into the stable physical layout; the untouched remainder is
+        # garbage that must not leak into the result.
+        kv_input_per_dev = torch.randn(cache_batch, nhk, sp_size, stable_cache_seq_per_dev, d_k) * 100
+        active = kv_input_per_dev[slot_id : slot_id + 1, :, :, :cache_seq_per_dev, :]
+        active.copy_(
+            torch.where(
+                kv_valid_per_dev.reshape(1, 1, sp_size, cache_seq_per_dev, 1),
+                kv_host.reshape(1, nhk, sp_size, cache_seq_per_dev, d_k),
+                active,
+            )
+        )
+        chunks.append(
+            {
+                "kv_actual_isl": kv_actual_isl,
+                "logical_n": logical_n,
+                "q_host": q_host,
+                "kv_host": kv_input_per_dev.reshape(cache_batch, nhk, stable_kv_input_seq_len, d_k),
+                "valid_rows": valid_rows,
+            }
+        )
+
+    runtime = open_ring_joint_sdpa_runtime(mesh_config, trace_region_size=RING_MLA_TRACE_REGION_SIZE)
+    mesh_device = runtime.mesh_device
+    sp_axis, tp_axis = runtime.sp_axis, runtime.tp_axis
+    trace_id = None
+    try:
+        mesh_device.enable_program_cache()  # a trace replays cached programs; capture cannot JIT-compile
+
+        q_shard_dims = [None, None]
+        q_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            q_shard_dims[tp_axis] = 1
+        kv_shard_dims = [None, None]
+        kv_shard_dims[sp_axis] = 2
+        persistent_shard_dims = [None, None]
+
+        def host_sharded(host_tensor, dims):
+            return ttnn.from_torch(
+                host_tensor,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=dims),
+            )
+
+        def upload(host_tensor, dims):
+            return ttnn.from_torch(
+                host_tensor,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=dims),
+            )
+
+        # Allocated ONCE. Under trace these addresses are baked into the capture, so every chunk must be
+        # delivered by updating these same buffers in place -- the model's exact discipline.
+        tt_q = upload(chunks[0]["q_host"], q_shard_dims)
+        tt_kv = upload(chunks[0]["kv_host"], kv_shard_dims)
+        persistent_output_buffer_kv = upload(
+            torch.zeros(cache_batch, nhk, persistent_seq_len, d_k), persistent_shard_dims
+        )
+        zeros_persistent_host = host_sharded(
+            torch.zeros(cache_batch, nhk, persistent_seq_len, d_k), persistent_shard_dims
+        )
+        tt_slot_id, tt_kv_actual_isl = _make_ring_mla_metadata(
+            mesh_device, slot_id=slot_id, actual_start=chunks[0]["kv_actual_isl"]
+        )
+
+        def load_chunk(i):
+            """Deliver chunk i the way a traced runner does: in-place refresh of the input and metadata
+            tensors, no reallocation. The gather buffer is re-zeroed so a replay that fails to gather
+            cannot pass on the previous chunk's leftovers."""
+            ttnn.copy_host_to_device_tensor(host_sharded(chunks[i]["q_host"], q_shard_dims), tt_q)
+            ttnn.copy_host_to_device_tensor(host_sharded(chunks[i]["kv_host"], kv_shard_dims), tt_kv)
+            ttnn.copy_host_to_device_tensor(zeros_persistent_host, persistent_output_buffer_kv)
+            ttnn.copy_host_to_device_tensor(_ring_mla_host_scalar_tensor(mesh_device, slot_id), tt_slot_id)
+            ttnn.copy_host_to_device_tensor(
+                _ring_mla_host_scalar_tensor(mesh_device, chunks[i]["kv_actual_isl"]), tt_kv_actual_isl
+            )
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=runtime.sdpa_compute_grid,
+            q_chunk_size=32,
+            k_chunk_size=32,
+            exp_approx_mode=False,
+        )
+        main_row_dim = q_shard_dims[0] if q_shard_dims[0] is not None else -1
+        main_col_dim = q_shard_dims[1] if q_shard_dims[1] is not None else -1
+        composer = ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim))
+
+        def call(*, use_metadata, logical_n, kv_actual_isl):
+            tt_out, _ = ttnn.transformer.ring_mla(
+                tt_q,
+                tt_kv,
+                persistent_output_buffer_kv=persistent_output_buffer_kv,
+                head_dim_v=d_v,
+                logical_n=logical_n,
+                is_balanced=False,
+                program_config=program_config,
+                compute_kernel_config=runtime.compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=runtime.ccl_semaphore_handles,
+                num_links=runtime.num_links,
+                cluster_axis=sp_axis,
+                mesh_device=mesh_device,
+                topology=runtime.topology,
+                subdevice_id=runtime.worker_sub_device_id,
+                ccl_core_grid_offset=(runtime.ccl_column, 0),
+                use_column_major_ccl=True,
+                kv_cache_batch_idx=None if use_metadata else slot_id,
+                kv_actual_isl=None if use_metadata else kv_actual_isl,
+                slot_id=tt_slot_id if use_metadata else None,
+                kv_actual_isl_tensor=tt_kv_actual_isl if use_metadata else None,
+            )
+            return tt_out
+
+        # 1) Scalar reference per chunk (host scalars, eager) -- the ground truth to match.
+        references = []
+        for i, chunk in enumerate(chunks):
+            load_chunk(i)
+            out = call(use_metadata=False, logical_n=chunk["logical_n"], kv_actual_isl=chunk["kv_actual_isl"])
+            references.append(ttnn.to_torch(out, mesh_composer=composer)[:, :, chunk["valid_rows"], :d_v])
+            ttnn.deallocate(out)
+
+        # 2) Compile the metadata-path program, then capture it ONCE. logical_n is the model's constant
+        #    placeholder -- the KV input's global capacity, the same for every chunk (mla.py sets
+        #    ring_logical_n = cache capacity on the metadata path) -- so the capture carries no per-chunk
+        #    information at all and every replay must derive its geometry from the metadata tensors.
+        capture_logical_n = stable_kv_input_seq_len
+        load_chunk(0)
+        warm = call(use_metadata=True, logical_n=capture_logical_n, kv_actual_isl=None)
+        ttnn.synchronize_device(mesh_device)
+        ttnn.deallocate(warm)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        tt_out_traced = call(use_metadata=True, logical_n=capture_logical_n, kv_actual_isl=None)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        # 3) Replay the single capture, refreshing only the inputs + metadata in place before each replay.
+        #    The order is deliberately not just ascending: a forward pass, a descending pass (where a stale
+        #    kv_actual_isl would be too LARGE and over-gather), then an out-of-order pass. Repeated
+        #    dispatches also matter in their own right -- the op-start drop-to-zero recurs per dispatch, so
+        #    more replays is strictly more exposure at ~10ms each.
+        replay_order = list(range(num_chunks)) + list(reversed(range(num_chunks))) + [0, num_chunks - 1, 1]
+        for replay_idx, i in enumerate(replay_order):
+            chunk = chunks[i]
+            load_chunk(i)
+            ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(mesh_device)
+            got = ttnn.to_torch(tt_out_traced, mesh_composer=composer)[:, :, chunk["valid_rows"], :d_v]
+            assert torch.equal(got, references[i]), (
+                f"replay {replay_idx} of order {replay_order}: "
+                f"chunk {i} (kv_actual_isl={chunk['kv_actual_isl']}, real logical_n={chunk['logical_n']}, "
+                f"capture placeholder logical_n={capture_logical_n}): traced metadata replay differs from the "
+                f"scalar path (max abs diff {(got - references[i]).abs().max().item()}). A replay matching "
+                f"chunk {i - 1} instead points at a stale metadata read; zeros point at the op-start "
+                f"drop-to-zero."
+            )
+            logger.info(
+                f"ring_mla trace replay {replay_idx} (chunk {i}, kv_actual_isl={chunk['kv_actual_isl']}): bit-exact"
+            )
+
+        logger.success(
+            f"ring_mla trace: 1 capture, {len(replay_order)} replays over {num_chunks} chunks "
+            f"(order {replay_order}), all bit-exact vs the scalar path"
+        )
+    finally:
+        if trace_id is not None:
+            ttnn.release_trace(mesh_device, trace_id)
         close_ring_joint_sdpa_runtime(runtime)
 
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3033,6 +3033,297 @@ def test_ring_mla_nd_sharded_indexed_kv_cache_accuracy():
     )
 
 
+# ============================================================================
+# TRACE-SAFE METADATA PATH: metadata-path == scalar-path (bit-exact)
+# ============================================================================
+# ring_mla gains an opt-in `metadata` tensor (the runner's canonical h2d_socket_sync payload
+# [slot_id, actual_start, actual_end], replicated uint32 DRAM). When set, the per-chunk scalars
+# (kv_cache_batch_idx = slot_id; kv_actual_isl = actual_start; logical_n = actual_start +
+# chunk_size_global) are read ON-DEVICE from this tensor instead of being baked into the program by
+# the host, so a single captured ttnn trace replays across chunks. These tests assert the metadata
+# path is BIT-IDENTICAL to the classic host-scalar path on every supported case (the op is the same
+# kernel math; only where the scalars come from differs).
+#
+# The migration is incremental (see TRACEABLE_METADATA_PATH.md): each scalar is moved on-device one
+# at a time. `META_PATH_HOST_SCALARS` lists the scalars whose on-device read has NOT landed yet -- a
+# listed scalar is still passed as a host arg on the metadata path so the comparison stays exact.
+# Drop an entry the moment its on-device read is implemented; the bit-exact assert then proves the
+# new on-device computation matches the host one.
+# kv_cache_batch_idx (metadata[0]) and kv_actual_isl (metadata[1]) are BOTH read on-device now (all-gather
+# reader + SDPA reader), so the metadata path passes neither as a host scalar -- the set is empty and the
+# bit-exact assert is fully discriminating. (The rotation test passes kv_actual_isl=None and relies
+# entirely on the on-device derivation, so keeping it in the set was stale/misleading.)
+META_PATH_HOST_SCALARS: set = set()
+
+
+def _make_ring_mla_scalar_tensor(mesh_device, value):
+    """1-element uint32 replicated DRAM tensor ([1,1,1,1]) holding a single per-chunk scalar that the
+    trace-safe ring_mla reads on-device. Mirrors the update_padded_kv_cache / rotary metadata layout."""
+    payload = torch.tensor([value], dtype=torch.int64).reshape(1, 1, 1, 1)
+    return ttnn.from_torch(
+        payload,
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def _make_ring_mla_metadata(mesh_device, slot_id, actual_start, actual_end):
+    """Build the two 1-element uint32 DRAM tensors the trace-safe ring_mla reads on-device: slot_id
+    (was metadata[0]) and kv_actual_isl == actual_start (was metadata[1]). actual_end is unused by the
+    op (logical_n is still passed as a host arg). Returns (slot_id_tensor, kv_actual_isl_tensor)."""
+    return (
+        _make_ring_mla_scalar_tensor(mesh_device, slot_id),
+        _make_ring_mla_scalar_tensor(mesh_device, actual_start),
+    )
+
+
+@pytest.mark.parametrize("kv_cache_batch_idx", [0, 1], ids=["slot0", "slot1"])
+def test_ring_mla_metadata_matches_scalar_indexed(kv_cache_batch_idx):
+    """Indexed K/V cache (no rotation): the metadata path (slot read on-device from metadata[0])
+    must produce a bit-identical output to the scalar path (kv_cache_batch_idx host arg).
+
+    This is the first migration increment -- it exercises kv_cache_batch_idx, which the fused
+    all-gather reader will read from metadata[0]. While 'kv_cache_batch_idx' is still in
+    META_PATH_HOST_SCALARS the metadata path also passes the host scalar, so the only thing under
+    test today is the metadata plumbing (nanobind kwarg + tensor_args + program hash). Once the
+    on-device read lands, drop it from the set and this asserts the on-device slot select."""
+    mesh_config = MESH_CONFIG
+    if mesh_config.sp_size < 2:
+        pytest.skip(f"ring_mla requires at least 2 devices in ring, got SP={mesh_config.sp_size}")
+
+    b, local_heads, per_device_seq_len = 1, 4, 128
+    nhq = local_heads * mesh_config.tp_size
+    nhk = 1
+    sq = per_device_seq_len * mesh_config.sp_size
+    d_q, d_k, d_v = 64, 64, 32
+    cache_batch = 2
+    assert 0 <= kv_cache_batch_idx < cache_batch
+
+    torch.manual_seed(1234)
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    sp_axis, tp_axis = runtime.sp_axis, runtime.tp_axis
+    try:
+        Q = fa_rand(b, nhq, sq, d_q)
+        KV = fa_rand(b, nhk, sq, d_k)
+        # Embed the real K/V at the requested cache slot; other slots are garbage that must not leak.
+        KV_input = fa_rand(cache_batch, nhk, sq, d_k) * 100
+        KV_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = KV
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=runtime.sdpa_compute_grid,
+            q_chunk_size=32,
+            k_chunk_size=32,
+            exp_approx_mode=False,
+        )
+
+        q_shard_dims = [None, None]
+        q_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            q_shard_dims[tp_axis] = 1
+        kv_shard_dims = [None, None]
+        kv_shard_dims[sp_axis] = 2
+        persistent_shard_dims = [None, None]  # gathered KV replicated (single latent head)
+
+        tt_Q = ttnn.from_torch(
+            Q,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=q_shard_dims),
+        )
+        tt_KV = ttnn.from_torch(
+            KV_input,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_shard_dims),
+        )
+        persistent_output_buffer_kv = ttnn.from_torch(
+            torch.zeros(cache_batch, nhk, sq, d_k),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_shard_dims
+            ),
+        )
+
+        # No rotation here: the whole sq is valid, so actual_start=0, actual_end=logical_n=sq.
+        tt_slot_id, tt_kv_actual_isl = _make_ring_mla_metadata(
+            mesh_device, slot_id=kv_cache_batch_idx, actual_start=0, actual_end=sq
+        )
+
+        main_row_dim = q_shard_dims[0] if q_shard_dims[0] is not None else -1
+        main_col_dim = q_shard_dims[1] if q_shard_dims[1] is not None else -1
+        composer = ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim))
+
+        def run(use_metadata):
+            # On the metadata path, a scalar still in META_PATH_HOST_SCALARS is also passed as a host
+            # arg (its on-device read has not landed yet) so the result stays bit-exact.
+            pass_kv_idx = (not use_metadata) or ("kv_cache_batch_idx" in META_PATH_HOST_SCALARS)
+            tt_out, _ = ttnn.transformer.ring_mla(
+                tt_Q,
+                tt_KV,
+                persistent_output_buffer_kv=persistent_output_buffer_kv,
+                head_dim_v=d_v,
+                logical_n=sq,
+                is_balanced=False,
+                program_config=program_config,
+                compute_kernel_config=runtime.compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=runtime.ccl_semaphore_handles,
+                num_links=runtime.num_links,
+                cluster_axis=sp_axis,
+                mesh_device=mesh_device,
+                topology=runtime.topology,
+                subdevice_id=runtime.worker_sub_device_id,
+                ccl_core_grid_offset=(runtime.ccl_column, 0),
+                use_column_major_ccl=True,
+                kv_cache_batch_idx=kv_cache_batch_idx if pass_kv_idx else None,
+                slot_id=tt_slot_id if use_metadata else None,
+                kv_actual_isl_tensor=tt_kv_actual_isl if use_metadata else None,
+            )
+            return ttnn.to_torch(tt_out, mesh_composer=composer)[:, :, :sq, :d_v]
+
+        out_scalar = run(use_metadata=False)
+        out_meta = run(use_metadata=True)
+
+        assert torch.equal(out_scalar, out_meta), (
+            f"slot {kv_cache_batch_idx}: metadata-path ring_mla output differs from scalar-path "
+            f"(max abs diff {(out_scalar - out_meta).abs().max().item()})"
+        )
+        logger.success(f"ring_mla slot {kv_cache_batch_idx}: metadata path == scalar path (bit-exact)")
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
+
+
+@pytest.mark.parametrize("kv_actual_isl", [64, 256, 320], ids=["kv64", "kv256", "kv320"])
+def test_ring_mla_metadata_matches_scalar_rotation(kv_actual_isl):
+    """KV-pad rotation: the metadata path (kv_actual_isl read on-device from metadata[1], with logical_nt
+    / q-mapping / ring masks derived in the reader and handed to compute via cb_kv_pad_derived) must be
+    bit-identical to the scalar path (host kv_actual_isl). This is the discriminating test for the task-4
+    on-device derivation: on the metadata path kv_actual_isl is dropped, so the host CANNOT compute the
+    q-mapping -- it comes solely from the reader's metadata-driven derivation. Both paths run indexed
+    (single-slot) mode at slot 0 so the only difference under test is where kv_actual_isl comes from."""
+    mesh_config = MESH_CONFIG
+    if mesh_config.sp_size < 2:
+        pytest.skip(f"ring_mla requires at least 2 devices in ring, got SP={mesh_config.sp_size}")
+    sp_size = mesh_config.sp_size
+    tile = 32
+    chunk_size_local = 64
+    chunk_size_global = chunk_size_local * sp_size
+    new_actual_isl = chunk_size_global  # one full new chunk
+    assert kv_actual_isl % tile == 0
+
+    b, local_heads = 1, 4
+    nhq = local_heads * mesh_config.tp_size
+    nhk = 1
+    d_q, d_k, d_v = 64, 64, 32
+    logical_n = kv_actual_isl + new_actual_isl
+
+    torch.manual_seed(1234)
+    old_cache_kv = fa_rand(b, nhk, kv_actual_isl, d_k)
+    new_tokens_q = fa_rand(b, nhq, new_actual_isl, d_q)
+    new_tokens_kv = fa_rand(b, nhk, new_actual_isl, d_k)
+    q_host, kv_host, valid_rows, _, num_cache_slabs = build_kv_pad_rotation_mla_inputs(
+        old_cache_kv, new_tokens_q, new_tokens_kv, kv_actual_isl, sp_size, chunk_size_local
+    )
+    cache_seq_per_dev = num_cache_slabs * chunk_size_local
+
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    sp_axis, tp_axis = runtime.sp_axis, runtime.tp_axis
+    try:
+        q_shard_dims = [None, None]
+        q_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            q_shard_dims[tp_axis] = 1
+        kv_shard_dims = [None, None]
+        kv_shard_dims[sp_axis] = 2  # latent K/V sharded along seq across the ring
+        persistent_shard_dims = [None, None]  # gathered KV replicated
+
+        tt_q = ttnn.from_torch(
+            q_host,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=q_shard_dims),
+        )
+        tt_kv = ttnn.from_torch(
+            kv_host,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_shard_dims),
+        )
+        persistent_output_buffer_kv = ttnn.from_torch(
+            torch.zeros(b, nhk, sp_size * cache_seq_per_dev, d_k),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_shard_dims
+            ),
+        )
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=runtime.sdpa_compute_grid,
+            q_chunk_size=32,
+            k_chunk_size=32,
+            exp_approx_mode=False,
+        )
+        # metadata tensors: slot_id=0, kv_actual_isl tensor = kv_actual_isl (actual_end=logical_n unused).
+        tt_slot_id, tt_kv_actual_isl = _make_ring_mla_metadata(
+            mesh_device, slot_id=0, actual_start=kv_actual_isl, actual_end=logical_n
+        )
+
+        main_row_dim = q_shard_dims[0] if q_shard_dims[0] is not None else -1
+        main_col_dim = q_shard_dims[1] if q_shard_dims[1] is not None else -1
+        composer = ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim))
+
+        def run(use_metadata):
+            tt_out, _ = ttnn.transformer.ring_mla(
+                tt_q,
+                tt_kv,
+                persistent_output_buffer_kv=persistent_output_buffer_kv,
+                head_dim_v=d_v,
+                logical_n=logical_n,
+                is_balanced=False,
+                program_config=program_config,
+                compute_kernel_config=runtime.compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=runtime.ccl_semaphore_handles,
+                num_links=runtime.num_links,
+                cluster_axis=sp_axis,
+                mesh_device=mesh_device,
+                topology=runtime.topology,
+                subdevice_id=runtime.worker_sub_device_id,
+                ccl_core_grid_offset=(runtime.ccl_column, 0),
+                use_column_major_ccl=True,
+                # Both paths run indexed at slot 0; the metadata path additionally drops kv_actual_isl so
+                # the q-mapping must be derived on-device from metadata[1].
+                kv_cache_batch_idx=None if use_metadata else 0,
+                kv_actual_isl=None if use_metadata else kv_actual_isl,
+                slot_id=tt_slot_id if use_metadata else None,
+                kv_actual_isl_tensor=tt_kv_actual_isl if use_metadata else None,
+            )
+            return ttnn.to_torch(tt_out, mesh_composer=composer)[:, :, valid_rows, :d_v]
+
+        out_scalar = run(use_metadata=False)
+        out_meta = run(use_metadata=True)
+        assert torch.equal(out_scalar, out_meta), (
+            f"kv_actual_isl={kv_actual_isl}: metadata-path ring_mla output differs from scalar-path "
+            f"(max abs diff {(out_scalar - out_meta).abs().max().item()})"
+        )
+        logger.success(f"ring_mla rotation kv_actual_isl={kv_actual_isl}: metadata path == scalar path (bit-exact)")
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
+
+
 # Generate perf test parameters dynamically based on detected hardware for different models (WAN, MLA, VideGen...)
 TEST_CONFIGS, TEST_CONFIG_IDS = generate_test_configs(MESH_CONFIG, RING_JOINT_PERF_MODEL_CONFIGS)
 TEST_CONFIG_MODELS = list(MODEL_CONFIGS.keys())

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Gather-extent derivation shared by the all-gather reader and writer on the trace-safe metadata path.
+// Both kernels must clamp the gather to the SAME slab prefix or the cb_output producer/consumer page
+// counts drift apart, so the formula lives here in one place instead of being duplicated per kernel.
+//
+// KEEP IN SYNC with the host reference, `compute_gather_valid_Ht`
+// (ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp): on the scalar
+// path the host computes the extent and passes it as a runtime arg, on the metadata path these kernels
+// recompute it on-device from kv_actual_isl. The metadata==scalar bit-exact tests only guard the points
+// they exercise, so a change to one side that is not mirrored in the other diverges silently elsewhere.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace ring_attention_all_gather {
+
+// gather_valid_Ht = ceil(logical_n / chunk_global) * chunk_local_tiles, where
+// logical_nt = kv_actual_isl / TILE_HEIGHT + chunk_global_tiles and chunk_global_tiles =
+// chunk_local_tiles * ring_size. TILE_HEIGHT is 32, hence the >> 5.
+inline uint32_t compute_gather_valid_Ht(uint32_t kv_actual_isl, uint32_t chunk_local_tiles, uint32_t ring_size) {
+    const uint32_t chunk_global_tiles = chunk_local_tiles * ring_size;
+    const uint32_t logical_nt_local = (kv_actual_isl >> 5) + chunk_global_tiles;
+    const uint32_t valid_slabs = (logical_nt_local + chunk_global_tiles - 1) / chunk_global_tiles;
+    return valid_slabs * chunk_local_tiles;
+}
+
+// Shrink each input's page range to the valid slab prefix. Never grows a range: a caller that already
+// has a tighter host-provided end keeps it.
+template <size_t NumInputs>
+inline void clamp_input_ranges_to_gather_extent(
+    uint32_t gather_valid_Ht,
+    const std::array<uint32_t, NumInputs>& input_tensor_Ht,
+    const std::array<uint32_t, NumInputs>& input_tensor_Wt,
+    std::array<uint32_t, NumInputs>& input_tile_id_end) {
+    for (uint32_t input_idx = 0; input_idx < NumInputs; input_idx++) {
+        const uint32_t valid_Ht =
+            gather_valid_Ht < input_tensor_Ht[input_idx] ? gather_valid_Ht : input_tensor_Ht[input_idx];
+        const uint32_t valid_pages = valid_Ht * input_tensor_Wt[input_idx];
+        if (valid_pages < input_tile_id_end[input_idx]) {
+            input_tile_id_end[input_idx] = valid_pages;
+        }
+    }
+}
+
+}  // namespace ring_attention_all_gather

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -10,6 +10,8 @@
 #include "api/tensor/noc_traits.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/metadata_scalar_read.hpp"
+#include "ring_attention_all_gather_metadata.hpp"
 #include <cstdint>
 #include <utility>
 
@@ -169,7 +171,6 @@ void kernel_main() {
     // matching ring_attention_all_gather_async_detail::input_batch_base_pages. The slot_id and
     // kv_actual_isl DRAM addresses are the next two runtime args (emitted before the optional signaler args).
     if constexpr (has_metadata) {
-        constexpr uint32_t kMetadataReadBytes = 4;  // 1-element uint32 page
         // Two 1-element uint32 DRAM tensors: slot_id (was metadata[0]) and kv_actual_isl (was
         // metadata[1]). Each gets its OWN accessor (meta_args / kv_meta_args): they are separately
         // allocated and can land in different DRAM banks, so a shared accessor reads the wrong bank for
@@ -193,54 +194,42 @@ void kernel_main() {
         // the real output CB (as the proven SDPA ring_joint_reader does with cb_q_in) is reliable.
         //
         // Scope of the empirical workarounds here (read-into-output-CB + single-read below): they hold for
-        // the tested configuration -- full worker core grids, ring sizes 1..8, on Blackhole, single dispatch.
-        // The two KNOWN root causes are handled deterministically, not empirically: the wrong-DRAM-bank read
-        // is fixed by kv_meta_args (its own accessor, above), and cross-chunk L1 staleness under trace by the
-        // invalidate_l1_cache() calls after each barrier. The remaining empirical part is the op-start NoC
+        // the tested configuration -- full worker core grids, ring sizes 1..8, on Blackhole, single dispatch
+        // and captured-trace replay. The two KNOWN root causes are handled deterministically, not
+        // empirically: the wrong-DRAM-bank read is fixed by kv_meta_args (its own accessor, above), and
+        // cross-chunk L1 staleness under trace by the invalidate_l1_cache() inside
+        // read_metadata_scalar_u32. The remaining empirical part is the op-start NoC
         // drop-to-zero on the FIRST read; a change to core allocation / ring size / dispatch timing could
         // resurface it, so it is not guaranteed outside the above envelope and wants a silicon root-cause
         // before this path is relied on under those changes.
         CircularBuffer cb_meta(cb_output_id);
         const uint32_t meta_l1 = cb_meta.get_write_ptr();
-        auto mv = CoreLocalMem<volatile uint32_t>(meta_l1);
-        const auto s_slot = TensorAccessor(meta_args, slot_id_addr);
-        meta_noc.async_read(s_slot, CoreLocalMem<uint8_t>(meta_l1), kMetadataReadBytes, {.page_id = 0}, {});
-        meta_noc.async_read_barrier();
-        // The metadata tensor is at a fixed DRAM address reused every chunk (the host updates it in place
-        // between trace replays); async_read_barrier orders the DMA but does NOT invalidate the RISC data
-        // cache, so without this the read can return the prior chunk's stale slot. Mirrors the SDPA reader.
-        invalidate_l1_cache();
-        const uint32_t slot_id = mv[0];
+        // read_metadata_scalar_u32 is the shared protocol (async_read page 0 -> barrier ->
+        // invalidate_l1_cache -> volatile load); the invalidate matters because this tensor sits at a
+        // fixed DRAM address the host refreshes in place between trace replays, so a cached L1 line would
+        // hand back the prior chunk's slot.
+        const uint32_t slot_id = trace_metadata::read_metadata_scalar_u32(meta_noc, meta_args, slot_id_addr, meta_l1);
         const uint32_t cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx;
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             input_batch_base[input_idx] = cache_batch_idx * input_batch_head_count[input_idx] *
                                           input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
         }
-        // Now read kv_actual_isl (reusing meta_l1) and clamp the gather extent.
-        // gather_valid_Ht = ceil(logical_n / chunk_global) * chunk_local_tiles, mirroring the host
-        // compute_gather_valid_Ht. logical_nt = kv_actual/32 + chunk_global_tiles; chunk_global_tiles =
-        // chunk_local_tiles * ring_size. TILE_HEIGHT = 32.
+        // Now read kv_actual_isl (reusing meta_l1) and clamp the gather extent. kv_actual_isl has its OWN
+        // accessor (kv_meta_args): it is a separately-allocated single-page tensor that can land in a
+        // different DRAM bank than slot_id, and a shared accessor's dspec bakes page 0's bank from one
+        // buffer -- reusing meta_args here silently returned the wrong bank's data.
+        //
         // Only the slot read (the kernel's FIRST NoC read, issued at peak op-start contention) suffers the
         // drop-to-zero corruption; this kv read runs a few instructions later once the storm subsides and
         // is reliable with a single read (verified: the rotation tests, which exercise kv_actual != 0, pass
         // with a single read and regress under the max-of-K re-read).
-        const auto s_kv_actual = TensorAccessor(kv_meta_args, kv_actual_isl_addr);
-        meta_noc.async_read(s_kv_actual, CoreLocalMem<uint8_t>(meta_l1), kMetadataReadBytes, {.page_id = 0}, {});
-        meta_noc.async_read_barrier();
-        invalidate_l1_cache();             // fixed-address reused tensor -> refetch the fresh value (see the slot read)
-        const uint32_t kv_actual = mv[0];  // kv_actual_isl (tile-aligned)
-        const uint32_t chunk_global_tiles = chunk_local_tiles * ring_size;
-        const uint32_t logical_nt_local = (kv_actual >> 5) + chunk_global_tiles;
-        const uint32_t valid_slabs = (logical_nt_local + chunk_global_tiles - 1) / chunk_global_tiles;
-        const uint32_t gather_valid_Ht = valid_slabs * chunk_local_tiles;
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            const uint32_t valid_Ht =
-                gather_valid_Ht < input_tensor_Ht[input_idx] ? gather_valid_Ht : input_tensor_Ht[input_idx];
-            const uint32_t valid_pages = valid_Ht * input_tensor_Wt[input_idx];
-            if (valid_pages < input_tile_id_end[input_idx]) {
-                input_tile_id_end[input_idx] = valid_pages;
-            }
-        }
+        const uint32_t kv_actual = trace_metadata::read_metadata_scalar_u32(
+            meta_noc, kv_meta_args, kv_actual_isl_addr, meta_l1);  // kv_actual_isl (tile-aligned)
+        // Shared with the writer, which must clamp to the same prefix (see the header's KEEP IN SYNC note).
+        const uint32_t gather_valid_Ht =
+            ring_attention_all_gather::compute_gather_valid_Ht(kv_actual, chunk_local_tiles, ring_size);
+        ring_attention_all_gather::clamp_input_ranges_to_gather_extent(
+            gather_valid_Ht, input_tensor_Ht, input_tensor_Wt, input_tile_id_end);
     }
 
     OpSignaler op_signaler;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -30,6 +30,13 @@ constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(7);  // 2
 constexpr uint32_t num_inputs = get_compile_time_arg_val(8);
 constexpr bool direction = get_compile_time_arg_val(9);  // 1 is forward, 0 is backward
 constexpr bool fuse_op = get_compile_time_arg_val(10);
+// Trace-safe metadata path: when set, the single-slot gather offset (input_batch_base) is recomputed
+// on-device from slot = slot_id[0] instead of taken from the (trace-frozen) runtime arg. cb_meta_id
+// is a tiny L1 CB for the read page; the metadata accessor's compile args follow the output accessors.
+// slot_id / kv_actual_isl are 1-element uint32 DRAM tensors sharing one accessor. When has_metadata is
+// false neither is emitted and this kernel is bit-identical.
+constexpr bool has_metadata = get_compile_time_arg_val(11);
+constexpr uint32_t cb_meta_id = get_compile_time_arg_val(12);
 
 // Prefetch: batch multiple packets of DRAM reads before a single barrier.
 // This keeps more reads in flight across interleaved DRAM banks, hiding latency.
@@ -89,11 +96,27 @@ FORCE_INLINE void prefetch_batch_read_tiles(
 }
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 11;
+    constexpr uint32_t page_size_base_idx = 13;
     constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<
         num_inputs,
         std::get<num_inputs - 1>(inputs_args).next_compile_time_args_offset()>();
+    // The metadata accessor's compile args follow the output accessors (metadata path only). When
+    // has_metadata is false the metadata accessor is NOT emitted, so fall back to a VALID (but unused)
+    // accessor offset -- the inputs-accessor start -- rather than 0: TensorAccessorArgs<> is instantiated
+    // here unconditionally (it is not a dependent template), and offset 0 names my_chip_id, which fails
+    // the accessor's internal static_assert. meta_args is only *used* inside `if constexpr(has_metadata)`.
+    constexpr uint32_t kMetaArgsOffset = has_metadata
+                                             ? std::get<num_inputs - 1>(outputs_args).next_compile_time_args_offset()
+                                             : (page_size_base_idx + num_inputs);
+    constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();  // slot_id accessor
+    // kv_actual_isl gets its OWN accessor: a separately-allocated single-page DRAM tensor can land in a
+    // DIFFERENT DRAM bank than slot_id, so reusing slot_id's dspec would read the wrong bank for it (the
+    // kv read silently returns 0). Mirrors the SDPA reader's kv_meta_args. The program factory appends it
+    // right after slot_id's accessor when has_metadata; otherwise fall back to meta_args' (valid, unused)
+    // offset so the unconditional TensorAccessorArgs<> never names a non-accessor compile arg.
+    constexpr uint32_t kKvMetaArgsOffset = has_metadata ? meta_args.next_compile_time_args_offset() : kMetaArgsOffset;
+    constexpr auto kv_meta_args = TensorAccessorArgs<kKvMetaArgsOffset>();  // kv_actual_isl accessor
 
     ///////////////////////////////////////////////////
     // ARGS
@@ -139,6 +162,86 @@ void kernel_main() {
     auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx);
     arg_idx += num_inputs;
     auto output_tensor_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
+
+    // Trace-safe single-slot gather: recompute input_batch_base from slot = slot_id[0] on-device,
+    // so a captured trace replays across cache slots (the host runtime-arg input_batch_base, set for the
+    // capture-time slot, would otherwise be frozen). input_batch_base = slot * num_heads * Ht * Wt,
+    // matching ring_attention_all_gather_async_detail::input_batch_base_pages. The slot_id and
+    // kv_actual_isl DRAM addresses are the next two runtime args (emitted before the optional signaler args).
+    if constexpr (has_metadata) {
+        constexpr uint32_t kMetadataReadBytes = 4;  // 1-element uint32 page
+        // Two 1-element uint32 DRAM tensors: slot_id (was metadata[0]) and kv_actual_isl (was
+        // metadata[1]). Each gets its OWN accessor (meta_args / kv_meta_args): they are separately
+        // allocated and can land in different DRAM banks, so a shared accessor reads the wrong bank for
+        // one (the kv_actual read silently returned 0).
+        // Read all metadata runtime args first, in emission order (slot addr, kv addr, chunk_local_tiles,
+        // then the per-layer factor) so OpSignaler downstream sees the correct arg_idx.
+        const uint32_t slot_id_addr = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t kv_actual_isl_addr = get_arg_val<uint32_t>(arg_idx++);
+        // chunk_local_tiles (per-device Q slab in tiles): recompute the gather extent on-device so the
+        // gather moves only the logical_n-valid prefix even when the host logical_n is a placeholder.
+        const uint32_t chunk_local_tiles = get_arg_val<uint32_t>(arg_idx++);
+        // (user, layer)-major KV-cache batch dim: cache_batch_idx = slot_id * kv_cache_num_layers +
+        // kv_cache_layer_idx (mirrors the SDPA reader / update_padded_kv_cache). slot_id holds only the
+        // user slot. Defaults (1, 0) reduce to slot_id, keeping callers bit-identical.
+        const uint32_t kv_cache_num_layers = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t kv_cache_layer_idx = get_arg_val<uint32_t>(arg_idx++);
+        Noc meta_noc;
+        // Read the metadata scalars into the OUTPUT CB's L1 as scratch (it is allocated but not yet
+        // reserved/filled here; the gather loop below reserves + overwrites it before first use). The tiny
+        // dedicated meta CB (cb_meta_id) gave an intermittent drop-to-zero on ~10% of cores; reading into
+        // the real output CB (as the proven SDPA ring_joint_reader does with cb_q_in) is reliable.
+        //
+        // Scope of the empirical workarounds here (read-into-output-CB + single-read below): they hold for
+        // the tested configuration -- full worker core grids, ring sizes 1..8, on Blackhole, single dispatch.
+        // The two KNOWN root causes are handled deterministically, not empirically: the wrong-DRAM-bank read
+        // is fixed by kv_meta_args (its own accessor, above), and cross-chunk L1 staleness under trace by the
+        // invalidate_l1_cache() calls after each barrier. The remaining empirical part is the op-start NoC
+        // drop-to-zero on the FIRST read; a change to core allocation / ring size / dispatch timing could
+        // resurface it, so it is not guaranteed outside the above envelope and wants a silicon root-cause
+        // before this path is relied on under those changes.
+        CircularBuffer cb_meta(cb_output_id);
+        const uint32_t meta_l1 = cb_meta.get_write_ptr();
+        auto mv = CoreLocalMem<volatile uint32_t>(meta_l1);
+        const auto s_slot = TensorAccessor(meta_args, slot_id_addr);
+        meta_noc.async_read(s_slot, CoreLocalMem<uint8_t>(meta_l1), kMetadataReadBytes, {.page_id = 0}, {});
+        meta_noc.async_read_barrier();
+        // The metadata tensor is at a fixed DRAM address reused every chunk (the host updates it in place
+        // between trace replays); async_read_barrier orders the DMA but does NOT invalidate the RISC data
+        // cache, so without this the read can return the prior chunk's stale slot. Mirrors the SDPA reader.
+        invalidate_l1_cache();
+        const uint32_t slot_id = mv[0];
+        const uint32_t cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx;
+        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+            input_batch_base[input_idx] = cache_batch_idx * input_batch_head_count[input_idx] *
+                                          input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
+        }
+        // Now read kv_actual_isl (reusing meta_l1) and clamp the gather extent.
+        // gather_valid_Ht = ceil(logical_n / chunk_global) * chunk_local_tiles, mirroring the host
+        // compute_gather_valid_Ht. logical_nt = kv_actual/32 + chunk_global_tiles; chunk_global_tiles =
+        // chunk_local_tiles * ring_size. TILE_HEIGHT = 32.
+        // Only the slot read (the kernel's FIRST NoC read, issued at peak op-start contention) suffers the
+        // drop-to-zero corruption; this kv read runs a few instructions later once the storm subsides and
+        // is reliable with a single read (verified: the rotation tests, which exercise kv_actual != 0, pass
+        // with a single read and regress under the max-of-K re-read).
+        const auto s_kv_actual = TensorAccessor(kv_meta_args, kv_actual_isl_addr);
+        meta_noc.async_read(s_kv_actual, CoreLocalMem<uint8_t>(meta_l1), kMetadataReadBytes, {.page_id = 0}, {});
+        meta_noc.async_read_barrier();
+        invalidate_l1_cache();             // fixed-address reused tensor -> refetch the fresh value (see the slot read)
+        const uint32_t kv_actual = mv[0];  // kv_actual_isl (tile-aligned)
+        const uint32_t chunk_global_tiles = chunk_local_tiles * ring_size;
+        const uint32_t logical_nt_local = (kv_actual >> 5) + chunk_global_tiles;
+        const uint32_t valid_slabs = (logical_nt_local + chunk_global_tiles - 1) / chunk_global_tiles;
+        const uint32_t gather_valid_Ht = valid_slabs * chunk_local_tiles;
+        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+            const uint32_t valid_Ht =
+                gather_valid_Ht < input_tensor_Ht[input_idx] ? gather_valid_Ht : input_tensor_Ht[input_idx];
+            const uint32_t valid_pages = valid_Ht * input_tensor_Wt[input_idx];
+            if (valid_pages < input_tile_id_end[input_idx]) {
+                input_tile_id_end[input_idx] = valid_pages;
+            }
+        }
+    }
 
     OpSignaler op_signaler;
     if constexpr (fuse_op) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -14,6 +14,8 @@
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/metadata_scalar_read.hpp"
+#include "ring_attention_all_gather_metadata.hpp"
 #include <cstdint>
 #include <utility>
 
@@ -110,26 +112,18 @@ void kernel_main() {
         const uint32_t chunk_local_tiles = get_arg_val<uint32_t>(arg_idx++);
         Noc meta_noc;
         CircularBuffer cb_meta(cb_meta_id);
-        const auto s_meta = TensorAccessor(meta_args, kv_actual_isl_addr);
-        meta_noc.async_read(s_meta, CoreLocalMem<uint8_t>(cb_meta.get_write_ptr()), 4, {.page_id = 0}, {});
-        meta_noc.async_read_barrier();
-        // Fixed-address reused tensor (host updates it in place between trace replays); async_read_barrier
-        // orders the DMA but not the RISC data cache, so refetch the fresh value. Mirrors the SDPA reader.
-        invalidate_l1_cache();
-        CoreLocalMem<volatile uint32_t> meta(cb_meta.get_write_ptr());
-        const uint32_t kv_actual = meta[0];  // kv_actual_isl (tile-aligned)
-        const uint32_t chunk_global_tiles = chunk_local_tiles * ring_size;
-        const uint32_t logical_nt_local = (kv_actual >> 5) + chunk_global_tiles;
-        const uint32_t valid_slabs = (logical_nt_local + chunk_global_tiles - 1) / chunk_global_tiles;
-        const uint32_t gather_valid_Ht = valid_slabs * chunk_local_tiles;
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            const uint32_t valid_Ht =
-                gather_valid_Ht < input_tensor_Ht[input_idx] ? gather_valid_Ht : input_tensor_Ht[input_idx];
-            const uint32_t valid_pages = valid_Ht * input_tensor_Wt[input_idx];
-            if (valid_pages < input_tile_id_end[input_idx]) {
-                input_tile_id_end[input_idx] = valid_pages;
-            }
-        }
+        // Shared read protocol (async_read page 0 -> barrier -> invalidate_l1_cache -> volatile load). The
+        // invalidate is required, not cosmetic: this tensor is at a fixed DRAM address the host refreshes in
+        // place between trace replays, so a cached L1 line would return the prior chunk's kv_actual_isl and
+        // silently clamp the gather to the wrong prefix.
+        const uint32_t kv_actual = trace_metadata::read_metadata_scalar_u32(
+            meta_noc, meta_args, kv_actual_isl_addr, cb_meta.get_write_ptr());  // kv_actual_isl (tile-aligned)
+        // Same formula the reader uses -- both MUST clamp to the same slab prefix or the cb_output
+        // producer/consumer page counts drift (see the header's KEEP IN SYNC note).
+        const uint32_t gather_valid_Ht =
+            ring_attention_all_gather::compute_gather_valid_Ht(kv_actual, chunk_local_tiles, ring_size);
+        ring_attention_all_gather::clamp_input_ranges_to_gather_extent(
+            gather_valid_Ht, input_tensor_Ht, input_tensor_Wt, input_tile_id_end);
     }
 
     size_t arg_for_fab = arg_idx;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -5,6 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -39,10 +40,22 @@ constexpr uint32_t num_inputs = get_compile_time_arg_val(12);
 constexpr bool direction = get_compile_time_arg_val(13);  // 1 is forward, 0 is backward
 constexpr uint32_t unicast_route_arg0 = get_compile_time_arg_val(14);
 constexpr uint32_t unicast_route_arg1 = get_compile_time_arg_val(15);
+// Trace-safe metadata path: when set, the writer recomputes the gather extent (valid_pages) on-device
+// from kv_actual_isl[0] (a 1-element uint32 DRAM tensor) so it stays matched to the reader's on-device
+// recompute (else they desync under a placeholder host logical_n). When false neither this nor the
+// metadata accessor is emitted.
+constexpr bool has_metadata = get_compile_time_arg_val(16);
+constexpr uint32_t cb_meta_id = get_compile_time_arg_val(17);
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 16;
+    constexpr uint32_t page_size_base_idx = 18;
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
+    // Metadata accessor follows the output accessors (metadata path only); fall back to a valid (unused)
+    // accessor offset when absent so TensorAccessorArgs<> never names a non-accessor compile arg.
+    constexpr uint32_t kMetaArgsOffset = has_metadata
+                                             ? std::get<num_inputs - 1>(outputs_args).next_compile_time_args_offset()
+                                             : (page_size_base_idx + num_inputs);
+    constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
 
     ///////////////////////////////////////////////////
     // ARGS
@@ -85,6 +98,40 @@ void kernel_main() {
     auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx);
     arg_idx += num_inputs;
     auto output_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
+
+    // Trace-safe metadata path: recompute the gather extent (valid_pages) on-device from kv_actual_isl[0]
+    // so it matches the reader's recompute even when the host logical_n is a placeholder. The
+    // kv_actual_isl DRAM address and chunk_local_tiles are the next two runtime args (after the
+    // output-buffer addrs, before the fabric args). Identical formula to the all-gather reader / host
+    // compute_gather_valid_Ht.
+    if constexpr (has_metadata) {
+        // kv_actual_isl is a 1-element uint32 DRAM tensor (was metadata[1]); read its page 0.
+        const uint32_t kv_actual_isl_addr = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t chunk_local_tiles = get_arg_val<uint32_t>(arg_idx++);
+        Noc meta_noc;
+        CircularBuffer cb_meta(cb_meta_id);
+        const auto s_meta = TensorAccessor(meta_args, kv_actual_isl_addr);
+        meta_noc.async_read(s_meta, CoreLocalMem<uint8_t>(cb_meta.get_write_ptr()), 4, {.page_id = 0}, {});
+        meta_noc.async_read_barrier();
+        // Fixed-address reused tensor (host updates it in place between trace replays); async_read_barrier
+        // orders the DMA but not the RISC data cache, so refetch the fresh value. Mirrors the SDPA reader.
+        invalidate_l1_cache();
+        CoreLocalMem<volatile uint32_t> meta(cb_meta.get_write_ptr());
+        const uint32_t kv_actual = meta[0];  // kv_actual_isl (tile-aligned)
+        const uint32_t chunk_global_tiles = chunk_local_tiles * ring_size;
+        const uint32_t logical_nt_local = (kv_actual >> 5) + chunk_global_tiles;
+        const uint32_t valid_slabs = (logical_nt_local + chunk_global_tiles - 1) / chunk_global_tiles;
+        const uint32_t gather_valid_Ht = valid_slabs * chunk_local_tiles;
+        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+            const uint32_t valid_Ht =
+                gather_valid_Ht < input_tensor_Ht[input_idx] ? gather_valid_Ht : input_tensor_Ht[input_idx];
+            const uint32_t valid_pages = valid_Ht * input_tensor_Wt[input_idx];
+            if (valid_pages < input_tile_id_end[input_idx]) {
+                input_tile_id_end[input_idx] = valid_pages;
+            }
+        }
+    }
+
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
     /* Args for overlapped all gather */

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -125,7 +125,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const CoreCoord core_grid_offset,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
     std::optional<uint32_t> input_batch_slice_idx,
-    std::optional<uint32_t> gather_valid_Ht) {
+    std::optional<uint32_t> gather_valid_Ht,
+    std::optional<Tensor> slot_id,
+    std::optional<Tensor> kv_actual_isl,
+    uint32_t chunk_local_tiles,
+    uint32_t kv_cache_num_layers,
+    uint32_t kv_cache_layer_idx) {
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -254,6 +259,34 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         }}},
     });
 
+    // Trace-safe metadata path: when slot_id / kv_actual_isl tensors are supplied, the readers recompute
+    // the single-slot gather offset from slot = slot_id[0] on-device (and the gather extent from
+    // kv_actual_isl[0]). A tiny dedicated CB (c_in3) holds the read page on both the forward and backward
+    // reader cores. Created only when present, so non-metadata callers' programs are bit-identical.
+    const bool has_metadata = slot_id.has_value();
+    const uint32_t meta_cb_index = tt::CB::c_in3;
+    if (has_metadata) {
+        constexpr uint32_t meta_cb_page_size_bytes = 32;  // holds a 1-element uint32 page with headroom
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = meta_cb_page_size_bytes,
+            .core_ranges = sender_forward_core_ranges,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(meta_cb_index),
+                .data_format = tt::DataFormat::RawUInt32,
+                .page_size = meta_cb_page_size_bytes,
+            }}},
+        });
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = meta_cb_page_size_bytes,
+            .core_ranges = sender_backward_core_ranges,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(meta_cb_index),
+                .data_format = tt::DataFormat::RawUInt32,
+                .page_size = meta_cb_page_size_bytes,
+            }}},
+        });
+    }
+
     // Tensor Info
     const uint32_t num_inputs = input_tensor.size();
 
@@ -269,17 +302,19 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     sender_reader_forward_kernel.core_ranges = sender_forward_core_ranges;
     sender_reader_forward_kernel.config = WriterConfigDescriptor{};
     sender_reader_forward_kernel.compile_time_args = {
-        ring_index,                       // my_chip_id
-        sender_forward_cb_index,          // cb_forward_id
-        num_pages_per_packet,             // packet_size_in_pages
-        op_config.get_page_size(),        // tensor0_page_size
-        num_targets_forward,              // num_slices_forward_direction
-        num_targets_backward,             // num_slices_backward_direction
-        static_cast<uint32_t>(topology),  // topology
-        tiles_to_write_per_packet,        // contig_pages_advanced
-        num_inputs,                       // num_inputs
-        1,                                // direction
-        fuse_op,                          // fused op
+        ring_index,                           // my_chip_id
+        sender_forward_cb_index,              // cb_forward_id
+        num_pages_per_packet,                 // packet_size_in_pages
+        op_config.get_page_size(),            // tensor0_page_size
+        num_targets_forward,                  // num_slices_forward_direction
+        num_targets_backward,                 // num_slices_backward_direction
+        static_cast<uint32_t>(topology),      // topology
+        tiles_to_write_per_packet,            // contig_pages_advanced
+        num_inputs,                           // num_inputs
+        1,                                    // direction
+        fuse_op,                              // fused op
+        static_cast<uint32_t>(has_metadata),  // 11 == has_metadata (trace-safe slot select)
+        meta_cb_index,                        // 12 == cb_meta_id
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -290,6 +325,16 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_reader_forward_kernel.compile_time_args);
+    }
+    // Metadata accessor follows the output accessors (metadata path only); matches the reader kernel's
+    // kMetaArgsOffset, which is gated on has_metadata. slot_id and kv_actual_isl each get their OWN
+    // accessor (appended in this order): they are separately-allocated single-page DRAM tensors that can
+    // land in different DRAM banks, so a shared accessor would read the wrong bank for one (the reader's
+    // kv_actual read silently returned 0). See the reader's meta_args / kv_meta_args.
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_forward_kernel.compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_reader_forward_kernel.compile_time_args);
     }
 
@@ -318,12 +363,19 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         1,                                        // direction
         unicast_backward_args[0],                 // unicast route arg0 (dst_mesh_id or 0)
         unicast_backward_args[1],                 // unicast route arg1 (dst_chip_id or distance_in_hops)
+        static_cast<uint32_t>(has_metadata),      // 16 == has_metadata (trace-safe gather-extent recompute)
+        meta_cb_index,                            // 17 == cb_meta_id
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_writer_forward_kernel.compile_time_args);
+    }
+    // Writer reads kv_actual_isl[0] only; append its accessor (same layout as slot_id).
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_writer_forward_kernel.compile_time_args);
     }
 
@@ -337,17 +389,19 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     sender_reader_backward_kernel.core_ranges = sender_backward_core_ranges;
     sender_reader_backward_kernel.config = WriterConfigDescriptor{};
     sender_reader_backward_kernel.compile_time_args = {
-        ring_index,                       // my_chip_id
-        sender_backward_cb_index,         // cb_backward_id
-        num_pages_per_packet,             // packet_size_in_pages
-        op_config.get_page_size(),        // tensor0_page_size
-        num_targets_forward,              // num_slices_forward_direction
-        num_targets_backward,             // num_slices_backward_direction
-        static_cast<uint32_t>(topology),  // topology
-        tiles_to_write_per_packet,        // contig_pages_advanced
-        num_inputs,                       // num_inputs
-        0,                                // direction
-        fuse_op,                          // fused op
+        ring_index,                           // my_chip_id
+        sender_backward_cb_index,             // cb_backward_id
+        num_pages_per_packet,                 // packet_size_in_pages
+        op_config.get_page_size(),            // tensor0_page_size
+        num_targets_forward,                  // num_slices_forward_direction
+        num_targets_backward,                 // num_slices_backward_direction
+        static_cast<uint32_t>(topology),      // topology
+        tiles_to_write_per_packet,            // contig_pages_advanced
+        num_inputs,                           // num_inputs
+        0,                                    // direction
+        fuse_op,                              // fused op
+        static_cast<uint32_t>(has_metadata),  // 11 == has_metadata (trace-safe slot select)
+        meta_cb_index,                        // 12 == cb_meta_id
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -358,6 +412,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_reader_backward_kernel.compile_time_args);
+    }
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_backward_kernel.compile_time_args);
+        // kv_actual_isl gets its OWN accessor (different DRAM bank possible; see the reader's kv_meta_args).
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_reader_backward_kernel.compile_time_args);
     }
 
@@ -386,12 +446,18 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         0,                                         // direction
         unicast_forward_args[0],                   // unicast route arg0 (dst_mesh_id or 0)
         unicast_forward_args[1],                   // unicast route arg1 (dst_chip_id or distance_in_hops)
+        static_cast<uint32_t>(has_metadata),       // 16 == has_metadata (trace-safe gather-extent recompute)
+        meta_cb_index,                             // 17 == cb_meta_id
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_writer_backward_kernel.compile_time_args);
+    }
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_writer_backward_kernel.compile_time_args);
     }
 
@@ -497,13 +563,25 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         reader_forward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_forward_rt_args.push_back(ring_size);                   // ring_size
         reader_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // out_ready_semaphore_backward
+            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
         reader_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(input_tensor[input_idx].buffer());
         }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(output_tensor[input_idx].buffer());
+        }
+        // slot_id + kv_actual_isl DRAM addresses + chunk_local_tiles (read by the reader before the
+        // optional signaler args; metadata path only). The reader reads slot = slot_id[0] for the gather
+        // slot and kv_actual = kv_actual_isl[0] for the gather extent; chunk_local_tiles lets it recompute
+        // the gather extent on-device.
+        if (has_metadata) {
+            reader_forward_rt_args.push_back(slot_id->buffer());
+            reader_forward_rt_args.push_back(kv_actual_isl->buffer());
+            reader_forward_rt_args.push_back(chunk_local_tiles);
+            // (user, layer)-major slot factor; read by the reader right after chunk_local_tiles.
+            reader_forward_rt_args.push_back(kv_cache_num_layers);
+            reader_forward_rt_args.push_back(kv_cache_layer_idx);
         }
         if (fuse_op) {
             std::vector<uint32_t> reader_forward_signaler_args;
@@ -517,13 +595,21 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         reader_backward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_backward_rt_args.push_back(ring_size);                   // ring_size
         reader_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // out_ready_semaphore_backward
+            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
         reader_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(input_tensor[input_idx].buffer());
         }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(output_tensor[input_idx].buffer());
+        }
+        if (has_metadata) {
+            reader_backward_rt_args.push_back(slot_id->buffer());
+            reader_backward_rt_args.push_back(kv_actual_isl->buffer());
+            reader_backward_rt_args.push_back(chunk_local_tiles);
+            // (user, layer)-major slot factor; read by the reader right after chunk_local_tiles.
+            reader_backward_rt_args.push_back(kv_cache_num_layers);
+            reader_backward_rt_args.push_back(kv_cache_layer_idx);
         }
         if (fuse_op) {
             std::vector<uint32_t> reader_backward_signaler_args;
@@ -545,10 +631,16 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.y));  // out_ready_sem_noc0_y
         writer_forward_rt_args.push_back(ring_size);                                            // ring_size
         writer_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // out_ready_semaphore_backward
+            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
         writer_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_forward_rt_args.push_back(output_tensor[input_idx].buffer());
+        }
+        // kv_actual_isl DRAM address + chunk_local_tiles (read by the writer after the output-buffer addrs
+        // and before the fabric args; metadata path only) for the on-device gather-extent recompute.
+        if (has_metadata) {
+            writer_forward_rt_args.push_back(kv_actual_isl->buffer());
+            writer_forward_rt_args.push_back(chunk_local_tiles);
         }
         writer_forward_rt_args.push_back(0u);
         writer_forward_rt_args.push_back(static_cast<uint32_t>(backward_device_coord.has_value()));
@@ -581,10 +673,14 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             static_cast<uint32_t>(sender_backward_worker_core.y));  // out_ready_sem_noc0_y
         writer_backward_rt_args.push_back(ring_size);               // ring_size
         writer_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // out_ready_semaphore_backward
+            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
         writer_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_backward_rt_args.push_back(output_tensor[input_idx].buffer());
+        }
+        if (has_metadata) {
+            writer_backward_rt_args.push_back(kv_actual_isl->buffer());
+            writer_backward_rt_args.push_back(chunk_local_tiles);
         }
         writer_backward_rt_args.push_back(static_cast<uint32_t>(forward_device_coord.has_value()));
         std::vector<uint32_t> writer_backward_extra_args;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -88,6 +88,23 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // only the valid (e.g. logical_n-sized) prefix. Capped to the input height per gathered tensor.
     // std::nullopt => gather the full input (default). The fused ring_joint_sdpa path also re-patches
     // this per dispatch on cache hits (see apply_ring_joint_scalar_runtime_args).
-    std::optional<uint32_t> gather_valid_Ht = std::nullopt);
+    std::optional<uint32_t> gather_valid_Ht = std::nullopt,
+    // Trace-safe slot select: when set (with input_batch_slice_idx engaged), the readers recompute the
+    // single-slot gather offset from slot = slot_id[0] on-device, so a captured trace replays across
+    // cache slots. slot_id / kv_actual_isl are 1-element uint32 DRAM tensors (were metadata[0] /
+    // metadata[1]); the reader uses slot_id[0] for the gather slot and kv_actual_isl[0] for the gather
+    // extent, and the writer uses kv_actual_isl[0]. std::nullopt => take the host input_batch_base
+    // (default; existing callers unaffected). Both must be supplied together on the metadata path.
+    std::optional<Tensor> slot_id = std::nullopt,
+    std::optional<Tensor> kv_actual_isl = std::nullopt,
+    // Per-device Q slab in tiles (metadata path only): lets the reader/writer recompute the gather extent
+    // (gather_valid_Ht) from kv_actual_isl[0] on-device, so the gather stays bounded even when the host
+    // logical_n is a placeholder. Unused when slot_id is absent.
+    uint32_t chunk_local_tiles = 0,
+    // (user, layer)-major KV-cache batch dim (metadata path only): the reader computes the gathered
+    // cache slot as slot * kv_cache_num_layers + kv_cache_layer_idx (slot = slot_id[0]), matching
+    // update_padded_kv_cache. Defaults (1, 0) reduce to slot, so single-layer callers are unaffected.
+    uint32_t kv_cache_num_layers = 1,
+    uint32_t kv_cache_layer_idx = 0);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -9,6 +9,7 @@
 
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/cb_api.h"  // ckernel::read_tile_value (UNPACK-mailbox CB scalar read; no cb_interface)
 #include <tt-metalium/constants.hpp>
 #include "compute_common.hpp"
 #include "compute_streaming.hpp"
@@ -113,12 +114,14 @@ void kernel_main() {
     const uint32_t ring_index_runtime = get_arg_val<uint32_t>(argidx++);
     const uint32_t forward_writes_expected = get_arg_val<uint32_t>(argidx++);
     const uint32_t backward_writes_expected = get_arg_val<uint32_t>(argidx++);
-    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_pre_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_pre_wrap_tile_count = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_post_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_valid_tile_count = get_arg_val<uint32_t>(argidx++);
-    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    // Mutable: on the kv_pad_from_metadata path these are overridden below from cb_kv_pad_derived
+    // (produced by the reader from metadata[1]), since compute cannot NoC-read the metadata DRAM tensor.
+    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_pre_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_pre_wrap_tile_count = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_post_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_valid_tile_count = get_arg_val<uint32_t>(argidx++);
+    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
 
     RingSDPAOpIndexer fused_op_indexer(
         ring_size_runtime, ring_index_runtime, forward_writes_expected, backward_writes_expected);
@@ -129,7 +132,9 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    constexpr uint32_t cb_arg_offset = 49;
+    // Compute fixed slot 49: trace-safe KV-pad derivation flag (cb_arg_offset bumped 49 -> 50).
+    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(49) == 1;
+    constexpr uint32_t cb_arg_offset = 50;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -156,6 +161,26 @@ void kernel_main() {
     constexpr uint32_t cb_sum_A = get_compile_time_arg_val(cb_arg_offset + 20);
     constexpr uint32_t cb_sum_B = get_compile_time_arg_val(cb_arg_offset + 21);
     constexpr uint32_t cb_exp_max_diff = get_compile_time_arg_val(cb_arg_offset + 22);
+    constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 23);
+
+    // Trace-safe KV-pad derivation: the reader computed logical_nt / q-mapping / active_ring_iter_mask
+    // from metadata[1] and handed them over via cb_kv_pad_derived (compute can't NoC-read DRAM). Override
+    // the (trace-frozen) runtime args with the reader's values before the ring loop uses them.
+    if constexpr (kv_pad_from_metadata) {
+        // Read the reader-produced scalars via ckernel::read_tile_value (UNPACK-mailbox CB read) -- the
+        // TRISC-safe way to pull a scalar out of a CB, mirroring sparse_sdpa_compute's cb_ctrl. The
+        // CircularBuffer::get_read_ptr() path references the cb_interface global which does not link on
+        // this compute kernel. wait_front/pop_front are LLK intrinsics and link fine.
+        CircularBuffer cb_derived(cb_kv_pad_derived);
+        cb_derived.wait_front(1);
+        logical_nt = ckernel::read_tile_value(cb_kv_pad_derived, /*tile=*/0, /*element_offset=*/0);
+        kv_pad_q_pre_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 1);
+        kv_pad_q_pre_wrap_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 2);
+        kv_pad_q_post_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 3);
+        kv_pad_q_valid_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 4);
+        active_ring_iter_mask = ckernel::read_tile_value(cb_kv_pad_derived, 0, 5);
+        cb_derived.pop_front(1);
+    }
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_q_in, cb_k_in, cb_qk_im);
     matmul_init(cb_q_in, cb_k_in);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/metadata_scalar_read.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/metadata_scalar_read.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/tensor_accessor.h"
+
+namespace trace_metadata {
+
+// Read one per-chunk metadata scalar -- page 0 of a 1-element uint32 DRAM tensor -- into L1 scratch and
+// return its value.
+//
+// Such a tensor sits at a FIXED DRAM address that the host refreshes in place between trace replays,
+// which is what lets a single captured program pick up new per-chunk scalars instead of having them baked
+// in as runtime args. Two steps of the sequence are easy to omit and both fail *silently*, with
+// plausible-but-wrong data rather than an error:
+//
+//   - `async_read_barrier()` orders the DMA but does NOT invalidate the RISC data cache. Since the
+//     address is reused every chunk, a cached L1 line hands back the PRIOR chunk's value. Hence
+//     `invalidate_l1_cache()` between the barrier and the load.
+//   - the load itself must be volatile, or it can be hoisted above the DMA.
+//
+// `dst_l1_addr` is deliberately the caller's choice: which CB's L1 may be borrowed as scratch, and at
+// which offset, is kernel-specific -- these small reads only land correctly at a CB page base on some
+// platforms -- so the caller passes an address it has reasoned about rather than this helper guessing.
+template <typename NocT, typename AccessorArgsT>
+inline uint32_t read_metadata_scalar_u32(
+    NocT& noc, const AccessorArgsT& accessor_args, uint32_t tensor_addr, uint32_t dst_l1_addr) {
+    const auto accessor = TensorAccessor(accessor_args, tensor_addr);
+    noc.async_read(accessor, CoreLocalMem<uint8_t>(dst_l1_addr), sizeof(uint32_t), {.page_id = 0}, {});
+    noc.async_read_barrier();
+    invalidate_l1_cache();
+    return CoreLocalMem<volatile uint32_t>(dst_l1_addr)[0];
+}
+
+}  // namespace trace_metadata

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_kv_pad_derivation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_kv_pad_derivation.hpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// On-device port of the host KV-pad-rotation derivations (ring_joint_sdpa_program_factory.cpp:
+// build_kv_pad_q_mapping, build_ring_work_plan_impl, kv_global_tile_for_host_ring_plan, logical_nt /
+// gather_valid_Ht). The trace-safe metadata path computes these in the SDPA reader from the per-chunk
+// kv_actual_isl (metadata[1]) and hands them to the writer + compute via L1 (compute cannot NoC-read
+// DRAM). All inputs other than kv_actual_isl are static per program. The host functions are the
+// reference; the metadata==scalar bit-exact test guards against any divergence between them.
+//
+// KEEP IN SYNC: the derivation now lives in THREE copies -- the host functions above (the reference),
+// and on-device in the SDPA reader and writer (both via this shared header, which at least unifies
+// reader+writer). A change to the host derivation MUST be mirrored here (and vice-versa); the bit-exact
+// test only guards the specific (kv_actual_isl, sp, chunk) points it exercises, so an unmirrored change
+// silently diverges the scalar and metadata paths outside those points.
+
+#pragma once
+
+#include <cstdint>
+
+#include "chunked_prefill_utils.hpp"                                              // chunked_kv_global_tile_for_local
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_id_sequencer.hpp"  // RingIdSequencer
+
+namespace ttnn::operations::transformer::sdpa::ring_joint {
+
+// 4 per-device Q-mapping tiles consumed by the compute kernel (kv_pad_q_*). See the host
+// build_kv_pad_q_mapping for the derivation; here laid out as plain fields for the L1 handoff.
+struct KvPadQMapping {
+    uint32_t q_pre_wrap_start_tile;
+    uint32_t q_pre_wrap_tile_count;
+    uint32_t q_post_wrap_start_tile;
+    uint32_t q_valid_tile_count;
+};
+
+struct RingWorkMasks {
+    uint32_t active_ring_iter_mask;
+    uint32_t single_valid_kv_chunk_mask;
+};
+
+inline uint32_t kv_pad_min_u32(uint32_t a, uint32_t b) { return a < b ? a : b; }
+inline uint32_t kv_pad_max_u32(uint32_t a, uint32_t b) { return a > b ? a : b; }
+
+// logical_n = kv_actual_isl + chunk_global; logical_nt = div_up(logical_n, TILE_HEIGHT).
+inline uint32_t compute_logical_nt(uint32_t kv_actual_isl, uint32_t chunk_global, uint32_t tile_height) {
+    const uint32_t logical_n = kv_actual_isl + chunk_global;
+    return (logical_n + tile_height - 1) / tile_height;
+}
+
+// Mirror of host kv_global_tile_for_host_ring_plan (ring_joint_sdpa_program_factory.cpp:174).
+inline uint32_t kv_global_tile_for_ring_plan(
+    bool is_chunked,
+    uint32_t ring_id,
+    uint32_t local_tile_start,
+    uint32_t q_chunk_group_tile_count,
+    uint32_t q_local_padded_tile_count,
+    uint32_t kv_local_padded_tile_count) {
+    if (is_chunked) {
+        return chunked_kv_global_tile_for_local(
+            ring_id, local_tile_start, q_chunk_group_tile_count, q_local_padded_tile_count);
+    }
+    return ring_id * kv_local_padded_tile_count + local_tile_start;
+}
+
+// Mirror of host build_kv_pad_q_mapping (ring_joint_sdpa_program_factory.cpp:257). The current valid Q
+// range is [kv_actual_tile_count, logical_tile_count), packed into this device's fixed Q slab; it may
+// straddle one global chunk-group boundary. Host TT_FATAL invariants are validated host-side and are
+// omitted here (the device path runs only after a successful host create).
+inline KvPadQMapping build_kv_pad_q_mapping_device(
+    uint32_t kv_actual_tile_count,
+    uint32_t logical_tile_count,
+    uint32_t ring_size,
+    uint32_t q_local_padded_tile_count,
+    uint32_t device_index) {
+    const uint32_t q_chunk_group_tile_count = ring_size * q_local_padded_tile_count;
+    const uint32_t first_group = kv_actual_tile_count / q_chunk_group_tile_count;
+    const uint32_t last_group = (logical_tile_count - 1) / q_chunk_group_tile_count;
+
+    // intersect_device_group: this device's Q slab within `group`, clamped to the valid range.
+    uint32_t first_start = 0, first_count = 0;
+    {
+        const uint32_t block_start = first_group * q_chunk_group_tile_count + device_index * q_local_padded_tile_count;
+        const uint32_t block_end = block_start + q_local_padded_tile_count;
+        const uint32_t start = kv_pad_max_u32(kv_actual_tile_count, block_start);
+        const uint32_t end = kv_pad_min_u32(logical_tile_count, block_end);
+        if (end > start) {
+            first_start = start;
+            first_count = end - start;
+        }
+    }
+    uint32_t second_start = 0, second_count = 0;
+    if (last_group != first_group) {
+        const uint32_t group = first_group + 1;
+        const uint32_t block_start = group * q_chunk_group_tile_count + device_index * q_local_padded_tile_count;
+        const uint32_t block_end = block_start + q_local_padded_tile_count;
+        const uint32_t start = kv_pad_max_u32(kv_actual_tile_count, block_start);
+        const uint32_t end = kv_pad_min_u32(logical_tile_count, block_end);
+        if (end > start) {
+            second_start = start;
+            second_count = end - start;
+        }
+    }
+
+    KvPadQMapping m;
+    m.q_pre_wrap_start_tile = first_start;
+    m.q_pre_wrap_tile_count = first_count;
+    m.q_post_wrap_start_tile = second_start;
+    m.q_valid_tile_count = first_count + second_count;
+    return m;
+}
+
+// Mirror of host build_ring_work_plan_impl (ring_joint_sdpa_program_factory.cpp:192). Walks the same
+// ring-id order via RingIdSequencer, marks ring iterations with non-padded spatial / joint KV work, and
+// applies the same causal unbalanced skip rule. logical_nt is the only per-chunk input.
+inline RingWorkMasks build_ring_work_masks_device(
+    uint32_t device_index,
+    uint32_t ring_size,
+    uint32_t backward_writes_expected,
+    uint32_t forward_writes_expected,
+    uint32_t num_local_k_chunks,
+    uint32_t k_chunk_tile_count,
+    uint32_t kv_local_padded_Nt,
+    bool kernel_chunked,
+    uint32_t q_chunk_group_tile_count,
+    uint32_t q_local_padded_Nt,
+    uint32_t logical_nt,
+    uint32_t num_joint_k_chunks,
+    uint32_t joint_seq_len,
+    bool kv_pad_rotation_enabled,
+    bool kernel_is_causal,
+    bool is_balanced) {
+    RingWorkMasks plan;
+    plan.active_ring_iter_mask = 0;
+    plan.single_valid_kv_chunk_mask = 0;
+
+    RingIdSequencer seq(device_index, ring_size, backward_writes_expected, forward_writes_expected);
+    auto noop_sync = [](uint32_t, uint32_t) {};
+
+    for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
+        const uint32_t ring_id = seq.get_next_ring_id(noop_sync);
+        const bool joint_contributes = ring_id == ring_size - 1 && num_joint_k_chunks > 0 && joint_seq_len != 0;
+        uint32_t valid_spatial_kv_chunks = 0;
+        for (uint32_t k_chunk = 0; k_chunk < num_local_k_chunks; ++k_chunk) {
+            const uint32_t local_tile_start = k_chunk * k_chunk_tile_count;
+            if (local_tile_start >= kv_local_padded_Nt) {
+                continue;
+            }
+            if (kv_global_tile_for_ring_plan(
+                    kernel_chunked,
+                    ring_id,
+                    local_tile_start,
+                    q_chunk_group_tile_count,
+                    q_local_padded_Nt,
+                    kv_local_padded_Nt) < logical_nt) {
+                valid_spatial_kv_chunks++;
+            }
+        }
+        const uint32_t valid_kv_chunks = valid_spatial_kv_chunks + (joint_contributes ? num_joint_k_chunks : 0);
+        const bool has_kv_work = (kernel_chunked && !kv_pad_rotation_enabled) || valid_spatial_kv_chunks > 0;
+        const bool ring_iter_does_work =
+            (has_kv_work || joint_contributes) && !(kernel_is_causal && device_index < ring_id && !is_balanced);
+        if (ring_iter_does_work) {
+            plan.active_ring_iter_mask |= (1u << ring_iter);
+        }
+        if (valid_kv_chunks <= 1) {
+            plan.single_valid_kv_chunk_mask |= (1u << ring_iter);
+        }
+    }
+    return plan;
+}
+
+}  // namespace ttnn::operations::transformer::sdpa::ring_joint

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -11,6 +11,7 @@
 #include "dataflow_common.hpp"
 #include "chunked_prefill_utils.hpp"
 #include "ring_joint_kv_pad_derivation.hpp"
+#include "metadata_scalar_read.hpp"
 #include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
@@ -383,14 +384,13 @@ void kernel_main() {
         constexpr uint32_t kKvDstOffset = 0;
         if constexpr (slot_from_metadata) {
             const uint32_t slot_id_addr = get_common_arg_val<uint32_t>(0);
-            const auto s_slot = TensorAccessor(meta_args, slot_id_addr);
-            meta_noc.async_read(s_slot, CoreLocalMem<uint32_t>(meta_l1 + kSlotDstOffset), 4, {.page_id = 0}, {});
-            meta_noc.async_read_barrier();
-            // Metadata tensor is at a FIXED DRAM address reused every chunk; the RISC data cache may hold
-            // the prior chunk's value for this L1 line (barrier orders the DMA, volatile still reads cache).
-            // Force a refetch of the freshly-DMA'd value, else an intermittently stale slot read corrupts.
-            invalidate_l1_cache();
-            const uint32_t slot_id = CoreLocalMem<volatile uint32_t>(meta_l1 + kSlotDstOffset)[0];
+            // read_metadata_scalar_u32 is the shared read protocol: async_read page 0 -> barrier ->
+            // invalidate_l1_cache -> volatile load. The invalidate is load-bearing -- the metadata tensor is
+            // at a FIXED DRAM address reused every chunk, so the RISC data cache may still hold the prior
+            // chunk's value for this L1 line (the barrier orders the DMA; a volatile load still reads cache),
+            // and an intermittently stale slot read corrupts the gather.
+            const uint32_t slot_id =
+                trace_metadata::read_metadata_scalar_u32(meta_noc, meta_args, slot_id_addr, meta_l1 + kSlotDstOffset);
             // The KV-cache batch dim is (user, layer)-major:
             //   cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx
             // (matches update_padded_kv_cache's writer: batch_idx = slot_idx * num_layers + layer_idx).
@@ -408,11 +408,11 @@ void kernel_main() {
             // (compute can't NoC-read DRAM). chunk_size_t == q_chunk_group_tile_count (ring_size *
             // q_local_padded_Nt).
             const uint32_t kv_actual_isl_addr = get_common_arg_val<uint32_t>(3);
-            const auto s_kv_actual = TensorAccessor(kv_meta_args, kv_actual_isl_addr);
-            meta_noc.async_read(s_kv_actual, CoreLocalMem<uint32_t>(meta_l1 + kKvDstOffset), 4, {.page_id = 0}, {});
-            meta_noc.async_read_barrier();
-            invalidate_l1_cache();  // fresh-metadata refetch (fixed DRAM addr reused per chunk; see slot read above)
-            const uint32_t kv_actual_isl = CoreLocalMem<volatile uint32_t>(meta_l1 + kKvDstOffset)[0];
+            // Its OWN accessor (kv_meta_args): slot_id and kv_actual_isl are separately allocated and can
+            // land in different DRAM banks, and a shared accessor's dspec bakes page 0's bank from one of
+            // them -- sharing silently returned the wrong bank's data.
+            const uint32_t kv_actual_isl = trace_metadata::read_metadata_scalar_u32(
+                meta_noc, kv_meta_args, kv_actual_isl_addr, meta_l1 + kKvDstOffset);
             const uint32_t kv_actual_tile_count = kv_actual_isl / 32;
             const uint32_t chunk_global = chunk_size_t * 32;
             logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_global, 32);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -10,6 +10,7 @@
 #include "api/core_local_mem.h"
 #include "dataflow_common.hpp"
 #include "chunked_prefill_utils.hpp"
+#include "ring_joint_kv_pad_derivation.hpp"
 #include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
@@ -212,7 +213,16 @@ void kernel_main() {
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
     constexpr bool has_joint_inputs = has_joint_q || has_joint_k;
 
-    constexpr auto q_args = TensorAccessorArgs<32>();
+    // Slot 32: trace-safe slot select. When set, kv_cache_batch_idx is read from the slot_id tensor[0]
+    // on-device (common runtime arg 0 = slot_id DRAM addr) instead of the per-core runtime arg, so a
+    // captured trace replays across cache slots. Tensor accessors therefore start at compile-arg slot 33.
+    constexpr bool slot_from_metadata = get_compile_time_arg_val(32) == 1;
+    // Slot 33: trace-safe KV-pad derivation. When set, the reader reads kv_actual_isl from the
+    // kv_actual_isl tensor[0] (common runtime arg 3 = its DRAM addr), derives logical_nt / q-mapping /
+    // ring masks on-device, and hands the compute-needed values to the compute kernel via
+    // cb_kv_pad_derived (compute cannot NoC-read the DRAM tensor).
+    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(33) == 1;
+    constexpr auto q_args = TensorAccessorArgs<34>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -220,6 +230,26 @@ void kernel_main() {
     constexpr uint32_t joint_tensor_args_offset = gathered_v_args.next_compile_time_args_offset();
     constexpr uint32_t post_tensor_args_offset =
         get_post_tensor_args_offset<has_joint_inputs, joint_tensor_args_offset>();
+    // The metadata accessor (metadata path only) follows the tensor accessors and precedes the chain
+    // semaphore compile args. Gate its offset on slot_from_metadata: when absent, fall back to a VALID
+    // (unused) accessor offset (q_args' slot 34) so TensorAccessorArgs<> -- instantiated unconditionally
+    // here -- never names a non-accessor compile arg (which would fail its internal static_assert).
+    // The chain/CB compile args then start after the metadata accessor when present.
+    constexpr uint32_t meta_args_offset = slot_from_metadata ? post_tensor_args_offset : 34;
+    constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();  // slot_id accessor
+    // kv_actual_isl gets its OWN accessor (a separately-allocated single-page DRAM tensor can land in a
+    // different DRAM bank than slot_id, so the slot accessor's dspec reads the wrong bank for it -- the kv
+    // read silently returned 0). Appended right after slot's when kv_pad_from_metadata; otherwise fall back
+    // to a VALID accessor offset so the unconditional TensorAccessorArgs<> never names a non-accessor arg.
+    constexpr uint32_t kv_meta_args_offset =
+        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : meta_args_offset;
+    constexpr auto kv_meta_args = TensorAccessorArgs<kv_meta_args_offset>();
+    // Split to avoid a nested conditional operator: first resolve the base when kv_pad is absent, then
+    // override it when kv_pad_from_metadata appends kv_actual_isl's accessor after slot's.
+    constexpr uint32_t chains_base_no_kv_pad =
+        slot_from_metadata ? meta_args.next_compile_time_args_offset() : post_tensor_args_offset;
+    constexpr uint32_t chains_base_offset =
+        kv_pad_from_metadata ? kv_meta_args.next_compile_time_args_offset() : chains_base_no_kv_pad;
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -237,7 +267,9 @@ void kernel_main() {
     }
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_cache_batch_idx = get_arg_val<uint32_t>(argidx++);
+    // Trace-safe slot select: kv_cache_batch_idx is read from metadata[0] on-device below (after the CB
+    // ids are known); the per-core arg here is a placeholder 0 on the metadata path.
+    uint32_t kv_cache_batch_idx = get_arg_val<uint32_t>(argidx++);
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     // Head chain runtime args (always present)
@@ -257,8 +289,9 @@ void kernel_main() {
         gqa_max_q_per_core = get_arg_val<uint32_t>(argidx++);
     }
 
-    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    // Mutable: on the kv_pad_from_metadata path these are recomputed on-device below from metadata[1].
+    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         true, /* wait_for_op_signal */
         argidx);
@@ -272,17 +305,16 @@ void kernel_main() {
     constexpr uint32_t chain_compile_arg_count = ring_joint::kChainCompileArgCount;
 
     uint32_t head_sender_semaphore_id =
-        get_compile_time_arg_val(post_tensor_args_offset + chain_sender_semaphore_arg_offset);
+        get_compile_time_arg_val(chains_base_offset + chain_sender_semaphore_arg_offset);
     uint32_t head_receiver_semaphore_id =
-        get_compile_time_arg_val(post_tensor_args_offset + chain_receiver_semaphore_arg_offset);
-    uint32_t head_valid_semaphore_id =
-        get_compile_time_arg_val(post_tensor_args_offset + chain_valid_semaphore_arg_offset);
+        get_compile_time_arg_val(chains_base_offset + chain_receiver_semaphore_arg_offset);
+    uint32_t head_valid_semaphore_id = get_compile_time_arg_val(chains_base_offset + chain_valid_semaphore_arg_offset);
     constexpr bool head_mcast_enabled =
-        get_compile_time_arg_val(post_tensor_args_offset + chain_mcast_enabled_arg_offset) == 1;
+        get_compile_time_arg_val(chains_base_offset + chain_mcast_enabled_arg_offset) == 1;
     constexpr uint32_t head_chain_arg_count = chain_compile_arg_count;
     constexpr uint32_t batch_chain_arg_count = k_uses_batch_chain ? chain_compile_arg_count : 0;
     constexpr uint32_t gqa_chain_arg_count = gqa_grouped_kv ? chain_compile_arg_count : 0;
-    constexpr uint32_t batch_chain_ct_offset = post_tensor_args_offset + head_chain_arg_count;
+    constexpr uint32_t batch_chain_ct_offset = chains_base_offset + head_chain_arg_count;
     constexpr uint32_t gqa_chain_ct_offset = batch_chain_ct_offset + batch_chain_arg_count;
 
     // Batch chain semaphores (only present for non-GQA shared-K modes).
@@ -322,10 +354,104 @@ void kernel_main() {
     }
 
     constexpr uint32_t cb_arg_offset =
-        post_tensor_args_offset + head_chain_arg_count + batch_chain_arg_count + gqa_chain_arg_count;
+        chains_base_offset + head_chain_arg_count + batch_chain_arg_count + gqa_chain_arg_count;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
+
+    // Trace-safe slot select: read the cache slot from the slot_id tensor[0] on-device (the per-core
+    // kv_cache_batch_idx above is a placeholder 0 on the metadata path and would be frozen by a captured
+    // trace). The slot_id DRAM address is common runtime arg 0 and the kv_actual_isl DRAM address is
+    // common runtime arg 3; the shared accessor (meta_args) sits between the tensor accessors and the
+    // chain semaphores.
+    if constexpr (slot_from_metadata || kv_pad_from_metadata) {
+        // Two 1-element uint32 DRAM tensors: slot_id (common arg 0, was metadata[0]) and kv_actual_isl
+        // (common arg 3, was metadata[1]). They share one layout, so ONE accessor (meta_args) reads each
+        // tensor's page 0 (4B). Read into cb_q_in's L1 as scratch -- it is allocated but not yet filled
+        // here, and the main loop overwrites it before first use. (A NoC read into a kernel stack buffer
+        // hangs; the destination must be a real L1 CB address.)
+        Noc meta_noc;
+        CircularBuffer cb_q_scratch(cb_q_in);
+        const uint32_t meta_l1 = cb_q_scratch.get_write_ptr();
+        // slot_id and kv_actual_isl both read into the SAME CB base offset (0), sequentially: slot is read,
+        // barrier'd, and FULLY consumed into kv_cache_batch_idx before the kv read reuses the slot. These
+        // small DRAM reads only land correctly at the CB page base (offset 0) on this platform -- a read
+        // into ANY nonzero offset (+16, +32) of the same CB silently lands zero (verified: kv_actual_isl at
+        // +32 deterministically returned 0, breaking the rotation q-mapping; +0 fixes it). Mirrors the
+        // proven all-gather reader, which also reads both scalars into offset 0.
+        constexpr uint32_t kSlotDstOffset = 0;
+        constexpr uint32_t kKvDstOffset = 0;
+        if constexpr (slot_from_metadata) {
+            const uint32_t slot_id_addr = get_common_arg_val<uint32_t>(0);
+            const auto s_slot = TensorAccessor(meta_args, slot_id_addr);
+            meta_noc.async_read(s_slot, CoreLocalMem<uint32_t>(meta_l1 + kSlotDstOffset), 4, {.page_id = 0}, {});
+            meta_noc.async_read_barrier();
+            // Metadata tensor is at a FIXED DRAM address reused every chunk; the RISC data cache may hold
+            // the prior chunk's value for this L1 line (barrier orders the DMA, volatile still reads cache).
+            // Force a refetch of the freshly-DMA'd value, else an intermittently stale slot read corrupts.
+            invalidate_l1_cache();
+            const uint32_t slot_id = CoreLocalMem<volatile uint32_t>(meta_l1 + kSlotDstOffset)[0];
+            // The KV-cache batch dim is (user, layer)-major:
+            //   cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx
+            // (matches update_padded_kv_cache's writer: batch_idx = slot_idx * num_layers + layer_idx).
+            // slot_id holds only the cache user id; the per-layer factor comes from common runtime args
+            // 1/2. Defaults (num_layers=1, layer_idx=0) reduce this to slot_id, keeping single-layer
+            // callers bit-identical to the original slot_id behavior.
+            const uint32_t kv_cache_num_layers = get_common_arg_val<uint32_t>(1);
+            const uint32_t kv_cache_layer_idx = get_common_arg_val<uint32_t>(2);
+            kv_cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx;
+        }
+        if constexpr (kv_pad_from_metadata) {
+            // kv_actual_isl tensor (common arg 3) holds actual_start = kv_actual_isl (tile-aligned).
+            // Derive the per-chunk values the host would otherwise have computed from the kv_actual_isl
+            // scalar, and hand the compute-needed subset to the compute kernel via cb_kv_pad_derived
+            // (compute can't NoC-read DRAM). chunk_size_t == q_chunk_group_tile_count (ring_size *
+            // q_local_padded_Nt).
+            const uint32_t kv_actual_isl_addr = get_common_arg_val<uint32_t>(3);
+            const auto s_kv_actual = TensorAccessor(kv_meta_args, kv_actual_isl_addr);
+            meta_noc.async_read(s_kv_actual, CoreLocalMem<uint32_t>(meta_l1 + kKvDstOffset), 4, {.page_id = 0}, {});
+            meta_noc.async_read_barrier();
+            invalidate_l1_cache();  // fresh-metadata refetch (fixed DRAM addr reused per chunk; see slot read above)
+            const uint32_t kv_actual_isl = CoreLocalMem<volatile uint32_t>(meta_l1 + kKvDstOffset)[0];
+            const uint32_t kv_actual_tile_count = kv_actual_isl / 32;
+            const uint32_t chunk_global = chunk_size_t * 32;
+            logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_global, 32);
+            const auto qmap = ring_joint::build_kv_pad_q_mapping_device(
+                kv_actual_tile_count, logical_nt, ring_size, q_local_padded_Nt, fused_op_receiver.seq.ring_index);
+            const auto masks = ring_joint::build_ring_work_masks_device(
+                fused_op_receiver.seq.ring_index,
+                ring_size,
+                fused_op_receiver.seq.expected[0],  // backward_writes_expected
+                fused_op_receiver.seq.expected[1],  // forward_writes_expected
+                num_local_k_chunks,
+                Sk_chunk_t,
+                kv_local_padded_Nt,
+                chunked_enabled,
+                chunk_size_t,
+                q_local_padded_Nt,
+                logical_nt,
+                num_joint_k_chunks,
+                L,
+                kv_pad_rotation_enabled,
+                is_causal != 0,
+                is_balanced != 0);
+            active_ring_iter_mask = masks.active_ring_iter_mask;
+
+            // Hand [logical_nt, q_pre_wrap_start, q_pre_wrap_count, q_post_wrap_start, q_valid_count,
+            // active_ring_iter_mask] to compute via cb_kv_pad_derived (cb_arg_offset + 3).
+            constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 3);
+            CircularBuffer cb_derived(cb_kv_pad_derived);
+            cb_derived.reserve_back(1);
+            CoreLocalMem<volatile uint32_t> d(cb_derived.get_write_ptr());
+            d[0] = logical_nt;
+            d[1] = qmap.q_pre_wrap_start_tile;
+            d[2] = qmap.q_pre_wrap_tile_count;
+            d[3] = qmap.q_post_wrap_start_tile;
+            d[4] = qmap.q_valid_tile_count;
+            d[5] = active_ring_iter_mask;
+            cb_derived.push_back(1);
+        }
+    }
 
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -10,7 +10,10 @@
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
+#include "ring_joint_kv_pad_derivation.hpp"
 #include "fused_op_receiver.hpp"
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
 // Eager-path reader: reads the previous ring iteration's normalized output and LSE from DRAM.
 // Used by the non-streaming (old sdpa_ring) path for sigmoid-based inter-iteration merging.
@@ -434,15 +437,25 @@ void kernel_main() {
     // path. The program factory masks kernel_is_causal off when chunked is on, so only one of
     // the two paths drives the stamp per program — but they share the CB slot layout.
     constexpr bool diag_tile_enabled = (is_causal == 1) || chunked_enabled;
+    // Slot 34: trace-safe KV-pad derivation. When set, the writer reads kv_actual_isl from the
+    // kv_actual_isl tensor[0] (common runtime arg 0 = its DRAM addr) and recomputes logical_nt + ring
+    // masks on-device (it's a dataflow kernel, can NoC-read), so a captured trace replays across chunks.
+    // Output accessors therefore start at compile-arg slot 35.
+    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(34) == 1;
 
     // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
     // and dropped by the compiler, eliminating runtime ternaries and the joint_out_generator.
     constexpr bool has_joint_q = num_joint_q_chunks > 0;
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
 
-    constexpr auto out_args = TensorAccessorArgs<34>();
+    constexpr auto out_args = TensorAccessorArgs<35>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
+    // Metadata accessor (metadata path only) follows the output accessors and precedes the CB compile
+    // args; gate the offset on kv_pad_from_metadata so the no-metadata program never names a non-accessor
+    // compile arg (fall back to a valid unused accessor offset = out_args' slot 35).
+    constexpr uint32_t meta_args_offset = kv_pad_from_metadata ? stats_args.next_compile_time_args_offset() : 35;
+    constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
@@ -450,15 +463,18 @@ void kernel_main() {
     const uint32_t stats_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
-    const uint32_t single_valid_kv_chunk_mask = get_arg_val<uint32_t>(argidx++);
+    // Mutable: on the kv_pad_from_metadata path these are recomputed on-device below from metadata[1].
+    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    uint32_t single_valid_kv_chunk_mask = get_arg_val<uint32_t>(argidx++);
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         false, /* wait_for_op_signal */
         argidx);
 
-    // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
-    constexpr uint32_t cb_arg_offset = stats_args.next_compile_time_args_offset();
+    // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm. The CB
+    // compile args start after the metadata accessor when it is present (kv_pad_from_metadata).
+    constexpr uint32_t cb_arg_offset =
+        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : stats_args.next_compile_time_args_offset();
     constexpr uint32_t cb_mask_in = get_compile_time_arg_val(cb_arg_offset + 3);
     constexpr uint32_t cb_scale_in = get_compile_time_arg_val(cb_arg_offset + 4);
     constexpr uint32_t cb_identity_scale_in = get_compile_time_arg_val(cb_arg_offset + 5);
@@ -477,6 +493,44 @@ void kernel_main() {
     constexpr uint32_t stats_tile_bytes = get_tile_size(cb_max_in);
 
     Noc noc;
+
+    // Trace-safe KV-pad derivation: recompute logical_nt + ring masks on-device from kv_actual_isl =
+    // kv_actual_isl tensor[0] (the per-core logical_nt/masks args are placeholders on the metadata path
+    // and would be frozen by a captured trace). The writer is a dataflow kernel, so it reads the tensor
+    // directly via NoC into cb_out's L1 scratch (free before the output write loop). chunk_size_t ==
+    // q_chunk_group.
+    if constexpr (kv_pad_from_metadata) {
+        // kv_actual_isl is a 1-element uint32 DRAM tensor (was metadata[1]); its DRAM address is common
+        // runtime arg 0. Read its page 0 (4B).
+        const uint32_t kv_actual_isl_addr = get_common_arg_val<uint32_t>(0);
+        const auto s_meta = TensorAccessor(meta_args, kv_actual_isl_addr);
+        CircularBuffer cb_meta_scratch(cb_out);
+        const uint32_t meta_l1 = cb_meta_scratch.get_write_ptr();
+        noc.async_read(s_meta, CoreLocalMem<uint32_t>(meta_l1), 4, {.page_id = 0}, {});
+        noc.async_read_barrier();
+        CoreLocalMem<volatile uint32_t> meta(meta_l1);
+        const uint32_t kv_actual_isl = meta[0];
+        logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_size_t * 32, 32);
+        const auto masks = ring_joint::build_ring_work_masks_device(
+            fused_op_receiver.seq.ring_index,
+            ring_size,
+            fused_op_receiver.seq.expected[0],  // backward_writes_expected
+            fused_op_receiver.seq.expected[1],  // forward_writes_expected
+            num_local_k_chunks,
+            Sk_chunk_t,
+            kv_local_padded_Nt,
+            chunked_enabled,
+            chunk_size_t,
+            q_local_padded_Nt,
+            logical_nt,
+            num_joint_k_chunks,
+            L,
+            /*kv_pad_rotation_enabled=*/true,
+            is_causal != 0,
+            is_balanced != 0);
+        active_ring_iter_mask = masks.active_ring_iter_mask;
+        single_valid_kv_chunk_mask = masks.single_valid_kv_chunk_mask;
+    }
 
     const auto out_writer = TensorAccessor(out_args, out_addr);
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
 #include "ring_joint_kv_pad_derivation.hpp"
+#include "metadata_scalar_read.hpp"
 #include "fused_op_receiver.hpp"
 
 namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
@@ -503,13 +504,15 @@ void kernel_main() {
         // kv_actual_isl is a 1-element uint32 DRAM tensor (was metadata[1]); its DRAM address is common
         // runtime arg 0. Read its page 0 (4B).
         const uint32_t kv_actual_isl_addr = get_common_arg_val<uint32_t>(0);
-        const auto s_meta = TensorAccessor(meta_args, kv_actual_isl_addr);
         CircularBuffer cb_meta_scratch(cb_out);
         const uint32_t meta_l1 = cb_meta_scratch.get_write_ptr();
-        noc.async_read(s_meta, CoreLocalMem<uint32_t>(meta_l1), 4, {.page_id = 0}, {});
-        noc.async_read_barrier();
-        CoreLocalMem<volatile uint32_t> meta(meta_l1);
-        const uint32_t kv_actual_isl = meta[0];
+        // Shared read protocol (async_read page 0 -> barrier -> invalidate_l1_cache -> volatile load). The
+        // invalidate matters here for the same reason it does in the reader, and was previously missing on
+        // this path: the tensor is at a FIXED DRAM address the host refreshes in place between trace
+        // replays, so without it the writer can derive logical_nt / the ring masks from the PRIOR chunk's
+        // kv_actual_isl while the reader uses the fresh one -- a silent reader/writer disagreement.
+        const uint32_t kv_actual_isl =
+            trace_metadata::read_metadata_scalar_u32(noc, meta_args, kv_actual_isl_addr, meta_l1);
         logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_size_t * 32, 32);
         const auto masks = ring_joint::build_ring_work_masks_device(
             fused_op_receiver.seq.ring_index,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -242,6 +242,15 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
             tensor_args.joint_v.has_value() == has_joint_tensors,
         "Joint tensors must be provided all together or omitted altogether");
 
+    // Metadata path: the two per-request tensors are supplied together or not at all. has_metadata() and
+    // the SDPA/all-gather program factories otherwise nullopt-deref kv_actual_isl when only slot_id is set
+    // (the public API always sets both, but a direct prim caller could pass one).
+    TT_FATAL(
+        tensor_args.slot_id.has_value() == tensor_args.kv_actual_isl.has_value(),
+        "metadata tensors slot_id and kv_actual_isl must be supplied together (got slot_id={}, kv_actual_isl={})",
+        tensor_args.slot_id.has_value(),
+        tensor_args.kv_actual_isl.has_value());
+
     std::vector<Tensor> sdpa_input_tensors = {input_tensor_q, gathered_input_tensor_k};
     if (has_gathered_v) {
         sdpa_input_tensors.push_back(tensor_args.gathered_v.value());
@@ -253,7 +262,9 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     }
 
     validate_ring_joint_all_gather_on_program_cache_miss(
-        args.all_gather_operation_attributes, args.all_gather_tensor_args, args.has_indexed_kv_cache());
+        args.all_gather_operation_attributes,
+        args.all_gather_tensor_args,
+        args.has_indexed_kv_cache() || tensor_args.has_metadata());
 
     // Check that SDPA coregrid does not overlap with AllGather coregrid
     TT_FATAL(args.program_config.has_value(), "Program config must be provided");
@@ -278,7 +289,9 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto joint_q_shape = has_joint_tensors ? tensor_args.joint_q.value().logical_shape() : q_shape;
     const auto joint_k_shape = has_joint_tensors ? tensor_args.joint_k.value().logical_shape() : q_shape;
     const auto joint_v_shape = has_joint_tensors ? tensor_args.joint_v.value().logical_shape() : q_shape;
-    const bool has_indexed_kv_cache = args.has_indexed_kv_cache();
+    // Metadata path is indexed (single-slot) too -- the slot is read on-device from metadata[0] instead
+    // of the host kv_cache_batch_idx scalar -- so the same K/V-cache-batch shape exemptions apply.
+    const bool has_indexed_kv_cache = args.has_indexed_kv_cache() || tensor_args.has_metadata();
     const uint32_t NVH = tensor_args.v_num_heads();
     const uint32_t VDH = tensor_args.v_head_dim(args.latent_v_head_dim);
 
@@ -635,6 +648,60 @@ RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
     };
 }
 
+ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
+    const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
+    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation();
+    const auto cache_key_logical_n = kv_pad_rotation_enabled ? 0 : args.logical_n;
+
+    std::vector<Tensor> input_tensors = {tensor_args.input_q, tensor_args.input_k};
+    if (tensor_args.input_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.input_v.value());
+    }
+    if (tensor_args.joint_q.has_value()) {
+        input_tensors.emplace_back(tensor_args.joint_q.value());
+        input_tensors.emplace_back(tensor_args.joint_k.value());
+    }
+    if (tensor_args.joint_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.joint_v.value());
+    }
+    input_tensors.emplace_back(tensor_args.gathered_k);
+    if (tensor_args.gathered_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.gathered_v.value());
+    }
+    return tt::tt_metal::operation::hash_operation<RingJointSDPADeviceOperation>(
+        input_tensors,
+        args.joint_strategy,
+        args.scale,
+        args.is_causal,
+        args.is_balanced,
+        args.is_cross,
+        cache_key_logical_n,
+        args.ring_size,
+        args.compute_kernel_config,
+        args.program_config,
+        args.ccl_core_grid_offset,
+        args.kv_cache_batch_idx.has_value(),
+        kv_pad_rotation_enabled,
+        // Metadata presence (never the per-chunk VALUES) keeps the trace-safe metadata program from
+        // colliding with the scalar program; one cached program is reused across all chunks/users.
+        tensor_args.has_metadata(),
+        // (user, layer)-major KV-cache batch factor. Unlike kv_cache_batch_idx (re-patched per dispatch),
+        // these are baked into the readers' create-time args (common arg 1/2 on SDPA; reader rt-args on
+        // all-gather) and are NOT re-patched on the metadata path. So each (num_layers, layer_idx) must
+        // key a distinct cached program -- otherwise layer N would replay layer M's baked layer_idx. With
+        // the defaults (1, 0) the hash is unchanged from before, so single-layer callers reuse one program.
+        args.kv_cache_num_layers,
+        args.kv_cache_layer_idx,
+        tensor_args.has_latent_v(),
+        tensor_args.v_num_heads(),
+        tensor_args.v_head_dim(args.latent_v_head_dim),
+        // all_gather sub-op: hash its attributes + inputs by reflection (main removed the explicit
+        // RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash; its default hash crefs these two,
+        // exactly as RingJointSDPAParams::attribute_values does).
+        args.all_gather_operation_attributes,
+        args.all_gather_tensor_args);
+}
+
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceOperation::create_op_performance_model(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args, RingJointSDPAResult& output_tensors) {
     Tensors input_tensors = {tensor_args.input_q, tensor_args.input_k};
@@ -729,7 +796,11 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
     const std::optional<uint32_t> kv_cache_batch_idx,
     const std::optional<uint32_t> kv_actual_isl,
-    const std::optional<uint32_t> latent_v_head_dim) {
+    const std::optional<uint32_t> latent_v_head_dim,
+    const std::optional<ttnn::Tensor>& slot_id,
+    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor,
+    const uint32_t kv_cache_num_layers,
+    const uint32_t kv_cache_layer_idx) {
     using OperationType = ttnn::prim::RingJointSDPADeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -810,7 +881,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         ccl_core_grid_offset,
         kv_cache_batch_idx,
         kv_actual_isl,
-        latent_v_head_dim.value_or(0));
+        latent_v_head_dim.value_or(0),
+        kv_cache_num_layers,
+        kv_cache_layer_idx);
 
     auto tensor_args = OperationType::tensor_args_t{
         .input_q = input_tensor_q,
@@ -820,7 +893,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         .joint_k = joint_tensor_k,
         .joint_v = joint_tensor_v,
         .gathered_k = persistent_output_buffer_k,
-        .gathered_v = persistent_output_buffer_v};
+        .gathered_v = persistent_output_buffer_v,
+        .slot_id = slot_id,
+        .kv_actual_isl = kv_actual_isl_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -29,6 +29,10 @@ struct RingJointSDPADeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
+    // Explicit override (rather than the default attribute-reflection hash): the trace-safe metadata path
+    // must key distinct programs on tensor_args.has_metadata() and on the per-layer (kv_cache_num_layers,
+    // kv_cache_layer_idx) that are baked into the readers' create-time args and NOT re-patched per dispatch.
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 RingJointSDPAResult ring_joint_scaled_dot_product_attention(
@@ -59,6 +63,10 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
     std::optional<uint32_t> kv_cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_actual_isl = std::nullopt,
-    std::optional<uint32_t> latent_v_head_dim = std::nullopt);
+    std::optional<uint32_t> latent_v_head_dim = std::nullopt,
+    const std::optional<ttnn::Tensor>& slot_id = std::nullopt,
+    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor = std::nullopt,
+    uint32_t kv_cache_num_layers = 1,
+    uint32_t kv_cache_layer_idx = 0);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -35,6 +35,13 @@ struct RingJointSDPAParams {
     std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt;
     std::optional<std::uint32_t> kv_actual_isl = std::nullopt;
     uint32_t latent_v_head_dim = 0;
+    // (user, layer)-major KV-cache batch dim (metadata path). The SDPA + all-gather readers compute the
+    // cache slot on-device as metadata[0] * kv_cache_num_layers + kv_cache_layer_idx (mirrors
+    // update_padded_kv_cache). Defaults (1, 0) reduce to metadata[0], so existing callers are unaffected.
+    // Hashed by compute_program_hash: each distinct (kv_cache_num_layers, kv_cache_layer_idx) gets its own
+    // cached program, so different layers can't collide onto one cached program and gather the wrong slot.
+    uint32_t kv_cache_num_layers = 1;
+    uint32_t kv_cache_layer_idx = 0;
 
     // We need a constructor, because all_gather_struct is not default initializable.
     RingJointSDPAParams(
@@ -53,7 +60,9 @@ struct RingJointSDPAParams {
         CoreCoord ccl_core_grid_offset,
         std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt,
         std::optional<std::uint32_t> kv_actual_isl = std::nullopt,
-        uint32_t latent_v_head_dim = 0) :
+        uint32_t latent_v_head_dim = 0,
+        uint32_t kv_cache_num_layers = 1,
+        uint32_t kv_cache_layer_idx = 0) :
         joint_strategy(std::move(joint_strategy)),
         scale(scale),
         is_causal(is_causal),
@@ -69,7 +78,9 @@ struct RingJointSDPAParams {
         ccl_core_grid_offset(ccl_core_grid_offset),
         kv_cache_batch_idx(kv_cache_batch_idx),
         kv_actual_isl(kv_actual_isl),
-        latent_v_head_dim(latent_v_head_dim) {}
+        latent_v_head_dim(latent_v_head_dim),
+        kv_cache_num_layers(kv_cache_num_layers),
+        kv_cache_layer_idx(kv_cache_layer_idx) {}
 
     std::uint32_t get_q_chunk_size() const { return program_config.has_value() ? program_config->q_chunk_size : 32; }
 
@@ -124,6 +135,21 @@ struct RingJointSDPAInputs {
     std::optional<Tensor> joint_v;
     Tensor gathered_k;
     std::optional<Tensor> gathered_v;
+
+    // Trace-safe metadata path (opt-in): two 1-element uint32 DRAM tensors holding the per-chunk
+    // scalars that would otherwise be host-computed and frozen by a ttnn trace. slot_id holds the
+    // cache-user slot (was metadata[0]); kv_actual_isl holds the prior valid global KV length (was
+    // metadata[1]). When present (both together), the readers/writer compute
+    // kv_cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx and derive
+    // logical_nt / q-mapping / ring masks on-device from kv_actual_isl, so one captured program
+    // replays across chunks. std::nullopt => classic host-scalar path (unchanged).
+    std::optional<Tensor> slot_id;
+    std::optional<Tensor> kv_actual_isl;
+
+    // Both metadata tensors are supplied together or not at all (enforced in validate_on_program_cache_miss);
+    // require both here so a caller that set only one takes the scalar path instead of nullopt-derefing the
+    // missing tensor downstream.
+    bool has_metadata() const { return slot_id.has_value() && kv_actual_isl.has_value(); }
 
     // Chunked-prefill is signalled implicitly by Q being shorter than the per-device K shard:
     // Q is the latest slab, K is the populated prefix from chunk 0 through the current chunk.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -184,6 +184,11 @@ uint32_t kv_global_tile_for_host_ring_plan(
 // Build the per-device ring-loop masks passed to reader/compute/writer. This mirrors the kernel
 // ring-id order, marks ring_iter entries that have non-padded spatial or joint KV work, and applies
 // the same causal unbalanced skip rule used by compute.
+//
+// KEEP IN SYNC with the on-device port in kernels/dataflow/ring_joint_kv_pad_derivation.hpp (SDPA reader
+// + writer read it): these host functions are the reference, so any change to the KV-pad derivation here
+// must be mirrored there, or the metadata (traced) path silently diverges from the scalar path outside
+// the points the bit-exact test exercises. See that header's KEEP IN SYNC note.
 template <bool TrackLastActiveIter>
 RingWorkPlan build_ring_work_plan_impl(
     const RingWritePlan& ring_write_plan, const RingJointRuntimeDerivation& derivation, bool is_balanced) {
@@ -353,7 +358,9 @@ RingJointRuntimeDerivation build_runtime_derivation(
     // Cross is non-causal on chunked-shaped tensors, so kernels and the work planner use the
     // non-chunked path.
     derivation.kernel_chunked = tensor_args.is_chunked() && !args.is_cross;
-    derivation.kv_pad_rotation_enabled = args.has_kv_pad_rotation();
+    // Metadata path enables rotation on the chunked case too (kv_actual read on-device from metadata[1]).
+    derivation.kv_pad_rotation_enabled =
+        args.has_kv_pad_rotation() || (tensor_args.has_metadata() && tensor_args.is_chunked());
     derivation.kernel_is_causal = args.is_causal && !derivation.kernel_chunked;
 
     TT_FATAL(
@@ -373,9 +380,11 @@ RingJointRuntimePlan build_runtime_plan(
 
     RingJointRuntimePlan plan;
     plan.logical_nt = derivation.logical_nt;
+    // On the metadata path kv_actual_isl is absent and the q-mapping is computed on-device from
+    // metadata[1]; only the scalar path computes it host-side here.
     const uint32_t kv_actual_tile_count =
-        derivation.kv_pad_rotation_enabled ? args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT : 0;
-    if (derivation.kv_pad_rotation_enabled) {
+        args.kv_actual_isl.has_value() ? args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT : 0;
+    if (args.kv_actual_isl.has_value()) {
         plan.kv_pad_q_mapping = build_kv_pad_q_mapping(
             kv_actual_tile_count,
             derivation.logical_nt,
@@ -399,7 +408,7 @@ RingJointRuntimeValues build_runtime_values(
 
     RingJointRuntimeValues values;
     values.logical_nt = derivation.logical_nt;
-    if (derivation.kv_pad_rotation_enabled) {
+    if (args.kv_actual_isl.has_value()) {
         const uint32_t kv_actual_tile_count = args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT;
         values.kv_pad_q_mapping = build_kv_pad_q_mapping(
             kv_actual_tile_count,
@@ -463,7 +472,8 @@ void write_runtime_arg(RuntimeArgsData& args, uint32_t index, uint32_t value, co
 // dispatch is bounded) and the cache-hit override path.
 std::optional<uint32_t> compute_gather_valid_Ht(
     const ttnn::prim::RingJointSDPAParams& args, const ttnn::prim::RingJointSDPAInputs& tensor_args) {
-    if (!args.has_kv_pad_rotation()) {
+    // Bound the gather whenever rotation is active -- scalar kv_actual_isl or the chunked metadata path.
+    if (!args.has_kv_pad_rotation() && !(tensor_args.has_metadata() && tensor_args.is_chunked())) {
         return std::nullopt;
     }
     const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
@@ -645,6 +655,12 @@ namespace {
 // create_workload_descriptor() can loop coords and reuse this body verbatim. The
 // op-specific name suffix avoids Unity-build collisions with the sibling ring
 // sdpa factories that share the same helper signature.
+//
+// This is a single-pass builder whose branches (chunked vs full, metadata vs scalar, forward/backward
+// ring halves) are tightly coupled through shared local offsets, so it reads clearest as one body. The
+// per-element-tensor metadata overload added the last few branches that nudged it just past the repo
+// cognitive-complexity threshold; suppress here rather than split the coupled body.
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const RingJointSDPAParams& args,
     const RingJointSDPAInputs& tensor_args,
@@ -778,7 +794,10 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     }
 
     // q_local_padded_N (Q rows per device) can be shorter than kv_local_padded_N for chunked prefill.
-    const bool indexed_kv_cache = args.has_indexed_kv_cache();
+    // Indexed (single-slot) mode is also engaged on the trace-safe metadata path, where the slot is read
+    // on-device from metadata[0] instead of the host kv_cache_batch_idx scalar.
+    const bool slot_from_metadata = tensor_args.has_metadata();
+    const bool indexed_kv_cache = args.has_indexed_kv_cache() || slot_from_metadata;
     // Latent-V mode: V tensors are omitted; the reader reuses K's buffer and
     // reads only the first vDHt head-dim tiles.
     const uint32_t B = q_shape[0];
@@ -803,7 +822,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t Lt = tt::div_up(L, tt::constants::TILE_HEIGHT);
     const uint32_t DHt = DH / tt::constants::TILE_WIDTH;
     const uint32_t vDHt = vDH / tt::constants::TILE_WIDTH;
-    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation();
+    // Rotation is enabled by a host kv_actual_isl scalar OR by the trace-safe metadata path (chunked
+    // only -- `&& is_chunked()` keeps the non-rotation indexed-cache metadata case off). On the metadata
+    // path the per-chunk derived values (logical_nt / q-mapping / masks) are computed in the kernels from
+    // metadata[1]; kv_pad_from_metadata gates that on-device derivation.
+    [[maybe_unused]] const bool kv_pad_from_metadata = tensor_args.has_metadata() && tensor_args.is_chunked();
+    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation() || kv_pad_from_metadata;
     const RingJointRuntimePlan runtime_plan = build_runtime_plan(args, tensor_args, ring_write_plan);
     const RingJointRuntimeArgLayout runtime_arg_layout = get_runtime_arg_layout(args, tensor_args);
     const uint32_t logical_nt = runtime_plan.logical_nt;
@@ -1177,6 +1201,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         compile_time_active_ring_iter_mask,
         NHV,
         static_cast<uint32_t>(v_shares_k_buffer),
+        // Slot 32: trace-safe slot select. When set, the reader reads kv_cache_batch_idx from
+        // metadata[0] on-device (common runtime arg 0) instead of the per-core kv_cache_batch_idx arg.
+        static_cast<uint32_t>(slot_from_metadata),
+        // Slot 33: trace-safe KV-pad derivation. When set, the reader reads kv_actual_isl from
+        // metadata[1], derives logical_nt / q-mapping / ring masks on-device, overrides its own
+        // logical_nt+active_ring_iter_mask, and pushes the compute-needed values to cb_kv_pad_derived.
+        static_cast<uint32_t>(kv_pad_from_metadata),
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
@@ -1188,6 +1219,19 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         TensorAccessorArgs(joint_tensor_q->buffer()).append_to(reader_compile_time_args);
         TensorAccessorArgs(joint_tensor_k->buffer()).append_to(reader_compile_time_args);
         TensorAccessorArgs(joint_tensor_v->buffer()).append_to(reader_compile_time_args);
+    }
+    // Metadata accessors follow the tensor accessors (metadata path only) and precede the chain semaphore
+    // compile args; the reader kernel gates their offsets on slot_from_metadata / kv_pad_from_metadata.
+    // sem_args_offset below is computed after this append, so the chain/CB compile-arg indices stay correct.
+    // slot_id and kv_actual_isl are SEPARATELY allocated single-page DRAM tensors that can land in different
+    // DRAM banks, so each needs its OWN accessor -- a shared accessor's dspec (bank for page 0) is baked
+    // from one buffer and reads the wrong bank for the other (kv read silently returned 0, breaking the
+    // rotation derivation). The writer already appends kv_actual_isl's own accessor for the same reason.
+    if (slot_from_metadata) {
+        TensorAccessorArgs(tensor_args.slot_id->buffer()).append_to(reader_compile_time_args);
+        if (kv_pad_from_metadata) {
+            TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(reader_compile_time_args);
+        }
     }
 
     /**
@@ -1298,11 +1342,20 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         compile_time_active_ring_iter_mask,
         compile_time_last_active_ring_iter,
         compile_time_single_valid_kv_chunk_mask,
+        // Slot 34: trace-safe KV-pad derivation -- the writer recomputes logical_nt + masks from
+        // metadata[1] on-device (it's dataflow). New writer fixed slot -> output accessors shift to 35.
+        static_cast<uint32_t>(kv_pad_from_metadata),
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
+    // Metadata accessor follows the output accessors (metadata path only); matches the writer kernel's
+    // meta_args_offset, which is gated on kv_pad_from_metadata. The writer reads kv_actual_isl on-device,
+    // so it uses the kv_actual_isl tensor's accessor (same layout as slot_id).
+    if (kv_pad_from_metadata) {
+        TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(writer_compile_time_args);
+    }
 
     std::vector<uint32_t> compute_compile_time_args = {
         B,
@@ -1353,7 +1406,11 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         compile_time_kv_pad_q_mapping.q_valid_tile_count,
         compile_time_active_ring_iter_mask,
         compile_time_last_active_ring_iter,
-        static_cast<uint32_t>(v_shares_k_buffer)};
+        static_cast<uint32_t>(v_shares_k_buffer),
+        // Trace-safe KV-pad derivation: when set, compute reads logical_nt / q-mapping /
+        // active_ring_iter_mask from cb_kv_pad_derived (produced by the reader) instead of its runtime
+        // args, so a captured trace replays across chunks. New compute fixed slot -> cb_arg_offset += 1.
+        static_cast<uint32_t>(kv_pad_from_metadata)};
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -1473,12 +1530,39 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t cb_signal =
         use_streaming_compute ? allocate_cb(signal_page_size, 1, tt::DataFormat::UInt16) : inactive_cb;
 
+    // Trace-safe KV-pad path: 1-page L1 CB the reader uses to hand the on-device-derived per-chunk
+    // scalars (logical_nt, 4 q-mapping tiles, active_ring_iter_mask) to the compute kernel, which cannot
+    // NoC-read the metadata DRAM tensor itself. Allocated unconditionally (tiny); only used when
+    // kv_pad_from_metadata. 64B page holds the 6 uint32 with headroom.
+    const uint32_t cb_kv_pad_derived = allocate_cb(64, 1, tt::DataFormat::UInt32);
+
     const std::vector<uint32_t> cb_compile_time_args = {
-        cb_q_in,     cb_k_in,     cb_v_in,         cb_mask_in,       cb_scale_in,    cb_identity_scale_in,
-        cb_stats_in, cb_prev_out, cb_col_identity, cb_recip_scratch, cb_sum_out,     cb_sum_in,
-        cb_signal,   cb_out,      cb_stats_out,    cb_qk_im,         cb_out_im_A,    cb_out_im_B,
-        cb_max_A,    cb_max_B,    cb_sum_A,        cb_sum_B,         cb_exp_max_diff};
-    const std::vector<uint32_t> reader_cb_compile_time_args = {cb_q_in, cb_k_in, cb_v_in};
+        cb_q_in,
+        cb_k_in,
+        cb_v_in,
+        cb_mask_in,
+        cb_scale_in,
+        cb_identity_scale_in,
+        cb_stats_in,
+        cb_prev_out,
+        cb_col_identity,
+        cb_recip_scratch,
+        cb_sum_out,
+        cb_sum_in,
+        cb_signal,
+        cb_out,
+        cb_stats_out,
+        cb_qk_im,
+        cb_out_im_A,
+        cb_out_im_B,
+        cb_max_A,
+        cb_max_B,
+        cb_sum_A,
+        cb_sum_B,
+        cb_exp_max_diff,
+        // index 23: compute reads the reader-produced KV-pad scalars from here (cb_arg_offset + 23).
+        cb_kv_pad_derived};
+    const std::vector<uint32_t> reader_cb_compile_time_args = {cb_q_in, cb_k_in, cb_v_in, cb_kv_pad_derived};
     reader_compile_time_args.insert(
         reader_compile_time_args.end(), reader_cb_compile_time_args.begin(), reader_cb_compile_time_args.end());
     writer_compile_time_args.insert(
@@ -2230,6 +2314,25 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     reader_kernel.compile_time_args = reader_compile_time_args;
     reader_kernel.defines = kernel_defines;
     reader_kernel.config = ReaderConfigDescriptor{};
+    // Trace-safe slot select: the slot_id tensor's raw DRAM address is common runtime arg 0; the reader
+    // reads slot = slot_id[0] from it on-device. Raw address (not a Buffer* binding) mirrors the proven
+    // update_padded_kv_cache pattern. The address is constant across chunks (persistent tensor), so a
+    // captured trace replays correctly without re-patching.
+    if (slot_from_metadata) {
+        // Common arg 0: slot_id DRAM address (reader reads slot = slot_id[0]).
+        // Common args 1/2: (user, layer)-major KV-cache batch factor, so the reader computes the slot as
+        // slot_id[0] * kv_cache_num_layers + kv_cache_layer_idx (matches update_padded_kv_cache). These
+        // are structural per-layer constants -- one program per layer -- so they're set once at create
+        // time and need no per-dispatch re-patch (a captured trace replays correctly). Defaults (1, 0)
+        // reduce the slot to slot_id[0], keeping single-layer callers bit-identical.
+        // Common arg 3: kv_actual_isl DRAM address (reader reads kv_actual_isl = kv_actual_isl_tensor[0]
+        // when kv_pad_from_metadata). Both 1-element tensors share one accessor (meta_args).
+        reader_kernel.emplace_common_runtime_args(
+            {tensor_args.slot_id->buffer()->address(),  // smuggled-rta-ok: metadata tensor addr (on-device)
+             args.kv_cache_num_layers,
+             args.kv_cache_layer_idx,
+             tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
+    }
 
     KernelDescriptor writer_kernel{};
     writer_kernel.kernel_source =
@@ -2239,6 +2342,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     writer_kernel.compile_time_args = writer_compile_time_args;
     writer_kernel.defines = kernel_defines;
     writer_kernel.config = WriterConfigDescriptor{};
+    // Trace-safe KV-pad derivation: the kv_actual_isl tensor's raw DRAM address is common runtime arg 0;
+    // the writer reads kv_actual_isl = kv_actual_isl_tensor[0] from it on-device (mirrors the reader).
+    if (kv_pad_from_metadata) {
+        writer_kernel.emplace_common_runtime_args(
+            {tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
+    }
 
     KernelDescriptor compute_kernel{};
     compute_kernel.kernel_source =
@@ -2413,8 +2522,15 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     }
     // Append the all-gather portion to `desc`. Buffer addresses are auto-patched on cache hits; the
     // indexed-mode input_batch_base scalar is re-patched in apply_ring_joint_scalar_runtime_args.
+    // Single-slot gather is engaged whenever the op is in indexed mode -- either a host kv_cache_batch_idx
+    // (scalar path) or a metadata tensor (trace-safe path, where the slot is read on-device from
+    // metadata[0]). On the metadata path the host slot is absent, so pass a valid placeholder (0) to turn
+    // on single-slot structure; the all-gather reader recomputes the real offset from metadata.
+    const bool ag_indexed = args.has_indexed_kv_cache() || tensor_args.has_metadata();
+    const std::optional<uint32_t> gather_slice_idx =
+        ag_indexed ? std::optional<uint32_t>(args.kv_cache_batch_idx.value_or(0)) : std::nullopt;
     // The trailing kv_cache_batch_idx makes the gather collect only that cache slot (std::nullopt =>
-    // full batch).
+    // full batch). When metadata is supplied the readers read slot_id from metadata[0] on-device.
     ring_attention_all_gather_async_multi_core_with_workers_helper(
         desc,
         all_gather_input_tensors,
@@ -2432,11 +2548,19 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         all_gather_fused_op_signaler,
         args.ccl_core_grid_offset,
         args.all_gather_operation_attributes.core_allocation_strategy,
-        args.kv_cache_batch_idx,
+        gather_slice_idx,
         // Bound the gather to the logical_n-valid prefix at create time so the first (cache-miss)
         // dispatch moves only kv_actual-sized data, not the whole oversized cache. Re-patched per
         // dispatch on cache hits in apply_ring_joint_scalar_runtime_args.
-        compute_gather_valid_Ht(args, tensor_args));
+        compute_gather_valid_Ht(args, tensor_args),
+        tensor_args.slot_id,
+        tensor_args.kv_actual_isl,
+        // chunk_local_tiles: per-device Q slab in tiles, for the reader's on-device gather-extent recompute.
+        tensor_args.input_q.padded_shape()[2] / tt::constants::TILE_HEIGHT,
+        // (user, layer)-major KV-cache batch factor: the all-gather reader computes the gathered slot as
+        // slot_id[0] * kv_cache_num_layers + kv_cache_layer_idx. Defaults (1, 0) keep callers unaffected.
+        args.kv_cache_num_layers,
+        args.kv_cache_layer_idx);
 
     return desc;
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -286,7 +286,11 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla(
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
     std::optional<uint32_t> kv_cache_batch_idx,
-    std::optional<uint32_t> kv_actual_isl) {
+    std::optional<uint32_t> kv_actual_isl,
+    const std::optional<ttnn::Tensor>& slot_id,
+    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor,
+    std::optional<uint32_t> kv_cache_num_layers,
+    std::optional<uint32_t> kv_cache_layer_idx) {
     auto output_tensors = ttnn::prim::ring_joint_scaled_dot_product_attention(
         input_tensor_q,
         input_tensor_kv,
@@ -315,7 +319,11 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla(
         core_allocation_strategy,
         kv_cache_batch_idx,
         kv_actual_isl,
-        head_dim_v);
+        head_dim_v,
+        slot_id,
+        kv_actual_isl_tensor,
+        kv_cache_num_layers.value_or(1),
+        kv_cache_layer_idx.value_or(0));
     return {output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX], output_tensors[prim::RING_JOINT_SDPA_STATS_OUTPUT_IDX]};
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -120,7 +120,19 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla(
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
     std::optional<uint32_t> kv_cache_batch_idx = std::nullopt,
-    std::optional<uint32_t> kv_actual_isl = std::nullopt);
+    std::optional<uint32_t> kv_actual_isl = std::nullopt,
+    // Trace-safe metadata path: when set (both together), the per-chunk scalars (kv_cache_batch_idx /
+    // kv_actual_isl / logical_n) are read on-device from these two 1-element uint32 DRAM tensors instead
+    // of being baked into the program, so one captured ttnn trace replays across chunks. slot_id holds
+    // the cache-user slot (was metadata[0]); kv_actual_isl_tensor holds the prior valid global KV length
+    // (was metadata[1]).
+    const std::optional<ttnn::Tensor>& slot_id = std::nullopt,
+    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor = std::nullopt,
+    // (user, layer)-major KV-cache batch dim (metadata path only). The readers compute the cache slot
+    // on-device as slot_id[0] * kv_cache_num_layers + kv_cache_layer_idx (mirrors
+    // update_padded_kv_cache). Resolve to 1/0 when nullopt -> slot = slot_id[0] (existing behavior).
+    std::optional<uint32_t> kv_cache_num_layers = std::nullopt,
+    std::optional<uint32_t> kv_cache_layer_idx = std::nullopt);
 
 struct ExecuteExpRingJointAttention {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -107,7 +107,11 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla_wrapper(
     bool use_column_major_ccl,
     bool is_balanced,
     std::optional<uint32_t> kv_cache_batch_idx,
-    std::optional<uint32_t> kv_actual_isl) {
+    std::optional<uint32_t> kv_actual_isl,
+    const std::optional<ttnn::Tensor>& slot_id,
+    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor,
+    std::optional<uint32_t> kv_cache_num_layers,
+    std::optional<uint32_t> kv_cache_layer_idx) {
     auto strategy = use_column_major_ccl ? ttnn::ccl::CoreAllocationStrategy::COL_MAJOR
                                          : ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
     return ttnn::transformer::ring_mla(
@@ -130,7 +134,11 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla_wrapper(
         compute_kernel_config,
         strategy,
         kv_cache_batch_idx,
-        kv_actual_isl);
+        kv_actual_isl,
+        slot_id,
+        kv_actual_isl_tensor,
+        kv_cache_num_layers,
+        kv_cache_layer_idx);
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> exp_ring_joint_scaled_dot_product_attention_wrapper(
@@ -718,7 +726,11 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("use_column_major_ccl") = false,
         nb::arg("is_balanced").noconvert() = false,
         nb::arg("kv_cache_batch_idx").noconvert() = nb::none(),
-        nb::arg("kv_actual_isl").noconvert() = nb::none());
+        nb::arg("kv_actual_isl").noconvert() = nb::none(),
+        nb::arg("slot_id").noconvert() = nb::none(),
+        nb::arg("kv_actual_isl_tensor").noconvert() = nb::none(),
+        nb::arg("kv_cache_num_layers").noconvert() = nb::none(),
+        nb::arg("kv_cache_layer_idx").noconvert() = nb::none());
 
     const auto* exp_ring_joint_doc = R"doc(
         ExpRingJointAttention operation that efficiently performs non-causal attention over two


### PR DESCRIPTION

Per-element-tensor overload: per-chunk scalars (slot_id / kv_actual_global / valid_global) can be passed as 1-element uint32 DRAM tensors read on-device, so a captured ttnn trace advances them per chunk via an in-place host update. Scalar overload unchanged. Includes the op-equivalence unit test (no trace, no model plumbing). Extracted from the validated rebased branch ppopovic/trace_rebased_on_main.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._


- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ppopovic/metadata_ring_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ppopovic/metadata_ring_mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppopovic/metadata_ring_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppopovic/metadata_ring_mla)
-

