### PR TITLE
[Bugfix] noc_async_read/write_shard: NOC id silently binds to offset parameter (#48263)

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1429,13 +1429,16 @@ FORCE_INLINE void noc_async_read_shard(
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::READ,
         dst_local_l1_addr,
-        s.get_shard_noc_addr(shard_id, noc),
+        s.get_shard_noc_addr(shard_id, /*offset=*/0, noc),
         s.get_aligned_page_size() * shard_volume,
         -1,
         false,
         noc);
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
-        s.get_shard_noc_addr(shard_id, noc), dst_local_l1_addr, s.get_aligned_page_size() * shard_volume, noc);
+        s.get_shard_noc_addr(shard_id, /*offset=*/0, noc),
+        dst_local_l1_addr,
+        s.get_aligned_page_size() * shard_volume,
+        noc);
 }
 
 // clang-format off
@@ -1463,13 +1466,16 @@ FORCE_INLINE void noc_async_write_shard(
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::WRITE_,
         src_local_l1_addr,
-        s.get_shard_noc_addr(shard_id, noc),
+        s.get_shard_noc_addr(shard_id, /*offset=*/0, noc),
         s.get_aligned_page_size() * shard_volume,
         NOC_UNICAST_WRITE_VC,
         posted,
         noc);
     noc_async_write<NOC_MAX_BURST_SIZE + 1, false, posted>(
-        src_local_l1_addr, s.get_shard_noc_addr(shard_id, noc), s.get_aligned_page_size() * shard_volume, noc);
+        src_local_l1_addr,
+        s.get_shard_noc_addr(shard_id, /*offset=*/0, noc),
+        s.get_aligned_page_size() * shard_volume,
+        noc);
 }
 
 // clang-format off


### PR DESCRIPTION
### Ticket

Fixes #48263 (Bug #10 from the AI-harvested bugs master issue #48188).

### Problem

`noc_async_read_shard` / `noc_async_write_shard` in `tt_metal/hw/inc/api/dataflow/dataflow_api.h` called:

```cpp
s.get_shard_noc_addr(shard_id, noc)
```

The `TensorAccessor` accessor has two overloads:

```cpp
// scalar
std::uint64_t get_shard_noc_addr(uint32_t shard_id, uint32_t offset = 0, uint8_t noc = noc_index) const;
// coordinate-array (SFINAE-gated on operator[])
template <typename ArrType, /* requires ArrType::operator[] */>
std::uint64_t get_shard_noc_addr(ArrType shard_coord, uint32_t offset = 0, uint8_t noc = noc_index) const;
```

`shard_id` is a scalar `uint32_t` (no `operator[]`), so the array overload is SFINAE-excluded and the **scalar** overload is selected. The `noc` argument (a `uint8_t`) therefore bound to the `offset` parameter, and the method's own `noc` silently defaulted to `noc_index`.

**Effect when a caller passes `noc != noc_index`:**
- (a) The requested NOC is ignored — the shard NOC address is always computed for the default NOC's coordinate translation / DRAM bank offset.
- (b) A spurious byte offset equal to the noc id (0 or 1) is added to the address.

The read/write then targets a wrong/garbage address. The bug is subtle because the surrounding `noc_async_read`/`noc_async_write` calls *do* pass `noc` correctly as their own last argument — only the address computation was corrupted.

### Fix

Route `noc` through the named parameter and make the offset explicit at all four call sites (lines 1432, 1438, 1466, 1472):

```cpp
s.get_shard_noc_addr(shard_id, /*offset=*/0, noc)
```

### Verification

- Verified against the overload signatures in `tensor_accessor.h`: the scalar overload accepts `(shard_id, 0, noc)` and now binds `noc` correctly.
- Swept the repo for other `get_shard_noc_addr(shard_id, noc)` two-arg call sites — none remain; the only other external callers (`tensor_accessor.h`, `models/.../flash_mla.hpp`) already pass the 3-arg form.
- `clang-format` / pre-commit hooks pass.
- Note: `dataflow_api.h` is device-side (JIT-compiled), so this is not exercised by the host build; full runtime validation requires hardware CI exercising a shard read/write on the non-default NOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Why no dedicated regression test

This is a compile-time argument-binding slip, and its runtime symptom is weak/latent:
- **No in-tree caller passes a non-default `noc`** — every call uses `noc = noc_index`, so the NOC selection is always coincidentally correct; the only live effect is the spurious `+offset` byte (= noc id, 0 or 1).
- **L1-sharded**: NOC 0/1 use mirrored coordinates that resolve to the *same physical core*, so the wrong-NOC effect produces no data difference at all — only the ≤1-byte offset (an alignment nuisance, not a clean diff).
- **DRAM-sharded**: a clean, large data corruption occurs, but **only when `noc != noc_index`** — which requires a dynamic-NOC kernel reading over the other NOC.

A test producing a deterministic wrong-vs-right comparison would therefore have to construct the exact future misuse this fix anticipates (a DRAM shard read over the non-default NOC). The fix is verified by inspection against the overload signatures; it prevents that future misuse from silently misbehaving.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-noc-shard-addr-48263)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-noc-shard-addr-48263)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix-noc-shard-addr-48263)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-noc-shard-addr-48263)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-noc-shard-addr-48263)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-noc-shard-addr-48263)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-noc-shard-addr-48263)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-noc-shard-addr-48263)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-noc-shard-addr-48263)
