### PR TITLE
[indexer_score] fix causal for block-cyclic chunk_start on a non-zero boundary chip

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1629,24 +1629,32 @@ ST_MSA_T = 5120  # block-pool straddle cache: 4*1280 whole chunks AND a whole nu
 
 
 def _straddle_ref(q_g, k_nat, w_g, sp, chunk_global, chunk_start, t_len):
-    """Per-SP-rank straddled reference over natural-order K, mirroring the op's device_causal_geometry /
-    update_padded_kv_cache rotation. Device r's q-row 0 sits at base = chunk_start + r*Sq; with offset =
-    base % cl, rows >= (cl - offset) jump by (chunk_global - cl)."""
+    """Per-SP-rank reference over natural-order K, mirroring the update_padded_kv_cache WRITER rotation
+    (== rotated_chip_positions): each token has a FIXED, ISL-independent block-cyclic home. Device r's
+    local query row s sits at pos(r, s) = (lr // cl)*chunk_global + r*cl + (lr % cl) with lr = update_idxt(r)
+    + s. This is NOT the linear chunk_start + r*Sq: a mid-slab chunk_start rotates which chip owns which
+    block (boundary_chip), so a token's placement must not depend on the cumulative ISL. Only the boundary
+    chip is mid-slab (its rows straddle a slab boundary); the others are block-aligned."""
     heads, gq = q_g.shape[1], q_g.shape[2]
-    sq = gq // sp  # per-device query rows
+    sq = gq // sp  # per-device query rows (== cl in the SP-only block-cyclic layout)
     cl = chunk_global // sp
