### PR TITLE
fix(ci): restore sanity-tests-debug startup after ttsim input rename

### DIFF
--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -119,7 +119,7 @@ jobs:
       enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
       enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
       run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
-      run-ttsim-integration-tests: false
+      run-ttsim-tests: false
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-22.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.wheel-artifact-name }}
@@ -156,7 +156,7 @@ jobs:
       enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
       enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
       run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
-      run-ttsim-integration-tests: false # ttsim requires gcc-12 which is not available on Ubuntu 24.04
+      run-ttsim-tests: false # ttsim requires gcc-12 which is not available on Ubuntu 24.04
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.wheel-artifact-name }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### PR Category
Bug fix

### Summary
Fixes `startup_failure` on the **Sanity tests nightly debug run** workflow (e.g. [run 28635608328](https://github.com/tenstorrent/tt-metal/actions/runs/28635608328)).

Pipeline reorg #47870 renamed the reusable input on `sanity-tests.yaml` from `run-ttsim-integration-tests` to `run-ttsim-tests`, but `sanity-tests-debug.yaml` was never updated. GitHub rejects unknown inputs when calling reusable workflows, so every scheduled and manual debug run since July 2 failed at startup with zero jobs.

This updates both Ubuntu 22.04 and 24.04 wormhole debug call sites to pass `run-ttsim-tests: false`, preserving the prior intent of skipping TTSim tests in debug pipelines.

### Notes for reviewers
- Validated locally with `actionlint` — the previous error was: `input "run-ttsim-integration-tests" is not defined in "./.github/workflows/sanity-tests.yaml"`.
- This is the same class of regression fixed previously in #45860; the input was dropped again during the ttsim SKU integration reorg (#47870).
- After merge, you can re-run [run 28635608328](https://github.com/tenstorrent/tt-metal/actions/runs/28635608328) or dispatch the workflow manually to confirm jobs are created.
- Test run: https://github.com/tenstorrent/tt-metal/actions/runs/28660311350

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27ea-1f9a-756a-9460-7f148acb5fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27ea-1f9a-756a-9460-7f148acb5fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cursor/fix-sanity-tests-debug-startup-5fd8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cursor/fix-sanity-tests-debug-startup-5fd8)