### PR TITLE
#19475: [ttnn] Add regression tests for untilize_with_unpadding narrow height-sharded CB page size

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -127,6 +127,9 @@ def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_chang
         # 2 cores
         ([1, 1, 128, 64], [0, 0, 127, 63], (64, 64), 2),
         ([1, 1, 128, 64], [0, 0, 100, 50], (64, 64), 2),
+        ([1, 1, 128, 2], [0, 0, 127, 1], (32, 32), 4),  # issue #19475: 4 bytes, below 16-byte NOC alignment
+        ([1, 1, 128, 4], [0, 0, 127, 3], (32, 32), 4),  # issue #19475: 8 bytes, below 16-byte NOC alignment
+        ([1, 1, 128, 8], [0, 0, 127, 7], (32, 32), 4),  # issue #19475: 16 bytes, at alignment boundary
     ],
 )
 @pytest.mark.parametrize("output_sharded", [True, False])
@@ -169,6 +172,42 @@ def test_untilize_with_unpadding_height_sharded(
     torch_result = torch_tensor[slices]
 
     assert_equal(result, torch_result)
+
+
+@pytest.mark.parametrize(
+    "hw, out_channels",
+    [
+        (2048, 2),  # issue #19475: 4 bytes, below 16-byte NOC alignment
+        (2048, 4),  # issue #19475: 8 bytes, below 16-byte NOC alignment
+        (2048, 8),  # issue #19475: 16 bytes, at alignment boundary
+    ],
+)
+def test_untilize_with_unpadding_height_sharded_narrow_width_regression(device, hw, out_channels):
+    """Regression test for issue #19475 / PR #38428.
+
+    HEIGHT_SHARDED TILE → ROW_MAJOR where the actual output row width is below
+    the 16-byte L1 NOC alignment boundary.  The CB page size must be
+    aligned_page_size (≥ 16 bytes), not block_row_size, to avoid overflow.
+    """
+    torch.manual_seed(0)
+    torch_input = torch.rand((hw, out_channels), dtype=torch.bfloat16)
+
+    num_cores = 64
+    shard_shape = [hw // num_cores, max(out_channels, 32)]  # pad width to TILE_WIDTH
+    core_range_set = ttnn.num_cores_to_corerangeset(num_cores, device.compute_with_storage_grid_size())
+    memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_range_set, shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    output_tensor_end = [hw - 1, out_channels - 1]
+
+    tt_tensor = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config)
+    tt_out = ttnn.untilize_with_unpadding(tt_tensor, output_tensor_end=output_tensor_end)
+    result = ttnn.to_torch(tt_out)
+
+    assert_equal(result, torch_input)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -127,9 +127,6 @@ def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_chang
         # 2 cores
         ([1, 1, 128, 64], [0, 0, 127, 63], (64, 64), 2),
         ([1, 1, 128, 64], [0, 0, 100, 50], (64, 64), 2),
-        ([1, 1, 128, 2], [0, 0, 127, 1], (32, 32), 4),  # issue #19475: 4 bytes, below 16-byte NOC alignment
-        ([1, 1, 128, 4], [0, 0, 127, 3], (32, 32), 4),  # issue #19475: 8 bytes, below 16-byte NOC alignment
-        ([1, 1, 128, 8], [0, 0, 127, 7], (32, 32), 4),  # issue #19475: 16 bytes, at alignment boundary
     ],
 )
 @pytest.mark.parametrize("output_sharded", [True, False])


### PR DESCRIPTION
### Ticket
#19475 

### Issue
 **Root cause fixed**: CB page size in `untilize_with_unpadding_multi_core_sharded_program_factory` was set to `block_row_size` (4 bytes for `out_channels=2`) instead of `aligned_page_size` (16 bytes = L1 NOC alignment on Wormhole). The writer kernel advanced its L1 write pointer by 16 bytes per row but the CB thought each page was only 4 bytes → CB overflow → corrupted output → PCC ~0.037. Fix was discovered via watcher CB sanitize (#38424). 
 
### What this PR does
Added regression tests covering:

- test_untilize_with_unpadding_height_sharded_narrow_width_regression — 64-core grid with out_channels ∈ {2, 4, 8} (below and at the 16-byte boundary)
- Extended test_untilize_with_unpadding_height_sharded parametrize with the same narrow-width cases on a smaller 4-core grid.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/untilizewithunpadding_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/untilizewithunpadding_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abdulla/untilizewithunpadding_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/untilizewithunpadding_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/untilizewithunpadding_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/untilizewithunpadding_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/untilizewithunpadding_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/untilizewithunpadding_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/untilizewithunpadding_test)