### PR TITLE
[tt_stl] Fix from_json for std::unordered_map to return unordered_map (not std::map)

### DIFF
--- a/tt_stl/tests/test_reflection.cpp
+++ b/tt_stl/tests/test_reflection.cpp
@@ -4,8 +4,11 @@
 
 #include <gmock/gmock.h>
 #include <tt_stl/reflection.hpp>
+#include <map>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <unordered_map>
 
 // Define test types in a DIFFERENT namespace to avoid ADL finding the operators
 // This is the scenario that triggers the ordering issue
@@ -130,6 +133,35 @@ TEST(ReflectionTest, FmtFormatContainerWithReflectable) {
     EXPECT_THAT(result, HasSubstr("name=fmt_test"));
     EXPECT_THAT(result, HasSubstr("x=15"));
     EXPECT_THAT(result, HasSubstr("y=25"));
+}
+
+// Regression test for issue #48265: from_json_t<std::unordered_map<K, V>> declared its
+// operator() return type as std::map<K, V> while returning a std::unordered_map, so any
+// instantiation of from_json for an unordered_map failed to compile. Exercising that
+// instantiation here guards it (and asserts the declared return type is unordered_map).
+TEST(ReflectionTest, FromJsonUnorderedMapRoundTrip) {
+    const std::unordered_map<std::string, int> original{{"a", 1}, {"b", 2}, {"c", 3}};
+
+    const nlohmann::json json_object = ttsl::json::to_json(original);
+    const auto restored = ttsl::json::from_json<std::unordered_map<std::string, int>>(json_object);
+
+    static_assert(
+        std::is_same_v<decltype(restored), const std::unordered_map<std::string, int>>,
+        "from_json for std::unordered_map must return std::unordered_map");
+    EXPECT_EQ(restored, original);
+}
+
+// The sibling std::map specialization (the correct one the bug was copy-pasted from) still works.
+TEST(ReflectionTest, FromJsonMapRoundTrip) {
+    const std::map<std::string, int> original{{"a", 1}, {"b", 2}, {"c", 3}};
+
+    const nlohmann::json json_object = ttsl::json::to_json(original);
+    const auto restored = ttsl::json::from_json<std::map<std::string, int>>(json_object);
+
+    static_assert(
+        std::is_same_v<decltype(restored), const std::map<std::string, int>>,
+        "from_json for std::map must return std::map");
+    EXPECT_EQ(restored, original);
 }
 
 }  // namespace

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -30,6 +30,7 @@
 #include <tt_stl/type_name.hpp>
 #include <tt_stl/fmt.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <cstdint>
 
 // NOLINTBEGIN(bugprone-multi-level-implicit-pointer-conversion)
 
@@ -817,8 +818,8 @@ template <typename T>
 struct update_object_of_type_t;
 
 /**
-* Recursively visits all elements in `object` that are instances of `object_t`,
-* calls the `callback` function with those instance in anticipation for an inplace modification.
+ * Recursively visits all elements in `object` that are instances of `object_t`,
+ * calls the `callback` function with those instance in anticipation for an inplace modification.
  */
 template <typename object_t, typename T>
 void update_object_of_type(auto&& callback, T& object) {
@@ -1471,9 +1472,7 @@ inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
 // The one lossy leaf is a type exposing ONLY to_hash(): its 8 hash bytes are appended, so for
 // such a type equality degrades to hash equality -- no worse than today, and none occur on the
 // tensor/shape path (TensorSpec is walked structurally down to the shape integers).
-inline void append_bytes(std::string& out, const void* p, std::size_t n) {
-    out.append(static_cast<const char*>(p), n);
-}
+inline void append_bytes(std::string& out, const void* p, std::size_t n) { out.append(static_cast<const char*>(p), n); }
 
 template <typename T>
 inline void append_canonical(std::string& out, const T& object);
@@ -1546,9 +1545,7 @@ inline void append_canonical(std::string& out, const T& object) {
         for (auto it = object.begin(); it != object.end(); ++it) {
             iterators.push_back(it);
         }
-        std::sort(iterators.begin(), iterators.end(), [](const auto& a, const auto& b) {
-            return a->first < b->first;
-        });
+        std::sort(iterators.begin(), iterators.end(), [](const auto& a, const auto& b) { return a->first < b->first; });
         const std::uint64_t n = object.size();
         append_bytes(out, &n, sizeof(n));
         for (const auto& it : iterators) {
@@ -1839,7 +1836,7 @@ struct to_json_t<std::unordered_map<K, V>> {
 
 template <typename K, typename V>
 struct from_json_t<std::unordered_map<K, V>> {
-    std::map<K, V> operator()(const nlohmann::json& json_object) {
+    std::unordered_map<K, V> operator()(const nlohmann::json& json_object) {
         std::unordered_map<K, V> object;
         for (const auto& [key, value] : json_object.items()) {
             object[from_json<K>(nlohmann::json::parse(key))] = from_json<V>(value);


### PR DESCRIPTION
Closes #48265. Sub-issue of #48188 (bug #12, AI-harvested bugs).

### Summary
`from_json_t<std::unordered_map<K, V>>::operator()` (`tt_stl/tt_stl/reflection.hpp`) declared its return type as `std::map<K, V>` while constructing and returning a local `std::unordered_map<K, V>`. `std::map` has no constructor accepting a `std::unordered_map`, so **any** instantiation of `from_json<std::unordered_map<...>>` fails to compile:

```
error: no viable conversion from returned value of type 'std::unordered_map<...>' to function return type 'std::map<...>'
```

It's a copy-paste slip from the `std::map` specialization directly above it. The intent is to deserialize into an `unordered_map`, so the declared return type was simply wrong. It went unnoticed because no current TU instantiated the specialization.

### Fix
```cpp
-    std::map<K, V> operator()(const nlohmann::json& json_object) {
+    std::unordered_map<K, V> operator()(const nlohmann::json& json_object) {
```

### Test
Added host-only round-trip tests to `tt_stl/tests/test_reflection.cpp` (`unit_tests_stl`):

- **`FromJsonUnorderedMapRoundTrip`** — instantiates `from_json<std::unordered_map<std::string, int>>` and round-trips it through `to_json`. Because the bug is a return-type mismatch, this is a **compile-time** guard: with the old `std::map` return type the TU fails to build. A `static_assert` also pins the declared return type to `std::unordered_map`.
- **`FromJsonMapRoundTrip`** — the sibling `std::map` path, as a control.

**Verified locally:** with the bug reintroduced `test_reflection.cpp` fails to compile (`reflection.hpp:…: no viable conversion from unordered_map to std::map`); with the fix both tests build and pass.

### Notes for reviewers
- The only logic change is the one-line return type. Some of the `reflection.hpp` diff (a `#include <cstdint>` and a few clang-format reflows of untouched lines) was applied automatically by the repo's `fix-cstdint` / `clang-format` pre-commit hooks when the file was touched — required to pass `all-static-checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-from-json-unordered-map-return-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-from-json-unordered-map-return-type)