### PR TITLE
[Ease-of-Use] Add op_block Compute API wrappers around op_tile

### DIFF
--- a/.github/deprecations.json
+++ b/.github/deprecations.json
@@ -32,6 +32,14 @@
       "introduced_by_pr": 49070,
       "grace": "30d",
       "owners": ["ncvetkovicTT"]
+    },
+    {
+      "id": "copy-block-matmul-partials-rename",
+      "description": "copy_block_matmul_partials in tt_metal/hw/inc/api/compute/tile_move_copy.h superseded by the uniform copy_block (functionally equivalent; same block unpack/datacopy paths) as part of the op_block Compute API surface (tt-metal#47477). The copy_block_matmul_partials forwarding shim is retained only for backwards compatibility; delete it once all call sites are migrated to copy_block.",
+      "files": ["tt_metal/hw/inc/api/compute/tile_move_copy.h"],
+      "introduced_by_pr": 49070,
+      "grace": "30d",
+      "owners": ["ncvetkovicTT"]
     }
   ]
 }

--- a/.github/deprecations.json
+++ b/.github/deprecations.json
@@ -24,6 +24,14 @@
       "introduced_by_pr": 23835,
       "grace": "30d",
       "owners": ["ncvetkovicTT"]
+    },
+    {
+      "id": "pack-tile-block-rename",
+      "description": "pack_tile_block in tt_metal/hw/inc/api/compute/pack.h renamed to pack_block for a uniform op_block Compute API surface (tt-metal#47477). The pack_tile_block forwarding shim is retained only for backwards compatibility; delete it once all call sites are migrated to pack_block.",
+      "files": ["tt_metal/hw/inc/api/compute/pack.h"],
+      "introduced_by_pr": 49070,
+      "grace": "30d",
+      "owners": ["ncvetkovicTT"]
     }
   ]
 }

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles.rst
@@ -4,3 +4,4 @@ add_tiles
 
 .. doxygenfunction:: add_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: add_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)
+.. doxygenfunction:: add_block(uint32_t icb0, uint32_t icb1, uint32_t start_itile0, uint32_t start_itile1, uint32_t start_idst, uint32_t ntiles)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles.rst
@@ -3,3 +3,4 @@ mul_tiles
 
 .. doxygenfunction:: mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: mul_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)
+.. doxygenfunction:: mul_block(uint32_t icb0, uint32_t icb1, uint32_t start_itile0, uint32_t start_itile1, uint32_t start_idst, uint32_t ntiles)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/reduce_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/reduce_tile.rst
@@ -3,3 +3,4 @@ reduce_tile
 
 .. doxygenfunction:: reduce_init
 .. doxygenfunction:: reduce_tile
+.. doxygenfunction:: reduce_block

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles.rst
@@ -4,3 +4,4 @@ sub_tiles
 
 .. doxygenfunction:: sub_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: sub_tiles( uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)
+.. doxygenfunction:: sub_block(uint32_t icb0, uint32_t icb1, uint32_t start_itile0, uint32_t start_itile1, uint32_t start_idst, uint32_t ntiles)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/transpose_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/transpose_tile.rst
@@ -3,3 +3,4 @@ transpose_tile
 
 .. doxygenfunction:: transpose_init(uint32_t icb, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: transpose_tile(uint32_t icb, uint32_t itile, uint32_t idst)
+.. doxygenfunction:: transpose_block(uint32_t icb, uint32_t start_itile, uint32_t start_idst, uint32_t ntiles)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
@@ -5,5 +5,6 @@ copy_tile
 
 .. doxygenfunction:: copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index)
+.. doxygenfunction:: copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles)
 .. doxygenfunction:: copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0)
 .. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, uint32_t transpose_within_16x16_face = false, uint32_t call_line = __builtin_LINE())

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
@@ -6,5 +6,6 @@ copy_tile
 .. doxygenfunction:: copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index)
 .. doxygenfunction:: copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles)
+.. doxygenfunction:: copy_block_matmul_partials(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles)
 .. doxygenfunction:: copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0)
 .. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, uint32_t transpose_within_16x16_face = false, uint32_t call_line = __builtin_LINE())

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_tile.rst
@@ -2,6 +2,7 @@ pack_tile
 =========
 
 .. doxygenfunction:: pack_tile
