### PR TITLE
[skip ci] Qwen2.5-VL-72B b32 decode: widen tolerance 0.15 -> 0.20 (host-correlated flakiness)

### DIFF
--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -994,12 +994,22 @@ targets:
             seq_len: 2048
             status: active
             perf:
-              # b32 aggregate decode verified healthy (324-381 t/s) across 3
-              # targeted reruns; the 07-01 scheduled drop to 184 t/s did not
-              # reproduce (confirmed one-off). Target/tolerance unchanged.
+              # b32 decode throughput is strongly host-correlated on the
+              # wh_llmbox_perf T3K pool, not commit-correlated: healthy hosts
+              # (f10cs06/07/08/09) measure 311-406 t/s across the last 10
+              # scheduled runs, while the degraded host f10cs05 runs ~142-185
+              # (tracked as infra, INFRA-3). The default 0.15 tolerance made the
+              # gate flip between "too fast" (f10cs09 ~400 > 399.7 upper bound,
+              # 07-03) and "regression" (f10cs05, 07-01) purely by which box the
+              # scheduler picked. Keep center 347.6 and widen tolerance to 0.20
+              # ([278, 417]) to bracket the healthy-host spread; f10cs05's ~⅔
+              # readings still fail by design (do not lower the gate to mask a
+              # degraded host).
               prefill_time_to_first_token: 1163
               decode_t/s/u: 10.86
+              decode_t_s_u_tolerance: 0.2
               decode_t/s: 347.6
+              decode_t_s_tolerance: 0.2
             accuracy: {}
             owner_id: U07RY6B5FLJ # Gongyu Wang
             team: models


### PR DESCRIPTION
## Summary

Widen the Qwen2.5-VL-72B `wh_llmbox_perf` **b32/seq2048** decode tolerance from the default **0.15 → 0.20** (center 347.6 unchanged) → band `[278, 417]` t/s. Applied to both `decode_t/s` and `decode_t/s/u`.

Follow-up to #48712 (which fixed the b1 gate); this addresses the b32 "too-fast" failure on the 2026-07-03 scheduled run.

## Why — the gate flakiness is host-driven, not a regression

b32 decode measured across the last 10 Tier 2 E2E scheduled runs is **strongly host-correlated** (which physical T3K box the scheduler picked), not commit-correlated:

| Host | b32 decode t/s | vs old band [295.5, 399.7] |
|---|---|---|
| f10cs09 | ~400–406 | over → "too fast" (07-03 fail) |
| f10cs06 / f10cs08 / f10cs07 | 311–339 | in band |
| **f10cs05** (degraded, INFRA-3) | 142–185 | under → "regression" (07-01 fail) |

The fixed 347.6 target sits between two host clusters, so with ±15% the gate flipped between "much better than expected" (f10cs09) and "regression" (f10cs05) purely by scheduling. Note the "07-01 collapse to 184 t/s" previously thought a one-off was in fact f10cs05, the degraded host.

## Behavior after change

- Band `[278, 417]` brackets all **healthy** hosts (311–406) → kills the spurious too-fast/normal-swing failures.
- **f10cs05** (142–185) still fails **by design** — it's a genuinely degraded host (~⅔ throughput), tracked as infra (INFRA-3). We deliberately do **not** widen far enough to mask it (same stance taken for the Qwen2.5-Coder-32B host-perf finding on #46214).
- Still catches a real gross regression (e.g. a true halving would fall below 278).

## Validation

- [x] YAML parses; new bands: `decode_t/s` [278.1, 417.1], `decode_t/s/u` [8.69, 13.03]; `validate_perf_targets.py` schema OK.
- [ ] Next scheduled Tier 2 E2E run on a healthy host passes the b32 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/qwen25-vl-72b-b32-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/qwen25-vl-72b-b32-tolerance)