### PR TITLE
[skip ci] Add failure-path diagnostic logging for flaky TestAsyncRuntimeAllocatedBuffers (#43725)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -150,13 +150,11 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             ttnn::wait_for_event(device_->mesh_command_queue(*io_cq), workload_event);
 
             // #43725 diag: capture the buffer addresses in play right before the CQ1 readback. output_tensor
-            // now holds neg's output (N); the read below sources from output_tensor.buffer(), so READ_SRC == N
-            // by construction, but it is captured separately in case any rebinding/indirection occurs.
+            // now holds neg's output (N), which is also the buffer the read below sources from.
             const uint64_t dbg_input = static_cast<uint64_t>(input_tensor.buffer()->address());
             const uint64_t dbg_D0 = static_cast<uint64_t>(dummy_buffer_0->address());
             const uint64_t dbg_N = static_cast<uint64_t>(output_tensor.buffer()->address());
             const uint64_t dbg_D1 = static_cast<uint64_t>(dummy_buffer_1->address());
-            const uint64_t dbg_read_src = static_cast<uint64_t>(output_tensor.buffer()->address());
 
             // Read using cq 1
             ttnn::read_buffer(io_cq, output_tensor, {readback_data});
@@ -164,17 +162,17 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             // Failure-path diagnostics for the intermittent memcmp==-128 flake tracked in #43725. This repeats
             // the comparison the EXPECT_EQ below already performs (host-side, on data already read back) and
             // logs only on a mismatch, so passing runs do zero extra I/O and the timing window that produces
-            // the race is left undisturbed. On a caught failure the addresses discriminate the two leading
-            // theories: N_eq_S / READSRC_eq_S == 1 => neg's output buffer (or the read source) aliased sqrt's
-            // still-live output (premature async buffer-address reuse); both == 0 => the read observed a
-            // distinct buffer, pointing instead at a NOC/completion-ordering race.
+            // the race is left undisturbed. On a caught failure N_eq_S discriminates the two leading theories:
+            // N_eq_S == 1 => neg's output buffer (N) aliased sqrt's still-live output (S), i.e. premature async
+            // buffer-address reuse; N_eq_S == 0 => the read observed a distinct buffer, pointing instead at a
+            // NOC/completion-ordering race.
             const int dbg_cmp =
                 std::memcmp(readback_data.get(), expected_data.get(), buf_size_datums * datum_size_bytes);
             if (dbg_cmp != 0) {
                 log_error(
                     LogTest,
                     "43725_DIAG loop={} input_val={} INPUT=0x{:x} S=0x{:x} D0=0x{:x} N=0x{:x} D1=0x{:x} "
-                    "READ_SRC=0x{:x} N_eq_S={} READSRC_eq_S={} memcmp={}",
+                    "N_eq_S={} memcmp={}",
                     loop,
                     input_val,
                     dbg_input,
@@ -182,9 +180,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
                     dbg_D0,
                     dbg_N,
                     dbg_D1,
-                    dbg_read_src,
                     (dbg_N == dbg_S) ? 1 : 0,
-                    (dbg_read_src == dbg_S) ? 1 : 0,
                     dbg_cmp);
             }
 

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -188,8 +188,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
                     dbg_cmp);
             }
 
-            EXPECT_EQ(std::memcmp(readback_data.get(), expected_data.get(), buf_size_datums * datum_size_bytes), 0)
-                << "Data mismatch at loop " << loop << " input_val " << input_val;
+            EXPECT_EQ(dbg_cmp, 0) << "Data mismatch at loop " << loop << " input_val " << input_val;
         }
     }
 }

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -133,6 +133,9 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             Tensor output_tensor;
             ttnn::with_command_queue_id(workload_dispatch_cq, [&]() { output_tensor = ttnn::sqrt(input_tensor); });
 
+            // #43725 diag: record sqrt's output buffer address before `neg` reassigns output_tensor.
+            const uint64_t dbg_S = static_cast<uint64_t>(output_tensor.buffer()->address());
+
             auto dummy_buffer_0 =
                 tt::tt_metal::tensor_impl::allocate_device_buffer(device_, TensorSpec(shape, tensor_layout));
 
@@ -145,8 +148,46 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             auto workload_event = ttnn::record_event(device_->mesh_command_queue(*workload_dispatch_cq));
             // Wait until cq 0 prog execution is done
             ttnn::wait_for_event(device_->mesh_command_queue(*io_cq), workload_event);
+
+            // #43725 diag: capture the buffer addresses in play right before the CQ1 readback. output_tensor
+            // now holds neg's output (N); the read below sources from output_tensor.buffer(), so READ_SRC == N
+            // by construction, but it is captured separately in case any rebinding/indirection occurs.
+            const uint64_t dbg_input = static_cast<uint64_t>(input_tensor.buffer()->address());
+            const uint64_t dbg_D0 = static_cast<uint64_t>(dummy_buffer_0->address());
+            const uint64_t dbg_N = static_cast<uint64_t>(output_tensor.buffer()->address());
+            const uint64_t dbg_D1 = static_cast<uint64_t>(dummy_buffer_1->address());
+            const uint64_t dbg_read_src = static_cast<uint64_t>(output_tensor.buffer()->address());
+
             // Read using cq 1
             ttnn::read_buffer(io_cq, output_tensor, {readback_data});