+.. doxygenfunction:: pack_block
 .. doxygenfunction:: pack_tile_block
 .. doxygenfunction:: pack_reconfig_data_format(const uint32_t new_operand)
 .. doxygenfunction:: pack_reconfig_data_format(const uint32_t old_operand, const uint32_t new_operand)

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -56,6 +56,9 @@ struct CopyBlockMatmulPartialsConfig {
     bool fp32_dest_acc_en = false;
     // Whether or not to sync full/half DST between MATH and PACK:
     bool dst_full_sync_en = false;
+    // Compute kernel exercised by the test. Defaults to the copy_block_matmul_partials / pack_tile_block
+    // kernel; the copy_block / pack_block variant points this at eltwise_copy_pack_block.cpp.
+    std::string compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp";
 };
 
 static std::vector<uint32_t> generate_copy_block_stimulus(
@@ -155,9 +158,7 @@ void run_single_core_copy_block_matmul_partials(
 
     experimental::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-
-            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
+        .source = test_config.compute_kernel,
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =
@@ -255,6 +256,9 @@ void run_single_core_copy_block_matmul_partials(
 // These tests aim to cover usage of these API calls:
 // - copy_block_matmul_partials
 // - pack_tile_block
+// and the uniform op_block surface that supersedes them:
+// - copy_block
+// - pack_block
 ////////////////////////////////////////////////////////////////////////////
 
 TEST_F(LLKMeshDeviceFixture, DISABLED_TensixComputeCopyBlockSingle) {
@@ -299,6 +303,56 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeCopyBlockComputeBottleneck) {
                 .compute_ublock = 1,
                 .fp32_dest_acc_en = fp32_dest_acc_en,
                 .dst_full_sync_en = dst_full_sync_en};
+            unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
+                this->devices_.at(0), test_config);
+            if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+                return;
+            }
+        }
+    }
+}
+
+// Same coverage as TensixComputeCopyBlockMultiple, but exercises the uniform op_block surface
+// (copy_block + pack_block) directly instead of the deprecated copy_block_matmul_partials /
+// pack_tile_block. The golden is an identity copy, so results must match bit-for-bit.
+TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockMultiple) {
+    static constexpr const char* kBlockKernel =
+        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp";
+    for (bool fp32_dest_acc_en : {true, false}) {
+        for (bool dst_full_sync_en : {true, false}) {
+            log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
+            unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+                .num_tiles = 8,
+                .reader_ublock = 8,
+                .writer_ublock = 8,
+                .compute_ublock = 4,  // compute_ublock must be <= get_dest_max_tiles (4 for SyncHalf+FP32)
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .dst_full_sync_en = dst_full_sync_en,
+                .compute_kernel = kBlockKernel};
+            unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
+                this->devices_.at(0), test_config);
+            if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+                return;
+            }
+        }
+    }
+}
+
+// copy_block + pack_block with a single tile per block (compute bottleneck shape).
+TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockComputeBottleneck) {
+    static constexpr const char* kBlockKernel =
+        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp";
+    for (bool fp32_dest_acc_en : {true, false}) {
+        for (bool dst_full_sync_en : {true, false}) {
+            log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
+            unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+                .num_tiles = 8,
+                .reader_ublock = 8,
+                .writer_ublock = 8,
+                .compute_ublock = 1,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .dst_full_sync_en = dst_full_sync_en,
+                .compute_kernel = kBlockKernel};
             unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
                 this->devices_.at(0), test_config);
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -248,6 +248,10 @@ void run_single_core_copy_block_matmul_partials(
     EXPECT_EQ(src_vec, result_vec);
 }
 
+// Compute kernel exercising the uniform copy_block + pack_block surface (shared by the
+// TensixComputeCopyPackBlock* cases below); the default kernel is the struct member initializer.
+constexpr const char* kBlockKernel = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp";
+
 }  // namespace unit_tests::compute::matmul_partials
 
 ////////////////////////////////////////////////////////////////////////////
