### PR TITLE
#42882: Bound RM slice CB size via sub-row NOC chunking

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1611,3 +1611,26 @@ def test_slice_rm_nd_misaligned_last_dim(device, shape, slice_start, slice_end):
         slice_start[4] : slice_end[4],
     ]
     assert_with_pcc(torch_expected, ttnn.to_torch(tt_output), 0.9999)
+
+
+# 258112 exercises last_chunk_size < chunk_size (256 B tail); 262144 exercises the exact-divisor branch (last_chunk_size == chunk_size).
+@pytest.mark.parametrize("last_dim", [258112, 262144])
+def test_slice_rm_wide_row_chunking(device, last_dim):
+    """RM slice with a last-dim row wider than the double-buffered CB L1 budget."""
+    begins = [0, 2, 0]
+    ends = [6, 3, last_dim]
+    step = [1, 1, 1]
+
+    torch_input = torch.rand([6, 3, last_dim], dtype=torch.float32)
+    torch_output = torch_input[0:6, 2:3, 0:last_dim]
+
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.float32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_output = ttnn.slice(ttnn_input, begins, ends, step, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    assert torch.equal(torch_output, ttnn.to_torch(ttnn_output))

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -21,8 +21,12 @@ void kernel_main() {
     const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(7);
     const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(8);
     const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(9);
+    // Sub-row chunking: `num_chunks_per_stick` NOC transfers of `chunk_size` per stick (last = `last_chunk_size`).
+    const uint32_t chunk_size = get_arg_val<uint32_t>(10);
+    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(11);
+    const uint32_t last_chunk_size = get_arg_val<uint32_t>(12);
 
-    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(10));
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(13));
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
@@ -41,11 +45,50 @@ void kernel_main() {
 
     uint32_t src_stick_id = start_id;
     uint32_t sticks_read = 0;
-    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+
+    if (num_chunks_per_stick > 1) {
+        // Chunked path: batch by `num_read_per_barrier` so the second CB pair pipelines behind the first.
+        for (uint32_t iter = 0; iter < num_sticks_per_core_read && sticks_read < num_sticks_per_core; ++iter) {
+            uint32_t c = 0;
+            while (c < num_chunks_per_stick) {
+                uint32_t batch = num_chunks_per_stick - c;
+                if (batch > num_read_per_barrier) {
+                    batch = num_read_per_barrier;
+                }
+                cb_in0.reserve_back(batch);
+                uint32_t src_buffer_l1_addr = cb_in0.get_write_ptr();
+                for (uint32_t k = 0; k < batch; ++k) {
+                    const uint32_t cur = c + k;
+                    const uint32_t offset = cur * chunk_size;
+                    const uint32_t sz = (cur == num_chunks_per_stick - 1) ? last_chunk_size : chunk_size;
+                    tt::data_movement::common::noc_async_read_sharded(
+                        noc, src_buffer_l1_addr, s0, src_stick_id, offset, sz);
+                    src_buffer_l1_addr += chunk_size;
+                }
+                noc.async_read_barrier();
+                cb_in0.push_back(batch);
+                c += batch;
+            }
+            sticks_read++;
+            src_stick_id++;
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                    id_per_dim[j] = 0;
+                    src_stick_id += num_padded_sticks[j];
+                } else {
+                    break;
+                }
+            }
+        }
+        return;
+    }
+
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read && sticks_read < num_sticks_per_core; ++iter) {
         cb_in0.reserve_back(num_read_per_barrier);
         uint32_t src_buffer_l1_addr = cb_in0.get_write_ptr();
 
-        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+        for (uint32_t i = 0; i < num_read_per_barrier && sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
             // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
             // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -20,6 +20,11 @@ void kernel_main() {
     // Per-shard page size: shard_W on B/W-sharded outputs, full row otherwise.
     // Feeds `noc_async_write_sharded`'s multi-shard split via `get_aligned_page_size()`.
     uint32_t page_size_override = get_arg_val<uint32_t>(7);
+    // Sub-row chunking (mirrors reader): `num_chunks_per_stick` CB pages of `chunk_size` per stick (last =
+    // `last_chunk_size`).
+    const uint32_t chunk_size = get_arg_val<uint32_t>(8);
+    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(9);
+    const uint32_t last_chunk_size = get_arg_val<uint32_t>(10);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
     constexpr auto dst_args = TensorAccessorArgs<1>();
@@ -32,11 +37,40 @@ void kernel_main() {
 
     uint32_t i_stick = start_id;
     uint32_t sticks_read = 0;
-    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+
+    if (num_chunks_per_stick > 1) {
+        // Chunked path (mirrors reader): batch by `num_read_per_barrier` so the second CB pair pipelines.
+        for (uint32_t iter = 0; iter < num_sticks_per_core_read && sticks_read < num_sticks_per_core; ++iter) {
+            uint32_t c = 0;
+            while (c < num_chunks_per_stick) {
+                uint32_t batch = num_chunks_per_stick - c;
+                if (batch > num_read_per_barrier) {
+                    batch = num_read_per_barrier;
+                }
+                cb_out0.wait_front(batch);
+                uint32_t l1_read_addr = cb_out0.get_read_ptr();
+                for (uint32_t k = 0; k < batch; ++k) {
+                    const uint32_t cur = c + k;
+                    const uint32_t offset = cur * chunk_size;
+                    const uint32_t sz = (cur == num_chunks_per_stick - 1) ? last_chunk_size : chunk_size;
+                    tt::data_movement::common::noc_async_write_sharded(noc, l1_read_addr, s0, i_stick, offset, sz);
+                    l1_read_addr += chunk_size;
+                }
+                noc.async_write_barrier();
+                cb_out0.pop_front(batch);
+                c += batch;
+            }
+            sticks_read++;
+            i_stick += 1;
+        }
+        return;
+    }
+
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read && sticks_read < num_sticks_per_core; ++iter) {
         cb_out0.wait_front(num_read_per_barrier);
         uint32_t l1_read_addr = cb_out0.get_read_ptr();
 
-        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+        for (uint32_t i = 0; i < num_read_per_barrier && sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
             // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
             // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -12,6 +12,9 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+
+#include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -19,6 +22,13 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 namespace {
+
+// Sub-row chunking: pair-batched NOC transfers per stick (last = `last_chunk_size`) so a wide row fits L1.
+struct ChunkingParams {
+    uint32_t chunk_size;
+    uint32_t num_chunks_per_stick;
+    uint32_t last_chunk_size;
+};
 
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
     const Tensor& input_tensor,
@@ -30,7 +40,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     const CoreRangeSet& core_group_2,
     uint32_t num_sticks_per_core_group_1,
     uint32_t num_sticks_per_core_group_2,
-    uint32_t max_read_size) {
+    uint32_t max_read_size,
+    const ChunkingParams& chunking) {
     auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
     auto output_shape = output_tensor.padded_shape();
@@ -94,7 +105,10 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         0,
         0,
         0,
-        0};
+        0,
+        chunking.chunk_size,
+        chunking.num_chunks_per_stick,
+        chunking.last_chunk_size};
     common_reader_kernel_args.insert(
         common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
     common_reader_kernel_args.insert(
@@ -117,10 +131,15 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
         if (num_sticks_per_core != 0) {
-            auto num_sticks_per_core_pad32 = num_sticks_per_core + ((32 - num_sticks_per_core % 32) % 32);
-            num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(
-                num_sticks_per_core_pad32, unpadded_row_size_bytes_offset, max_read_size);
-            num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+            if (chunking.num_chunks_per_stick > 1) {
+                num_sticks_per_core_read = num_sticks_per_core;
+                num_read_per_barrier = 2;
+            } else {
+                auto num_sticks_per_core_pad32 = round_up_to_mul32(num_sticks_per_core);
+                num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(
+                    num_sticks_per_core_pad32, unpadded_row_size_bytes_offset, max_read_size);
+                num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+            }
         }
 
         id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
@@ -150,6 +169,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             num_read_per_barrier,
             num_sticks_written,
             writer_page_size,
+            chunking.chunk_size,
+            chunking.num_chunks_per_stick,
+            chunking.last_chunk_size,
         };
         num_sticks_written += num_sticks_per_core;
         ret_val.emplace_back(reader_kernel_args, writer_kernel_args);
@@ -159,8 +181,18 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }
 
 constexpr uint32_t MAX_READ_SIZE = 4096;
+constexpr uint32_t CHUNK_TARGET_BYTES = 8192;  // NOC-friendly chunk when splitting a wide row
 
-std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
+struct SliceCbSizing {
+    uint32_t cb_page_size;
+    uint32_t num_read_per_barrier;
+    uint32_t misalignment;
+    ChunkingParams chunking;
+};
+
+// Chunks sub-row when double-buffered row page overflows L1; gated on misalignment==0
+// (misalign path uses a whole-stick memmove that doesn't compose with chunk boundaries).
+SliceCbSizing compute_cb_size(
     const Tensor& input,
     const Tensor& output,
     const Shape& output_tensor_start,
@@ -182,20 +214,66 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
         alignment *= 2;
     }
     const uint32_t unpadded_row_size_bytes = output.padded_shape()[-1] * input.element_size();
-    const uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
-    const uint32_t stick_stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
+    const uint32_t stick_size_aligned = tt::round_up(unpadded_row_size_bytes, alignment);
+
+    const uint32_t l1_budget = ttnn::operations::data_movement::get_max_l1_space(input);
+
+    SliceCbSizing s{
+        .cb_page_size = stick_size_aligned,
+        .num_read_per_barrier = 0,
+        .misalignment = misalignment,
+        .chunking = {stick_size_aligned, 1, stick_size_aligned},
+    };
+
+    const bool needs_chunking = (misalignment == 0) && (static_cast<uint64_t>(2u) * stick_size_aligned > l1_budget) &&
+                                (stick_size_aligned > alignment);
+    uint32_t stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
+
+    if (needs_chunking) {
+        // l1_budget/8 leaves headroom for reader + writer CBs pair-batched (each 4*chunk_size).
+        uint32_t max_chunk = std::min<uint32_t>(CHUNK_TARGET_BYTES, static_cast<uint32_t>(l1_budget / 8));
+        max_chunk = (max_chunk / alignment) * alignment;
+        TT_FATAL(
+            max_chunk >= alignment,
+            "ttnn::slice: L1 budget {} B too small for sub-row chunking (alignment {} B)",
+            l1_budget,
+            alignment);
+
+        const uint32_t num_chunks = (unpadded_row_size_bytes + max_chunk - 1) / max_chunk;
+        const uint32_t remainder = unpadded_row_size_bytes % max_chunk;
+        s.chunking = {
+            .chunk_size = max_chunk,
+            .num_chunks_per_stick = num_chunks,
+            .last_chunk_size = (remainder == 0) ? max_chunk : remainder,
+        };
+        s.cb_page_size = max_chunk;
+        stride_for_merge = max_chunk;
+    }
+
+    TT_FATAL(
+        static_cast<uint64_t>(2u) * s.cb_page_size <= l1_budget,
+        "ttnn::slice: required CB size {} B exceeds per-core L1 budget {} B "
+        "(row_bytes={}, misalignment={}); consider slicing along a non-width dim",
+        2u * s.cb_page_size,
+        l1_budget,
+        unpadded_row_size_bytes,
+        misalignment);
+
     const uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2
                                          ? num_sticks_per_core_group_1
                                          : num_sticks_per_core_group_2;
-    uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
     if (num_input_pages != 0) {
-        auto num_sticks_per_core_pad32 = num_input_pages + ((32 - num_input_pages % 32) % 32);
-        num_sticks_per_core_read =
-            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, stick_stride_for_merge, MAX_READ_SIZE);
-        num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+        if (needs_chunking) {
+            s.num_read_per_barrier = 2;
+        } else {
+            auto num_sticks_per_core_pad32 = round_up_to_mul32(num_input_pages);
+            uint32_t num_sticks_per_core_read =
+                tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, stride_for_merge, MAX_READ_SIZE);
+            s.num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+        }
     }
 
