### PR TITLE
[Bugfix] WorkerConfigBufferMgr::PrintStatus: dead loop condition skips queued entries (#48268)

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
@@ -203,4 +203,27 @@ TEST(WorkerConfigBuffer, VeryBasic) {
     EXPECT_FALSE(reservation3.first.need_sync);
 }
 
+// Regression for #48268: PrintStatus walked the ring buffer starting from alloc_index_ instead of
+// free_index_, so the `while (free_index != alloc_index_)` loop was immediately false and no queued
+// entries were ever visited. Exercise the walk (now factored into get_queued_entry_indices) and
+// confirm it returns the queued (freeable) entries. Prior to the fix this vector was always empty.
+TEST(WorkerConfigBuffer, PrintStatusWalksQueuedEntries) {
+    WorkerConfigBufferMgr mgr;
+    mgr.init_add_buffer(0, 1024);
+
+    // Allocate three entries without freeing any: free_index_ stays at 0 while alloc_index_
+    // advances to 3, leaving entries 0, 1, 2 queued.
+    for (uint32_t i = 0; i < 3; i++) {
+        auto reservation = mgr.reserve({10});
+        EXPECT_FALSE(reservation.first.need_sync);
+        mgr.alloc(i + 1);
+    }
+
+    EXPECT_EQ(mgr.get_queued_entry_indices(0), (std::vector<size_t>{0, 1, 2}));
+
+    // After freeing up to sync_count 2, entries 0 and 1 are reclaimed; only entry 2 remains queued.
+    mgr.free(2);
+    EXPECT_EQ(mgr.get_queued_entry_indices(0), (std::vector<size_t>{2}));
+}
+
 }  // namespace worker_config_buffer_tests

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -216,23 +216,33 @@ void WorkerConfigBufferMgr::mark_completely_full(uint32_t sync) {
     }
 }
 
+std::vector<size_t> WorkerConfigBufferMgr::get_queued_entry_indices(size_t buffer_type) const {
+    std::vector<size_t> indices;
+    // Walk the ring buffer from the oldest freeable entry (free_index_) up to, but not including,
+    // the alloc entry (alloc_index_). Starting from alloc_index_ here would make the loop empty.
+    size_t free_index = this->free_index_[buffer_type];
+    while (free_index != this->alloc_index_[buffer_type]) {
+        indices.push_back(free_index);
+        free_index = (free_index + 1) % this->entries_.size();
+    }
+    return indices;
+}
+
 void WorkerConfigBufferMgr::PrintStatus() {
     size_t num_buffer_types = this->reservation_.size();
     for (size_t i = 0; i < num_buffer_types; i++) {
         fprintf(stderr, "Buffer type %zu\n", i);
         log_info(tt::LogTest, "Buffer type {}", i);
 
-        size_t free_index = this->free_index_[i];
-        while (free_index != this->alloc_index_[i]) {
+        for (size_t free_index : this->get_queued_entry_indices(i)) {
             auto& entry = this->entries_[free_index][i];
             log_info(
                 tt::LogTest, "Free index {} has values {} {} {}", free_index, entry.addr, entry.size, entry.sync_count);
-
-            free_index = (free_index + 1) % this->entries_.size();
         }
-        auto& entry = this->entries_[free_index][i];
+        size_t alloc_index = this->alloc_index_[i];
+        auto& entry = this->entries_[alloc_index][i];
         log_info(
-            tt::LogTest, "Alloc index {} has values {} {} {}", free_index, entry.addr, entry.size, entry.sync_count);
+            tt::LogTest, "Alloc index {} has values {} {} {}", alloc_index, entry.addr, entry.size, entry.sync_count);
     }
 }
 

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -222,7 +222,7 @@ void WorkerConfigBufferMgr::PrintStatus() {
         fprintf(stderr, "Buffer type %zu\n", i);
         log_info(tt::LogTest, "Buffer type {}", i);
 
-        size_t free_index = this->alloc_index_[i];
+        size_t free_index = this->free_index_[i];
         while (free_index != this->alloc_index_[i]) {
             auto& entry = this->entries_[free_index][i];
             log_info(

--- a/tt_metal/impl/dispatch/worker_config_buffer.hpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 #include <tt-metalium/hal_types.hpp>
@@ -43,6 +44,10 @@ public:
 
     // Test/Debug
     uint32_t get_last_slot_addr(HalProgrammableCoreType programmable_core_type) const;
+
+    // Returns the ring-buffer indices of the currently-queued (freeable) entries for a buffer type,
+    // in walk order from free_index_ up to (but not including) alloc_index_.
+    std::vector<size_t> get_queued_entry_indices(size_t buffer_type) const;
 
     void PrintStatus();
 


### PR DESCRIPTION
### Ticket

Fixes #48268 (Bug #15 from the AI-harvested bugs master issue #48188).

### Problem

`WorkerConfigBufferMgr::PrintStatus` initialized the loop cursor from `alloc_index_[i]`:

```cpp
size_t free_index = this->alloc_index_[i];
while (free_index != this->alloc_index_[i]) {   // immediately false
    ...
}
```

The `while` condition is `free_index != alloc_index_[i]` — which is false on entry, so the per-entry loop **never executes**. The function only ever prints the single alloc-index entry and never the queued entries it's meant to dump.

### Fix

Initialize the cursor from `free_index_[i]` (the oldest valid entry, per the member's own comment `// points to the next entry to free`), so the loop walks the queued entries from `free_index` up to `alloc_index_[i]`:

```cpp
size_t free_index = this->free_index_[i];
```

### Regression test

`PrintStatus` produces only log output (`log_info`/`fprintf(stderr)`), which isn't reliably capturable. To make the walk testable without depending on the logger, the ring-buffer walk is factored into a small const helper `get_queued_entry_indices(buffer_type)` (alongside the existing `// Test/Debug` accessors like `get_last_slot_addr`); `PrintStatus` now delegates to it, preserving its logging.

Added host-side gtest `WorkerConfigBuffer.PrintStatusWalksQueuedEntries` (`tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp`): allocate three entries without freeing (→ `free_index_=0`, `alloc_index_=3`) and assert the queued indices are `{0,1,2}`, then `free(2)` and assert `{2}`.

Verified locally (`unit_tests_api`):
- **With the fix**: passes; full `WorkerConfigBuffer.*` suite (7 tests) green.
- **Without the fix** (walk starting from `alloc_index_`): fails — `get_queued_entry_indices` returns `{}` instead of the expected sequence.

`PrintStatus` itself has no in-tree callers (ad-hoc debug helper), but the extracted walk logic it relies on is now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-worker-config-printstatus-48268)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-worker-config-printstatus-48268)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix-worker-config-printstatus-48268)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-worker-config-printstatus-48268)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-worker-config-printstatus-48268)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-worker-config-printstatus-48268)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-worker-config-printstatus-48268)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-worker-config-printstatus-48268)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-worker-config-printstatus-48268)
