### PR TITLE
[tt_metal] Fix tt_memory DISCRETE load applying segment permutation twice

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -39,6 +39,7 @@ set(UNIT_TESTS_API_SOURCES
     test_banked.cpp
     test_bit_utils.cpp
     test_filesystem_utils.cpp
+    test_tt_memory.cpp
     test_graph_tracking.cpp
     test_buffer_region.cpp
     test_compile_time_args.cpp

--- a/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "tt_metal/llrt/tt_elffile.hpp"
+#include "tt_metal/llrt/tt_memory.h"
+
+namespace ll_api {
+
+// Friend of ll_api::memory (declared in tt_memory.h). Lets the tests inject synthetic ELF
+// segments and drive the address-ordering logic without an on-disk ELF file.
+class MemorySegmentOrderingTest : public ::testing::Test {
+protected:
+    using word_t = memory::word_t;
+
+    // Build a memory from synthetic segments, running the same packing logic the
+    // (path, loading) constructor uses.
+    static memory build(const std::vector<ElfFile::Segment>& segments, memory::Loading loading) {
+        memory m;
+        m.loading_ = loading;
+        m.pack_from_segments("<test>", segments);
+        return m;
+    }
+
+    // Collect (addr, len) for each span, in the order pack_from_segments emitted them.
+    static std::vector<std::pair<std::uint64_t, std::uint32_t>> span_order(const memory& m) {
+        std::vector<std::pair<std::uint64_t, std::uint32_t>> spans;
+        m.process_spans([&](std::vector<std::uint32_t>::const_iterator, std::uint64_t addr, std::uint32_t len) {
+            spans.emplace_back(addr, len);
+        });
+        return spans;
+    }
+};
+
+// Regression test for the DISCRETE double-indexing bug (issue #48262). An ncrisc-style binary
+// places its data segment at a LOWER address than text, so the address sort produces a
+// non-identity permutation. The spans must come out in ascending address order.
+TEST_F(MemorySegmentOrderingTest, DiscreteEmitsSpansInAscendingAddressOrder) {
+    // segments[0] is text (the loader treats the first segment as text), placed high in memory;
+    // the data segment is placed lower -- the ncrisc layout that triggers a non-identity sort.
+    const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // addr 0x2000, 2 words
+    const std::vector<word_t> data_contents = {0x3333'3333};               // addr 0x1000, 1 word
+
+    std::vector<ElfFile::Segment> segments;
+    segments.emplace_back(std::span<const word_t>(text_contents), /*addr=*/0x2000, /*lma=*/0x2000, /*membytes=*/8);
+    segments.emplace_back(std::span<const word_t>(data_contents), /*addr=*/0x1000, /*lma=*/0x1000, /*membytes=*/4);
+
+    const memory m = build(segments, memory::Loading::DISCRETE);
+
+    // Ascending address order: data (0x1000) first, then text (0x2000).
+    // With the bug the order was reversed (text 0x2000 first), so this is the fail-without-fix check.
+    const std::vector<std::pair<std::uint64_t, std::uint32_t>> expected = {{0x1000, 1}, {0x2000, 2}};
+    EXPECT_EQ(span_order(m), expected);
+
+    // data_ is packed in span order too, so a wrong span order corrupts the packed image.
+    const std::vector<word_t> expected_data = {0x3333'3333, 0x1111'1111, 0x2222'2222};
+    EXPECT_EQ(m.data(), expected_data);
+
+    // text_addr_/text_size_ always come from segments[0] regardless of ordering.
+    EXPECT_EQ(m.get_text_addr(), 0x2000u);
+    EXPECT_EQ(m.get_text_size(), 8u);
+}
+
+// The identity-permutation paths (non-DISCRETE) coalesce contiguous segments into a single span.
+// This guards the refactor: the fix must not change non-DISCRETE behaviour.
+TEST_F(MemorySegmentOrderingTest, ContiguousCoalescesIntoSingleSpan) {
+    const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // lma 0x1000, 2 words
+    const std::vector<word_t> data_contents = {0x3333'3333};               // lma 0x1008, 1 word
+
+    std::vector<ElfFile::Segment> segments;
+    segments.emplace_back(std::span<const word_t>(text_contents), /*addr=*/0x1000, /*lma=*/0x1000, /*membytes=*/8);
+    segments.emplace_back(std::span<const word_t>(data_contents), /*addr=*/0x1008, /*lma=*/0x1008, /*membytes=*/4);
+
+    const memory m = build(segments, memory::Loading::CONTIGUOUS);
+
+    const std::vector<std::pair<std::uint64_t, std::uint32_t>> expected = {{0x1000, 3}};
+    EXPECT_EQ(span_order(m), expected);
+
+    const std::vector<word_t> expected_data = {0x1111'1111, 0x2222'2222, 0x3333'3333};
+    EXPECT_EQ(m.data(), expected_data);
+}
+
+}  // namespace ll_api

--- a/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
@@ -67,7 +67,7 @@ TEST_F(MemorySegmentOrderingTest, DiscreteEmitsSpansInAscendingAddressOrder) {
 }
 
 // The identity-permutation paths (non-DISCRETE) coalesce contiguous segments into a single span.
-// This guards the refactor: the fix must not change non-DISCRETE behaviour.
+// This guards that non-DISCRETE behaviour: contiguous segments must still collapse to one span.
 TEST_F(MemorySegmentOrderingTest, ContiguousCoalescesIntoSingleSpan) {
     const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // lma 0x1000, 2 words
     const std::vector<word_t> data_contents = {0x3333'3333};               // lma 0x1008, 1 word

--- a/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
@@ -37,9 +37,9 @@ protected:
     }
 };
 
-// Regression test for the DISCRETE double-indexing bug (issue #48262). An ncrisc-style binary
-// places its data segment at a LOWER address than text, so the address sort produces a
-// non-identity permutation. The spans must come out in ascending address order.
+// DISCRETE loading must emit spans in ascending address order even when the address sort is a
+// non-identity permutation. An ncrisc-style binary places its data segment at a LOWER address than
+// text, which produces exactly such a permutation, so it exercises that ordering.
 TEST_F(MemorySegmentOrderingTest, DiscreteEmitsSpansInAscendingAddressOrder) {
     // segments[0] is text (the loader treats the first segment as text), placed high in memory;
     // the data segment is placed lower -- the ncrisc layout that triggers a non-identity sort.
@@ -53,7 +53,7 @@ TEST_F(MemorySegmentOrderingTest, DiscreteEmitsSpansInAscendingAddressOrder) {
     const memory m = build(segments, memory::Loading::DISCRETE);
 
     // Ascending address order: data (0x1000) first, then text (0x2000).
-    // With the bug the order was reversed (text 0x2000 first), so this is the fail-without-fix check.
+    // Source/segment order would place text (0x2000) first, so this verifies the address sort is applied.
     const std::vector<std::pair<std::uint64_t, std::uint32_t>> expected = {{0x1000, 1}, {0x2000, 2}};
     EXPECT_EQ(span_order(m), expected);
 

--- a/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
@@ -11,36 +11,23 @@
 #include "tt_metal/llrt/tt_memory.h"
 
 namespace ll_api {
+namespace {
 
-// Friend of ll_api::memory (declared in tt_memory.h). Lets the tests inject synthetic ELF
-// segments and drive the address-ordering logic without an on-disk ELF file.
-class MemorySegmentOrderingTest : public ::testing::Test {
-protected:
-    using word_t = memory::word_t;
+using word_t = memory::word_t;
 
-    // Build a memory from synthetic segments, running the same packing logic the
-    // (path, loading) constructor uses.
-    static memory build(const std::vector<ElfFile::Segment>& segments, memory::Loading loading) {
-        memory m;
-        m.loading_ = loading;
-        m.pack_from_segments("<test>", segments);
-        return m;
-    }
-
-    // Collect (addr, len) for each span, in the order pack_from_segments emitted them.
-    static std::vector<std::pair<std::uint64_t, std::uint32_t>> span_order(const memory& m) {
-        std::vector<std::pair<std::uint64_t, std::uint32_t>> spans;
-        m.process_spans([&](std::vector<std::uint32_t>::const_iterator, std::uint64_t addr, std::uint32_t len) {
-            spans.emplace_back(addr, len);
-        });
-        return spans;
-    }
-};
+// Collect (addr, len) for each span, in the order the packing logic emitted them.
+std::vector<std::pair<std::uint64_t, std::uint32_t>> span_order(const memory& m) {
+    std::vector<std::pair<std::uint64_t, std::uint32_t>> spans;
+    m.process_spans([&](std::vector<std::uint32_t>::const_iterator, std::uint64_t addr, std::uint32_t len) {
+        spans.emplace_back(addr, len);
+    });
+    return spans;
+}
 
 // DISCRETE loading must emit spans in ascending address order even when the address sort is a
 // non-identity permutation. An ncrisc-style binary places its data segment at a LOWER address than
 // text, which produces exactly such a permutation, so it exercises that ordering.
-TEST_F(MemorySegmentOrderingTest, DiscreteEmitsSpansInAscendingAddressOrder) {
+TEST(MemorySegmentOrdering, DiscreteEmitsSpansInAscendingAddressOrder) {
     // segments[0] is text (the loader treats the first segment as text), placed high in memory;
     // the data segment is placed lower -- the ncrisc layout that triggers a non-identity sort.
     const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // addr 0x2000, 2 words
@@ -50,7 +37,7 @@ TEST_F(MemorySegmentOrderingTest, DiscreteEmitsSpansInAscendingAddressOrder) {
     segments.emplace_back(std::span<const word_t>(text_contents), /*addr=*/0x2000, /*lma=*/0x2000, /*membytes=*/8);
     segments.emplace_back(std::span<const word_t>(data_contents), /*addr=*/0x1000, /*lma=*/0x1000, /*membytes=*/4);
 
-    const memory m = build(segments, memory::Loading::DISCRETE);
+    const memory m = memory::from_segments(segments, memory::Loading::DISCRETE);
 
     // Ascending address order: data (0x1000) first, then text (0x2000).
     // Source/segment order would place text (0x2000) first, so this verifies the address sort is applied.
@@ -68,7 +55,7 @@ TEST_F(MemorySegmentOrderingTest, DiscreteEmitsSpansInAscendingAddressOrder) {
 
 // The identity-permutation paths (non-DISCRETE) coalesce contiguous segments into a single span.
 // This guards that non-DISCRETE behaviour: contiguous segments must still collapse to one span.
-TEST_F(MemorySegmentOrderingTest, ContiguousCoalescesIntoSingleSpan) {
+TEST(MemorySegmentOrdering, ContiguousCoalescesIntoSingleSpan) {
     const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // lma 0x1000, 2 words
     const std::vector<word_t> data_contents = {0x3333'3333};               // lma 0x1008, 1 word
 
@@ -76,7 +63,7 @@ TEST_F(MemorySegmentOrderingTest, ContiguousCoalescesIntoSingleSpan) {
     segments.emplace_back(std::span<const word_t>(text_contents), /*addr=*/0x1000, /*lma=*/0x1000, /*membytes=*/8);
     segments.emplace_back(std::span<const word_t>(data_contents), /*addr=*/0x1008, /*lma=*/0x1008, /*membytes=*/4);
 
-    const memory m = build(segments, memory::Loading::CONTIGUOUS);
+    const memory m = memory::from_segments(segments, memory::Loading::CONTIGUOUS);
 
     const std::vector<std::pair<std::uint64_t, std::uint32_t>> expected = {{0x1000, 3}};
     EXPECT_EQ(span_order(m), expected);
@@ -85,4 +72,5 @@ TEST_F(MemorySegmentOrderingTest, ContiguousCoalescesIntoSingleSpan) {
     EXPECT_EQ(m.data(), expected_data);
 }
 
+}  // namespace
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -15,8 +15,8 @@
 namespace ll_api {
 
 memory::memory() {
-    constexpr uint32_t initial_data_space_ = 0x400;
-    constexpr uint32_t initial_span_space_ = 4;
+    constexpr std::uint32_t initial_data_space_ = 0x400;
+    constexpr std::uint32_t initial_span_space_ = 4;
 
     data_.reserve(initial_data_space_);
     link_spans_.reserve(initial_span_space_);
@@ -36,15 +36,16 @@ memory::memory(const std::string& path, Loading loading) : loading_(loading) {
             std::string out_elf_path = std::string(path) + ".xip.elf";
             try {
                 elf.WriteImage(out_elf_path);
-            } catch (const std::exception &e) {
-                log_warning(tt::LogLLRuntime, "Failed to write XIP ELF for disassembly ({}): {}", out_elf_path, e.what());
+            } catch (const std::exception& e) {
+                log_warning(
+                    tt::LogLLRuntime, "Failed to write XIP ELF for disassembly ({}): {}", out_elf_path, e.what());
             } catch (...) {
                 log_warning(tt::LogLLRuntime, "Failed to write XIP ELF for disassembly: {}", out_elf_path);
             }
         }
     }
 
-    auto const& segments = elf.GetSegments();
+    const auto& segments = elf.GetSegments();
 
     // The ELF file puts the text segment first, but one set of
     // binaries (ncrisc) places data a lower address, and at least one
@@ -67,7 +68,7 @@ memory::memory(const std::string& path, Loading loading) : loading_(loading) {
     auto lma = segments[0].lma;
 
     for (unsigned ix : map) {
-        auto const& segment = segments[map[ix]];
+        const auto& segment = segments[ix];
         if (not segment.relocs.empty()) {
             TT_THROW("{}: unexpected dynamic relocations", path);
         }
@@ -89,33 +90,34 @@ bool memory::operator==(const memory& other) const { return data_ == other.data_
 
 void memory::fill_from_mem_template(
     const memory& mem_template,
-    const std::function<void(std::vector<uint32_t>::iterator, uint64_t addr, uint32_t len)>& callback) {
+    const std::function<void(std::vector<std::uint32_t>::iterator, std::uint64_t addr, std::uint32_t len)>& callback) {
     link_spans_ = mem_template.link_spans_;
     data_.resize(mem_template.data_.size());
     process_spans(callback);
 }
 
 void memory::process_spans(
-    const std::function<void(std::vector<uint32_t>::const_iterator, uint64_t addr, uint32_t len)>& callback) const {
-    uint32_t offset = 0;
+    const std::function<void(std::vector<std::uint32_t>::const_iterator, std::uint64_t addr, std::uint32_t len)>&
+        callback) const {
+    std::uint32_t offset = 0;
     for (const auto& span : link_spans_) {
-        std::vector<uint32_t>::const_iterator cit = data_.cbegin() + offset;
+        std::vector<std::uint32_t>::const_iterator cit = data_.cbegin() + offset;
         callback(cit, span.addr, span.len);
         offset += span.len;
     }
 }
 
 void memory::process_spans(
-    const std::function<void(std::vector<uint32_t>::iterator, uint64_t addr, uint32_t len)>& callback) {
-    uint32_t offset = 0;
+    const std::function<void(std::vector<std::uint32_t>::iterator, std::uint64_t addr, std::uint32_t len)>& callback) {
+    std::uint32_t offset = 0;
     for (const auto& span : link_spans_) {
-        std::vector<uint32_t>::iterator it = data_.begin() + offset;
+        std::vector<std::uint32_t>::iterator it = data_.begin() + offset;
         callback(it, span.addr, span.len);
         offset += span.len;
     }
 }
 
-void memory::update_spans(std::function<void(uint64_t& addr)>& callback) {
+void memory::update_spans(std::function<void(std::uint64_t& addr)>& callback) {
     for (auto& span : link_spans_) {
         callback(span.addr);
     }

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -45,8 +45,10 @@ memory::memory(const std::string& path, Loading loading) : loading_(loading) {
         }
     }
 
-    const auto& segments = elf.GetSegments();
+    pack_from_segments(path, elf.GetSegments());
+}
 
+void memory::pack_from_segments(const std::string& path, const std::vector<ElfFile::Segment>& segments) {
     // The ELF file puts the text segment first, but one set of
     // binaries (ncrisc) places data a lower address, and at least one
     // consumer (unknown) requires spans in address order, so generate
@@ -57,7 +59,7 @@ memory::memory(const std::string& path, Loading loading) : loading_(loading) {
     for (unsigned ix = 0; ix != segments.size(); ix++) {
         map.push_back(ix);
     }
-    if (loading == Loading::DISCRETE) {
+    if (loading_ == Loading::DISCRETE) {
         std::sort(
             map.begin(), map.end(), [&](unsigned a, unsigned b) { return segments[a].address < segments[b].address; });
     }
@@ -67,18 +69,20 @@ memory::memory(const std::string& path, Loading loading) : loading_(loading) {
     text_size_ = segments[0].contents.size() * sizeof(word_t);
     auto lma = segments[0].lma;
 
+    // `ix` is already the (address-sorted, for DISCRETE) segment index, so index `segments` with it
+    // directly -- indexing `map` a second time would apply the permutation twice and cancel the sort.
     for (unsigned ix : map) {
         const auto& segment = segments[ix];
         if (not segment.relocs.empty()) {
             TT_THROW("{}: unexpected dynamic relocations", path);
         }
-        if (loading != Loading::DISCRETE) {
+        if (loading_ != Loading::DISCRETE) {
             if (segment.lma != lma) {
                 TT_THROW("{}: inconsistent load addresses for packing", path);
             }
             lma += segment.contents.size() * sizeof(word_t);
         }
-        if (loading == Loading::DISCRETE ? !segment.contents.empty() : link_spans_.empty()) {
+        if (loading_ == Loading::DISCRETE ? !segment.contents.empty() : link_spans_.empty()) {
             link_spans_.emplace_back(segment.address, 0);
         }
         link_spans_.back().len += segment.contents.size();

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -48,6 +48,13 @@ memory::memory(const std::string& path, Loading loading) : loading_(loading) {
     pack_from_segments(path, elf.GetSegments());
 }
 
+memory memory::from_segments(const std::vector<ElfFile::Segment>& segments, Loading loading) {
+    memory m;
+    m.loading_ = loading;
+    m.pack_from_segments("<segments>", segments);
+    return m;
+}
+
 void memory::pack_from_segments(const std::string& path, const std::vector<ElfFile::Segment>& segments) {
     // The ELF file puts the text segment first, but one set of
     // binaries (ncrisc) places data a lower address, and at least one

--- a/tt_metal/llrt/tt_memory.h
+++ b/tt_metal/llrt/tt_memory.h
@@ -7,8 +7,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <string_view>
 #include <vector>
+
+#include "tt_elffile.hpp"
 
 namespace ll_api {
 
@@ -29,9 +32,17 @@ private:
 
     std::vector<word_t> data_;
     std::vector<struct span> link_spans_;
-    uint32_t text_size_ = 0;
-    uint32_t text_addr_ = 0;
+    std::uint32_t text_size_ = 0;
+    std::uint32_t text_addr_ = 0;
     Loading loading_{Loading::DISCRETE};
+
+    // Populate link_spans_/data_/text_addr_/text_size_ from ELF segments, ordering by address for
+    // DISCRETE loads. Split out of the (path, loading) constructor so the ordering logic can be
+    // exercised by unit tests with synthetic segments (no on-disk ELF needed).
+    void pack_from_segments(const std::string& path, const std::vector<ElfFile::Segment>& segments);
+
+    // Grants the ordering unit test access to loading_ and pack_from_segments.
+    friend class MemorySegmentOrderingTest;
 
 public:
     memory();
@@ -49,10 +60,10 @@ public:
     bool operator==(const memory& other) const;
     Loading get_loading() const { return loading_; }
 
-    uint32_t get_text_size() const { return this->text_size_; }
-    uint32_t get_packed_size() const { return data_.size() * sizeof(word_t); }
-    uint32_t get_text_addr() const { return this->text_addr_; }
-    void set_text_addr(const uint32_t& addr) { this->text_addr_ = addr; }
+    std::uint32_t get_text_size() const { return this->text_size_; }
+    std::uint32_t get_packed_size() const { return data_.size() * sizeof(word_t); }
+    std::uint32_t get_text_addr() const { return this->text_addr_; }
+    void set_text_addr(const std::uint32_t& addr) { this->text_addr_ = addr; }
 
     size_t size() const { return data_.size(); }
 
@@ -61,14 +72,17 @@ public:
     // Process spans in arg mem to fill data in *this (eg, from device)
     void fill_from_mem_template(
         const memory& mem_template,
-        const std::function<void(std::vector<uint32_t>::iterator, uint64_t addr, uint32_t len)>& callback);
+        const std::function<void(std::vector<std::uint32_t>::iterator, std::uint64_t addr, std::uint32_t len)>&
+            callback);
 
     // Iterate over spans_ to act on data_ (eg., to device)
     void process_spans(
-        const std::function<void(std::vector<uint32_t>::const_iterator, uint64_t addr, uint32_t len)>& callback) const;
+        const std::function<void(std::vector<std::uint32_t>::const_iterator, std::uint64_t addr, std::uint32_t len)>&
+            callback) const;
     void process_spans(
-        const std::function<void(std::vector<uint32_t>::iterator, uint64_t addr, uint32_t len)>& callback);
-    void update_spans(std::function<void(uint64_t& addr)>& callback);
+        const std::function<void(std::vector<std::uint32_t>::iterator, std::uint64_t addr, std::uint32_t len)>&
+            callback);
+    void update_spans(std::function<void(std::uint64_t& addr)>& callback);
 };
 
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_memory.h
+++ b/tt_metal/llrt/tt_memory.h
@@ -37,16 +37,17 @@ private:
     Loading loading_{Loading::DISCRETE};
 
     // Populate link_spans_/data_/text_addr_/text_size_ from ELF segments, ordering by address for
-    // DISCRETE loads. Split out of the (path, loading) constructor so the ordering logic can be
-    // exercised by unit tests with synthetic segments (no on-disk ELF needed).
+    // DISCRETE loads. Shared by the (path, loading) constructor and from_segments().
     void pack_from_segments(const std::string& path, const std::vector<ElfFile::Segment>& segments);
-
-    // Grants the ordering unit test access to loading_ and pack_from_segments.
-    friend class MemorySegmentOrderingTest;
 
 public:
     memory();
     memory(const std::string& path, Loading loading);
+
+    // Build a memory directly from in-memory ELF segments (no on-disk ELF), running the same
+    // address-ordering/packing logic as the (path, loading) constructor. Lets the segment-ordering
+    // behaviour be unit-tested with synthetic segments.
+    static memory from_segments(const std::vector<ElfFile::Segment>& segments, Loading loading);
 
     // These can be large objects, so ban copying ...
     memory(const memory&) = delete;


### PR DESCRIPTION
Closes #48262. Sub-issue of #48188 (bug #9, AI-harvested bugs).

### Summary
In `memory::memory(path, loading)` (`tt_metal/llrt/tt_memory.cpp`), the segment loop is `for (unsigned ix : map)`, so `ix` **already holds a segment index** (`map`'s values are segment indices). The body then did `segments[map[ix]]`, indexing `map` a **second time** — applying the address permutation twice.

- For non-`DISCRETE` loadings `map` is the identity permutation (`map[i]==i`), so the bug was masked.
- For `Loading::DISCRETE` (the default in `get_risc_binary`, used for Wormhole active-eth), `map` is sorted by segment address. For ncrisc-style binaries where data sits below text, the sort yields a non-identity permutation (e.g. `map=[1,0]`). Double-indexing then visits `segments[0]` then `segments[1]` — original **text-first** order — instead of the requested address order, defeating the DISCRETE sort and producing `link_spans_`/`data_` in the wrong order for consumers that require address-ordered spans.

### Fix
Index `segments[ix]` directly, since `ix` is already the mapped (address-sorted for DISCRETE) segment index.

```cpp
-        auto const& segment = segments[map[ix]];
+        const auto& segment = segments[ix];
```

### Test
Added a host-only regression test (`tests/tt_metal/tt_metal/api/test_tt_memory.cpp`, runs in the `unit_tests_api` suite, no device needed):

- **`DiscreteEmitsSpansInAscendingAddressOrder`** — builds a `memory` from synthetic ncrisc-style segments (data segment below text) and asserts the emitted spans come out in ascending address order. This is the fail-without-fix check: with the old `segments[map[ix]]` it emits `{(0x2000,2),(0x1000,1)}` (text-first) and packs `data_` in the wrong order.
- **`ContiguousCoalescesIntoSingleSpan`** — guards that the non-`DISCRETE` (identity-map) path still coalesces into one span, unchanged by the fix.

To make the ordering logic testable without an on-disk ELF (`ReadImage` needs a full valid RISC-V ELF executable), the segment-packing loop was extracted from the constructor into a private `pack_from_segments()` helper, and a small public static factory `memory::from_segments(segments, loading)` builds a `memory` from in-memory `ElfFile::Segment`s (constructor is public) using that same logic. The test drives the ordering through the public factory plus the already-public `process_spans`/`data()` — no friend class and no access to private members.

**Verified locally:** with the bug reintroduced the DISCRETE test fails (spans reversed, data mis-packed); with the fix both tests pass.

### Notes for reviewers
- The only logic change is the one line in `pack_from_segments`. Some of the diff (`uint*_t` → `std::uint*_t`, a few clang-format reflows) was applied automatically by the repo's `fix-cstdint` / `clang-format` pre-commit hooks when the files were touched — required to pass `all-static-checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-tt-memory-discrete-double-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-tt-memory-discrete-double-index)
