### PR TITLE
[Cleanup] Migrate embedding_backward to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
@@ -5,6 +5,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/reshuffle.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     const uint32_t tiles_per_core = get_arg_val<uint32_t>(0);
@@ -19,16 +20,21 @@ void kernel_main() {
     constexpr uint32_t cb_chunk_count_scratch = tt::CBIndex::c_25;
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
+    CircularBuffer cb_grad_obj(cb_grad);
+    CircularBuffer cb_out_intermed_obj(cb_out_intermed);
+    CircularBuffer cb_mask_obj(cb_mask);
+    CircularBuffer cb_out_obj(cb_out);
+
     unary_op_init_common(cb_grad, cb_out);
 
     for (uint32_t i = 0; i < input_height; ++i) {
-        cb_wait_front(cb_grad, max_tiles_per_core);
+        cb_grad_obj.wait_front(max_tiles_per_core);
 
         // Get chunk_count from CB using mailbox-based synchronization (issue #27979)
         uint32_t chunk_count = read_tile_value(cb_chunk_count_scratch, 0, 0);
 
         for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
-            cb_wait_front(cb_mask, 1);
+            cb_mask_obj.wait_front(1);
 
             // Get idx_addr from CB using mailbox-based synchronization (issue #27979)
             uint32_t idx_addr = get_tile_address(cb_mask, 0);
@@ -38,9 +44,9 @@ void kernel_main() {
             asm volatile("fence");
 #endif
 
-            cb_wait_front(cb_out_intermed, max_tiles_per_core);
+            cb_out_intermed_obj.wait_front(max_tiles_per_core);
 
-            cb_reserve_back(cb_out, max_tiles_per_core);
+            cb_out_obj.reserve_back(max_tiles_per_core);
 
             for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
                 tile_regs_acquire();
@@ -63,12 +69,12 @@ void kernel_main() {
                 tile_regs_release();
             }
 
-            cb_push_back(cb_out, max_tiles_per_core);
-            cb_pop_front(cb_out_intermed, max_tiles_per_core);
+            cb_out_obj.push_back(max_tiles_per_core);
+            cb_out_intermed_obj.pop_front(max_tiles_per_core);
 
-            cb_pop_front(cb_mask, 1);
+            cb_mask_obj.pop_front(1);
         }
 
-        cb_pop_front(cb_grad, max_tiles_per_core);
+        cb_grad_obj.pop_front(max_tiles_per_core);
     }
 }

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
@@ -13,48 +13,48 @@ void kernel_main() {
     constexpr uint32_t max_tiles_per_core = get_compile_time_arg_val(0);
     constexpr uint32_t input_height = get_compile_time_arg_val(1);
 
-    constexpr uint32_t cb_grad = tt::CBIndex::c_0;
-    constexpr uint32_t cb_index = tt::CBIndex::c_1;
-    constexpr uint32_t cb_out_intermed = tt::CBIndex::c_2;
-    constexpr uint32_t cb_mask = tt::CBIndex::c_24;
-    constexpr uint32_t cb_chunk_count_scratch = tt::CBIndex::c_25;
-    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t cb_grad_idx = tt::CBIndex::c_0;
+    constexpr uint32_t cb_index_idx = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out_intermed_idx = tt::CBIndex::c_2;
+    constexpr uint32_t cb_mask_idx = tt::CBIndex::c_24;
+    constexpr uint32_t cb_chunk_count_scratch_idx = tt::CBIndex::c_25;
+    constexpr uint32_t cb_out_idx = tt::CBIndex::c_16;
 
-    CircularBuffer cb_grad_obj(cb_grad);
-    CircularBuffer cb_out_intermed_obj(cb_out_intermed);
-    CircularBuffer cb_mask_obj(cb_mask);
-    CircularBuffer cb_out_obj(cb_out);
+    CircularBuffer cb_grad(cb_grad_idx);
+    CircularBuffer cb_out_intermed(cb_out_intermed_idx);
+    CircularBuffer cb_mask(cb_mask_idx);
+    CircularBuffer cb_out(cb_out_idx);
 
-    unary_op_init_common(cb_grad, cb_out);
+    unary_op_init_common(cb_grad_idx, cb_out_idx);
 
     for (uint32_t i = 0; i < input_height; ++i) {
-        cb_grad_obj.wait_front(max_tiles_per_core);
+        cb_grad.wait_front(max_tiles_per_core);
 
         // Get chunk_count from CB using mailbox-based synchronization (issue #27979)
-        uint32_t chunk_count = read_tile_value(cb_chunk_count_scratch, 0, 0);
+        uint32_t chunk_count = read_tile_value(cb_chunk_count_scratch_idx, 0, 0);
 
         for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
-            cb_mask_obj.wait_front(1);
+            cb_mask.wait_front(1);
 
             // Get idx_addr from CB using mailbox-based synchronization (issue #27979)
-            uint32_t idx_addr = get_tile_address(cb_mask, 0);
+            uint32_t idx_addr = get_tile_address(cb_mask_idx, 0);
 #if defined(ARCH_BLACKHOLE)
             // Workaround for tt-metal issue #11816:
             // Flush the cache, forces going to L1 to access data
             asm volatile("fence");
 #endif
 
-            cb_out_intermed_obj.wait_front(max_tiles_per_core);
+            cb_out_intermed.wait_front(max_tiles_per_core);
 
-            cb_out_obj.reserve_back(max_tiles_per_core);
+            cb_out.reserve_back(max_tiles_per_core);
 
             for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
                 tile_regs_acquire();
                 tile_regs_wait();
 
-                copy_tile(cb_grad, hidden_dim, 0);
+                copy_tile(cb_grad_idx, hidden_dim, 0);
 
-                copy_tile(cb_out_intermed, hidden_dim, 1);
+                copy_tile(cb_out_intermed_idx, hidden_dim, 1);
 
                 reshuffle_rows_tile_init();
                 // reshuffle_rows_tile expects that tiles have a header of 16 bytes.
@@ -63,18 +63,18 @@ void kernel_main() {
                 // tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
                 reshuffle_rows_tile(0, idx_addr - 16);
 
-                pack_tile(1, cb_out, hidden_dim);  // reshuffle puts output into Tile 1 in DEST
+                pack_tile(1, cb_out_idx, hidden_dim);  // reshuffle puts output into Tile 1 in DEST
 
                 tile_regs_commit();
                 tile_regs_release();
             }
 
-            cb_out_obj.push_back(max_tiles_per_core);
-            cb_out_intermed_obj.pop_front(max_tiles_per_core);
+            cb_out.push_back(max_tiles_per_core);
+            cb_out_intermed.pop_front(max_tiles_per_core);
 
-            cb_mask_obj.pop_front(1);
+            cb_mask.pop_front(1);
         }
 
-        cb_grad_obj.pop_front(max_tiles_per_core);
+        cb_grad.pop_front(max_tiles_per_core);
     }
 }

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 
 constexpr uint32_t INPUT_SIZE = 32;
 
