### PR TITLE
[vllm] Switch nightly to run from standalone plugin

### DIFF
--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -212,7 +212,7 @@ jobs:
           repository: tenstorrent/vllm-tt-plugin
           path: docker-job/vllm-tt-plugin
           ref: ${{ inputs.vllm-tt-plugin-ref }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: ⬇️ Checkout vLLM fork
         if: ${{ inputs.vllm-source == 'fork' }}

--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -15,10 +15,20 @@ on:
       enabled-skus:
         required: true
         type: string
+      vllm-source:
+        description: "Where the TT backend comes from: 'plugin' (upstream vLLM + standalone tenstorrent/vllm-tt-plugin) or 'fork' (tenstorrent/vllm)"
+        required: false
+        default: plugin
+        type: string
       vllm-commit:
-        description: "vLLM branch or sha"
+        description: "tenstorrent/vllm branch or sha (vllm-source=fork only)"
         required: false
         default: dev
+        type: string
+      vllm-tt-plugin-ref:
+        description: "tenstorrent/vllm-tt-plugin branch or sha (vllm-source=plugin only)"
+        required: false
+        default: main
         type: string
       model:
         description: "Model to test (or 'all' for all models)"
@@ -133,8 +143,13 @@ jobs:
       image: ${{ inputs.docker-image }}
       env:
         TT_METAL_HOME: /work
-        vllm_dir: /work/vllm
-        PYTHONPATH: /work:/work/vllm
+        # Every source-layout difference between the two vllm-source modes is
+        # resolved here, so the test steps below stay mode-agnostic. PLUGIN_DIR
+        # holds examples/ and tests/tt; BENCH_SRC_DIR holds the upstream
+        # benchmarks/ tree, which the published vLLM wheel does not ship.
+        PLUGIN_DIR: ${{ inputs.vllm-source == 'fork' && '/work/vllm/plugins/vllm-tt-plugin' || '/work/vllm-tt-plugin' }}
+        BENCH_SRC_DIR: ${{ inputs.vllm-source == 'fork' && '/work/vllm' || '/work/vllm-source' }}
+        PYTHONPATH: ${{ inputs.vllm-source == 'fork' && '/work:/work/vllm' || '/work:/work/vllm-tt-plugin/src' }}
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         HF_HUB_OFFLINE: 1
@@ -182,7 +197,25 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
 
-      - name: ⬇️ Checkout vLLM
+      - name: 🔎 Validate vllm-source
+        run: |
+          case "${{ inputs.vllm-source }}" in
+            plugin|fork) echo "vllm-source=${{ inputs.vllm-source }}" ;;
+            *) echo "❌ vllm-source must be 'plugin' or 'fork', got '${{ inputs.vllm-source }}'"; exit 1 ;;
+          esac
+
+      - name: ⬇️ Checkout vLLM TT plugin
+        if: ${{ inputs.vllm-source != 'fork' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          repository: tenstorrent/vllm-tt-plugin
+          path: docker-job/vllm-tt-plugin
+          ref: ${{ inputs.vllm-tt-plugin-ref }}
+          fetch-depth: 0
+
+      - name: ⬇️ Checkout vLLM fork
+        if: ${{ inputs.vllm-source == 'fork' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
@@ -200,15 +233,38 @@ jobs:
         with:
           log-file: ${{ env.FILE_INSTALL_LOG }}
           run: |
-            VLLM_TARGET_DEVICE=empty uv pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
-            if [ -d vllm/plugins/vllm-tt-plugin ]; then
-              uv pip install --no-deps -e vllm/plugins/vllm-tt-plugin
+            if [ "${{ inputs.vllm-source }}" = "fork" ]; then
+              VLLM_TARGET_DEVICE=empty uv pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
+              if [ -d vllm/plugins/vllm-tt-plugin ]; then
+                uv pip install --no-deps -e vllm/plugins/vllm-tt-plugin
+              fi
+            else
+              # The plugin owns the vLLM version pin and its dependency overrides,
+              # so the install procedure lives there and is sourced verbatim. It
+              # resolves paths relative to the plugin root.
+              pushd vllm-tt-plugin
+              source docs/install-vllm-tt.sh
+              popd
             fi
             # Per-model Python deps when the model directory pins versions that
             # differ from the docker image (Gemma4 needs transformers==5.5.0).
             case "${{ matrix.test-group.model }}" in
               google/gemma-4-*) uv pip install -r models/demos/gemma4/requirements.txt ;;
             esac
+
+      - name: ⬇️ Checkout vLLM benchmark sources
+        # The structured-output benchmark is a script under benchmarks/, which the
+        # published vLLM distribution does not install. Fetch the tree at exactly
+        # the installed version; the fork already carries it in its own checkout.
+        if: ${{ inputs.vllm-source != 'fork' && matrix.test-group.structured-output }}
+        timeout-minutes: 10
+        run: |
+          VLLM_VERSION="$(python3 -c 'from importlib.metadata import version; print(version("vllm").split("+", 1)[0])')"
+          echo "Fetching vLLM benchmark sources for v${VLLM_VERSION}"
+          git init vllm-source
+          git -C vllm-source remote add origin https://github.com/vllm-project/vllm.git
+          git -C vllm-source fetch --depth 1 origin "refs/tags/v${VLLM_VERSION}"
+          git -C vllm-source checkout --detach FETCH_HEAD
 
       - name: 🚀 Run server
         timeout-minutes: 1
@@ -288,7 +344,7 @@ jobs:
 
           echo "vLLM server args: ${VLLM_SERVER_ARGS[@]}"
 
-          python3 vllm/plugins/vllm-tt-plugin/examples/server_example_tt.py "${VLLM_SERVER_ARGS[@]}" > "${FILE_SERVER_LOG}" 2>&1 &
+          python3 "${PLUGIN_DIR}/examples/server_example_tt.py" "${VLLM_SERVER_ARGS[@]}" > "${FILE_SERVER_LOG}" 2>&1 &
 
           # Store server's pid for cleanup
           echo $! > ${FILE_SERVER_PID}
@@ -465,7 +521,7 @@ jobs:
               ADDITIONAL_STRUCTURED_OUTPUT_ARGS=()
             fi
 
-            python3 vllm/benchmarks/benchmark_serving_structured_output.py \
+            python3 "${BENCH_SRC_DIR}/benchmarks/benchmark_serving_structured_output.py" \
               --backend vllm \
               --model ${{ matrix.test-group.model }} \
               --num-prompts 32 \
@@ -536,9 +592,9 @@ jobs:
           run: |
             FILTER="${{ matrix.test-group.sampling-test-filter }}"
             if [ -n "$FILTER" ]; then
-              pytest vllm/plugins/vllm-tt-plugin/tests/tt -v -k "$FILTER" --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
+              pytest "${PLUGIN_DIR}/tests/tt" -v -k "$FILTER" --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
             else
-              pytest vllm/plugins/vllm-tt-plugin/tests/tt -v --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
+              pytest "${PLUGIN_DIR}/tests/tt" -v --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
             fi
 
       - name: 🧹 Cleanup server process

--- a/.github/workflows/vllm-model-tests.yaml
+++ b/.github/workflows/vllm-model-tests.yaml
@@ -44,8 +44,20 @@ on:
           - "1"
           - "2"
           - "3"
+      vllm-source:
+        description: "Where the TT backend comes from"
+        required: false
+        type: choice
+        default: plugin
+        options:
+          - "plugin"
+          - "fork"
+      vllm-tt-plugin-ref:
+        description: "tenstorrent/vllm-tt-plugin branch or sha (vllm-source=plugin)"
+        required: false
+        default: main
       vllm-commit:
-        description: "vLLM branch or sha"
+        description: "tenstorrent/vllm branch or sha (vllm-source=fork)"
         required: false
         default: dev
       platform:
@@ -162,5 +174,7 @@ jobs:
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
       model: ${{ needs.resolve-skus.outputs.model }}
       tier: ${{ needs.resolve-skus.outputs.tier }}
+      vllm-source: ${{ inputs.vllm-source || 'plugin' }}
+      vllm-tt-plugin-ref: ${{ inputs.vllm-tt-plugin-ref || 'main' }}
       vllm-commit: ${{ inputs.vllm-commit || 'dev' }}
       mlperf-read-only: ${{ inputs.mlperf-write-access != true }}


### PR DESCRIPTION
## What

Runs **vLLM Model Tests** against upstream vLLM + the standalone [`tenstorrent/vllm-tt-plugin`](https://github.com/tenstorrent/vllm-tt-plugin) instead of the `tenstorrent/vllm` fork. Plugin is the default, including for the nightly cron. The fork stays selectable.

Reworked on top of current `main`: #50910 renamed `vllm-nightly-tests-impl.yaml` to `vllm-model-tests-impl.yaml` and moved the matrix into `tests/pipeline_reorg/vllm_model_tests.yaml`, so the previous branch no longer applied.

## How

New `vllm-source` dispatch input, `plugin` | `fork`, default `plugin`.

| | `plugin` (default) | `fork` |
|---|---|---|
| checkout | `tenstorrent/vllm-tt-plugin` @ `vllm-tt-plugin-ref` (default `main`) | `tenstorrent/vllm` @ `vllm-commit` (default `dev`) |
| install | `source docs/install-vllm-tt.sh` from the plugin | `uv pip install vllm/` + `--no-deps -e plugins/vllm-tt-plugin` |
| `benchmarks/` tree | shallow fetch of the `v<installed-version>` tag from `vllm-project/vllm` | already present in the fork checkout |

The install procedure is sourced from the plugin rather than duplicated in the workflow, because the plugin owns the vLLM version pin and the dependency overrides that keep `numpy<2` (see `docs/vllm-overrides.txt`).

Rather than duplicating step bodies per mode, the two source-layout differences resolve once in `container.env` — `PLUGIN_DIR`, `BENCH_SRC_DIR`, `PYTHONPATH` — so the server, structured-output, and sampling steps are mode-agnostic.

Details:
- `workflow_call` inputs cannot be `choice`, so a guard step fails the job on any `vllm-source` other than `plugin` / `fork`.
- Scheduled runs have no `inputs`, so the cron falls through to `plugin`.
- The upstream-sources fetch is gated on `structured-output`; only the legs that run that benchmark clone the tree. It targets the exact installed version because the published vLLM distribution does not ship `benchmarks/`.
- Dropped the `vllm_dir` container env var: no reader in tt-metal, the fork, or the plugin.

## Validation

`pre-commit` (yamllint + check-yaml) passes. Behaviour change is confined to the two workflow files; the fork path is byte-equivalent to `main` apart from the shared `PLUGIN_DIR` / `BENCH_SRC_DIR` indirection.

* CI plugin: https://github.com/tenstorrent/tt-metal/actions/runs/30983959083/job/92237063582
* CI fork: https://github.com/tenstorrent/tt-metal/actions/runs/30984013407/job/92237727498

## Out of scope

Carried over from the earlier version of this branch but deliberately **not** included, to keep this a pipeline-source switch:
- relaxing the structured-output gate from `== 100.0` to `>= 93.75` (2/32 allowed);
- GPT-OSS-120B low-latency `benchmark-timeout` 15 → 30, which also needs the `wh_galaxy_perf` job timeout raised past 95 min and a re-run of `verify_time_budget.py`;
- `additional-structured-output-args` for the Qwen3-VL-32B entry;
- renaming the bh_loudbox Llama entry to `DP=8`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/vllm-nightly-oot-plugin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/vllm-nightly-oot-plugin)
