### PR TITLE
Fix #46879: rope_1d decode test builds prefill trans-mat at TILE_SIZE

### DIFF
--- a/models/common/tests/modules/rope/test_rope_1d.py
+++ b/models/common/tests/modules/rope/test_rope_1d.py
@@ -345,8 +345,10 @@ def test_rope_1d_decode_forward_vs_reference(
     assert "decode" in trans_mats
     assert "prefill" in trans_mats
 
-    # Prefill trans mat PCC: TTTv2 uses head_dim x head_dim
-    prefill_ref = get_rot_transformation_mat(dhead=head_dim)  # [1, 1, head_dim, head_dim]
+    # Prefill trans mat PCC: the rotary_embedding_llama op requires a single
+    # TILE_SIZE x TILE_SIZE tile (TT_FATAL on any other shape), so the module
+    # builds the prefill trans-mat at TILE_SIZE, not head_dim. See rope_1d.py.
+    prefill_ref = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE)  # [1, 1, 32, 32]
     prefill_tt = to_torch_auto_compose(trans_mats["prefill"])
     prefill_tt_trimmed = prefill_tt[:1, :1, : prefill_ref.shape[2], : prefill_ref.shape[3]]
     pcc_prefill, msg_prefill = comp_pcc(prefill_ref.to(torch.bfloat16), prefill_tt_trimmed.to(torch.bfloat16), 0.9999)


### PR DESCRIPTION
Closes #46879

test_rope_1d_decode_forward_vs_reference built the prefill transformation matrix reference at head_dim (64/128), while the module -- and the underlying ttnn.experimental.rotary_embedding_llama op, which TT_FATALs on any trans-mat that is not exactly one 32x32 tile -- build it at TILE_SIZE=32. comp_pcc then tried to correlate a head_dim^2-element array against a 1024-element one and died with a size mismatch (4096/16384 vs 1024), failing all 60 parametrizations on both local and CI (wh_llmbox).

Mirror the already-correct decode check and build prefill_ref at ttnn.TILE_SIZE. Test-only; no production code changed. Changing the module instead would satisfy the test but TT_FATAL in real prefill, since the op requires 32x32.

Verified on T3K (same device class as the failing wh_llmbox CI job): all 60 test_rope_1d_decode_forward_vs_reference variants pass, and the full rope module set is green.

CI workflow pipeline, relevant tests are pasing: https://github.com/tenstorrent/tt-metal/actions/runs/28669656325


Those are the cases that were previously failing: https://github.com/tenstorrent/tt-metal/actions/runs/28669656325/job/85031044990

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apascual/46879-rope-1d-decode-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/46879-rope-1d-decode-test-fix)