@@ -316,8 +320,6 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeCopyBlockComputeBottleneck) {
 // (copy_block + pack_block) directly instead of the deprecated copy_block_matmul_partials /
 // pack_tile_block. The golden is an identity copy, so results must match bit-for-bit.
 TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockMultiple) {
-    static constexpr const char* kBlockKernel =
-        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp";
     for (bool fp32_dest_acc_en : {true, false}) {
         for (bool dst_full_sync_en : {true, false}) {
             log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
@@ -328,7 +330,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockMultiple) {
                 .compute_ublock = 4,  // compute_ublock must be <= get_dest_max_tiles (4 for SyncHalf+FP32)
                 .fp32_dest_acc_en = fp32_dest_acc_en,
                 .dst_full_sync_en = dst_full_sync_en,
-                .compute_kernel = kBlockKernel};
+                .compute_kernel = unit_tests::compute::matmul_partials::kBlockKernel};
             unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
                 this->devices_.at(0), test_config);
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
@@ -340,8 +342,6 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockMultiple) {
 
 // copy_block + pack_block with a single tile per block (compute bottleneck shape).
 TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockComputeBottleneck) {
-    static constexpr const char* kBlockKernel =
-        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp";
     for (bool fp32_dest_acc_en : {true, false}) {
         for (bool dst_full_sync_en : {true, false}) {
             log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
@@ -352,7 +352,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockComputeBottleneck) {
                 .compute_ublock = 1,
                 .fp32_dest_acc_en = fp32_dest_acc_en,
                 .dst_full_sync_en = dst_full_sync_en,
-                .compute_kernel = kBlockKernel};
+                .compute_kernel = unit_tests::compute::matmul_partials::kBlockKernel};
             unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
                 this->devices_.at(0), test_config);
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/pack.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+// Exercises the uniform op_block Compute API surface (copy_block + pack_block), i.e. the renamed
+// performant block paths that superseded copy_block_matmul_partials / pack_tile_block. Mirrors
+// eltwise_copy_block_matmul_partials.cpp but issues a single block call per ublock instead of a
+// loop of single-tile calls, so the golden (identity copy) is identical.
+void kernel_main() {
+    constexpr uint32_t num_tiles = get_arg(args::num_tiles);
+    constexpr uint32_t num_single_transfer = get_arg(args::num_single_transfer);
+
+    constexpr uint32_t outer_loop = num_tiles / num_single_transfer;
+
+    DataflowBuffer dfb_in(dfb::in);
+    DataflowBuffer dfb_out(dfb::out);
+    unary_op_init_common(dfb::in, dfb::out);
+
+    for (uint32_t b = 0; b < outer_loop; ++b) {
+        dfb_in.wait_front(num_single_transfer);
+        dfb_out.reserve_back(num_single_transfer);
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        copy_block(dfb::in, 0, 0, num_single_transfer);
+
+        pack_block(0, dfb::out, num_single_transfer);
+
+        tile_regs_commit();
+        tile_regs_release();
+        dfb_in.pop_front(num_single_transfer);
+        dfb_out.push_back(num_single_transfer);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_pack_block.cpp
@@ -29,9 +29,9 @@ void kernel_main() {
         tile_regs_acquire();
         tile_regs_wait();
 
-        copy_block(dfb::in, 0, 0, num_single_transfer);
+        copy_block(dfb::in, /* start_in_tile_index */ 0, /* start_dst_tile_index */ 0, num_single_transfer);
 
-        pack_block(0, dfb::out, num_single_transfer);
+        pack_block(/* ifrom_dst */ 0, dfb::out, num_single_transfer);
 
         tile_regs_commit();
         tile_regs_release();

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -249,8 +249,10 @@ ALWI void sub_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
  * (`mul_tiles_init`) to have been called first. The DST register buffer must be in acquired state via
  * *acquire_dst* call. This call is blocking and is only available on the compute engine.
  *
- * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
- * (MOPs / REPLAY buffers) by tt-metal#47482 without changing this signature.
+ * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
+ * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
+ * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47482.
  *
  * Return value: None
  *
@@ -279,8 +281,10 @@ ALWI void mul_block(
  * to have been called first. The DST register buffer must be in acquired state via *acquire_dst* call. This call
  * is blocking and is only available on the compute engine.
  *
- * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
- * (MOPs / REPLAY buffers) by tt-metal#47482 without changing this signature.
+ * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
+ * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
+ * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47482.
  *
  * Return value: None
  *
@@ -309,8 +313,10 @@ ALWI void add_block(
  * (`sub_tiles_init`) to have been called first. The DST register buffer must be in acquired state via
  * *acquire_dst* call. This call is blocking and is only available on the compute engine.
  *
- * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
- * (MOPs / REPLAY buffers) by tt-metal#47482 without changing this signature.
+ * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
+ * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
+ * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47482.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -241,6 +241,96 @@ ALWI void sub_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
           EltwiseBinaryReuseDestType::NONE>(icb0, icb1, idst, true /* clear_fp32_dst_acc */)));
 }
 
+// clang-format off
+/**
+ * Performs element-wise multiplication C=A*B on `ntiles` consecutive tile pairs from two CBs, writing each result
+ * to a consecutive DST register slot. This is the uniform block entry point for the multiply op: its body is a
+ * simple loop over `mul_tiles`, so it inherits `mul_tiles`'s semantics and requires the same initialization
+ * (`mul_tiles_init`) to have been called first. The DST register buffer must be in acquired state via
+ * *acquire_dst* call. This call is blocking and is only available on the compute engine.
+ *
+ * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
+ * (MOPs / REPLAY buffers) by tt-metal#47482 without changing this signature.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                              | Type     | Valid Range                                    | Required |
+ * |-----------------|----------------------------------------------------------|----------|------------------------------------------------|----------|
+ * | icb0            | The identifier of the circular buffer (CB) containing A  | uint32_t | 0 to 31                                        | True     |
+ * | icb1            | The identifier of the circular buffer (CB) containing B  | uint32_t | 0 to 31                                        | True     |
+ * | start_itile0    | The index of the first tile A within the first CB        | uint32_t | Must be less than the size of the CB           | True     |
+ * | start_itile1    | The index of the first tile B within the second CB       | uint32_t | Must be less than the size of the CB           | True     |
+ * | start_idst      | The index of the first tile in DST REG for the result C  | uint32_t | Must be less than the acquired size of DST REG | True     |
+ * | ntiles          | The number of consecutive tile pairs to multiply         | uint32_t | start_idst + ntiles <= acquired DST REG size   | True     |
+ */
+// clang-format on
+ALWI void mul_block(
+    uint32_t icb0, uint32_t icb1, uint32_t start_itile0, uint32_t start_itile1, uint32_t start_idst, uint32_t ntiles) {
+    for (uint32_t i = 0; i < ntiles; ++i) {
+        mul_tiles(icb0, icb1, start_itile0 + i, start_itile1 + i, start_idst + i);
+    }
+}
+
+// clang-format off
+/**
+ * Performs element-wise addition C=A+B on `ntiles` consecutive tile pairs from two CBs, writing each result to a
+ * consecutive DST register slot. This is the uniform block entry point for the add op: its body is a simple loop
+ * over `add_tiles`, so it inherits `add_tiles`'s semantics and requires the same initialization (`add_tiles_init`)
+ * to have been called first. The DST register buffer must be in acquired state via *acquire_dst* call. This call
+ * is blocking and is only available on the compute engine.
+ *
+ * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
+ * (MOPs / REPLAY buffers) by tt-metal#47482 without changing this signature.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                              | Type     | Valid Range                                    | Required |
+ * |-----------------|----------------------------------------------------------|----------|------------------------------------------------|----------|
+ * | icb0            | The identifier of the circular buffer (CB) containing A  | uint32_t | 0 to 31                                        | True     |
+ * | icb1            | The identifier of the circular buffer (CB) containing B  | uint32_t | 0 to 31                                        | True     |
+ * | start_itile0    | The index of the first tile A within the first CB        | uint32_t | Must be less than the size of the CB           | True     |
+ * | start_itile1    | The index of the first tile B within the second CB       | uint32_t | Must be less than the size of the CB           | True     |
+ * | start_idst      | The index of the first tile in DST REG for the result C  | uint32_t | Must be less than the acquired size of DST REG | True     |
+ * | ntiles          | The number of consecutive tile pairs to add              | uint32_t | start_idst + ntiles <= acquired DST REG size   | True     |
+ */
+// clang-format on
+ALWI void add_block(
+    uint32_t icb0, uint32_t icb1, uint32_t start_itile0, uint32_t start_itile1, uint32_t start_idst, uint32_t ntiles) {
+    for (uint32_t i = 0; i < ntiles; ++i) {
+        add_tiles(icb0, icb1, start_itile0 + i, start_itile1 + i, start_idst + i);
+    }
+}
+
+// clang-format off
+/**
+ * Performs element-wise subtraction C=A-B on `ntiles` consecutive tile pairs from two CBs, writing each result to
+ * a consecutive DST register slot. This is the uniform block entry point for the subtract op: its body is a simple
+ * loop over `sub_tiles`, so it inherits `sub_tiles`'s semantics and requires the same initialization
+ * (`sub_tiles_init`) to have been called first. The DST register buffer must be in acquired state via
+ * *acquire_dst* call. This call is blocking and is only available on the compute engine.
+ *
+ * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
+ * (MOPs / REPLAY buffers) by tt-metal#47482 without changing this signature.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                              | Type     | Valid Range                                    | Required |
+ * |-----------------|----------------------------------------------------------|----------|------------------------------------------------|----------|
+ * | icb0            | The identifier of the circular buffer (CB) containing A  | uint32_t | 0 to 31                                        | True     |
+ * | icb1            | The identifier of the circular buffer (CB) containing B  | uint32_t | 0 to 31                                        | True     |
+ * | start_itile0    | The index of the first tile A within the first CB        | uint32_t | Must be less than the size of the CB           | True     |
+ * | start_itile1    | The index of the first tile B within the second CB       | uint32_t | Must be less than the size of the CB           | True     |
+ * | start_idst      | The index of the first tile in DST REG for the result C  | uint32_t | Must be less than the acquired size of DST REG | True     |
+ * | ntiles          | The number of consecutive tile pairs to subtract         | uint32_t | start_idst + ntiles <= acquired DST REG size   | True     |
+ */
+// clang-format on
+ALWI void sub_block(
+    uint32_t icb0, uint32_t icb1, uint32_t start_itile0, uint32_t start_itile1, uint32_t start_idst, uint32_t ntiles) {
+    for (uint32_t i = 0; i < ntiles; ++i) {
+        sub_tiles(icb0, icb1, start_itile0 + i, start_itile1 + i, start_idst + i);
+    }
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -250,7 +250,7 @@ ALWI void sub_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
  * *acquire_dst* call. This call is blocking and is only available on the compute engine.
  *
  * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
- * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * hardware MOP / REPLAY buffer (as is being done for Quasar) so the whole block issues as a single
  * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
  * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47482.
  *
@@ -282,7 +282,7 @@ ALWI void mul_block(
  * is blocking and is only available on the compute engine.
  *
  * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
- * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * hardware MOP / REPLAY buffer (as is being done for Quasar) so the whole block issues as a single
  * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
  * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47482.
  *
@@ -314,7 +314,7 @@ ALWI void add_block(
  * *acquire_dst* call. This call is blocking and is only available on the compute engine.
  *
  * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
- * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * hardware MOP / REPLAY buffer (as is being done for Quasar) so the whole block issues as a single
  * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
  * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47482.
  *

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -20,7 +20,9 @@ namespace ckernel {
 /**
  * Initializes the packer to pack tiles into the specified output circular buffer.
  *
- * Call this function before using `pack_tile` or `pack_block`.
+ * This explicit init is only needed when packing without an op-specific init. `pack_tile` /
+ * `pack_block` do not require it once a preceding op-specific init (`tilize_init`, `reduce_init`,
+ * etc.) has already configured the packer — see the NOTE on `pack_tile`.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -20,7 +20,7 @@ namespace ckernel {
 /**
  * Initializes the packer to pack tiles into the specified output circular buffer.
  *
- * Call this function before using `pack_tile` or `pack_tile_block`.
+ * Call this function before using `pack_tile` or `pack_block`.
  *
  * Return value: None
  *
@@ -96,21 +96,22 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
 // clang-format off
 /**
  * Copies a block of tiles from the DEST register buffer starting at a specified index
- * to a specified circular buffer (CB). The DEST register buffer must be in acquired
+ * to a specified circular buffer (CB). This is the uniform block entry point for the pack
+ * op group. The DEST register buffer must be in acquired
  * state via *acquire_dst* call. This call is blocking and is only available on the
  * compute engine. Before calling this function, cb_reserve_back(n) must be called to
- * reserve at least n > 0 tiles in the output CB. Each call to `pack_tile_block` will
+ * reserve at least n > 0 tiles in the output CB. Each call to `pack_block` will
  * copy `ntiles` tiles from the DEST register to the reserved region of the CB, starting
  * from index 0. The internal write pointer in the CB is advanced by `ntiles` after each
  * call, and is reset by another cb_push_back call. Operates in tandem with functions
  * cb_reserve_back and cb_push_back.
  *
  * A typical use case is for the producer to ensure that there are enough tiles available
- * in the buffer via cb_reserve_back, then use pack_tile_block to copy a block of tiles
+ * in the buffer via cb_reserve_back, then use pack_block to copy a block of tiles
  * from the DEST slots to the reserved space in the CB, and finally call cb_push_back to
  * announce visibility of the reserved section of the circular buffer to the consumer.
  *
- * NOTE: pack_tile_block doesn't need explicit initialization function prior to its call. Other op-specific
+ * NOTE: pack_block doesn't need explicit initialization function prior to its call. Other op-specific
  * initialization functions (such as `tilize_init`, `reduce_init`, etc.) ensure proper initialization
  * of the packer. The reason for this stems from the fact that MATH and PACK threads need to be explicitly
  * synchronized in the kernels. To ensure this synchronization, tile packing is implemented as a separate
@@ -125,13 +126,32 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
  * | Function   | ntiles    | The number of tiles to copy from DEST to CB       | uint32_t | Must be less than the size of the DEST register (16) | True     |
  */
 // clang-format on
-ALWI void pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
+ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
     LLK_SAN_FUNCTION();
 #ifndef ARCH_QUASAR
     PACK((llk_matmul_pack<DST_ACCUM_MODE, false, PackMode::Default>(ifrom_dst, icb, ntiles)));
 #else
     PACK((llk_pack_block(ifrom_dst, icb, ntiles)));
 #endif
+}
+
+// clang-format off
+/**
+ * @deprecated Renamed to `pack_block()`. This forwarding shim is retained only for backwards
+ * compatibility and will be removed after the deprecation grace period (see .github/deprecations.json).
+ *
+ * Return value: None
+ *
+ * | Param Type | Name      | Description                                       | Type     | Valid Range                                          | Required |
+ * |------------|-----------|---------------------------------------------------|----------|------------------------------------------------------|----------|
+ * | Function   | ifrom_dst | The index of the first tile in the DEST register  | uint32_t | Must be less than the size of the DEST register (16) | True     |
+ * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
+ * | Function   | ntiles    | The number of tiles to copy from DEST to CB       | uint32_t | Must be less than the size of the DEST register (16) | True     |
+ */
+// clang-format on
+[[deprecated("Renamed to pack_block().")]] ALWI void pack_tile_block(
+    uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
+    pack_block(ifrom_dst, icb, ntiles);
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -119,6 +119,10 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
  * synchronized in the kernels. To ensure this synchronization, tile packing is implemented as a separate
  * API call.
  *
+ * NOTE: In the future the block pack must be folded further into a hardware MOP / REPLAY buffer (as
+ * already done on Quasar) inside llk-lib, without changing this signature. Tracked under the Compute
+ * API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47480.
+ *
  * Return value: None
  *
  * | Param Type | Name      | Description                                       | Type     | Valid Range                                          | Required |

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -138,7 +138,7 @@ ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
 // clang-format off
 /**
  * @deprecated Renamed to `pack_block()`. This forwarding shim is retained only for backwards
- * compatibility and will be removed after the deprecation grace period (see .github/deprecations.json).
+ * compatibility and will be removed after August 15th, 2026 (see .github/deprecations.json).
  *
  * Return value: None
  *
@@ -149,8 +149,8 @@ ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
  * | Function   | ntiles    | The number of tiles to copy from DEST to CB       | uint32_t | Must be less than the size of the DEST register (16) | True     |
  */
 // clang-format on
-[[deprecated("Renamed to pack_block().")]] ALWI void pack_tile_block(
-    uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
+[[deprecated("Renamed to pack_block(); pack_tile_block will be removed after August 15th, 2026.")]] ALWI void
+pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
     pack_block(ifrom_dst, icb, ntiles);
 }
 

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -120,7 +120,7 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
  * API call.
  *
  * NOTE: In the future the block pack must be folded further into a hardware MOP / REPLAY buffer (as
- * already done on Quasar) inside llk-lib, without changing this signature. Tracked under the Compute
+ * is being done for Quasar) inside llk-lib, without changing this signature. Tracked under the Compute
  * API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47480.
  *
  * Return value: None

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -161,6 +161,46 @@ ALWI void reduce_tile(
 
 // clang-format off
 /**
+ * Performs a reduction operation *B = reduce(A)* on `ntiles` consecutive tiles from the input CB, writing each
+ * partial result to a consecutive DST register slot. This is the uniform block entry point for the reduce op
+ * group: its body is a simple loop over `reduce_tile`, so it inherits `reduce_tile`'s semantics and requires the
+ * same initialization (`reduce_init`) to have been called first. The scaling-factor tile (`itile_scaler`) is reused
+ * for every tile in the block. The DST register buffer must be in acquired state via *acquire_dst* call.
+ *
+ * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
+ * (MOPs / REPLAY buffers) by tt-metal#47478 without changing this signature.
+ * NOTE: Before the next operation is initialized, the `reduce_uninit` function must be called to reset the packer
+ * state to default.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name         | Description                                                      | Type      | Valid Range                                    | Required |
+ * |------------|--------------|------------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type  | The type of reduce op - sum, average or maximum                  | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim   | The dimension of reduce op - row, column or both                 | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Function   | icb          | The identifier of the circular buffer (CB) containing operand A  | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | icb_scaler   | CB holding scaling factors (see reduce_init/reduce_tile)         | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | start_itile  | The index of the first tile within the first CB                  | uint32_t  | Must be less than the size of the CB           | True     |
+ * | Function   | itile_scaler | The index of the tile within the scaling factor CB               | uint32_t  | Must be less than the size of the CB           | True     |
+ * | Function   | start_idst   | The index of the first tile in DST REG for the result            | uint32_t  | Must be less than the acquired size of DST REG | True     |
+ * | Function   | ntiles       | The number of consecutive tiles to reduce                        | uint32_t  | start_idst + ntiles <= acquired DST REG size   | True     |
+ */
+// clang-format on
+template <PoolType reduce_type, ReduceDim reduce_dim>
+ALWI void reduce_block(
+    std::uint32_t icb,
+    std::uint32_t icb_scaler,
+    std::uint32_t start_itile,
+    std::uint32_t itile_scaler,
+    std::uint32_t start_idst,
+    std::uint32_t ntiles) {
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        reduce_tile<reduce_type, reduce_dim>(icb, icb_scaler, start_itile + i, itile_scaler, start_idst + i);
+    }
+}
+
+// clang-format off
+/**
  * Performs a math-only reduction operation on a tile in the DST register. Assumes that source tiles are already in source registers.
  * Naive implementation of reduce_tile_math; assumes that the num_faces are laid out row-wise first. That is:
  *

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -167,8 +167,10 @@ ALWI void reduce_tile(
  * same initialization (`reduce_init`) to have been called first. The scaling-factor tile (`itile_scaler`) is reused
  * for every tile in the block. The DST register buffer must be in acquired state via *acquire_dst* call.
  *
- * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
- * (MOPs / REPLAY buffers) by tt-metal#47478 without changing this signature.
+ * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
+ * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
+ * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47478.
  * NOTE: Before the next operation is initialized, the `reduce_uninit` function must be called to reset the packer
  * state to default.
  *

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -168,7 +168,7 @@ ALWI void reduce_tile(
  * for every tile in the block. The DST register buffer must be in acquired state via *acquire_dst* call.
  *
  * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
- * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * hardware MOP / REPLAY buffer (as is being done for Quasar) so the whole block issues as a single
  * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
  * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47478.
  * NOTE: Before the next operation is initialized, the `reduce_uninit` function must be called to reset the packer

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -125,8 +125,10 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
  * `start_in_tile_index + ntiles` tiles available in the input CB. This call is blocking and is only
  * available on the compute engine.
  *
- * NOTE: The blocking will be pushed further down into llk-lib (MOPs / REPLAY buffers) by
- * tt-metal#47485 without changing this signature.
+ * NOTE: In the future the blocking must be folded further into a hardware MOP / REPLAY buffer (as
+ * already done on Quasar) inside llk-lib, so the whole block issues as a single packed op, without
+ * changing this signature. Tracked under the Compute API Split effort (tt-metal#35739); the per-op
+ * push-down lands in tt-metal#47485.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -115,6 +115,53 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
         dst_tile_index, in_cb_id)));
 }
 
+// clang-format off
+/**
+ * Copies a block of `ntiles` consecutive tiles from the specified input CB into consecutive DST
+ * register slots. This is the uniform block entry point for the copy/datacopy op group: its body is
+ * a simple loop over `copy_tile`, so it inherits `copy_tile`'s semantics (unpack into SRC, move into
+ * DST) and requires the same initialization (`copy_tile_init` / `copy_tile_to_dst_init_short`) to have
+ * been called first. The DST register buffer must be in acquired state via *acquire_dst* call, and
+ * `cb_wait_front(n)` must have made at least `start_in_tile_index + ntiles` tiles available in the
+ * input CB. This call is blocking and is only available on the compute engine.
+ *
+ * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
+ * (MOPs / REPLAY buffers) by tt-metal#47485 without changing this signature.
+ *
+ * Return value: None
+ *
+ * | Argument             | Description                                                | Data type | Valid range                                         | required |
+ * |----------------------|------------------------------------------------------------|-----------|-----------------------------------------------------|----------|
+ * | in_cb_id             | The identifier of the source circular buffer (CB)          | uint32_t  | 0 to 31                                             | True     |
+ * | start_in_tile_index  | The index of the first tile to copy from the input CB      | uint32_t  | Must be less than the size of the CB                | True     |
+ * | start_dst_tile_index | The index of the first destination tile in the DST register| uint32_t  | Must be less than the size of the DST register (16) | True     |
+ * | ntiles               | The number of consecutive tiles to copy                    | uint32_t  | start_dst_tile_index + ntiles <= DST register size  | True     |
+ * */
+// clang-format on
+ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
+    for (uint32_t i = 0; i < ntiles; ++i) {
+        copy_tile(in_cb_id, start_in_tile_index + i, start_dst_tile_index + i);
+    }
+}
+
+// clang-format off
+/**
+ * Copies a block of `ntiles` consecutive tiles from the specified input CB into consecutive DST
+ * register slots, using the block unpack/datacopy llk paths intended for reloading matmul partial
+ * results back into DST. Functionally equivalent to `copy_block`, but retained as a distinct entry
+ * point for the matmul-partials use case. The DST register buffer must be in acquired state via
+ * *acquire_dst* call and requires the same initialization as `copy_tile`.
+ *
+ * Return value: None
+ *
+ * | Argument             | Description                                                | Data type | Valid range                                         | required |
+ * |----------------------|------------------------------------------------------------|-----------|-----------------------------------------------------|----------|
+ * | in_cb_id             | The identifier of the source circular buffer (CB)          | uint32_t  | 0 to 31                                             | True     |
+ * | start_in_tile_index  | The index of the first tile to copy from the input CB      | uint32_t  | Must be less than the size of the CB                | True     |
+ * | start_dst_tile_index | The index of the first destination tile in the DST register| uint32_t  | Must be less than the size of the DST register (16) | True     |
+ * | ntiles               | The number of consecutive tiles to copy                    | uint32_t  | start_dst_tile_index + ntiles <= DST register size  | True     |
+ * */
+// clang-format on
 ALWI void copy_block_matmul_partials(
     uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
 #ifndef ARCH_QUASAR

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -118,15 +118,15 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
 // clang-format off
 /**
  * Copies a block of `ntiles` consecutive tiles from the specified input CB into consecutive DST
- * register slots. This is the uniform block entry point for the copy/datacopy op group: its body is
- * a simple loop over `copy_tile`, so it inherits `copy_tile`'s semantics (unpack into SRC, move into
- * DST) and requires the same initialization (`copy_tile_init` / `copy_tile_to_dst_init_short`) to have
- * been called first. The DST register buffer must be in acquired state via *acquire_dst* call, and
- * `cb_wait_front(n)` must have made at least `start_in_tile_index + ntiles` tiles available in the
- * input CB. This call is blocking and is only available on the compute engine.
+ * register slots. This is the uniform block entry point for the copy/datacopy op group. It uses the
+ * block unpack/datacopy llk paths and requires the same initialization as `copy_tile`
+ * (`copy_tile_init` / `copy_tile_to_dst_init_short`). The DST register buffer must be in acquired
+ * state via *acquire_dst* call, and `cb_wait_front(n)` must have made at least
+ * `start_in_tile_index + ntiles` tiles available in the input CB. This call is blocking and is only
+ * available on the compute engine.
  *
- * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
- * (MOPs / REPLAY buffers) by tt-metal#47485 without changing this signature.
+ * NOTE: The blocking will be pushed further down into llk-lib (MOPs / REPLAY buffers) by
+ * tt-metal#47485 without changing this signature.
  *
  * Return value: None
  *
@@ -139,18 +139,20 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
  * */
 // clang-format on
 ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
-    for (uint32_t i = 0; i < ntiles; ++i) {
-        copy_tile(in_cb_id, start_in_tile_index + i, start_dst_tile_index + i);
-    }
+#ifndef ARCH_QUASAR
+    LLK_SAN_FUNCTION();
+#endif
+    UNPACK((llk_unpack_A_block<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+        in_cb_id, start_in_tile_index, ntiles)));
+    MATH((llk_math_eltwise_unary_datacopy_block<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+        start_dst_tile_index, ntiles, in_cb_id)));
 }
 
 // clang-format off
 /**
- * Copies a block of `ntiles` consecutive tiles from the specified input CB into consecutive DST
- * register slots, using the block unpack/datacopy llk paths intended for reloading matmul partial
- * results back into DST. Functionally equivalent to `copy_block`, but retained as a distinct entry
- * point for the matmul-partials use case. The DST register buffer must be in acquired state via
- * *acquire_dst* call and requires the same initialization as `copy_tile`.
+ * @deprecated Use `copy_block()`, which is functionally equivalent (same block unpack/datacopy paths).
+ * This forwarding shim is retained only for backwards compatibility and will be removed after
+ * August 15th, 2026 (see .github/deprecations.json).
  *
  * Return value: None
  *
@@ -162,15 +164,10 @@ ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t s
  * | ntiles               | The number of consecutive tiles to copy                    | uint32_t  | start_dst_tile_index + ntiles <= DST register size  | True     |
  * */
 // clang-format on
-ALWI void copy_block_matmul_partials(
+[[deprecated("Use copy_block(); copy_block_matmul_partials will be removed after August 15th, 2026.")]] ALWI void
+copy_block_matmul_partials(
     uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
-#ifndef ARCH_QUASAR
-    LLK_SAN_FUNCTION();
-#endif
-    UNPACK((llk_unpack_A_block<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        in_cb_id, start_in_tile_index, ntiles)));
-    MATH((llk_math_eltwise_unary_datacopy_block<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
-        start_dst_tile_index, ntiles, in_cb_id)));
+    copy_block(in_cb_id, start_in_tile_index, start_dst_tile_index, ntiles);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -126,7 +126,7 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
  * available on the compute engine.
  *
  * NOTE: In the future the blocking must be folded further into a hardware MOP / REPLAY buffer (as
- * already done on Quasar) inside llk-lib, so the whole block issues as a single packed op, without
+ * is being done for Quasar) inside llk-lib, so the whole block issues as a single packed op, without
  * changing this signature. Tracked under the Compute API Split effort (tt-metal#35739); the per-op
  * push-down lands in tt-metal#47485.
  *

--- a/tt_metal/hw/inc/api/compute/transpose.h
+++ b/tt_metal/hw/inc/api/compute/transpose.h
@@ -150,8 +150,10 @@ ALWI void transpose_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
  * `compute_kernel_hw_startup(icb, ocb)`) to have been called first. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only available on the compute engine.
  *
- * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
- * (MOPs / REPLAY buffers) by tt-metal#47483 without changing this signature.
+ * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
+ * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
+ * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47483.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/compute/transpose.h
+++ b/tt_metal/hw/inc/api/compute/transpose.h
@@ -141,4 +141,32 @@ ALWI void transpose_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
 #endif
 }
 
