### PR TITLE
Test Only: improve Quasar LLK test infrastructure

### DIFF
--- a/tt_metal/tt-llk/.cursor/scripts/run_test.sh
+++ b/tt_metal/tt-llk/.cursor/scripts/run_test.sh
@@ -37,6 +37,9 @@
 #   --lock-timeout N  Seconds to wait for the lock (default: 900)
 #   --sim-path PATH   Override TT_UMD_SIMULATOR_PATH
 #                     (default: /proj_sw/user_dev/$USER/tt-umd-simulators/build/emu-<arch>-1x3)
+#   --reuse-simulator-server
+#                     Quasar only. Connect to an existing tt-exalens server on
+#                     --port instead of letting pytest own the simulator.
 #   --no-split        Skip compile-producer step; run pytest --run-simulator without
 #                     --compile-consumer (combined compile+run in one pytest invocation).
 #                     Use for issue-solver tests that don't pre-build ELFs.
@@ -97,6 +100,7 @@ JOBS="15"
 LOCKFILE=""  # set in _validate based on ARCH if not user-overridden
 LOCK_TIMEOUT="900"
 SIM_PATH=""
+REUSE_SIMULATOR_SERVER="false"
 NO_SPLIT="false"
 LOG_DIR=""
 VERBOSE="false"
@@ -115,6 +119,7 @@ while [[ $# -gt 0 ]]; do
     --lock)          LOCKFILE="$2";      shift 2 ;;
     --lock-timeout)  LOCK_TIMEOUT="$2";  shift 2 ;;
     --sim-path)      SIM_PATH="$2";      shift 2 ;;
+    --reuse-simulator-server) REUSE_SIMULATOR_SERVER="true"; shift ;;
     --log-dir)       LOG_DIR="$2";       shift 2 ;;
     --no-split)      NO_SPLIT="true";    shift   ;;
     --verbose|-v)    VERBOSE="true";     shift   ;;
@@ -218,6 +223,11 @@ _validate() {
     blackhole|wormhole)  MODE="hardware"  ;;
     *)                   MODE="simulator" ;;
   esac
+
+  if [[ "$REUSE_SIMULATOR_SERVER" == "true" && "$ARCH" != "quasar" ]]; then
+    echo "ERROR: --reuse-simulator-server is only supported for arch=quasar" >&2
+    exit 4
+  fi
 }
 
 # ── count ─────────────────────────────────────────────────────────────────────
