### PR TITLE
Fix BH tilize UNPACR_NOP zerosrc encoding

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -45,7 +45,7 @@ inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const
     // otherwise the single-op BH workaround body is used. Both prepend unpack_srca unless unpacking to dest.
     if (skip_bh_workaround)
     {
-        static constexpr std::uint32_t unpack_srcb_zerosrc = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::UNP_NOP, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+        static constexpr std::uint32_t unpack_srcb_zerosrc = TT_OP_UNPACR_NOP(SrcB, 0, 0, 0, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
         ckernel_template tmp(outerloop, innerloop, unpack_srcb_zerosrc, unpack_srcb_set_dvalid);
         if (!unpack_to_dest)
         {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Several BH ttnn tilize and sparse SDPA tests were failing in the simulator with `UndefinedBehavior: tensix_decode_unpacr_nop: invalid opcode bits set`, caused by the 8-bit tilize fallback path emitting `TT_OP_UNPACR_NOP` with `p_unpacr_nop::UNP_NOP` in the `Set_Dvalid` argument. That constant belongs to the low `Unpack_Pop` field, not the one-bit `Set_Dvalid` field, so the macro shifted it into an undocumented opcode bit while trying to build the SrcB zerosrc operation. The change passes `0` for `Set_Dvalid` on the zerosrc op and leaves the following explicit set-dvalid op unchanged, preserving the intended two-step sequence while emitting a valid Blackhole `UNPACR_NOP` encoding.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/unpacr-nop-reserved-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/unpacr-nop-reserved-bit)