### PR TITLE
#48340: Fix L1 CB clash and preserve sharding in ttnn::split default memory config

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
@@ -2,30 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Universal I/O coverage for ttnn.split.
-
-Tests the composite layer's transparent conversion of:
-  * interleaved inputs in L1 and DRAM
-  * mixed buffer locations (L1 in, DRAM out)
-  * ROW_MAJOR inputs/outputs
-  * sharded inputs (HEIGHT/WIDTH/BLOCK) with interleaved output
-  * interleaved input with sharded output (equal splits)
-  * program-cache reuse: same shape → no rebuild, different shape → rebuild
-  * supported dtype combinations
-  * various ranks and dimensions
-"""
+"""Universal I/O coverage for ttnn.split: interleaved/sharded/DRAM MC combos, dtype/rank/dim matrices, program cache, no-spec synthesis, L1 CB-clash regression."""
 
 import pytest
 import torch
 import ttnn
 
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
+
 pytestmark = pytest.mark.use_module_device
 
 TILE = 32
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+# Helpers.
 
 L1 = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
 DRAM = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
@@ -39,10 +28,12 @@ def _from_torch(t, device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mc=None
 def _check(tt_outputs, torch_outputs):
     assert len(tt_outputs) == len(torch_outputs), f"chunk count {len(tt_outputs)} != {len(torch_outputs)}"
     for i, (tt_t, ref) in enumerate(zip(tt_outputs, torch_outputs)):
-        out = ttnn.to_torch(tt_t).float()
-        ref_f = ref.float()
+        out = ttnn.to_torch(tt_t)
         assert list(tt_t.shape) == list(ref.shape), f"chunk {i}: shape {list(tt_t.shape)} != {list(ref.shape)}"
-        assert torch.allclose(out, ref_f, rtol=1e-2, atol=1e-2), f"chunk {i}: max_diff={(out - ref_f).abs().max():.4f}"
+        try:
+            assert_equal(ref, out)
+        except AssertionError as e:
+            raise AssertionError(f"chunk {i}: {e}") from e
 
 
 def _make_height_sharded_cfg(num_shards, shard_h, shard_w, buffer=ttnn.BufferType.L1):
@@ -63,9 +54,7 @@ def _make_block_sharded_cfg(grid_y, grid_x, shard_h, shard_w, buffer=ttnn.Buffer
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, buffer, spec)
 
 
-# ---------------------------------------------------------------------------
-# 1. Interleaved baseline — L1 and DRAM
-# ---------------------------------------------------------------------------
+# 1. Interleaved baseline — L1 and DRAM.
 
 
 @pytest.mark.parametrize(
@@ -114,9 +103,7 @@ def test_interleaved_l1_input_dram_output(device):
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 2. ROW_MAJOR layout — interleaved
-# ---------------------------------------------------------------------------
+# 2. ROW_MAJOR layout — interleaved.
 
 
 @pytest.mark.parametrize(
@@ -140,9 +127,7 @@ def test_row_major_interleaved(device, shape, split_size, dim):
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 3. Sharded inputs → interleaved output (de-sharding path)
-# ---------------------------------------------------------------------------
+# 3. Sharded inputs → interleaved output (de-sharding path).
 
 
 @pytest.mark.parametrize(
@@ -216,9 +201,7 @@ def test_block_sharded_input_interleaved_output(device, shape, grid_y, grid_x, s
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 4. ROW_MAJOR sharded inputs → interleaved output
-# ---------------------------------------------------------------------------
+# 4. ROW_MAJOR sharded inputs → interleaved output.
 
 
 @pytest.mark.parametrize(
@@ -294,9 +277,7 @@ def test_row_major_block_sharded_input(device, shape, grid_y, grid_x, split_size
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 5. Interleaved input → sharded output (equal splits)
-# ---------------------------------------------------------------------------
+# 5. Interleaved input → sharded output (equal splits).
 
 
 @pytest.mark.parametrize(
@@ -337,17 +318,11 @@ def test_interleaved_input_sharded_output(device, sharding_type, shape, split_si
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 6. Sharded input → sharded output (split along non-sharded dim)
-# ---------------------------------------------------------------------------
+# 6. Sharded input → sharded output (split along non-sharded dim).
 
 
 def test_height_sharded_roundtrip(device):
-    """HEIGHT_SHARDED input, split along last dim → HEIGHT_SHARDED output.
-
-    The shard spec for the output is explicitly constructed for the output shape
-    (each chunk has half the last-dim width of the input).
-    """
+    """HEIGHT_SHARDED input, split along last dim → HEIGHT_SHARDED output; output spec built for chunk shape."""
     torch.manual_seed(9)
     shape = [4 * TILE, 2 * TILE]
     split_size = TILE
@@ -368,9 +343,7 @@ def test_height_sharded_roundtrip(device):
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 7. Dtype coverage: bfloat16 and float32
-# ---------------------------------------------------------------------------
+# 7. Dtype coverage: bfloat16 and float32.
 
 
 @pytest.mark.parametrize(
@@ -391,14 +364,13 @@ def test_dtype_coverage(device, torch_dtype, ttnn_dtype, layout):
     tt_out = ttnn.split(tt_in, TILE, dim=-1)
     out = [ttnn.to_torch(tt_t).to(torch_dtype) for tt_t in tt_out]
     for i, (o, r) in enumerate(zip(out, ref)):
-        assert torch.allclose(
-            o.float(), r.float(), rtol=1e-2, atol=1e-2
-        ), f"chunk {i}: dtype={ttnn_dtype} layout={layout} mismatch"
+        try:
+            assert_equal(r, o)
+        except AssertionError as e:
+            raise AssertionError(f"chunk {i}: dtype={ttnn_dtype} layout={layout}: {e}") from e
 
 
-# ---------------------------------------------------------------------------
-# 8. Program-cache: same shape → reuse; different shape → rebuild
-# ---------------------------------------------------------------------------
+# 8. Program-cache: same shape → reuse; different shape → rebuild.
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -435,13 +407,11 @@ def test_program_cache_shape_change(device):
     _check(tt_out_b, ref_b)
 
 
-# ---------------------------------------------------------------------------
-# 9. Sharded input with no explicit output config → DRAM interleaved default
-# ---------------------------------------------------------------------------
+# 9. Sharded input, default MC → sharded output with rescaled shard_spec.
 
 
-def test_sharded_input_default_output_is_dram(device):
-    """Sharded input with no memory_config arg must produce DRAM interleaved output."""
+def test_sharded_input_default_preserves_sharding(device):
+    """HEIGHT_SHARDED input + no memory_config → HEIGHT_SHARDED output with adjusted spec."""
     torch.manual_seed(13)
     shape = [4 * TILE, 2 * TILE]
     t = torch.randn(shape, dtype=torch.bfloat16)
@@ -449,17 +419,163 @@ def test_sharded_input_default_output_is_dram(device):
 
     in_cfg = _make_height_sharded_cfg(shape[0] // TILE, TILE, shape[-1])
     tt_in = _from_torch(t, device, mc=in_cfg)
-    # No memory_config provided → should default to DRAM interleaved
     tt_out = ttnn.split(tt_in, TILE, dim=-1)
     for tt_t in tt_out:
-        assert not tt_t.memory_config().is_sharded(), "Default output for sharded input should be interleaved"
-        assert tt_t.memory_config().buffer_type == ttnn.BufferType.DRAM
+        mc = tt_t.memory_config()
+        assert mc.is_sharded(), "Default output for sharded input should preserve sharding"
+        assert mc.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+        assert mc.buffer_type == ttnn.BufferType.L1
+        assert mc.shard_spec is not None
+        assert list(mc.shard_spec.shape) == [TILE, TILE], f"expected shard [32,32], got {list(mc.shard_spec.shape)}"
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 10. Various ranks and dimensions
-# ---------------------------------------------------------------------------
+# 9b. Sharded input → sharded output with no shard_spec (synthesize_spec path).
+
+
+@pytest.mark.parametrize(
+    "input_layout, shape, split_size",
+    [
+        # HEIGHT: [128, 64] halved on last dim → adjusted shard [32, 32] (tile-aligned).
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [4 * TILE, 2 * TILE], TILE, id="height_in"),
+        # BLOCK: [128, 128] on 2x2 grid, halved on last dim → adjusted shard [64, 32] (tile-aligned).
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, [4 * TILE, 4 * TILE], 2 * TILE, id="block_in"),
+    ],
+)
+def test_sharded_input_to_sharded_no_spec(device, input_layout, shape, split_size):
+    """User passes sharded output MC without shard_spec → split must synthesize (not FATAL)."""
+    torch.manual_seed(21)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, split_size, dim=-1)
+
+    if input_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+        in_cfg = _make_height_sharded_cfg(shape[0] // TILE, TILE, shape[-1])
+    else:
+        in_cfg = _make_block_sharded_cfg(2, 2, shape[0] // 2, shape[-1] // 2)
+
+    out_no_spec = ttnn.MemoryConfig(input_layout, ttnn.BufferType.L1)
+    tt_in = _from_torch(t, device, mc=in_cfg)
+    tt_out = ttnn.split(tt_in, split_size, dim=-1, memory_config=out_no_spec)
+    for tt_t in tt_out:
+        mc = tt_t.memory_config()
+        assert mc.is_sharded() and mc.shard_spec is not None, "shard_spec must be synthesized"
+        assert mc.memory_layout == input_layout
+    _check(tt_out, ref)
+
+
+# 9c. Interleaved input → sharded output with no shard_spec (synthesize_spec path).
+
+
+@pytest.mark.parametrize(
+    "memory_layout, shape, split_size",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [4 * TILE, 2 * TILE], TILE, id="H_out"),
+        pytest.param(ttnn.TensorMemoryLayout.WIDTH_SHARDED, [2 * TILE, 4 * TILE], 2 * TILE, id="W_out"),
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, [2 * TILE, 4 * TILE], 2 * TILE, id="B_out"),
+    ],
+)
+def test_interleaved_to_sharded_no_spec(device, memory_layout, shape, split_size):
+    """Interleaved input, sharded output MC without shard_spec → split must generate a valid spec."""
+    torch.manual_seed(22)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, split_size, dim=-1)
+    tt_in = _from_torch(t, device, mc=L1)
+    out_no_spec = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+    tt_out = ttnn.split(tt_in, split_size, dim=-1, memory_config=out_no_spec)
+    for tt_t in tt_out:
+        mc = tt_t.memory_config()
+        assert mc.is_sharded() and mc.shard_spec is not None
+        assert mc.memory_layout == memory_layout
+    _check(tt_out, ref)
+
+
+# 9d. Sub-tile rescale → graceful DRAM downgrade (tile-alignment guard on rescaled shard_w=16 < TILE).
+
+
+def test_sub_tile_rescale_downgrade_to_dram(device):
+    """Rescaled shard would be sub-tile → must fall back to DRAM (no crash, correct values)."""
+    torch.manual_seed(23)
+    shape = [2 * TILE, 2 * TILE]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, TILE, dim=-1)
+
+    in_cfg = _make_block_sharded_cfg(2, 2, TILE, TILE)
+    tt_in = _from_torch(t, device, mc=in_cfg)
+    tt_out = ttnn.split(tt_in, TILE, dim=-1)
+    for tt_t in tt_out:
+        mc = tt_t.memory_config()
+        assert not mc.is_sharded(), "Sub-tile rescaled shard must trigger DRAM downgrade"
+        assert mc.buffer_type == ttnn.BufferType.DRAM
+    _check(tt_out, ref)
+
+
+# 9e. L1 CB-clash regression: large N-way L1 split must not crash; DRAM or L1 output both acceptable.
+
+
+def test_l1_ci_regression_many_chunks_no_crash(device):
+    """Large L1-interleaved input, 32-way split, no MC. L1 CB-clash regression."""
+    torch.manual_seed(24)
+    num_chunks = 32
+    shape = [1, 1, TILE, num_chunks * TILE]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, TILE, dim=-1)
+    tt_in = _from_torch(t, device, mc=L1)
+    tt_out = ttnn.split(tt_in, TILE, dim=-1)
+    assert len(tt_out) == num_chunks
+    _check(tt_out, ref)
+
+
+# 9f. DRAM-sharded input → rescaled DRAM-sharded output.
+
+
+def test_dram_sharded_input_rescale(device):
+    """DRAM-sharded input, no MC → DRAM-sharded output with rescaled spec."""
+    torch.manual_seed(25)
+    shape = [4 * TILE, 2 * TILE]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, TILE, dim=-1)
+
+    num_cores = 4
+    compute_grid = device.compute_with_storage_grid_size()
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    shard_shape = [shape[0] // num_cores, shape[-1]]
+    spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    in_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, spec)
+
+    tt_in = _from_torch(t, device, mc=in_cfg)
+    tt_out = ttnn.split(tt_in, TILE, dim=-1)
+    for tt_t in tt_out:
+        mc = tt_t.memory_config()
+        assert mc.is_sharded()
+        assert mc.buffer_type == ttnn.BufferType.DRAM
+        assert list(mc.shard_spec.shape) == [TILE, TILE]
+    _check(tt_out, ref)
+
+
+# 9g. COL_MAJOR shard orientation propagation.
+
+
+def test_col_major_shard_orientation_preserved(device):
+    """COL_MAJOR HEIGHT_SHARDED input → default output preserves COL_MAJOR orientation."""
+    torch.manual_seed(26)
+    shape = [4 * TILE, 2 * TILE]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, TILE, dim=-1)
+
+    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, shape[0] // TILE - 1))})
+    spec = ttnn.ShardSpec(grid, [TILE, shape[-1]], ttnn.ShardOrientation.COL_MAJOR)
+    in_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+
+    tt_in = _from_torch(t, device, mc=in_cfg)
+    tt_out = ttnn.split(tt_in, TILE, dim=-1)
+    for tt_t in tt_out:
+        mc = tt_t.memory_config()
+        assert mc.is_sharded()
+        assert mc.shard_spec.orientation == ttnn.ShardOrientation.COL_MAJOR
+    _check(tt_out, ref)
+
+
+# 10. Various ranks and dimensions.
 
 
 @pytest.mark.parametrize(
@@ -483,9 +599,7 @@ def test_various_ranks_and_dims(device, shape, split_size, dim):
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 11. Unequal splits (split_sizes list)
-# ---------------------------------------------------------------------------
+# 11. Unequal splits (split_sizes list).
 
 
 @pytest.mark.parametrize(
@@ -525,9 +639,7 @@ def test_unequal_splits_sharded_input(device, shape, split_sizes, dim):
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 12. N-way equal TILE splits via native kernel (no slice fallback)
-# ---------------------------------------------------------------------------
+# 12. N-way equal TILE splits via native kernel (no fallback path).
 
 
 @pytest.mark.parametrize(
@@ -539,7 +651,7 @@ def test_unequal_splits_sharded_input(device, shape, split_sizes, dim):
     ],
 )
 def test_tile_n_way_equal_split(device, shape, num_chunks, dim):
-    """Equal N-way TILE split uses the native N-chunk kernel, not N slice calls."""
+    """Equal N-way TILE split uses the native N-chunk kernel."""
     torch.manual_seed(19)
     t = torch.randn(shape, dtype=torch.bfloat16)
     split_size = shape[dim if dim >= 0 else len(shape) + dim] // num_chunks
@@ -550,16 +662,11 @@ def test_tile_n_way_equal_split(device, shape, num_chunks, dim):
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 13. Slice-fallback 2-level batching boundary (num_chunks just above
-#     SPLIT_BATCH_SIZE=64 triggers the sqrt-N batching path in
-#     split_with_slice_impl). num_chunks > grid_dim_y also forces the slice
-#     fallback rather than the native TILE kernel.
-# ---------------------------------------------------------------------------
+# 13. Fallback batching boundary: num_chunks > SPLIT_BATCH_SIZE=64 triggers the sqrt-N batching path.
 
 
 @pytest.mark.parametrize("num_chunks", [64, 65, 130])
-def test_slice_fallback_batching_boundary(device, num_chunks):
+def test_fallback_batching_boundary(device, num_chunks):
     """Large equal-chunk splits across the SPLIT_BATCH_SIZE=64 boundary."""
     torch.manual_seed(20)
     split_size = TILE
@@ -569,4 +676,130 @@ def test_slice_fallback_batching_boundary(device, num_chunks):
     tt_in = _from_torch(t, device, mc=L1)
     tt_out = ttnn.split(tt_in, split_size, dim=-1, memory_config=L1)
     assert len(tt_out) == num_chunks
+    _check(tt_out, ref)
+
+
+# 14. Rank-5 input — verifies split's dim-normalization on higher ranks.
+
+
+@pytest.mark.parametrize(
+    "shape, split_size, dim",
+    [
+        ([1, 2, 3, 32, 64], TILE, -1),
+        ([2, 1, 3, 64, 32], TILE, -2),
+    ],
+)
+def test_rank5_interleaved(device, shape, split_size, dim):
+    """Rank-5 TILE + interleaved input, split on tile-aligned dim."""
+    torch.manual_seed(27)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, split_size, dim=dim)
+    tt_in = _from_torch(t, device, mc=L1)
+    tt_out = ttnn.split(tt_in, split_size, dim=dim, memory_config=L1)
+    _check(tt_out, ref)
+
+
+# 15. N=1 single-chunk split (trivial identity) — must not crash and must return input unchanged.
+
+
+def test_single_chunk_identity(device):
+    """split_sizes=[dim_size] on dim yields one output identical to the input."""
+    torch.manual_seed(28)
+    shape = [2 * TILE, 2 * TILE]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, 2 * TILE, dim=-1)
+    assert len(ref) == 1
+    tt_in = _from_torch(t, device, mc=L1)
+    tt_out = ttnn.split(tt_in, 2 * TILE, dim=-1, memory_config=L1)
+    _check(tt_out, ref)
+
+
+# 16. Multi-batch / multi-channel sharded inputs (N>1 or C>1) — verify rank-4 sharding is preserved through split.
+
+
+@pytest.mark.parametrize(
+    "shape, sharding, split_size",
+    [
+        pytest.param([2, 1, 64, 64], "height", TILE, id="N2_H_shard"),
+        pytest.param([1, 2, 64, 64], "block", TILE, id="C2_B_shard"),
+        pytest.param([2, 2, 32, 64], "height", TILE, id="N2C2_H_shard"),
+    ],
+)
+def test_multi_batch_channel_sharded(device, shape, sharding, split_size):
+    """N>1 and/or C>1 sharded input, split on last dim; validates rank-4 padded-shape flattening."""
+    torch.manual_seed(29)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, split_size, dim=-1)
+
+    compute_grid = device.compute_with_storage_grid_size()
+    flat_h = shape[0] * shape[1] * shape[2]
+    if sharding == "height":
+        ncores = flat_h // TILE
+        shard_grid = ttnn.num_cores_to_corerangeset(ncores, compute_grid, True)
+        spec = ttnn.ShardSpec(shard_grid, [TILE, shape[-1]], ttnn.ShardOrientation.ROW_MAJOR)
+        in_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+    else:
+        shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))})
+        spec = ttnn.ShardSpec(shard_grid, [flat_h // 2, shape[-1] // 2], ttnn.ShardOrientation.ROW_MAJOR)
+        in_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, spec)
+
+    tt_in = _from_torch(t, device, mc=in_cfg)
+    tt_out = ttnn.split(tt_in, split_size, dim=-1)
+    _check(tt_out, ref)
+
+
+# 17. ROW_MAJOR sharded → sharded output no-spec (composite roundtrip through synthesize_spec).
+
+
+def test_row_major_sharded_to_sharded_no_spec(device):
+    """RM BLOCK_SHARDED input → BLOCK_SHARDED output no-spec; exercises RM composite path."""
+    torch.manual_seed(30)
+    shape = [1, 1, 64, 128]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, 64, dim=-1)
+
+    in_cfg = _make_block_sharded_cfg(2, 2, 32, 64)
+    out_no_spec = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+
+    tt_in = _from_torch(t, device, layout=ttnn.ROW_MAJOR_LAYOUT, mc=in_cfg)
+    tt_out = ttnn.split(tt_in, 64, dim=-1, memory_config=out_no_spec)
+    for tt_t in tt_out:
+        mc = tt_t.memory_config()
+        assert mc.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        assert mc.shard_spec is not None
+    _check(tt_out, ref)
+
+
+# 18. bfloat8_b dtype coverage (TILE only; block-quantized dtype requires TILE + PCC-based check).
+
+
+def test_bfloat8_b_dtype_tile(device):
+    """bfloat8_b split — must go through TILE path; PCC-based check (bf8_b is block-quantized)."""
+    torch.manual_seed(31)
+    shape = [2 * TILE, 2 * TILE]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+
+    tt_in = ttnn.from_torch(t, dtype=ttnn.bfloat8_b, device=device, memory_config=L1, layout=ttnn.TILE_LAYOUT)
+    tt_out = ttnn.split(tt_in, TILE, dim=-1, memory_config=L1)
+    got = torch.cat([ttnn.to_torch(c) for c in tt_out], dim=-1).float()
+    assert list(got.shape) == list(t.shape)
+    assert_with_pcc(t.float(), got, 0.9999)
+
+
+# 19. Native single-core sharded input — 1-core HEIGHT_SHARDED edge case.
+
+
+def test_native_single_core_sharded_input(device):
+    """1-core HEIGHT_SHARDED input, split on last dim; verifies degenerate shard grid."""
+    torch.manual_seed(32)
+    shape = [TILE, 2 * TILE]
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, TILE, dim=-1)
+
+    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    spec = ttnn.ShardSpec(grid, [TILE, 2 * TILE], ttnn.ShardOrientation.ROW_MAJOR)
+    in_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+
+    tt_in = _from_torch(t, device, mc=in_cfg)
+    tt_out = ttnn.split(tt_in, TILE, dim=-1)
     _check(tt_out, ref)

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -8,7 +8,11 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/split/split.hpp"
 #include "ttnn/operations/data_movement/split/device/split_device_operation.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
 #include "ttnn/operations/data_movement/view/view.hpp"
+
+#include <tt-metalium/hal.hpp>
+#include <tt-logger/tt-logger.hpp>
 
 namespace ttnn {
 
@@ -45,11 +49,7 @@ std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor& input_tensor, 
     return results;
 }
 
-// Maximum number of slice calls per level before 2-level batching kicks in.
-// Each unique slice_start produces a distinct program cache entry; with N chunks
-// that means N cold JIT compilations (~100 ms each).  Batching outer slices into
-// groups of SPLIT_BATCH_SIZE reduces unique hashes from O(N) to O(N/B + B),
-// minimised at B = sqrt(N).  64 keeps cold-JIT time under ~13 s for N = 4096.
+// 2-level batching cutoff (B=sqrt(N) minimises unique slice_starts); 64 caps cold-JIT ~13 s at N=4096.
 constexpr uint32_t SPLIT_BATCH_SIZE = 64;
 
 std::vector<ttnn::Tensor> split_with_slice_impl(
@@ -68,10 +68,7 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
 
     const auto num_chunks = static_cast<uint32_t>(split_sizes.size());
 
-    // 2-level batching for large equal-chunk splits.
-    // All outer slices have unique slice_starts on the original tensor (O(N/B) hashes).
-    // All inner slices on same-shape batch tensors share the same B program hashes
-    // across every outer batch, so total unique compilations = O(N/B + B).
+    // 2-level batching for large equal-chunk splits: total unique compilations = O(N/B + B).
     const bool all_equal = num_chunks > 1 && std::all_of(split_sizes.begin(), split_sizes.end(), [&](auto s) {
                                return s == split_sizes[0];
                            });
@@ -130,19 +127,139 @@ std::vector<ttnn::Tensor> split(
     const ttsl::SmallVector<int64_t>& split_sizes,
     int64_t dim,
     const std::optional<MemoryConfig>& memory_config_arg) {
-    // Capture the desired output memory config.
-    // When no explicit config is given, mirror the input's memory config — except for a
-    // sharded input, where the per-chunk output shape generally won't fit the input's shard
-    // spec, so default to DRAM interleaved. An explicit sharded output config is honored and
-    // produced natively by the device kernel (its shard spec must match the chunk shape).
+    // Default output MC: mirror input; rescale shard_spec per-chunk; DRAM on rescale fail or L1 overflow.
     const MemoryConfig desired_mem_cfg = [&]() -> MemoryConfig {
+        const auto& in_mc = input_tensor.memory_config();
+        const size_t num_chunks_local = split_sizes.size();
+        const int64_t norm_dim_local = input_tensor.logical_shape().get_normalized_index(dim);
+        const bool equal_split =
+            std::all_of(split_sizes.begin(), split_sizes.end(), [&](auto s) { return s == split_sizes[0]; });
+
+        // Compute per-chunk padded shape used to rescale/synthesize output shard_spec.
+        auto per_chunk_padded = [&]() -> std::optional<ttnn::Shape> {
+            if (!equal_split) {
+                return std::nullopt;
+            }
+            const auto& in_padded = input_tensor.padded_shape();
+            const uint32_t padded_dim = in_padded[norm_dim_local];
+            if (padded_dim % static_cast<uint32_t>(num_chunks_local) != 0) {
+                return std::nullopt;
+            }
+            ttnn::SmallVector<uint32_t> v(in_padded.cbegin(), in_padded.cend());
+            v[norm_dim_local] = padded_dim / static_cast<uint32_t>(num_chunks_local);
+            return ttnn::Shape(v);
+        };
+
+        // Fill a missing shard_spec on any sharded MC (mirrors slice::resolve_mc).
+        auto synthesize_spec = [&](const MemoryConfig& mc) -> MemoryConfig {
+            if (!mc.is_sharded() || mc.shard_spec().has_value()) {
+                return mc;
+            }
+            auto chunk_padded = per_chunk_padded();
+            if (chunk_padded.has_value() && in_mc.is_sharded() && in_mc.shard_spec().has_value() &&
+                in_mc.memory_layout() == mc.memory_layout()) {
+                auto adj = ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape(
+                    *in_mc.shard_spec(), input_tensor.padded_shape(), *chunk_padded);
+                if (adj.has_value()) {
+                    return MemoryConfig(mc.memory_layout(), mc.buffer_type(), adj);
+                }
+            }
+            if (chunk_padded.has_value()) {
+                auto synth = ttnn::operations::data_movement::transpose::generate_transpose_shard_spec(
+                    input_tensor, *chunk_padded, mc.memory_layout());
+                return MemoryConfig(mc.memory_layout(), mc.buffer_type(), synth);
+            }
+            log_warning(tt::LogOp, "ttnn.split: cannot synthesize shard_spec for sharded MC; downgrading to DRAM.");
+            return ttnn::DRAM_MEMORY_CONFIG;
+        };
+
         if (memory_config_arg.has_value()) {
-            return *memory_config_arg;
+            return synthesize_spec(*memory_config_arg);
         }
-        if (input_tensor.memory_config().is_sharded()) {
+
+        // L1 CB-clash guard: true when N L1 chunks + slice CBs fit L1 on core [0,0].
+        auto l1_budget_ok = [&]() -> bool {
+            // Skip: DRAM has no CB clash; N ≤ 2 uses the native TILE fast path (single bounded-L1 kernel).
+            if (in_mc.buffer_type() != tt::tt_metal::BufferType::L1 || num_chunks_local <= 2) {
+                return true;
+            }
+            auto* dev = input_tensor.device();
+            const auto lowest = dev->lowest_occupied_compute_l1_address();
+            uint32_t max_l1 = lowest.value_or(dev->l1_size_per_core());
+            const uint32_t base = dev->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+            max_l1 = (max_l1 > base) ? (max_l1 - base) : 0;
+
+            // Padded volume + tile_size(DataFormat) so bfp8_b/bfp4_b exponents + TILE padding aren't under-counted.
+            uint64_t chunk_bytes = 0;
+            uint64_t page_bytes = 0;
+            if (input_tensor.layout() == tt::tt_metal::Layout::TILE) {
+                const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+                const uint64_t tile_bytes = tt::tile_size(data_format);
+                const uint64_t total_tiles =
+                    input_tensor.physical_volume() / (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+                chunk_bytes = (total_tiles / static_cast<uint64_t>(num_chunks_local)) * tile_bytes;
+                page_bytes = tile_bytes;
+            } else {
+                const uint64_t elem = input_tensor.element_size();
+                chunk_bytes = input_tensor.physical_volume() / static_cast<uint64_t>(num_chunks_local) * elem;
+                page_bytes = tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH * elem;
+            }
+            // CB overhead scales with N: each slice call stamps its own reader+writer CBs on core [0,0].
+            constexpr uint64_t CB_PAGES_PER_SLICE = 4;
+            const uint64_t cb_overhead_bytes =
+                static_cast<uint64_t>(num_chunks_local) * CB_PAGES_PER_SLICE * page_bytes;
+            const uint64_t est_bytes = chunk_bytes * num_chunks_local + cb_overhead_bytes;
+
+            if (est_bytes > static_cast<uint64_t>(max_l1)) {
+                log_warning(
+                    tt::LogOp,
+                    "ttnn.split: L1 budget exceeded (need ~{} B, have {} B for {} chunks); DRAM downgrade.",
+                    est_bytes,
+                    max_l1,
+                    num_chunks_local);
+                return false;
+            }
+            return true;
+        };
+
+        // Sharded input, no user MC: adjust input's spec if present, else DRAM (nd-sharded has no legacy spec).
+        if (in_mc.is_sharded()) {
+            auto chunk_padded = per_chunk_padded();
+            if (!chunk_padded.has_value()) {
+                log_warning(tt::LogOp, "ttnn.split: unequal/non-divisible split on sharded input; DRAM downgrade.");
+                return ttnn::DRAM_MEMORY_CONFIG;
+            }
+            if (!in_mc.shard_spec().has_value()) {
+                // ND-sharded: no legacy spec, and generate_transpose_shard_spec can't emit ND geometry.
+                log_warning(tt::LogOp, "ttnn.split: nd-sharded input (no legacy shard_spec); DRAM downgrade.");
+                return ttnn::DRAM_MEMORY_CONFIG;
+            }
+            auto derived = ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape(
+                *in_mc.shard_spec(), input_tensor.padded_shape(), *chunk_padded);
+            if (!derived.has_value()) {
+                log_warning(tt::LogOp, "ttnn.split: shard_spec can't be rescaled to per-chunk shape; DRAM downgrade.");
+                return ttnn::DRAM_MEMORY_CONFIG;
+            }
+            if (input_tensor.layout() == tt::tt_metal::Layout::TILE &&
+                (derived->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                 derived->shape[1] % tt::constants::TILE_WIDTH != 0)) {
+                log_warning(
+                    tt::LogOp,
+                    "ttnn.split: derived shard [{}, {}] not tile-aligned; DRAM downgrade.",
+                    derived->shape[0],
+                    derived->shape[1]);
+                return ttnn::DRAM_MEMORY_CONFIG;
+            }
+            if (!l1_budget_ok()) {
+                return ttnn::DRAM_MEMORY_CONFIG;
+            }
+            return MemoryConfig(in_mc.memory_layout(), in_mc.buffer_type(), derived);
+        }
+
+        if (!l1_budget_ok()) {
             return ttnn::DRAM_MEMORY_CONFIG;
         }
-        return input_tensor.memory_config();
+        return in_mc;
     }();
 
     TT_FATAL(!split_sizes.empty(), "split_sizes must not be empty");
@@ -151,50 +268,28 @@ std::vector<ttnn::Tensor> split(
         "split_size should be greater than 0, instead got: {}",
         split_sizes);
 
-    // Native sharded I/O: the device kernels (and ttnn::slice in the fallback) read and write
-    // sharded buffers directly via TensorAccessor, so no host-side conversion is needed.
+    // Sharded I/O handled natively by device kernels and slice via TensorAccessor (no de-shard).
     const Tensor& working_input = input_tensor;
     const MemoryConfig& op_mem_cfg = desired_mem_cfg;
 
     const auto& input_shape = working_input.logical_shape();
-
-    // Normalize negative dimension to positive index
     int64_t normalized_dim = input_shape.get_normalized_index(dim);
-
     std::vector<ttnn::Tensor> results;
 
     const uint32_t num_chunks = static_cast<uint32_t>(split_sizes.size());
 
-    // True when all requested chunk sizes are equal and together cover the full dimension.
+    // Equal N-way split fully covering the dim.
     bool is_equal_n_way_split =
         std::all_of(split_sizes.begin(), split_sizes.end(), [&](auto s) { return s == split_sizes[0]; }) &&
         split_sizes[0] * static_cast<int64_t>(num_chunks) == static_cast<int64_t>(input_shape[normalized_dim]);
 
-    // ---------------------------------------------------------------------------
-    // Fast path 1: TILE layout, equal N-way split on the last dim.
-    // Uses the native N-chunk TILE device kernel (single-pass, no slice overhead).
-    //
-    // The native TILE kernel is selected only when ALL of the following hold (see
-    // can_use_tile_kernel below); otherwise the split falls back to N independent
-    // ttnn::slice calls (split_with_slice_impl), which handle every other case
-    // (ROW_MAJOR, unequal sizes, non-last-dim, batch>1 for N>2, etc.):
-    //   - equal N-way split that exactly covers the dimension (is_equal_n_way_split)
-    //   - split dim is the last dim (normalized_dim == rank - 1)
-    //   - input is TILE layout, rank >= 2
-    //   - at least 2 tiles in each of the last two dims
-    //   - padded tile count in the split dim is divisible by num_chunks
-    //   - it all fits the core grid: z_4d <= grid_dim_x and num_chunks <= grid_dim_y
-    //   - shape4d[0] == 1 for N>2 (the N==2 path collapses batch via reshape instead)
-    // Sharded input/output are handled natively on both paths (no de-shard step).
-    // ---------------------------------------------------------------------------
+    // TILE fast path (native N-chunk kernel): equal split on last dim, TILE, rank≥2, ≥2 tiles/dim, N-divisible, fits
+    // grid, shape4d[0]==1 for N>2; else N slice calls.
     tt::tt_metal::IDevice* device = working_input.device();
     const uint32_t grid_dim_x = device->compute_with_storage_grid_size().x;
     const uint32_t grid_dim_y = device->compute_with_storage_grid_size().y;
 
-    // Compute the 4D shape the device kernel will see (call squeeze_shape_to_4D once).
-    // For rank < 4: unsqueeze_to_4D prepends 1s → shape4d = [1...1, dims...]
-    // For rank == 4: identity
-    // For rank > 4: squeeze_shape_to_4D merges the leading (rank-3) dims into shape4d[0]
+    // Compute the 4D shape the kernel sees: rank<4 pads with 1s, rank>4 merges leading dims into [0].
     std::array<uint32_t, 4> shape4d = {1, 1, 1, 1};
     if (input_shape.rank() > static_cast<size_t>(detail::RANK_FOUR)) {
         const auto s4 = ttnn::operations::data_movement::squeeze_shape_to_4D(working_input.logical_shape());
@@ -207,25 +302,18 @@ std::vector<ttnn::Tensor> split(
         }
     }
 
-    // The program factory sets num_cores_z = shape4d[1] (z dimension).
-    // For N==2, split_last_dim_two_chunks_tiled reshapes [B,C,H,W]→[1,B*C,H,W], so z = B*C.
-    // For N>2, prim::split receives shape4d directly, so z = shape4d[1].
-    // num_cores_r = num_cores_x * num_cores_z must fit in grid_dim_x.
+    // num_cores_z = shape4d[1] (N==2 collapses batch via reshape → z = B*C); must fit grid_dim_x.
     const uint32_t z_4d = (num_chunks == detail::TWO_CHUNKS) ? shape4d[0] * shape4d[1] : shape4d[1];
     bool fits_in_core_grid = input_shape.rank() >= 2 && z_4d < grid_dim_x + 1;
 
-    // The program factory requires the padded tile count in the split dim to be
-    // divisible by num_chunks (otherwise the Y-core grouping doesn't work out).
+    // Program factory requires padded tile count in split dim divisible by num_chunks.
     uint32_t padded_tiles_in_split_dim = working_input.padded_shape()[-1] / tt::constants::TILE_WIDTH;
     bool tiles_divisible_by_chunks = (padded_tiles_in_split_dim % num_chunks == 0);
 
-    // prim::split hard-requires shape4d[0]==1 (see validate_on_program_cache_miss).
-    // N==2 handles batch>1 via reshape; N>2 requires shape4d[0]==1 already.
+    // prim::split hard-requires shape4d[0]==1 for N>2 (N==2 handles batch>1 via reshape).
     bool batch_ok_for_n_gt2 = (num_chunks == detail::TWO_CHUNKS) || (shape4d[0] == 1);
 
-    // The program factory groups Y-cores into num_chunks equal groups.
-    // If num_chunks > grid_dim_y, max_cores_per_chunk = grid_dim_y/num_chunks = 0, producing an
-    // invalid CoreRange. Guard against this.
+    // Guard against grid_dim_y/num_chunks == 0 (invalid CoreRange in program factory).
     bool chunks_fit_in_y_grid = (num_chunks <= grid_dim_y);
 
     bool can_use_tile_kernel = is_equal_n_way_split && normalized_dim == static_cast<int64_t>(input_shape.rank()) - 1 &&
@@ -243,8 +331,7 @@ std::vector<ttnn::Tensor> split(
         } else {
             input_tensor_4d = working_input;
         }
-        // For N>2, use prim::split directly (generalised factory).
-        // For N==2, split_last_dim_two_chunks_tiled handles the batch>1 reshape.
+        // N>2: prim::split directly. N==2: split_last_dim_two_chunks_tiled handles batch>1 reshape.
         std::vector<Tensor> outputs_4d;
         if (num_chunks == detail::TWO_CHUNKS) {
             outputs_4d = detail::split_last_dim_two_chunks_tiled(input_tensor_4d, op_mem_cfg);
@@ -258,9 +345,26 @@ std::vector<ttnn::Tensor> split(
             results.emplace_back(ttnn::view(t, ttnn::Shape(final_shape)));
         }
     } else {
-        // Fallback: unequal splits, ROW_MAJOR, batch>1 for N>2, or anything not
-        // handled by the TILE fast path above. Uses N independent slice calls.
-        results = detail::split_with_slice_impl(working_input, split_sizes, normalized_dim, op_mem_cfg);
+        // Slice fallback: if outputs downgraded to DRAM, migrate L1 input too so per-slice CBs don't clash.
+        Tensor slice_input = working_input;
+        if (slice_input.memory_config().buffer_type() == tt::tt_metal::BufferType::L1 &&
+            op_mem_cfg.buffer_type() == tt::tt_metal::BufferType::DRAM && split_sizes.size() > 2) {
+            const MemoryConfig dram_interleaved{
+                tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+            // Padded volume + tile_size(DataFormat) so bfp8_b/bfp4_b exponents are counted.
+            uint64_t input_bytes = 0;
+            if (slice_input.layout() == tt::tt_metal::Layout::TILE) {
+                const auto df = tt::tt_metal::datatype_to_dataformat_converter(slice_input.dtype());
+                const uint64_t total_tiles =
+                    slice_input.physical_volume() / (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+                input_bytes = total_tiles * tt::tile_size(df);
+            } else {
+                input_bytes = slice_input.physical_volume() * slice_input.element_size();
+            }
+            log_warning(tt::LogOp, "ttnn.split: migrating L1 input ({} B) to DRAM before slice fallback.", input_bytes);
+            slice_input = ttnn::to_memory_config(slice_input, dram_interleaved, std::nullopt);
+        }
+        results = detail::split_with_slice_impl(slice_input, split_sizes, normalized_dim, op_mem_cfg);
     }
 
     return results;


### PR DESCRIPTION
### Ticket
Link to Github Issue #48340

### Problem
`ttnn::split` had two silent-lossy defaults that could crash long-running CI jobs and drop information for callers:

1. **CI failure #48340 — L1 CB clash.** With no `memory_config` passed, `ttnn::split` mirrored the L1-interleaved input for the output. For large inputs with many chunks (e.g. `(1, 1, 32, 128256)`, `N = 32`), the N per-chunk L1 buffers plus the static circular buffers used by each per-slice fallback call overflow L1 on core `[0,0]`, aborting with an out-of-memory error.
2. **Sharded input silently downgraded to DRAM.** For a sharded input with no explicit `memory_config`, the op returned `DRAM_MEMORY_CONFIG` unconditionally — the caller's sharding intent was dropped without warning. Passing a sharded `MemoryConfig` with a missing `shard_spec` also crashed the native TILE fast path with `bad optional access` because `SplitDeviceOperation::compute_output_specs` does not synthesize a spec.

### What this PR does
- **Sharded-input default now rescales instead of dropping** — derives a valid per-chunk `shard_spec` via `adjust_shard_spec_to_shape` and keeps the caller's `memory_layout` + `buffer_type`. Covers `HEIGHT_SHARDED`, `WIDTH_SHARDED`, `BLOCK_SHARDED` on both the TILE fast path and the per-slice fallback.
- **User-supplied sharded MC without a spec is now synthesized** — a shared `synthesize_spec` helper reuses the input's spec when layouts match (via `adjust_shard_spec_to_shape`), else synthesizes one for the per-chunk shape. Fixes the `bad optional access` on the TILE fast path.
- **L1 budget guard for issue #48340** — an `l1_budget_ok` check (using `lowest_occupied_compute_l1_address()` + base allocator addr) downgrades the output `MemoryConfig` to DRAM when N chunks + estimated per-slice CBs would exceed available L1. Applies to both L1-interleaved and L1-sharded outputs when `N > 2`.
- **L1 input migration before fallback** — when the output was forced to DRAM (budget guard) but the input still lives in L1 and `N > 2`, the input is migrated to DRAM via `to_memory_config` before the fallback loop so per-slice reader-side CBs cannot clash with the input on core `[0,0]`.
- **All fallbacks now emit `log_warning`** — unequal / non-divisible split on sharded, non-tile-aligned rescale, unsynthesizable user MC, L1 budget exceeded, L1→DRAM input migration. No silent downgrades remain.
- **Expanded universal-IO test suite (`test_universal_input_tm_split.py`)** — 69 test cases covering every code path exercised by the fix (see Tests below).

### Tests
Wormhole B0 (N150):

| Suite | Result |
| --- | --- |
| `tests/ttnn/nightly/unit_tests/operations/data_movement/test_split.py` | **282 passed, 224 skipped** — no regressions |
| `tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py` | **69 passed** — full universal-IO matrix |

Universal-IO coverage added / updated in this PR:

| Section | Test | Coverage |
| --- | --- | --- |
| 9 | `test_sharded_input_default_preserves_sharding` | Sharded input + no MC → sharded output with rescaled `shard_spec` |
| 9b | `test_sharded_input_to_sharded_no_spec` (H, B) | User passes sharded MC with no `shard_spec` → op synthesizes |
| 9c | `test_interleaved_to_sharded_no_spec` (H, W, B) | Interleaved in → sharded no-spec out |
| 9d | `test_sub_tile_rescale_downgrade_to_dram` | Rescaled shard would be sub-tile → graceful DRAM fallback |
| 9e | `test_l1_ci_regression_many_chunks_no_crash` | **#48340 regression** — 32-way L1 split must not CB-clash |
| 9f | `test_dram_sharded_input_rescale` | DRAM-sharded input → rescaled DRAM-sharded output |
| 9g | `test_col_major_shard_orientation_preserved` | Orientation propagation for `COL_MAJOR` shards |
| 14 | `test_rank5_interleaved` | Rank-5 dim normalization |
| 15 | `test_single_chunk_identity` | N=1 trivial identity edge case |
| 16 | `test_multi_batch_channel_sharded` | N>1 / C>1 sharded input flattening |
| 17 | `test_row_major_sharded_to_sharded_no_spec` | ROW_MAJOR sharded → sharded no-spec composite roundtrip |
| 18 | `test_bfloat8_b_dtype_tile` | Block-quantized bfloat8_b dtype (PCC-based check) |
| 19 | `test_native_single_core_sharded_input` | 1-core degenerate shard grid |

### CI: repro on fix branch
Ran the same workflow that surfaced #48340 (`ttnn - run sweeps model traced`) on this branch to confirm the crash no longer reproduces on the failing vectors:

| Run | Branch | Result |
| --- | --- | --- |
| [Fix-branch dispatch](https://github.com/tenstorrent/tt-metal/actions/runs/28767540520) | `mouliraj/split_ci_fix` | **success** — CB / L1 clash no longer reproduces |
| [Most recent failing run on main](https://github.com/tenstorrent/tt-metal/actions/runs/28348972865/job/83979669024) | `main` | failed at per-slice fallback → CB / L1 clash on core `[0-0 - 0-0]` |
| [Earlier failing run on main](https://github.com/tenstorrent/tt-metal/actions/runs/28311482933/job/83878158190) | `main` | same failure |

### Notes for Reviewers
- The internal (no-user-MC) sharded branch deliberately does **not** call `generate_transpose_shard_spec` — grid-jumping is reserved for explicit user MCs. On any rescale/tile-alignment failure the op warns and returns `DRAM_MEMORY_CONFIG`.
- The L1 CB overhead estimate is intentionally conservative — a false positive costs one extra DRAM allocation; a false negative was #48340.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/split_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/split_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/split_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/split_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/split_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/split_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/split_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/split_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/split_ci_fix)

