### PR TITLE
Add chunked Kimi to CI

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -350,10 +350,7 @@ models:
     wh_llmbox_perf: 1290
     wh_galaxy: 345
     wh_galaxy_perf: 150
-    # Sum of all models/bh_galaxy demo test timeouts must stay under this. Raised
-    # 440 -> 450 to fit the added Galaxy DeepSeek Prefill chunked Kimi code_debug 55k
-    # stage (timeout 40): 440 (existing) + 40 = 480, rounded down to 450 for headroom.
-    bh_galaxy: 450
+    bh_galaxy: 470
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -350,7 +350,10 @@ models:
     wh_llmbox_perf: 1290
     wh_galaxy: 345
     wh_galaxy_perf: 150
-    bh_galaxy: 440
+    # Sum of all models/bh_galaxy demo test timeouts must stay under this. Raised
+    # 440 -> 450 to fit the added Galaxy DeepSeek Prefill chunked Kimi code_debug 55k
+    # stage (timeout 40): 440 (existing) + 40 = 480, rounded down to 450 for headroom.
+    bh_galaxy: 450
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/workflows/galaxy-deepseek-prefill-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests.yaml
@@ -11,7 +11,7 @@ on:
           Comma-separated stages to run, e.g. "mla,prefill_block,kimi_moe".
           Empty or "all" runs every stage. Valid stages: moe_gate, mla, mla_chunked,
           kv_cache_table, prefill_block, prefill_transformer, kimi_mla, kimi_moe,
-          kimi_prefill_block, dsa_mla, dsa_mla_glm, glm_moe, prefill_block_determinism,
+          kimi_prefill_block, kimi_chunked, dsa_mla, dsa_mla_glm, glm_moe, prefill_block_determinism,
           prefill_transformer_determinism.
           The "module" group also runs every stage; the "sdpa_perf" group runs the
           ring joint SDPA perf checks (built with the profiler).

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -106,10 +106,12 @@ GATED_LAYER_DEPTH = 10
 # chunk c). A single margin (the perf_margin pytest arg) is applied to every chunk. Recalibrate by
 # re-reading the "chunk timing stats" table from a fresh green CI run.
 KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S = {
-    # test_kimi_prefill_transformer_chunked_no_pcc[...-L61-chunks5-ten_iters]
-    # Baseline from https://github.com/tenstorrent/tt-metal/actions/runs/28753487696 (run attempt 2):
-    # the per-chunk median column of the "chunk timing stats" table (9 post-warmup iters, iter 0 omitted).
-    (61, 5, 10): [1.330, 1.326, 1.326, 1.340, 1.369],
+    # test_kimi_prefill_transformer_chunked_no_pcc[...-L61-chunks_eleven-ten_iters] (55k / code_debug).
+    # TODO: populate the 11 per-chunk medians from the first green code_debug 55k CI run's
+    # "chunk timing stats" table; until then this config runs record-only (no perf gate). The old 5-chunk
+    # longbook baseline was [1.330, 1.326, 1.326, 1.340, 1.369] (run 28753487696) -- chunks 0-4 should be
+    # ~unchanged (chunk c attends to KV[0:c*CHUNK] regardless of n_chunks); chunks 5-10 are new.
+    # (61, 11, 10): [...],
 }
 # Default +/- tolerance band around each baseline chunk median (fraction). Overridable per test via the
 # perf_margin pytest argument (see test_prefill_block_perf.py's `margin` column for the design).

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -37,7 +37,6 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole, profiler
-from models.demos.common.prefill.runners.runner_utils import build_h2d_service
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
@@ -53,16 +52,6 @@ SEQ_CACHE = 55 * 1024  # 56320 KV cache length (1 user)
 # Larger KV cache for the no-PCC perf sweep only (up to 100k ISL = 20 chunks). Kept separate from
 # SEQ_CACHE so the PCC tests and the _PADDED_FULL_55K split (which assert against 55*1024) are untouched.
 SEQ_CACHE_NOPCC = 100 * 1024  # 102400 KV cache length (1 user)
-
-# H2D stream-service constants (mirror prefill_runner.py). Used by the with-service variant of the
-# no-PCC test: build the H2D service so its persistent receiver kernel spins on its worker core during
-# the whole prefill, reproducing the request-loop's service-presence dispatch tax WITHOUT any producer
-# or socket (tokens still come from the local path). See run_chunked_transformer_no_pcc(with_h2d_service).
-H2D_METADATA_SIZE_BYTES = 12
-H2D_MAPPER_CONFIG = ttnn.MeshMapperConfig(
-    placements=[ttnn.PlacementShard(0), ttnn.PlacementReplicate()],
-)
-H2D_SYNC_WORKER_CORES = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
 
 
 def _resolve_trace_dir(variant) -> Path:
@@ -112,15 +101,15 @@ LAYER_PCC_THRESHOLD = 0.88
 GATED_LAYER_DEPTH = 10
 
 # Per-chunk baseline medians (seconds) for the no-PCC perf gate, pulled from a known-good CI run. Keyed