-    return std::make_tuple(cb_page_size, num_read_per_barrier, misalignment);
+    return s;
 }
 
 }  // namespace
@@ -226,18 +304,18 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
 
     constexpr uint8_t src0_cb_index = 0;
 
-    // CB sizing varies with slice_start; padded_shape folds into compute_program_hash() so each
-    // unique CB layout gets its own cache entry (total_size/page_size are not patched on cache hit).
-    const auto [cb_page_size, num_read_per_barrier, misalignment] = ttnn::operations::data_movement::compute_cb_size(
+    // CB sizing (incl. chunking) derives from padded_shape + slice_start + alignment, all of which
+    // fold into compute_program_hash(), so cache entries stay distinct per unique CB layout.
+    const auto sizing = ttnn::operations::data_movement::compute_cb_size(
         input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);
 
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_read_per_barrier * 2 * cb_page_size,
+        .total_size = sizing.num_read_per_barrier * 2 * sizing.cb_page_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = src0_cb_index,
             .data_format = cb_data_format,
-            .page_size = cb_page_size,
+            .page_size = sizing.cb_page_size,
         }}},
     });
 
@@ -276,7 +354,8 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
         core_group_2,
         num_sticks_per_core_group_1,
         num_sticks_per_core_group_2,
-        ttnn::operations::data_movement::MAX_READ_SIZE);
+        ttnn::operations::data_movement::MAX_READ_SIZE,
+        sizing.chunking);
 
     reader_desc.runtime_args.reserve(all_cores_vec.size());
     writer_desc.runtime_args.reserve(all_cores_vec.size());


