### PR TITLE
[skip ci] Remove Evan from merge gate Slack pings

### DIFF
--- a/.github/actions/slack-report-merge-gate/action.yaml
+++ b/.github/actions/slack-report-merge-gate/action.yaml
@@ -13,7 +13,11 @@ runs:
     - name: Format Slack User Mentions
       id: format_mentions
       run: |
-        MENTIONS=$(echo "<@${{ inputs.owner }}>" | sed 's/,/> <@/g')
+        if [ -z "${{ inputs.owner }}" ]; then
+          MENTIONS=""
+        else
+          MENTIONS=$(echo "<@${{ inputs.owner }}>" | sed 's/,/> <@/g')
+        fi
         echo "mentions=$MENTIONS" >> $GITHUB_OUTPUT
       shell: bash
     - name: Report Github Pipeline Status Slack Action

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -466,7 +466,7 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
-          owner: "U08GTDV8MDH"
+          owner: ""
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:


### PR DESCRIPTION
## Summary
- Removes @ebanerjeeTT's  Slack ID (`U08GTDV8MDH`) from the `owner` field in the merge gate failure notification, so Evan stops getting pinged on every merge gate failure
- Updates the `slack-report-merge-gate` action to gracefully handle an empty `owner` — instead of emitting a malformed `<@>` in the message, it now omits the mention entirely

## Changes
- `.github/workflows/merge-gate.yaml`: set `owner: ""` instead of my Slack ID
- `.github/actions/slack-report-merge-gate/action.yaml`: skip mention formatting when `owner` is blank

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/removing-pings-from-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/removing-pings-from-merge-gate)