@@ -296,7 +306,9 @@ _do_compile() {
 _do_simulate() {
   _validate
   if [[ "$MODE" == "simulator" ]]; then
-    _vlog "consume: $(_test_label) (arch=${ARCH}, mode=simulator, port=${PORT})"
+    local reuse_note=""
+    [[ "$REUSE_SIMULATOR_SERVER" == "true" ]] && reuse_note=", reuse-server=true"
+    _vlog "consume: $(_test_label) (arch=${ARCH}, mode=simulator, port=${PORT}${reuse_note})"
   else
     _vlog "consume: $(_test_label) (arch=${ARCH}, mode=hardware)"
   fi
@@ -319,6 +331,7 @@ _do_simulate() {
   local pytest_flags="--timeout=${TIMEOUT} -rN"
   if [[ "$MODE" == "simulator" ]]; then
     pytest_flags="${pytest_flags} --run-simulator --port=${PORT}"
+    [[ "$REUSE_SIMULATOR_SERVER" == "true" ]] && pytest_flags="${pytest_flags} --reuse-simulator-server"
   fi
   [[ "$NO_SPLIT" == "false" ]] && pytest_flags="${pytest_flags} --compile-consumer"
   [[ -n "$MAXFAIL" ]] && pytest_flags="${pytest_flags} --maxfail=${MAXFAIL}"
@@ -336,16 +349,16 @@ _do_simulate() {
     pytest_target="$(_quote_args "${TEST_FILES[@]}")"
   fi
 
-  # Write the consumer script. Simulator mode prepends port-cleanup and the
-  # TT_UMD_SIMULATOR_PATH env var; hardware mode skips both since BH/WH run
-  # against silicon directly.
+  # Write the consumer script. Owned simulator mode prepends port cleanup and
+  # all simulator modes set TT_UMD_SIMULATOR_PATH. Hardware mode skips both
+  # since BH/WH run against silicon directly.
   # Single-quotes around variable expansions are intentional: the values are
   # fixed at script-write time and contain no shell-special chars that matter
   # to the inner bash invocation.
   {
     printf '#!/bin/bash\n'
     printf 'set -u\n\n'
-    if [[ "$MODE" == "simulator" ]]; then
+    if [[ "$MODE" == "simulator" && "$REUSE_SIMULATOR_SERVER" != "true" ]]; then
       printf '# Kill any process holding port %s\n' "${PORT}"
       printf 'STALE=$(lsof -ti :%s 2>/dev/null || true)\n' "${PORT}"
       printf 'if [ -n "$STALE" ]; then\n'

--- a/tt_metal/tt-llk/.cursor/scripts/run_test.sh
+++ b/tt_metal/tt-llk/.cursor/scripts/run_test.sh
@@ -6,7 +6,7 @@
 # have to manage any of that themselves.
 #
 # Usage:
-#   run_llk_tests.sh <COMMAND> --worktree DIR --arch ARCH --test FILE [OPTIONS]
+#   run_llk_tests.sh <COMMAND> --worktree DIR --arch ARCH --test FILE [FILE ...] [OPTIONS]
 #
 # Commands:
 #   count     Count test variants (collection-only; outputs integer to stdout)
@@ -19,7 +19,9 @@
 #   --worktree DIR    Absolute path to the LLK working directory
 #                     (contains tests/ and tt_llk_<arch>/ as direct children)
 #   --arch     ARCH   Target architecture (quasar, blackhole, ...)
-#   --test     FILE   Test file name, e.g. test_sfpu_square_quasar.py
+#   --test     FILE   Test file name, e.g. test_sfpu_square_quasar.py.
+#                    Additional trailing test file names are accepted for
+#                    count/compile/simulate/run.
 #
 # Optional:
 #   --maxfail  N      Stop after N failures (simulate/run; omit for verification)
@@ -85,6 +87,7 @@ shift 2>/dev/null || true
 WORKTREE=""
 ARCH=""
 TEST_FILE=""
+TEST_FILES=()
 MAXFAIL=""
 K_FILTER=""
 TEST_ID=""
@@ -102,7 +105,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --worktree)      WORKTREE="$2";      shift 2 ;;
     --arch)          ARCH="$2";          shift 2 ;;
-    --test)          TEST_FILE="$2";     shift 2 ;;
+    --test)          TEST_FILE="$2"; TEST_FILES+=("$2"); shift 2 ;;
     --maxfail)       MAXFAIL="$2";       shift 2 ;;
     --k)             K_FILTER="$2";      shift 2 ;;
     --test-id)       TEST_ID="$2";       shift 2 ;;
@@ -120,9 +123,14 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      echo "ERROR: Unknown option: $1" >&2
-      echo "Run with --help for usage." >&2
-      exit 4
+      if [[ "$1" == -* ]]; then
+        echo "ERROR: Unknown option: $1" >&2
+        echo "Run with --help for usage." >&2
+        exit 4
+      fi
+      TEST_FILES+=("$1")
+      [[ -z "$TEST_FILE" ]] && TEST_FILE="$1"
+      shift
       ;;
   esac
 done
@@ -135,14 +143,34 @@ _vlog() {
   fi
 }
 