### PR DESCRIPTION
### Ticket
Link to Github Issue #42882

### Problem
The row-major `ttnn::slice` factory (`SliceRmProgramFactory`) sized its src0 CB as `2 * num_read_per_barrier * row_page`, treating a whole last-dim row as a single CB page. For wide last-dim rows this overflows the per-core L1 budget once double-buffered — e.g. output `[6, 1, 258112]` fp32 gives `row_page ≈ 1.03 MB`, so the CB grows to `~2.07 MB`, past the ~1.5 MB L1 budget. The op aborts at `validate_circular_buffer_region` with a generic "circular buffer exceeds max L1 size" error, blocking customer models that slice along the middle dim of wide tensors.

There was no L1-aware sizing on this path — `MAX_READ_SIZE = 4096` only bounded `merge_num_sticks_to_read` for the narrow-stick batching case, which does not help when a single stick already exceeds the CB budget.

### What this PR does
- **Sub-row NOC chunking in `compute_cb_size`** — when `2 * row_page > L1 budget` and last-dim `misalignment == 0`, each stick is split into `ceil(row_bytes / chunk_size)` sub-row segments of `chunk_size` bytes (target 8 KB, capped by `L1 / 8` to leave headroom for both CBs pair-batched); the tail chunk is `last_chunk_size`. `num_read_per_barrier` is set to `2` in the chunked path so the CB is sized `2 * num_read_per_barrier * chunk_size = 4 * chunk_size` and a second pair of chunks can pipeline behind the first. L1 budget is queried the same way as the `split` fix — `l1_size_per_core() - lowest_occupied_compute_l1_address() - base allocator addr`.
- **Pair-batched chunked reader/writer paths** — the reader and writer kernels get a chunked branch that reserves `num_read_per_barrier` pages, issues that many `noc_async_read_sharded` / `noc_async_write_sharded` calls with `offset = c * chunk_size, size = min(chunk_size, remaining)`, then a single barrier + push per batch (matching the non-chunked branch's `reserve(N) → N transfers → barrier → push(N)` pattern). Odd tails are handled via `min(batch, chunks_remaining)`. The non-chunked path is untouched, so all pre-existing shapes take the same code as before.
- **Actionable `TT_FATAL` for the residual case** — if even a single chunk can't fit L1 (misaligned wide-row path with no chunking), the op now aborts with a scoped message including `row_bytes`, `misalignment`, and the L1 budget, instead of the generic `validate_circular_buffer_region` throw.
- **Program-cache safety preserved** — the new `chunk_size` / `num_chunks_per_stick` / `last_chunk_size` are derived purely from `padded_shape + slice_start + alignment`, all of which already fold into `compute_program_hash()`, so cache entries stay distinct per unique CB layout.
- **New regression test** (`test_slice_rm_wide_row_chunking`) — parametrized over `last_dim = [258112, 262144]` to exercise both `last_chunk_size < chunk_size` (256 B tail) and the exact-divisor branch (`last_chunk_size == chunk_size`). Uses `torch.equal` since RM slice is bit-exact.

### Tests
All on Wormhole B0 (N150):

| Suite | Result |
| --- | --- |
| `tests/ttnn/unit_tests/operations/data_movement/test_slice.py` | **414 passed, 38 skipped** — no regressions |
| `test_slice_rm_wide_row_chunking[last_dim=258112]` | **PASSED** — tail branch (`last_chunk_size=256 < chunk_size=8192`), `torch.equal` bit-exact |
| `test_slice_rm_wide_row_chunking[last_dim=262144]` | **PASSED** — exact-divisor branch (`last_chunk_size == chunk_size == 8192`), `torch.equal` bit-exact |
| `test_slice_rm_nd_misaligned_last_dim` | **PASSED** — misaligned-last-dim path unchanged |
| `test_issue_38841_regression`, `test_issue_47602_program_cache_collision_on_shape_change`, `test_issue_47602_same_shape_reuses_cache_entry` | **PASSED** — no cache-hash regression |

Before/after for the failing shape:

| Shape | Row bytes | CB (before) | CB (after) | Barriers/stick | Result |
| --- | --- | --- | --- | --- | --- |
| `[6, 1, 258112]` fp32 | 1,032,448 B | 2,064,896 B (overflow) | 32,768 B (fits) | ~127 → ~64 | `PASS` (was `TT_THROW`) |

### Notes for Reviewers
- **Reference:** the chunked NOC pattern mirrors the tile-block sizing already used by `tilize` / `untilize` factories; the batched `reserve → N transfers → single barrier → push` cadence matches the non-chunked branch of this same kernel.
- **Scope:** limited to the interleaved / height-sharded RM path (`SliceRmProgramFactory`). The strided variant (`SliceRmStrideProgramFactory`, `reader_multicore_slice_4d/_nd`) and the parallel `experimental/quasar` slice have the same latent bug and are candidates for follow-up PRs — not touched here to keep this PR scoped to the reported failure and to what's covered by tests.
- **Perf follow-up:** this PR bounds L1 for wide rows and halves the per-stick barrier count via pair-batching, but does not address the parallel-dim under-utilization those shapes expose (only 6 of ~64 cores get work for `[6, 1, 258112]`). A width-parallel work-split on top of this fix is the natural next step — it complements chunking rather than replacing it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/slice_cb_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/slice_cb_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/slice_cb_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/slice_cb_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/slice_cb_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/slice_cb_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/slice_cb_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/slice_cb_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/slice_cb_issue)