-# by (num_layers, n_chunks, num_iters, with_h2d_service) so only the exact config we have a CI number
-# for is gated; every other combo in the no-PCC sweep stays record-only. Each list has one entry per
-# chunk (index c == chunk c). A single margin (the perf_margin pytest arg) is applied to every chunk.
-# Recalibrate by re-reading the "chunk timing stats" table from a fresh green CI run.
+# by (num_layers, n_chunks, num_iters) so only the exact config we have a CI number for is gated; every
+# other combo in the no-PCC sweep stays record-only. Each list has one entry per chunk (index c ==
+# chunk c). A single margin (the perf_margin pytest arg) is applied to every chunk. Recalibrate by
+# re-reading the "chunk timing stats" table from a fresh green CI run.
 KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S = {
-    # test_kimi_prefill_transformer_chunked_no_pcc[...-L61-chunks5-ten_iters-nosvc]
+    # test_kimi_prefill_transformer_chunked_no_pcc[...-L61-chunks5-ten_iters]
     # Baseline from https://github.com/tenstorrent/tt-metal/actions/runs/28753487696 (run attempt 2):
     # the per-chunk median column of the "chunk timing stats" table (9 post-warmup iters, iter 0 omitted).
-    (61, 5, 10, False): [1.330, 1.326, 1.326, 1.340, 1.369],
+    (61, 5, 10): [1.330, 1.326, 1.326, 1.340, 1.369],
 }
 # Default +/- tolerance band around each baseline chunk median (fraction). Overridable per test via the
 # perf_margin pytest argument (see test_prefill_block_perf.py's `margin` column for the design).
