### PR TITLE
[deepseek_v3_d_p] block-cyclic per-user lightning-indexer key cache (GLM/DS sparse chunked prefill)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -28,7 +28,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import (
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
-from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions
+from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
@@ -376,6 +376,133 @@ def run_sparse_mla_chunked_case(
     logger.info(f"[{variant.name}] Chunked output PCC: {pcc_message}")
     ttnn.synchronize_device(mesh_device)
     logger.info(f"[{variant.name}] sparse MLA chunked complete")
+
+
+def run_sparse_mla_rotated_case(
+    variant, config, mesh_device, iters_isl, chunk_size_global, ds_layer, ds_checkpoint, ds_repo
+):
+    """Rotation/padding scenario (sparse analogue of test_mla._run_chunked_prefill): one DENSE sequence
+    chunked VARIABLY by iters_isl (per-iter valid token counts). Each iter's real tokens are rotated to
+    start at the previous iter's real end (actual_start=kv_actual, tile-aligned); the fixed-width chunk's
+    non-valid rows are zeroed. This exercises: partial chunks, rotated (mid-slab) chunk_start, and — the
+    thing under test — that a later iter never attends the pad a partial earlier iter left in the cache
+    (the next iter's write overwrites it before scoring; causal masks the tail). Ground truth is the
+    single-shot sparse reference over the whole dense sequence; we compare each iter's valid region."""
+    seed = 42
+    sp_axis, tp_axis = 0, 1
+    mesh_shape = list(mesh_device.shape)
+    sp = mesh_shape[sp_axis]
+    tile = ttnn.TILE_SIZE
+    chunk_local = chunk_size_global // sp
+    for v in iters_isl:
+        assert 0 < v <= chunk_size_global and v % tile == 0, f"iter isl {v}: tile-aligned, <= {chunk_size_global}"
+    total_len = sum(iters_isl)
+
+    weights, src_tag = build_weights(
+        variant, config, seed=seed, layer=ds_layer, checkpoint_path=ds_checkpoint, repo=ds_repo
+    )
+    max_window = max(sum(iters_isl[:i]) + chunk_size_global for i in range(len(iters_isl)))
+    seq_len_cache = ((max_window + chunk_size_global - 1) // chunk_size_global) * chunk_size_global
+    config.max_seq_len = seq_len_cache
+    logger.info(
+        f"[{variant.name}] rotated: iters={iters_isl} total={total_len} chunk={chunk_size_global} cache={seq_len_cache} mesh={tuple(mesh_device.shape)}"
+    )
+
+    hidden = make_hidden(total_len, config.hidden_size, seed)[0]  # [total_len, H]
+    cache_dir = cpu_ref_cache_dir(variant)
+    ref_output, ref_kvpe = run_cpu_reference(
+        config, weights, hidden.unsqueeze(0), total_len, cache_dir, cache_tag=f"{src_tag}_rot{total_len}_funcidx"
+    )
+    ref_output = ref_output[0]  # [total_len, out_dim]
+    out_dim = ref_output.shape[-1]
+    ref_kvpe = ref_kvpe.reshape(-1, ref_kvpe.shape[-1])  # [total_len, kvpe_dim]
+
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=seq_len_cache,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_chunked=True,
+        slot_num=1,
+        layer_num=1,
+    )
+    rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
+    rope_tensors = rope.get_rope_tensors_indexed(
+        cache_seq_len_global=seq_len_cache, chunk_size_global=chunk_size_global
+    )
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len_cache,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+    )
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+
+    out_accum = torch.zeros(total_len, out_dim, dtype=torch.bfloat16)
+    for i, isl in enumerate(iters_isl):
+        kv_actual = sum(iters_isl[:i])
+        valid_end = kv_actual + isl
+        positions = rotated_chip_positions(kv_actual, sp, chunk_local)
+        flat = [positions[c][r] for c in range(sp) for r in range(chunk_local)]
+        gather_idx = torch.tensor([min(gp, total_len - 1) for gp in flat], dtype=torch.long)
+        chunk_in = hidden[gather_idx].clone()
+        chunk_in[torch.tensor([gp >= valid_end for gp in flat])] = 0.0
+        tt_h = ttnn.from_torch(
+            chunk_in.reshape(1, 1, chunk_size_global, config.hidden_size),
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+        )
+        tt_out = mla_tt.forward(tt_h, rope_tensors, tt_kvpe_cache, actual_start=kv_actual, cache_user_id=0)
+        out_flat = ttnn.to_torch(
+            tt_out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
+        ).to(torch.bfloat16)[0, 0]
+        valid_pairs = [(row, gp) for row, gp in enumerate(flat) if gp < valid_end]
+        out_accum[torch.tensor([gp for _, gp in valid_pairs])] = out_flat[torch.tensor([row for row, _ in valid_pairs])]
+        rot = "rotated" if kv_actual % chunk_size_global != 0 else "aligned"
+        _, m = comp_pcc(ref_output[kv_actual:valid_end], out_accum[kv_actual:valid_end], 0)
+        logger.info(f"[{variant.name}] iter {i} (kv_actual={kv_actual} isl={isl} {rot}): valid-region PCC {m}")
+
+    # ISOLATION: is the block-cyclic WRITE correct under rotation? Un-rotate the final KVPE cache and
+    # compare per-iter region + full to the reference. If cache matches but output above diverged, the
+    # bug is in SCORING (indexer top-k / sparse_sdpa), not the write.
+    cache_sr = ttnn.to_torch(
+        tt_kvpe_cache, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+    ).to(torch.bfloat16)[:, :1]
+    p = blockcyclic_positions(sp, chunk_size_global, cache_sr.shape[2])
+    nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
+    nat[p] = cache_sr[0, 0]
+    for i, isl in enumerate(iters_isl):
+        s = sum(iters_isl[:i])
+        _, m = comp_pcc(ref_kvpe[s : s + isl], nat[s : s + isl], 0)
+        logger.info(f"[{variant.name}] KVPE cache region iter {i} [{s}:{s + isl}]: {m}")
+    _, mk = comp_pcc(ref_kvpe[:total_len], nat[:total_len], 0)
+    logger.info(f"[{variant.name}] KVPE cache full PCC: {mk}")
+
+    _, msg = assert_with_pcc(
+        ref_output.reshape(1, 1, total_len, out_dim), out_accum.reshape(1, 1, total_len, out_dim), SPARSE_OUTPUT_PCC
+    )
+    logger.info(f"[{variant.name}] rotated full PCC: {msg}")
+    ttnn.synchronize_device(mesh_device)
+
+
+@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ANCHOR_CASES, indirect=["variant", "mesh_device"])
+@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize("iters_isl", [[2560, 2592, 5120]], ids=["maxedge"])
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_mla_rotated(
+    mesh_device, seq_len, iters_isl, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
+):
+    run_sparse_mla_rotated_case(variant, config_only, mesh_device, iters_isl, 5120, ds_layer, ds_checkpoint, ds_repo)
 
 
 # One combined parametrization (variant, mesh_device, seq_len) instead of three independent axes: the

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -502,7 +502,7 @@ def run_sparse_mla_rotated_case(
 def test_sparse_mla_rotated(
     mesh_device, seq_len, iters_isl, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
 ):
-    run_sparse_mla_rotated_case(variant, config_only, mesh_device, iters_isl, 5120, ds_layer, ds_checkpoint, ds_repo)
+    run_sparse_mla_rotated_case(variant, config_only, mesh_device, iters_isl, seq_len, ds_layer, ds_checkpoint, ds_repo)
 
 
 # One combined parametrization (variant, mesh_device, seq_len) instead of three independent axes: the

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -144,6 +144,21 @@ def _topology_from_device_params(device_params):
     )
 
 
