### PR TITLE
emule: restore Object-Intent ASAN under the fiber engine

### DIFF
--- a/tt_metal/impl/emulation/SANITIZER_CHECKS.md
+++ b/tt_metal/impl/emulation/SANITIZER_CHECKS.md
@@ -253,7 +253,7 @@ Two properties make this safe:
   still aborts. Real OOB bugs (e.g. the untilize / repeat / nd_reshard kernel
   overruns) are not masked.
 - **Invisible to Object Intent (§12).** Host-poke ranges live in their own array,
-  are **not** appended to `__emule_l1_resolved_ranges`, and are **not** snapshotted
+  are **not** appended to `__emule_self->san_resolved_log`, and are **not** snapshotted
   by Object Intent — so a host-NOC write into a poked destination can't be
   misread as an "unintended write."
 
@@ -450,7 +450,7 @@ no-violation control, and the per-check opt-out env test).
 ### 12. Object Intent Violation
 **Lives in:** `[metal] tt_metal/impl/emulation/emule_sanitizers.cpp` (the
 pre-launch byte snapshot + post-join `memcmp`); the per-kernel "resolved set"
-(`__emule_l1_resolved_ranges`) is recorded by `__emule_asan_check_oob_tensor`
+(the fiber ctx `__emule_self->san_resolved_log`) is recorded by `__emule_asan_check_oob_tensor`
 (`[emule] include/jit_hw/asan/asan_l1_checks.h`), reached via the
 `__emule_local_l1_to_ptr` chokepoint.
 **What it catches:** a kernel that scribbles on *another* buffer's bytes — valid,

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -134,9 +134,8 @@ thread_local const uint64_t* __emule_l1_padding_ranges = nullptr;
 thread_local uint32_t __emule_l1_padding_ranges_count = 0;
 thread_local const uint64_t* __emule_l1_host_ranges = nullptr;
 thread_local uint32_t __emule_l1_host_ranges_count = 0;
-thread_local uint64_t* __emule_l1_resolved_ranges = nullptr;
-thread_local uint32_t* __emule_l1_resolved_ranges_count = nullptr;
-thread_local uint32_t __emule_l1_resolved_ranges_capacity = 0;
+// Object-Intent resolved-range log now lives in the fiber ctx (ThreadCommonCtx::
+// san_resolved_*), reached via __emule_self — no thread-local. See tt-emule #241.
 thread_local uint32_t __emule_cb_reserved_pages[32] = {};
 thread_local uint32_t __emule_cb_waited_pages[32] = {};
 // Dirty-CB leak flags: set by reserve/wait, cleared by push/pop; still-set at
