### PR TITLE
Update group_norm DRAM grid validation test setup

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
@@ -30,8 +30,8 @@ from ttnn._ttnn.operations.normalization import (
 # groupnorm_input_mask.cpp  create_group_norm_input_mask_impl():
 #   TT_FATAL — num_cores_across_channel must be > 0
 # ---------------------------------------------------------------------------
-def test_input_mask_num_cores_across_channel_zero():
-    with pytest.raises(RuntimeError, match="num_cores_across_channel must be > 0"):
+def test_input_mask_num_cores_across_channel_zero(expect_error):
+    with expect_error(RuntimeError, "num_cores_across_channel must be > 0"):
         create_group_norm_input_mask(
             num_channel=256,
             num_groups=32,
@@ -44,8 +44,8 @@ def test_input_mask_num_cores_across_channel_zero():
 # groupnorm_input_mask.cpp  create_group_norm_input_mask_impl():
 #   TT_FATAL — num_groups must be divisible by num_cores_across_channel
 # ---------------------------------------------------------------------------
-def test_input_mask_num_groups_not_divisible_by_num_cores():
-    with pytest.raises(RuntimeError, match="must be divisible by num_cores_across_channel"):
+def test_input_mask_num_groups_not_divisible_by_num_cores(expect_error):
+    with expect_error(RuntimeError, "must be divisible by num_cores_across_channel"):
         create_group_norm_input_mask(
             num_channel=256,
             num_groups=32,
@@ -58,8 +58,8 @@ def test_input_mask_num_groups_not_divisible_by_num_cores():
 # groupnorm_nanobind.cpp  _find_expected_dram_grid (wrapper):
 #   RuntimeError — no valid DRAM grid (calls find_expected_dram_grid)
 # ---------------------------------------------------------------------------
-def test_find_expected_dram_grid_no_valid_grid():
-    with pytest.raises(RuntimeError, match="Cannot find a valid DRAM group-norm grid"):
+def test_find_expected_dram_grid_no_valid_grid(expect_error):
+    with expect_error(RuntimeError, "Cannot find a valid DRAM group-norm grid"):
         _find_expected_dram_grid(
             max_x=8,
             max_y=8,
@@ -78,7 +78,7 @@ def test_find_expected_dram_grid_no_valid_grid():
 # groupnorm.cpp  get_mask_tensor():
 #   TT_FATAL — num_virtual_cols == 0 (non-L1 buffer path; DRAM height-sharded skips validate_dram_grid)
 # ---------------------------------------------------------------------------
-def test_get_mask_tensor_num_virtual_cols_zero(device):
+def test_get_mask_tensor_num_virtual_cols_zero(device, expect_error):
     torch_x = torch.randn(1, 1, 32, 48, dtype=torch.bfloat16)
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
@@ -95,7 +95,7 @@ def test_get_mask_tensor_num_virtual_cols_zero(device):
         dram_height_sharded,
     )
 
-    with pytest.raises(RuntimeError, match="Cannot determine num_virtual_cols"):
+    with expect_error(RuntimeError, "Cannot determine num_virtual_cols"):
         ttnn.group_norm(x, num_groups=16, core_grid=ttnn.CoreGrid(x=1, y=1), inplace=True)
 
 
@@ -125,9 +125,9 @@ def test_get_mask_tensor_num_virtual_cols_zero(device):
         ),
     ],
 )
-def test_validate_dram_grid(input_shape, num_groups, core_grid, msg_pattern, device):
+def test_validate_dram_grid(input_shape, num_groups, core_grid, msg_pattern, device, expect_error):
     x = ttnn.empty(input_shape, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT, device=device)
-    with pytest.raises(RuntimeError, match=msg_pattern):
+    with expect_error(RuntimeError, msg_pattern):
         ttnn.group_norm(x, num_groups=num_groups, core_grid=core_grid, inplace=False)
 
 
@@ -154,13 +154,13 @@ def test_validate_dram_grid(input_shape, num_groups, core_grid, msg_pattern, dev
         ),
     ],
 )
-def test_num_out_blocks_exceeds_block_ht(input_shape, core_grid, num_out_blocks, device):
+def test_num_out_blocks_exceeds_block_ht(input_shape, core_grid, num_out_blocks, device, expect_error):
     x = ttnn.from_torch(
         torch.randn(*input_shape, dtype=torch.bfloat16),
         device=device,
         layout=ttnn.TILE_LAYOUT,
     )
-    with pytest.raises(RuntimeError, match=r"num_out_blocks.*must be in"):
+    with expect_error(RuntimeError, r"num_out_blocks.*must be in"):
         ttnn.group_norm(
             x,
             num_groups=32,

--- a/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
@@ -103,8 +103,8 @@ def test_get_mask_tensor_num_virtual_cols_zero(device):
 # groupnorm.cpp  validate_dram_grid():
 #   TT_THROW — invalid core_grid for input dimensions; suggests largest valid sub-grid
 #     (param id: invalid_grid_with_suggestion)
-#   TT_THROW — cannot find any valid core grid for given Ht, W, num_groups
-#     (param id: no_valid_grid)
+#   TT_THROW — invalid core_grid for padded input dimensions; suggests largest valid sub-grid
+#     (param id: invalid_grid_for_padded_channels)
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "input_shape, num_groups, core_grid, msg_pattern",
@@ -120,13 +120,13 @@ def test_get_mask_tensor_num_virtual_cols_zero(device):
             (1, 1, 32, 48),
             16,
             ttnn.CoreGrid(x=32, y=1),
-            r"Cannot find any valid core grid",
-            id="no_valid_grid",
+            r"Requested core_grid .* is invalid for the input dimensions",
+            id="invalid_grid_for_padded_channels",
         ),
     ],
 )
 def test_validate_dram_grid(input_shape, num_groups, core_grid, msg_pattern, device):
-    x = ttnn.empty(input_shape, dtype=ttnn.DataType.BFLOAT16, device=device)
+    x = ttnn.empty(input_shape, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT, device=device)
     with pytest.raises(RuntimeError, match=msg_pattern):
         ttnn.group_norm(x, num_groups=num_groups, core_grid=core_grid, inplace=False)
 


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py::test_validate_dram_grid` was failing before it reached the DRAM grid validation it was intended to exercise, because the test constructed an interleaved `ROW_MAJOR` input and group_norm now rejects non-sharded ROW_MAJOR inputs before validating the requested core grid. The test now constructs the input in `TILE_LAYOUT`, which satisfies the interleaved group_norm layout precondition and lets the requested invalid grids reach `validate_dram_grid`. The second parametrization was also updated to expect the invalid-grid-with-suggestion error: once the input is TILE layout, the logical 48-channel shape is padded to 64 channels, so the validator can find a smaller valid grid instead of taking the no-valid-grid branch. The direct `_find_expected_dram_grid` CPU helper test continues to cover the true no-valid-grid case.

### Notes for reviewers
Static checker also required me to make a bunch of expect_error changes

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/group-norm-dram-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/group-norm-dram-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/group-norm-dram-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/group-norm-dram-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/group-norm-dram-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/group-norm-dram-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/group-norm-dram-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/group-norm-dram-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/group-norm-dram-grid)