### PR TITLE
[skip ci] Temporarily skip test_image_transformer_inference on Wormhole B0 (T3K)

### DIFF
--- a/models/tt_transformers/tests/multimodal/mistral_24b/test_pixtral_transformer.py
+++ b/models/tt_transformers/tests/multimodal/mistral_24b/test_pixtral_transformer.py
@@ -8,7 +8,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_allclose, comp_pcc
+from models.common.utility_functions import comp_allclose, comp_pcc, skip_for_wormhole_b0
 from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.model_config import ModelArgs
 from models.tt_transformers.tt.multimodal.mistral_24b.vision_pixtral_transformer import TtPixtralTransformer
@@ -32,6 +32,7 @@ from models.tt_transformers.tt.multimodal.mistral_24b.vision_pixtral_transformer
     [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "num_command_queues": 1}],
     indirect=True,
 )
+@skip_for_wormhole_b0("Circular buffer region clashes with L1 buffers on T3K, refs #47960")
 def test_image_transformer_inference(batch, num_chunks, mesh_device):
     pcc_required = 0.99
 


### PR DESCRIPTION
The test `test_image_transformer_inference[wormhole_b0-device_params0-8-1-1]` has been failing for 7+ days on the T3K (wh_llmbox) Wormhole B0 hardware with a RuntimeError: statically allocated circular buffers clash with L1 buffers during a matmul op. Temporarily skipping on Wormhole B0 until the underlying L1 memory allocation issue is resolved. refs #47960

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lifecycle/disable-issue-47960)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47960)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:lifecycle/disable-issue-47960)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lifecycle/disable-issue-47960)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lifecycle/disable-issue-47960)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lifecycle/disable-issue-47960)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lifecycle/disable-issue-47960)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lifecycle/disable-issue-47960)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lifecycle/disable-issue-47960)