+
+            // Failure-path diagnostics for the intermittent memcmp==-128 flake tracked in #43725. This repeats
+            // the comparison the EXPECT_EQ below already performs (host-side, on data already read back) and
+            // logs only on a mismatch, so passing runs do zero extra I/O and the timing window that produces
+            // the race is left undisturbed. On a caught failure the addresses discriminate the two leading
+            // theories: N_eq_S / READSRC_eq_S == 1 => neg's output buffer (or the read source) aliased sqrt's
+            // still-live output (premature async buffer-address reuse); both == 0 => the read observed a
+            // distinct buffer, pointing instead at a NOC/completion-ordering race.
+            const int dbg_cmp =
+                std::memcmp(readback_data.get(), expected_data.get(), buf_size_datums * datum_size_bytes);
+            if (dbg_cmp != 0) {
+                log_error(
+                    LogTest,
+                    "43725_DIAG loop={} input_val={} INPUT=0x{:x} S=0x{:x} D0=0x{:x} N=0x{:x} D1=0x{:x} "
+                    "READ_SRC=0x{:x} N_eq_S={} READSRC_eq_S={} memcmp={}",
+                    loop,
+                    input_val,
+                    dbg_input,
+                    dbg_S,
+                    dbg_D0,
+                    dbg_N,
+                    dbg_D1,
+                    dbg_read_src,
+                    (dbg_N == dbg_S) ? 1 : 0,
+                    (dbg_read_src == dbg_S) ? 1 : 0,
+                    dbg_cmp);
+            }
+
             EXPECT_EQ(std::memcmp(readback_data.get(), expected_data.get(), buf_size_datums * datum_size_bytes), 0)
                 << "Data mismatch at loop " << loop << " input_val " << input_val;
         }


### PR DESCRIPTION
### What / why

`MultiCommandQueueSingleDeviceFixture.TestAsyncRuntimeAllocatedBuffers`
(`tests/ttnn/unit_tests/gtests/test_async_runtime.cpp`) fails intermittently in
merge-gate — roughly 0.25% of runs, ~1–2×/week on the N300-viommu smoke lane —
with a `memcmp() == -128` data mismatch. The `-128` signature corresponds to a
readback of `+sqrt(x)` where `-sqrt(x)` was expected (bf16 `0x40xx` vs `0xC0xx`),
i.e. the CQ1 readback observes the buffer as if `neg` had not taken effect. The
failure has never been captured with enough runtime state to confirm root cause.

This PR adds **failure-path-only** diagnostic logging so the next natural
occurrence in merge-gate is self-describing, without perturbing the passing path.

### What it does

Inside the test's inner loop it:

- captures `sqrt`'s output buffer address (`S`) before `neg` reassigns
  `output_tensor`;
- just before the CQ1 `read_buffer`, captures the input, both dummy buffers
  (`D0`/`D1`), and `neg`'s output (`N`);
- after readback, re-runs the same host-side `memcmp` the test already asserts on
  and calls `log_error` **only when that comparison is non-zero**, tagged
  `43725_DIAG`, printing all five addresses plus the `N_eq_S` flag.

All captures are cheap host-side member reads (no device round-trips) and the
`memcmp` duplicates one the test performs anyway. **On a passing run this adds
zero I/O and emits nothing** — there is no unconditional logging, so the exact
timing window that produces the race is left undisturbed (avoiding a heisenbug
that unconditional per-iteration logging would risk).

### What it's designed to capture

On a caught failure `N_eq_S` disambiguates the two leading theories:

- `N_eq_S == 1` → `neg`'s fresh output buffer resolved to `sqrt`'s still-live
  DRAM address → **premature async buffer-address reuse / allocator-bookkeeping
  bug**.
- `N_eq_S == 0` → the read observed a genuinely distinct buffer and still saw
  pre-`neg` data → points at a **NOC / completion-ordering race** instead.

Either outcome redirects the fix; without a caught failure both remain unproven.

### Validation

- Compiles cleanly (`unit_tests_ttnn`, RelWithDebInfo).
- Runs green under ttsim Fast Dispatch (2 HW CQs), **emitting zero `43725_DIAG`
  lines** — confirming the passing path is completely silent. ttsim does not model
  NOC write latency and does not reproduce the timing flake, so this validates the
  passing-path-is-unaffected property only, not the bug itself. Catching the bug
  requires the real N300-viommu merge-gate lane.

### Notes for reviewers

- Diagnostic-only: **no behavior change on the passing path.** Deliberately uses
  `Relates to #43725`, not `Closes` — this helps *catch* the bug, it does not fix
  it.
- Reviewers can decide how long to keep it landed: until the next occurrence is
  captured, or as permanent low-cost diagnostics (the cost is one extra host-side
  `memcmp`/addr-read per iteration, only in this one test).

Relates to #43725

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:diag-43725-buffer-aliasing-capture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:diag-43725-buffer-aliasing-capture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:diag-43725-buffer-aliasing-capture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:diag-43725-buffer-aliasing-capture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:diag-43725-buffer-aliasing-capture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:diag-43725-buffer-aliasing-capture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:diag-43725-buffer-aliasing-capture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=diag-43725-buffer-aliasing-capture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:diag-43725-buffer-aliasing-capture)