### PR TITLE
Use row-wise work splitting for fast_reduce_nc sub-core grids

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -140,7 +140,8 @@ tt::tt_metal::ProgramDescriptor FastReduceNCProgramFactory::create_descriptor(
             divide_by_shards
                 ? dspec.core_groups_tuple()
                 : (use_sub_core_grids
-                       ? tt::tt_metal::split_work_to_cores(*operation_attributes.sub_core_grids, num_output_tiles)
+                       ? tt::tt_metal::split_work_to_cores(
+                             *operation_attributes.sub_core_grids, num_output_tiles, /*row_wise=*/true)
                        : tt::tt_metal::split_work_to_cores(grid, num_output_tiles, /*row_wise=*/true));
     num_cols_per_core_group_1 *= shard_factor;
     num_cols_per_core_group_2 *= shard_factor;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`test_sum_subcores` could produce non-finite results for BFLOAT8_B reductions when a disjoint `sub_core_grids` set was used, including `tests/ttnn/unit_tests/operations/reduce/test_sum.py::test_sum_subcores[shape=(16, 41, 63, 63)-dtype=DataType.BFLOAT8_B-sub_core_grids={[1-0 - 3-6], [5-0 - 6-6]}]`. The fast NC reduction program factory assigned runtime arguments by iterating sub-core ranges in row-major order, but the sub-core `split_work_to_cores` call used its default column-wise ordering. That mismatch caused some cores to receive tile offsets inconsistent with the core-group work split, leaving structured regions of the output corrupted and allowing the final scalar reduction to become `inf`. The change passes `row_wise=true` for sub-core grid splitting, matching the existing runtime-argument ordering and the non-sub-core path, so each core gets the tile range implied by its work group.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/fast-reduce-row-wise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/fast-reduce-row-wise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/fast-reduce-row-wise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/fast-reduce-row-wise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/fast-reduce-row-wise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/fast-reduce-row-wise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/fast-reduce-row-wise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/fast-reduce-row-wise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/fast-reduce-row-wise)