+_quote_args() {
+  local out="" quoted arg
+  for arg in "$@"; do
+    printf -v quoted '%q' "$arg"
+    out+="${quoted} "
+  done
+  printf '%s' "${out% }"
+}
+
+_test_label() {
+  local joined
+  printf -v joined '%s, ' "${TEST_FILES[@]}"
+  printf '%s' "${joined%, }"
+}
+
 # Validate required args and derive VENV, TEST_DIR, SIM_PATH.
 # Sets these as script-global variables; exits on any problem.
 _validate() {
   local errors=0
   [[ -z "$WORKTREE"  ]] && { echo "ERROR: --worktree is required" >&2; ((errors++)); }
   [[ -z "$ARCH"      ]] && { echo "ERROR: --arch is required"     >&2; ((errors++)); }
-  [[ -z "$TEST_FILE" ]] && { echo "ERROR: --test is required"     >&2; ((errors++)); }
+  [[ ${#TEST_FILES[@]} -eq 0 ]] && { echo "ERROR: --test is required"     >&2; ((errors++)); }
+  [[ -n "$TEST_ID" && ${#TEST_FILES[@]} -gt 1 ]] && {
+    echo "ERROR: --test-id can only be used with one test file" >&2
+    ((errors++))
+  }
   [[ $errors -gt 0 ]] && exit 4
+  TEST_FILE="${TEST_FILES[0]}"
 
   VENV="${WORKTREE}/tests/.venv"
   # Test layout is arch-dependent:
@@ -163,12 +191,15 @@ _validate() {
     echo "ERROR: test directory not found: ${TEST_DIR}" >&2
     exit 3
   fi
-  if [[ ! -f "${TEST_DIR}/${TEST_FILE}" ]]; then
-    echo "ERROR: test file not found: ${TEST_DIR}/${TEST_FILE}" >&2
-    echo "       Hint: blackhole/wormhole tests live at tests/python_tests/," >&2
-    echo "             quasar tests live at tests/python_tests/quasar/." >&2
-    exit 3
-  fi
+  local test_file
+  for test_file in "${TEST_FILES[@]}"; do
+    if [[ ! -f "${TEST_DIR}/${test_file}" ]]; then
+      echo "ERROR: test file not found: ${TEST_DIR}/${test_file}" >&2
+      echo "       Hint: blackhole/wormhole tests live at tests/python_tests/," >&2
+      echo "             quasar tests live at tests/python_tests/quasar/." >&2
+      exit 3
+    fi
+  done
 
   if [[ -z "$SIM_PATH" ]]; then
     SIM_PATH="/proj_sw/user_dev/${USER}/tt-umd-simulators/build/emu-${ARCH}-1x3"
@@ -196,7 +227,7 @@ _validate() {
 
 _do_count() {
   _validate
-  _vlog "count: ${TEST_FILE} (arch=${ARCH})"
+  _vlog "count: $(_test_label) (arch=${ARCH})"
 
   local output exit_code
   exit_code=0
@@ -204,7 +235,7 @@ _do_count() {
     # shellcheck disable=SC1091
     source "${VENV}/bin/activate"
     cd "${TEST_DIR}"
-    CHIP_ARCH="${ARCH}" pytest --compile-producer --co -q "${TEST_FILE}" 2>&1
+    CHIP_ARCH="${ARCH}" pytest --compile-producer --co -q "${TEST_FILES[@]}" 2>&1
   ) || exit_code=$?
 
   # Show collection log to the agent (stderr stays visible in Bash tool output)
@@ -228,7 +259,7 @@ _do_count() {
 
 _do_compile() {
   _validate
-  _vlog "compile: ${TEST_FILE} (arch=${ARCH}, -n ${JOBS}${K_FILTER:+, -k '${K_FILTER}'})"
+  _vlog "compile: $(_test_label) (arch=${ARCH}, -n ${JOBS}${K_FILTER:+, -k '${K_FILTER}'})"
 
   # The two-phase flow requires compile and simulate to filter to the same set:
   # simulate's --compile-consumer reads per-variant artifacts that producer
@@ -243,14 +274,14 @@ _do_compile() {
       # shellcheck disable=SC1091
       source "${VENV}/bin/activate"
       cd "${TEST_DIR}"
-      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${kflag[@]}" "${TEST_FILE}"
+      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${kflag[@]}" "${TEST_FILES[@]}"
     ) > >(tee -a "${LOG_DIR}/compile.log") 2> >(tee -a "${LOG_DIR}/compile.log" >&2)
   else
     (
       # shellcheck disable=SC1091
       source "${VENV}/bin/activate"
       cd "${TEST_DIR}"
-      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${kflag[@]}" "${TEST_FILE}"
+      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${kflag[@]}" "${TEST_FILES[@]}"
     )
   fi
 }
@@ -265,9 +296,9 @@ _do_compile() {
 _do_simulate() {
   _validate
   if [[ "$MODE" == "simulator" ]]; then
-    _vlog "consume: ${TEST_FILE} (arch=${ARCH}, mode=simulator, port=${PORT})"
+    _vlog "consume: $(_test_label) (arch=${ARCH}, mode=simulator, port=${PORT})"
   else
-    _vlog "consume: ${TEST_FILE} (arch=${ARCH}, mode=hardware)"
+    _vlog "consume: $(_test_label) (arch=${ARCH}, mode=hardware)"
   fi
 
   # Remove temp scripts left by runs that died before their trap fired
@@ -300,9 +331,9 @@ _do_simulate() {
   elif [[ -n "$K_FILTER" ]]; then
     local quoted_k
     printf -v quoted_k '%q' "${K_FILTER}"
-    pytest_target="-k ${quoted_k} '${TEST_FILE}'"
+    pytest_target="-k ${quoted_k} $(_quote_args "${TEST_FILES[@]}")"
   else
-    pytest_target="'${TEST_FILE}'"
+    pytest_target="$(_quote_args "${TEST_FILES[@]}")"
   fi
 
   # Write the consumer script. Simulator mode prepends port-cleanup and the
@@ -378,7 +409,7 @@ _do_simulate() {
 
 _do_run() {
   _validate
-  _vlog "run ($([ "$NO_SPLIT" = true ] && echo combined || echo compile+simulate)): ${TEST_FILE} (arch=${ARCH})"
+  _vlog "run ($([ "$NO_SPLIT" = true ] && echo combined || echo compile+simulate)): $(_test_label) (arch=${ARCH})"
 
   if [[ "$NO_SPLIT" == "false" ]]; then
     _do_compile

--- a/tt_metal/tt-llk/docs/tests/reusable_simulator_server.md
+++ b/tt_metal/tt-llk/docs/tests/reusable_simulator_server.md
@@ -1,0 +1,294 @@
+# Reusing a tt-exalens Simulator Server for LLK Pytest Runs
+
+This guide explains how to keep one RTL simulator-backed `tt-exalens` server
+running and use separate short `pytest` invocations to run LLK tests against it.
+This is useful when simulator startup dominates iteration time.
+
+The standard `pytest --run-simulator` flow owns the whole simulator lifecycle:
+
+1. `pytest` starts `tt-exalens`.
+2. `pytest` waits until the simulator is ready.
+3. The test runs.
+4. `pytest` stops `tt-exalens` during session teardown.
+
+That is simple and safe, but each new `pytest` command pays the full simulator
+startup cost. The reusable server flow splits the owner process from the client
+process:
+
+1. One terminal starts `tt-exalens --server` and leaves it running.
+2. Another terminal runs `pytest --run-simulator --reuse-simulator-server`.
+3. Each pytest process connects to the existing server and exits without
+   stopping it.
+4. You stop `tt-exalens` manually when done.
+
+## When to Use This
+
+Use this flow for tight development loops where you repeatedly run the same LLK
+test or a small set of tests on the same simulator instance.
+
+Good examples:
+
+- Performance microbenchmarks.
+- Debugging one test while changing Python or C++ test code.
+- Running many short pytest invocations where the simulator state is known to be
+  clean enough between runs.
+
+Avoid this flow when:
+
+- You need a fresh simulator process for every test.
+- The test leaves persistent device state that affects later test runs.
+- You are using ttsim through a `.so` simulator path. Reuse mode is for the RTL
+  `tt-exalens --server` flow, not in-process ttsim.
+- You need `--reset-simulator-per-test`.
+
+## Required Environment Variables
+
+Set these in every terminal involved in the flow unless your shell startup
+already exports them.
+
+```bash
+export CHIP_ARCH=quasar
+export TT_METAL_SIMULATOR="/proj_sw/user_dev/${USER}/tt-umd-simulators/build/emu-quasar-1x3/"
+export TT_UMD_SIMULATOR_PATH="$TT_METAL_SIMULATOR"
+export NNG_SOCKET_ADDR="tcp://tensix-l-01:54948"
+export NNG_SOCKET_LOCAL_PORT=5555
+```
+
+Variable meanings:
+
+- `CHIP_ARCH` selects the LLK architecture. For Quasar tests, use `quasar`.
+- `TT_METAL_SIMULATOR` is the simulator build path used by the LLK test harness.
+  For this reuse flow it should point to an RTL simulator directory, not a `.so`.
+- `TT_UMD_SIMULATOR_PATH` is accepted as an older alias. Keeping it equal to
+  `TT_METAL_SIMULATOR` is useful for compatibility with existing scripts.
+- `NNG_SOCKET_ADDR` is the NNG endpoint used by the simulator environment.
+- `NNG_SOCKET_LOCAL_PORT` is the local NNG port used by `tt-exalens`.
+
+`LLK_HOME` is normally initialized by the pytest harness if it is not already
+set, so you usually do not need to export it manually.
+
+The `--port` pytest option and `tt-exalens --port` value are the remote
+`tt-exalens` server port. This is separate from `NNG_SOCKET_LOCAL_PORT`.
+
+## One-Time Setup in Each Terminal
+
+From the repository root or any LLK test directory:
+
+```bash
+export CHIP_ARCH=quasar
+export TT_METAL_SIMULATOR="/proj_sw/user_dev/${USER}/tt-umd-simulators/build/emu-quasar-1x3/"
+export TT_UMD_SIMULATOR_PATH="$TT_METAL_SIMULATOR"
+export NNG_SOCKET_ADDR="tcp://tensix-l-01:54948"
+export NNG_SOCKET_LOCAL_PORT=5555
+```
+
+Then go to the Python tests directory containing the test you want to run. For
+example:
+
+```bash
+cd /proj_sw/user_dev/${USER}/tt-metal/tt_metal/tt-llk/tests/python_tests/quasar
+```
+
+## Terminal 1: Start the Reusable Server
+
+Start `tt-exalens` manually and leave this terminal running:
+
+```bash
+tt-exalens --port=5556 --server -s "$TT_METAL_SIMULATOR"
+```
+
+Wait until the output shows the simulator is ready. The ready marker currently
+includes:
+
+```text
+[4B MODE]
+```
+
+Keep this process running while you use reuse mode from another terminal.
+
+## Terminal 2: Run Pytest Clients
+
+Run the test with `--reuse-simulator-server` and the same port:
+
+```bash
+pytest -x --run-simulator --reuse-simulator-server --port=5556 \
+  perf_sfpu_nop_quasar.py -vv
+```
+
+You can run the same command repeatedly. Each invocation is a new pytest process,
+but it connects to the same long-lived `tt-exalens` server.
+
+Expected pytest log shape:
+
+```text
+Connecting to existing tt-exalens server (port=5556)...
+```
+
+You should not see pytest logs like these in reuse mode:
+
+```text
+Starting tt-exalens server ...
+Stopping tt-exalens ...
+```
+
+Those messages belong to the normal owned mode.
+
+## Comparing Normal Mode and Reuse Mode
+
+Normal owned mode:
+
+```bash
+pytest -x --run-simulator --port=5556 perf_sfpu_nop_quasar.py -vv
+```
+
+Use this when you want pytest to start and stop the simulator automatically.
+
+Reusable server mode:
+
+```bash
+# Terminal 1
+tt-exalens --port=5556 --server -s "$TT_METAL_SIMULATOR"
+
+# Terminal 2
+pytest -x --run-simulator --reuse-simulator-server --port=5556 \
+  perf_sfpu_nop_quasar.py -vv
+```
+
+Use this when you want to avoid restarting the simulator for every pytest
+command.
+
+Do not run normal owned mode on the same port while a reusable server is active.
+The normal owner path intentionally cleans up stale `tt-exalens` processes on
+the selected port before starting a new one.
+
+## Running Multiple Repetitions
+
+If you only need to repeat the same test within one pytest process, you can also
+use `pytest-repeat`:
+
+```bash
+pytest -x --run-simulator --reuse-simulator-server --port=5556 \
+  --count=10 perf_sfpu_nop_quasar.py -vv
+```
+
+This still uses the long-lived external server, but it keeps the repeated test
+executions inside one pytest session.
+
+## Stopping tt-exalens When Done
+
+The reusable server is externally managed, so pytest will not stop it. Stop it
+from the terminal that started it by pressing `Ctrl+C`.
+
+If the server does not exit, find it:
+
+```bash
+pgrep -af "tt-exalens.*--port=5556"
+```
+
+Terminate it gracefully:
+
+```bash
+pkill -TERM -f "[t]t-exalens --port=5556 --server"
+```
+
+Check whether anything remains:
+
+```bash
+pgrep -af "tt-exalens|emu-quasar-1x3"
+```
+
+If a simulator child process remains after `tt-exalens` exits, terminate it by
+PID:
+
+```bash
+kill -TERM <pid>
+```
+
+If it still does not stop after a short wait:
+
+```bash
+kill -KILL <pid>
+```
+
+Use `SIGKILL` only as a last resort because it does not give the process a
+chance to clean up.
+
+## Supported and Unsupported Flag Combinations
+
+Required:
+
+```bash
+--run-simulator --reuse-simulator-server
+```
+
+Unsupported:
+
+```bash
+--reuse-simulator-server
+```
+
+Reuse mode requires `--run-simulator`.
+
+```bash
+--run-simulator --reuse-simulator-server --reset-simulator-per-test
+```
+
+Reuse mode cannot reset the simulator between tests because pytest does not own
+the external `tt-exalens` server.
+
+Reuse mode is also unsupported when `TT_METAL_SIMULATOR` points to a `.so`
+ttsim library. In-process ttsim does not use `ExalensServer`.
+
+## Troubleshooting
+
+### Pytest Cannot Connect
+
+Check that the server is running on the same port:
+
+```bash
+pgrep -af "tt-exalens.*--port=5556"
+```
+
+Make sure the pytest command uses the same port:
+
+```bash
+pytest --run-simulator --reuse-simulator-server --port=5556 ...
+```
+
+Also confirm both terminals have the same simulator environment:
+
+```bash
+printf 'CHIP_ARCH=%s\nTT_METAL_SIMULATOR=%s\nTT_UMD_SIMULATOR_PATH=%s\nNNG_SOCKET_ADDR=%s\nNNG_SOCKET_LOCAL_PORT=%s\n' \
+  "$CHIP_ARCH" \
+  "$TT_METAL_SIMULATOR" \
+  "$TT_UMD_SIMULATOR_PATH" \
+  "$NNG_SOCKET_ADDR" \
+  "$NNG_SOCKET_LOCAL_PORT"
+```
+
+### Pytest Starts tt-exalens Anyway
+
+Check that the pytest command includes:
+
+```bash
+--reuse-simulator-server
+```
+
+Without that flag, `pytest --run-simulator` uses the normal owner mode and will
+start and stop `tt-exalens` itself.
+
+### A Later Run Behaves Differently
+
+The simulator process is reused, so persistent simulator state can matter. If a
+test looks stateful or flaky, stop the external server and start a fresh one:
+
+```bash
+pkill -TERM -f "[t]t-exalens --port=5556 --server"
+tt-exalens --port=5556 --server -s "$TT_METAL_SIMULATOR"
+```
+
+For tests that require isolation, use normal owned mode instead:
+
+```bash
+pytest -x --run-simulator --port=5556 perf_sfpu_nop_quasar.py -vv
+```

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import atexit
@@ -51,6 +51,7 @@ from ttexalens import check_context, tt_exalens_init
 from ttexalens.tt_exalens_lib import get_tensix_state
 
 _exalens_server: Optional[ExalensServer] = None
+_reuse_simulator_connected = False
 
 
 # This is a workaround for this issue: https://github.com/tenstorrent/tt-exalens/issues/958
@@ -146,6 +147,13 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Restart the tt-exalens server after each test. "
+        "Only effective with --run-simulator.",
+    )
+    parser.addoption(
+        "--reuse-simulator-server",
+        action="store_true",
+        default=False,
+        help="Connect to an existing tt-exalens server instead of starting one. "
         "Only effective with --run-simulator.",
     )
 
@@ -380,6 +388,25 @@ def pytest_configure(config):
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
 
+    if (
+        TestConfig.TEST_TARGET.reuse_simulator_server
+        and not TestConfig.TEST_TARGET.run_simulator
+    ):
+        pytest.exit(
+            "ERROR: --reuse-simulator-server requires --run-simulator.",
+            returncode=1,
+        )
+
+    if (
+        TestConfig.TEST_TARGET.reuse_simulator_server
+        and TestConfig.TEST_TARGET.reset_simulator_per_test
+    ):
+        pytest.exit(
+            "ERROR: --reuse-simulator-server cannot be used with "
+            "--reset-simulator-per-test.",
+            returncode=1,
+        )
+
     if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
         if TestConfig.TEST_TARGET.run_simulator:
             if _SIMULATOR_PATH is None:
@@ -393,13 +420,21 @@ def pytest_configure(config):
                 # ttsim: already initialized at module import above; runs in-process, no server.
                 # --reset-simulator-per-test restarts the ExalensServer, which ttsim doesn't use,
                 # so it would be a silent no-op. Fail fast to avoid confusing false-green runs.
+                if TestConfig.TEST_TARGET.reuse_simulator_server:
+                    pytest.exit(
+                        "ERROR: --reuse-simulator-server is not supported with ttsim. "
+                        "Re-run without it.",
+                        returncode=1,
+                    )
                 if TestConfig.TEST_TARGET.reset_simulator_per_test:
                     pytest.exit(
                         "ERROR: --reset-simulator-per-test is not supported with ttsim. "
                         "Re-run without it.",
                         returncode=1,
                     )
-            elif not hasattr(config, "workerinput"):
+            elif not TestConfig.TEST_TARGET.reuse_simulator_server and not hasattr(
+                config, "workerinput"
+            ):
                 # RTL simulator: only the controller process manages the server; xdist workers
                 # just connect to the already-running instance.
                 global _exalens_server
@@ -411,53 +446,7 @@ def pytest_configure(config):
             tt_exalens_init.init_ttexalens(use_4B_mode=False)
 
 
-def pytest_ignore_collect(collection_path, config):
-    # Skip collecting the quasar/ dir on non-quasar arch — those tests are
-    # deselected there anyway, so there's no need to collect them.
-    if (
-        get_chip_architecture() != ChipArchitecture.QUASAR
-        and "quasar" in collection_path.parts
-    ):
-        return True
-    return None
-
-
-def _collapse_runtime_only_variants(config, items):
-    """Keep only one test per unique compile key, dropping runtime only duplicates.
-
-    Tests decorated with ``@parametrize`` that use ``runtime()`` markers carry a
-    ``compile_key_fn`` on their ``runtime_axes`` pytest mark.  That function extracts
-    the compile time subset of each item's params.  Items that share the same compile
-    key produce identical ELFs, so only the first is kept for the compile-producer pass.
-    """
-    from helpers.param_config import RUNTIME_AXES_MARK
-
-    seen = set()
-    keep = []
-    deselected = []
-    for item in items:
-        marker = item.get_closest_marker(RUNTIME_AXES_MARK)
-        if marker is None:
-            keep.append(item)
-            continue
-        compile_key_fn = marker.kwargs["compile_key_fn"]
-        key = (item.nodeid.split("[")[0], repr(compile_key_fn(item.callspec.params)))
-        if key not in seen:
-            seen.add(key)
-            keep.append(item)
-        else:
-            deselected.append(item)
-
-    if deselected:
-        config.hook.pytest_deselected(items=deselected)
-        items[:] = keep
-
-
-@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
-    if TestConfig.BUILD_MODE == BuildMode.PRODUCE and not TestConfig.SPEED_OF_LIGHT:
-        _collapse_runtime_only_variants(config, items)
-
     test_order_file = config.getoption("--test-order-file")
 
     if not test_order_file:
@@ -682,6 +671,22 @@ def pytest_runtest_makereport(item, call):
 _reset_simulator_pending = False
 
 
+def _init_reused_simulator_remote() -> None:
+    """Connect this pytest process to an externally managed tt-exalens server."""
+    global _reuse_simulator_connected
+    if _reuse_simulator_connected:
+        return
+
+    logger.info(
+        "Connecting to existing tt-exalens server (port={})...",
+        TestConfig.TEST_TARGET.simulator_port,
+    )
+    tt_exalens_init.init_ttexalens_remote(
+        port=TestConfig.TEST_TARGET.simulator_port, use_4B_mode=False
+    )
+    _reuse_simulator_connected = True
+
+
 def pytest_runtest_teardown(item, nextitem):
     """Mark that a restart is needed before the next test."""
     if not TestConfig.TEST_TARGET.reset_simulator_per_test:
@@ -699,6 +704,10 @@ def pytest_runtest_teardown(item, nextitem):
 def pytest_runtest_setup(item):
     """Start the server on the first test, or restart between tests if requested."""
     global _exalens_server, _reset_simulator_pending
+
+    if TestConfig.TEST_TARGET.reuse_simulator_server:
+        _init_reused_simulator_remote()
+        return
 
     if _exalens_server is None:
         return
@@ -750,10 +759,6 @@ def counter_report(request, worker_id):
     if PerfConfig.TEST_COUNTER == 0:
         return
 
-    temp_report.assert_single_schema(
-        context=f"{test_module} counters (worker {worker_id})"
-    )
-
     counters_path = TestConfig.PERF_DATA_DIR / f"{test_module}.{worker_id}.counters.csv"
 
     if counters_path.exists():
@@ -779,11 +784,6 @@ def perf_report(request, worker_id):
 
     if PerfConfig.TEST_COUNTER == 0:
         return
-
-    # Fail loud before writing: a single CSV must hold exactly one column schema.
-    # More than one means two unrelated tests/ops share this module (split them
-    # into separate files) or one test emits inconsistent columns across its sweep.
-    temp_report.assert_single_schema(context=f"{test_module} (worker {worker_id})")
 
     raw_path = TestConfig.PERF_DATA_DIR / f"{test_module}.{worker_id}.csv"
     post_path = TestConfig.PERF_DATA_DIR / f"{test_module}.{worker_id}.post.csv"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/target_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/target_config.py
@@ -35,6 +35,7 @@ class TestTargetConfig:
             self.device_id: int = device_id
             self.log_level: str = log_level
             self.reset_simulator_per_test: bool = False
+            self.reuse_simulator_server: bool = False
             TestTargetConfig._initialized = True
 
     def update_from_pytest_config(self, config):
@@ -43,4 +44,7 @@ class TestTargetConfig:
         self.simulator_port = config.getoption("--port", default=5555)
         self.reset_simulator_per_test = config.getoption(
             "--reset-simulator-per-test", default=False
+        )
+        self.reuse_simulator_server = config.getoption(
+            "--reuse-simulator-server", default=False
         )


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Improves the LLK Quasar test workflow by adding support for reusable `tt-exalens` simulator servers and updating `.cursor/scripts/run_test.sh` so `count`, `compile`, `simulate`, and `run` can operate on multiple Python test files instead of only one `--test` file per invocation.

The reusable simulator flow lets developers keep one RTL-backed `tt-exalens` server alive across short pytest runs, avoiding repeated simulator startup cost during tight iteration loops. The runner update lets developers pass a small set of test files through one command, sharing setup and compile/simulate orchestration across those files.

Closes #49077 #49078

### Notes for reviewers
Please focus on the simulator ownership split in `tests/python_tests/conftest.py`: normal `--run-simulator` still owns and stops `tt-exalens`, while `--reuse-simulator-server` only connects to an externally managed server and rejects unsupported combinations with ttsim or `--reset-simulator-per-test`.

Also review the parsing, quoting, and validation in `.cursor/scripts/run_test.sh` for multi-file inputs. The script now accepts additional test files after `--test`, forwards every selected file to pytest for count/compile/simulate/run, and keeps `--test-id` restricted to a single test file.

Validation was manual from branch inspection; I did not run the Quasar simulator flow in this session.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/improve_quasar_test_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/improve_quasar_test_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/improve_quasar_test_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/improve_quasar_test_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/improve_quasar_test_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/improve_quasar_test_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/improve_quasar_test_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/improve_quasar_test_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/improve_quasar_test_infra)