@@ -3054,6 +3053,14 @@ static void launch_cores(
     std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>>> dfb_keepalive;
     dfb_keepalive.reserve(core_setups.size());
 
+    // Object-Intent (ASAN §12): one tracker per core, owned here so it outlives the fiber
+    // run (run_until_idle below, for the non-deferred single-device path). The deferred
+    // mesh path skips OI — per-fiber ASAN state is single-device-scoped (see the ASAN note
+    // in the spawn lambda) and the trackers must not outlive this frame across a deferred
+    // run_mesh_dispatch. Empty (no snapshot/verify cost) when ASAN is off. See tt-emule #241.
+    std::vector<std::unique_ptr<ObjectIntentTracker>> intent_trackers;
+    const bool object_intent_active = !defer_run && oob_state.object_intent_strict;
+
     for (size_t core_idx = 0; core_idx < core_setups.size(); ++core_idx) {
         auto& cs = core_setups[core_idx];
         auto* core = cs.core;
@@ -3073,6 +3080,25 @@ static void launch_cores(
         std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>> per_thread_dfbs;
         if (cs.has_dfbs) {
             per_thread_dfbs = build_per_thread_dfb_interfaces(*cs.ki_list, cs.dfb_allocs);
+        }
+
+        // Object-Intent: snapshot this core's non-I/O live buffers BEFORE its kernel runs
+        // (on the dispatch thread, so L1 still holds the pre-kernel bytes). Self-gates to a
+        // no-op unless ASAN is on and this is a single-kernel core; the fiber(s) below then
+        // record resolved extents and verify at exit. See tt-emule #241 and ObjectIntentTracker.
+        ObjectIntentTracker* intent_tracker = nullptr;
+        if (object_intent_active) {
+            intent_trackers.push_back(std::make_unique<ObjectIntentTracker>());
+            intent_tracker = intent_trackers.back().get();
+            static const std::vector<uint32_t> kEmptyRtArgs;
+            intent_tracker->pre_launch_snapshot(
+                oob_state,
+                cs.ki_list->size(),
+                cs.ki_list->size() == 1 ? (*cs.ki_list)[0].rt_arg_values : kEmptyRtArgs,
+                l1_data,
+                cs.persistent_cb_ranges,
+                lx,
+                ly);
         }
 
         for (size_t kidx = 0; kidx < cs.ki_list->size(); ++kidx) {
@@ -3124,11 +3150,14 @@ static void launch_cores(
             // sweep_per_kernel_dirty_cbs / clear (+ the identity globals the sanitizer .cpp reads,
             // mirroring the ctx). All inert when TT_METAL_EMULE_ASAN is off — set_sanitizer_thread_locals
             // early-returns, so the by-value oob_state view (owned by dispatch_to_device's OobStateOwner)
-            // is never dereferenced. Under the fiber engine these worker-thread-locals are best-effort
-            // (shared across parked fibers on a worker); per-fiber ASAN state + the per-core ObjectIntent
-            // snapshot/verify are a follow-up, so ASAN is aimed at single-device runs.
+            // is never dereferenced. The range thread-locals are program-uniform, so a peer fiber
+            // re-arming them on a shared worker is harmless. The Object-Intent resolved-range log is
+            // per-fiber, so it lives in the fiber ctx (__emule_self->san_resolved_*) and needs no
+            // thread-local / swap-in restore. Object-Intent snapshot/verify run per single-kernel core
+            // on the non-deferred (single-device) path; deferred mesh runs skip OI. See tt-emule #241.
             sched.spawn(
-                [ki_ptr, lx, ly, cb_array, oob_state, sem_base = cs.sem_base, sem_size = cs.sem_size]() {
+                [ki_ptr, lx, ly, cb_array, l1_data, intent_tracker, oob_state, sem_base = cs.sem_base,
+                 sem_size = cs.sem_size]() {
                     auto& ki = *ki_ptr;
                     __processor_id = ki.processor_id;
                     __emule_neo_id = ki.is_tensix ? ki.processor_id : 0;
@@ -3136,6 +3165,14 @@ static void launch_cores(
                     __emule_kernel_name = ki.kernel_name.empty() ? nullptr : ki.kernel_name.c_str();
                     __emule_pending_noc_reads = 0;
                     set_sanitizer_thread_locals(oob_state, sem_base, sem_size);
+
+                    // Arm the Object-Intent resolved-range log in this fiber's ctx (reset count,
+                    // enable recording). The kernel-side OOB check appends resolved extents to
+                    // __emule_self->san_resolved_log; teardown accumulates and verify diffs them.
+                    if (intent_tracker != nullptr) {
+                        __emule_self->san_resolved_active = true;
+                        __emule_self->san_resolved_count = 0;
+                    }
                     try {
                         for (size_t t = 0; t < ki.variants.size(); ++t) {
                             if (ki.run_all_variants) {
@@ -3146,10 +3183,24 @@ static void launch_cores(
                         }
                         sweep_per_kernel_dirty_cbs(oob_state, cb_array, ki.processor_id, lx, ly);
                     } catch (...) {
+                        if (intent_tracker != nullptr) {
+                            intent_tracker->accumulate_resolved(
+                                oob_state, __emule_self->san_resolved_log, __emule_self->san_resolved_count);
+                            __emule_self->san_resolved_active = false;
+                        }
                         clear_sanitizer_thread_locals();
                         std::throw_with_nested(std::runtime_error(
                             "EMULE: kernel on core (" + std::to_string(lx) + "," + std::to_string(ly) +
                             ") failed"));
+                    }
+                    if (intent_tracker != nullptr) {
+                        // Accumulate this kernel's resolved extents, then verify: any non-I/O
+                        // buffer whose bytes changed but was never resolved is an Object-Intent
+                        // violation (aborts). No-op for multi-kernel cores (nothing snapshotted).
+                        intent_tracker->accumulate_resolved(
+                            oob_state, __emule_self->san_resolved_log, __emule_self->san_resolved_count);
+                        __emule_self->san_resolved_active = false;
+                        intent_tracker->verify_post_launch(l1_data, lx, ly, __emule_kernel_name);
                     }
                     __emule_kernel_name = nullptr;
                     __emule_pending_noc_reads = 0;

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -147,6 +147,8 @@ void FiberSchedulerImpl::install_fiber(Fiber* f) {
     __emule_self = f->owned_ctx.get();       // the single thread_local repoint
     my_x[0] = my_x[1] = f->id.phys_x;        // restore the silicon-named coords
     my_y[0] = my_y[1] = f->id.phys_y;
+    // Per-fiber ASAN state (e.g. the Object-Intent resolved-range log) lives in the ctx
+    // above, so it swaps in with __emule_self — nothing else to restore here. See tt-emule #241.
 }
 
 void FiberSchedulerImpl::worker_main(unsigned w) {

--- a/tt_metal/impl/emulation/emule_sanitizers.cpp
+++ b/tt_metal/impl/emulation/emule_sanitizers.cpp
@@ -80,30 +80,14 @@ void ObjectIntentTracker::pre_launch_snapshot(
     }
 }
 
-void ObjectIntentTracker::setup_kernel_tls(
-    const EmuleOobTensorState& oob, uint64_t* local_log, uint32_t cap, uint32_t* count) {
-    if (!oob.object_intent_strict) {
-        __emule_l1_resolved_ranges = nullptr;
-        __emule_l1_resolved_ranges_count = nullptr;
-        __emule_l1_resolved_ranges_capacity = 0;
-        return;
-    }
-    __emule_l1_resolved_ranges = local_log;
-    __emule_l1_resolved_ranges_count = count;
-    __emule_l1_resolved_ranges_capacity = cap;
-}
-
-void ObjectIntentTracker::teardown_kernel_tls(
-    const EmuleOobTensorState& oob, const uint64_t* local_log, uint32_t local_count) {
-    __emule_l1_resolved_ranges = nullptr;
-    __emule_l1_resolved_ranges_count = nullptr;
-    __emule_l1_resolved_ranges_capacity = 0;
-    // snapshots_ non-empty ⇒ single-kernel core (one thread here): gating on it keeps
+void ObjectIntentTracker::accumulate_resolved(
+    const EmuleOobTensorState& oob, const uint64_t* resolved_log, uint32_t count) {
+    // snapshots_ non-empty ⇒ single-kernel core (one fiber here): gating on it keeps
     // this append off multi-kernel cores, where concurrent inserts would race.
-    if (!oob.object_intent_strict || snapshots_.empty() || local_count == 0) {
+    if (!oob.object_intent_strict || snapshots_.empty() || count == 0) {
         return;
     }
-    resolved_acc_.insert(resolved_acc_.end(), local_log, local_log + local_count);
+    resolved_acc_.insert(resolved_acc_.end(), resolved_log, resolved_log + count);
 }
 
 void ObjectIntentTracker::verify_post_launch(

--- a/tt_metal/impl/emulation/emule_sanitizers.hpp
+++ b/tt_metal/impl/emulation/emule_sanitizers.hpp
@@ -40,9 +40,7 @@ extern thread_local const uint64_t* __emule_l1_padding_ranges;
 extern thread_local uint32_t __emule_l1_padding_ranges_count;
 extern thread_local const uint64_t* __emule_l1_host_ranges;
 extern thread_local uint32_t __emule_l1_host_ranges_count;
-extern thread_local uint64_t* __emule_l1_resolved_ranges;
-extern thread_local uint32_t* __emule_l1_resolved_ranges_count;
-extern thread_local uint32_t __emule_l1_resolved_ranges_capacity;
+// (Object-Intent resolved-range log lives in the fiber ctx, not a thread-local — #241.)
 extern thread_local uint32_t __emule_cb_reserved_pages[32];
 extern thread_local uint32_t __emule_cb_waited_pages[32];
 extern thread_local bool __emule_cb_reserve_dangling[32];
@@ -95,8 +93,10 @@ public:
         const std::vector<uint64_t>& persistent_cb_ranges,
         uint32_t lx,
         uint32_t ly);
-    void setup_kernel_tls(const EmuleOobTensorState& oob, uint64_t* local_log, uint32_t cap, uint32_t* count);
-    void teardown_kernel_tls(const EmuleOobTensorState& oob, const uint64_t* local_log, uint32_t local_count);
+    // Accumulate a finished kernel's resolved-range log (from the fiber ctx) into the
+    // per-core resolved set that verify_post_launch consults. No-op for multi-kernel
+    // cores (nothing was snapshotted).
+    void accumulate_resolved(const EmuleOobTensorState& oob, const uint64_t* resolved_log, uint32_t count);
     void verify_post_launch(const uint8_t* l1_data, uint32_t lx, uint32_t ly, const char* kernel_name) const;
 
 private:


### PR DESCRIPTION
## What

Restores the Object-Intent ASAN check under the multichip cooperative fiber engine (#48548). Fixes the emule side of [tt-emule #241](https://github.com/tenstorrent/tt-emule/issues/241).

## Why

The fiber engine runs each kernel as a cooperatively-scheduled fiber on a shared worker pool instead of one OS thread per (core, RISC). That refactor dropped the Object-Intent orchestration from `launch_cores`: `ObjectIntentTracker`'s `pre_launch_snapshot` / `verify_post_launch` (+ the per-kernel resolved-range plumbing) were left **defined but uncalled**, so the `Object_Intent_*Violation*` death-tests silently no-op ("failed to die"). The range thread-locals are still armed in-fiber, so OOB / CB-boundary / padding / semaphore checks keep firing — only Object-Intent regressed.

## How

- **`launch_cores`** owns a per-core `ObjectIntentTracker` on the single-device (non-deferred) path, outliving the `run_until_idle` below. It snapshots the core's non-I/O live buffers on the dispatch thread before the fiber runs; each kernel fiber records resolved extents, then verifies at exit. Self-gates to a no-op unless ASAN is on and the core is single-kernel (unchanged attribution rule). Deferred multi-chip mesh runs skip Object-Intent (ASAN is single-device-scoped).
- **The resolved-range log lives in the fiber context** (`ThreadCommonCtx::san_resolved_active` / `_count` / `_log[64]`, tt-emule side), reached via `__emule_self`, so it swaps in with the fiber. This is the one piece of per-fiber sanitizer state that is *not* program-uniform, and putting it in the ctx **removes the `__emule_l1_resolved_ranges*` thread-locals entirely** — no per-swap-in restore, one fewer set of thread-locals than before (per review: per-fiber state belongs in the fiber ctx, not thread-locals the scheduler shuttles). The kernel-side `__emule_asan_check_oob_tensor` appends straight to `__emule_self->san_resolved_log`; `ObjectIntentTracker::accumulate_resolved` folds a finished kernel's log into the per-core resolved set that `verify_post_launch` consults.

## Dependency

Requires the tt-emule `ThreadCommonCtx::san_resolved_{active,count,log}` fields + the updated `asan_l1_checks.h` reader — companion tt-emule PR [#250](https://github.com/tenstorrent/tt-emule/pull/250) (which also bumps its pin to this commit and re-enables the death-tests). Verified together locally.

## Verification

Wormhole n150, `TT_METAL_EMULE_ASAN` on:
- `Object_Intent_Provenance_Violation_SanityCheck` / `Object_Intent_Provenance_NonAdjacent_Violation` now **die as expected**.
- `Object_Intent_*NoViolation*` controls + `OOB_Tensor_*` + `CB_Boundary_*` stay green.
- tt-emule wormhole C++ regression: **54 passed / 0 failed**; blackhole C++: **19 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholami/emule-asan-objectintent-fiber)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholami/emule-asan-objectintent-fiber)
