### PR TITLE
Allow overriding x86 -march for Ivy Bridge hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,10 @@ if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
 
+set(TT_X86_MARCH "x86-64-v3" CACHE STRING "x86_64 architecture passed to -march")
+
 add_compile_options(
-    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=x86-64-v3>"
+    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=${TT_X86_MARCH}>"
     -fPIC
     -pipe # use pipes instead of tmp files
     -fvisibility-inlines-hidden

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,8 +196,10 @@ if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
 
+set(TT_X86_MARCH "x86-64-v3" CACHE STRING "x86_64 architecture passed to -march")
+
 add_compile_options(
-    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=x86-64-v3>"
+    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=${TT_X86_MARCH}>"
     -fPIC
     -pipe # use pipes instead of tmp files
     -fvisibility-inlines-hidden

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -47,6 +47,7 @@ show_help() {
     echo "  --cpm-use-local-packages         Attempt to use locally installed dependencies."
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
+    echo "  --host-march                     Set x86 host -march value. Default is x86-64-v3."
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
@@ -88,6 +89,7 @@ cpm_source_cache=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
 toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
+host_march="x86-64-v3"
 
 
 configure_only="OFF"
@@ -131,6 +133,7 @@ cpm-use-local-packages
 c-compiler-path:
 ttnn-shared-sub-libs
 toolchain-path:
+host-march:
 configure-only
 without-distributed
 without-python-bindings
@@ -216,6 +219,8 @@ while true; do
             c_compiler_path="$2";shift;;
         --toolchain-path)
             toolchain_path="$2";shift;;
+        --host-march)
+            host_march="$2";shift;;
         --release)
             build_type="Release";;
         --development)
@@ -290,6 +295,7 @@ echo "INFO: Enable Distributed: $enable_distributed"
 echo "INFO: With python bindings: $with_python_bindings"
 echo "INFO: Enable Tracy: $tracy_enabled"
 echo "INFO: Enable LTO: $enable_lto"
+echo "INFO: Host march: $host_march"
 echo "INFO: Warnings as errors: $warnings_as_errors"
 
 # Prepare cmake arguments
@@ -297,6 +303,7 @@ cmake_args+=("-B" "$build_dir")
 cmake_args+=("-G" "Ninja")
 cmake_args+=("-DCMAKE_BUILD_TYPE=$build_type")
 cmake_args+=("-DCMAKE_INSTALL_PREFIX=$cmake_install_prefix")
+cmake_args+=("-DTT_X86_MARCH=$host_march")
 
 if [ "$cxx_compiler_path" != "" ]; then
     echo "INFO: C++ compiler: $cxx_compiler_path"

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -53,6 +53,7 @@ show_help() {
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
     echo "  --use-system-sfpi                Use the SFPI toolchain already installed on the system/image instead of downloading it."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
+    echo "  --host-march                     Set x86 host -march value. Default is x86-64-v3."
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
@@ -96,6 +97,7 @@ c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
 use_system_sfpi="OFF"
 toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
+host_march="x86-64-v3"
 
 
 configure_only="OFF"
@@ -141,6 +143,7 @@ c-compiler-path:
 ttnn-shared-sub-libs
 use-system-sfpi
 toolchain-path:
+host-march:
 configure-only
 without-distributed
 without-python-bindings
@@ -230,6 +233,8 @@ while true; do
             c_compiler_path="$2";shift;;
         --toolchain-path)
             toolchain_path="$2";shift;;
+        --host-march)
+            host_march="$2";shift;;
         --release)
             build_type="Release";;
         --development)
@@ -331,6 +336,7 @@ else
 fi
 echo "INFO: Tracy debug-verbosity categories: $perf_debug_categories_effective"
 echo "INFO: Enable LTO: $enable_lto"
+echo "INFO: Host march: $host_march"
 echo "INFO: Warnings as errors: $warnings_as_errors"
 
 # Prepare cmake arguments
@@ -338,6 +344,7 @@ cmake_args+=("-B" "$build_dir")
 cmake_args+=("-G" "Ninja")
 cmake_args+=("-DCMAKE_BUILD_TYPE=$build_type")
 cmake_args+=("-DCMAKE_INSTALL_PREFIX=$cmake_install_prefix")
+cmake_args+=("-DTT_X86_MARCH=$host_march")
 
 if [ "$cxx_compiler_path" != "" ]; then
     echo "INFO: C++ compiler: $cxx_compiler_path"


### PR DESCRIPTION
## Summary
- add TT_X86_MARCH CMake cache variable for x86_64 host builds
- add `build_metal.sh --host-march` to pass the CMake knob through the standard build script
- keep the existing default at x86-64-v3 so modern hosts retain current optimizations
- update the UMD submodule to the matching branch commit

## Motivation
Ivy Bridge hosts support AVX but not the full x86-64-v3 baseline, so default host code can fault with illegal instructions. This keeps x86-64-v3 as the default and lets older source builds opt in with either `-DTT_X86_MARCH=ivybridge` or `./build_metal.sh --host-march ivybridge`.

## Dependency
Depends on the matching tt-umd PR: https://github.com/tenstorrent/tt-umd/pull/2979

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/ivybridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/ivybridge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/ivybridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/ivybridge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/ivybridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/ivybridge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/ivybridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/ivybridge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/ivybridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/ivybridge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/ivybridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/ivybridge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/ivybridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/ivybridge)
