### PR TITLE
[CI] Qwen3.6-27B: tune tier-1 unit + e2e timeouts, refresh TTFT@128 target

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -318,7 +318,7 @@ models:
     wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 20
-    bh_quietbox_2: 240
+    bh_quietbox_2: 230
     bh_galaxy: 70
   unit_tier2:
     wh_llmbox: 114

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -292,7 +292,7 @@ models:
     wh_n150: 28
     wh_galaxy_perf: 120
     bh_p150: 27
-    bh_quietbox_2: 155
+    bh_quietbox_2: 165
     bh_galaxy: 78
   e2e_tier2:
     wh_llmbox_perf: 266

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -318,7 +318,7 @@ models:
     wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 20
-    bh_quietbox_2: 230
+    bh_quietbox_2: 250
     bh_galaxy: 70
   unit_tier2:
     wh_llmbox: 114

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -292,7 +292,7 @@ models:
     wh_n150: 28
     wh_galaxy_perf: 120
     bh_p150: 27
-    bh_quietbox_2: 165
+    bh_quietbox_2: 180
     bh_galaxy: 78
   e2e_tier2:
     wh_llmbox_perf: 266

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -318,7 +318,7 @@ models:
     wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 20
-    bh_quietbox_2: 250
+    bh_quietbox_2: 240
     bh_galaxy: 70
   unit_tier2:
     wh_llmbox: 114

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -1182,7 +1182,7 @@ targets:
             seq_len: 128
             status: active
             perf:
-              prefill_time_to_first_token: 820.0
+              prefill_time_to_first_token: 514.0
               decode_t/s: 18.2
               decode_t/s/u: 18.2
               tolerance: 0.2

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -333,12 +333,12 @@
 - name: Qwen3.6-27B e2e tests
   cmd: |
     export HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=Qwen/Qwen3.6-27B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3.6-27B
-    pytest --timeout 300 models/demos/blackhole/qwen36/demo/text_demo.py -k "traced_128 and not traced_128k"
-    pytest --timeout 300 models/demos/blackhole/qwen36/demo/text_demo.py -k "determinism_128"
+    pytest --timeout 600 models/demos/blackhole/qwen36/demo/text_demo.py -k "traced_128 and not traced_128k"
+    pytest --timeout 600 models/demos/blackhole/qwen36/demo/text_demo.py -k "determinism_128"
   model: qwen3.6-27b
   skus:
     bh_quietbox_2:
-      timeout: 10
+      timeout: 18
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -333,12 +333,12 @@
 - name: Qwen3.6-27B e2e tests
   cmd: |
     export HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=Qwen/Qwen3.6-27B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3.6-27B
-    pytest --timeout 600 models/demos/blackhole/qwen36/demo/text_demo.py -k "traced_128 and not traced_128k"
-    pytest --timeout 600 models/demos/blackhole/qwen36/demo/text_demo.py -k "determinism_128"
+    pytest --timeout 1200 models/demos/blackhole/qwen36/demo/text_demo.py -k "traced_128 and not traced_128k"
+    pytest --timeout 1200 models/demos/blackhole/qwen36/demo/text_demo.py -k "determinism_128"
   model: qwen3.6-27b
   skus:
     bh_quietbox_2:
-      timeout: 18
+      timeout: 30
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -174,11 +174,10 @@
     pytest --timeout 90 models/demos/blackhole/qwen36/tests/test_gdn_tp.py
     pytest --timeout 60 models/demos/blackhole/qwen36/tests/test_mlp_tp.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_model_tp.py
-    pytest --timeout 900 models/demos/blackhole/qwen36/tests/test_generate_tp.py
   model: qwen3.6-27b
   skus:
     bh_quietbox_2:
-      timeout: 22
+      timeout: 12
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -170,15 +170,15 @@
 - name: Qwen3.6 unit tests
   cmd: |
     export HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=Qwen/Qwen3.6-27B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3.6-27B
-    pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_attention_tp.py
-    pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_gdn_tp.py
-    pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_mlp_tp.py
+    pytest --timeout 90 models/demos/blackhole/qwen36/tests/test_attention_tp.py
+    pytest --timeout 90 models/demos/blackhole/qwen36/tests/test_gdn_tp.py
+    pytest --timeout 60 models/demos/blackhole/qwen36/tests/test_mlp_tp.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_model_tp.py
-    pytest --timeout 1200 models/demos/blackhole/qwen36/tests/test_generate_tp.py
+    pytest --timeout 900 models/demos/blackhole/qwen36/tests/test_generate_tp.py
   model: qwen3.6-27b
   skus:
     bh_quietbox_2:
-      timeout: 32
+      timeout: 22
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -174,10 +174,11 @@
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_gdn_tp.py
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_mlp_tp.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_model_tp.py
+    pytest --timeout 1200 models/demos/blackhole/qwen36/tests/test_generate_tp.py
   model: qwen3.6-27b
   skus:
     bh_quietbox_2:
-      timeout: 12
+      timeout: 32
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models


### PR DESCRIPTION
## What

Tunes the Qwen3.6-27B (`bh_quietbox_2`, tier 1) CI timeouts so the tier-1 unit and e2e jobs stop being killed by `pytest-timeout` on a cold TP tensor cache, and recenters the TTFT@128 perf target to the measured value.

### E2E (`models_e2e_tests.yaml`)
- `text_demo.py` (`traced_128` / `determinism_128`) pytest `--timeout` **300 → 1200s**, job `timeout` **10 → 30** min. The `traced_128` case was being killed during full-model weight load on a cold TP tensor cache.

### Unit (`models_unit_tests.yaml`)
- **Tighten** pytest `--timeout` to ~1.5× observed warm-cache run times:
  - `test_attention_tp.py` 120→90, `test_gdn_tp.py` 120→90, `test_mlp_tp.py` 120→60 (`test_model_tp.py` 300 unchanged).
- Job `timeout` and unit budget are unchanged from `main`.

### Perf target (`models/model_targets.yaml`)
- Qwen3.6-27B TTFT@128 target **820 → 514 ms** — the model got faster; lower the target to the measured 514 ms so the tolerance band recenters. Only the 128-token entry is updated (the 4096/8192 entries aren't exercised by the `traced_128`/`determinism_128` e2e tests).

### Budget (`.github/time_budget.yaml`)
- `models.e2e_tier1.bh_quietbox_2` **155 → 180**.

## Observed vs new timeouts (warm-cache unit run)

| pytest | actual | timeout |
|---|---|---|
| test_attention_tp.py | 32s | 90 |
| test_gdn_tp.py | 40s | 90 |
| test_mlp_tp.py | 6s | 60 |
| test_model_tp.py | 196s | 300 |

## Notes
- An earlier revision of this branch also added `test_generate_tp.py` to the unit entry (with a job-timeout and unit-budget bump); it has since been **removed**, so the unit job timeout and `unit_tier1` budget are back to their `main` values.
- The `e2e_tier1` cap bump is cross-team governance — flagging **#tt-metal-infra** for sign-off.
- Margins are sized for a cold per-runner kernel JIT cache, which dominates the measured times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/qwen36-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/qwen36-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/qwen36-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/qwen36-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/qwen36-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/qwen36-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/qwen36-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/qwen36-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/qwen36-ci-timeouts)