@@ -115,36 +119,50 @@ void kernel_main() {
     const auto index_s = TensorAccessor(index_args, index_tensor_addr);
     const auto out_s = TensorAccessor(out_args, output_tensor_addr);
 
+    Noc noc;
+    CircularBuffer cb_grad_obj(cb_grad);
+    CircularBuffer cb_index_obj(cb_index);
+    CircularBuffer cb_out_intermed_obj(cb_out_intermed);
+    CircularBuffer cb_mask_obj(cb_mask);
+    CircularBuffer cb_chunk_count_scratch_obj(cb_chunk_count_scratch);
+    CircularBuffer cb_id_out0_obj(cb_id_out0);
+
     uint32_t index_block_size = get_tile_size(cb_index) >> 5;  // we only need 32 elements
-    uint32_t index_l1_addr = get_write_ptr(cb_index);          // static
+    uint32_t index_l1_addr = cb_index_obj.get_write_ptr();     // static
 
     uint32_t chunk_indexes[INPUT_SIZE];
 
     // ZERO out output this core is responsible for
-    uint32_t out_read_ptr = get_read_ptr(cb_out_intermed);
+    uint32_t out_read_ptr = cb_out_intermed_obj.get_read_ptr();
     // Fill one tile with zeros
     generate_zeros_cb(out_read_ptr);
     // Fill all of output (for this core) to zeros
     uint32_t out_tile_idx = hidden_offset;
     for (uint32_t i = 0; i < num_embeddings; ++i) {
         for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-            noc_async_write_page(out_tile_idx + hidden_dim, out_s, out_read_ptr);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(out_read_ptr), out_s, out_page_size, {}, {.page_id = out_tile_idx + hidden_dim});
         }
         out_tile_idx += tiles_per_hidden;
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 
-    uint32_t chunk_count_l1_addr = get_read_ptr(cb_chunk_count_scratch);
+    uint32_t chunk_count_l1_addr = cb_chunk_count_scratch_obj.get_read_ptr();
     auto chunk_count_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(chunk_count_l1_addr);
 
     uint32_t grad_tile_idx = hidden_offset;
     for (uint32_t b = 0; b < batch_size; ++b) {
-        uint64_t index_seq_noc_addr = index_s.get_noc_addr(b);
+        uint32_t index_seq_offset = 0;
         for (uint32_t s = 0; s < seq_len_tiles; ++s) {
-            noc_async_read(index_seq_noc_addr, index_l1_addr, index_block_size);
-            noc_async_read_barrier();
+            noc.async_read(
+                index_s,
+                CoreLocalMem<uint32_t>(index_l1_addr),
+                index_block_size,
+                {.page_id = b, .offset_bytes = index_seq_offset},
+                {});
+            noc.async_read_barrier();
 
-            index_seq_noc_addr += index_block_size;
+            index_seq_offset += index_block_size;
 
             // maps the next chunk of indexes to the corresponding output masks
             uint32_t chunk_count = process_index_chunk(index_l1_addr, chunk_indexes);
@@ -152,21 +170,26 @@ void kernel_main() {
             // Pass chunk_count to compute UNPACK
             chunk_count_ptr[0] = chunk_count;
 
-            cb_reserve_back(cb_grad, max_tiles_per_core);
-            uint32_t grad_write_ptr = get_write_ptr(cb_grad);
+            cb_grad_obj.reserve_back(max_tiles_per_core);
+            uint32_t grad_write_ptr = cb_grad_obj.get_write_ptr();
             for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-                noc_async_read_page(grad_tile_idx + hidden_dim, grad_s, grad_write_ptr);
+                noc.async_read(
+                    grad_s,
+                    CoreLocalMem<uint32_t>(grad_write_ptr),
+                    grad_page_size,
+                    {.page_id = grad_tile_idx + hidden_dim},
+                    {});
                 grad_write_ptr += grad_page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_grad, max_tiles_per_core);
+            noc.async_read_barrier();
+            cb_grad_obj.push_back(max_tiles_per_core);
             grad_tile_idx += tiles_per_hidden;
 
             for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
                 uint32_t chunk_idx = chunk_indexes[chunk];
 
-                cb_reserve_back(cb_mask, 1);
-                uint32_t mask_l1_addr = get_write_ptr(cb_mask);
+                cb_mask_obj.reserve_back(1);
+                uint32_t mask_l1_addr = cb_mask_obj.get_write_ptr();
                 generate_mask(index_l1_addr, chunk_idx, mask_l1_addr);
 
 // TODO: Remove debug prints
@@ -177,26 +200,36 @@ void kernel_main() {
                     DPRINT("{}: {} -> {}\n", chunk, idx, msk);
                 }
 #endif
-                cb_push_back(cb_mask, 1);
+                cb_mask_obj.push_back(1);
 
-                cb_reserve_back(cb_out_intermed, max_tiles_per_core);
-                uint32_t out_write_ptr = get_write_ptr(cb_out_intermed);
+                cb_out_intermed_obj.reserve_back(max_tiles_per_core);
+                uint32_t out_write_ptr = cb_out_intermed_obj.get_write_ptr();
                 out_tile_idx = chunk_idx * tiles_per_hidden + hidden_offset;
                 for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-                    noc_async_read_page(out_tile_idx + hidden_dim, out_s, out_write_ptr);
+                    noc.async_read(
+                        out_s,
+                        CoreLocalMem<uint32_t>(out_write_ptr),
+                        out_page_size,
+                        {.page_id = out_tile_idx + hidden_dim},
+                        {});
                     out_write_ptr += out_page_size;
                 }
-                noc_async_read_barrier();
-                cb_push_back(cb_out_intermed, max_tiles_per_core);
+                noc.async_read_barrier();
+                cb_out_intermed_obj.push_back(max_tiles_per_core);
 
-                cb_wait_front(cb_id_out0, max_tiles_per_core);
-                uint32_t out_read_ptr = get_read_ptr(cb_id_out0);
+                cb_id_out0_obj.wait_front(max_tiles_per_core);
+                uint32_t out0_read_ptr = cb_id_out0_obj.get_read_ptr();
                 for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-                    noc_async_write_page(out_tile_idx + hidden_dim, out_s, out_read_ptr);
-                    out_read_ptr += out_page_size;
+                    noc.async_write(
+                        CoreLocalMem<uint32_t>(out0_read_ptr),
+                        out_s,
+                        out_page_size,
+                        {},
+                        {.page_id = out_tile_idx + hidden_dim});
+                    out0_read_ptr += out_page_size;
                 }
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_out0, max_tiles_per_core);
+                noc.async_write_barrier();
+                cb_id_out0_obj.pop_front(max_tiles_per_core);
             }  // chunk_count
         }  // seq_len_tiles
     }  // batch_size

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
@@ -101,15 +101,15 @@ void kernel_main() {
     constexpr uint32_t seq_len_tiles = get_compile_time_arg_val(2);
     constexpr uint32_t num_embeddings = get_compile_time_arg_val(3);
 
-    constexpr uint32_t cb_grad = tt::CBIndex::c_0;
-    constexpr uint32_t cb_index = tt::CBIndex::c_1;
-    constexpr uint32_t cb_out_intermed = tt::CBIndex::c_2;
-    constexpr uint32_t cb_mask = tt::CBIndex::c_24;
-    constexpr uint32_t cb_chunk_count_scratch = tt::CBIndex::c_25;
-    constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_grad_idx = tt::CBIndex::c_0;
+    constexpr uint32_t cb_index_idx = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out_intermed_idx = tt::CBIndex::c_2;
+    constexpr uint32_t cb_mask_idx = tt::CBIndex::c_24;
+    constexpr uint32_t cb_chunk_count_scratch_idx = tt::CBIndex::c_25;
+    constexpr uint32_t cb_id_out0_idx = tt::CBIndex::c_16;
 
-    constexpr uint32_t grad_page_size = get_tile_size(cb_grad);
-    constexpr uint32_t out_page_size = get_tile_size(cb_id_out0);
+    constexpr uint32_t grad_page_size = get_tile_size(cb_grad_idx);
+    constexpr uint32_t out_page_size = get_tile_size(cb_id_out0_idx);
 
     constexpr auto grad_args = TensorAccessorArgs<7>();
     constexpr auto index_args = TensorAccessorArgs<grad_args.next_compile_time_args_offset()>();
@@ -120,20 +120,20 @@ void kernel_main() {
     const auto out_s = TensorAccessor(out_args, output_tensor_addr);
 
     Noc noc;
-    CircularBuffer cb_grad_obj(cb_grad);
-    CircularBuffer cb_index_obj(cb_index);
-    CircularBuffer cb_out_intermed_obj(cb_out_intermed);
-    CircularBuffer cb_mask_obj(cb_mask);
-    CircularBuffer cb_chunk_count_scratch_obj(cb_chunk_count_scratch);
-    CircularBuffer cb_id_out0_obj(cb_id_out0);
+    CircularBuffer cb_grad(cb_grad_idx);
+    CircularBuffer cb_index(cb_index_idx);
+    CircularBuffer cb_out_intermed(cb_out_intermed_idx);
+    CircularBuffer cb_mask(cb_mask_idx);
+    CircularBuffer cb_chunk_count_scratch(cb_chunk_count_scratch_idx);
+    CircularBuffer cb_id_out0(cb_id_out0_idx);
 
-    uint32_t index_block_size = get_tile_size(cb_index) >> 5;  // we only need 32 elements
-    uint32_t index_l1_addr = cb_index_obj.get_write_ptr();     // static
+    uint32_t index_block_size = get_tile_size(cb_index_idx) >> 5;  // we only need 32 elements
+    uint32_t index_l1_addr = cb_index.get_write_ptr();             // static
 
     uint32_t chunk_indexes[INPUT_SIZE];
 
     // ZERO out output this core is responsible for
-    uint32_t out_read_ptr = cb_out_intermed_obj.get_read_ptr();
+    uint32_t out_read_ptr = cb_out_intermed.get_read_ptr();
     // Fill one tile with zeros
     generate_zeros_cb(out_read_ptr);
     // Fill all of output (for this core) to zeros
@@ -147,7 +147,7 @@ void kernel_main() {
     }
     noc.async_write_barrier();
 
-    uint32_t chunk_count_l1_addr = cb_chunk_count_scratch_obj.get_read_ptr();
+    uint32_t chunk_count_l1_addr = cb_chunk_count_scratch.get_read_ptr();
     auto chunk_count_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(chunk_count_l1_addr);
 
     uint32_t grad_tile_idx = hidden_offset;
@@ -170,8 +170,8 @@ void kernel_main() {
             // Pass chunk_count to compute UNPACK
             chunk_count_ptr[0] = chunk_count;
 
-            cb_grad_obj.reserve_back(max_tiles_per_core);
-            uint32_t grad_write_ptr = cb_grad_obj.get_write_ptr();
+            cb_grad.reserve_back(max_tiles_per_core);
+            uint32_t grad_write_ptr = cb_grad.get_write_ptr();
             for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
                 noc.async_read(
                     grad_s,
@@ -182,14 +182,14 @@ void kernel_main() {
                 grad_write_ptr += grad_page_size;
             }
             noc.async_read_barrier();
-            cb_grad_obj.push_back(max_tiles_per_core);
+            cb_grad.push_back(max_tiles_per_core);
             grad_tile_idx += tiles_per_hidden;
 
             for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
                 uint32_t chunk_idx = chunk_indexes[chunk];
 
-                cb_mask_obj.reserve_back(1);
-                uint32_t mask_l1_addr = cb_mask_obj.get_write_ptr();
+                cb_mask.reserve_back(1);
+                uint32_t mask_l1_addr = cb_mask.get_write_ptr();
                 generate_mask(index_l1_addr, chunk_idx, mask_l1_addr);
 
 // TODO: Remove debug prints
@@ -200,10 +200,10 @@ void kernel_main() {
                     DPRINT("{}: {} -> {}\n", chunk, idx, msk);
                 }
 #endif
-                cb_mask_obj.push_back(1);
+                cb_mask.push_back(1);
 
-                cb_out_intermed_obj.reserve_back(max_tiles_per_core);
-                uint32_t out_write_ptr = cb_out_intermed_obj.get_write_ptr();
+                cb_out_intermed.reserve_back(max_tiles_per_core);
+                uint32_t out_write_ptr = cb_out_intermed.get_write_ptr();
                 out_tile_idx = chunk_idx * tiles_per_hidden + hidden_offset;
                 for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
                     noc.async_read(
@@ -215,10 +215,10 @@ void kernel_main() {
                     out_write_ptr += out_page_size;
                 }
                 noc.async_read_barrier();
-                cb_out_intermed_obj.push_back(max_tiles_per_core);
+                cb_out_intermed.push_back(max_tiles_per_core);
 
-                cb_id_out0_obj.wait_front(max_tiles_per_core);
-                uint32_t out0_read_ptr = cb_id_out0_obj.get_read_ptr();
+                cb_id_out0.wait_front(max_tiles_per_core);
+                uint32_t out0_read_ptr = cb_id_out0.get_read_ptr();
                 for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
                     noc.async_write(
                         CoreLocalMem<uint32_t>(out0_read_ptr),
@@ -229,7 +229,7 @@ void kernel_main() {
                     out0_read_ptr += out_page_size;
                 }
                 noc.async_write_barrier();
-                cb_id_out0_obj.pop_front(max_tiles_per_core);
+                cb_id_out0.pop_front(max_tiles_per_core);
             }  // chunk_count
         }  // seq_len_tiles
     }  // batch_size


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to #45003. Migrates `embedding_backward` onto the Device 2.0 data-movement API.

`embedding_backward` already constructed `TensorAccessor`s, so only the circular-buffer and NoC calls needed swapping

### Notes for reviewers

- Kernel-side only; no host or op-infrastructure changes
- The swap: CB free-functions such as `cb_reserve_back`, `cb_push_back`, etc. replaced with `CircularBuffer` methods

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/pr1-d2-index-fill-embedding-bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/pr1-d2-index-fill-embedding-bw)

