### PR TITLE
[Feature] Store SFPU accuracy results as Parquet

### DIFF
--- a/tt_metal/tt-llk/docs/tests/accuracy_tests.md
+++ b/tt_metal/tt-llk/docs/tests/accuracy_tests.md
@@ -1,0 +1,58 @@
+# SFPU Accuracy Tests
+
+The accuracy suite sweeps SFPU ops across their input domain on hardware
+(Wormhole and Blackhole only), compares each result against a torch golden
+reference, and writes a per-op file of golden-vs-hardware error data. Use it to
+see how accurate an op is across its range, in absolute, relative, and ULP
+error.
+
+The tests live in `tests/python_tests/accuracy/`.
+
+## Running
+
+These are ordinary pytest tests. Just set the device arch via `CHIP_ARCH`.
+The examples below use paths relative to `tests/python_tests/` and `CHIP_ARCH = wormhole`.
+
+```bash
+# one op
+CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py -k Reciprocal -s
+
+# runs every op in the given test file
+CHIP_ARCH=wormhole pytest accuracy/test_examples_accuracy.py -s
+```
+
+## Output
+
+Results go to `accuracy/_csv_output/<arch>/` (e.g. `wh/`, `bh/`), one file per op
+(`exp.parquet`, `reciprocal.parquet`, ...). Each run clears the intermediate
+shards, then rewrites only the ops in that run — so a partial run leaves other
+ops' files untouched and you can build up the results incrementally. To start
+fresh, delete `accuracy/_csv_output/`.
+
+### File format: Parquet by default, CSV on request
+
+The default output is **Parquet** — much smaller to store than CSV, and the
+source of truth. Parquet isn't human-readable, so there are two ways to get CSV:
+
+```bash
+# 1. Write CSV directly instead of Parquet:
+CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py -k Reciprocal --csv
+
+# 2. Convert an existing Parquet file to CSV (no hardware run needed):
+python -m accuracy.to_csv accuracy/_csv_output/wh/exp.parquet   # one file
+python -m accuracy.to_csv accuracy/_csv_output/wh               # whole dir
+```
+
+Both CSV paths produce identical output: floats use `%.9g` (lossless for the
+float32-or-smaller data), and booleans render as `T`/`F`.
+
+### Columns
+
+| group | columns |
+|-------|---------|
+| identity | `op`, `input_format`, `output_format`, `chip_arch`, `distribution`, `intervals`, `seed` |
+| data | `sample_index`, `test_value`, `golden_result`, `hardware_result` |
+| config | `approx_mode`, `fast_mode`, `dest_acc` (0/1) |
+| metrics | `signed_error`, `rel_error`, `signed_ulp_error`, `is_finite_hw`, `is_finite_golden` |
+
+Rows are sorted ascending by `test_value` within each (format, config) block.

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
@@ -45,8 +45,8 @@ from helpers.test_variant_parameters import (
 
 _THIS_DIR = Path(__file__).resolve().parent
 
-# ── CSV schema ──────────────────────────
-CSV_COLUMNS: List[str] = [
+# ── Output schema ──────────────────────────
+OUTPUT_COLUMNS: List[str] = [
     "op",
     "input_format",
     "output_format",
@@ -55,9 +55,9 @@ CSV_COLUMNS: List[str] = [
     "intervals",
     "seed",
     "sample_index",
-    "x",
-    "golden",
-    "hw",
+    "test_value",
+    "golden_result",
+    "hardware_result",
     "approx_mode",
     "fast_mode",
     "dest_acc",
@@ -67,11 +67,6 @@ CSV_COLUMNS: List[str] = [
     "is_finite_hw",
     "is_finite_golden",
 ]
-
-# Float precision on disk: float32 needs up to 9 significant digits to
-# round-trip exactly (bf16/fp16 need far fewer), so %.9g is lossless for every
-# format we sweep while staying far shorter than full float64 repr.
-FLOAT_FORMAT = "%.9g"
 
 _ARCH_ABBR = {"wormhole": "wh", "blackhole": "bh", "quasar": "qsr"}
 _FMT_ABBR = {
@@ -88,7 +83,7 @@ _ARCH = os.getenv("CHIP_ARCH", "unknown").lower()
 OUTPUT_DIR = _THIS_DIR / "_csv_output" / _ARCH_ABBR.get(_ARCH, _ARCH)
 SHARD_DIR = OUTPUT_DIR / "_shards"
 
-# How rows are ordered inside each final per-op CSV.
+# How rows are ordered inside each final per-op file.
 MERGE_SORT_COLS = [
     "op",
     "input_format",
@@ -96,7 +91,7 @@ MERGE_SORT_COLS = [
     "approx_mode",
     "fast_mode",
     "dest_acc",
-    "x",
+    "test_value",
 ]
 
 # How many input points each op's curve is sampled at.
@@ -189,11 +184,11 @@ def rows_dataframe(
     hw,
     out_fmt_enum_name: str,
 ) -> "pd.DataFrame":
-    """Build the CSV rows for one variant (one op + format + config).
+    """Build the output rows for one variant (one op + format + config).
 
     Takes the raw sweep arrays (x, golden, hw), sorts them by x, computes the
-    error columns (via accuracy_metrics), and returns a DataFrame in CSV_COLUMNS
-    order — ready to hand to write_shard.
+    error columns (via accuracy_metrics), and returns a DataFrame in
+    OUTPUT_COLUMNS order — ready to hand to write_shard.
     """
     x = np.asarray(x, dtype=np.float64)
     golden = np.asarray(golden, dtype=np.float64)
@@ -216,26 +211,26 @@ def rows_dataframe(
             "intervals": intervals,
             "seed": seed,
             "sample_index": np.arange(n, dtype=np.int64),
-            "x": x,
-            "golden": golden,
-            "hw": hw,
+            "test_value": x,
+            "golden_result": golden,
+            "hardware_result": hw,
             "approx_mode": approx,
             "fast_mode": fast,
             "dest_acc": dest,
             "signed_error": m["signed_error"],
             "rel_error": m["rel_error"],
             "signed_ulp_error": m["signed_ulp_error"],
-            "is_finite_hw": np.where(m["is_finite_hw"], "T", "F"),
-            "is_finite_golden": np.where(m["is_finite_golden"], "T", "F"),
+            "is_finite_hw": m["is_finite_hw"],
+            "is_finite_golden": m["is_finite_golden"],
         }
     )
-    return df[CSV_COLUMNS]
+    return df[OUTPUT_COLUMNS]
 
 
 def write_shard(df: "pd.DataFrame", variant: str) -> Path:
-    """Write one variant's DataFrame to SHARD_DIR/{variant}.csv.
+    """Write one variant's DataFrame to SHARD_DIR/{variant}.parquet.
 
-    *variant* is the unique shard stem (it is no longer a CSV column, so it is
+    *variant* is the unique shard stem (it is not an output column, so it is
     passed explicitly).
 
     The write is atomic: data goes to a per-process temp file, then os.replace
@@ -243,36 +238,36 @@ def write_shard(df: "pd.DataFrame", variant: str) -> Path:
     same shard, the reader never sees a half-written file — one clean copy wins.
     """
     SHARD_DIR.mkdir(parents=True, exist_ok=True)
-    shard_path = SHARD_DIR / f"{variant}.csv"
+    shard_path = SHARD_DIR / f"{variant}.parquet"
     tmp_path = SHARD_DIR / f"{variant}.{os.getpid()}.tmp"
-    df.to_csv(tmp_path, index=False, float_format=FLOAT_FORMAT)
+    df.to_parquet(tmp_path, engine="pyarrow", compression="zstd", index=False)
     os.replace(tmp_path, shard_path)
     return shard_path
 
 
 def merge_shards() -> List[Path]:
-    """Merge current-run shards into one sorted CSV per op (overwrite).
+    """Merge current-run shards into one sorted Parquet file per op (overwrite).
 
     Reads only the shards present in SHARD_DIR, groups by op, sorts by
-    MERGE_SORT_COLS, and overwrites OUTPUT_DIR/{op}.csv from scratch. Never
-    reads a pre-existing final CSV.
+    MERGE_SORT_COLS, and overwrites OUTPUT_DIR/{op}.parquet from scratch. Never
+    reads a pre-existing final file.
 
-    Only ops present in the current run are rewritten. Other per-op CSVs are
+    Only ops present in the current run are rewritten. Other per-op files are
     left as-is. Delete OUTPUT_DIR first for a completely fresh set.
     """
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    shard_files = sorted(SHARD_DIR.glob("*.csv")) if SHARD_DIR.exists() else []
+    shard_files = sorted(SHARD_DIR.glob("*.parquet")) if SHARD_DIR.exists() else []
     if not shard_files:
         return []
 
-    frames = [pd.read_csv(f) for f in shard_files]
+    frames = [pd.read_parquet(f) for f in shard_files]
     combined = pd.concat(frames, ignore_index=True)
 
     written: List[Path] = []
     for op_name, group in combined.groupby("op", sort=True):
         ordered = group.sort_values(MERGE_SORT_COLS, kind="stable")
-        out_path = OUTPUT_DIR / f"{op_name}.csv"
-        ordered.to_csv(out_path, index=False, float_format=FLOAT_FORMAT)
+        out_path = OUTPUT_DIR / f"{op_name}.parquet"
+        ordered.to_parquet(out_path, engine="pyarrow", compression="zstd", index=False)
         written.append(out_path)
     return written
 
@@ -280,7 +275,7 @@ def merge_shards() -> List[Path]:
 def clear_shards() -> None:
     """Remove the shard dir so a run starts with no stale shards.
 
-    Only the intermediate shards are cleared — the merged per-op CSVs in
+    Only the intermediate shards are cleared — the merged per-op files in
     OUTPUT_DIR are intentionally left (so partial runs accumulate, and a crash
     can't lose the existing corpus). See merge_shards for the full trade-off.
     """

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
@@ -94,8 +94,35 @@ MERGE_SORT_COLS = [
     "test_value",
 ]
 
+OUTPUT_FORMATS = ("parquet", "csv")
+DEFAULT_OUTPUT_FORMAT = "parquet"
+
+# On disk float32 needs up to 9 significant digits to round-trip exactly
+# (bf16/fp16 need fewer), so %.9g is lossless for every format we sweep while
+# staying far shorter than the full float64 repr. Only used for csv output.
+FLOAT_FORMAT = "%.9g"
+
 # How many input points each op's curve is sampled at.
 DEFAULT_SWEEP_POINTS = 2048
+
+
+def _write_op_file(df: "pd.DataFrame", stem: str, output_format: str) -> Path:
+    """Write one merged per-op DataFrame to OUTPUT_DIR/{stem}.{ext}.
+
+    Parquet is compact and lossless. CSV is the human-readable view: bools
+    render as T/F and floats use FLOAT_FORMAT (matches to_csv.py).
+    """
+    if output_format == "parquet":
+        out_path = OUTPUT_DIR / f"{stem}.parquet"
+        df.to_parquet(out_path, engine="pyarrow", compression="zstd", index=False)
+        return out_path
+
+    out_path = OUTPUT_DIR / f"{stem}.csv"
+    df = df.copy()
+    for col in df.select_dtypes(include="bool").columns:
+        df[col] = df[col].map({True: "T", False: "F"})
+    df.to_csv(out_path, index=False, float_format=FLOAT_FORMAT)
+    return out_path
 
 
 def _distribution_label(distribution: DistributionKind) -> str:
@@ -245,16 +272,21 @@ def write_shard(df: "pd.DataFrame", variant: str) -> Path:
     return shard_path
 
 
-def merge_shards() -> List[Path]:
-    """Merge current-run shards into one sorted Parquet file per op (overwrite).
+def merge_shards(output_format: str = DEFAULT_OUTPUT_FORMAT) -> List[Path]:
+    """Merge current-run shards into one sorted file per op (overwrite).
 
-    Reads only the shards present in SHARD_DIR, groups by op, sorts by
-    MERGE_SORT_COLS, and overwrites OUTPUT_DIR/{op}.parquet from scratch. Never
-    reads a pre-existing final file.
+    Reads only the shards present in SHARD_DIR, groups by op, sorts by MERGE_SORT_COLS, and
+    overwrites OUTPUT_DIR/{op}.{output_format} from scratch. Never reads a pre-existing final file.
+
+    *output_format* is "parquet" (compact default) or "csv" (human-readable).
 
     Only ops present in the current run are rewritten. Other per-op files are
     left as-is. Delete OUTPUT_DIR first for a completely fresh set.
     """
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(
+            f"output_format must be one of {OUTPUT_FORMATS}, got {output_format!r}"
+        )
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     shard_files = sorted(SHARD_DIR.glob("*.parquet")) if SHARD_DIR.exists() else []
     if not shard_files:
@@ -266,9 +298,7 @@ def merge_shards() -> List[Path]:
     written: List[Path] = []
     for op_name, group in combined.groupby("op", sort=True):
         ordered = group.sort_values(MERGE_SORT_COLS, kind="stable")
-        out_path = OUTPUT_DIR / f"{op_name}.parquet"
-        ordered.to_parquet(out_path, engine="pyarrow", compression="zstd", index=False)
-        written.append(out_path)
+        written.append(_write_op_file(ordered, op_name, output_format))
     return written
 
 

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
@@ -5,14 +5,30 @@ pytest hooks for the accuracy suite (auto-loaded by pytest; nothing imports it).
 
 They bracket the whole run so each per-op file reflects only this run:
   - before the run: delete leftover shard files (clear_shards)
-  - after the run: merge this run's shards into one Parquet file per op (merge_shards)
+  - after the run: merge this run's shards into one file per op (merge_shards)
+
+The merged output is Parquet by default; pass --csv (or set
+ACCURACY_OUTPUT_FORMAT=csv for the run_test.sh wrapper, which can't forward the
+flag) to emit CSV instead.
 
 When tests run in parallel (pytest -n) there are many worker processes plus one
 controller. We run clear/merge only on the controller (the single process
 without `config.workerinput`) so it happens once, not once per worker.
 """
 
+import os
+
 from helpers.logger import logger
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--csv",
+        action="store_true",
+        default=False,
+        help="Write the merged per-op files as CSV instead of the default "
+        "Parquet. Same as setting ACCURACY_OUTPUT_FORMAT=csv.",
+    )
 
 
 def _is_controller(config) -> bool:
@@ -29,10 +45,21 @@ def pytest_configure(config):
 def pytest_sessionfinish(session, exitstatus):
     config = session.config
     if _is_controller(config):
-        from accuracy.accuracy_harness import OUTPUT_DIR, merge_shards
+        from accuracy.accuracy_harness import (
+            DEFAULT_OUTPUT_FORMAT,
+            OUTPUT_DIR,
+            merge_shards,
+        )
 
-        written = merge_shards()
+        if config.getoption("--csv"):
+            output_format = "csv"
+        else:
+            output_format = os.getenv("ACCURACY_OUTPUT_FORMAT", DEFAULT_OUTPUT_FORMAT)
+        written = merge_shards(output_format)
         if written:
             logger.success(
-                "Merged {} per-op Parquet file(s) into {}", len(written), OUTPUT_DIR
+                "Merged {} per-op {} file(s) into {}",
+                len(written),
+                output_format,
+                OUTPUT_DIR,
             )

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
@@ -3,9 +3,9 @@
 """
 pytest hooks for the accuracy suite (auto-loaded by pytest; nothing imports it).
 
-They bracket the whole run so each per-op CSV reflects only this run:
+They bracket the whole run so each per-op file reflects only this run:
   - before the run: delete leftover shard files (clear_shards)
-  - after the run: merge this run's shards into one CSV per op (merge_shards)
+  - after the run: merge this run's shards into one Parquet file per op (merge_shards)
 
 When tests run in parallel (pytest -n) there are many worker processes plus one
 controller. We run clear/merge only on the controller (the single process
@@ -33,4 +33,6 @@ def pytest_sessionfinish(session, exitstatus):
 
         written = merge_shards()
         if written:
-            logger.success("Merged {} per-op CSV(s) into {}", len(written), OUTPUT_DIR)
+            logger.success(
+                "Merged {} per-op Parquet file(s) into {}", len(written), OUTPUT_DIR
+            )

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/to_csv.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/to_csv.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Convert the harness's Parquet output to CSV so we can read it.
+
+The harness writes Parquet, which isn't human-readable. Run this to get a CSV
+we can open as text or in a spreadsheet:
+
+    python -m accuracy.to_csv _csv_output/wh/exp.parquet   # one file
+    python -m accuracy.to_csv _csv_output/wh               # whole dir
+
+Each <name>.parquet becomes <name>.csv next to it. The CSV is just a view;
+the Parquet stays the source of truth.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def convert(path: Path) -> Path:
+    """Write <path>.csv next to a single .parquet file and return the csv path."""
+    csv_path = path.with_suffix(".csv")
+    df = pd.read_parquet(path)
+    # Write bools as T/F, not pandas' True/False.
+    for col in df.select_dtypes(include="bool").columns:
+        df[col] = df[col].map({True: "T", False: "F"})
+    # %.9g keeps full float32 precision without the extra float64 noise digits.
+    df.to_csv(csv_path, index=False, float_format="%.9g")
+    return csv_path
+
+
+def main(args: list[str]) -> None:
+    if not args:
+        print(__doc__)
+        raise SystemExit(2)
+
+    for arg in args:
+        target = Path(arg)
+        files = sorted(target.glob("*.parquet")) if target.is_dir() else [target]
+        for f in files:
+            print(convert(f))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tt_metal/tt-llk/tests/requirements.txt
+++ b/tt_metal/tt-llk/tests/requirements.txt
@@ -28,6 +28,7 @@ pandas==2.3.3
 plotly==6.5.0
 pluggy==1.6.0
 pre-commit==4.5.0
+pyarrow==24.0.0
 pydantic==2.12.5
 pygments==2.20.0
 pytest==9.0.3


### PR DESCRIPTION
### Summary
The accuracy harness previously wrote its per-op results as CSV. Those files
get large (a single op's sweep was ~15.5 MB) and are slow to store and load.

This PR switches the harness output to Parquet (zstd-compressed). The same
data now takes ~0.45 MB instead, with no loss of information.

Parquet isn't human-readable, so this PR also adds `to_csv.py`, an on-demand
converter that writes a CSV from given Parquet file. Used when we want to eyeball
the results as text or in a spreadsheet:

    python -m accuracy.to_csv _csv_output/wh/exp.parquet   # one file
    python -m accuracy.to_csv _csv_output/wh               # whole dir

### Notes for reviewers
- Parquet is now the source of truth. CSV is only a convenience view.
- The converter writes floats with `%.9g` (lossless for float32, which is the
  most precision our data ever has) and bools as `T`/`F`.
- Requires `pyarrow` for reading/writing Parquet.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/parquet-demo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/parquet-demo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/parquet-demo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/parquet-demo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/parquet-demo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/parquet-demo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/parquet-demo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/parquet-demo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/parquet-demo)