### PR TITLE
[sampling] Disable argmax fast-path when logprobs are requested

### DIFF
--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -514,7 +514,17 @@ class TTSampling(LightweightModule):
         empty_slots: list[int] | None = None,
     ):
         """Update sampling parameters (k, p, temperature, logprobs) dynamically."""
-        self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
+        # Merge the logprobs request into the persistent per-slot state first, then read
+        # the batch-wide flag. The argmax fast-path cannot emit logprobs (it never runs a
+        # softmax over the vocab), so it must be disabled whenever any slot wants them.
+        # Reading the merged flag (rather than the incoming arg) also covers empty_slots
+        # partial updates, where the incoming arg only describes the newly-admitted slots.
+        self.log_probs_calculator.set_log_probs_mode(
+            enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
+        )
+        self._force_argmax_sampling = (
+            self._is_force_argmax_sampling(k, p, temp) and not self.log_probs_calculator.enable_log_probs
+        )
         _log_sampling_debug(
             self._sampling_debug_enabled,
             "TTSampling reset params",
@@ -560,10 +570,6 @@ class TTSampling(LightweightModule):
             ttnn.copy_host_to_device_tensor(self.k_tensor_new, self.k_tensor)
             ttnn.copy_host_to_device_tensor(self.p_tensor_new, self.p_tensor)
             ttnn.copy_host_to_device_tensor(self.temp_tensor_new, self.temp_tensor)
-
-        self.log_probs_calculator.set_log_probs_mode(
-            enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
-        )
 
     def forward(
         self,
@@ -631,8 +637,8 @@ class TTSampling(LightweightModule):
                 output_tensor=tt_out_tok,
                 keepdim=False,
             )
-            # Argmax path: logprobs not supported (force-argmax is disabled
-            # when logprobs are enabled via format_sampling_params guard).
+            # Argmax path: logprobs not supported. force-argmax is disabled whenever any
+            # slot requests logprobs (see reset_params), so reaching here means none did.
             self.tt_log_probs = None
             return tt_out_tok, self.tt_log_probs
 


### PR DESCRIPTION
### Problem
The in-trace argmax fast-path (`allow_force_argmax`) never runs a softmax over the vocab, so it cannot produce logprobs: it returns `None`, which `generator.py` turns into a tensor of ones. On device configs where logprobs are supported (`num_devices in (8, 32)`, e.g. Galaxy), any model with `allow_force_argmax=True` — notably `Llama-3.1-8B` on Galaxy — silently returns dummy logprobs for a greedy request with `enable_log_probs=True`.

### Change
Disable force-argmax whenever any slot requests logprobs, so those requests fall back to the full sampling path that computes real logprobs. `reset_params` now:
1. calls `set_log_probs_mode(...)` first, then
2. computes `_force_argmax_sampling = _is_force_argmax_sampling(...) and not self.log_probs_calculator.enable_log_probs`.

Reading the merged batch-wide flag (rather than the incoming `enable_log_probs` arg) also covers `empty_slots` partial updates, where the incoming arg only describes newly-admitted slots while a persistent slot may still want logprobs. The reorder is safe: the k/p/temp tensor upload and `set_log_probs_mode` touch disjoint state.

### Context
Split out from #48886 (single-chip P150 perf config change) at reviewer request. On single-chip, on-device logprobs are unsupported (`LogProbsCalculator._is_supported` requires `num_devices in (8, 32)`), so this guard is a no-op there — it addresses the pre-existing Galaxy behavior, which is a different device class and risk profile than #48886.

### Test plan
- Galaxy (num_devices=32), `Llama-3.1-8B`: greedy request (`temperature=0, top_k=1`) with `enable_log_probs=True` should now return real sampled-token logprobs rather than ones, and greedy without logprobs should still take the argmax fast-path.
- Existing on-device sampling / logprobs tests.

Note: I do not have Galaxy hardware; the guard logic is verified by inspection and the fields it reads (`log_probs_calculator.enable_log_probs`) are exercised by the existing logprobs path. Galaxy CI / a reviewer with hardware should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)