### PR TITLE
[untilize] Fix writer kernels sourcing NoC write from get_write_ptr() instead of get_read_ptr()

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -11,45 +12,45 @@
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_id_out0 = 16;
+    constexpr std::uint32_t cb_id_out0 = 16;
 
-    constexpr uint32_t total_num_rows = get_compile_time_arg_val(0);
-    constexpr uint32_t ncores = get_compile_time_arg_val(1);
-    constexpr uint32_t third_dim = get_compile_time_arg_val(2);
-    constexpr uint32_t tile_width = get_compile_time_arg_val(3);
-    constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(4);
+    constexpr std::uint32_t total_num_rows = get_compile_time_arg_val(0);
+    constexpr std::uint32_t ncores = get_compile_time_arg_val(1);
+    constexpr std::uint32_t third_dim = get_compile_time_arg_val(2);
+    constexpr std::uint32_t tile_width = get_compile_time_arg_val(3);
+    constexpr std::uint32_t unpadded_X_size = get_compile_time_arg_val(4);
     constexpr auto dst_args = TensorAccessorArgs<5>();
 
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t core_number = get_arg_val<uint32_t>(1);
+    const std::uint32_t dst_addr = get_arg_val<std::uint32_t>(0);
+    const std::uint32_t core_number = get_arg_val<std::uint32_t>(1);
 
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
     CircularBuffer cb_out0(cb_id_out0);
 