+def _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, slot_num=1):
+    """Block-cyclic indexer key cache, allocated OUTSIDE ttMLA (mirrors tt_kvpe_cache) and passed into
+    ttMLA.forward(index_kv_cache=...) every call. BF8 (matches BF16 top-k within bf16 noise, half the memory)."""
+    return init_kvpe_cache(
+        kvpe_cache_head_dim=getattr(config, "index_head_dim", 128),
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        num_users=slot_num,
+        dtype=ttnn.bfloat8_b,
+    )
+
+
 def run_sparse_mla_accuracy_case(
     variant, config, mesh_device, seq_len, topology, ds_layer=None, ds_checkpoint=None, ds_repo=None
 ):
@@ -310,6 +325,7 @@ def run_sparse_mla_chunked_case(
         num_kvpe_cache_layers=1,
     )
 
+    tt_index_kv_cache = _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis)
     logger.debug(f"[{variant.name}] sparse MLA chunked: constructing TT module and indexed RoPE tensors")
     mla_tt = ttMLA(
         config,
@@ -343,7 +359,7 @@ def run_sparse_mla_chunked_case(
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
         )
-        out = mla_tt.forward(tt_x, rope_tensors, tt_kvpe_cache, actual_start=s)
+        out = mla_tt.forward(tt_x, rope_tensors, tt_kvpe_cache, actual_start=s, index_kv_cache=tt_index_kv_cache)
         outs.append(
             ttnn.to_torch(
                 out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
@@ -417,6 +433,7 @@ def run_sparse_mla_rotated_case(
     out_dim = ref_output.shape[-1]
     ref_kvpe = ref_kvpe.reshape(-1, ref_kvpe.shape[-1])  # [total_len, kvpe_dim]
 
+    tt_index_kv_cache = _init_index_kv_cache(config, mesh_device, seq_len_cache, mesh_shape, sp_axis, slot_num=1)
     mla_tt = ttMLA(
         config,
         weights,
@@ -461,7 +478,9 @@ def run_sparse_mla_rotated_case(
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
         )
-        tt_out = mla_tt.forward(tt_h, rope_tensors, tt_kvpe_cache, actual_start=kv_actual, cache_user_id=0)
+        tt_out = mla_tt.forward(
+            tt_h, rope_tensors, tt_kvpe_cache, actual_start=kv_actual, cache_user_id=0, index_kv_cache=tt_index_kv_cache
+        )
         out_flat = ttnn.to_torch(
             tt_out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
         ).to(torch.bfloat16)[0, 0]

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -46,7 +46,6 @@ from unittest import mock
 
 import pandas as pd
 import pytest
-import torch
 from loguru import logger
 from ttnn.device import is_blackhole
 
@@ -216,17 +215,19 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         num_kvpe_cache_layers=1,
     )
 
-    # Represent `cache` already-processed tokens by POPULATING the caches directly (no warm-up
-    # forwards). The indexer K-cache (replicated, natural order, grown by concat) is filled with random
-    # keys so the measured chunk scores against a full `cache`-length prefix. The KVPE block-cyclic
-    # cache is left at its init: the measured chunk writes its own slab and the gather reads the full
-    # prefix, and cache values don't change op shapes/timing.
-    mla._indexer._index_kbuf = ttnn.from_torch(
-        torch.randn(1, 1, cache, mla._indexer.index_args.index_head_dim, dtype=torch.bfloat16),
-        device=mesh_device,
-        layout=ttnn.TILE_LAYOUT,
-        dtype=ttnn.bfloat16,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    # Block-cyclic indexer key cache: allocated externally (same ownership as the KVPE cache) and passed
+    # into forward. Left at its zero init — for a profiling proxy the cache CONTENTS don't affect op
+    # shapes/timing (the gather + score always cover the full `total`-length prefix), so representing the
+    # `cache` already-processed tokens needs no warm-up write. The KVPE cache is likewise left at init.
+    index_kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=mla._indexer.index_args.index_head_dim,
+        mesh_device=mesh_device,
+        seq_len=total,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        num_users=1,
+        dtype=ttnn.bfloat8_b,
     )
 
     hidden = make_hidden(chunk, config.hidden_size, seed=42)  # only the measured chunk
@@ -247,7 +248,7 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         f"local MLA heads={config.num_attention_heads // tp}, local indexer heads={config.index_n_heads // tp}"
     )
     signpost("start")
-    out = mla.forward(tt_x, rope, kvpe_cache, actual_start=cache)
+    out = mla.forward(tt_x, rope, kvpe_cache, actual_start=cache, index_kv_cache=index_kv_cache)
     ttnn.deallocate(out)
     ttnn.synchronize_device(mesh_device)
     signpost("stop")

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -421,10 +421,10 @@ class TtIndexer:
         cache. forward() calls this on every chunk so the key-cache stays complete — else later chunks
         score against missing keys for the early prefix. (Dense v3.1 binds a NullIndexer, so write_k never
         runs there.) Two paths, fixed by self._blockcyclic:
-          - block-cyclic (GLM chunked): rope the PER-CHIP shard at its block-cyclic positions, then write
+          - block-cyclic (GLM/DS chunked): rope the PER-CHIP shard at its block-cyclic positions, then write
             it in place via update_padded_kv_cache (per-user slot, pad-aware kv_actual_global offset) — no
             SP all-gather, no O(n^2) concat; the cache stays SP-sharded.
-          - natural (single-shot / DS chunked): SP all-gather to full-glob + natural rope + concat-grow."""
+          - natural (single-shot, all variants): SP all-gather to full-glob + natural rope + concat-grow."""
         k = ttnn.linear(
             hidden_states,
             self._idx_wk,

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -20,7 +20,6 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_perm_matrix
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
 # module-level INDEXER_WEIGHT_NAMES alias is defined at the bottom of this file for back-compat.
@@ -236,19 +235,13 @@ class TtIndexer:
         # rope is reconciled by _rope_perm below (permute q/k rope halves so the interleaved op matches the
         # DS reference). Single-shot (all variants) stays on the natural gather+concat path.
         self._blockcyclic = is_chunked
-        # Natural path: lazily grown replicated cache. Block-cyclic path: persistent [num_users,1,S/sp,D_idx].
+        # Block-cyclic key cache (persistent [num_users,1,S/sp,D_idx]) is NOT owned here: exactly like the
+        # MLA KVPE cache, the caller allocates it and passes it into forward(index_kv_cache=...) every call;
+        # the indexer never self-allocates it. write_k typecasts the roped key to the cache's dtype before
+        # the in-place write, so the caller controls the dtype (BF8 is validated — rotated + accuracy suites
+        # match BF16 within bf16 noise, ~5e-4 PCC — so it can be allocated BF8 to halve the memory).
+        # self._index_kbuf below is the NATURAL (single-shot) path's internal concat-grown cache only.
         self._index_kbuf = None
-        if self._blockcyclic:
-            self._index_kbuf = init_kvpe_cache(
-                kvpe_cache_head_dim=self.index_args.index_head_dim,
-                mesh_device=self.mesh_device,
-                seq_len=seq_len,
-                mesh_shape=mesh_shape,
-                sp_axis=self.sp_axis,
-                num_kvpe_cache_layers=1,
-                num_users=slot_num,
-                dtype=ttnn.bfloat16,  # keep indexer keys bf16 (the natural concat path did); avoid bf8 top-k loss
-            )
         self._upload_weights(idx_host)
         self._build_rope_tables()
         # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
@@ -397,7 +390,7 @@ class TtIndexer:
         ttnn.deallocate(nope)
         return out
 
-    def _gather_index_kbuf(self) -> ttnn.Tensor:
+    def _gather_index_kbuf(self, index_kbuf: ttnn.Tensor) -> ttnn.Tensor:
         """Read the block-cyclic ND-sharded key cache back to a replicated full-T [num_users,1,T,D_idx]
         (block-cyclic order preserved, bf16 TILE) for indexer_score_dsa's block-cyclic reader — the
         analogue of ttMLA._gather_kvpe_prefix, but the score op consumes TILE so no RM/typecast step.
@@ -410,13 +403,13 @@ class TtIndexer:
         the per-slab gather with the score matmul so each SP key slab is gathered and scored as it arrives,
         overlapping the CCL with the op's own compute instead of paying a full gather up front. Op-level
         change (ring indexer_score), not a host-side reorder."""
-        cache_i = ttnn.to_memory_config(self._index_kbuf, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
+        cache_i = ttnn.to_memory_config(index_kbuf, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
         full = self._sp_all_gather(cache_i, dim=2)  # [B,1,T,D_idx] replicated, block-cyclic
         if self.sp_factor > 1:
             ttnn.deallocate(cache_i)
         return full
 
-    def write_k(self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0):
+    def write_k(self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0, index_kbuf=None):
         """Device K stem (wk + TP all-reduce + k_norm + device rope) written into the device index-key
         cache. forward() calls this on every chunk so the key-cache stays complete — else later chunks
         score against missing keys for the early prefix. (Dense v3.1 binds a NullIndexer, so write_k never
@@ -446,8 +439,10 @@ class TtIndexer:
             # write it into this user's slot. update_padded_kv_cache places each chip's rows at the
             # block-cyclic offset (pad-aware) — the same math the query/key rope above uses.
             k = self._bc_rope_pe(k, rope_tensors, start_pos)  # [1, 1, S/sp, D_idx] bf16
+            if k.dtype != index_kbuf.dtype:  # write dtype must match the cache (update_padded_kv_cache asserts)
+                k = ttnn.typecast(k, index_kbuf.dtype)
             ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
-                self._index_kbuf,
+                index_kbuf,
                 k,
                 slot_idx=cache_user_id,
                 layer_idx=0,
@@ -463,7 +458,7 @@ class TtIndexer:
         # the retired non-block-cyclic chunked mode. The live cost is the all-gather + full replication
         # (glob keys/chip vs glob/sp block-cyclic).
         #
-        # TODO(refactor, drop natural path -- pavlepopovic review): fold single-shot onto the block-cyclic
+        # TODO(refactor, drop natural path): fold single-shot onto the block-cyclic
         # path (treat it as one full-seq chunk at start_pos=0): SP-sharded cache + in-place
         # update_padded_kv_cache, no all-gather / no replication / no concat -- then delete this branch,
         # _device_rope_pe's natural use, and _sp_all_gather. Dependency: single-shot must supply the
@@ -494,10 +489,15 @@ class TtIndexer:
         start_pos: int = 0,
         rope_tensors: dict = None,
         cache_user_id: int = 0,
+        index_kv_cache: ttnn.Tensor = None,
     ) -> ttnn.Tensor:
         """Indexer forward → top-k key indices [1, 1, S/sp, k] over the device index-key cache, SP-sharded
         on the query axis (each chip scores its own S/sp rows; no Q/W all-gather). Fully on-device:
         stems, RoPE, cache, logits, topk — no host.
+
+        ``index_kv_cache`` (block-cyclic path): the persistent per-user key cache, allocated by the caller and
+        passed in every call — the same ownership as ttMLA's KVPE ``kvpe_cache``. Required for the block-cyclic
+        path (the indexer never self-allocates it); ignored by the natural (single-shot) path.
 
         ``qr`` is the shared q_a latent (q_a_proj + TP all-reduce + q_a_layernorm) — ttMLA computes it once
         and passes it in; the indexer applies wq_b to it (no q_a stem of its own). ``qr`` is NOT deallocated
@@ -512,7 +512,20 @@ class TtIndexer:
         a = self.index_args
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
-        self.write_k(hidden_states, seq_len, start_pos, rope_tensors=rope_tensors, cache_user_id=cache_user_id)
+        # Block-cyclic key cache is caller-owned (like the KVPE cache) — required, never self-allocated.
+        if self._blockcyclic:
+            assert index_kv_cache is not None, (
+                "block-cyclic indexer requires an externally-allocated index_kv_cache passed to forward() "
+                "(same ownership as the MLA KVPE cache); none was provided"
+            )
+        self.write_k(
+            hidden_states,
+            seq_len,
+            start_pos,
+            rope_tensors=rope_tensors,
+            cache_user_id=cache_user_id,
+            index_kbuf=index_kv_cache,
+        )
 
         # Q stem: the shared q_a latent (qr) -> indexer wq_b.
         q = ttnn.linear(
@@ -576,7 +589,7 @@ class TtIndexer:
             # It also needs the logits sliced to [0, end_pos) before top-k (that path validated correct at the
             # OP level, but is deferred). Investigate: slice-vs-stale-tail interaction + whether the extra
             # slice/copy is cheaper than the saved score/top-k work before turning this on.
-            k_full = self._gather_index_kbuf()  # [num_users, 1, T, D_idx] bf16 TILE, block-cyclic
+            k_full = self._gather_index_kbuf(index_kv_cache)  # [num_users, 1, T, D_idx] bf16 TILE, block-cyclic
             logits = ttnn.experimental.indexer_score_dsa(
                 q_dev,
                 k_full,

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -228,7 +228,6 @@ class TtIndexer:
             index_rope_interleave=getattr(config, "index_rope_interleave", False),
         )
         self.seq_len = seq_len
-        self.slot_num = slot_num
         self.is_chunked = is_chunked
         # Block-cyclic key-cache path (chunked prefill): mirrors the MLA KVPE cache — a persistent,
         # per-user, block-cyclic ND-sharded key cache written by update_padded_kv_cache and scored by

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -19,7 +19,11 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.mla.rope import get_cos_sin_matrix, get_rot_transformation_mat
+from models.demos.deepseek_v3_d_p.tt.mla.rope import (
+    get_cos_sin_matrix,
+    get_rot_transformation_mat,
+    interleaved_to_halfsplit_perm,
+)
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
@@ -232,11 +236,11 @@ class TtIndexer:
         self.is_chunked = is_chunked
         # Block-cyclic key-cache path (chunked prefill): mirrors the MLA KVPE cache — a persistent,
         # per-user, block-cyclic ND-sharded key cache written by update_padded_kv_cache and scored by
-        # indexer_score_dsa's block-cyclic reader. Gated on interleaved RoPE: it needs an on-device
-        # INDEXED rope (rotary_embedding_indexed), which only serves the interleaved (GLM) convention;
-        # DS-v3.2's half-split (rotary_embedding_hf) has no indexed variant, so DS chunked — and all
-        # single-shot — stay on the natural gather+concat path.
-        self._blockcyclic = is_chunked and self.index_args.index_rope_interleave
+        # indexer_score_dsa's block-cyclic reader. Both variants use it; the rope is always the interleaved
+        # on-device INDEXED op (rotary_embedding_indexed). GLM is natively interleaved; DS-v3.2's half-split
+        # rope is reconciled by _rope_perm below (permute q/k rope halves so the interleaved op matches the
+        # DS reference). Single-shot (all variants) stays on the natural gather+concat path.
+        self._blockcyclic = is_chunked
         # Natural path: lazily grown replicated cache. Block-cyclic path: persistent [num_users,1,S/sp,D_idx].
         self._index_kbuf = None
         if self._blockcyclic:
@@ -252,6 +256,28 @@ class TtIndexer:
             )
         self._upload_weights(idx_host)
         self._build_rope_tables()
+        # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
+        # half-split (rotate_half) rope arrangement. Permute the rope half (half-split -> interleaved) so
+        # the interleaved op pairs the right dims with each frequency; applied to BOTH q and k, the
+        # permutation cancels in q·k, so the score (hence top-k) matches the DS half-split reference. GLM
+        # is natively interleaved -> no permute. NOTE: the stored key is then in interleaved layout —
+        # reindex by rope.interleaved_to_halfsplit_perm to compare it against a half-split reference.
+        self._rope_perm = None
+        if self._blockcyclic and not self.index_args.index_rope_interleave:
+            # Build the half-split -> interleaved permutation matrix from rope.py's canonical convention
+            # (single source of truth). interleaved_to_halfsplit_perm() returns p with
+            # halfsplit = interleaved[p]; its inverse (argsort) maps halfsplit -> interleaved, i.e.
+            # out[j] = in[src[j]], realised as the matmul weight perm[src[j], j] = 1.
+            src = torch.argsort(interleaved_to_halfsplit_perm(64))
+            perm = torch.zeros(64, 64, dtype=torch.bfloat16)
+            perm[src, torch.arange(64)] = 1.0
+            self._rope_perm = ttnn.from_torch(
+                perm,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
 
     # Inlined TP/SP collectives — the indexer owns its own copy so it depends on tt_ccl, not on ttMLA
     # (the dense MLA forward keeps its own equivalents; both go through the same tt_ccl handles).
@@ -367,13 +393,19 @@ class TtIndexer:
     def _bc_rope_pe(self, x: ttnn.Tensor, rope_tensors: dict, kv_actual_global: int) -> ttnn.Tensor:
         """Block-cyclic INDEXED RoPE on the rope half (first 64) of the last dim (block-cyclic path only).
         x [1, n_heads, S/sp, D_idx] SP-sharded on seq; rope_tensors are the whole-cache block-cyclic
-        cos/sin/trans built by RotarySetup.get_rope_tensors_indexed — reused verbatim from ttMLA (for GLM
-        the indexer's interleaved rope == the MLA's, same 64-dim table). The op derives each shard-row's
+        cos/sin/trans built by RotarySetup.get_rope_tensors_indexed — reused verbatim from ttMLA (the
+        interleaved table, same 64-dim, shared with the MLA q_pe/k_pe rope). The op derives each shard-row's
         block-cyclic global position on-device from kv_actual_global, exactly as MLA's _apply_rope_padded,
-        so keys land at the same positions update_padded_kv_cache writes them to."""
+        so keys land at the same positions update_padded_kv_cache writes them to. For DS (half-split
+        weights) self._rope_perm first reorders the rope half into the interleaved arrangement so this
+        interleaved op matches the DS reference (the permutation cancels in q·k, applied to both q and k)."""
         h, n = x.shape[1], x.shape[2]
         pe = ttnn.slice(x, [0, 0, 0, 0], [1, h, n, 64])
         nope = ttnn.slice(x, [0, 0, 0, 64], [1, h, n, self.index_args.index_head_dim])
+        if self._rope_perm is not None:  # DS: half-split -> interleaved arrangement for the interleaved op
+            pe_i = ttnn.linear(pe, self._rope_perm, compute_kernel_config=self.hifi4_fp32_compute_kernel_config)
+            ttnn.deallocate(pe)
+            pe = pe_i
         pe = ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
             pe,
             rope_tensors["cos_matrix"],

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.tt.mla.rope import get_cos_sin_matrix, get_rot_transformation_mat
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
 # module-level INDEXER_WEIGHT_NAMES alias is defined at the bottom of this file for back-compat.
@@ -193,6 +194,9 @@ class TtIndexer:
         tt_ccl,
         ccl_num_links: int,
         ccl_topology,
+        seq_len: int = 1024,
+        slot_num: int = 1,
+        is_chunked: bool = False,
     ):
         """Architecture constants are read from the HF config (DS defaults below; GLM sets
         index_rope_interleave / index_n_heads etc.). θ / YaRN / rope table length come from the
@@ -223,7 +227,29 @@ class TtIndexer:
             index_topk=getattr(config, "index_topk", 2048),
             index_rope_interleave=getattr(config, "index_rope_interleave", False),
         )
+        self.seq_len = seq_len
+        self.slot_num = slot_num
+        self.is_chunked = is_chunked
+        # Block-cyclic key-cache path (chunked prefill): mirrors the MLA KVPE cache — a persistent,
+        # per-user, block-cyclic ND-sharded key cache written by update_padded_kv_cache and scored by
+        # indexer_score_dsa's block-cyclic reader. Gated on interleaved RoPE: it needs an on-device
+        # INDEXED rope (rotary_embedding_indexed), which only serves the interleaved (GLM) convention;
+        # DS-v3.2's half-split (rotary_embedding_hf) has no indexed variant, so DS chunked — and all
+        # single-shot — stay on the natural gather+concat path.
+        self._blockcyclic = is_chunked and self.index_args.index_rope_interleave
+        # Natural path: lazily grown replicated cache. Block-cyclic path: persistent [num_users,1,S/sp,D_idx].
         self._index_kbuf = None
+        if self._blockcyclic:
+            self._index_kbuf = init_kvpe_cache(
+                kvpe_cache_head_dim=self.index_args.index_head_dim,
+                mesh_device=self.mesh_device,
+                seq_len=seq_len,
+                mesh_shape=mesh_shape,
+                sp_axis=self.sp_axis,
+                num_kvpe_cache_layers=1,
+                num_users=slot_num,
+                dtype=ttnn.bfloat16,  # keep indexer keys bf16 (the natural concat path did); avoid bf8 top-k loss
+            )
         self._upload_weights(idx_host)
         self._build_rope_tables()
 
@@ -338,11 +364,57 @@ class TtIndexer:
             )
         return ttnn.concat([pe, nope], dim=-1)
 
-    def write_k(self, hidden_states: ttnn.Tensor, seq_len: int, start_pos: int):
-        """Device K stem (wk + TP all-reduce + k_norm + SP all-gather + device rope),
-        appended to the device index-key cache. forward() calls this on every chunk so the key-cache
-        stays complete — else later chunks score against missing keys for the early prefix. (Dense v3.1
-        binds a NullIndexer instead, so write_k never runs there.)"""
+    def _bc_rope_pe(self, x: ttnn.Tensor, rope_tensors: dict, kv_actual_global: int) -> ttnn.Tensor:
+        """Block-cyclic INDEXED RoPE on the rope half (first 64) of the last dim (block-cyclic path only).
+        x [1, n_heads, S/sp, D_idx] SP-sharded on seq; rope_tensors are the whole-cache block-cyclic
+        cos/sin/trans built by RotarySetup.get_rope_tensors_indexed — reused verbatim from ttMLA (for GLM
+        the indexer's interleaved rope == the MLA's, same 64-dim table). The op derives each shard-row's
+        block-cyclic global position on-device from kv_actual_global, exactly as MLA's _apply_rope_padded,
+        so keys land at the same positions update_padded_kv_cache writes them to."""
+        h, n = x.shape[1], x.shape[2]
+        pe = ttnn.slice(x, [0, 0, 0, 0], [1, h, n, 64])
+        nope = ttnn.slice(x, [0, 0, 0, 64], [1, h, n, self.index_args.index_head_dim])
+        pe = ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
+            pe,
+            rope_tensors["cos_matrix"],
+            rope_tensors["sin_matrix"],
+            rope_tensors["trans_matrix"],
+            kv_actual_global=kv_actual_global,
+            cluster_axis=self.sp_axis,
+        )
+        out = ttnn.concat([pe, nope], dim=-1)
+        ttnn.deallocate(pe)
+        ttnn.deallocate(nope)
+        return out
+
+    def _gather_index_kbuf(self) -> ttnn.Tensor:
+        """Read the block-cyclic ND-sharded key cache back to a replicated full-T [num_users,1,T,D_idx]
+        (block-cyclic order preserved, bf16 TILE) for indexer_score_dsa's block-cyclic reader — the
+        analogue of ttMLA._gather_kvpe_prefix, but the score op consumes TILE so no RM/typecast step.
+        The op selects this user's slot via cache_batch_idx; the unwritten suffix is never scored
+        (future positions are causally masked).
+
+        PERF TODO: this SP all-gather is currently a blocking barrier — it materializes the whole full-T
+        key cache before indexer_score_dsa runs. It should instead be FUSED INTO the score op (ring-joint
+        style, like ring_mla / ring-joint SDPA fuse the KV all-gather with the attention compute): pipeline
+        the per-slab gather with the score matmul so each SP key slab is gathered and scored as it arrives,
+        overlapping the CCL with the op's own compute instead of paying a full gather up front. Op-level
+        change (ring indexer_score), not a host-side reorder."""
+        cache_i = ttnn.to_memory_config(self._index_kbuf, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
+        full = self._sp_all_gather(cache_i, dim=2)  # [B,1,T,D_idx] replicated, block-cyclic
+        if self.sp_factor > 1:
+            ttnn.deallocate(cache_i)
+        return full
+
+    def write_k(self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0):
+        """Device K stem (wk + TP all-reduce + k_norm + device rope) written into the device index-key
+        cache. forward() calls this on every chunk so the key-cache stays complete — else later chunks
+        score against missing keys for the early prefix. (Dense v3.1 binds a NullIndexer, so write_k never
+        runs there.) Two paths, fixed by self._blockcyclic:
+          - block-cyclic (GLM chunked): rope the PER-CHIP shard at its block-cyclic positions, then write
+            it in place via update_padded_kv_cache (per-user slot, pad-aware kv_actual_global offset) — no
+            SP all-gather, no O(n^2) concat; the cache stays SP-sharded.
+          - natural (single-shot / DS chunked): SP all-gather to full-glob + natural rope + concat-grow."""
         k = ttnn.linear(
             hidden_states,
             self._idx_wk,
@@ -358,15 +430,28 @@ class TtIndexer:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             compute_kernel_config=self.default_compute_kernel_config,
         )
+
+        if self._blockcyclic:
+            # Rope the per-chip shard at its block-cyclic positions (kv_actual_global=start_pos), then
+            # write it into this user's slot. update_padded_kv_cache places each chip's rows at the
+            # block-cyclic offset (pad-aware) — the same math the query/key rope above uses.
+            k = self._bc_rope_pe(k, rope_tensors, start_pos)  # [1, 1, S/sp, D_idx] bf16
+            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                self._index_kbuf,
+                k,
+                slot_idx=cache_user_id,
+                layer_idx=0,
+                num_layers=1,
+                kv_actual_global=start_pos,
+                cluster_axis=self.sp_axis,
+            )
+            ttnn.deallocate(k)
+            return
+
+        # Natural path (single-shot / DS chunked): full/replicated, grown by concat (O(n^2)).
         glob = seq_len * self.sp_factor
         k = self._sp_all_gather(k, dim=2)  # [1, 1, glob, D_idx] full, replicated, natural order
-        k = self._device_rope_pe(k, glob, start_pos)  # on-device non-interleaved rope
-        # Grow the replicated device cache by concat (natural order; no block-cyclic).
-        # FOLLOW-UP (scoped redesign, not a drop-in): concat reallocates the whole key-cache each chunk
-        # (O(n^2) copies over a long prefill). Reusing the MLA block-cyclic KVPE cache machinery
-        # (update_padded_kv_cache + a gather/un-rotate read like _gather_kvpe_prefix) would avoid that,
-        # but it changes the indexer key-cache layout (replicated-natural -> block-cyclic-SP) and the
-        # scoring read path, so it is tracked as its own task rather than done here.
+        k = self._device_rope_pe(k, glob, start_pos)  # on-device rope
         # The rest of this MLA code manually deallocates intermediate device tensors, so free the device
         # buffers we drop here too rather than relying on Python ref-loss (which would accumulate device
         # allocations over a long chunked prefill or across repeated requests).
@@ -380,20 +465,33 @@ class TtIndexer:
             ttnn.deallocate(old)  # ...so the old cache and this chunk's keys are both free to drop
             ttnn.deallocate(k)
 
-    def forward(self, hidden_states: ttnn.Tensor, qr: ttnn.Tensor, seq_len: int, start_pos: int = 0) -> ttnn.Tensor:
+    def forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        qr: ttnn.Tensor,
+        seq_len: int,
+        start_pos: int = 0,
+        rope_tensors: dict = None,
+        cache_user_id: int = 0,
+        actual_end: int = None,
+    ) -> ttnn.Tensor:
         """Indexer forward → top-k key indices [1, 1, S/sp, k] over the device index-key cache, SP-sharded
         on the query axis (each chip scores its own S/sp rows; no Q/W all-gather). Fully on-device:
-        stems, RoPE, cache, logits, topk — no host. K stays full/replicated (every query scores all keys).
+        stems, RoPE, cache, logits, topk — no host.
 
         ``qr`` is the shared q_a latent (q_a_proj + TP all-reduce + q_a_layernorm) — ttMLA computes it once
         and passes it in; the indexer applies wq_b to it (no q_a stem of its own). ``qr`` is NOT deallocated
         here — ttMLA's _q_stem consumes it afterwards. ``hidden_states`` is still needed for the K stem
         (write_k) and the per-head weights (weights_proj). (write_k is called internally here; ttMLA.forward
-        only ever calls self._indexer.forward — it never calls write_k directly.)"""
+        only ever calls self._indexer.forward — it never calls write_k directly.)
+
+        Block-cyclic path (GLM chunked): ``rope_tensors`` (the MLA's block-cyclic indexed cos/sin/trans),
+        ``cache_user_id`` (per-user slot), and ``actual_end`` (valid global length → kv_len pad mask) drive
+        the per-user block-cyclic key cache + block-cyclic scoring. Natural path ignores them."""
         a = self.index_args
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
-        self.write_k(hidden_states, seq_len, start_pos)
+        self.write_k(hidden_states, seq_len, start_pos, rope_tensors=rope_tensors, cache_user_id=cache_user_id)
 
         # Q stem: the shared q_a latent (qr) -> indexer wq_b.
         q = ttnn.linear(
@@ -406,7 +504,10 @@ class TtIndexer:
         q, _, _ = ttnn.experimental.nlp_create_qkv_heads(
             q, num_heads=heads_local, num_kv_heads=0, transpose_k_heads=False, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )  # [1, H_idx/tp, S/sp, D_idx]
-        q_dev = self._device_rope_pe(q, glob, start_pos, sp_shard=True)  # per-chip query positions
+        if self._blockcyclic:  # block-cyclic indexed rope (same op/tables as the key rope + MLA q_pe)
+            q_dev = self._bc_rope_pe(q, rope_tensors, start_pos)
+        else:
+            q_dev = self._device_rope_pe(q, glob, start_pos, sp_shard=True)  # per-chip natural query positions
 
         # weights_proj: device stem -> reduce-scatter the H_idx heads across tp (each chip keeps the
         # reduced H_idx/tp slice matching its wq_b heads) -> SP gather -> scale -> [1, 1, glob, H_idx/tp].
@@ -438,14 +539,34 @@ class TtIndexer:
         # sp_rank*seq_len. topk below then stays SP-sharded ([1,1,S/sp,k]) — fed straight to sparse_mla.
         # indexer_score wants per-head weights [1, H_idx/tp, S/sp, 1]; wts is [1, 1, S/sp, H_idx/tp].
         weights = ttnn.permute(wts, (0, 3, 2, 1))
-        logits = ttnn.experimental.indexer_score_dsa(
-            q_dev,
-            self._index_kbuf,
-            weights,
-            chunk_start_idx=start_pos,
-            program_config=cfg,
-            cluster_axis=self.sp_axis,
-        )
+        if self._blockcyclic:
+            # Gather the per-user block-cyclic key cache to replicated full-T; the op reads it back in
+            # logical order via invP, selects this user's slot via cache_batch_idx, and applies the
+            # straddle for a non-slab-aligned start_pos (padded chunk). kv_len masks pad keys within the
+            # valid range (None → causal alone masks the unwritten future suffix).
+            k_full = self._gather_index_kbuf()  # [num_users, 1, T, D_idx] bf16 TILE, block-cyclic
+            logits = ttnn.experimental.indexer_score_dsa(
+                q_dev,
+                k_full,
+                weights,
+                chunk_start_idx=start_pos,
+                program_config=cfg,
+                cluster_axis=self.sp_axis,
+                cache_batch_idx=cache_user_id,
+                block_cyclic_sp_axis=self.sp_axis,
+                block_cyclic_chunk_local=seq_len,  # per-chip chunk == chunk_size_global / sp
+                kv_len=actual_end,
+            )
+            ttnn.deallocate(k_full)
+        else:
+            logits = ttnn.experimental.indexer_score_dsa(
+                q_dev,
+                self._index_kbuf,
+                weights,
+                chunk_start_idx=start_pos,
+                program_config=cfg,
+                cluster_axis=self.sp_axis,
+            )
         # All-reduce(SUM) the partial logits over tp -> full head-summed logit before top-k. The op emits
         # ROW_MAJOR; _tp_rs_ag (reduce_scatter+all_gather) runs in TILE, so round-trip the layout.
         if self.tp_factor > 1:

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -483,7 +483,6 @@ class TtIndexer:
         start_pos: int = 0,
         rope_tensors: dict = None,
         cache_user_id: int = 0,
-        actual_end: int = None,
     ) -> ttnn.Tensor:
         """Indexer forward → top-k key indices [1, 1, S/sp, k] over the device index-key cache, SP-sharded
         on the query axis (each chip scores its own S/sp rows; no Q/W all-gather). Fully on-device:
@@ -495,9 +494,10 @@ class TtIndexer:
         (write_k) and the per-head weights (weights_proj). (write_k is called internally here; ttMLA.forward
         only ever calls self._indexer.forward — it never calls write_k directly.)
 
-        Block-cyclic path (GLM chunked): ``rope_tensors`` (the MLA's block-cyclic indexed cos/sin/trans),
-        ``cache_user_id`` (per-user slot), and ``actual_end`` (valid global length → kv_len pad mask) drive
-        the per-user block-cyclic key cache + block-cyclic scoring. Natural path ignores them."""
+        Block-cyclic path (GLM/DS chunked): ``rope_tensors`` (the MLA's block-cyclic indexed cos/sin/trans)
+        and ``cache_user_id`` (per-user slot) drive the per-user block-cyclic key cache + block-cyclic
+        scoring. Scoring currently spans the full preallocated cache width (see the kv_len TODO below).
+        Natural path ignores rope_tensors/cache_user_id."""
         a = self.index_args
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
@@ -552,8 +552,19 @@ class TtIndexer:
         if self._blockcyclic:
             # Gather the per-user block-cyclic key cache to replicated full-T; the op reads it back in
             # logical order via invP, selects this user's slot via cache_batch_idx, and applies the
-            # straddle for a non-slab-aligned start_pos (padded chunk). kv_len masks pad keys within the
-            # valid range (None → causal alone masks the unwritten future suffix).
+            # straddle for a non-slab-aligned start_pos (padded chunk). Scores the FULL preallocated width T:
+            # positions past each query are causally -inf, and top-k below drops those (-inf -> sentinel).
+            #
+            # TODO(perf, indexer kv_len): on an over-allocated cache (T >> written extent, e.g. a 55k slot
+            # with a 5k chunk written) this scores the whole T. The op supports bounding the scored logical
+            # prefix via kv_len (the tightest legal value is end_pos = start_pos + chunk_global; it cannot go
+            # lower because the pad query rows push the fullest-device causal window to end_pos, and the op
+            # TT_FATALs on kv_len < that). Wiring kv_len=end_pos here is NOT correct on its own: kv_len only
+            # writes logits[:, :, :, :end_pos] and leaves the tail [end_pos, T) STALE (not -inf), so the
+            # downstream top-k over full-T then picks garbage columns (observed: rotated-prefill PCC -> 0.0).
+            # It also needs the logits sliced to [0, end_pos) before top-k (that path validated correct at the
+            # OP level, but is deferred). Investigate: slice-vs-stale-tail interaction + whether the extra
+            # slice/copy is cheaper than the saved score/top-k work before turning this on.
             k_full = self._gather_index_kbuf()  # [num_users, 1, T, D_idx] bf16 TILE, block-cyclic
             logits = ttnn.experimental.indexer_score_dsa(
                 q_dev,
@@ -565,7 +576,6 @@ class TtIndexer:
                 cache_batch_idx=cache_user_id,
                 block_cyclic_sp_axis=self.sp_axis,
                 block_cyclic_chunk_local=seq_len,  # per-chip chunk == chunk_size_global / sp
-                kv_len=actual_end,
             )
             ttnn.deallocate(k_full)
         else:

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -19,11 +19,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.mla.rope import (
-    get_cos_sin_matrix,
-    get_rot_transformation_mat,
-    interleaved_to_halfsplit_perm,
-)
+from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_perm_matrix
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
@@ -264,15 +260,9 @@ class TtIndexer:
         # reindex by rope.interleaved_to_halfsplit_perm to compare it against a half-split reference.
         self._rope_perm = None
         if self._blockcyclic and not self.index_args.index_rope_interleave:
-            # Build the half-split -> interleaved permutation matrix from rope.py's canonical convention
-            # (single source of truth). interleaved_to_halfsplit_perm() returns p with
-            # halfsplit = interleaved[p]; its inverse (argsort) maps halfsplit -> interleaved, i.e.
-            # out[j] = in[src[j]], realised as the matmul weight perm[src[j], j] = 1.
-            src = torch.argsort(interleaved_to_halfsplit_perm(64))
-            perm = torch.zeros(64, 64, dtype=torch.bfloat16)
-            perm[src, torch.arange(64)] = 1.0
+            # rope.interleaved_perm_matrix owns the half-split -> interleaved convention (single source).
             self._rope_perm = ttnn.from_torch(
-                perm,
+                interleaved_perm_matrix(64).to(torch.bfloat16),
                 device=self.mesh_device,
                 layout=ttnn.TILE_LAYOUT,
                 dtype=ttnn.bfloat16,
@@ -325,27 +315,16 @@ class TtIndexer:
         )
 
     def _build_rope_tables(self):
-        """Precompute device cos/sin for the indexer RoPE via the shared builder
-        (``get_cos_sin_matrix``). ``index_rope_interleave`` picks the layout + matching device op:
-        DS (False) -> rotate_half (halves [c0,c1,..,c0,c1,..], no trans_mat) -> rotary_embedding_hf;
-        GLM (True) -> interleaved (duplicated pairs [c0,c0,c1,c1,..] + trans_mat) ->
-        rotary_embedding_llama (matches the MLA's own rope). Tables are pure rotations (no mscale
-        baked in, matching the reference indexer). Op selection stays in ``_device_rope_pe``.
-
-        Frequencies come from the HF ``self.config`` — the single source of truth and identical to the
-        MLA's own rope (same θ / YaRN); the builder always applies YaRN, which is a no-op at
-        ``rope_factor==1`` (GLM). Tables are full-length; ``_device_rope_pe`` slices per chunk."""
-        interleave = self.index_args.index_rope_interleave
-        cos, sin = get_cos_sin_matrix(self.config, interleave=interleave)  # pure rotation tables (no mscale)
-        repl = lambda t: ttnn.from_torch(
-            t.to(torch.bfloat16),
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat16,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        """Precompute the indexer's natural-path RoPE tables via RotarySetup.get_indexer_rope_tables
+        (single source of rope-convention logic). ``index_rope_interleave`` picks the layout + matching
+        device op in ``_device_rope_pe``: DS (False) -> rotate_half, no trans_mat -> rotary_embedding_hf;
+        GLM (True) -> interleaved + trans_mat -> rotary_embedding_llama (matches the MLA's own rope).
+        Full-length replicated pure rotations (no mscale); ``_device_rope_pe`` slices per chunk. (The
+        block-cyclic path instead reuses ttMLA's block-cyclic rope_tensors passed into forward.)"""
+        tables = RotarySetup(self.config, self.mesh_device, sp_axis=self.sp_axis).get_indexer_rope_tables(
+            interleave=self.index_args.index_rope_interleave
         )
-        self._idx_cos, self._idx_sin = repl(cos), repl(sin)
-        self._idx_trans = repl(get_rot_transformation_mat()) if interleave else None
+        self._idx_cos, self._idx_sin, self._idx_trans = tables["cos"], tables["sin"], tables["trans"]
 
     def _upload_weights(self, idx_host):
         """Indexer weights → device via the shared converter. `idx_host` may be a full host dict

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -458,7 +458,18 @@ class TtIndexer:
             ttnn.deallocate(k)
             return
 
-        # Natural path (single-shot / DS chunked): full/replicated, grown by concat (O(n^2)).
+        # Natural path (single-shot, all variants): SP all-gather to a full/replicated cache. write_k runs
+        # once here (start_pos==0), so the concat-grow below is dead for current configs -- it only fired in
+        # the retired non-block-cyclic chunked mode. The live cost is the all-gather + full replication
+        # (glob keys/chip vs glob/sp block-cyclic).
+        #
+        # TODO(refactor, drop natural path -- pavlepopovic review): fold single-shot onto the block-cyclic
+        # path (treat it as one full-seq chunk at start_pos=0): SP-sharded cache + in-place
+        # update_padded_kv_cache, no all-gather / no replication / no concat -- then delete this branch,
+        # _device_rope_pe's natural use, and _sp_all_gather. Dependency: single-shot must supply the
+        # block-cyclic INDEXED rope tables (mla.py builds natural-order tables via _apply_rope_one_shot in
+        # single-shot; _bc_rope_pe needs get_rope_tensors_indexed). Verify block-cyclic alignment holds for
+        # single-shot seq lengths and that test_sparse_mla_vs_trace.py (is_chunked=False) passes unified.
         glob = seq_len * self.sp_factor
         k = self._sp_all_gather(k, dim=2)  # [1, 1, glob, D_idx] full, replicated, natural order
         k = self._device_rope_pe(k, glob, start_pos)  # on-device rope

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -439,6 +439,9 @@ class ttMLA:
                 tt_ccl=self.tt_ccl,
                 ccl_num_links=self.ccl_num_links,
                 ccl_topology=self.ccl_topology,
+                seq_len=seq_len,
+                slot_num=slot_num,
+                is_chunked=is_chunked,
             )
         else:
             self._indexer = NullIndexer()  # dense v3.1: forward calls .forward() -> None (dense path)
@@ -970,7 +973,14 @@ class ttMLA:
         # indexer top-k simply selects all available causal keys, so sparse is numerically equal to dense
         # there.) The indexer's forward also writes its K-cache (a no-op on the dense null-indexer), so no
         # separate warm-up write is needed.
-        indices = self._indexer.forward(hidden_states, qr, seq_len_local, start_pos=kv_actual_isl or 0)
+        indices = self._indexer.forward(
+            hidden_states,
+            qr,
+            seq_len_local,
+            start_pos=kv_actual_isl or 0,
+            rope_tensors=rope_tensors,
+            cache_user_id=cache_user_id,
+        )
 
         tt_q = self._q_stem(qr, rope_tensors, kv_actual_isl, seq_len_local)
         keep_kvpe_bf16 = self._has_indexer and not is_chunked

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -935,6 +935,7 @@ class ttMLA:
         actual_start: Optional[int] = None,
         cache_user_id: int = 0,
         return_kv_intermediates: bool = False,
+        index_kv_cache: Optional[ttnn.Tensor] = None,
     ) -> "ttnn.Tensor | tuple[ttnn.Tensor, Optional[dict]]":
         if self.kv_only:
             return self._forward_kv_only(
@@ -980,6 +981,7 @@ class ttMLA:
             start_pos=kv_actual_isl or 0,
             rope_tensors=rope_tensors,
             cache_user_id=cache_user_id,
+            index_kv_cache=index_kv_cache,
         )
 
         tt_q = self._q_stem(qr, rope_tensors, kv_actual_isl, seq_len_local)

--- a/models/demos/deepseek_v3_d_p/tt/mla/rope.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/rope.py
@@ -106,6 +106,19 @@ def interleaved_to_halfsplit_perm(rope_dim: int = 64) -> torch.Tensor:
     return torch.cat([torch.arange(0, rope_dim, 2), torch.arange(1, rope_dim, 2)])
 
 
+def interleaved_perm_matrix(rope_dim: int = 64) -> torch.Tensor:
+    """``[rope_dim, rope_dim]`` permutation matrix that reorders a half-split rope layout into the
+    interleaved one (``out = in @ P``). Purpose: run a half-split (DeepSeek) q/k through the
+    interleaved-only ``rotary_embedding_indexed`` op — applied to BOTH q and k the permutation cancels
+    in ``q·k`` (score/top-k unchanged), while letting the interleaved op pair the right dims with each
+    frequency. Built from ``interleaved_to_halfsplit_perm`` (its inverse), the canonical convention:
+    ``interleaved = halfsplit[argsort(p)]``, so ``P[argsort(p)[j], j] = 1``."""
+    src = torch.argsort(interleaved_to_halfsplit_perm(rope_dim))  # out[j] = in[src[j]]
+    perm = torch.zeros(rope_dim, rope_dim)
+    perm[src, torch.arange(rope_dim)] = 1.0
+    return perm
+
+
 class RotarySetup:
     """Rotary positional embedding setup for MLA prefill with SP sharding and balanced reordering."""
 
@@ -246,3 +259,24 @@ class RotarySetup:
         )
 
         return {"cos_matrix": cos_matrix, "sin_matrix": sin_matrix, "trans_matrix": trans_matrix}
+
+    def get_indexer_rope_tables(self, interleave: bool) -> dict[str, ttnn.Tensor]:
+        """Full-length REPLICATED cos/sin (+ trans_matrix iff ``interleave``) for the DSA lightning
+        indexer's natural-path RoPE. Distinct from ``get_rope_tensors`` (SP-sharded, interleaved-only,
+        for the MLA q_pe/k_pe): the indexer keeps a replicated full/gathered key cache, chooses its
+        convention per config (GLM interleaved -> ``rotary_embedding_llama``; DeepSeek half-split ->
+        ``rotary_embedding_hf``), and slices the tables per chunk itself. Pure rotations (no mscale),
+        same theta/YaRN as the MLA. Returns ``{"cos", "sin", "trans"}`` with ``trans=None`` for the
+        half-split (DeepSeek) convention."""
+        cos, sin = get_cos_sin_matrix(self.hf_config, interleave=interleave)
+
+        def repl(t):
+            return ttnn.from_torch(
+                t.to(torch.bfloat16),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+
+        return {"cos": repl(cos), "sin": repl(sin), "trans": repl(get_rot_transformation_mat()) if interleave else None}


### PR DESCRIPTION
## What

Issue #48887.Gives the DeepSeek/GLM sparse **lightning indexer** (`tt/mla/indexer.py`) a block-cyclic, per-user, pad/rotation-aware key cache that mirrors the MLA KVPE cache — so GLM-5.1 (and DS-v3.2) sparse **chunked / padded / multi-user** prefill works the way the dense (Kimi) path already does.

Previously the indexer key cache was natural-order, single-user, single-shot: `write_k` did an SP all-gather + natural RoPE + `ttnn.concat` (O(n²)) into one shared buffer reset on `start_pos==0`. That only holds for contiguous, exact-aligned, single-user input — it breaks under the production block-cyclic chunked feed (rotation, partial chunks, multiple users).

## Changes (all in `tt/mla/`)

- **Cache (2a):** persistent per-user block-cyclic ND-sharded key cache — **allocated by the caller and passed into `ttMLA.forward(index_kv_cache=...)` every call, exactly like the MLA KVPE cache** (the indexer never self-allocates it; the block-cyclic path asserts it was provided). Written per-chip by `update_padded_kv_cache` (drops the SP all-gather + O(n²) concat). **BF8** — validated to match BF16 top-k within bf16 noise (~5e-4 PCC), half the cache memory; `write_k` typecasts the roped key to the cache dtype before the in-place write. Gated on `is_chunked` — single-shot stays on the natural path.
- **RoPE (item 3):** block-cyclic indexed rope via `rotary_embedding_indexed`, reusing ttMLA's block-cyclic `rope_tensors`. GLM is natively interleaved; **DS-v3.2** (half-split) is reconciled by a rope-half permutation (`rope.interleaved_perm_matrix`) so the interleaved op matches its reference — the permutation cancels in `q·k`.
- **Scoring (2c):** gather to replicated block-cyclic and pass `cache_batch_idx` + `block_cyclic_sp_axis`/`block_cyclic_chunk_local` to `indexer_score_dsa`. Scoring spans the full preallocated cache width (causal masks the unwritten tail); bounding it via `kv_len` is deferred — see follow-ups.
- **Multi-user (2d):** thread `cache_user_id` from `ttMLA.forward`; per-user slots (closes interleaved multi-user).
- **Refactor:** centralize the indexer rope-convention in `rope.py` (`RotarySetup.get_indexer_rope_tables` + `interleaved_perm_matrix`).

## Testing (8-chip Blackhole, 2x4)

- `test_sparse_mla`: **14/14** — accuracy 8, determinism 2, chunked 2, rotated 2.
- `test_sparse_mla_cache`: **6/6**. `test_sparse_mla_perf` impl (51.2k-cache / 1.28k-chunk proxy, the over-allocated case): **1/1**.
- **Rotated/padded** (`test_sparse_mla_rotated`, `iters_isl=[2560,2592,5120]`): partial + rotated chunks through the block-cyclic indexer vs the single-shot sparse reference — full PCC **0.9940** (glm) / **0.9920** (dsv32), KVPE cache **0.9999**.
- BF8 vs BF16 A/B on the same suites: identical within ~5e-4 (no top-k regression).
- Single-shot accuracy/determinism: unaffected (natural path). `vs_trace` needs external golden traces (not run here); its single-shot indexer path is covered by accuracy/determinism.

## Review follow-ups (TODOs left in code)

- **Drop the natural path** (pavlepopovic): fold single-shot onto the block-cyclic path (one full-seq chunk at `start_pos=0`) so the SP all-gather + concat path can be deleted. Needs single-shot to supply block-cyclic indexed rope tables.
- **`kv_len` work-bound:** on an over-allocated cache, bound the scored logical prefix to `end_pos` to skip the unwritten tail. Correct only if the logits are also sliced to `[0, end_pos)` before top-k (setting `kv_len` alone leaves the tail stale → top-k picks garbage). Not correctness-critical today (causal already masks the tail).
- **Runtime threading:** thread `index_kv_cache` through `tt_prefill_*` for the sparse runtime path (dense R1 only today).

## History

Rebased onto `main` after **#48935** (`indexer_score` boundary-chip causal fix) merged — no longer stacked. The rotated/padded path depends on that fix (rotated iter 0.772 → ~0.99 with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/indexer-blockcyclic-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/indexer-blockcyclic-cache)
