### PR TITLE
Test Only: Fix fused fp32 mismatch expected error

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -799,7 +799,7 @@ class TestMatmulFusion:
             epsilon=1e-5,
         )
 
-        with expect_error((ValueError, RuntimeError)):
+        with expect_error((ValueError, RuntimeError), "fp32_dest_acc_en mismatch"):
             Sequential(mm, ln).build(device)
 
 


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Fix the fused `TestMatmulFusion::test_fp32_mismatch_error` regression by passing the required expected-error message to the `expect_error` fixture.

Closes #49032
Closes #49034

### Notes for reviewers
The expected message matches the validation raised when fused phases use inconsistent `fp32_dest_acc_en` settings.

Tests not run per request.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/fix_regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_regression)