+// clang-format off
+/**
+ * Performs a 32x32 transpose operation *B[w,h] = A[h,w]* on `ntiles` consecutive tiles from the input
+ * CB, writing each result to a consecutive DST register slot. This is the uniform block entry point for
+ * the transpose op group: its body is a simple loop over `transpose_tile`, so it inherits
+ * `transpose_tile`'s semantics and requires the same initialization (`transpose_init`, preceded once by
+ * `compute_kernel_hw_startup(icb, ocb)`) to have been called first. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only available on the compute engine.
+ *
+ * NOTE: The loop implementation is transitional. The blocking will be pushed down into llk-lib
+ * (MOPs / REPLAY buffers) by tt-metal#47483 without changing this signature.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                  | Type     | Valid Range                                    | Required |
+ * |----------------|--------------------------------------------------------------|----------|------------------------------------------------|----------|
+ * | icb            | The identifier of the circular buffer (CB) containing A      | uint32_t | 0 to 31                                        | True     |
+ * | start_itile    | The index of the first tile A within the CB                  | uint32_t | Must be less than the size of the CB           | True     |
+ * | start_idst     | The index of the first destination tile in DST REG           | uint32_t | Must be less than the acquired size of DST REG | True     |
+ * | ntiles         | The number of consecutive tiles to transpose                 | uint32_t | start_idst + ntiles <= acquired DST REG size   | True     |
+ */
+// clang-format on
+ALWI void transpose_block(uint32_t icb, uint32_t start_itile, uint32_t start_idst, uint32_t ntiles) {
+    for (uint32_t i = 0; i < ntiles; ++i) {
+        transpose_tile(icb, start_itile + i, start_idst + i);
+    }
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/transpose.h
+++ b/tt_metal/hw/inc/api/compute/transpose.h
@@ -151,7 +151,7 @@ ALWI void transpose_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
  * acquired state via *acquire_dst* call. This call is blocking and is only available on the compute engine.
  *
  * NOTE: The loop implementation is transitional. In the future this for-loop must be folded into a
- * hardware MOP / REPLAY buffer (as already done on Quasar) so the whole block issues as a single
+ * hardware MOP / REPLAY buffer (as is being done for Quasar) so the whole block issues as a single
  * packed op; the blocking then lives in llk-lib without changing this signature. Tracked under the
  * Compute API Split effort (tt-metal#35739); the per-op push-down lands in tt-metal#47483.
  *


### PR DESCRIPTION
Part of #35739 (Compute API Split). Closes #47477.

## What

Adds a uniform per-op-group `op_block` entry point to the Compute API so kernels can adopt a consistent `*_block` surface. The per-op-group follow-ups then push the actual blocking down into llk-lib (MOPs / REPLAY buffers) by swapping **only the wrapper internals** — with zero kernel-side changes.

Pure Compute-API change. Where a group already had a block path, this PR gives it the uniform name and `[[deprecated]]`s the old one (30-day grace; message states removal after **August 15th, 2026**).

## New wrappers (for-loop over `op_tile`, transitional until their follow-up)

| Group | Header | Added | Loops over |
|-------|--------|-------|-----------|
| Reduce | `reduce.h` | `reduce_block` | `reduce_tile` |
| Eltwise binary (FPU) | `eltwise_binary.h` | `add_block`, `sub_block`, `mul_block` | `add_tiles` / `sub_tiles` / `mul_tiles` |
| Transpose | `transpose.h` | `transpose_block` | `transpose_tile` |

Each mirrors its `op_tile` signature with a `start_*` index base plus `ntiles`, requires the same `*_init`, and carries a `NOTE` pointing at the follow-up that will make it performant.

## Renames of existing block paths → uniform name + deprecation shim

These groups already had a performant block path; the uniform-named function inherits that same implementation (no perf regression), and the old name becomes a `[[deprecated]]` forwarding shim (removal after **August 15th, 2026**; grace tracked in `.github/deprecations.json`):

| Old name | New name | Header |
|----------|----------|--------|
| `pack_tile_block` | `pack_block` | `pack.h` |
| `copy_block_matmul_partials` | `copy_block` | `tile_move_copy.h` |

In-tree call sites are intentionally left untouched — the JIT kernel build sets `-Wno-error=deprecated-declarations`, so kernels stay green; the warnings only nudge migration.

## Groups already uniform (unchanged)

`matmul_block`, `tilize_block` / `fast_tilize_block`, `untilize_block`, `pack_untilize_block`.

## Naming notes

- **Transpose** → `transpose_block` in `transpose.h`. Issue text says `transpose_wh_block`, but the `_wh` suffix was already dropped on `main` (`transpose_wh.h` is now a `[[deprecated]]` shim). The wrapper follows the current convention next to `transpose_tile`.
- Bcast (`add_tiles_bcast`, …) and the DEST transpose variant are folded in by the eltwise-binary / transpose follow-ups (#47482 / #47483). Experimental block variants (`matmul_block_no_mop`, `pack_block_contiguous`, `fast_untilize_block`) are Tier-2 and out of scope; they will be folded into their core op under #47554.

## Docs

`.rst` pages under `docs/.../kernel_apis/` document each new wrapper (`add_block`, `sub_block`, `mul_block`, `reduce_block`, `transpose_block`, `copy_block`, `pack_block`) on its op page.

## Follow-ups that swap these internals (no signature/kernel changes)

- #47478 Reduce · #47480 Pack · #47482 Eltwise binary · #47483 Transpose · #47485 Copy/datacopy

## Testing

- New `unit_tests_llk` coverage: `TensixComputeCopyPackBlock{Multiple,ComputeBottleneck}` (exercise `copy_block` + `pack_block`) — pass bit-exact on WH B0 across `fp32_dest_acc_en` / `dst_full_sync_en` and block shapes; existing `copy_block_matmul_partials` / `pack_tile_block` tests (now hitting the shims) also pass.
- CI validation (Sanity + Nightly L2) posted below: every PR-touched category green on WH+BH; all reds reproduced on the scheduled-`main` baseline.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/compute-api-op-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/compute-api-op-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/compute-api-op-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/compute-api-op-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/compute-api-op-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/compute-api-op-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/compute-api-op-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/compute-api-op-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/compute-api-op-block)