@@ -857,8 +846,6 @@ def run_chunked_transformer_no_pcc(
     num_links,
     topology,
     num_iters,
-    with_h2d_service=False,
-    h2d_isolated_claim=False,
     routing_use_l1_small_for_semaphores=False,
     baseline_chunk_times_s=None,
     perf_margin=None,
@@ -866,11 +853,8 @@ def run_chunked_transformer_no_pcc(
     """No-PCC perf/smoke variant of run_chunked_transformer: build the transformer ONCE, then drive the
     full n_chunks-chunk prefill `num_iters` times with return_intermediates=False (no per-layer host
     readback, no PCC). Tokens are the real (longbook) ids from the golden trace when present, else a
-    deterministic in-vocab pattern, so this is trace-optional. With with_h2d_service the H2D stream
-    service is built so its persistent receiver kernel spins on its worker core for the whole prefill,
-    reproducing the request-loop's service-presence dispatch tax WITHOUT any producer or socket (the
-    service is never fed). The KV cache is reused across iterations (each chunk overwrites the same
-    [0, total_len) region in order).
+    deterministic in-vocab pattern, so this is trace-optional. The KV cache is reused across iterations
+    (each chunk overwrites the same [0, total_len) region in order).
 
     Perf gate: when `baseline_chunk_times_s` is provided (a per-chunk list of baseline medians pulled
     from a known-good CI run), each chunk's measured median must stay within +/- `perf_margin` of its
@@ -966,8 +950,7 @@ def run_chunked_transformer_no_pcc(
 
     logger.info(
         f"chunked transformer (no-PCC): num_layers={num_layers} mesh={mesh_shape} n_chunks={n_chunks} "
-        f"total_len={total_len} cache={SEQ_CACHE_NOPCC} chunk={CHUNK} num_iters={num_iters} "
-        f"with_h2d_service={with_h2d_service}"
+        f"total_len={total_len} cache={SEQ_CACHE_NOPCC} chunk={CHUNK} num_iters={num_iters}"
     )
 
     iteration_chunk_times: list[list[float]] = []
@@ -1049,28 +1032,6 @@ def run_chunked_transformer_no_pcc(
 
     mesh_device.enable_program_cache()
 
-    # Background H2D-service variant: build the H2D stream service so its persistent receiver kernel
-    # spins for the whole prefill, reproducing the request-loop's service-presence dispatch tax WITHOUT
-    # a producer or socket (tokens still come from the local path; the service is never fed). Mirrors
-    # prefill_runner request-mode: clear the model's custom sub-device manager first so the service's
-    # init program validates against the whole-chip default. isolated_claim (h2dsvc_isolated variant)
-    # needs a source-side change not ported to this branch; only nosvc / h2dsvc_regular run here.
-    bg_h2d_service = None
-    if with_h2d_service:
-        mesh_device.clear_loaded_sub_device_manager()
-        bg_h2d_service = build_h2d_service(
-            mesh_device,
-            mesh_shape=tuple(mesh_shape),
-            chunk_size=CHUNK,
-            mapper_config=H2D_MAPPER_CONFIG,
-            worker_cores=H2D_SYNC_WORKER_CORES,
-            metadata_size_bytes=H2D_METADATA_SIZE_BYTES,
-        )
-        logger.info(
-            f"[h2d-bg] H2D service built and spinning in the background (unused; no producer/socket); "
-            f"isolated_claim={h2d_isolated_claim}"
-        )
-
     # Profiling warmup: run chunk 0 once through all layers so every kernel is JIT-compiled and the
     # program cache is populated BEFORE the measured region. Gated by TT_PREFILL_PROFILE_WARMUP so
     # normal runs are unaffected. Bracketed by PROFILE_WARMUP_START / PROFILE_MEASURE_START signposts;
@@ -1135,17 +1096,9 @@ def run_chunked_transformer_no_pcc(
         logger.info(f"iter {it} done ({n_chunks} chunks) in {iter_total:.3f} seconds")
     profiler.end("tt_forward")
 
-    # Release the H2D service while the mesh + command queues + service core are still alive (its dtor
-    # frees a command queue and the service-core L1; running it after mesh close aborts).
-    if bg_h2d_service is not None:
-        del bg_h2d_service
-        gc.collect()
-        logger.info("[h2d-bg] H2D service released")
-
     profiler.end("total_test_time")
     logger.success(
-        f"Chunked prefill no-PCC run done (num_layers={num_layers}, n_chunks={n_chunks}, "
-        f"num_iters={num_iters}, with_h2d_service={with_h2d_service})"
+        f"Chunked prefill no-PCC run done (num_layers={num_layers}, n_chunks={n_chunks}, " f"num_iters={num_iters})"
     )
     perf_failures = print_duration_table(iteration_chunk_times)
     for key in profiler.times:
@@ -1157,15 +1110,8 @@ def run_chunked_transformer_no_pcc(
 
 # No-PCC perf/smoke variant: runs the full n_chunks-chunk prefill `num_iters` times with no golden
 # trace dependency, no intermediate readback, and no PCC. Requires only the Kimi TTNN weight cache (set
-# TT_KIMI_PREFILL_TTNN_CACHE + KIMI_K2_6_HF_MODEL); the golden trace is optional. Service modes:
-#   nosvc           - no H2D stream service (baseline)
-#   h2dsvc_regular  - resident H2D service, legacy claim -> per-op dispatch tax on every model op
+# TT_KIMI_PREFILL_TTNN_CACHE + KIMI_K2_6_HF_MODEL); the golden trace is optional.
 @pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin5pct"])
-@pytest.mark.parametrize(
-    "with_h2d_service, h2d_isolated_claim",
-    [(False, False), (True, False), (True, True)],
-    ids=["nosvc", "h2dsvc_regular", "h2dsvc_isolated"],
-)
 @pytest.mark.parametrize(
     "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
 )
@@ -1206,15 +1152,13 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
     num_layers,
     n_chunks,
     num_iters,
-    with_h2d_service,
-    h2d_isolated_claim,
     num_links,
     topology,
     perf_margin,
 ):
     # Gate against the CI baseline only for the exact config we have a recorded number for; every other
     # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert).
-    baseline_chunk_times_s = KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters, with_h2d_service))
+    baseline_chunk_times_s = KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters))
     run_chunked_transformer_no_pcc(
         variant,
         config_only,
@@ -1226,8 +1170,6 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
         num_links,
         topology,
         num_iters,
-        with_h2d_service=with_h2d_service,
-        h2d_isolated_claim=h2d_isolated_claim,
         routing_use_l1_small_for_semaphores=True,
         baseline_chunk_times_s=baseline_chunk_times_s,
         perf_margin=perf_margin,
@@ -1236,12 +1178,7 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
 
 # DeepSeek counterpart of the no-PCC perf sweep above: same chunked driver, deepseek_v3_d_p variant
 # (DeepSeekV3Config fabric payload, no L1_SMALL routing semaphores). Used to compare DeepSeek vs Kimi
-# chunked-prefill perf at matched ISL (n_chunks x CHUNK), num_layers, and service mode.
-@pytest.mark.parametrize(
-    "with_h2d_service, h2d_isolated_claim",
-    [(False, False), (True, False), (True, True)],
-    ids=["nosvc", "h2dsvc_regular", "h2dsvc_isolated"],
-)
+# chunked-prefill perf at matched ISL (n_chunks x CHUNK) and num_layers.
 @pytest.mark.parametrize(
     "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
 )
@@ -1282,8 +1219,6 @@ def test_ds_prefill_transformer_chunked_no_pcc(
     num_layers,
     n_chunks,
     num_iters,
-    with_h2d_service,
-    h2d_isolated_claim,
     num_links,
     topology,
 ):
@@ -1298,7 +1233,5 @@ def test_ds_prefill_transformer_chunked_no_pcc(
         num_links,
         topology,
         num_iters,
-        with_h2d_service=with_h2d_service,
-        h2d_isolated_claim=h2d_isolated_claim,
         routing_use_l1_small_for_semaphores=False,
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -25,15 +25,19 @@ Override the trace dir with PREFILL_TRACE_DIR.
 import gc
 import json
 import os
+import statistics
+import time
 from pathlib import Path
 
 import pytest
 import torch
 from loguru import logger
 from safetensors import safe_open
+from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole, profiler
+from models.demos.common.prefill.runners.runner_utils import build_h2d_service
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
@@ -46,6 +50,19 @@ from tests.ttnn.utils_for_testing import comp_pcc
 
 CHUNK = 5 * 1024  # 5120 tokens per chunk
 SEQ_CACHE = 55 * 1024  # 56320 KV cache length (1 user)
+# Larger KV cache for the no-PCC perf sweep only (up to 100k ISL = 20 chunks). Kept separate from
+# SEQ_CACHE so the PCC tests and the _PADDED_FULL_55K split (which assert against 55*1024) are untouched.
+SEQ_CACHE_NOPCC = 100 * 1024  # 102400 KV cache length (1 user)
+
+# H2D stream-service constants (mirror prefill_runner.py). Used by the with-service variant of the
+# no-PCC test: build the H2D service so its persistent receiver kernel spins on its worker core during
+# the whole prefill, reproducing the request-loop's service-presence dispatch tax WITHOUT any producer
+# or socket (tokens still come from the local path). See run_chunked_transformer_no_pcc(with_h2d_service).
+H2D_METADATA_SIZE_BYTES = 12
+H2D_MAPPER_CONFIG = ttnn.MeshMapperConfig(
+    placements=[ttnn.PlacementShard(0), ttnn.PlacementReplicate()],
+)
+H2D_SYNC_WORKER_CORES = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
 
 
 def _resolve_trace_dir(variant) -> Path:
@@ -93,6 +110,21 @@ LAYER_PCC_THRESHOLD = 0.88
 # Deepest config whose per-layer PCC is asserted; deeper runs (L61) stay record-only until their
 # accumulation headroom is pinned.
 GATED_LAYER_DEPTH = 10
+
+# Per-chunk baseline medians (seconds) for the no-PCC perf gate, pulled from a known-good CI run. Keyed
+# by (num_layers, n_chunks, num_iters, with_h2d_service) so only the exact config we have a CI number
+# for is gated; every other combo in the no-PCC sweep stays record-only. Each list has one entry per
+# chunk (index c == chunk c). A single margin (the perf_margin pytest arg) is applied to every chunk.
+# Recalibrate by re-reading the "chunk timing stats" table from a fresh green CI run.
+KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S = {
+    # test_kimi_prefill_transformer_chunked_no_pcc[...-L61-chunks5-ten_iters-nosvc]
+    # Baseline from https://github.com/tenstorrent/tt-metal/actions/runs/28753487696 (run attempt 2):
+    # the per-chunk median column of the "chunk timing stats" table (9 post-warmup iters, iter 0 omitted).
+    (61, 5, 10, False): [1.330, 1.326, 1.326, 1.340, 1.369],
+}
+# Default +/- tolerance band around each baseline chunk median (fraction). Overridable per test via the
+# perf_margin pytest argument (see test_prefill_block_perf.py's `margin` column for the design).
+DEFAULT_PERF_MARGIN = 0.05
 
 
 def _load_metadata_token_ids(trace_dir: Path, total_len: int) -> torch.Tensor:
@@ -811,4 +843,462 @@ def test_glm_prefill_transformer_chunked(
         num_links,
         topology,
         routing_use_l1_small_for_semaphores=True,
+    )
+
+
+def run_chunked_transformer_no_pcc(
+    variant,
+    config,
+    mesh_device,
+    weight_cache_path,
+    num_layers,
+    n_chunks,
+    gate_fallback_mode,
+    num_links,
+    topology,
+    num_iters,
+    with_h2d_service=False,
+    h2d_isolated_claim=False,
+    routing_use_l1_small_for_semaphores=False,
+    baseline_chunk_times_s=None,
+    perf_margin=None,
+):
+    """No-PCC perf/smoke variant of run_chunked_transformer: build the transformer ONCE, then drive the
+    full n_chunks-chunk prefill `num_iters` times with return_intermediates=False (no per-layer host
+    readback, no PCC). Tokens are the real (longbook) ids from the golden trace when present, else a
+    deterministic in-vocab pattern, so this is trace-optional. With with_h2d_service the H2D stream
+    service is built so its persistent receiver kernel spins on its worker core for the whole prefill,
+    reproducing the request-loop's service-presence dispatch tax WITHOUT any producer or socket (the
+    service is never fed). The KV cache is reused across iterations (each chunk overwrites the same
+    [0, total_len) region in order).
+
+    Perf gate: when `baseline_chunk_times_s` is provided (a per-chunk list of baseline medians pulled
+    from a known-good CI run), each chunk's measured median must stay within +/- `perf_margin` of its
+    baseline; a single `perf_margin` covers every chunk. The table appends the baseline, tolerance band,
+    and PASS/FAIL per chunk, and the run fails if any chunk is out of band. When no baseline is given the
+    table is record-only (perf-exploration combos)."""
+    if weight_cache_path is None:
+        pytest.skip(f"pretrained weights unavailable (set {variant.ttnn_cache_env} + {variant.env_var})")
+
+    def format_duration(seconds: float) -> str:
+        return f"{seconds:7.3f}s"
+
+    def print_duration_table(iteration_chunk_times: list[list[float]]) -> list[str]:
+        """Log the per-chunk median/stddev table (and, when a baseline is set, the tolerance band +
+        PASS/FAIL). Returns the list of human-readable failure messages (empty if all chunks pass or if
+        there is no baseline) so the caller can assert after the table has been printed."""
+        # Iteration 0 includes compile/JIT effects; exclude it from perf stats.
+        samples = iteration_chunk_times[1:]
+        if not samples:
+            logger.warning("No post-warmup iterations available for chunk timing stats (need num_iters >= 2)")
+            return []
+
+        gated = baseline_chunk_times_s is not None
+        if gated and len(baseline_chunk_times_s) != n_chunks:
+            raise ValueError(
+                f"baseline_chunk_times_s has {len(baseline_chunk_times_s)} entries but n_chunks={n_chunks}"
+            )
+        margin = perf_margin if perf_margin is not None else 0.0
+
+        headers = ["chunk", "median_time", "stddev"]
+        if gated:
+            headers += ["baseline", "low", "high", "status"]
+        rows = []
+        failures: list[str] = []
+        for chunk_idx in range(n_chunks):
+            chunk_samples = [row[chunk_idx] for row in samples]
+            median_time = statistics.median(chunk_samples)
+            stddev_time = statistics.stdev(chunk_samples) if len(chunk_samples) >= 2 else 0.0
+            row = [f"chunk {chunk_idx}", format_duration(median_time), format_duration(stddev_time)]
+            if gated:
+                baseline = baseline_chunk_times_s[chunk_idx]
+                low = baseline * (1.0 - margin)
+                high = baseline * (1.0 + margin)
+                ok = low <= median_time <= high
+                row += [
+                    format_duration(baseline),
+                    format_duration(low),
+                    format_duration(high),
+                    "PASS" if ok else "FAIL",
+                ]
+                if not ok:
+                    failures.append(
+                        f"chunk {chunk_idx} median {median_time:.3f}s outside "
+                        f"baseline {baseline:.3f}s +/- {margin * 100:.1f}% band [{low:.3f}s, {high:.3f}s]"
+                    )
+            rows.append(row)
+
+        widths = [len(header) for header in headers]
+        for row in rows:
+            for idx, cell in enumerate(row):
+                widths[idx] = max(widths[idx], len(cell))
+
+        def render_row(values: list[str]) -> str:
+            return "| " + " | ".join(value.ljust(widths[idx]) for idx, value in enumerate(values)) + " |"
+
+        separator = "+-" + "-+-".join("-" * width for width in widths) + "-+"
+
+        margin_note = f", baseline gate +/- {margin * 100:.1f}%" if gated else ", record-only (no baseline)"
+        logger.info(f"chunk timing stats computed over {len(samples)} iterations (iter 0 omitted){margin_note}")
+        logger.info("\n" + separator)
+        logger.info(render_row(headers))
+        logger.info(separator)
+        for row in rows:
+            logger.info(render_row(row))
+        logger.info(separator)
+        return failures
+
+    profiler.clear()
+    profiler.start("total_test_time")
+
+    sp_axis, tp_axis = 0, 1
+    mesh_shape = list(mesh_device.shape)
+    sp = mesh_shape[sp_axis]
+    tp = mesh_shape[tp_axis]
+    assert (sp, tp) == (8, 4), f"this test targets mesh-8x4, got {mesh_shape}"
+
+    chunk_local = CHUNK // sp  # 640
+    total_len = n_chunks * CHUNK
+    assert total_len <= SEQ_CACHE_NOPCC, f"{n_chunks} chunks ({total_len}) exceed cache {SEQ_CACHE_NOPCC}"
+
+    kvpe_dim = config.qk_rope_head_dim + config.kv_lora_rank
+    config.max_seq_len = SEQ_CACHE_NOPCC
+
+    logger.info(
+        f"chunked transformer (no-PCC): num_layers={num_layers} mesh={mesh_shape} n_chunks={n_chunks} "
+        f"total_len={total_len} cache={SEQ_CACHE_NOPCC} chunk={CHUNK} num_iters={num_iters} "
+        f"with_h2d_service={with_h2d_service}"
+    )
+
+    iteration_chunk_times: list[list[float]] = []
+
+    # Token ids: prefer the real (code_debug/longbook) ids from the golden trace (same source as the PCC
+    # test) but never compared here; fall back to a deterministic in-vocab pattern so this stays
+    # trace-optional. _resolve_trace_dir raises when the base dir is absent (e.g. the code_debug dataset
+    # isn't staged on this host), so swallow that too and fall back -- the verdict is trace-independent.
+    vocab_size = config.vocab_size
+    try:
+        trace_dir = _resolve_trace_dir(variant)
+    except FileNotFoundError:
+        trace_dir = None
+    if trace_dir is not None and trace_dir.exists():
+        trace_tokens = _load_metadata_token_ids(trace_dir, total_len)
+        if trace_tokens.numel() < total_len:
+            reps = (total_len + trace_tokens.numel() - 1) // trace_tokens.numel()
+            trace_tokens = trace_tokens.repeat(reps)[:total_len]
+        token_ids_full = trace_tokens % vocab_size
+        logger.info(f"no-PCC: loaded {token_ids_full.numel()} token ids from trace {trace_dir}")
+    else:
+        token_ids_full = torch.arange(total_len, dtype=torch.int64) % vocab_size
+        logger.info(f"no-PCC: trace not found ({trace_dir}); using synthetic token ids")
+
+    # --- Weights from the prebuilt TTNN cache (empty state_dict when complete). ---
+    effective_cache_path = weight_cache_path / f"{sp}x{tp}"
+    experts_per_chip = variant.model_config.NUM_ROUTED_EXPERTS // (sp * tp)
+    assert TtPrefillTransformer.check_cache_complete(
+        effective_cache_path,
+        num_layers,
+        experts_per_chip=experts_per_chip,
+        first_k_dense=variant.model_config.NUM_DENSE_LAYERS,
+    ), f"TTNN cache incomplete for {num_layers} layers at {effective_cache_path}"
+
+    profiler.start("tt_transformer_creation")
+    transformer = TtPrefillTransformer(
+        mesh_device=mesh_device,
+        config=config,
+        model_cfg=variant.model_config,
+        state_dict={},
+        num_layers=num_layers,
+        seq_len=CHUNK,  # per-chunk size -> MoE/FFN dispatch buffers
+        max_seq_len=SEQ_CACHE_NOPCC,  # KV ring buffer + RoPE cos/sin cache = full no-PCC cache (up to 100k)
+        dispatch_buffer_capacity_factor=8,
+        num_links=num_links,
+        topology=topology,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=False,
+        gate_fallback_mode=gate_fallback_mode,
+        weight_cache_path=effective_cache_path,
+        lm_head_is_column_parallel=True,
+        is_chunked=True,
+        slot_num=1,
+        routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
+    )
+    ttnn.synchronize_device(mesh_device)
+    gc.collect()
+    profiler.end("tt_transformer_creation")
+
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=kvpe_dim,
+        mesh_device=mesh_device,
+        seq_len=SEQ_CACHE_NOPCC,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_layers,
+        num_users=1,
+    )
+
+    # Precompute per-chunk SP-sharded token tiles once (reused across iterations). Chunk-aligned offsets
+    # make the block-cyclic rotation degenerate to a plain per-chip reshape.
+    chunk_tok_host = []
+    for c in range(n_chunks):
+        kv_actual = c * CHUNK
+        positions = rotated_chip_positions(kv_actual, sp, chunk_local)
+        flat = torch.tensor([positions[ch][r] for ch in range(sp) for r in range(chunk_local)], dtype=torch.long)
+        chunk_tok_host.append(token_ids_full[flat].reshape(sp, 1, chunk_local))
+
+    mesh_device.enable_program_cache()
+
+    # Background H2D-service variant: build the H2D stream service so its persistent receiver kernel
+    # spins for the whole prefill, reproducing the request-loop's service-presence dispatch tax WITHOUT
+    # a producer or socket (tokens still come from the local path; the service is never fed). Mirrors
+    # prefill_runner request-mode: clear the model's custom sub-device manager first so the service's
+    # init program validates against the whole-chip default. isolated_claim (h2dsvc_isolated variant)
+    # needs a source-side change not ported to this branch; only nosvc / h2dsvc_regular run here.
+    bg_h2d_service = None
+    if with_h2d_service:
+        mesh_device.clear_loaded_sub_device_manager()
+        bg_h2d_service = build_h2d_service(
+            mesh_device,
+            mesh_shape=tuple(mesh_shape),
+            chunk_size=CHUNK,
+            mapper_config=H2D_MAPPER_CONFIG,
+            worker_cores=H2D_SYNC_WORKER_CORES,
+            metadata_size_bytes=H2D_METADATA_SIZE_BYTES,
+        )
+        logger.info(
+            f"[h2d-bg] H2D service built and spinning in the background (unused; no producer/socket); "
+            f"isolated_claim={h2d_isolated_claim}"
+        )
+
+    # Profiling warmup: run chunk 0 once through all layers so every kernel is JIT-compiled and the
+    # program cache is populated BEFORE the measured region. Gated by TT_PREFILL_PROFILE_WARMUP so
+    # normal runs are unaffected. Bracketed by PROFILE_WARMUP_START / PROFILE_MEASURE_START signposts;
+    # the per-layer post-processor keeps only ops AFTER PROFILE_MEASURE_START, so this compile pass is
+    # excluded from the device-time / op2op breakdown.
+    if os.environ.get("TT_PREFILL_PROFILE_WARMUP", "0") == "1":
+        signpost("PROFILE_WARMUP_START")
+        warm_tokens = ttnn.from_torch(
+            chunk_tok_host[0],
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=(0, None)),
+        )
+        transformer.forward(
+            warm_tokens,
+            tt_kvpe_cache,
+            actual_isl=CHUNK,
+            actual_start=0,
+            actual_end=CHUNK,
+            cache_user_id=0,
+            return_intermediates=False,
+        )
+        ttnn.synchronize_device(mesh_device)
+        ttnn.deallocate(warm_tokens)
+        logger.info("[profile] warmup chunk 0 complete (kernels JITted); measured region begins")
+        signpost("PROFILE_MEASURE_START")
+
+    profiler.start("tt_forward")
+    for it in range(num_iters):
+        iter_start = time.time()
+        chunk_times: list[float] = []
+        for c in range(n_chunks):
+            kv_actual = c * CHUNK
+            tt_tokens = ttnn.from_torch(
+                chunk_tok_host[c],
+                device=mesh_device,
+                dtype=ttnn.uint32,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=(0, None)),
+            )
+            chunk_start = time.time()
+            # forward with return_intermediates=False: nothing is cloned to host, no PCC. Chunked
+            # prefill is full-chunk (all positions real) so actual_end is kv_actual + CHUNK; forward
+            # uses self.indexed_rope. The small (first_token) return is discarded.
+            transformer.forward(
+                tt_tokens,
+                tt_kvpe_cache,
+                actual_isl=CHUNK,
+                actual_start=kv_actual,
+                actual_end=kv_actual + CHUNK,
+                cache_user_id=0,
+                return_intermediates=False,
+            )
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(tt_tokens)
+            chunk_times.append(time.time() - chunk_start)
+        iter_total = time.time() - iter_start
+        iteration_chunk_times.append(chunk_times)
+        logger.info(f"iter {it} done ({n_chunks} chunks) in {iter_total:.3f} seconds")
+    profiler.end("tt_forward")
+
+    # Release the H2D service while the mesh + command queues + service core are still alive (its dtor
+    # frees a command queue and the service-core L1; running it after mesh close aborts).
+    if bg_h2d_service is not None:
+        del bg_h2d_service
+        gc.collect()
+        logger.info("[h2d-bg] H2D service released")
+
+    profiler.end("total_test_time")
+    logger.success(
+        f"Chunked prefill no-PCC run done (num_layers={num_layers}, n_chunks={n_chunks}, "
+        f"num_iters={num_iters}, with_h2d_service={with_h2d_service})"
+    )
+    perf_failures = print_duration_table(iteration_chunk_times)
+    for key in profiler.times:
+        logger.info(f"  {key}: {profiler.get(key) * 1000:.2f} ms")
+
+    # Assert AFTER the table is logged so the full per-chunk breakdown is always visible on failure.
+    assert not perf_failures, "chunk timing out of baseline tolerance:\n  " + "\n  ".join(perf_failures)
+
+
+# No-PCC perf/smoke variant: runs the full n_chunks-chunk prefill `num_iters` times with no golden
+# trace dependency, no intermediate readback, and no PCC. Requires only the Kimi TTNN weight cache (set
+# TT_KIMI_PREFILL_TTNN_CACHE + KIMI_K2_6_HF_MODEL); the golden trace is optional. Service modes:
+#   nosvc           - no H2D stream service (baseline)
+#   h2dsvc_regular  - resident H2D service, legacy claim -> per-op dispatch tax on every model op
+@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin5pct"])
+@pytest.mark.parametrize(
+    "with_h2d_service, h2d_isolated_claim",
+    [(False, False), (True, False), (True, True)],
+    ids=["nosvc", "h2dsvc_regular", "h2dsvc_isolated"],
+)
+@pytest.mark.parametrize(
+    "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
+)
+@pytest.mark.parametrize(
+    "n_chunks",
+    [1, 2, 5, 10, 11, 20],
+    ids=["chunks1", "chunks2", "chunks5", "chunks10", "chunks_eleven", "chunks20"],
+)
+@pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
+                # L1_SMALL region for the MoE routing all-gather's semaphores (see TtMoERoutingSetup).
+                "l1_small_size": 512,
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["kimi_k2_6"], indirect=True, ids=["kimi"])
+@pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
+@pytest.mark.timeout(0)
+def test_kimi_prefill_transformer_chunked_no_pcc(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    weight_cache_path,
+    num_layers,
+    n_chunks,
+    num_iters,
+    with_h2d_service,
+    h2d_isolated_claim,
+    num_links,
+    topology,
+    perf_margin,
+):
+    # Gate against the CI baseline only for the exact config we have a recorded number for; every other
+    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert).
+    baseline_chunk_times_s = KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters, with_h2d_service))
+    run_chunked_transformer_no_pcc(
+        variant,
+        config_only,
+        mesh_device,
+        weight_cache_path,
+        num_layers,
+        n_chunks,
+        GateComputeMode.DEVICE_FP32,
+        num_links,
+        topology,
+        num_iters,
+        with_h2d_service=with_h2d_service,
+        h2d_isolated_claim=h2d_isolated_claim,
+        routing_use_l1_small_for_semaphores=True,
+        baseline_chunk_times_s=baseline_chunk_times_s,
+        perf_margin=perf_margin,
+    )
+
+
+# DeepSeek counterpart of the no-PCC perf sweep above: same chunked driver, deepseek_v3_d_p variant
+# (DeepSeekV3Config fabric payload, no L1_SMALL routing semaphores). Used to compare DeepSeek vs Kimi
+# chunked-prefill perf at matched ISL (n_chunks x CHUNK), num_layers, and service mode.
+@pytest.mark.parametrize(
+    "with_h2d_service, h2d_isolated_claim",
+    [(False, False), (True, False), (True, True)],
+    ids=["nosvc", "h2dsvc_regular", "h2dsvc_isolated"],
+)
+@pytest.mark.parametrize(
+    "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
+)
+@pytest.mark.parametrize(
+    "n_chunks",
+    [1, 2, 5, 10, 11, 20],
+    ids=["chunks1", "chunks2", "chunks5", "chunks10", "chunks_eleven", "chunks20"],
+)
+@pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(
+                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
+                ),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["deepseek_v3_d_p"], indirect=True, ids=["deepseek_v3"])
+@pytest.mark.skipif(not is_blackhole(), reason="DeepSeek prefill requires Blackhole")
+@pytest.mark.timeout(0)
+def test_ds_prefill_transformer_chunked_no_pcc(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    weight_cache_path,
+    num_layers,
+    n_chunks,
+    num_iters,
+    with_h2d_service,
+    h2d_isolated_claim,
+    num_links,
+    topology,
+):
+    run_chunked_transformer_no_pcc(
+        variant,
+        config_only,
+        mesh_device,
+        weight_cache_path,
+        num_layers,
+        n_chunks,
+        GateComputeMode.DEVICE_FP32,
+        num_links,
+        topology,
+        num_iters,
+        with_h2d_service=with_h2d_service,
+        h2d_isolated_claim=h2d_isolated_claim,
+        routing_use_l1_small_for_semaphores=False,
     )

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -247,3 +247,27 @@
       timeout: 15
   owner_id: U08RL15T4N8
   team: models
+
+- name: "(Galaxy) DeepSeek Prefill - Chunked Kimi (longbook_qa 25k)"
+  # 25k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 5 chunks x 5120 = 25600 tokens,
+  # 10 iterations, no H2D service (nosvc). No-PCC: it drives the real chunked-prefill path end to end
+  # (build once, forward 10x) and passes on completion -- no golden readback, no accuracy compare.
+  #
+  # Paths (CI mounts /mnt/MLPerf:ro):
+  #   KIMI_K2_6_HF_MODEL  -> dequantized Kimi HF checkpoint (config.json + safetensors.index.json)
+  #   TT_KIMI_PREFILL_TTNN_CACHE is intentionally NOT set; the conftest falls back to the
+  #     shared cache path under KIMI_K2_6_HF_MODEL/tensor_cache_bh_32dev/8x4.
+  #   PREFILL_TRACE_DIR   -> longbook_qa_eng golden trace; metadata.json token_ids feed the prefill.
+  cmd: |
+    export MESH_DEVICE=TG
+    export KIMI_K2_6_HF_MODEL=/mnt/MLPerf/huggingface/hub/Kimi-K2.6-dequantized
+    export PREFILL_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache/golden/structured_traces/kimi_longbook_55k_vllm
+    pytest "models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-chunks5-ten_iters-nosvc-margin5pct]" -xvs
+  test_type: kimi_chunked
+  test_group: module
+  skus:
+    bh_galaxy:
+      # Green run took ~19 min; 40 leaves ~2x headroom for build/Galaxy variance.
+      timeout: 40
+  owner_id: U08RL15T4N8
+  team: models

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -248,26 +248,26 @@
   owner_id: U08RL15T4N8
   team: models
 
-- name: "(Galaxy) DeepSeek Prefill - Chunked Kimi (longbook_qa 25k)"
-  # 25k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 5 chunks x 5120 = 25600 tokens,
-  # 10 iterations, no H2D service (nosvc). No-PCC: it drives the real chunked-prefill path end to end
-  # (build once, forward 10x) and passes on completion -- no golden readback, no accuracy compare.
+- name: "(Galaxy) DeepSeek Prefill - Chunked Kimi (code_debug 55k)"
+  # 55k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 11 chunks x 5120 = 56320 tokens
+  # (the full code_debug trace), 10 iterations. No-PCC: it drives the real chunked-prefill path end to
+  # end (build once, forward 10x) and passes on completion -- no golden readback, no accuracy compare.
   #
   # Paths (CI mounts /mnt/MLPerf:ro):
   #   KIMI_K2_6_HF_MODEL  -> dequantized Kimi HF checkpoint (config.json + safetensors.index.json)
   #   TT_KIMI_PREFILL_TTNN_CACHE is intentionally NOT set; the conftest falls back to the
   #     shared cache path under KIMI_K2_6_HF_MODEL/tensor_cache_bh_32dev/8x4.
-  #   PREFILL_TRACE_DIR   -> longbook_qa_eng golden trace; metadata.json token_ids feed the prefill.
+  #   PREFILL_TRACE_DIR   -> code_debug (56320) golden trace; metadata.json token_ids feed the prefill.
   cmd: |
     export MESH_DEVICE=TG
     export KIMI_K2_6_HF_MODEL=/mnt/MLPerf/huggingface/hub/Kimi-K2.6-dequantized
-    export PREFILL_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache/golden/structured_traces/kimi_longbook_55k_vllm
-    pytest "models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-chunks5-ten_iters-margin5pct]" -xvs
+    export PREFILL_TRACE_DIR=/mnt/MLPerf/kimi-prefill-cache/vllm-kimi-k26-codedebug-56320
+    pytest "models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-chunks_eleven-ten_iters-margin5pct]" -xvs
   test_type: kimi_chunked
   test_group: module
   skus:
     bh_galaxy:
-      # Green run took ~19 min; 40 leaves ~2x headroom for build/Galaxy variance.
-      timeout: 40
+      # Job takes under 20 minutes; 30 minute timeout provides buffer for variance.
+      timeout: 30
   owner_id: U08RL15T4N8
   team: models

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -262,7 +262,7 @@
     export MESH_DEVICE=TG
     export KIMI_K2_6_HF_MODEL=/mnt/MLPerf/huggingface/hub/Kimi-K2.6-dequantized
     export PREFILL_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache/golden/structured_traces/kimi_longbook_55k_vllm
-    pytest "models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-chunks5-ten_iters-nosvc-margin5pct]" -xvs
+    pytest "models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-chunks5-ten_iters-margin5pct]" -xvs
   test_type: kimi_chunked
   test_group: module
   skus:


### PR DESCRIPTION
## Description
Adding new job in DeepSeek Prefill CI. It's running chunked-prefill on Kimi on `code_debug` dataset.

## Details
- Adds performance margin.
- Relies on already pre-computed model cache in the CI.

## CIs
- https://github.com/tenstorrent/tt-metal/actions/runs/28864154892

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/chunked_kimi_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/chunked_kimi_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kgrujcic/chunked_kimi_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/chunked_kimi_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/chunked_kimi_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/chunked_kimi_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/chunked_kimi_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/chunked_kimi_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/chunked_kimi_ci)