### PR TITLE
Compute: make Quasar-unsupported APIs fail at compile time

### DIFF
--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -129,9 +129,9 @@ ALWI void unary_bcast_uninit(uint32_t icb) {
 #endif
 }
 
+#ifndef ARCH_QUASAR
 template <BroadcastType old_bcast_type, BroadcastType new_bcast_type>
 void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_ocb, uint32_t new_ocb) {
-#ifndef ARCH_QUASAR
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
     // Pass through uses A2D and potentially direct unpack to dest.
     constexpr DataCopyType data_copy_type =
@@ -163,8 +163,8 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
 #endif
 
     PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(old_ocb, new_ocb)));
-#endif
 }
+#endif
 
 /**
  * Shorthand template instantiation of sub_tiles_bcast.

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -127,17 +127,17 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) { compute_kerne
  * Must be paired with disable_fp32_dest_acc() when switching back to
  * BF16 accumulation mode within the same kernel.
  *
- * Only available on Wormhole and Blackhole (no-op on Quasar).
+ * Only available on Wormhole and Blackhole. Not supported on Quasar (compile error)
  *
  * Return value: None
  */
 // clang-format on
-ALWI void enable_fp32_dest_acc() {
 #ifndef ARCH_QUASAR
+ALWI void enable_fp32_dest_acc() {
     MATH((llk_math_set_fp32_dest_acc(true)));
     PACK((llk_pack_set_fp32_dest_acc(true)));
-#endif
 }
+#endif
 
 // clang-format off
 /**
@@ -150,16 +150,16 @@ ALWI void enable_fp32_dest_acc() {
  * reconfiguration that is safe to call mid-kernel without re-running
  * compute_kernel_hw_startup.
  *
- * Only available on Wormhole and Blackhole (no-op on Quasar).
+ * Only available on Wormhole and Blackhole. Not supported on Quasar (compile error)
  *
  * Return value: None
  */
 // clang-format on
-ALWI void disable_fp32_dest_acc() {
 #ifndef ARCH_QUASAR
+ALWI void disable_fp32_dest_acc() {
     MATH((llk_math_set_fp32_dest_acc(false)));
     PACK((llk_pack_set_fp32_dest_acc(false)));
-#endif
 }
+#endif
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -320,12 +320,12 @@ mm_init(
  * | idst           | The index of the tile in DST REG to which the result C will be written. | uint32_t | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 template <uint32_t num_faces = 4>
 [[deprecated("Unused; slated for removal. Use matmul_tiles() instead.")]] ALWI void matmul_tiles_math(uint32_t idst) {
-#ifndef ARCH_QUASAR
     MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE, num_faces>(idst)));
-#endif
 }
+#endif
 
 // clang-format off
 /**
@@ -361,13 +361,13 @@ template <uint32_t num_faces = 4>
  * | transpose      | The transpose flag for performing transpose operation on B    | uint32_t | Any positive value will indicate transpose is set | False    |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 [[deprecated("Call reconfig_data_format_srca(old_srca, in1) then matmul_init(in0, in1, transpose).")]] ALWI void
 mm_init_short_with_dt(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t c_in_old_srca, const uint32_t transpose = 0) {
-#ifndef ARCH_QUASAR
     reconfig_data_format_srca(c_in_old_srca, in1_cb_id);
     matmul_init(in0_cb_id, in1_cb_id, transpose);
-#endif
 }
+#endif
 
 // clang-format off
 /**
@@ -475,6 +475,7 @@ mm_block_init(
  * | kt_dim         | The inner dimension.                                       | uint32_t | Must be equal to block A column dimension | False    |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 [[deprecated("Call reconfig_data_format_srca(old_in1, in1) then matmul_block_init(...).")]] ALWI void
 mm_block_init_short_with_dt(
     uint32_t in0_cb_id,
@@ -486,11 +487,10 @@ mm_block_init_short_with_dt(
     uint32_t kt_dim = 1,
     uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
-#ifndef ARCH_QUASAR
     reconfig_data_format_srca(old_in1_cb_id, in1_cb_id);
     matmul_block_init(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim, call_line);
-#endif
 }
+#endif
 
 // clang-format off
 /**
@@ -510,6 +510,7 @@ mm_block_init_short_with_dt(
  * | kt_dim         | The inner dimension.                                       | uint32_t | Must be equal to block A column dimension | False    |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 [[deprecated("Call reconfig_data_format(old_in1, in1, old_in0, in0) then matmul_block_init(...).")]] ALWI void
 mm_block_init_short_with_both_dt(
     uint32_t in0_cb_id,
@@ -521,10 +522,9 @@ mm_block_init_short_with_both_dt(
     uint32_t rt_dim = 1,
     uint32_t kt_dim = 1) {
     LLK_SAN_FUNCTION();
-#ifndef ARCH_QUASAR
     reconfig_data_format(old_in1_cb_id, in1_cb_id, old_in0_cb_id, in0_cb_id);
     matmul_block_init(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim);
-#endif
 }
+#endif
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -173,11 +173,11 @@ ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) { PACK((llk_pack_reconf
  * | Function   | num_rows | Number of rows to pack from dest to L1 (each row = 16 datums)  | uint32_t | 1 to 64     | True     |
  */
 // clang-format on
-ALWI void pack_rows_init(uint32_t num_rows) {
 #ifndef ARCH_QUASAR
+ALWI void pack_rows_init(uint32_t num_rows) {
     PACK((llk_pack_rows_init(num_rows)));
-#endif
 }
+#endif
 
 // clang-format off
 /**
@@ -202,11 +202,11 @@ ALWI void pack_rows_init(uint32_t num_rows) {
  * | Function   | output_index | The index in the output CB to write to            | uint32_t | Must be less than the size of the CB                 | False    |
  */
 // clang-format on
-ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
 #ifndef ARCH_QUASAR
+ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
     PACK((llk_pack_rows(idst, ocb, output_index)));
-#endif
 }
+#endif
 
 // clang-format off
 /**
@@ -221,11 +221,11 @@ ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
  * Return value: None
  */
 // clang-format on
-ALWI void pack_rows_uninit() {
 #ifndef ARCH_QUASAR
+ALWI void pack_rows_uninit() {
     PACK((llk_pack_rows_uninit()));
-#endif
 }
+#endif
 
 /**
  * Configures packer ReLU activation at runtime.

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -73,16 +73,16 @@ ALWI void copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
  * | transpose      | Flag to perform transpose on SrcA                                 | uint32_t | Any positive value will indicate transpose is set | False    |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 ALWI void copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0) {
     LLK_SAN_FUNCTION();
     // This reconfig call checks if old operand has different data format to
     // new operand idx, otherwise no reconfig call occurs
-#ifndef ARCH_QUASAR
     UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_cbid, new_cbid)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_cbid, new_cbid)));
     copy_tile_to_dst_init_short(new_cbid, transpose);
-#endif
 }
+#endif
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/welford.h
+++ b/tt_metal/hw/inc/api/compute/welford.h
@@ -53,18 +53,14 @@ ALWI void welford_init() {
  * running mean/M2 accumulators in LREG4/5. Example usage of this is in `welford_update` - this is called once per tile
  * when the `do_scale` path runs `mul_tiles_bcast_scalar` in the same DST window.
  */
-ALWI void welford_reinit(uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
 #ifndef ARCH_QUASAR
+ALWI void welford_reinit(uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
     state_configure(cbid, call_line);
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         /*transpose=*/0, /*transpose_within_16x16_face=*/false, cbid)));
     MATH((llk_math_welfords_sfpu_reinit<DST_ACCUM_MODE>(cbid)));
-#else
-    (void)cbid;
-    (void)call_line;
-    ASSERT(false && "welford_reinit is unsupported on ARCH_QUASAR");
-#endif
 }
+#endif
 
 /**
  * @brief Clears stale mean and m2 values stored in the registers.


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Cleanup
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Compute API functions were no-ops on Quasar, their whole body sat behind `#ifndef ARCH_QUASAR` so kernels that used them compiled cleanly but silently misbehaved, a recurring time sink during Ops bring-up. This PR guards the full function definition on Quasar so calling an unsupported API is now a compile error instead of a silent no-op. It covers the 12 un-ported and deprecated functions.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Functions that are intentional no-ops on Quasar notably state_configure, which 16 init functions call on Quasar to feed the
Wormhole/Blackhole sentinel. Thus they are deliberately left as-is, since erroring them would break the Quasar build without catching any kernel bug.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skotarac/compute_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skotarac/compute_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skotarac/compute_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skotarac/compute_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skotarac/compute_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skotarac/compute_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skotarac/compute_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skotarac/compute_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skotarac/compute_compile)