-    auto write_block = [&](uint32_t num_rows,
-                           uint32_t mul,
-                           uint32_t size_per_row_per_block,
-                           uint32_t start_id,
-                           uint32_t width_size,
-                           uint32_t size_2d) {
-        uint32_t onetile = 1;
+    auto write_block = [&](std::uint32_t num_rows,
+                           std::uint32_t mul,
+                           std::uint32_t size_per_row_per_block,
+                           std::uint32_t start_id,
+                           std::uint32_t width_size,
+                           std::uint32_t size_2d) {
+        std::uint32_t onetile = 1;
         bool has_rows = (num_rows) > 0;
 
         cb_out0.wait_front(onetile * has_rows);
-        uint32_t l1_read_addr = cb_out0.get_write_ptr();
+        std::uint32_t l1_read_addr = cb_out0.get_read_ptr();
 
-        for (uint32_t k = 0; k < num_rows; k++) {
-            uint32_t total_size = mul * size_per_row_per_block + start_id + width_size;
-            uint32_t padded_size = total_size - unpadded_X_size;
-            uint32_t write_size = width_size;
+        for (std::uint32_t k = 0; k < num_rows; k++) {
+            std::uint32_t total_size = mul * size_per_row_per_block + start_id + width_size;
+            std::uint32_t padded_size = total_size - unpadded_X_size;
+            std::uint32_t write_size = width_size;
 
             if (mul == ncores - 1 && padded_size > 0) {
                 write_size = width_size - padded_size;
             }
 
-            CoreLocalMem<uint32_t> src(l1_read_addr);
+            CoreLocalMem<std::uint32_t> src(l1_read_addr);
             noc.async_write(
                 src,
                 s,
@@ -69,14 +70,14 @@ void kernel_main() {
         cb_out0.pop_front(onetile * has_rows);
     };
 
-    const uint32_t size_per_row_per_block = get_arg_val<uint32_t>(3);
-    const uint32_t blocks_per_core = get_arg_val<uint32_t>(4);
-    const uint32_t width_size = get_arg_val<uint32_t>(5);
+    const std::uint32_t size_per_row_per_block = get_arg_val<std::uint32_t>(3);
+    const std::uint32_t blocks_per_core = get_arg_val<std::uint32_t>(4);
+    const std::uint32_t width_size = get_arg_val<std::uint32_t>(5);
 
-    uint32_t size_2d = 0;
-    for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
-        uint32_t start_id = 0;
-        for (uint32_t b = 0; b < blocks_per_core; b++) {
+    std::uint32_t size_2d = 0;
+    for (std::uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
+        std::uint32_t start_id = 0;
+        for (std::uint32_t b = 0; b < blocks_per_core; b++) {
             write_block(total_num_rows, core_number, size_per_row_per_block, start_id, width_size, size_2d);
             start_id += width_size;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -11,41 +12,41 @@
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_id_out0 = 16;
+    constexpr std::uint32_t cb_id_out0 = 16;
 
-    constexpr uint32_t total_num_rows = get_compile_time_arg_val(0);
-    constexpr uint32_t third_dim = get_compile_time_arg_val(1);
-    constexpr uint32_t tile_height = get_compile_time_arg_val(2);
-    constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(3);
+    constexpr std::uint32_t total_num_rows = get_compile_time_arg_val(0);
+    constexpr std::uint32_t third_dim = get_compile_time_arg_val(1);
+    constexpr std::uint32_t tile_height = get_compile_time_arg_val(2);
+    constexpr std::uint32_t unpadded_X_size = get_compile_time_arg_val(3);
     constexpr auto dst_args = TensorAccessorArgs<4>();
 
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const std::uint32_t dst_addr = get_arg_val<std::uint32_t>(0);
 
     const auto s = TensorAccessor(dst_args, dst_addr);
     Noc noc;
     CircularBuffer cb_out0(cb_id_out0);
 
-    auto write_block = [&](uint32_t num_rows,
-                           uint32_t start_row_id,
-                           uint32_t start_column_id,
-                           uint32_t width_size,
-                           uint32_t size_2d,
-                           uint32_t single_block_size) {
+    auto write_block = [&](std::uint32_t num_rows,
+                           std::uint32_t start_row_id,
+                           std::uint32_t start_column_id,
+                           std::uint32_t width_size,
+                           std::uint32_t size_2d,
+                           std::uint32_t single_block_size) {
         bool has_rows = (num_rows) > 0;
 
         cb_out0.wait_front(single_block_size * has_rows);
-        uint32_t l1_read_addr = cb_out0.get_write_ptr();
+        std::uint32_t l1_read_addr = cb_out0.get_read_ptr();
 
-        for (uint32_t k = start_row_id; k < start_row_id + num_rows; k++) {
-            uint32_t total_size = start_column_id + width_size;
-            uint32_t write_size = width_size;
+        for (std::uint32_t k = start_row_id; k < start_row_id + num_rows; k++) {
+            std::uint32_t total_size = start_column_id + width_size;
+            std::uint32_t write_size = width_size;
 
             if (total_size > unpadded_X_size) {
-                uint32_t padded_size = total_size - unpadded_X_size;
+                std::uint32_t padded_size = total_size - unpadded_X_size;
                 write_size -= padded_size;
             }
 
-            CoreLocalMem<uint32_t> src(l1_read_addr);
+            CoreLocalMem<std::uint32_t> src(l1_read_addr);
             noc.async_write(
                 src, s, write_size, {.offset_bytes = 0}, {.page_id = size_2d + k, .offset_bytes = start_column_id});
 
@@ -57,24 +58,24 @@ void kernel_main() {
         cb_out0.pop_front(single_block_size * has_rows);
     };
 
-    const uint32_t width_size = get_arg_val<uint32_t>(1);
+    const std::uint32_t width_size = get_arg_val<std::uint32_t>(1);
 
-    uint32_t size_2d = 0;
-    for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
-        uint32_t start_row_id = get_arg_val<uint32_t>(2);
-        uint32_t start_column_id = get_arg_val<uint32_t>(3);
-        uint32_t single_block_size_row_arg = get_arg_val<uint32_t>(4);
-        uint32_t single_block_size_col_arg = get_arg_val<uint32_t>(5);
-        uint32_t sub_block_width_size = get_arg_val<uint32_t>(6);
-        uint32_t single_sub_block_size_row_arg = get_arg_val<uint32_t>(7);
+    std::uint32_t size_2d = 0;
+    for (std::uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
+        std::uint32_t start_row_id = get_arg_val<std::uint32_t>(2);
+        std::uint32_t start_column_id = get_arg_val<std::uint32_t>(3);
+        std::uint32_t single_block_size_row_arg = get_arg_val<std::uint32_t>(4);
+        std::uint32_t single_block_size_col_arg = get_arg_val<std::uint32_t>(5);
+        std::uint32_t sub_block_width_size = get_arg_val<std::uint32_t>(6);
+        std::uint32_t single_sub_block_size_row_arg = get_arg_val<std::uint32_t>(7);
 
-        for (uint32_t b = 0; b < single_block_size_col_arg; b++) {
-            uint32_t this_block_num_rows = tile_height;
+        for (std::uint32_t b = 0; b < single_block_size_col_arg; b++) {
+            std::uint32_t this_block_num_rows = tile_height;
             if (start_row_id + tile_height > total_num_rows) {
                 this_block_num_rows = total_num_rows - start_row_id;
             }
-            for (uint32_t m = 0; m < width_size; m += sub_block_width_size) {
-                uint32_t start_column_id_u = start_column_id + m;
+            for (std::uint32_t m = 0; m < width_size; m += sub_block_width_size) {
+                std::uint32_t start_column_id_u = start_column_id + m;
                 if (this_block_num_rows > 0) {
                     write_block(
                         this_block_num_rows,


### PR DESCRIPTION
## Problem
Fixes #48993.

The untilize output writer kernels source the L1 address for the output NoC write from the CB **write** pointer instead of the **read** pointer, after `cb_out0.wait_front(...)`:

```cpp
uint32_t l1_read_addr = cb_out0.get_write_ptr();   // was: wrong pointer
```

The writer is the **consumer** of the output CB (`c_16`), so the NoC-write source must be `get_read_ptr()`. All sibling writer kernels already use `get_read_ptr()`.

**Latent today:** the output CB is one block (zero double-buffer slack), so `write_ptr == read_ptr == base` and output is correct. It would **corrupt output** if the output CB were ever double-buffered (read/write pointers diverge → writer sources the wrong block). See #48993 for full detail.

## Fix
Use `get_read_ptr()` in both writer kernels:
- `writer_unary_stick_layout_wh_multicore.cpp`
- `writer_unary_stick_layout_col_multicore.cpp`

(The `uint32_t` → `std::uint32_t` normalization in the diff is applied automatically by the repo's `fix-cstdint` pre-commit hook on the touched files.)

## Verification
- `test_to_layout_wide_tensor` (wh writer) — 4 passed.
- `test_untilize_with_unpadding.py` (col + wh writers) — 339 passed, 6 skipped, 12 xfailed (pre-existing, unrelated).

## Notes
Discovered while investigating the flaky untilize #44357. This is a **distinct, deterministic** latent bug and does **not** explain that flakiness. A fail-without/pass-with regression test would require a double-buffered output-CB config (the factories currently always use a single-block CB), so this is verified by no-regression on existing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-untilize-writer-read-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-untilize-writer-read-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix-untilize-writer-read-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-untilize-writer-read-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-untilize-writer-read-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-untilize-writer-read-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-untilize-writer-read-ptr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-untilize-writer-read-ptr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-untilize-writer-read-ptr)