+    boundary_slab = chunk_start // chunk_global
+    boundary_chip = (chunk_start // cl) % sp
+    offset = chunk_start % cl
     refs = []
     for r in range(sp):
-        base = chunk_start + r * sq
-        offset = base % cl
-        straddle_row = cl - offset
+        update_idxt = (
+            (boundary_slab + 1) * cl
+            if r < boundary_chip
+            else (boundary_slab * cl + offset if r == boundary_chip else boundary_slab * cl)
+        )
         sl = slice(r * sq, (r + 1) * sq)
         qh, kh, wh = q_g[:, :, sl, :].float(), k_nat[:, 0].float(), w_g[:, :, sl, :].float()
         score = torch.zeros(1, sq, t_len)
         for h in range(heads):
             score += torch.relu(qh[:, h] @ kh.transpose(-2, -1)) * wh[:, h]
-        s = torch.arange(sq)
-        pos = base + s + torch.where(s >= straddle_row, chunk_global - cl, 0)  # straddled natural position
+        lr = update_idxt + torch.arange(sq)
+        pos = (lr // cl) * chunk_global + r * cl + (lr % cl)  # block-cyclic home (writer rotation)
         future = torch.arange(t_len).unsqueeze(0) > pos.unsqueeze(1)
         refs.append(score.masked_fill(future, float("-inf")).unsqueeze(1))
     return torch.cat(refs, dim=2)
@@ -1662,21 +1670,28 @@ def _straddle_msa_pooled_ref(q_g, k_nat, sp, chunk_global, chunk_start, t_len, s
     sq = q_g.shape[2] // sp
     cl = chunk_global // sp
     nb = t_len // block_size
+    boundary_slab = chunk_start // chunk_global
+    boundary_chip = (chunk_start // cl) % sp
+    offset = chunk_start % cl
     refs = []
     for r in range(sp):
-        base = chunk_start + r * sq
-        offset = base % cl
-        straddle_row = cl - offset
+        # Writer rotation (== _straddle_ref / update_padded_kv_cache): each token's block-cyclic home is
+        # ISL-independent, so device r starts at its true logical block (update_idxt), NOT chunk_start + r*Sq.
+        update_idxt = (
+            (boundary_slab + 1) * cl
+            if r < boundary_chip
+            else (boundary_slab * cl + offset if r == boundary_chip else boundary_slab * cl)
+        )
         sl = slice(r * sq, (r + 1) * sq)
         qh, kh = q_g[:, :, sl, :].float(), k_nat[:, 0].float()
         score = torch.zeros(1, sq, t_len)
         for h in range(heads):
             score += (qh[:, h] @ kh.transpose(-2, -1)) * scale  # MSA: raw dot, no relu
-        s = torch.arange(sq)
-        pos = base + s + torch.where(s >= straddle_row, chunk_global - cl, 0)  # straddled natural position
+        lr = update_idxt + torch.arange(sq)
+        pos = (lr // cl) * chunk_global + r * cl + (lr % cl)  # block-cyclic home (writer rotation)
         future = torch.arange(t_len).unsqueeze(0) > pos.unsqueeze(1)
         pooled = score.masked_fill(future, float("-inf")).reshape(1, sq, nb, block_size).amax(dim=-1)
-        pooled[:, torch.arange(sq), pos // block_size] = float("inf")  # forced-local: own straddled block
+        pooled[:, torch.arange(sq), pos // block_size] = float("inf")  # forced-local: own block
         refs.append(pooled.unsqueeze(1))
     return torch.cat(refs, dim=2)
 
@@ -1684,11 +1699,20 @@ def _straddle_msa_pooled_ref(q_g, k_nat, sp, chunk_global, chunk_start, t_len, s
 @pytest.mark.parametrize("mesh_device", [(2, 1)], ids=["sp2"], indirect=True)
 @pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
 def test_indexer_score_qb_straddle(mesh_device, case_id, heads):
-    """Mid-slab-boundary straddle on a REAL sp=2 mesh: block-cyclic K + a non-slab-aligned chunk_start (704,
-    offset 64) makes each device's queries straddle a slab boundary, so the causal diagonal must jump by
-    (chunk_global - cl) at q-row (cl - offset). This FAILS on the current op (linear diagonal, wrong -inf map);
-    the straddle geometry carved from #48500 makes it pass. Scaled stand-in for maxedge iter2 (test_mla)."""
-    sp = 2
+    """Mid-slab-boundary straddle + block-cyclic chip rotation on a REAL SP mesh: block-cyclic K + a
+    non-slab-aligned chunk_start (704) makes each device's queries straddle a slab boundary AND (when the
+    start block index isn't a multiple of sp) rotates which chip owns which block. The causal diagonal must
+    use the writer's rotation (rotated_chip_positions), not the linear chunk_start + r*Sq (sp2 here: cl=640,
+    boundary_chip=1, offset=64). Geometry is sp-generic (sp derived from the mesh); also verified locally at
+    sp=8 (cl=160, boundary_chip=4 mid-ring) to guard against overfitting to sp=2 -- kept at sp=2 in CI to
+    avoid an 8-chip reservation. Scaled stand-in for the maxedge rotated-prefill case (test_mla).
+
+    Also a PROGRAM-CACHE regression: chunk_start (and the derived per-device chunk_start_tiles / straddle)
+    are hash-EXCLUDED runtime args, re-patched by override_runtime_arguments on a hit. Two chunk_starts with
+    a DIFFERENT boundary_chip run through ONE cached program -- ST_CS (mid-slab: rotation + straddle) then 0
+    (aligned: linear) -- so the second call must be a cache hit (no recompile) yet still correct, exercising
+    the re-patch and not just create_at."""
+    sp = mesh_device.shape[0]
     q_g, k_nat, w_g = _global_inputs(heads, ST_CHUNK, ST_T, seed=42)
     k_bc = _to_slab(k_nat, sp, ST_CHUNK)
     mesh_shape = tuple(mesh_device.shape)
@@ -1696,20 +1720,32 @@ def test_indexer_score_qb_straddle(mesh_device, case_id, heads):
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
     w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
     k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
 
-    out = ttnn.experimental.indexer_score_dsa(
-        q_dev,
-        k_dev,
-        w_dev,
-        chunk_start_idx=ST_CS,  # explicit, mid-slab -> offset 64
-        cluster_axis=0,
-        block_cyclic_sp_axis=0,
-        block_cyclic_chunk_local=ST_CHUNK // sp,
-        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0),
-    )
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
-    ref = _straddle_ref(q_g, k_nat, w_g, sp, ST_CHUNK, ST_CS, ST_T)
-    assert_indexer_match(out_t, ref, ST_CHUNK, ST_T, check_neg=True)
+    def run(chunk_start):
+        out = ttnn.experimental.indexer_score_dsa(
+            q_dev,
+            k_dev,
+            w_dev,
+            chunk_start_idx=chunk_start,
+            cluster_axis=0,
+            block_cyclic_sp_axis=0,
+            block_cyclic_chunk_local=ST_CHUNK // sp,
+            program_config=cfg,
+        )
+        out_t = ttnn.to_torch(
+            out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1))
+        )
+        ref = _straddle_ref(q_g, k_nat, w_g, sp, ST_CHUNK, chunk_start, ST_T)
+        assert_indexer_match(out_t, ref, ST_CHUNK, ST_T, check_neg=True)
+
+    mesh_device.enable_program_cache()
+    run(ST_CS)  # miss: boundary_chip=1 (sp2), offset 64 -> rotation + straddle
+    entries = mesh_device.num_program_cache_entries()
+    run(0)  # hit: boundary_chip=0, offset 0 -> linear; must re-patch the geometry, not recompile
+    assert (
+        mesh_device.num_program_cache_entries() == entries
+    ), "switching boundary_chip recompiled -- chunk_start / straddle must be hash-excluded runtime args"
 
 
 @pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -50,15 +50,19 @@ constexpr uint32_t writer_straddle_q_tile = 1 + 8;    // mid-slab forced-local b
 constexpr uint32_t writer_straddle_jump_tiles = 1 + 9;
 }  // namespace rt_arg
 
-// Per-device causal geometry for the block-cyclic slab layout, all in tiles. Each device scores Sq queries;
-// on a mesh device r's q-row 0 sits at chunk_start_idx + r*Sq. When those Sq queries cross a CACHE slab
-// boundary (a multiple of cl = the cache's per-shard width = block_cyclic->chunk_local), the post-boundary
-// q-rows live in the next slab, so the causal diagonal JUMPS by (chunk_global - cl) tiles at q-row
-// (cl - offset), where chunk_global = sp * chunk_local. offset == 0, or Sq fitting inside one slab
-// (offset + Sq <= cl), leaves the diagonal linear -- the common chunk-aligned case and any re-split where Sq
-// divides cl. No block_cyclic -> plain linear, no straddle. sp is derived from the mesh, so a slab implies a
-// real mesh; the straddle is always evaluated when present (validate_block_cyclic guarantees Sq <= cl, so a
-// device crosses at most one boundary). Shared by create_at (device_index from the coordinate) and override
+// Per-device causal geometry for the block-cyclic slab layout, all in tiles. The global chunk
+// [chunk_start_idx, chunk_start_idx + chunk_global) is written round-robin across the sp chips by
+// update_padded_kv_cache, so chip c's Sq queries are a CONTIGUOUS logical block whose start follows the
+// writer's rotation -- NOT the linear chunk_start_idx + c*Sq. Two effects of a mid-slab chunk_start_idx:
+//   (a) block rotation: the starting block index (chunk_start_idx / chunk_local) can land on a chip != 0
+//       (boundary_chip), rotating which chip owns which block -- so chip c's logical start is the writer's
+//       update_idxt, mirroring rotated_chip_positions[c][0], not chunk_start_idx + c*chunk_local; and
+//   (b) straddle: the boundary chip's Sq queries cross a slab boundary, so its causal diagonal JUMPS by
+//       (chunk_global - chunk_local) tiles at q-row (chunk_local - offset).
+// The linear form only misses (a) when boundary_chip != 0 -- exactly the mid-slab, non-chip-0-start case
+// (e.g. the multi-turn rotated prefill). Chunk-aligned (offset == 0, boundary_chip == 0) reduces to linear.
+// No block_cyclic -> plain linear. The both-axes case (cluster_axis unset, block_cyclic_chunk_local == tp*Sq)
+// keeps the prior linear+straddle form. Shared by create_at (device_index from the coordinate) and override
 // (stored device_index).
 struct DeviceCausalGeometry {
     uint32_t chunk_start_tiles;    // global position of this device's q-row 0 (tiles)
@@ -68,17 +72,41 @@ struct DeviceCausalGeometry {
 inline DeviceCausalGeometry device_causal_geometry(
     const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
     const uint32_t TW = tt::constants::TILE_WIDTH;
-    const uint32_t chunk_start = args.chunk_start_idx + device_index * Sq;
     if (!args.block_cyclic.has_value()) {
-        return {chunk_start / TW, 0u, 0u};  // contiguous K -> linear diagonal, never straddles
+        return {(args.chunk_start_idx + device_index * Sq) / TW, 0u, 0u};  // contiguous K -> linear diagonal
     }
-    const uint32_t cl = args.block_cyclic->chunk_local;  // cache per-shard slab width (elements)
-    const uint32_t chunk_global = args.block_cyclic->sp * args.block_cyclic->chunk_local;
-    const uint32_t offset = chunk_start % cl;  // position within the cache slab
+    const uint32_t sp = args.block_cyclic->sp;
+    const uint32_t chunk_local = args.block_cyclic->chunk_local;  // cache per-shard slab width (elements)
+    const uint32_t chunk_global = sp * chunk_local;
+
+    if (args.cluster_axis.has_value()) {
+        // SP-only block-cyclic: device_index is the SP-ring index and owns ONE block (Sq == chunk_local).
+        // Mirror the update_padded_kv_cache writer's update_idxt (== rotated_chip_positions[device_index][0])
+        // so the diagonal starts at this chip's TRUE logical block -- handling the boundary_chip rotation that
+        // the linear chunk_start_idx + c*Sq misses. Only the boundary chip is mid-slab, so only it straddles.
+        const uint32_t boundary_slab = args.chunk_start_idx / chunk_global;
+        const uint32_t boundary_chip = (args.chunk_start_idx / chunk_local) % sp;
+        const uint32_t offset = args.chunk_start_idx % chunk_local;
+        const uint32_t update_idxt = device_index < boundary_chip    ? (boundary_slab + 1) * chunk_local
+                                     : device_index == boundary_chip ? boundary_slab * chunk_local + offset
+                                                                     : boundary_slab * chunk_local;
+        const uint32_t logical_start =
+            (update_idxt / chunk_local) * chunk_global + device_index * chunk_local + (update_idxt % chunk_local);
+        uint32_t straddle_q_tile = 0, straddle_jump_tiles = 0;
+        if (device_index == boundary_chip && offset != 0 && offset + Sq > chunk_local) {
+            straddle_q_tile = (chunk_local - offset) / TW;
+            straddle_jump_tiles = (chunk_global - chunk_local) / TW;
+        }
+        return {logical_start / TW, straddle_q_tile, straddle_jump_tiles};
+    }
+
+    // Both-axes (cluster_axis unset): prior linear + within-block straddle geometry.
+    const uint32_t chunk_start = args.chunk_start_idx + device_index * Sq;
+    const uint32_t offset = chunk_start % chunk_local;
     uint32_t straddle_q_tile = 0, straddle_jump_tiles = 0;
-    if (offset != 0 && offset + Sq > cl) {
-        straddle_q_tile = (cl - offset) / TW;
-        straddle_jump_tiles = (chunk_global - cl) / TW;
+    if (offset != 0 && offset + Sq > chunk_local) {
+        straddle_q_tile = (chunk_local - offset) / TW;
+        straddle_jump_tiles = (chunk_global - chunk_local) / TW;
     }
     return {chunk_start / TW, straddle_q_tile, straddle_jump_tiles};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -80,6 +80,11 @@ inline DeviceCausalGeometry device_causal_geometry(
     const uint32_t chunk_global = sp * chunk_local;
 
     if (args.cluster_axis.has_value()) {
+        TT_FATAL(
+            device_index < sp,
+            "indexer_score: device_index {} out of range for block-cyclic sp={} (check cluster_axis vs block_cyclic_sp_axis)",
+            device_index,
+            sp);
         // SP-only block-cyclic: device_index is the SP-ring index and owns ONE block (Sq == chunk_local).
         // Mirror the update_padded_kv_cache writer's update_idxt (== rotated_chip_positions[device_index][0])
         // so the diagonal starts at this chip's TRUE logical block -- handling the boundary_chip rotation that


### PR DESCRIPTION
## What

`indexer_score_dsa`'s `device_causal_geometry` derived each device's causal diagonal from the **linear** per-device start `chunk_start_idx + device_index*Sq`. That is wrong for a block-cyclic K cache when `chunk_start_idx` is mid-slab and its starting block index (`chunk_start_idx / chunk_local`) lands on a chip other than 0.

`update_padded_kv_cache` places the global chunk's blocks **round-robin across the sp chips starting at `boundary_chip`** — so a token's cache home is fixed and **ISL-independent**. The linear form instead makes each device's assumed positions drift with the cumulative ISL, so the causal mask lands on the wrong keys (a query attends the wrong *valid* keys of its own chunk).

The straddle from #48808 only handled the *within-block* offset (`offset != 0`), so it covered a boundary chip that's block-0-aligned but missed the **inter-block chip rotation** (`boundary_chip != 0`, `offset == 0`).

## Fix

Mirror the writer's `update_idxt` (identical to `rotated_chip_positions` / the `update_padded_kv_cache` writer) in `device_causal_geometry`, so each device's causal diagonal starts at its **true** logical block. Only the boundary chip is mid-slab, so only it straddles a slab boundary. Scoped to the SP-only block-cyclic path (`cluster_axis` set); the contiguous and both-axes paths are unchanged.

Also corrects `_straddle_ref` in the op test: #48808 landed with a self-consistent but **wrong** reference that used the linear positions (`base = chunk_start + r*Sq`) — placement must be ISL-independent, so the reference now uses the writer rotation.

## Testing (Blackhole, sp2/sp4)

- `test_indexer_score` `qb_straddle` (glm5, dsv32; `ST_CS=704` → `boundary_chip=1`) now asserts the writer rotation and passes; `qb_block_cyclic` / `qb_both_axes` / `slab_invp` / `partial_block_cyclic` unaffected — **16/16 passed**.
- End-to-end (GLM sparse MLA, rotated chunked prefill `iters_isl=[2560,2592,5120]`): a rotated partial chunk recovered from output PCC **0.772 → 0.99** (isolated: block-cyclic KVPE write was already correct at 0.9999; the divergence was purely this indexer-score causal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/indexer-score-rotated-causal-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/indexer-score-rotated-causal-fix)