### PR TITLE
[Bug fix] Fix FP16 subnormal decode in safetensors loader

### DIFF
--- a/tt-train/sources/ttml/serialization/safetensors.cpp
+++ b/tt-train/sources/ttml/serialization/safetensors.cpp
@@ -156,7 +156,7 @@ std::vector<float> SafetensorSerialization::bytes_to_float_vec(
                         ++shift;
                     }
                     hm &= 0x03FFu;
-                    e = 127 - 15 - shift;
+                    e = 127 - 14 - shift;
                     m = (uint32_t)hm << 13;
                 }
             } else if (he == 0x1Fu) {  // inf/NaN

--- a/tt-train/tests/serialization/safetensors_test.cpp
+++ b/tt-train/tests/serialization/safetensors_test.cpp
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <cstring>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -96,4 +99,35 @@ TEST(SafeTensorsTest, DISABLED_LoadSimpleMlp) {
     EXPECT_EQ(tensors[3].name, "net.2.weight");
     EXPECT_EQ(tensors[4].name, "net.4.bias");
     EXPECT_EQ(tensors[5].name, "net.4.weight");
+}
+
+TEST(SafeTensorsTest, F16DecodeSubnormals) {
+    // uint16 F16 bit patterns, little-endian, decoded via bytes_to_float_vec.
+    const std::vector<uint16_t> halves = {
+        0x0000,  // +0
+        0x0001,  // smallest subnormal, 2^-24
+        0x0200,  // mid subnormal, 2^-15
+        0x03FF,  // largest subnormal
+        0x0400,  // smallest normal, 2^-14
+        0x3C00,  // 1.0
+    };
+    const std::vector<float> expected = {
+        0.0f,
+        5.9604645e-08f,
+        3.0517578e-05f,
+        6.0975552e-05f,
+        6.1035156e-05f,
+        1.0f,
+    };
+
+    std::vector<std::byte> bytes(halves.size() * sizeof(uint16_t));
+    std::memcpy(bytes.data(), halves.data(), bytes.size());
+
+    auto out = ttml::serialization::SafetensorSerialization::bytes_to_float_vec(
+        std::span<const std::byte>(bytes.data(), bytes.size()), "F16");
+
+    ASSERT_EQ(out.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(out[i], expected[i]);
+    }
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The subnormal branch of `half2float` in the safetensors F16 loader used a biased exponent of `127 - 15 - shift`, which is one too small. As a result every FP16 subnormal value decoded to **exactly half** its correct magnitude:

| bits | correct | before this PR |
|------|---------|----------------|
| `0x0001` (smallest subnormal) | `5.96e-08` | `2.98e-08` |
| `0x03FF` (largest subnormal)  | `6.10e-05` | `3.05e-05` |

After the normalization loop, a subnormal is `1.m * 2^(-14 - shift)`, so the biased exponent should be `127 - 14 - shift`. Normal and zero values are unaffected. Fixes the off-by-one by changing the bias to `127 - 14 - shift`.

Closes #48264

### Notes for reviewers
- One-line arithmetic fix in `tt-train/sources/ttml/serialization/safetensors.cpp`.
- Added `SafeTensorsTest.F16DecodeSubnormals`, a host-only test that decodes crafted F16 bit patterns through the public `bytes_to_float_vec` and checks the subnormal range plus the normal/zero boundary (`0x0400` = `2^-14`, `0x3C00` = `1.0`). No device required.
