### PR TITLE
Fix deprecated TTNN/Metalium API usage surfaced by tt-train clang-tidy

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -1,7 +1,7 @@
 Runtime Arguments
 ==================
 
-.. doxygenfunction:: tt::tt_metal::SetRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, stl::Span<const uint32_t> runtime_args)
+.. doxygenfunction:: tt::tt_metal::SetRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, ttsl::Span<const uint32_t> runtime_args)
 
 .. doxygenfunction:: tt::tt_metal::SetRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, std::initializer_list<uint32_t> runtime_args)
 
@@ -11,7 +11,7 @@ Runtime Arguments
 
 .. doxygenfunction:: tt::tt_metal::GetRuntimeArgs(const Program &program, KernelHandle kernel_id)
 
-.. doxygenfunction:: tt::tt_metal::SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args)
+.. doxygenfunction:: tt::tt_metal::SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, ttsl::Span<const uint32_t> runtime_args)
 
 .. doxygenfunction:: tt::tt_metal::SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, std::initializer_list<uint32_t> runtime_args)
 

--- a/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
+++ b/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
@@ -17,7 +17,7 @@
 
 namespace {
 template <typename T>
-ttnn::Tensor GenInputTensor(const ttnn::SmallVector<uint32_t>& shape) {
+ttnn::Tensor GenInputTensor(const ttsl::SmallVector<uint32_t>& shape) {
     using namespace tt::tt_metal;
     static std::mt19937 gen(42);  // fixed seed for reproducibility
 
@@ -37,8 +37,8 @@ ttnn::Tensor GenInputTensor(const ttnn::SmallVector<uint32_t>& shape) {
 
 void BM_pad_rm_2d_last_dim_right(benchmark::State& state) {
     auto input_tensor = GenInputTensor<bfloat16>({8192, 8100});
-    ttnn::SmallVector<uint32_t> padded_shape = {8192, 8192};
-    ttnn::SmallVector<uint32_t> tensor_start = {0, 0};
+    ttsl::SmallVector<uint32_t> padded_shape = {8192, 8192};
+    ttsl::SmallVector<uint32_t> tensor_start = {0, 0};
 
     for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(
@@ -52,8 +52,8 @@ void BM_pad_rm_2d_last_dim_right(benchmark::State& state) {
 
 void BM_pad_rm_2d_last_dim_left_right(benchmark::State& state) {
     auto input_tensor = GenInputTensor<bfloat16>({8192, 8100});
-    ttnn::SmallVector<uint32_t> padded_shape = {8192, 8192};
-    ttnn::SmallVector<uint32_t> tensor_start = {0, 92};
+    ttsl::SmallVector<uint32_t> padded_shape = {8192, 8192};
+    ttsl::SmallVector<uint32_t> tensor_start = {0, 92};
 
     for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(
@@ -67,8 +67,8 @@ void BM_pad_rm_2d_last_dim_left_right(benchmark::State& state) {
 
 void BM_pad_rm_4d_last_dim_left_right(benchmark::State& state) {
     auto input_tensor = GenInputTensor<bfloat16>({16, 20, 512, 500});
-    ttnn::SmallVector<uint32_t> padded_shape = {16, 20 + 12, 512 + 30, 500 + 30};
-    ttnn::SmallVector<uint32_t> tensor_start = {0, 1, 3, 4};
+    ttsl::SmallVector<uint32_t> padded_shape = {16, 20 + 12, 512 + 30, 500 + 30};
+    ttsl::SmallVector<uint32_t> tensor_start = {0, 1, 3, 4};
 
     for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(
@@ -85,8 +85,8 @@ void BM_pad_rm_2d_scaling(benchmark::State& state) {
     int N_padded = N + (2 * 100);
 
     auto input_tensor = GenInputTensor<bfloat16>({8192, N});
-    ttnn::SmallVector<uint32_t> padded_shape = {8192, N_padded};
-    ttnn::SmallVector<uint32_t> tensor_start = {0, 100};
+    ttsl::SmallVector<uint32_t> padded_shape = {8192, N_padded};
+    ttsl::SmallVector<uint32_t> tensor_start = {0, 100};
 
     for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(

--- a/tests/ttnn/unit_tests/gtests/conv/test_conv2d.cpp
+++ b/tests/ttnn/unit_tests/gtests/conv/test_conv2d.cpp
@@ -152,7 +152,7 @@ TEST_P(Conv2DFixture, Conv2DCalculateCorrectly) {
         std::vector<float> weight_vector = weight_tensor.to_vector<float>();
 
         // (N,Ci,H,W) -> (N,H,W,Ci)
-        input_tensor = ttnn::permute(input_tensor, SmallVector<int64_t>{0, 2, 3, 1});
+        input_tensor = ttnn::permute(input_tensor, ttsl::SmallVector<int64_t>{0, 2, 3, 1});
 
         // Run Conv2D
         auto [output_tensor, output_dimensions] = std::get<static_cast<int>(ConvResultType::OUTPUT_DIM)>(ttnn::conv2d(
@@ -193,7 +193,7 @@ TEST_P(Conv2DFixture, Conv2DCalculateCorrectly) {
                  param.output_channels}));
 
         // (N,H',W',Co) -> (N,Co,H',W')
-        output_tensor = ttnn::permute(output_tensor, SmallVector<int64_t>{0, 3, 1, 2});
+        output_tensor = ttnn::permute(output_tensor, ttsl::SmallVector<int64_t>{0, 3, 1, 2});
 
         // Copy output tensor to host for comparison
         std::vector<float> res = output_tensor.to_vector<float>();

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -61,7 +61,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     }
     // Create golden data using tt_eager APIs
     Tensor np_tensor = ttnn::full(input_shape, static_cast<float>(1), DataType::BFLOAT16, Layout::TILE, *device_);
-    ttnn::SmallVector<int64_t> reduce_dims = {3};
+    ttsl::SmallVector<int64_t> reduce_dims = {3};
     Tensor np_out = ttnn::moreh_sum(np_tensor, reduce_dims, false, std::nullopt, std::nullopt, std::nullopt);
     Tensor np_out_host = np_out.cpu();
     const Tensor reference_tensor = ttnn::distributed::get_device_tensors(np_out_host).front();

--- a/tests/ttnn/unit_tests/gtests/test_reduction.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_reduction.cpp
@@ -104,7 +104,7 @@ TEST_P(SumTensorBothDimsFixture, SumTensorCorrectly) {
     auto& device = *device_;
     std::array<uint32_t, 2> dimensions = {param.h, param.w};
     ttnn::Shape shape(dimensions);
-    SmallVector<int> dim = {0, 1};
+    ttsl::SmallVector<int> dim = {0, 1};
 
     {
         const auto input_tensor = ttnn::ones(shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, device);
@@ -254,7 +254,7 @@ class MinMaxTensorBothDimsFixture : public TTNNFixtureWithSuiteDevice<MinMaxTens
 TEST_P(MinMaxTensorBothDimsFixture, MinMaxTensorCorrectly) {
     auto param = GetParam();
     auto& device = *device_;
-    SmallVector<int> dim = {-2, -1};
+    ttsl::SmallVector<int> dim = {-2, -1};
     {
         const ttnn::Shape tensor_shape{1, 1, param.h, param.w};
         const MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -56,7 +56,8 @@ void ReadShard(
     // TODO: #26591 - `is_local` Handling should be done under `MeshCommandQueue`.
     // Tracking removal of free function APIs in this file in this issue.
     auto* mesh_device = mesh_cq.device();
-    if (!mesh_device->is_local(coord)) {
+    auto devices = mesh_device->get_view().get_devices(MeshCoordinateRange(coord, coord));
+    if (devices.empty()) {
         return;
     }
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -66,7 +66,7 @@ void append_fabric_connection_rt_args(
     const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,
     ProgramOrDescriptor& worker_program_or_desc,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     CoreType core_type = CoreType::WORKER);
 
@@ -89,7 +89,7 @@ void append_routing_plane_connection_manager_rt_args(
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     FabricApiType api_type = FabricApiType::Linear,
     CoreType core_type = CoreType::WORKER);
@@ -103,7 +103,7 @@ uint32_t append_routing_plane_connection_manager_rt_args(
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     FabricApiType api_type = FabricApiType::Linear,
     CoreType core_type = CoreType::WORKER);
@@ -215,7 +215,7 @@ public:
         const FabricNodeId& dst_fabric_node_id,
         uint32_t link_idx,
         ProgramOrDescriptor& mux_program_or_desc,
-        const CoreCoord& mux_logical_core) const;
+        const tt::tt_metal::CoreCoord& mux_logical_core) const;
 
     uint8_t get_num_channels(FabricMuxChannelType channel_type) const;
     uint8_t get_num_buffers(FabricMuxChannelType channel_type) const;

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -474,14 +474,14 @@ void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program&
  * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                |                                                                     | Yes      |
  * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any logical Tensix core coordinate(s) on which the kernel is placed | Yes      |
- * | runtime_args | The runtime args to be written                                         | stl::Span<const uint32_t>                              |                                                                     | Yes      |
+ * | runtime_args | The runtime args to be written                                         | ttsl::Span<const uint32_t>                              |                                                                     | Yes      |
  */
 // clang-format on
 void SetRuntimeArgs(
     const Program& program,
     KernelHandle kernel,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    stl::Span<const uint32_t> runtime_args);
+    ttsl::Span<const uint32_t> runtime_args);
 
 // clang-format off
 /**
@@ -536,10 +536,10 @@ void SetRuntimeArgs(
  * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
  * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                |                                                                     | Yes      |
- * | runtime_args | The runtime args to be written                                         | stl::Span<const uint32_t>                              |                                                                     | Yes      |
+ * | runtime_args | The runtime args to be written                                         | ttsl::Span<const uint32_t>                              |                                                                     | Yes      |
  */
 // clang-format on
-void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args);
+void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, ttsl::Span<const uint32_t> runtime_args);
 
 // clang-format off
 /**

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -112,11 +112,23 @@ public:
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking) = 0;
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     [[deprecated("Use enqueue_write_shards with distributed::ShardDataTransfer instead.")]]
     void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<ShardDataTransfer>& shard_data_transfers,
         bool blocking);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     // MeshBuffer Read APIs
     virtual void enqueue_read_mesh_buffer(
@@ -131,11 +143,23 @@ public:
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) = 0;
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     [[deprecated("Use enqueue_read_shards with distributed::ShardDataTransfer instead.")]]
     void enqueue_read_shards(
         const std::vector<ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     virtual MeshEvent enqueue_record_event(
         ttsl::Span<const SubDeviceId> sub_device_ids = {},
@@ -161,10 +185,22 @@ private:
 
 public:
     explicit ShardDataTransfer(const MeshCoordinate& shard_coord) : shard_coord_(shard_coord) {}
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     explicit ShardDataTransfer(const MeshCommandQueue::ShardDataTransfer& shard_data_transfer) :
         shard_coord_(shard_data_transfer.shard_coord),
         host_data_(shard_data_transfer.host_data),
         region_(shard_data_transfer.region) {}
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     MeshCoordinate shard_coord() const { return shard_coord_; }
     void* host_data() const { return host_data_; }

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -176,7 +176,7 @@ void ConfigureKernelGroup(
 }
 
 inline void SetRuntimeArgsImpl(
-    const Program& program, KernelHandle kernel_id, const CoreCoord& c, stl::Span<const uint32_t> runtime_args) {
+    const Program& program, KernelHandle kernel_id, const CoreCoord& c, ttsl::Span<const uint32_t> runtime_args) {
     if (!runtime_args.empty()) {
         program.impl().get_kernel(kernel_id)->set_runtime_args(c, runtime_args);
     }
@@ -186,7 +186,7 @@ inline void SetRuntimeArgsImpl(
     const Program& program,
     KernelHandle kernel_id,
     const CoreRange& core_range,
-    stl::Span<const uint32_t> runtime_args) {
+    ttsl::Span<const uint32_t> runtime_args) {
     if (!runtime_args.empty()) {
         auto kernel = program.impl().get_kernel(kernel_id);
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
@@ -201,7 +201,7 @@ inline void SetRuntimeArgsImpl(
     const Program& program,
     KernelHandle kernel_id,
     const CoreRangeSet& core_range_set,
-    stl::Span<const uint32_t> runtime_args) {
+    ttsl::Span<const uint32_t> runtime_args) {
     if (!runtime_args.empty()) {
         auto kernel = program.impl().get_kernel(kernel_id);
         for (const auto& core_range : core_range_set.ranges()) {
@@ -1749,7 +1749,7 @@ void SetRuntimeArgs(
     const Program& program,
     KernelHandle kernel_id,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    stl::Span<const uint32_t> runtime_args) {
+    ttsl::Span<const uint32_t> runtime_args) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureSetRuntimeArgsUint32, program, kernel_id, core_spec, runtime_args);
     std::visit([&](auto&& core_spec) { SetRuntimeArgsImpl(program, kernel_id, core_spec, runtime_args); }, core_spec);
@@ -1785,7 +1785,7 @@ void SetRuntimeArgs(
     }
 }
 
-void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args) {
+void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, ttsl::Span<const uint32_t> runtime_args) {
     ZoneScoped;
     if (!runtime_args.empty()) {
         program.impl().get_kernel(kernel_id)->set_common_runtime_args(runtime_args);

--- a/ttnn/api/tools/profiler/op_profiler_serialize.hpp
+++ b/ttnn/api/tools/profiler/op_profiler_serialize.hpp
@@ -414,11 +414,14 @@ inline std::string op_meta_data_serialized_json(
                 /* Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed */    \
                 /* regression tests well-formed data. */                                                              \
                 /* TODO: (Issue #20233): Move the zone below outside TracyOpMeshWorkload. */                          \
-                if (!(mesh_device)->is_local(coord)) {                                                                \
+                auto devices = (mesh_device)                                                                          \
+                                   ->get_view()                                                                       \
+                                   .get_devices(tt::tt_metal::distributed::MeshCoordinateRange(coord, coord));        \
+                if (devices.empty()) {                                                                                \
                     continue;                                                                                         \
                 }                                                                                                     \
                 ZoneScopedN("TT_DNN_DEVICE_OP");                                                                      \
-                auto device_id = (mesh_device)->get_device(coord)->id();                                              \
+                auto device_id = devices.front()->id();                                                               \
                 auto op_id = tt::tt_metal::detail::EncodePerDeviceProgramID(base_program_id, device_id, false);       \
                 std::string op_message = tt::tt_metal::op_profiler::op_meta_data_serialized_json(                     \
                     operation,                                                                                        \

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -63,7 +63,7 @@ public:
     void track_deallocate(tt::tt_metal::Buffer* buffer) override;
 
     void track_allocate_cb(
-        const CoreRangeSet& core_range,
+        const tt::tt_metal::CoreRangeSet& core_range,
         uint64_t addr,
         uint64_t size,
         bool is_globally_allocated,

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -304,7 +304,7 @@ void GraphProcessor::track_deallocate(tt::tt_metal::Buffer* buffer) {
 }
 
 void GraphProcessor::track_allocate_cb(
-    const CoreRangeSet& core_range_set,
+    const tt::tt_metal::CoreRangeSet& core_range_set,
     uint64_t addr,
     uint64_t size,
     bool is_globally_allocated,

--- a/ttnn/core/graph/graph_trace_utils.cpp
+++ b/ttnn/core/graph/graph_trace_utils.cpp
@@ -33,7 +33,7 @@ ttnn::Shape parse_shape(std::string_view shape_string) {
     std::string_view shape_values = shape_string.substr(start, end - start);
 
     // Vector to hold the parsed shape values
-    SmallVector<uint32_t> shape;
+    ttsl::SmallVector<uint32_t> shape;
     const char* str = shape_values.data();
     const char* end_str = str + shape_values.size();
 

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -178,7 +178,7 @@ flatbuffers::Offset<flatbuffer::NdShardSpec> to_flatbuffer(
 
 tt::tt_metal::NdShardSpec from_flatbuffer(const flatbuffer::NdShardSpec* spec) {
     return tt::tt_metal::NdShardSpec(
-        Shape(SmallVector<uint32_t>(spec->shard_shape()->cbegin(), spec->shard_shape()->cend())),
+        Shape(ttsl::SmallVector<uint32_t>(spec->shard_shape()->cbegin(), spec->shard_shape()->cend())),
         from_flatbuffer(spec->grid()),
         from_flatbuffer(spec->orientation()),
         from_flatbuffer(spec->shard_distribution_strategy()));
@@ -203,7 +203,8 @@ tt::tt_metal::TensorLayout from_flatbuffer(const flatbuffer::TensorLayout* layou
         from_flatbuffer(layout->data_type()),
         page_config,
         ttnn::from_flatbuffer(layout->memory_config()),
-        tt::tt_metal::Alignment(SmallVector<uint32_t>(layout->alignment()->cbegin(), layout->alignment()->cend())));
+        tt::tt_metal::Alignment(
+            ttsl::SmallVector<uint32_t>(layout->alignment()->cbegin(), layout->alignment()->cend())));
 }
 
 flatbuffers::Offset<flatbuffer::TensorLayout> to_flatbuffer(
@@ -287,7 +288,7 @@ flatbuffers::Offset<flatbuffer::TensorSpec> to_flatbuffer(
 
 tt::tt_metal::TensorSpec from_flatbuffer(const flatbuffer::TensorSpec* spec) {
     return tt::tt_metal::TensorSpec(
-        Shape(SmallVector<uint32_t>(spec->shape()->cbegin(), spec->shape()->cend())),
+        Shape(ttsl::SmallVector<uint32_t>(spec->shape()->cbegin(), spec->shape()->cend())),
         from_flatbuffer(spec->tensor_layout()));
 }
 

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -458,7 +458,7 @@ void pytensor_module(nb::module_& mod) {
             "__init__",
             [](Tensor* t,
                std::vector<T>&& data,
-               const ttnn::SmallVector<uint32_t>& shape,
+               const ttsl::SmallVector<uint32_t>& shape,
                DataType data_type,
                Layout layout,
                const std::optional<Tile>& tile,
@@ -512,7 +512,7 @@ void pytensor_module(nb::module_& mod) {
             "__init__",
             [](Tensor* t,
                std::vector<T>&& data,
-               const ttnn::SmallVector<uint32_t>& shape,
+               const ttsl::SmallVector<uint32_t>& shape,
                DataType data_type,
                Layout layout,
                std::optional<MeshDevice*> device,
@@ -567,7 +567,7 @@ void pytensor_module(nb::module_& mod) {
             "__init__",
             [](Tensor* t,
                std::vector<T>&& data,
-               const ttnn::SmallVector<uint32_t>& shape,
+               const ttsl::SmallVector<uint32_t>& shape,
                DataType data_type,
                Layout layout,
                std::optional<MeshDevice*> device,
@@ -908,8 +908,8 @@ void pytensor_module(nb::module_& mod) {
         .def(
             "pad",
             [](const Tensor& self,
-               const ttnn::SmallVector<uint32_t>& output_tensor_shape,
-               const ttnn::SmallVector<uint32_t>& input_tensor_start,
+               const ttsl::SmallVector<uint32_t>& output_tensor_shape,
+               const ttsl::SmallVector<uint32_t>& input_tensor_start,
                float pad_value) {
                 return self.pad(ttnn::Shape(output_tensor_shape), ttnn::Shape(input_tensor_start), pad_value);
             },
@@ -982,8 +982,8 @@ void pytensor_module(nb::module_& mod) {
         .def(
             "unpad",
             [](const Tensor& self,
-               const ttnn::SmallVector<uint32_t>& output_tensor_start,
-               const ttnn::SmallVector<uint32_t>& output_tensor_end) {
+               const ttsl::SmallVector<uint32_t>& output_tensor_start,
+               const ttsl::SmallVector<uint32_t>& output_tensor_end) {
                 return self.unpad(ttnn::Shape(output_tensor_start), ttnn::Shape(output_tensor_end));
             },
             R"doc(
@@ -1105,7 +1105,7 @@ void pytensor_module(nb::module_& mod) {
         )doc")
         .def(
             "unpad_from_tile",
-            [](const Tensor& self, const ttnn::SmallVector<uint32_t>& output_tensor_shape) {
+            [](const Tensor& self, const ttsl::SmallVector<uint32_t>& output_tensor_shape) {
                 return self.unpad_from_tile(ttnn::Shape(output_tensor_shape));
             },
             R"doc(
@@ -1506,7 +1506,7 @@ void pytensor_module(nb::module_& mod) {
         .def(
             "reshape",
             [](Tensor& self, int N, int C, int H, int W) {
-                return ttnn::reshape(self, ttnn::SmallVector<int>{N, C, H, W});
+                return ttnn::reshape(self, ttsl::SmallVector<int>{N, C, H, W});
             },
             nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
@@ -1529,7 +1529,7 @@ void pytensor_module(nb::module_& mod) {
             )doc")
         .def(
             "reshape",
-            [](Tensor& self, const ttnn::SmallVector<int32_t>& shape) -> Tensor { return ttnn::reshape(self, shape); },
+            [](Tensor& self, const ttsl::SmallVector<int32_t>& shape) -> Tensor { return ttnn::reshape(self, shape); },
             nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
                 Reshapes TT tensor

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -346,7 +346,7 @@ tt::tt_metal::WorkloadDescriptor AllBroadcastProgramFactory::create_workload_des
     auto* mesh_device = input.device();
     auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
     const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
+    ttsl::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
 
     // Allocate the two workload-scoped GlobalSemaphores.  Park them on the
     // descriptor's `semaphores` vector so their device-side allocations stay

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
@@ -39,7 +39,7 @@ AllGatherDeviceOperation::AllGatherProgram::create_mesh_workload(
     };
 
     // 1 barrier semaphore used to ensure that all the buffers are allocated
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {sd_id};
+    ttsl::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {sd_id};
     auto barrier_semaphore =
         ttnn::global_semaphore::create_global_semaphore(mesh_device, subdevice_core_range_set, 0, sem_buffer_type);
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevice_ids);

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.cpp
@@ -55,7 +55,7 @@ ttnn::Tensor all_to_all_combine(
                 .optional_output_tensor = optional_output_tensor,
             });
         // currently full only supports tile layout
-        ttnn::SmallVector<uint32_t> output_shape;
+        ttsl::SmallVector<uint32_t> output_shape;
         output_shape.reserve(output_spec.logical_shape().rank());
         for (size_t i = 0; i < output_spec.logical_shape().rank(); i++) {
             output_shape.push_back(output_spec.logical_shape()[i]);

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
@@ -31,7 +31,7 @@ BroadcastProgramFactory::cached_mesh_workload_t BroadcastProgramFactory::create_
     auto* mesh_device = tensor_args.input_tensor.device();
     auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
     const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
+    ttsl::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
 
     auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
     auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -403,13 +403,13 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
 std::vector<ttnn::Tensor> unpad_output_tensor(
     const std::vector<ttnn::Tensor>& output_tensor,
     const uint32_t num_devices,
-    const ttnn::SmallVector<uint32_t>& unpad_elements,
+    const ttsl::SmallVector<uint32_t>& unpad_elements,
     const int dim) {
     std::vector<ttnn::Tensor> combined_tensors;
 
-    ttnn::SmallVector<uint32_t> begins = {0, 0, 0, 0};
-    ttnn::SmallVector<uint32_t> ends = {1, 1, 1, 1};
-    ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
+    ttsl::SmallVector<uint32_t> begins = {0, 0, 0, 0};
+    ttsl::SmallVector<uint32_t> ends = {1, 1, 1, 1};
+    ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
     ends = unpad_elements;
 
     for (int i = 0; i < num_devices; ++i) {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -99,7 +99,7 @@ class EriscDatamoverBuilder;
 std::vector<ttnn::Tensor> unpad_output_tensor(
     const std::vector<ttnn::Tensor>& output_tensor,
     uint32_t num_devices,
-    const ttnn::SmallVector<uint32_t>& unpad_elements,
+    const ttsl::SmallVector<uint32_t>& unpad_elements,
     int dim);
 
 class LineTopology {

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
@@ -113,7 +113,7 @@ size_t get_num_links(const tt::tt_metal::distributed::MeshDevice& mesh_device, s
         {{tt::tt_fabric::RoutingDirection::N, tt::tt_fabric::RoutingDirection::S},
          {tt::tt_fabric::RoutingDirection::W, tt::tt_fabric::RoutingDirection::E}}};
 
-    ttnn::SmallVector<size_t> cluster_axes;
+    ttsl::SmallVector<size_t> cluster_axes;
     if (cluster_axis.has_value()) {
         cluster_axes = {cluster_axis.value()};
     } else {

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
@@ -44,7 +44,7 @@ ReduceScatterDeviceOperation::ReduceScatterProgram::create_mesh_workload(
         ttnn::global_semaphore::create_global_semaphore(mesh_device, subdevice_core_range_set, 0, sem_buffer_type),
     };
     // 1 barrier semaphore used to ensure that all the buffers are allocated
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {sd_id};
+    ttsl::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {sd_id};
     auto barrier_semaphore =
         ttnn::global_semaphore::create_global_semaphore(mesh_device, subdevice_core_range_set, 0, sem_buffer_type);
     tt::tt_metal::distributed::Synchronize(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -673,13 +673,13 @@ static Tensor conv_group_weight_zero_pad_helper(
                     for (int m = 0; m < original_weight_shape[3]; m++) {
                         // Get value from original weight tensor
                         auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<uint32_t>{curr_batch_idx, j, k, m}, original_strides);
+                            ttsl::SmallVector<uint32_t>{curr_batch_idx, j, k, m}, original_strides);
                         auto value = conv_weight_tensor_buffer[value_flat_input_index];
 
                         // Copy value to output tensor at the adjusted position
                         auto new_channel_idx = new_channel_start_idx + j;
                         auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<uint32_t>{new_batch_idx, new_channel_idx, k, m}, output_strides);
+                            ttsl::SmallVector<uint32_t>{new_batch_idx, new_channel_idx, k, m}, output_strides);
                         output_buffer[output_flat_input_index] = value;
                     }
                 }
@@ -741,10 +741,10 @@ static Tensor conv_depthwise_weight_bcast_helper(
                         const uint32_t k = tap_index / window_w;
                         const uint32_t l = tap_index % window_w;
                         auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<uint32_t>{i, 0, k, l}, original_strides);
+                            ttsl::SmallVector<uint32_t>{i, 0, k, l}, original_strides);
                         auto value = conv_weight_tensor_buffer[value_flat_input_index];
                         auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<uint32_t>{i, j, 0u, 0u}, output_strides);
+                            ttsl::SmallVector<uint32_t>{i, j, 0u, 0u}, output_strides);
                         output_buffer[output_flat_input_index] = value;
                     }
                 }
@@ -844,12 +844,12 @@ static Tensor conv_transpose2d_group_weight_zero_pad_helper(
                     for (int w = 0; w < original_weight_shape[3]; w++) {
                         // Get value from original weight tensor
                         auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<uint32_t>{i, c, h, w}, original_weight_strides);
+                            ttsl::SmallVector<uint32_t>{i, c, h, w}, original_weight_strides);
                         auto value = conv_weight_tensor_buffer[value_flat_input_index];
 
                         // Copy value to output tensor at the adjusted position
                         auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<uint32_t>{i, global_out_channel, h, w}, output_weight_strides);
+                            ttsl::SmallVector<uint32_t>{i, global_out_channel, h, w}, output_weight_strides);
                         output_buffer[output_flat_input_index] = value;
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -112,8 +112,9 @@ Tensor to_layout_impl(
                 "produces a shard height of 1. Move to interleaved first, then tilize.",
                 tensor.padded_shape().size());
             const bool is_scalar = tensor.padded_shape().size() == 0;
-            SmallVector<uint32_t> new_padded_shape =
-                is_scalar ? SmallVector<uint32_t>{1, 1} : SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
+            ttsl::SmallVector<uint32_t> new_padded_shape =
+                is_scalar ? ttsl::SmallVector<uint32_t>{1, 1}
+                          : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
             tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
         }
     }
@@ -168,7 +169,7 @@ Tensor to_layout_impl(
                 output_memory_config =
                     memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
             }
-            Shape output_tensor_end(SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
+            Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
             int logical_rank = tensor.logical_shape().rank();
             for (int index = -1; index >= -logical_rank; --index) {
                 output_tensor_end[index] = tensor.logical_shape()[index] - 1;
@@ -180,7 +181,7 @@ Tensor to_layout_impl(
             if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
                 // ttnn::tilize_with_val_padding doesn't support height sharded tensors
                 // workaround by applying padding and then tilizing
-                SmallVector<std::array<uint32_t, 2>> padding = {
+                ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
                     {0, 0},
                     {0, 0},
                     {0, padded_output_shape[2] - output_shape[2]},
@@ -245,7 +246,7 @@ Tensor to_layout_impl(
             sub_core_grids);
     }
     if (layout == ttnn::TILE_LAYOUT) {
-        SmallVector<uint32_t> padded_input_start;
+        ttsl::SmallVector<uint32_t> padded_input_start;
         for (int index = 0; index < padded_output_shape.rank(); ++index) {
             padded_input_start.push_back(0);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
@@ -29,14 +29,14 @@ std::vector<ttnn::Tensor> chunk(const ttnn::Tensor& input_tensor, const uint32_t
     while (start < size_along_dim) {
         int end = std::min(start + chunk_size, size_along_dim);
 
-        ttnn::SmallVector<int> slice_start(num_dims, 0);
-        ttnn::SmallVector<int> slice_end(num_dims);
+        ttsl::SmallVector<int> slice_start(num_dims, 0);
+        ttsl::SmallVector<int> slice_end(num_dims);
         for (int i = 0; i < num_dims; ++i) {
             slice_end[i] = size[i];
         }
         slice_start[dim] = start;
         slice_end[dim] = end;
-        ttnn::SmallVector<int> slice_step(num_dims, 1);
+        ttsl::SmallVector<int> slice_step(num_dims, 1);
 
         ttnn::Tensor chunk_tensor = ttnn::slice(input_tensor, slice_start, slice_end, slice_step);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -18,7 +18,7 @@ ttnn::Shape squeeze_shape_to_ND(const ttnn::Shape& shape, const uint32_t n) {
     if (shape.rank() <= n) {
         return shape;
     }
-    ttnn::SmallVector<uint32_t> shape_nd(n);
+    ttsl::SmallVector<uint32_t> shape_nd(n);
     std::copy(shape.view().rbegin(), shape.view().rbegin() + n, shape_nd.rbegin());
     const auto rank_diff_end = shape.rank() - n + 1;
     shape_nd[0] = std::accumulate(shape.cbegin(), shape.cbegin() + rank_diff_end, 1, std::multiplies<uint32_t>());
@@ -61,7 +61,7 @@ ttnn::Tensor squeeze_from_ND_to_4D(const ttnn::Tensor& tensor, const std::option
 }
 
 ttnn::Shape unsqueeze_shape_to_ND(const ttnn::Shape& shape, const uint32_t n) {
-    ttnn::SmallVector<uint32_t> shape_vector(n, 1);
+    ttsl::SmallVector<uint32_t> shape_vector(n, 1);
     std::copy(shape.view().rbegin(), shape.view().rend(), shape_vector.rbegin());
     return ttnn::Shape(shape_vector);
 }
@@ -459,7 +459,7 @@ ttnn::Tensor pad_to_tile_vol(
         auto padded_height = tt::round_up(padded_shape[-2], tt::constants::TILE_HEIGHT);
         auto padded_width = tt::round_up(padded_shape[-1], tt::constants::TILE_WIDTH);
         uint32_t num_non_hw_dims = rank - 2u;
-        auto padding_vec = ttnn::SmallVector<std::array<uint32_t, 2>>(num_non_hw_dims, {0, 0});
+        auto padding_vec = ttsl::SmallVector<std::array<uint32_t, 2>>(num_non_hw_dims, {0, 0});
         padding_vec.reserve(rank);
         padding_vec.emplace_back(0, padded_height - padded_shape[-2]);
         padding_vec.emplace_back(0, padded_width - padded_shape[-1]);
@@ -517,7 +517,7 @@ ttnn::Shape compute_padded_shape(
         logical_shape = ttnn::Shape({1, logical_shape[0]});
     }
 
-    ttnn::SmallVector<uint32_t> output_shape_vec(logical_shape.rank());
+    ttsl::SmallVector<uint32_t> output_shape_vec(logical_shape.rank());
     std::copy(logical_shape.cbegin(), logical_shape.cend(), output_shape_vec.begin());
 
     const std::array<uint32_t, 2> tile_shape = {tt::constants::TILE_WIDTH, tt::constants::TILE_HEIGHT};
@@ -534,7 +534,7 @@ ttnn::Shape pad_to_tile_shape(const ttnn::Shape& unpadded_shape) {
     using namespace tt::constants;
     auto rank = unpadded_shape.rank();
     TT_ASSERT(rank >= 1, "rank of shape to pad to tile shape must be at least 1.");
-    SmallVector<uint32_t> padded_shape_vec(rank);
+    ttsl::SmallVector<uint32_t> padded_shape_vec(rank);
 
     for (auto i = 0; i < rank; ++i) {
         padded_shape_vec[i] = unpadded_shape[i];

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -72,8 +72,8 @@ MassagedConcat build_unsqueeze_concat(int input_rank, const MemoryConfig& output
             while (res.logical_shape().rank() > input_rank) {
                 const auto shape = res.logical_shape();
                 const auto full_shape = res.padded_shape();
-                SmallVector<uint32_t> shape_vec{};
-                SmallVector<uint32_t> full_shape_vec{};
+                ttsl::SmallVector<uint32_t> shape_vec{};
+                ttsl::SmallVector<uint32_t> full_shape_vec{};
                 for (int i = 1; i < shape.rank(); i++) {
                     shape_vec.push_back(shape[i]);
                     full_shape_vec.push_back(full_shape[i]);
@@ -115,7 +115,7 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     TT_FATAL(
                         input_tensor.layout() == ttnn::TILE_LAYOUT,
                         "ttnn.concat: expected all input tensors to be in tile layout");
-                    ttnn::SmallVector<uint32_t> ends(
+                    ttsl::SmallVector<uint32_t> ends(
                         input_tensor.logical_shape().cbegin(), input_tensor.logical_shape().cend());
                     std::transform(ends.begin(), ends.end(), ends.begin(), [](const auto l) { return l - 1; });
                     return ttnn::untilize_with_unpadding(input_tensor, ttnn::Shape(ends), std::nullopt);
@@ -411,14 +411,14 @@ ttnn::Tensor concat(
                 std::vector<ttnn::Tensor> chunk_inputs;
                 chunk_inputs.reserve(input_tensors.size());
                 for (const auto& t : input_tensors) {
-                    ttnn::SmallVector<uint32_t> starts(rank, 0);
-                    ttnn::SmallVector<uint32_t> ends(rank);
+                    ttsl::SmallVector<uint32_t> starts(rank, 0);
+                    ttsl::SmallVector<uint32_t> ends(rank);
                     for (int i = 0; i < rank; i++) {
                         ends[i] = t.logical_shape()[i];
                     }
                     starts[rank - 2] = row_start;
                     ends[rank - 2] = row_end;
-                    ttnn::SmallVector<uint32_t> step(rank, 1);
+                    ttsl::SmallVector<uint32_t> step(rank, 1);
                     chunk_inputs.push_back(ttnn::slice(t, starts, ends, step, mem_config));
                 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
@@ -10,8 +10,8 @@
 
 namespace {
 
-ttnn::SmallVector<uint32_t> create_repetition_vector(const ttnn::Tensor& tensor, std::span<const int32_t> shape) {
-    ttnn::SmallVector<uint32_t> expansion_vector(shape.size());
+ttsl::SmallVector<uint32_t> create_repetition_vector(const ttnn::Tensor& tensor, std::span<const int32_t> shape) {
+    ttsl::SmallVector<uint32_t> expansion_vector(shape.size());
     auto tensor_shape = tensor.logical_shape();
     const auto source_rank = tensor_shape.rank();
     const auto new_rank = shape.size();

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand_nanobind.cpp
@@ -20,7 +20,7 @@ namespace {
 
 ttnn::Tensor expand_wrapper(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int32_t>& output_shape,
+    const ttsl::SmallVector<int32_t>& output_shape,
     const std::optional<ttnn::MemoryConfig>& memory_config) {
     return ttnn::expand(input_tensor, output_shape, memory_config);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -69,7 +69,7 @@ std::vector<Tensor> fold_with_transpose_(
     log_debug(tt::LogOp, "pad_output: {}", pad_output.logical_shape());
 
     auto transpose_hc_output = ttnn::prim::permute(
-        pad_output, ttnn::SmallVector<uint32_t>({0, 3, 1, 2}), std::make_optional(L1_mem_config), std::nullopt);
+        pad_output, ttsl::SmallVector<uint32_t>({0, 3, 1, 2}), std::make_optional(L1_mem_config), std::nullopt);
 
     log_debug(tt::LogOp, "transpose_hc_output: {}", transpose_hc_output.logical_shape());
 
@@ -470,7 +470,7 @@ Tensor fold(
 
     // Apply padding if needed
     if (has_hw_padding || has_c_padding) {
-        ttnn::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding_spec;
+        ttsl::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding_spec;
         padding_spec.push_back({0, 0});                     // N dimension
         padding_spec.push_back({pad_top, pad_bottom});      // H dimension
         padding_spec.push_back({pad_left, pad_right});      // W dimension

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
@@ -66,9 +66,9 @@ Tensor pre_gather_transform_tensor(
     // Since index_tensor.size(d) <= input_tensor.size(d) for all dimensions d != dim we slice input tensor to be the
     // same shape ignoring the dimension of the operation as the index tensor - this allows easy mapping of cells
     // between tensors
-    const ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
-    const ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-    const ttnn::SmallVector<uint32_t> end_index = {
+    const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+    const ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+    const ttsl::SmallVector<uint32_t> end_index = {
         index_tensor_padded_shape[0],
         index_tensor_padded_shape[1],
         index_tensor_padded_shape[2],
@@ -131,7 +131,7 @@ Tensor post_gather_transform_tensor(
                 (orig_rank <= 4) ? index_dim : (index_dim + (output_tensor.padded_shape().rank() - orig_rank));
             output_tensor = ttnn::transpose(output_tensor, dim_adj, -1, index_tensor.memory_config());
         }
-        ttnn::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
+        ttsl::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
         output_tensor = ttnn::reshape(output_tensor, ttnn::Shape{result_shape});
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa.cpp
@@ -24,7 +24,7 @@ Tensor pre_tosa_gather_transform_input_index_tensor(const Tensor& input_tensor, 
     // Unsqueeze the input tensor to add a new dimension
     const Tensor unsqueezed_tensor = ttnn::unsqueeze(input_tensor, -1);
     // Create a shape vector for the new tensor
-    ttnn::SmallVector<int32_t> shape_vector = {input_tensor.logical_shape()[0], input_tensor.logical_shape()[1], C};
+    ttsl::SmallVector<int32_t> shape_vector = {input_tensor.logical_shape()[0], input_tensor.logical_shape()[1], C};
     Tensor expanded_tensor = ttnn::expand(unsqueezed_tensor, shape_vector, unsqueezed_tensor.memory_config());
 
     return expanded_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill.cpp
@@ -81,7 +81,7 @@ Tensor indexed_fill(
 
     // Permute fallback: bring target dim to front, run the primitive at dim=0, permute back.
     // Build perm = [dim, 0, 1, ..., dim-1, dim+1, ..., rank-1]
-    SmallVector<int64_t> perm;
+    ttsl::SmallVector<int64_t> perm;
     perm.reserve(rank);
     perm.push_back(dim);
     for (int64_t i = 0; i < rank; ++i) {
@@ -90,7 +90,7 @@ Tensor indexed_fill(
         }
     }
 
-    SmallVector<int64_t> inv_perm(rank);
+    ttsl::SmallVector<int64_t> inv_perm(rank);
     for (int64_t i = 0; i < rank; ++i) {
         inv_perm[perm[i]] = i;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -18,7 +18,7 @@ namespace ttnn::operations::data_movement::detail {
 bool eq_spans(const auto a, const auto b) { return std::equal(a.begin(), a.end(), b.begin(), b.end()); }
 
 ttnn::Shape update_original_shape(const ttnn::Shape& padded_shape, const ttnn::Shape& input_shape) {
-    ttnn::SmallVector<uint32_t> updated_shape;
+    ttsl::SmallVector<uint32_t> updated_shape;
     size_t input_rank = input_shape.rank();
     for (size_t i = 0; i < input_rank - 2; i++) {
         updated_shape.push_back(input_shape[i]);
@@ -101,7 +101,7 @@ ttnn::Tensor pad_impl(
             if (height_distinct(input_logical_shape, output_padded_shape)) {
                 // we will decompose the padding into two parts and run two
                 // separate pads.
-                ttnn::SmallVector<uint32_t> adjusted_input_tensor_start{0, 0, 0, input_tensor_start[3]};
+                ttsl::SmallVector<uint32_t> adjusted_input_tensor_start{0, 0, 0, input_tensor_start[3]};
 
                 TT_FATAL(
                     not(height_distinct(input_logical_shape, output_shape_width_padded) and
@@ -157,7 +157,7 @@ ttnn::Tensor pad_impl(
 
 ttnn::Tensor pad_impl(
     const ttnn::Tensor& input_tensor,
-    ttnn::SmallVector<PadSpecDim> padding,
+    ttsl::SmallVector<PadSpecDim> padding,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -214,7 +214,7 @@ ttnn::Tensor pad_impl(
 }
 
 std::tuple<ttnn::Shape, ttnn::Shape> compute_requested_shape(
-    const ttnn::Shape& input_logical_shape, const ttnn::SmallVector<PadSpecDim>& pad_spec) {
+    const ttnn::Shape& input_logical_shape, const ttsl::SmallVector<PadSpecDim>& pad_spec) {
     if (std::all_of(pad_spec.begin(), pad_spec.end(), [](auto& p) {
             return p.before_elements == 0 && p.after_elements == 0;
         })) {
@@ -222,7 +222,7 @@ std::tuple<ttnn::Shape, ttnn::Shape> compute_requested_shape(
     }
 
     const auto rank = input_logical_shape.rank();
-    ttnn::SmallVector<uint32_t> requested_logical_shape_vec(rank, 0);
+    ttsl::SmallVector<uint32_t> requested_logical_shape_vec(rank, 0);
 
     std::transform(
         input_logical_shape.cbegin(),
@@ -237,7 +237,7 @@ std::tuple<ttnn::Shape, ttnn::Shape> compute_requested_shape(
 
 ttnn::Tensor invoke_rm(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<PadSpecDim>& padding_vec,
+    const ttsl::SmallVector<PadSpecDim>& padding_vec,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -249,7 +249,7 @@ ttnn::Tensor invoke_rm(
 
     // output_tensor is currently 4D. We have to squeeze back to the original rank
     if (original_rank <= 4) {
-        auto to_vec = [](const auto& span) { return ttnn::SmallVector<uint32_t>{span.begin(), span.end()}; };
+        auto to_vec = [](const auto& span) { return ttsl::SmallVector<uint32_t>{span.begin(), span.end()}; };
         auto output_shape = to_vec(output_tensor.padded_shape().view());
         auto padded_shape = to_vec(output_tensor.padded_shape().view());
         if (const auto rank_diff = output_shape.size() - original_rank; rank_diff) {
@@ -268,7 +268,7 @@ ttnn::Tensor invoke_rm(
 
 ttnn::Tensor invoke_tile(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<PadSpecDim>& padding_vec,
+    const ttsl::SmallVector<PadSpecDim>& padding_vec,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -285,7 +285,7 @@ ttnn::Tensor invoke_tile(
 
     // Consistent with behavior expected by callers
     if (input_tensor.storage_type() != StorageType::DEVICE) {
-        ttnn::Shape zeros(ttnn::SmallVector<uint32_t>(input_logical_shape.rank(), 0));
+        ttnn::Shape zeros(ttsl::SmallVector<uint32_t>(input_logical_shape.rank(), 0));
         return input_tensor.pad(requested_padded_shape, zeros, value);
     }
 
@@ -306,7 +306,7 @@ ttnn::Tensor invoke_tile(
     } else {
         // need to align the requested padding to tile size. Note that begin padding is not supported so now just
         // set to zero
-        ttnn::SmallVector<PadSpecDim> padded_padding_vec;
+        ttsl::SmallVector<PadSpecDim> padded_padding_vec;
         padded_padding_vec.reserve(requested_rank);
         std::transform(
             requested_padded_shape.cbegin(),
@@ -352,7 +352,7 @@ namespace ttnn {
 
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<operations::data_movement::PadSpecDim>& padding,
+    const ttsl::SmallVector<operations::data_movement::PadSpecDim>& padding,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -360,7 +360,7 @@ ttnn::Tensor pad(
     using PadSpecDim = operations::data_movement::PadSpecDim;
     const int original_rank = input_tensor.logical_shape().rank();
 
-    ttnn::SmallVector<PadSpecDim> working_padding = padding;
+    ttsl::SmallVector<PadSpecDim> working_padding = padding;
 
     if (int diff = original_rank - padding.size(); diff != 0) {
         TT_FATAL(diff > 0, "ttnn.pad: padding len can't be larger than input tensor rank");
@@ -395,13 +395,13 @@ ttnn::Tensor pad(
 
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<std::array<uint32_t, 2>>& padding,
+    const ttsl::SmallVector<std::array<uint32_t, 2>>& padding,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using PadSpecDim = operations::data_movement::PadSpecDim;
-    ttnn::SmallVector<PadSpecDim> padding_impl;
+    ttsl::SmallVector<PadSpecDim> padding_impl;
     std::transform(padding.begin(), padding.end(), std::back_inserter(padding_impl), [](auto& p) {
         return PadSpecDim(p[0], p[1]);
     });
@@ -418,7 +418,7 @@ ttnn::Tensor pad(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using PadSpecDim = operations::data_movement::PadSpecDim;
-    ttnn::SmallVector<PadSpecDim> padding_impl;
+    ttsl::SmallVector<PadSpecDim> padding_impl;
     const auto& log_shape = input_tensor.logical_shape();
     for (uint32_t i = 0; i < output_padded_shape.size(); ++i) {
         padding_impl.emplace_back(

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
@@ -27,7 +27,7 @@ struct PadSpecDim {
 // to a different code path than Python-driven tests cover.
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<operations::data_movement::PadSpecDim>& padding,
+    const ttsl::SmallVector<operations::data_movement::PadSpecDim>& padding,
     float value,
     bool use_multicore = true,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
@@ -35,7 +35,7 @@ ttnn::Tensor pad(
 
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<std::array<uint32_t, 2>>& padding,
+    const ttsl::SmallVector<std::array<uint32_t, 2>>& padding,
     float value,
     bool use_multicore = true,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_nanobind.cpp
@@ -44,7 +44,7 @@ void bind_pad(nb::module_& mod) {
         ttnn::overload_t(
             nb::overload_cast<
                 const ttnn::Tensor&,
-                const ttnn::SmallVector<std::array<uint32_t, 2>>&,
+                const ttsl::SmallVector<std::array<uint32_t, 2>>&,
                 float,
                 bool,
                 const std::optional<MemoryConfig>&,

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -61,7 +61,7 @@ PermuteDeviceOperation::spec_return_value_t PermuteDeviceOperation::compute_outp
     const auto& input_tensor = tensor_args.input_tensor;
     auto input_shape = input_tensor.logical_shape();
 
-    SmallVector<uint32_t> output_shape_vec(attributes.dims.size());
+    ttsl::SmallVector<uint32_t> output_shape_vec(attributes.dims.size());
     std::transform(attributes.dims.begin(), attributes.dims.end(), output_shape_vec.begin(), [&](auto dim) {
         return input_shape[dim];
     });
@@ -71,7 +71,7 @@ PermuteDeviceOperation::spec_return_value_t PermuteDeviceOperation::compute_outp
 
     // Derive shard_spec when sharded output lacks one.
     if (output_mem_config.is_sharded() && !output_mem_config.shard_spec().has_value()) {
-        SmallVector<uint32_t> output_padded_vec(output_shape.view().begin(), output_shape.view().end());
+        ttsl::SmallVector<uint32_t> output_padded_vec(output_shape.view().begin(), output_shape.view().end());
         if (input_tensor.layout() == Layout::TILE && output_shape.rank() >= 2) {
             const auto& tile = input_tensor.tensor_spec().tile();
             auto r = output_shape.rank();
@@ -165,7 +165,7 @@ ttsl::hash::hash_t PermuteDeviceOperation::compute_program_hash(
 namespace ttnn::prim {
 ttnn::operations::data_movement::PermuteDeviceOperation::tensor_return_value_t permute(
     const Tensor& input_tensor,
-    const SmallVector<uint32_t>& dims,
+    const ttsl::SmallVector<uint32_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor,
     float pad_value) {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -19,7 +19,7 @@ namespace ttnn::operations::data_movement {
 
 struct PermuteDeviceOperation {
     struct operation_attributes_t {
-        const SmallVector<uint32_t> dims;
+        const ttsl::SmallVector<uint32_t> dims;
         const MemoryConfig output_mem_config;
         const float pad_value = 0.0f;
     };
@@ -99,7 +99,7 @@ struct PermuteDeviceOperation {
 namespace ttnn::prim {
 ttnn::operations::data_movement::PermuteDeviceOperation::tensor_return_value_t permute(
     const Tensor& input_tensor,
-    const SmallVector<uint32_t>& dims,
+    const ttsl::SmallVector<uint32_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor,
     float pad_value = 0.0f);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -33,7 +33,7 @@ uint32_t tile_size(const ttnn::Tensor& input_tensor) {
 ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
     const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     const auto& shape = input_tensor.padded_shape();
-    ttnn::SmallVector<uint32_t> tiled_shape;
+    ttsl::SmallVector<uint32_t> tiled_shape;
     tiled_shape.reserve(shape.rank());
     for (int i = 0; i < shape.rank(); i++) {
         uint32_t dim = 0;
@@ -50,8 +50,8 @@ ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
     return res;
 }
 
-ttnn::SmallVector<uint32_t> get_strides(const ttnn::Shape& shape) {
-    ttnn::SmallVector<uint32_t> strides(shape.rank());
+ttsl::SmallVector<uint32_t> get_strides(const ttnn::Shape& shape) {
+    ttsl::SmallVector<uint32_t> strides(shape.rank());
     strides[shape.rank() - 1] = 1;
     for (int i = shape.rank() - 2; i >= 0; i--) {
         strides[i] = strides[i + 1] * shape[i + 1];
@@ -60,15 +60,15 @@ ttnn::SmallVector<uint32_t> get_strides(const ttnn::Shape& shape) {
 }
 
 // Function to compute the inverse of a permutation
-ttnn::SmallVector<uint32_t> get_inverse_permutation(const ttnn::SmallVector<uint32_t>& perm) {
+ttsl::SmallVector<uint32_t> get_inverse_permutation(const ttsl::SmallVector<uint32_t>& perm) {
     // Get the size of the permutation
     size_t n = perm.size();
 
     // Create a vector for the inverse permutation
-    ttnn::SmallVector<uint32_t> inverse_permutation(n);
+    ttsl::SmallVector<uint32_t> inverse_permutation(n);
 
     // Validate the input permutation
-    ttnn::SmallVector<bool> seen(n, false);
+    ttsl::SmallVector<bool> seen(n, false);
     for (size_t i = 0; i < n; ++i) {
         if (perm[i] >= n || seen[perm[i]]) {
             TT_FATAL(false, "Invalid permutation: duplicate or out of range value");

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -28,7 +28,7 @@ inline bool is_rm_block_or_width_sharded(const ttnn::Tensor& t) {
 
 ttnn::Tensor permute_impl(
     const ttnn::Tensor& a,
-    const ttnn::SmallVector<uint32_t>& dims,
+    const ttsl::SmallVector<uint32_t>& dims,
     const std::optional<MemoryConfig>& output_mem_config,
     float pad_value = 0.0f) {
     uint32_t rank = a.logical_shape().rank();
@@ -49,7 +49,7 @@ ttnn::Tensor permute_impl(
         if (output_mem_config.has_value() && output_mem_config->is_sharded() &&
             !output_mem_config->shard_spec().has_value()) {
             const auto& padded_in = a.padded_shape();
-            ttnn::SmallVector<uint32_t> out_padded_vec(padded_in.rank());
+            ttsl::SmallVector<uint32_t> out_padded_vec(padded_in.rank());
             for (size_t i = 0; i < dims.size(); ++i) {
                 out_padded_vec[i] = padded_in[dims[i]];
             }
@@ -149,13 +149,13 @@ ttnn::Tensor permute_impl(
 
 ttnn::Tensor permute_launch(
     const ttnn::Tensor& a,
-    const ttnn::SmallVector<uint32_t>& dims,
+    const ttsl::SmallVector<uint32_t>& dims,
     const std::optional<MemoryConfig>& output_mem_config,
     float pad_value = 0.0f) {
     return permute_impl(a, dims, output_mem_config, pad_value);
 }
 
-bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& dims) {
+bool is_permute_nop(const ttnn::Tensor& a, const ttsl::SmallVector<uint32_t>& dims) {
     // Rank <= 1 is always a no-op.
     const auto rank = a.logical_shape().rank();
     if (rank <= 1) {
@@ -163,7 +163,7 @@ bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& di
     }
 
     // Identity permutation.
-    ttnn::SmallVector<uint32_t> seq_dims(rank);
+    ttsl::SmallVector<uint32_t> seq_dims(rank);
     std::iota(seq_dims.begin(), seq_dims.end(), 0);
     if (dims == seq_dims) {
         return true;
@@ -177,7 +177,7 @@ bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& di
 
     // Shape change → not a no-op.
     const auto& shape = a.logical_shape();
-    ttnn::SmallVector<uint32_t> perm_shape(rank);
+    ttsl::SmallVector<uint32_t> perm_shape(rank);
     for (uint32_t i = 0; i < rank; ++i) {
         perm_shape[i] = shape[dims[i]];
     }
@@ -203,7 +203,7 @@ namespace ttnn {
 
 ttnn::Tensor permute(
     const ttnn::Tensor& input_tensor,
-    const SmallVector<int64_t>& dims,
+    const ttsl::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
     float pad_value) {
     const auto input_rank = input_tensor.logical_shape().rank();
@@ -212,7 +212,7 @@ ttnn::Tensor permute(
         "The number of dimensions in the tensor input does not match the length of the desired ordering");
     TT_FATAL(is_device_tensor(input_tensor), "Tensor must already be on device");
 
-    SmallVector<uint32_t> normalized_dims(dims.size());
+    ttsl::SmallVector<uint32_t> normalized_dims(dims.size());
     std::transform(dims.begin(), dims.end(), normalized_dims.begin(), [input_tensor](std::int64_t idx) {
         return input_tensor.logical_shape().get_normalized_index(idx);
     });
@@ -220,8 +220,8 @@ ttnn::Tensor permute(
         return ttnn::to_memory_config(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     }
 
-    auto adjust_order = [](const ttnn::SmallVector<uint32_t>& dims) {
-        ttnn::SmallVector<uint32_t> new_order;
+    auto adjust_order = [](const ttsl::SmallVector<uint32_t>& dims) {
+        ttsl::SmallVector<uint32_t> new_order;
         TT_FATAL(dims.size() <= 4, "Minimum rank of tensor required is 4");
         int additional_ranks = 4 - dims.size();
         for (int i = 0; i < additional_ranks; i++) {
@@ -255,7 +255,7 @@ ttnn::Tensor permute(
     return output_tensor;
 }
 
-ttnn::Tensor permute(const ttnn::Tensor& input_tensor, const SmallVector<int64_t>& dims, float pad_value) {
+ttnn::Tensor permute(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<int64_t>& dims, float pad_value) {
     return permute(input_tensor, dims, std::nullopt, pad_value);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
@@ -11,10 +11,10 @@ namespace ttnn {
 
 ttnn::Tensor permute(
     const ttnn::Tensor& input_tensor,
-    const SmallVector<int64_t>& dims,
+    const ttsl::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
     float pad_value = 0.0f);
 
-ttnn::Tensor permute(const ttnn::Tensor& input_tensor, const SmallVector<int64_t>& dims, float pad_value = 0.0f);
+ttnn::Tensor permute(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<int64_t>& dims, float pad_value = 0.0f);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_nanobind.cpp
@@ -38,7 +38,7 @@ void bind_permute(nb::module_& mod) {
         ttnn::overload_t(
             nb::overload_cast<
                 const ttnn::Tensor&,
-                const ttnn::SmallVector<int64_t>&,
+                const ttsl::SmallVector<int64_t>&,
                 const std::optional<ttnn::MemoryConfig>&,
                 float>(&ttnn::permute),
             nb::arg("input_tensor").noconvert(),
@@ -47,7 +47,7 @@ void bind_permute(nb::module_& mod) {
             nb::arg("memory_config") = nb::none(),
             nb::arg("pad_value") = 0.0f),
         ttnn::overload_t(
-            nb::overload_cast<const ttnn::Tensor&, const ttnn::SmallVector<int64_t>&, float>(&ttnn::permute),
+            nb::overload_cast<const ttnn::Tensor&, const ttsl::SmallVector<int64_t>&, float>(&ttnn::permute),
             nb::arg("input_tensor").noconvert(),
             nb::arg("dims"),
             nb::arg("pad_value") = 0.0f));

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -32,7 +32,7 @@ struct UpperRepeatDims {
 ttnn::Tensor repeat_upper_dims_rm(
     const ttnn::Tensor& tensor, const uint32_t dim, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
     const auto& input_shape = tensor.logical_shape();
-    ttnn::SmallVector<uint32_t> collapsed_shape_vector(4);
+    ttsl::SmallVector<uint32_t> collapsed_shape_vector(4);
 
     collapsed_shape_vector[UpperRepeatDims::collapsed_upper] =
         std::accumulate(input_shape.cbegin(), input_shape.cbegin() + dim, 1, std::multiplies<uint32_t>());
@@ -54,7 +54,7 @@ ttnn::Tensor repeat_upper_dims_rm(
 ttnn::Tensor repeat_last_dim_rm(
     const ttnn::Tensor& tensor, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
     const auto& input_shape = tensor.logical_shape();
-    ttnn::SmallVector<uint32_t> collapsed_shape_vector(2);
+    ttsl::SmallVector<uint32_t> collapsed_shape_vector(2);
 
     collapsed_shape_vector[0] =
         std::accumulate(input_shape.cbegin(), input_shape.cend() - 1, 1, std::multiplies<uint32_t>());
@@ -71,17 +71,17 @@ ttnn::Tensor repeat_last_dim_rm(
     return ttnn::view(out_tensor, ttnn::Shape(expected_shape));
 }
 
-std::tuple<ttnn::Tensor, ttnn::SmallVector<uint32_t>> match_input_rank(
-    const ttnn::Tensor& tensor, const SmallVector<uint32_t>& repetition_vector) {
+std::tuple<ttnn::Tensor, ttsl::SmallVector<uint32_t>> match_input_rank(
+    const ttnn::Tensor& tensor, const ttsl::SmallVector<uint32_t>& repetition_vector) {
     auto working_tensor = tensor;
     const auto& input_shape = working_tensor.logical_shape();
-    SmallVector<uint32_t> working_repetition_vector;
+    ttsl::SmallVector<uint32_t> working_repetition_vector;
 
     const auto total_reps =
         std::accumulate(repetition_vector.cbegin(), repetition_vector.cend(), 1, std::multiplies<uint_fast32_t>());
 
     if (input_shape.rank() < repetition_vector.size()) {
-        ttnn::SmallVector<uint32_t> new_shape_vec(repetition_vector.size(), 1);
+        ttsl::SmallVector<uint32_t> new_shape_vec(repetition_vector.size(), 1);
         std::copy_backward(input_shape.cbegin(), input_shape.cend(), new_shape_vec.end());
         working_tensor = ttnn::view(working_tensor, ttnn::Shape(new_shape_vec));
         working_repetition_vector = repetition_vector;
@@ -160,7 +160,7 @@ namespace ttnn {
 
 ttnn::Tensor repeat(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<uint32_t>& repetition_vector,
+    const ttsl::SmallVector<uint32_t>& repetition_vector,
     const std::optional<MemoryConfig>& memory_config) {
     auto [working_tensor, working_repetition_vector] =
         operations::data_movement::detail::match_input_rank(input_tensor, repetition_vector);
@@ -290,7 +290,8 @@ ttnn::Tensor repeat(
 }
 
 ttnn::Tensor repeat(const ttnn::Tensor& input_tensor, const ttnn::Shape& repeat_dims) {
-    return ttnn::repeat(input_tensor, SmallVector<uint32_t>(repeat_dims.cbegin(), repeat_dims.cend()), std::nullopt);
+    return ttnn::repeat(
+        input_tensor, ttsl::SmallVector<uint32_t>(repeat_dims.cbegin(), repeat_dims.cend()), std::nullopt);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
@@ -9,7 +9,7 @@ namespace ttnn {
 
 ttnn::Tensor repeat(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<uint32_t>& repetition_vector,
+    const ttsl::SmallVector<uint32_t>& repetition_vector,
     const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
 ttnn::Tensor repeat(const ttnn::Tensor& input_tensor, const ttnn::Shape& repeat_dims);

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat_nanobind.cpp
@@ -9,7 +9,7 @@
 #include <nanobind/stl/optional.h>
 
 #include "ttnn-nanobind/bind_function.hpp"
-#include "ttnn-nanobind/small_vector_caster.hpp"  // for SmallVector<uint32_t>
+#include "ttnn-nanobind/small_vector_caster.hpp"  // for ttsl::SmallVector<uint32_t>
 
 #include "repeat.hpp"
 
@@ -34,7 +34,7 @@ void bind_repeat(nb::module_& mod) {
     ttnn::bind_function<"repeat">(
         mod,
         doc,
-        nb::overload_cast<const ttnn::Tensor&, const ttnn::SmallVector<uint32_t>&, const std::optional<MemoryConfig>&>(
+        nb::overload_cast<const ttnn::Tensor&, const ttsl::SmallVector<uint32_t>&, const std::optional<MemoryConfig>&>(
             &ttnn::repeat),
         nb::arg("input_tensor"),
         nb::arg("repeat_dims"),

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
@@ -39,7 +39,7 @@ ttnn::Tensor repeat_interleave(
 
     rm_input = ttnn::to_layout(rm_input, Layout::ROW_MAJOR);
     const auto& rm_input_shape = rm_input.logical_shape();
-    SmallVector<uint32_t> final_shape;
+    ttsl::SmallVector<uint32_t> final_shape;
     final_shape.reserve(input_rank);
     for (uint32_t i = 0; i < rm_input_shape.rank(); i++) {
         final_shape.push_back(rm_input_shape[i]);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
@@ -11,7 +11,7 @@
 
 #include "reshape.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
-#include "ttnn-nanobind/small_vector_caster.hpp"  // for SmallVector<int32_t>
+#include "ttnn-nanobind/small_vector_caster.hpp"  // for ttsl::SmallVector<int32_t>
 
 namespace ttnn::operations::data_movement {
 
@@ -25,7 +25,7 @@ ttnn::Tensor reshape_on_device_wrapper(
     int Y,
     int X,
     const std::optional<MemoryConfig>& memory_config_arg) {
-    return reshape_on_device(input_tensor, ttnn::SmallVector<int32_t>{W, Z, Y, X}, memory_config_arg);
+    return reshape_on_device(input_tensor, ttsl::SmallVector<int32_t>{W, Z, Y, X}, memory_config_arg);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
@@ -22,7 +22,7 @@ namespace detail {
 
 ttnn::Tensor reshape_shape_vector_wrapper(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int32_t>& shape,
+    const ttsl::SmallVector<int32_t>& shape,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value,
     const ttnn::TileReshapeMapMode reshape_tile_mode,
@@ -98,7 +98,7 @@ void bind_reshape_view_operation(nb::module_& mod) {
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("skip_padding_fill") = false),
 
-        // Overload 3: shape vector (SmallVector<int32_t>)
+        // Overload 3: shape vector (ttsl::SmallVector<int32_t>)
         ttnn::overload_t(
             &reshape_shape_vector_wrapper,
             nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll.cpp
@@ -17,8 +17,8 @@ namespace ttnn {
 
 ttnn::Tensor roll(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int>& shifts,
-    const ttnn::SmallVector<int>& input_dims,
+    const ttsl::SmallVector<int>& shifts,
+    const ttsl::SmallVector<int>& input_dims,
     const std::optional<MemoryConfig>& memory_config) {
     ttnn::Tensor result = input_tensor;
     auto size = result.logical_shape();
@@ -49,7 +49,7 @@ ttnn::Tensor roll(
         adjusted_shifts[i] = ((shift % shift_size) + shift_size) % shift_size;
     }
 
-    const ttnn::SmallVector<int> stride_vector(num_dims, 1);
+    const ttsl::SmallVector<int> stride_vector(num_dims, 1);
 
     // Sharded inputs use the native sharded roll device op, applied one dim at a time. A
     // tilized roll is native only when shifts on the last two dims are tile-aligned (a
@@ -121,8 +121,8 @@ ttnn::Tensor roll(
             continue;
         }
 
-        ttnn::SmallVector<int> start_left(num_dims, 0), end_left;
-        ttnn::SmallVector<int> start_right(num_dims, 0), end_right;
+        ttsl::SmallVector<int> start_left(num_dims, 0), end_left;
+        ttsl::SmallVector<int> start_right(num_dims, 0), end_right;
 
         for (int j = 0; j < num_dims; ++j) {
             end_left.push_back(size[j]);
@@ -152,8 +152,8 @@ ttnn::Tensor roll(const ttnn::Tensor& input_tensor, const int shift, const std::
         !input_tensor.is_sharded(),
         "ttnn::roll without dims does not support sharded inputs. Convert to interleaved first.");
 
-    ttnn::SmallVector<int> shifts = {shift};
-    ttnn::SmallVector<int> dims = {1};  // Rolling will happen on dimension 1 after flattening
+    ttsl::SmallVector<int> shifts = {shift};
+    ttsl::SmallVector<int> dims = {1};  // Rolling will happen on dimension 1 after flattening
 
     auto original_shape = input_tensor.logical_shape();
 
@@ -178,8 +178,8 @@ ttnn::Tensor roll(
     const int shift,
     const int dim,
     const std::optional<MemoryConfig>& memory_config) {
-    ttnn::SmallVector<int> shifts = {shift};
-    ttnn::SmallVector<int> dims = {dim};
+    ttsl::SmallVector<int> shifts = {shift};
+    ttsl::SmallVector<int> dims = {dim};
 
     return roll(input_tensor, shifts, dims, memory_config);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll.hpp
@@ -8,8 +8,8 @@ namespace ttnn {
 
 ttnn::Tensor roll(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int>& shifts,
-    const ttnn::SmallVector<int>& input_dims,
+    const ttsl::SmallVector<int>& shifts,
+    const ttsl::SmallVector<int>& input_dims,
     const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
 ttnn::Tensor roll(

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
@@ -30,8 +30,8 @@ void bind_roll(nb::module_& mod) {
         ttnn::overload_t(
             nb::overload_cast<
                 const ttnn::Tensor&,
-                const ttnn::SmallVector<int>&,
-                const ttnn::SmallVector<int>&,
+                const ttsl::SmallVector<int>&,
+                const ttsl::SmallVector<int>&,
                 const std::optional<MemoryConfig>&>(&ttnn::roll),
             nb::arg("input_tensor"),
             nb::arg("shifts"),

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
@@ -155,9 +155,9 @@ Tensor pre_scatter_transform_tensor(
 
     Tensor processed_tensor = input_tensor;
     if (index_shape.has_value()) {
-        const ttnn::SmallVector<uint32_t> start(index_shape->rank(), 0);
-        const ttnn::SmallVector<uint32_t> steps(index_shape->rank(), 1);
-        const ttnn::SmallVector<uint32_t> end(index_shape->cbegin(), index_shape->cend());
+        const ttsl::SmallVector<uint32_t> start(index_shape->rank(), 0);
+        const ttsl::SmallVector<uint32_t> steps(index_shape->rank(), 1);
+        const ttsl::SmallVector<uint32_t> end(index_shape->cbegin(), index_shape->cend());
         processed_tensor = ttnn::slice(processed_tensor, start, end, steps, processed_tensor.memory_config());
     }
     // if layout is tile, convert to row-major first
@@ -184,9 +184,9 @@ Tensor pre_scatter_transform_tensor(
 
     Tensor processed_tensor = input_tensor;
     if (index_shape.has_value()) {
-        const ttnn::SmallVector<uint32_t> start(index_shape->rank(), 0);
-        const ttnn::SmallVector<uint32_t> steps(index_shape->rank(), 1);
-        const ttnn::SmallVector<uint32_t> end(index_shape->cbegin(), index_shape->cend());
+        const ttsl::SmallVector<uint32_t> start(index_shape->rank(), 0);
+        const ttsl::SmallVector<uint32_t> steps(index_shape->rank(), 1);
+        const ttsl::SmallVector<uint32_t> end(index_shape->cbegin(), index_shape->cend());
         processed_tensor = ttnn::slice(processed_tensor, start, end, steps, processed_tensor.memory_config());
     }
     // if layout is tile, convert to row-major first - this allows for minimized memory usage by transpose (no padding)

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter.cpp
@@ -37,7 +37,7 @@ Tensor pre_tosa_scatter_transform_tensor(
     Tensor processed_tensor = tensor;
     if (input_tensor_type == InputTensorType::INDEX) {
         processed_tensor =
-            ttnn::expand(ttnn::unsqueeze(tensor, -1), SmallVector<int32_t>{N, W, C}, tensor.memory_config());
+            ttnn::expand(ttnn::unsqueeze(tensor, -1), ttsl::SmallVector<int32_t>{N, W, C}, tensor.memory_config());
         // WARNING: the rest of this if statement is to be removed after fixing the int32 transpose issue (PR: #23415)
         auto* device = processed_tensor.device();
         processed_tensor = processed_tensor.cpu();

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -177,7 +177,7 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
 SliceDeviceOperation::spec_return_value_t SliceDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
+    ttsl::SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
 
     if (args.use_tensor_args) {
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -212,9 +212,9 @@ ttnn::Tensor slice(
     }
 
     // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
-    ttnn::SmallVector<uint32_t> modified_begins(input_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_ends(input_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_step(input_rank, 1);
+    ttsl::SmallVector<uint32_t> modified_begins(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_ends(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_step(input_rank, 1);
 
     // Wrap indices and adjust begins, ends, and step
     for (size_t i = 0; i < begins.size(); ++i) {
@@ -229,7 +229,7 @@ ttnn::Tensor slice(
         }
     }
 
-    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttnn::SmallVector<uint32_t>& modified_ends) {
+    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttsl::SmallVector<uint32_t>& modified_ends) {
         return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
     };
 
@@ -259,7 +259,7 @@ ttnn::Tensor slice(
             const auto& shard_spec_val = output_memory_config.shard_spec().value();
 
             // Compute output dimensions, tile-aligned if using TILE path
-            ttnn::SmallVector<uint32_t> output_dims(input_rank);
+            ttsl::SmallVector<uint32_t> output_dims(input_rank);
             for (size_t i = 0; i < input_rank; i++) {
                 output_dims[i] = output_dim_i(i, modified_ends);
             }
@@ -328,13 +328,13 @@ ttnn::Tensor slice(
         input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config);
     }
 
-    ttnn::SmallVector<uint32_t> padded_ends = modified_ends;
+    ttsl::SmallVector<uint32_t> padded_ends = modified_ends;
     if (input.layout() == Layout::TILE) {
         padded_ends[input_rank - 2] = std::max(tt::round_up(padded_ends[input_rank - 2], tile_shape[0]), tile_shape[0]);
         padded_ends[input_rank - 1] = std::max(tt::round_up(padded_ends[input_rank - 1], tile_shape[1]), tile_shape[1]);
     }
 
-    ttnn::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
+    ttsl::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
     actual_shape_vec.reserve(input_rank);
     final_padded_shape_vec.reserve(input_rank);
     bool empty = false;
@@ -418,7 +418,7 @@ ttnn::Tensor slice(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<T>>& step,
+    const std::optional<ttsl::SmallVector<T>>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,
@@ -474,8 +474,8 @@ ttnn::Tensor slice(
 
         // Create dummy shapes for SliceDeviceOperation (will be ignored when use_tensor_args=true)
         uint32_t input_rank = input_tensor.logical_shape().rank();
-        ttnn::SmallVector<uint32_t> dummy_shape(input_rank, 0);
-        ttnn::SmallVector<uint32_t> dummy_step_shape(input_rank, 1);
+        ttsl::SmallVector<uint32_t> dummy_shape(input_rank, 0);
+        ttsl::SmallVector<uint32_t> dummy_step_shape(input_rank, 1);
         ttnn::Shape dummy_start(dummy_shape);
         ttnn::Shape dummy_end(dummy_shape);
         ttnn::Shape dummy_step(dummy_step_shape);
@@ -507,7 +507,7 @@ ttnn::Tensor slice(
     ttsl::Span<const T> output_tensor_end_span(output_tensor_end_vector.data(), output_tensor_end_vector.size());
 
     // generate the step value if it is not provided
-    ttnn::SmallVector<T> step_value = step.value_or(ttnn::SmallVector<T>(output_tensor_start_span.size(), 1));
+    ttsl::SmallVector<T> step_value = step.value_or(ttsl::SmallVector<T>(output_tensor_start_span.size(), 1));
 
     return ttnn::slice<T>(
         input_tensor,
@@ -567,7 +567,7 @@ template ttnn::Tensor slice<uint32_t>(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<uint32_t>>& step,
+    const std::optional<ttsl::SmallVector<uint32_t>>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -22,9 +22,9 @@ ttnn::Tensor slice(
 template <typename T>
 ttnn::Tensor slice(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<T>& begins,
-    const ttnn::SmallVector<T>& ends,
-    const ttnn::SmallVector<T>& step,
+    const ttsl::SmallVector<T>& begins,
+    const ttsl::SmallVector<T>& ends,
+    const ttsl::SmallVector<T>& step,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<float>& pad_value = std::nullopt,
@@ -56,7 +56,7 @@ ttnn::Tensor slice(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<T>>& step = std::nullopt,
+    const std::optional<ttsl::SmallVector<T>>& step = std::nullopt,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<float>& pad_value = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -25,14 +25,14 @@ namespace {
 
 ttnn::Tensor slice_small_vector_wrapper(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int>& slice_start,
-    const ttnn::SmallVector<int>& slice_end,
-    const std::optional<ttnn::SmallVector<int>>& step,
+    const ttsl::SmallVector<int>& slice_start,
+    const ttsl::SmallVector<int>& slice_end,
+    const std::optional<ttsl::SmallVector<int>>& step,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,
     const std::optional<CoreRangeSet>&& sub_core_grids) {
-    const auto step_value = step.value_or(ttnn::SmallVector<int>(slice_end.size(), 1));
+    const auto step_value = step.value_or(ttsl::SmallVector<int>(slice_end.size(), 1));
     return ttnn::slice(
         input_tensor,
         slice_start,
@@ -80,7 +80,7 @@ void bind_slice(nb::module_& mod) {
                 const ttnn::Tensor&,
                 const ttnn::Tensor&,
                 const ttnn::Tensor&,
-                const std::optional<ttnn::SmallVector<uint32_t>>&,
+                const std::optional<ttsl::SmallVector<uint32_t>>&,
                 const std::optional<MemoryConfig>&,
                 const std::optional<Tensor>&,
                 const std::optional<float>&,
@@ -118,7 +118,7 @@ void bind_slice(nb::module_& mod) {
             nb::arg("output_tensor") = nb::none(),
             nb::arg("pad_value") = nb::none(),
             nb::arg("sub_core_grids") = nb::none()),
-        // Overload 3: SmallVector<int> version (int32_t template parameter)
+        // Overload 3: ttsl::SmallVector<int> version (int32_t template parameter)
         ttnn::overload_t(
             &slice_small_vector_wrapper,
             nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -131,9 +131,9 @@ std::vector<Tensor> post_sort_transform_tensor(
 
     const int8_t normalized_dim = dim < 0 ? orig_rank + dim : dim;
     if (output_logical_shape[-1] != original_lshape[normalized_dim]) {
-        const ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
-        const ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        const ttnn::SmallVector<uint32_t> end_index = {
+        const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        const ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+        const ttsl::SmallVector<uint32_t> end_index = {
             output_logical_shape[-4],
             output_logical_shape[-3],
             output_logical_shape[-2],
@@ -152,9 +152,9 @@ std::vector<Tensor> post_sort_transform_tensor(
         if (result_combined_h != original_combined_h) {
             const uint32_t nc = cur_shape[0] * cur_shape[1];
             const uint32_t h_sliced = original_combined_h / nc;
-            const ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
-            const ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            const ttnn::SmallVector<uint32_t> end_index = {cur_shape[0], cur_shape[1], h_sliced, cur_shape[3]};
+            const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+            const ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+            const ttsl::SmallVector<uint32_t> end_index = {cur_shape[0], cur_shape[1], h_sliced, cur_shape[3]};
             result[0] = ttnn::slice(result[0], start_index, end_index, step, input_memory_config);
             result[1] = ttnn::slice(result[1], start_index, end_index, step, input_memory_config);
         }
@@ -165,7 +165,7 @@ std::vector<Tensor> post_sort_transform_tensor(
         result[0] = ttnn::squeeze_from_4D(result[0], orig_rank);
         result[1] = ttnn::squeeze_from_4D(result[1], orig_rank);
     } else if (orig_rank == 1) {
-        const ttnn::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
+        const ttsl::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
         result[0] = ttnn::reshape(result[0], ttnn::Shape{result_shape});
         result[1] = ttnn::reshape(result[1], ttnn::Shape{result_shape});
     } else if (orig_rank > 4) {
@@ -180,7 +180,7 @@ std::vector<Tensor> post_sort_transform_tensor(
         // ttnn::experimental::view) and entirely bypasses the device reshape
         // kernel.  This is essential for UINT16 indices, which the device
         // reshape kernel rejects, and avoids the cost of a dtype round-trip.
-        ttnn::SmallVector<uint32_t> reshape_target(input_shape.cbegin(), input_shape.cend());
+        ttsl::SmallVector<uint32_t> reshape_target(input_shape.cbegin(), input_shape.cend());
         if (!is_dim_last_idx) {
             const int normalized = dim < 0 ? orig_rank + dim : dim;
             std::swap(reshape_target[normalized], reshape_target[orig_rank - 1]);

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -31,7 +31,7 @@ std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor& input_tensor, 
 
     const int Y = shape[2], X = shape[3];
     const Tensor& reshaped_tensor =
-        ttnn::reshape_on_device(input_tensor, ttnn::SmallVector<int32_t>{1, -1, Y, X}, mem_config);
+        ttnn::reshape_on_device(input_tensor, ttsl::SmallVector<int32_t>{1, -1, Y, X}, mem_config);
 
     auto part_reshaped = impl_split_last_dim_two_chunks_tiled(reshaped_tensor, mem_config);
 
@@ -39,7 +39,7 @@ std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor& input_tensor, 
     results.reserve(part_reshaped.size());
     for (auto& part : part_reshaped) {
         results.emplace_back(
-            ttnn::reshape_on_device(part, ttnn::SmallVector<int32_t>{-1, (int32_t)shape[1], Y, X / 2}, mem_config));
+            ttnn::reshape_on_device(part, ttsl::SmallVector<int32_t>{-1, (int32_t)shape[1], Y, X / 2}, mem_config));
     }
 
     return results;
@@ -54,7 +54,7 @@ constexpr uint32_t SPLIT_BATCH_SIZE = 64;
 
 std::vector<ttnn::Tensor> split_with_slice_impl(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int64_t>& split_sizes,
+    const ttsl::SmallVector<int64_t>& split_sizes,
     const int32_t dim,
     const MemoryConfig& memory_config) {
     const auto& input_shape = input_tensor.logical_shape();
@@ -83,9 +83,9 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
         std::vector<ttnn::Tensor> results;
         results.reserve(num_chunks);
 
-        const ttnn::SmallVector<int64_t> steps(input_shape.rank(), 1);
-        ttnn::SmallVector<int64_t> begins(input_shape.rank(), 0);
-        ttnn::SmallVector<int64_t> ends(input_shape.cbegin(), input_shape.cend());
+        const ttsl::SmallVector<int64_t> steps(input_shape.rank(), 1);
+        ttsl::SmallVector<int64_t> begins(input_shape.rank(), 0);
+        ttsl::SmallVector<int64_t> ends(input_shape.cbegin(), input_shape.cend());
         const ttsl::Span<const int64_t> ssteps(steps);
 
         for (uint32_t b = 0; b < n_batches; b++) {
@@ -98,7 +98,7 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
             auto batch_tensor = ttnn::slice(input_tensor, sbegins, sends, ssteps, memory_config);
 
             // actual_batch <= SPLIT_BATCH_SIZE so this recurse goes to the flat loop below.
-            const ttnn::SmallVector<int64_t> inner_sizes(actual_batch, chunk_size);
+            const ttsl::SmallVector<int64_t> inner_sizes(actual_batch, chunk_size);
             auto inner = split_with_slice_impl(batch_tensor, inner_sizes, dim, memory_config);
             results.insert(results.end(), inner.begin(), inner.end());
         }
@@ -110,8 +110,8 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
     results.reserve(split_sizes.size());
 
     // int64_t coordinates (matching the batching path above) for large-dim consistency.
-    const ttnn::SmallVector<int64_t> steps(input_shape.rank(), 1);
-    ttnn::SmallVector<int64_t> begins(input_shape.rank(), 0), ends(input_shape.cbegin(), input_shape.cend());
+    const ttsl::SmallVector<int64_t> steps(input_shape.rank(), 1);
+    ttsl::SmallVector<int64_t> begins(input_shape.rank(), 0), ends(input_shape.cbegin(), input_shape.cend());
     const ttsl::Span<const int64_t> sbegins(begins), ssteps(steps), sends(ends);
 
     ends[dim] = 0;
@@ -127,7 +127,7 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
 
 std::vector<ttnn::Tensor> split(
     const ttnn::Tensor& input_tensor,
-    const SmallVector<int64_t>& split_sizes,
+    const ttsl::SmallVector<int64_t>& split_sizes,
     int64_t dim,
     const std::optional<MemoryConfig>& memory_config_arg) {
     // Capture the desired output memory config.
@@ -253,7 +253,7 @@ std::vector<ttnn::Tensor> split(
         }
         results.reserve(num_chunks);
         for (const auto& t : outputs_4d) {
-            ttnn::SmallVector<uint32_t> final_shape(input_shape.cbegin(), input_shape.cend());
+            ttsl::SmallVector<uint32_t> final_shape(input_shape.cbegin(), input_shape.cend());
             final_shape.back() = t.logical_shape()[-1];
             results.emplace_back(ttnn::view(t, ttnn::Shape(final_shape)));
         }
@@ -279,7 +279,7 @@ std::vector<ttnn::Tensor> split(
 
     const auto num_chunks = std::ceil(static_cast<float>(input_shape[normalized_dim]) / static_cast<float>(split_size));
 
-    const ttnn::SmallVector<int64_t> split_sizes(num_chunks, split_size);
+    const ttsl::SmallVector<int64_t> split_sizes(num_chunks, split_size);
     // Pass memory_config_arg directly so the split_sizes overload applies the
     // same sharding-default logic (sharded input → DRAM output when no explicit config).
     return ttnn::split(input_tensor, split_sizes, normalized_dim, memory_config_arg);

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
@@ -14,7 +14,7 @@ namespace ttnn {
 
 std::vector<ttnn::Tensor> split(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int64_t>& split_sizes,
+    const ttsl::SmallVector<int64_t>& split_sizes,
     int64_t dim = 0,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split_nanobind.cpp
@@ -53,11 +53,11 @@ void bind_split(nb::module_& mod) {
             nb::kw_only(),
             nb::arg("memory_config") = nb::none()),
 
-        // Overload 2: list of split_sizes (SmallVector<int64_t>)
+        // Overload 2: list of split_sizes (ttsl::SmallVector<int64_t>)
         ttnn::overload_t(
             nb::overload_cast<
                 const ttnn::Tensor&,
-                const ttnn::SmallVector<int64_t>&,
+                const ttsl::SmallVector<int64_t>&,
                 int64_t,
                 const std::optional<ttnn::MemoryConfig>&>(&ttnn::split),
             nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -8,13 +8,13 @@
 
 namespace ttnn {
 
-ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttnn::SmallVector<int>& dim) {
+ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<int>& dim) {
     const auto& original_logical_shape = input_tensor.logical_shape();
     const auto& padded_shape = input_tensor.padded_shape();
     auto input_tensor_rank = original_logical_shape.rank();
 
-    SmallVector<uint32_t> new_logical_shape(original_logical_shape.cbegin(), original_logical_shape.cend());
-    SmallVector<uint32_t> new_padded_shape(padded_shape.cbegin(), padded_shape.cend());
+    ttsl::SmallVector<uint32_t> new_logical_shape(original_logical_shape.cbegin(), original_logical_shape.cend());
+    ttsl::SmallVector<uint32_t> new_padded_shape(padded_shape.cbegin(), padded_shape.cend());
 
     // Explicitly copy dim to avoid modifying the input
     auto dims = dim;
@@ -68,13 +68,13 @@ ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttnn::SmallVector<i
 }
 
 ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, int dim) {
-    ttnn::SmallVector<int> dims{dim};
+    ttsl::SmallVector<int> dims{dim};
     return squeeze(input_tensor, dims);
 }
 
 ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor) {
     auto input_tensor_rank = input_tensor.logical_shape().rank();
-    ttnn::SmallVector<int> dims(input_tensor_rank);
+    ttsl::SmallVector<int> dims(input_tensor_rank);
     std::iota(dims.begin(), dims.end(), 0);
     return squeeze(input_tensor, dims);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
@@ -10,7 +10,7 @@
 namespace ttnn {
 
 // Note: dim is passed by non-const reference because it's convenient to modify it for processing
-Tensor squeeze(const Tensor& input_tensor, const SmallVector<int>& dim);
+Tensor squeeze(const Tensor& input_tensor, const ttsl::SmallVector<int>& dim);
 Tensor squeeze(const Tensor& input_tensor, int dim);
 Tensor squeeze(const Tensor& input_tensor);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_nanobind.cpp
@@ -22,7 +22,7 @@ namespace {
 // the wrapper boundary (GIL held), so the body runs with the GIL released
 // (call_guard applied by bind_function).
 ttnn::Tensor squeeze_wrapper(
-    const ttnn::Tensor& input_tensor, std::optional<std::variant<int, ttnn::SmallVector<int>>> dim) {
+    const ttnn::Tensor& input_tensor, std::optional<std::variant<int, ttsl::SmallVector<int>>> dim) {
     if (!dim.has_value()) {  // None
         return ttnn::squeeze(input_tensor);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -118,7 +118,7 @@ ttnn::Tensor tilize_with_val_padding(
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<uint32_t>& output_padded_shape,
+    const ttsl::SmallVector<uint32_t>& output_padded_shape,
     const tt::tt_metal::PadValue pad_value,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -11,7 +11,7 @@ namespace ttnn {
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<uint32_t>& output_padded_shape,
+    const ttsl::SmallVector<uint32_t>& output_padded_shape,
     tt::tt_metal::PadValue pad_value,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -118,7 +118,7 @@ inline Tensor transpose_(
         output_mem_constructed = output_mem_config.value();
     }
 
-    auto prim_permute = [&](const ttnn::Tensor& input, const ttnn::SmallVector<uint32_t>& dims) -> ttnn::Tensor {
+    auto prim_permute = [&](const ttnn::Tensor& input, const ttsl::SmallVector<uint32_t>& dims) -> ttnn::Tensor {
         return ttnn::prim::permute(input, dims, output_mem_constructed, std::nullopt, pad_value);
     };
 
@@ -126,26 +126,26 @@ inline Tensor transpose_(
     switch (transpose_dim) {
         case ttnn::prim::TransposeOpDim::HC:
             if (interleaved_rm) {
-                return prim_permute(a, ttnn::SmallVector<uint32_t>{0, 2, 1, 3});
+                return prim_permute(a, ttsl::SmallVector<uint32_t>{0, 2, 1, 3});
             }
             break;
         case ttnn::prim::TransposeOpDim::NH:
             return ttnn::permute(
-                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({2, 1, 0, 3}), output_mem_config, pad_value);
+                (const ttnn::Tensor)a, ttsl::SmallVector<int64_t>({2, 1, 0, 3}), output_mem_config, pad_value);
         case ttnn::prim::TransposeOpDim::NW:
             return ttnn::permute(
-                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({3, 1, 2, 0}), output_mem_config, pad_value);
+                (const ttnn::Tensor)a, ttsl::SmallVector<int64_t>({3, 1, 2, 0}), output_mem_config, pad_value);
         case ttnn::prim::TransposeOpDim::CW:
             return ttnn::permute(
-                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({0, 3, 2, 1}), output_mem_config, pad_value);
+                (const ttnn::Tensor)a, ttsl::SmallVector<int64_t>({0, 3, 2, 1}), output_mem_config, pad_value);
         case ttnn::prim::TransposeOpDim::CN:
             if (interleaved_rm) {
-                return prim_permute(a, ttnn::SmallVector<uint32_t>({1, 0, 2, 3}));
+                return prim_permute(a, ttsl::SmallVector<uint32_t>({1, 0, 2, 3}));
             }
             break;
         case ttnn::prim::TransposeOpDim::WH:
             if (interleaved_rm) {
-                return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+                return prim_permute(a, ttsl::SmallVector<uint32_t>({0, 1, 3, 2}));
             }
             if (a.layout() == Layout::ROW_MAJOR) {
                 // Only compute the RM WH CB-vs-L1 budget when actually on the RM WH path:
@@ -160,7 +160,7 @@ inline Tensor transpose_(
                 max_l1_space =
                     max_l1_space - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
                 if (cb_size_for_rm > max_l1_space) {
-                    return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+                    return prim_permute(a, ttsl::SmallVector<uint32_t>({0, 1, 3, 2}));
                 }
             }
             break;
@@ -176,7 +176,7 @@ ttnn::Tensor transpose_nd(
     const std::optional<MemoryConfig>& memory_config_arg,
     float pad_value = 0.0f) {
     const auto rank = input_tensor.logical_shape().rank();
-    ttnn::SmallVector<int64_t> permutation;
+    ttsl::SmallVector<int64_t> permutation;
     permutation.reserve(rank);
     for (uint32_t i = 0; i < rank; ++i) {
         permutation.push_back(i);
@@ -218,7 +218,7 @@ ttnn::Tensor transpose_impl(
                 const auto& input_padded = input_tensor.padded_shape();
                 const uint32_t n1 = input_logical.get_normalized_index(dim1);
                 const uint32_t n2 = input_logical.get_normalized_index(dim2);
-                ttnn::SmallVector<uint32_t> out_padded_vec(input_padded.cbegin(), input_padded.cend());
+                ttsl::SmallVector<uint32_t> out_padded_vec(input_padded.cbegin(), input_padded.cend());
                 std::swap(out_padded_vec[n1], out_padded_vec[n2]);
                 auto output_padded_shape = ttnn::Shape(std::move(out_padded_vec));
                 auto spec = generate_transpose_shard_spec(

--- a/ttnn/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.cpp
@@ -13,7 +13,7 @@ ttnn::Tensor unsqueeze(const ttnn::Tensor& input_tensor, const int dim) {
     const int32_t max_dim = (int)(rank);
     const int32_t min_dim = -(max_dim)-1;
 
-    SmallVector<uint32_t> output_shape_vector;
+    ttsl::SmallVector<uint32_t> output_shape_vector;
 
     int normal_dim;
     // Handle negative dimension by converting it to positive

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -216,7 +216,7 @@ void UntilizeWithUnpaddingDeviceOperation::validate_on_program_cache_miss(
 
 TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
-    SmallVector<uint32_t> out_shape;
+    ttsl::SmallVector<uint32_t> out_shape;
     const auto& input_tensor_a = input;
     size_t rank = input_tensor_a.logical_shape().rank();
     out_shape.reserve(rank);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -12,7 +12,7 @@ using namespace tt::tt_metal;
 
 ttnn::Shape squeeze_vector_shape(ttnn::Shape output_shape) {
     if (output_shape.rank() > 4) {
-        ttnn::SmallVector<uint32_t> output_shape_4d(output_shape.rank());
+        ttsl::SmallVector<uint32_t> output_shape_4d(output_shape.rank());
         output_shape_4d[0] = 1;
         int extra_rank = output_shape.size() - 4;
         for (int i = extra_rank; i >= 0; i--) {
@@ -72,7 +72,7 @@ Tensor untilize_with_unpadding(
     bool fp32_dest_acc_en = input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
                             input_tensor.dtype() == DataType::FLOAT32;
 
-    ttnn::SmallVector<uint32_t> output_end_vector;
+    ttsl::SmallVector<uint32_t> output_end_vector;
     ttnn::Shape output_end;
     const auto& input_shape = input_tensor.logical_shape();
     if (input_shape.rank() > 4) {

--- a/ttnn/cpp/ttnn/operations/data_movement/view/view_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/view/view_nanobind.cpp
@@ -50,9 +50,9 @@ void bind_view(nb::module_& mod) {
     ttnn::bind_function<"view">(
         mod,
         doc,
-        // Bind first overload: view(Tensor, SmallVector<int32_t>)
+        // Bind first overload: view(Tensor, ttsl::SmallVector<int32_t>)
         ttnn::overload_t(&view_shape_vector_wrapper, nb::arg("input_tensor"), nb::arg("shape")),
-        // Bind second overload: view(Tensor, SmallVector<int32_t>)
+        // Bind second overload: view(Tensor, ttsl::SmallVector<int32_t>)
         ttnn::overload_t(
             nb::overload_cast<const ttnn::Tensor&, const ttnn::Shape&>(&ttnn::view),
             nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -909,7 +909,7 @@ Tensor binary_operation_addalpha(
     float alpha,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return ttnn::detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -931,7 +931,7 @@ Tensor binary_operation_subalpha(
     float alpha,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return ttnn::detail::invoke_binary_ng(
         lhs,
         rhs,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -430,7 +430,7 @@ Tensor prelu(const Tensor& input_a, const Tensor& input_b, const std::optional<M
         s_a[1]);
     Tensor b = input_b;
     if (s_a.rank() > 2) {
-        SmallVector<uint32_t> reshape(s_a.rank(), 1);
+        ttsl::SmallVector<uint32_t> reshape(s_a.rank(), 1);
         reshape[1] = s_a[1];
         b = ttnn::reshape(input_b, ttnn::Shape(reshape));
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -525,19 +525,19 @@ std::vector<std::optional<Tensor>> concat_bw(
         input_grad, other_grad, input_tensor_a_arg, other, {are_required_outputs[0], are_required_outputs[1]});
 
     if (are_required_outputs[0]) {
-        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> end_index = {
+        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<uint32_t> end_index = {
             input_tensor_a_arg.logical_shape()[0],
             input_tensor_a_arg.logical_shape()[1],
             input_tensor_a_arg.logical_shape()[2],
             input_tensor_a_arg.logical_shape()[3]};
-        ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index, end_index, step, std::nullopt, input_grad);
         grad_tensor[0] = input_grad;
     }
 
     if (are_required_outputs[1]) {
-        ttnn::SmallVector<uint32_t> start_index_2 = {0, 0, 0, 0};
+        ttsl::SmallVector<uint32_t> start_index_2 = {0, 0, 0, 0};
         if (dim == 0) {
             start_index_2 = {input_tensor_a_arg.logical_shape()[0], 0, 0, 0};
         } else if (dim == 1) {
@@ -547,12 +547,12 @@ std::vector<std::optional<Tensor>> concat_bw(
         } else if (dim == 3) {
             start_index_2 = {0, 0, 0, input_tensor_a_arg.logical_shape()[3]};
         }
-        ttnn::SmallVector<uint32_t> end_index_2 = {
+        ttsl::SmallVector<uint32_t> end_index_2 = {
             grad_tensor_arg.logical_shape()[0],
             grad_tensor_arg.logical_shape()[1],
             grad_tensor_arg.logical_shape()[2],
             grad_tensor_arg.logical_shape()[3]};
-        ttnn::SmallVector<uint32_t> step_2 = {1, 1, 1, 1};
+        ttsl::SmallVector<uint32_t> step_2 = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index_2, end_index_2, step_2, std::nullopt, other_grad);
         grad_tensor[1] = other_grad;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -231,7 +231,7 @@ ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() co
         binary_op_type,
         lhs_activations,
         rhs_activations,
-        (is_where_op || is_quant_op) ? ttnn::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
+        (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
         memory_config,
         get_dtype(),
         compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -32,9 +32,9 @@ struct BinaryNgDeviceOperation {
 
     struct operation_attributes_t {
         BinaryOpType binary_op_type;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> post_activations;
         std::optional<unary::ScalarVariant> scalar;
         tt::tt_metal::MemoryConfig memory_config;
         DataType input_dtype;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -464,9 +464,9 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     }
 
     {
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations = operation_attributes.lhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations = operation_attributes.rhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations = operation_attributes.post_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations = operation_attributes.lhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations = operation_attributes.rhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> post_activations = operation_attributes.post_activations;
 
         if (op_config.process_lhs.has_value()) {
             lhs_activations.push_back(*op_config.process_lhs);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -860,7 +860,7 @@ ttnn::Shape compute_broadcasted_output(const ttnn::Shape& shape_a, const ttnn::S
     const int rank_a = shape_a.rank();
     const int rank_b = shape_b.rank();
     const int larger_rank = std::max(rank_a, rank_b);
-    SmallVector<uint32_t> output_shape(larger_rank, 1);
+    ttsl::SmallVector<uint32_t> output_shape(larger_rank, 1);
     for (int i = -1; i >= -larger_rank; --i) {
         auto dim_a = (i >= -rank_a) ? shape_a[i] : 1;
         auto dim_b = (i >= -rank_b) ? shape_b[i] : 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -109,7 +109,7 @@ static ttnn::Shape compute_broadcasted_output_binary(const ttnn::Shape& a_shape,
     const int rank_a = a_shape.rank();
     const int rank_b = b_shape.rank();
     const int largest_rank = std::max(rank_a, rank_b);
-    SmallVector<uint32_t> output_shape(largest_rank, 1);
+    ttsl::SmallVector<uint32_t> output_shape(largest_rank, 1);
 
     for (int i = -1; i >= -largest_rank; --i) {
         auto a_dim = (i >= -rank_a) ? a_shape[i] : 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -33,7 +33,7 @@ Tensor _variance_impl(
     const Tensor& /*mean_y*/,
     Tensor& y_minus_mean_y,
     const std::optional<MemoryConfig>& output_mem_config) {
-    ttnn::SmallVector<int> dims = {2, 3};
+    ttsl::SmallVector<int> dims = {2, 3};
     constexpr float correction = 0.0f;
     auto shape_wh = y.padded_shape();
     float scale = 1.0f / ((float)(shape_wh[3] * shape_wh[2]) - correction);
@@ -62,13 +62,13 @@ std::vector<Tensor> split_tensor_for_glu(
     std::vector<Tensor> t_split;
     ttnn::Shape inshape(input_a.padded_shape());
     TT_FATAL(((inshape[dim] / 2) % tt::constants::TILE_WIDTH == 0), "Split tensor dimension should be in full tile");
-    ttnn::SmallVector<uint32_t> s_a = {0, 0, 0, 0};
-    ttnn::SmallVector<uint32_t> e_a = {input_a.padded_shape()[0], inshape[1], inshape[2], inshape[3] / 2};
+    ttsl::SmallVector<uint32_t> s_a = {0, 0, 0, 0};
+    ttsl::SmallVector<uint32_t> e_a = {input_a.padded_shape()[0], inshape[1], inshape[2], inshape[3] / 2};
 
-    ttnn::SmallVector<uint32_t> s_b = {0, 0, 0, inshape[3] / 2};
-    ttnn::SmallVector<uint32_t> e_b = {inshape[0], inshape[1], inshape[2], inshape[3]};
+    ttsl::SmallVector<uint32_t> s_b = {0, 0, 0, inshape[3] / 2};
+    ttsl::SmallVector<uint32_t> e_b = {inshape[0], inshape[1], inshape[2], inshape[3]};
 
-    auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
+    auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
     Tensor t_a = ttnn::slice(input_a, s_a, e_a, step, output_mem_config);
     Tensor t_b = ttnn::slice(input_a, s_b, e_b, step, output_mem_config);
 
@@ -131,7 +131,7 @@ Tensor multigammaln(const Tensor& x, const std::optional<MemoryConfig>& output_m
 
 Tensor var_hw(const Tensor& y, const std::optional<MemoryConfig>& output_mem_config) {
     auto output_memory_config = output_mem_config.value_or(y.memory_config());
-    ttnn::SmallVector<int> dims = {2, 3};
+    ttsl::SmallVector<int> dims = {2, 3};
     Tensor mean_y = ttnn::mean(y, dims, true);
     return detail::_variance_impl(y, mean_y, output_memory_config);
 }
@@ -146,7 +146,7 @@ Tensor std_hw(const Tensor& y, const std::optional<MemoryConfig>& output_mem_con
 // Function normalize
 // use transformation y = (y - mean(y))/std(y) by broadcast
 Tensor normalize_hw(const Tensor& y, const std::optional<MemoryConfig>& output_mem_config) {
-    ttnn::SmallVector<int> dims = {2, 3};
+    ttsl::SmallVector<int> dims = {2, 3};
     Tensor mean_y = ttnn::mean(y, dims, true);
     Tensor y_minus_mean_y = ttnn::bcast(y, mean_y, ttnn::BcastOpMath::SUB, ttnn::BcastOpDim::HW);
     Tensor std_y = detail::_std(y, mean_y, y_minus_mean_y, output_mem_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1642,7 +1642,7 @@ std::vector<Tensor> repeat_bw(
         return grad_tensor;
     }
     if (shape[0] > 1) {
-        ttnn::SmallVector<int64_t> dim = {0};
+        ttsl::SmallVector<int64_t> dim = {0};
         TT_FATAL(shape[1] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[1], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {1, shape_wh[1], shape_wh[2], shape_wh[3]};
         const auto required = ttnn::Shape(intended_shape_array);
@@ -1657,7 +1657,7 @@ std::vector<Tensor> repeat_bw(
         return grad_tensor;
     }
     if (shape[1] > 1) {
-        ttnn::SmallVector<int64_t> dim = {1};
+        ttsl::SmallVector<int64_t> dim = {1};
         TT_FATAL(shape[0] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[0], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], 1, shape_wh[2], shape_wh[3]};
         const auto required = ttnn::Shape(intended_shape_array);
@@ -1724,13 +1724,13 @@ std::vector<Tensor> prod_bw(
 
     // all_dimensions = False
     Tensor updated_grad = prod_result;
-    auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
+    auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
     if (prod_result.logical_shape() != grad.padded_shape()) {
         if (*dim == 3 || *dim == -1) {
-            ttnn::SmallVector<int64_t> after_permute_dims = {0, 3, 1, 2};
+            ttsl::SmallVector<int64_t> after_permute_dims = {0, 3, 1, 2};
             Tensor required = ttnn::permute(grad, after_permute_dims, output_memory_config);
-            ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttnn::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[2]};
             Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             after_permute_dims = {0, 2, 3, 1};
@@ -1741,10 +1741,10 @@ std::vector<Tensor> prod_bw(
                 updated_grad = pad_updated_grad.to_device(input.device());
             }
         } else if (*dim == 2 || *dim == -2) {
-            ttnn::SmallVector<int64_t> after_permute_dims = {0, 2, 1, 3};
+            ttsl::SmallVector<int64_t> after_permute_dims = {0, 2, 1, 3};
             Tensor required = ttnn::permute(grad, after_permute_dims, output_memory_config);
-            ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttnn::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[3]};
             Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             updated_grad = ttnn::permute(new_slice_tensor, after_permute_dims, output_memory_config);
@@ -1778,11 +1778,11 @@ std::vector<Tensor> prod_bw(
     if (*dim == 1 || *dim == -3) {
         Tensor tensor_1_temp = reciprocal_input;
         if (reciprocal_input.padded_shape()[1] % 32 != 0) {
-            ttnn::SmallVector<std::array<uint32_t, 2>> padding = {
+            ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
                 {0, 0}, {0, 32 - (reciprocal_input.padded_shape()[1] % 32)}, {0, 0}, {0, 0}};
             tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0, true, std::nullopt);
         }
-        ttnn::SmallVector<int64_t> after_permute_dims = {0, 2, 3, 1};
+        ttsl::SmallVector<int64_t> after_permute_dims = {0, 2, 3, 1};
         Tensor tensor_1 = ttnn::permute(tensor_1_temp, after_permute_dims, output_memory_config);
         Tensor tensor_2 = ttnn::permute(temp, after_permute_dims, output_memory_config);
 
@@ -1815,10 +1815,10 @@ std::vector<Tensor> prod_bw(
             output_memory_config);
         Tensor grad_result = result;
         if (reciprocal_input.padded_shape()[1] % 32 != 0) {
-            ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttnn::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<uint32_t> end_index = {
                 input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
-            auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
+            auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
             grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
         }
         grad_tensor.emplace_back(grad_result);
@@ -1827,11 +1827,11 @@ std::vector<Tensor> prod_bw(
     // dim 0
     Tensor tensor_1_temp = reciprocal_input;
     if (reciprocal_input.padded_shape()[0] % 32 != 0) {
-        ttnn::SmallVector<std::array<uint32_t, 2>> padding = {
+        ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
             {0, (32 - (reciprocal_input.padded_shape()[0] % 32))}, {0, 0}, {0, 0}, {0, 0}};
         tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0, false, std::nullopt);
     }
-    ttnn::SmallVector<int64_t> after_permute_dims = {3, 1, 2, 0};
+    ttsl::SmallVector<int64_t> after_permute_dims = {3, 1, 2, 0};
     Tensor tensor_1 = ttnn::permute(tensor_1_temp, after_permute_dims, output_memory_config);
     Tensor tensor_2 = ttnn::permute(temp, after_permute_dims, output_memory_config);
 
@@ -1863,8 +1863,8 @@ std::vector<Tensor> prod_bw(
         output_memory_config);
     Tensor grad_result = result;
     if (reciprocal_input.padded_shape()[0] % 32 != 0) {
-        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> end_index = {
+        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<uint32_t> end_index = {
             input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
         grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -171,7 +171,7 @@ uint32_t default_workers(
     // Above 4 workers we start getting performance drops, so we limit to 4 workers or less, depending on the number of
     // available cores This was determined by the sweep
     // tests/ttnn/multidevice_perf_tests/sweep_all_gather_hyperparameters_T3K.py
-    ttnn::SmallVector<uint32_t> candidate_worker_counts;
+    ttsl::SmallVector<uint32_t> candidate_worker_counts;
     // if per link data moved is greater than 0.25 MB, we search greedily for 4 workers, otherwise we search greedily
     // for 2 workers. for ring, half the data is moved per link, so we divide by 2
     double data_moved_per_link_bytes = double(output_data_size_bytes) * (ring_size - 1) / ring_size / num_links /

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
@@ -288,7 +288,7 @@ tt::tt_metal::WorkloadDescriptor AllGatherViaBroadcastFactory::create_workload_d
     auto* mesh_device = tensor_args.input_tensor.device();
     auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
     const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
+    ttsl::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
 
     // Workload-scoped semaphores: allocated once on cache miss and parked on
     // workload_descriptor.semaphores so they outlive the cached workload (the

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -38,7 +38,7 @@ uint32_t finding_scatter_dim(const ttnn::Tensor& input_tensor, size_t num_worker
 
     TT_FATAL(rank >= 2, "Expected input tensor to be of at least rank 2");
 
-    ttnn::SmallVector<uint32_t> shape_vec(padded_shape.cbegin(), padded_shape.cend());
+    ttsl::SmallVector<uint32_t> shape_vec(padded_shape.cbegin(), padded_shape.cend());
     if (layout == Layout::TILE) {
         const auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
         auto tile_shape_it = tile_shape.crbegin();
@@ -114,7 +114,7 @@ Tensor local_sum_float32(
         input_tensor = ttnn::to_layout(gathered_tensor, Layout::TILE);
     }
 
-    ttnn::SmallVector<uint32_t> reshape_dims_vec;
+    ttsl::SmallVector<uint32_t> reshape_dims_vec;
     for (int i = 0; i < rank; ++i) {
         if (i == reduce_dim) {
             reshape_dims_vec.push_back(num_devices);
@@ -191,7 +191,7 @@ ttnn::Tensor all_reduce_async(
         log_debug(tt::LogOp, "Using composite all gather + local reduce");
 
         // Reshape (B, C, H, W) -> (1, B, C, H, W)
-        ttnn::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank() + 1);
+        ttsl::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank() + 1);
         ag_shape_vec[0] = 1;
         std::copy(initial_shape.cbegin(), initial_shape.cend(), ag_shape_vec.begin() + 1);
         auto reshaped_tensor = ttnn::reshape(working_input_tensor, ttnn::Shape(ag_shape_vec));
@@ -314,7 +314,7 @@ ttnn::Tensor all_reduce_async(
         log_debug(tt::LogOp, "Using composite all gather + local reduce");
 
         // Reshape (B, C, H, W) -> (1, B, C, H, W)
-        ttnn::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank() + 1);
+        ttsl::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank() + 1);
         ag_shape_vec[0] = 1;
         std::copy(initial_shape.cbegin(), initial_shape.cend(), ag_shape_vec.begin() + 1);
         auto reshaped_tensor = ttnn::reshape(working_input_tensor, ttnn::Shape(ag_shape_vec));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
@@ -17,7 +17,7 @@ namespace {
 ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
     const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     const auto& shape = input_tensor.padded_shape();
-    ttnn::SmallVector<uint32_t> tiled_shape;
+    ttsl::SmallVector<uint32_t> tiled_shape;
     tiled_shape.reserve(shape.rank());
     for (int i = 0; i < shape.rank(); i++) {
         uint32_t dim = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -138,7 +138,7 @@ ttnn::Tensor composite_reduce_scatter(
     // insert the internal padding (only pad on the dim we're scattering on)
     auto logical_shape = split_tensors[0].logical_shape();
     auto padded_shape = split_tensors[0].padded_shape();
-    ttnn::SmallVector<std::array<uint32_t, 2>> padding = {
+    ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
         {0, padded_shape[-2] - logical_shape[-2]}, {0, padded_shape[-1] - logical_shape[-1]}};
     for (uint32_t i = 0; i < num_devices; ++i) {
         split_tensors[i] = ttnn::pad(split_tensors[i], padding, 0, true, split_tensors[i].memory_config());
@@ -177,8 +177,8 @@ ttnn::Tensor composite_reduce_scatter(
         rs_output_tensor =
             ttnn::untilize_with_unpadding(padded_native_rs_output_tensor, ends, native_rs_output_memory_config);
     } else {
-        const ttnn::SmallVector<int32_t> steps(output_shape.rank(), 1);
-        ttnn::SmallVector<int32_t> begins(output_shape.rank(), 0), ends(output_shape.cbegin(), output_shape.cend());
+        const ttsl::SmallVector<int32_t> steps(output_shape.rank(), 1);
+        ttsl::SmallVector<int32_t> begins(output_shape.rank(), 0), ends(output_shape.cbegin(), output_shape.cend());
         const ttsl::Span<const int32_t> sbegins(begins), ssteps(steps), sends(ends);
         rs_output_tensor =
             ttnn::slice(padded_native_rs_output_tensor, sbegins, sends, ssteps, native_rs_output_memory_config);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
@@ -586,7 +586,7 @@ DeepseekMoEReduceScatterMeshWorkloadFactory::create_mesh_workload(
     tt::tt_metal::GlobalSemaphore pre_op_semaphore_barrier =
         ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
 
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> sub_device_ids = {sd_id};
+    ttsl::SmallVector<tt::tt_metal::SubDeviceId> sub_device_ids = {sd_id};
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, sub_device_ids);
 
     for (const auto& coord : tensor_coords.coords()) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -21,7 +21,7 @@ namespace ttnn::operations::experimental::ccl {
 namespace detail {
 
 std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
-    ttnn::SmallVector<uint32_t> device_order;
+    ttsl::SmallVector<uint32_t> device_order;
     device_order.reserve(ring_size - 1);
     // Add all indices except ring_index
     for (uint32_t i = 0; i < ring_size; i++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -20,7 +20,7 @@ namespace ttnn::operations::experimental::ccl {
 namespace detail::rs_heads_fusion {
 
 std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
-    ttnn::SmallVector<uint32_t> device_order;
+    ttsl::SmallVector<uint32_t> device_order;
     device_order.reserve(ring_size - 1);
     // Add all indices except ring_index
     for (uint32_t i = 0; i < ring_size; i++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
@@ -41,7 +41,7 @@ uint32_t reduce_scatter_default_workers(
     auto subdevice_core_range_set = mesh_device.worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
     uint32_t num_cores = subdevice_core_range_set.num_cores();
     log_trace(tt::LogOp, "DEBUG: num_cores: {}", num_cores);
-    ttnn::SmallVector<uint32_t> candidate_worker_counts;
+    ttsl::SmallVector<uint32_t> candidate_worker_counts;
     double data_moved_per_link_bytes = double(input_data_size_bytes) * (ring_size - 1) / ring_size / num_links /
                                        (topology == ttnn::ccl::Topology::Ring ? 2 : 1);
     log_trace(tt::LogOp, "DEBUG: data_moved_per_link_bytes: {}", data_moved_per_link_bytes);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -59,7 +59,7 @@ uint32_t strided_default_workers(
     // Above 4 workers we start getting performance drops, so we limit to 4 workers or less, depending on the number of
     // available cores This was determined by the sweep
     // tests/ttnn/multidevice_perf_tests/sweep_all_gather_hyperparameters_T3K.py
-    ttnn::SmallVector<uint32_t> candidate_worker_counts;
+    ttsl::SmallVector<uint32_t> candidate_worker_counts;
     // if per link data moved is greater than 0.25 MB, we search greedily for 4 workers, otherwise we search greedily
     // for 2 workers. for ring, half the data is moved per link, so we divide by 2
     double data_moved_per_link_bytes = double(output_data_size_bytes) * (ring_size - 1) / ring_size / num_links /

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -87,14 +87,14 @@ static Tensor conv_group_weight_zero_pad_helper(
                     for (int k = 0; k < original_weight_shape[3]; k++) {
                         for (int m = 0; m < original_weight_shape[4]; m++) {
                             auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
-                                ttnn::SmallVector<uint32_t>{
+                                ttsl::SmallVector<uint32_t>{
                                     (uint32_t)curr_batch_idx, (uint32_t)j, (uint32_t)d, (uint32_t)k, (uint32_t)m},
                                 original_strides);
                             auto value = conv_weight_tensor_buffer[value_flat_input_index];
 
                             auto new_channel_idx = new_channel_start_idx + j;
                             auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
-                                ttnn::SmallVector<uint32_t>{
+                                ttsl::SmallVector<uint32_t>{
                                     (uint32_t)new_batch_idx,
                                     (uint32_t)new_channel_idx,
                                     (uint32_t)d,
@@ -163,12 +163,12 @@ Tensor prepare_conv3d_weights(
     }
     prepare_weights = ttnn::operations::core::to_device(prepare_weights, device, std::nullopt);
 
-    ttnn::SmallVector<int64_t> dims_1 = {2, 3, 4, 1, 0};
+    ttsl::SmallVector<int64_t> dims_1 = {2, 3, 4, 1, 0};
     prepare_weights = ttnn::permute(prepare_weights, dims_1);
     uint32_t C = prepare_weights.logical_shape()[3];
     uint32_t ALIGN_PAD = alignment - (C % alignment);
     if (C % alignment != 0) {
-        ttnn::SmallVector<std::array<uint32_t, 2>> padding_shape({{0, 0}, {0, 0}, {0, 0}, {0, ALIGN_PAD}, {0, 0}});
+        ttsl::SmallVector<std::array<uint32_t, 2>> padding_shape({{0, 0}, {0, 0}, {0, 0}, {0, ALIGN_PAD}, {0, 0}});
         prepare_weights = ttnn::pad(prepare_weights, padding_shape, 0.0f, /*use_multicore=*/true);
     }
     // Reshape and permute weights
@@ -190,7 +190,7 @@ Tensor prepare_conv3d_weights(
 
     prepare_weights =
         ttnn::reshape(prepare_weights, ttnn::Shape{kD, kH, kW, num_C_in_blocks, C_in_block, out_channels});
-    ttnn::SmallVector<int64_t> dims_2 = {3, 0, 1, 2, 4, 5};
+    ttsl::SmallVector<int64_t> dims_2 = {3, 0, 1, 2, 4, 5};
     prepare_weights = ttnn::permute(prepare_weights, dims_2);
     prepare_weights = ttnn::reshape(prepare_weights, ttnn::Shape{-1, out_channels});
     return prepare_weights;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.cpp
@@ -130,7 +130,7 @@ ttnn::Tensor routed_expert_ffn_chunked(
             N);
         full_output = *output;
     } else {
-        ttnn::SmallVector<uint32_t> out_dims(x_rank, 1u);
+        ttsl::SmallVector<uint32_t> out_dims(x_rank, 1u);
         out_dims[x_rank - 2] = M;
         out_dims[x_rank - 1] = N;
         full_output = ttnn::empty(

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
@@ -70,7 +70,7 @@ void PaddedSliceDeviceOperation::validate_on_program_cache_miss(
 TensorSpec PaddedSliceDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
+    ttsl::SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
 
     TT_FATAL(out_shape.size() == 4, "Only 4D tensors are supported for padded_slice");
     auto output_dim_i = [&args](size_t i) {

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
@@ -73,9 +73,9 @@ ttnn::Tensor padded_slice(
     }
 
     // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
-    ttnn::SmallVector<uint32_t> modified_begins(input_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_ends(input_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_step(input_rank, 1);
+    ttsl::SmallVector<uint32_t> modified_begins(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_ends(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_step(input_rank, 1);
 
     // Wrap indices and adjust begins, ends, and step
     for (size_t i = 0; i < begins.size(); ++i) {
@@ -90,13 +90,13 @@ ttnn::Tensor padded_slice(
         }
     }
 
-    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttnn::SmallVector<uint32_t>& modified_ends) {
+    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttsl::SmallVector<uint32_t>& modified_ends) {
         return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
     };
 
-    ttnn::SmallVector<uint32_t> padded_ends = modified_ends;
+    ttsl::SmallVector<uint32_t> padded_ends = modified_ends;
 
-    ttnn::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
+    ttsl::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
     actual_shape_vec.reserve(input_rank);
     final_padded_shape_vec.reserve(input_rank);
     bool empty = false;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.hpp
@@ -24,9 +24,9 @@ Tensor padded_slice(
 template <typename T>
 Tensor padded_slice(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<T>& begins,
-    const ttnn::SmallVector<T>& ends,
-    const ttnn::SmallVector<T>& step,
+    const ttsl::SmallVector<T>& begins,
+    const ttsl::SmallVector<T>& ends,
+    const ttsl::SmallVector<T>& step,
     const MemoryConfig& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<float>& pad_value = std::nullopt) {

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice_nanobind.cpp
@@ -21,9 +21,9 @@ namespace {
 
 ttnn::Tensor padded_slice_wrapper(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int>& begins,
-    const ttnn::SmallVector<int>& ends,
-    const std::optional<ttnn::SmallVector<int>>& step,
+    const ttsl::SmallVector<int>& begins,
+    const ttsl::SmallVector<int>& ends,
+    const std::optional<ttsl::SmallVector<int>>& step,
     const MemoryConfig& memory_config,
     const std::optional<ttnn::Tensor>& output_tensor,
     const std::optional<float>& pad_value) {
@@ -31,7 +31,7 @@ ttnn::Tensor padded_slice_wrapper(
         input_tensor,
         begins,
         ends,
-        step.value_or(ttnn::SmallVector<int>(ends.size(), 1)),
+        step.value_or(ttsl::SmallVector<int>(ends.size(), 1)),
         memory_config,
         output_tensor,
         pad_value);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary.cpp
@@ -858,7 +858,7 @@ Tensor binary_operation_addalpha(
     float alpha,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -880,7 +880,7 @@ Tensor binary_operation_subalpha(
     float alpha,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
         lhs,
         rhs,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
@@ -431,7 +431,7 @@ Tensor prelu(const Tensor& input_a, const Tensor& input_b, const std::optional<M
         s_a[1]);
     Tensor b = input_b;
     if (s_a.rank() > 2) {
-        SmallVector<uint32_t> reshape(s_a.rank(), 1);
+        ttsl::SmallVector<uint32_t> reshape(s_a.rank(), 1);
         reshape[1] = s_a[1];
         b = ttnn::operations::experimental::quasar::reshape(input_b, ttnn::Shape(reshape));
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -233,7 +233,7 @@ ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() co
         binary_op_type,
         lhs_activations,
         rhs_activations,
-        (is_where_op || is_quant_op) ? ttnn::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
+        (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
         memory_config,
         get_dtype(),
         compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
@@ -33,9 +33,9 @@ struct BinaryNgDeviceOperation {
 
     struct operation_attributes_t {
         BinaryOpType binary_op_type;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> post_activations;
         std::optional<unary::ScalarVariant> scalar;
         tt::tt_metal::MemoryConfig memory_config;
         DataType input_dtype;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
@@ -452,9 +452,9 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     }
 
     {
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations = operation_attributes.lhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations = operation_attributes.rhs_activations;
-        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations = operation_attributes.post_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations = operation_attributes.lhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations = operation_attributes.rhs_activations;
+        ttsl::SmallVector<unary::EltwiseUnaryWithParam> post_activations = operation_attributes.post_activations;
 
         if (op_config.process_lhs.has_value()) {
             lhs_activations.push_back(*op_config.process_lhs);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
@@ -856,7 +856,7 @@ ttnn::Shape compute_broadcasted_output(const ttnn::Shape& shape_a, const ttnn::S
     const int rank_a = shape_a.rank();
     const int rank_b = shape_b.rank();
     const int larger_rank = std::max(rank_a, rank_b);
-    SmallVector<uint32_t> output_shape(larger_rank, 1);
+    ttsl::SmallVector<uint32_t> output_shape(larger_rank, 1);
     for (int i = -1; i >= -larger_rank; --i) {
         auto dim_a = (i >= -rank_a) ? shape_a[i] : 1;
         auto dim_b = (i >= -rank_b) ? shape_b[i] : 1;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
@@ -72,7 +72,7 @@ std::vector<Tensor> fold_with_transpose_(
     log_debug(tt::LogOp, "pad_output: {}", pad_output.logical_shape());
 
     auto transpose_hc_output = ttnn::prim::permute(
-        pad_output, ttnn::SmallVector<uint32_t>({0, 3, 1, 2}), std::make_optional(L1_mem_config), std::nullopt);
+        pad_output, ttsl::SmallVector<uint32_t>({0, 3, 1, 2}), std::make_optional(L1_mem_config), std::nullopt);
 
     log_debug(tt::LogOp, "transpose_hc_output: {}", transpose_hc_output.logical_shape());
 
@@ -475,7 +475,7 @@ Tensor fold(
 
     // Apply padding if needed
     if (has_hw_padding || has_c_padding) {
-        ttnn::SmallVector<ttnn::operations::experimental::quasar::PadSpecDim> padding_spec;
+        ttsl::SmallVector<ttnn::operations::experimental::quasar::PadSpecDim> padding_spec;
         padding_spec.push_back({0, 0});                     // N dimension
         padding_spec.push_back({pad_top, pad_bottom});      // H dimension
         padding_spec.push_back({pad_left, pad_right});      // W dimension

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
@@ -142,7 +142,7 @@ ttnn::Shape compute_matmul_output_shape(
 
     // Handle the vector matmul case: if a_rank == 1, remove the second-to-last dimension
     if (a_rank == 1 && output_shape.rank() > 1) [[unlikely]] {
-        ttnn::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
+        ttsl::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
         // Copy all elements except the second-to-last dimension
         size_t dst_idx = 0;
         for (size_t src_idx = 0; src_idx < output_shape.rank(); ++src_idx) {
@@ -155,7 +155,7 @@ ttnn::Shape compute_matmul_output_shape(
 
     // Handle the case where b_rank == 1, remove the last dimension
     if (b_rank == 1) [[unlikely]] {
-        ttnn::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
+        ttsl::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
         for (auto index = 0; index < output_shape.rank() - 1; ++index) {
             new_shape[index] = output_shape[index];
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
@@ -29,7 +29,7 @@ using ttnn::operations::data_movement::squeeze_or_unsqueeze_shape_to_ND;
 bool eq_spans(const auto a, const auto b) { return std::equal(a.begin(), a.end(), b.begin(), b.end()); }
 
 ttnn::Shape update_original_shape(const ttnn::Shape& padded_shape, const ttnn::Shape& input_shape) {
-    ttnn::SmallVector<uint32_t> updated_shape;
+    ttsl::SmallVector<uint32_t> updated_shape;
     size_t input_rank = input_shape.rank();
     for (size_t i = 0; i < input_rank - 2; i++) {
         updated_shape.push_back(input_shape[i]);
@@ -112,7 +112,7 @@ ttnn::Tensor pad_impl(
             if (height_distinct(input_logical_shape, output_padded_shape)) {
                 // we will decompose the padding into two parts and run two
                 // separate pads.
-                ttnn::SmallVector<uint32_t> adjusted_input_tensor_start{0, 0, 0, input_tensor_start[3]};
+                ttsl::SmallVector<uint32_t> adjusted_input_tensor_start{0, 0, 0, input_tensor_start[3]};
 
                 TT_FATAL(
                     not(height_distinct(input_logical_shape, output_shape_width_padded) and
@@ -168,7 +168,7 @@ ttnn::Tensor pad_impl(
 
 ttnn::Tensor pad_impl(
     const ttnn::Tensor& input_tensor,
-    ttnn::SmallVector<PadSpecDim> padding,
+    ttsl::SmallVector<PadSpecDim> padding,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -225,7 +225,7 @@ ttnn::Tensor pad_impl(
 }
 
 std::tuple<ttnn::Shape, ttnn::Shape> compute_requested_shape(
-    const ttnn::Shape& input_logical_shape, const ttnn::SmallVector<PadSpecDim>& pad_spec) {
+    const ttnn::Shape& input_logical_shape, const ttsl::SmallVector<PadSpecDim>& pad_spec) {
     if (std::all_of(pad_spec.begin(), pad_spec.end(), [](auto& p) {
             return p.before_elements == 0 && p.after_elements == 0;
         })) {
@@ -233,7 +233,7 @@ std::tuple<ttnn::Shape, ttnn::Shape> compute_requested_shape(
     }
 
     const auto rank = input_logical_shape.rank();
-    ttnn::SmallVector<uint32_t> requested_logical_shape_vec(rank, 0);
+    ttsl::SmallVector<uint32_t> requested_logical_shape_vec(rank, 0);
 
     std::transform(
         input_logical_shape.cbegin(),
@@ -248,7 +248,7 @@ std::tuple<ttnn::Shape, ttnn::Shape> compute_requested_shape(
 
 ttnn::Tensor invoke_rm(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<PadSpecDim>& padding_vec,
+    const ttsl::SmallVector<PadSpecDim>& padding_vec,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -260,7 +260,7 @@ ttnn::Tensor invoke_rm(
 
     // output_tensor is currently 4D. We have to squeeze back to the original rank
     if (original_rank <= 4) {
-        auto to_vec = [](const auto& span) { return ttnn::SmallVector<uint32_t>{span.begin(), span.end()}; };
+        auto to_vec = [](const auto& span) { return ttsl::SmallVector<uint32_t>{span.begin(), span.end()}; };
         auto output_shape = to_vec(output_tensor.padded_shape().view());
         auto padded_shape = to_vec(output_tensor.padded_shape().view());
         if (const auto rank_diff = output_shape.size() - original_rank; rank_diff) {
@@ -280,7 +280,7 @@ ttnn::Tensor invoke_rm(
 
 ttnn::Tensor invoke_tile(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<PadSpecDim>& padding_vec,
+    const ttsl::SmallVector<PadSpecDim>& padding_vec,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -297,7 +297,7 @@ ttnn::Tensor invoke_tile(
 
     // Consistent with behavior expected by callers
     if (input_tensor.storage_type() != StorageType::DEVICE) {
-        ttnn::Shape zeros(ttnn::SmallVector<uint32_t>(input_logical_shape.rank(), 0));
+        ttnn::Shape zeros(ttsl::SmallVector<uint32_t>(input_logical_shape.rank(), 0));
         return input_tensor.pad(requested_padded_shape, zeros, value);
     }
 
@@ -318,7 +318,7 @@ ttnn::Tensor invoke_tile(
     } else {
         // need to align the requested padding to tile size. Note that begin padding is not supported so now just
         // set to zero
-        ttnn::SmallVector<PadSpecDim> padded_padding_vec;
+        ttsl::SmallVector<PadSpecDim> padded_padding_vec;
         padded_padding_vec.reserve(requested_rank);
         std::transform(
             requested_padded_shape.cbegin(),
@@ -366,7 +366,7 @@ namespace ttnn::operations::experimental::quasar {
 
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<operations::experimental::quasar::PadSpecDim>& padding,
+    const ttsl::SmallVector<operations::experimental::quasar::PadSpecDim>& padding,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -374,7 +374,7 @@ ttnn::Tensor pad(
     using PadSpecDim = operations::experimental::quasar::PadSpecDim;
     const int original_rank = input_tensor.logical_shape().rank();
 
-    ttnn::SmallVector<PadSpecDim> working_padding = padding;
+    ttsl::SmallVector<PadSpecDim> working_padding = padding;
 
     if (int diff = original_rank - padding.size(); diff != 0) {
         TT_FATAL(diff > 0, "ttnn.pad: padding len can't be larger than input tensor rank");
@@ -409,13 +409,13 @@ ttnn::Tensor pad(
 
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<std::array<uint32_t, 2>>& padding,
+    const ttsl::SmallVector<std::array<uint32_t, 2>>& padding,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using PadSpecDim = operations::experimental::quasar::PadSpecDim;
-    ttnn::SmallVector<PadSpecDim> padding_impl;
+    ttsl::SmallVector<PadSpecDim> padding_impl;
     std::transform(padding.begin(), padding.end(), std::back_inserter(padding_impl), [](auto& p) {
         return PadSpecDim(p[0], p[1]);
     });
@@ -432,7 +432,7 @@ ttnn::Tensor pad(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using PadSpecDim = operations::experimental::quasar::PadSpecDim;
-    ttnn::SmallVector<PadSpecDim> padding_impl;
+    ttsl::SmallVector<PadSpecDim> padding_impl;
     const auto& log_shape = input_tensor.logical_shape();
     for (uint32_t i = 0; i < output_padded_shape.size(); ++i) {
         padding_impl.emplace_back(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.hpp
@@ -24,7 +24,7 @@ struct PadSpecDim {
 // to a different code path than Python-driven tests cover.
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<PadSpecDim>& padding,
+    const ttsl::SmallVector<PadSpecDim>& padding,
     float value,
     bool use_multicore = true,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
@@ -32,7 +32,7 @@ ttnn::Tensor pad(
 
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<std::array<uint32_t, 2>>& padding,
+    const ttsl::SmallVector<std::array<uint32_t, 2>>& padding,
     float value,
     bool use_multicore = true,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.cpp
@@ -44,7 +44,7 @@ void bind_pad(nb::module_& mod) {
         ttnn::overload_t(
             nb::overload_cast<
                 const ttnn::Tensor&,
-                const ttnn::SmallVector<std::array<uint32_t, 2>>&,
+                const ttsl::SmallVector<std::array<uint32_t, 2>>&,
                 float,
                 bool,
                 const std::optional<MemoryConfig>&,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/generic_pools.cpp
@@ -252,7 +252,7 @@ static std::vector<Tensor> pool2d_L1(
         // Apply zero padding to channels if needed - we need it in case when output dtype is block float because if we
         // have random values it would affect common exponent calculation
         if (padding_needed > 0 && is_block_float(dtype)) {
-            ttnn::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};
+            ttsl::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};
             input_tensor_flattened = ttnn::pad(input_tensor_flattened, pad_spec, 0.0f);
         }
         input_tensor_sharded = ttnn::operations::experimental::quasar::to_memory_config(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.cpp
@@ -30,7 +30,7 @@ namespace ttnn::operations::experimental::quasar {
 template <reduction_common::ReduceType reduce_type>
 Tensor reduce(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, ttnn::SmallVector<int>>>& dim_arg = std::nullopt,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
     bool keepdim = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
@@ -40,9 +40,9 @@ Tensor reduce(
 
 // input_shape has original shape while output_shape has reduction applied and last 2 dims padded.
 // Need to get slice parameters based on the minimum of the two shapes.
-std::tuple<ttnn::SmallVector<int>, ttnn::SmallVector<int>, ttnn::SmallVector<int>> get_slice_parameters(
+std::tuple<ttsl::SmallVector<int>, ttsl::SmallVector<int>, ttsl::SmallVector<int>> get_slice_parameters(
     Shape input_shape, Shape output_shape) {
-    ttnn::SmallVector<int> start{}, end{}, step{};
+    ttsl::SmallVector<int> start{}, end{}, step{};
     TT_FATAL(
         input_shape.size() == output_shape.size(),
         "Input shape size {} and output shape size {} need to be equal.",
@@ -56,9 +56,9 @@ std::tuple<ttnn::SmallVector<int>, ttnn::SmallVector<int>, ttnn::SmallVector<int
     return {start, end, step};
 }
 
-std::pair<ttnn::SmallVector<int>, ttnn::SmallVector<int>> split_height_width_dims(
-    const ttnn::SmallVector<int>& dim, const Tensor& input_tensor_arg) {
-    ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
+std::pair<ttsl::SmallVector<int>, ttsl::SmallVector<int>> split_height_width_dims(
+    const ttsl::SmallVector<int>& dim, const Tensor& input_tensor_arg) {
+    ttsl::SmallVector<int> non_height_width_dims{}, height_width_dims{};
     const auto& input_shape = input_tensor_arg.logical_shape();
     int rank = input_shape.size();
     for (int d : dim) {
@@ -101,9 +101,9 @@ Tensor adjust_shape(
     const Tensor& tensor,
     const Shape& input_shape,
     bool keepdim,
-    const ttnn::SmallVector<int>& height_width_dims,
-    const ttnn::SmallVector<int>& non_height_width_dims) {
-    ttnn::SmallVector<uint32_t> output_shape;
+    const ttsl::SmallVector<int>& height_width_dims,
+    const ttsl::SmallVector<int>& non_height_width_dims) {
+    ttsl::SmallVector<uint32_t> output_shape;
     for (int axis = 0; axis < input_shape.size(); axis++) {
         bool in_height_width_dims =
             std::find(height_width_dims.begin(), height_width_dims.end(), axis) != height_width_dims.end();
@@ -125,12 +125,12 @@ Tensor adjust_shape(
 template <reduction_common::ReduceType reduce_type>
 static Tensor reduce_impl(
     const Tensor& input_tensor_arg,
-    const ttnn::SmallVector<int>& dim,
+    const ttsl::SmallVector<int>& dim,
     const bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
-    const ttnn::SmallVector<int>& non_height_width_dims,
+    const ttsl::SmallVector<int>& non_height_width_dims,
     const std::optional<CoreRangeSet>& sub_core_grids,
     // Sum precision chain: when active, intermediate stages stay FP32 and only
     // the stage with is_last_in_chain=true packs the final bf16 result.
@@ -308,12 +308,12 @@ static Tensor reduce_impl(
 template <reduction_common::ReduceType reduce_type>
 static Tensor std_var_impl(
     const Tensor& input_tensor_arg,
-    const ttnn::SmallVector<int>& dim,
+    const ttsl::SmallVector<int>& dim,
     const bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
-    const ttnn::SmallVector<int>& non_height_width_dims,
+    const ttsl::SmallVector<int>& non_height_width_dims,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     auto input_shape = input_tensor_arg.logical_shape();
@@ -366,7 +366,7 @@ static Tensor std_var_impl(
     ttnn::Tensor input_tensor = input_tensor_arg;
     uint32_t reduce_batch_size = 1;
     bool needs_inverse_permute = false;
-    ttnn::SmallVector<int64_t> permute_swap;
+    ttsl::SmallVector<int64_t> permute_swap;
 
     if (single_h || single_w) {
         reduce_dim = single_w ? tt::tt_metal::ReduceOpDim::W : tt::tt_metal::ReduceOpDim::H;
@@ -392,7 +392,7 @@ static Tensor std_var_impl(
 
         // Build permutation: kept dims first (in original order), then all
         // reduction dims.  dim is already sorted ascending by generate_reduce_dim.
-        ttnn::SmallVector<int64_t> perm;
+        ttsl::SmallVector<int64_t> perm;
         perm.reserve(rank);
         for (uint32_t i = 0; i < rank; ++i) {
             if (std::find(dim.begin(), dim.end(), static_cast<int>(i)) == dim.end()) {
@@ -450,7 +450,7 @@ bool call_fast_nc(DataType dtype) {
 
 Tensor non_height_width_reduce(
     const ttnn::Tensor& input_tensor,
-    ttnn::SmallVector<int> dims,
+    ttsl::SmallVector<int> dims,
     const std::optional<MemoryConfig>& memory_config_arg,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
@@ -493,17 +493,17 @@ Tensor non_height_width_reduce(
 template <reduction_common::ReduceType reduce_type>
 Tensor reduce(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, ttnn::SmallVector<int>>>& dim_arg,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg,
     const bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    ttnn::SmallVector<int> dim = reduction_common::generate_reduce_dim(input_tensor_arg, dim_arg);
+    ttsl::SmallVector<int> dim = reduction_common::generate_reduce_dim(input_tensor_arg, dim_arg);
     float pad_value = get_pad_value(reduce_type, input_tensor_arg.dtype());
     // TODO: generalize to support all types, parameters, and formats. Issue #18566
-    ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
+    ttsl::SmallVector<int> non_height_width_dims{}, height_width_dims{};
 
     if constexpr (
         reduce_type == reduction_common::ReduceType::Std || reduce_type == reduction_common::ReduceType::Var) {
@@ -602,7 +602,7 @@ Tensor pool_sum(
     float scalar) {
     return reduce_impl<reduction_common::ReduceType::Sum>(
         input_tensor_arg,
-        ttnn::SmallVector<int>({dim}),
+        ttsl::SmallVector<int>({dim}),
         /*keepdim=*/true,
         memory_config_arg,
         compute_kernel_config,
@@ -617,7 +617,7 @@ namespace ttnn::operations::experimental::quasar {
 
 Tensor sum(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg,
     bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
@@ -637,7 +637,7 @@ Tensor sum(
 
 Tensor mean(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg,
     bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
@@ -657,7 +657,7 @@ Tensor mean(
 
 Tensor max(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg,
     bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
@@ -690,7 +690,7 @@ Tensor max(
 
 Tensor min(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg,
     bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
@@ -723,7 +723,7 @@ Tensor min(
 
 Tensor std(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg,
     bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
@@ -744,7 +744,7 @@ Tensor std(
 
 Tensor var(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg,
     bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.hpp
@@ -26,7 +26,7 @@ Tensor pool_sum(
 // Generic reductions
 Tensor sum(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg = std::nullopt,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
     bool keepdim = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
@@ -36,7 +36,7 @@ Tensor sum(
 
 Tensor mean(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg = std::nullopt,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
     bool keepdim = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
@@ -46,7 +46,7 @@ Tensor mean(
 
 Tensor max(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg = std::nullopt,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
     bool keepdim = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
@@ -56,7 +56,7 @@ Tensor max(
 
 Tensor min(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg = std::nullopt,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
     bool keepdim = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
@@ -68,7 +68,7 @@ Tensor min(
 // used. The parameter is kept only for API compatibility and will be removed.
 Tensor std(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg = std::nullopt,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
     bool keepdim = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
@@ -81,7 +81,7 @@ Tensor std(
 // used. The parameter is kept only for API compatibility and will be removed.
 Tensor var(
     const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg = std::nullopt,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
     bool keepdim = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape_nanobind.cpp
@@ -22,7 +22,7 @@ namespace detail {
 
 ttnn::Tensor reshape_shape_vector_wrapper(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int32_t>& shape,
+    const ttsl::SmallVector<int32_t>& shape,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value,
     const TileReshapeMapMode reshape_tile_mode,
@@ -98,7 +98,7 @@ void bind_reshape_view_operation(nb::module_& mod) {
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("skip_padding_fill") = false),
 
-        // Overload 3: shape vector (SmallVector<int32_t>)
+        // Overload 3: shape vector (ttsl::SmallVector<int32_t>)
         ttnn::overload_t(
             &reshape_shape_vector_wrapper,
             nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
@@ -176,7 +176,7 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
 SliceDeviceOperation::spec_return_value_t SliceDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
+    ttsl::SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
 
     if (args.use_tensor_args) {
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.cpp
@@ -207,9 +207,9 @@ ttnn::Tensor slice(
     }
 
     // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
-    ttnn::SmallVector<uint32_t> modified_begins(input_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_ends(input_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_step(input_rank, 1);
+    ttsl::SmallVector<uint32_t> modified_begins(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_ends(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_step(input_rank, 1);
 
     // Wrap indices and adjust begins, ends, and step
     for (size_t i = 0; i < begins.size(); ++i) {
@@ -224,7 +224,7 @@ ttnn::Tensor slice(
         }
     }
 
-    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttnn::SmallVector<uint32_t>& modified_ends) {
+    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttsl::SmallVector<uint32_t>& modified_ends) {
         return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
     };
 
@@ -254,7 +254,7 @@ ttnn::Tensor slice(
             const auto& shard_spec_val = output_memory_config.shard_spec().value();
 
             // Compute output dimensions, tile-aligned if using TILE path
-            ttnn::SmallVector<uint32_t> output_dims(input_rank);
+            ttsl::SmallVector<uint32_t> output_dims(input_rank);
             for (size_t i = 0; i < input_rank; i++) {
                 output_dims[i] = output_dim_i(i, modified_ends);
             }
@@ -324,13 +324,13 @@ ttnn::Tensor slice(
             ttnn::operations::experimental::quasar::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config);
     }
 
-    ttnn::SmallVector<uint32_t> padded_ends = modified_ends;
+    ttsl::SmallVector<uint32_t> padded_ends = modified_ends;
     if (input.layout() == Layout::TILE) {
         padded_ends[input_rank - 2] = std::max(tt::round_up(padded_ends[input_rank - 2], tile_shape[0]), tile_shape[0]);
         padded_ends[input_rank - 1] = std::max(tt::round_up(padded_ends[input_rank - 1], tile_shape[1]), tile_shape[1]);
     }
 
-    ttnn::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
+    ttsl::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
     actual_shape_vec.reserve(input_rank);
     final_padded_shape_vec.reserve(input_rank);
     bool empty = false;
@@ -414,7 +414,7 @@ ttnn::Tensor slice(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<T>>& step,
+    const std::optional<ttsl::SmallVector<T>>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,
@@ -470,8 +470,8 @@ ttnn::Tensor slice(
 
         // Create dummy shapes for SliceDeviceOperation (will be ignored when use_tensor_args=true)
         uint32_t input_rank = input_tensor.logical_shape().rank();
-        ttnn::SmallVector<uint32_t> dummy_shape(input_rank, 0);
-        ttnn::SmallVector<uint32_t> dummy_step_shape(input_rank, 1);
+        ttsl::SmallVector<uint32_t> dummy_shape(input_rank, 0);
+        ttsl::SmallVector<uint32_t> dummy_step_shape(input_rank, 1);
         ttnn::Shape dummy_start(dummy_shape);
         ttnn::Shape dummy_end(dummy_shape);
         ttnn::Shape dummy_step(dummy_step_shape);
@@ -503,7 +503,7 @@ ttnn::Tensor slice(
     ttsl::Span<const T> output_tensor_end_span(output_tensor_end_vector.data(), output_tensor_end_vector.size());
 
     // generate the step value if it is not provided
-    ttnn::SmallVector<T> step_value = step.value_or(ttnn::SmallVector<T>(output_tensor_start_span.size(), 1));
+    ttsl::SmallVector<T> step_value = step.value_or(ttsl::SmallVector<T>(output_tensor_start_span.size(), 1));
 
     return slice<T>(
         input_tensor,
@@ -553,7 +553,7 @@ template ttnn::Tensor slice<uint32_t>(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<uint32_t>>& step,
+    const std::optional<ttsl::SmallVector<uint32_t>>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice.hpp
@@ -22,9 +22,9 @@ ttnn::Tensor slice(
 template <typename T>
 ttnn::Tensor slice(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<T>& begins,
-    const ttnn::SmallVector<T>& ends,
-    const ttnn::SmallVector<T>& step,
+    const ttsl::SmallVector<T>& begins,
+    const ttsl::SmallVector<T>& ends,
+    const ttsl::SmallVector<T>& step,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<float>& pad_value = std::nullopt,
@@ -56,7 +56,7 @@ ttnn::Tensor slice(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<T>>& step = std::nullopt,
+    const std::optional<ttsl::SmallVector<T>>& step = std::nullopt,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<float>& pad_value = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/slice_nanobind.cpp
@@ -24,14 +24,14 @@ namespace {
 
 ttnn::Tensor slice_small_vector_wrapper(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int>& slice_start,
-    const ttnn::SmallVector<int>& slice_end,
-    const std::optional<ttnn::SmallVector<int>>& step,
+    const ttsl::SmallVector<int>& slice_start,
+    const ttsl::SmallVector<int>& slice_end,
+    const std::optional<ttsl::SmallVector<int>>& step,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,
     const std::optional<CoreRangeSet>&& sub_core_grids) {
-    const auto step_value = step.value_or(ttnn::SmallVector<int>(slice_end.size(), 1));
+    const auto step_value = step.value_or(ttsl::SmallVector<int>(slice_end.size(), 1));
     return ttnn::operations::experimental::quasar::slice(
         input_tensor,
         slice_start,
@@ -79,7 +79,7 @@ void bind_slice(nb::module_& mod) {
                 const ttnn::Tensor&,
                 const ttnn::Tensor&,
                 const ttnn::Tensor&,
-                const std::optional<ttnn::SmallVector<uint32_t>>&,
+                const std::optional<ttsl::SmallVector<uint32_t>>&,
                 const std::optional<MemoryConfig>&,
                 const std::optional<Tensor>&,
                 const std::optional<float>&,
@@ -117,7 +117,7 @@ void bind_slice(nb::module_& mod) {
             nb::arg("output_tensor") = nb::none(),
             nb::arg("pad_value") = nb::none(),
             nb::arg("sub_core_grids") = nb::none()),
-        // Overload 3: SmallVector<int> version (int32_t template parameter)
+        // Overload 3: ttsl::SmallVector<int> version (int32_t template parameter)
         ttnn::overload_t(
             &slice_small_vector_wrapper,
             nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -124,7 +124,7 @@ ttnn::Tensor tilize_with_val_padding(
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<uint32_t>& output_padded_shape,
+    const ttsl::SmallVector<uint32_t>& output_padded_shape,
     const tt::tt_metal::PadValue pad_value,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::experimental::quasar {
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<uint32_t>& output_padded_shape,
+    const ttsl::SmallVector<uint32_t>& output_padded_shape,
     tt::tt_metal::PadValue pad_value,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
@@ -112,8 +112,9 @@ Tensor to_layout_impl(
                 "produces a shard height of 1. Move to interleaved first, then tilize.",
                 tensor.padded_shape().size());
             const bool is_scalar = tensor.padded_shape().size() == 0;
-            SmallVector<uint32_t> new_padded_shape =
-                is_scalar ? SmallVector<uint32_t>{1, 1} : SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
+            ttsl::SmallVector<uint32_t> new_padded_shape =
+                is_scalar ? ttsl::SmallVector<uint32_t>{1, 1}
+                          : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
             tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
         }
     }
@@ -169,7 +170,7 @@ Tensor to_layout_impl(
                 output_memory_config =
                     memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
             }
-            Shape output_tensor_end(SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
+            Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
             int logical_rank = tensor.logical_shape().rank();
             for (int index = -1; index >= -logical_rank; --index) {
                 output_tensor_end[index] = tensor.logical_shape()[index] - 1;
@@ -181,7 +182,7 @@ Tensor to_layout_impl(
             if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
                 // ttnn::tilize_with_val_padding doesn't support height sharded tensors
                 // workaround by applying padding and then tilizing
-                SmallVector<std::array<uint32_t, 2>> padding = {
+                ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
                     {0, 0},
                     {0, 0},
                     {0, padded_output_shape[2] - output_shape[2]},
@@ -247,7 +248,7 @@ Tensor to_layout_impl(
             sub_core_grids);
     }
     if (layout == ttnn::TILE_LAYOUT) {
-        SmallVector<uint32_t> padded_input_start;
+        ttsl::SmallVector<uint32_t> padded_input_start;
         for (int index = 0; index < padded_output_shape.rank(); ++index) {
             padded_input_start.push_back(0);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/transpose.cpp
@@ -114,7 +114,7 @@ inline Tensor transpose_(
         output_mem_constructed = output_mem_config.value();
     }
 
-    auto prim_permute = [&](const ttnn::Tensor& input, const ttnn::SmallVector<uint32_t>& dims) -> ttnn::Tensor {
+    auto prim_permute = [&](const ttnn::Tensor& input, const ttsl::SmallVector<uint32_t>& dims) -> ttnn::Tensor {
         return ttnn::prim::permute(input, dims, output_mem_constructed, std::nullopt, pad_value);
     };
 
@@ -122,26 +122,26 @@ inline Tensor transpose_(
     switch (transpose_dim) {
         case ttnn::prim::qsr::TransposeOpDim::HC:
             if (interleaved_rm) {
-                return prim_permute(a, ttnn::SmallVector<uint32_t>{0, 2, 1, 3});
+                return prim_permute(a, ttsl::SmallVector<uint32_t>{0, 2, 1, 3});
             }
             break;
         case ttnn::prim::qsr::TransposeOpDim::NH:
             return ttnn::permute(
-                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({2, 1, 0, 3}), output_mem_config, pad_value);
+                (const ttnn::Tensor)a, ttsl::SmallVector<int64_t>({2, 1, 0, 3}), output_mem_config, pad_value);
         case ttnn::prim::qsr::TransposeOpDim::NW:
             return ttnn::permute(
-                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({3, 1, 2, 0}), output_mem_config, pad_value);
+                (const ttnn::Tensor)a, ttsl::SmallVector<int64_t>({3, 1, 2, 0}), output_mem_config, pad_value);
         case ttnn::prim::qsr::TransposeOpDim::CW:
             return ttnn::permute(
-                (const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({0, 3, 2, 1}), output_mem_config, pad_value);
+                (const ttnn::Tensor)a, ttsl::SmallVector<int64_t>({0, 3, 2, 1}), output_mem_config, pad_value);
         case ttnn::prim::qsr::TransposeOpDim::CN:
             if (interleaved_rm) {
-                return prim_permute(a, ttnn::SmallVector<uint32_t>({1, 0, 2, 3}));
+                return prim_permute(a, ttsl::SmallVector<uint32_t>({1, 0, 2, 3}));
             }
             break;
         case ttnn::prim::qsr::TransposeOpDim::WH:
             if (interleaved_rm) {
-                return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+                return prim_permute(a, ttsl::SmallVector<uint32_t>({0, 1, 3, 2}));
             }
             if (a.layout() == Layout::ROW_MAJOR) {
                 // Only compute the RM WH CB-vs-L1 budget when actually on the RM WH path:
@@ -156,7 +156,7 @@ inline Tensor transpose_(
                 max_l1_space =
                     max_l1_space - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
                 if (cb_size_for_rm > max_l1_space) {
-                    return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+                    return prim_permute(a, ttsl::SmallVector<uint32_t>({0, 1, 3, 2}));
                 }
             }
             break;
@@ -172,7 +172,7 @@ ttnn::Tensor transpose_nd(
     const std::optional<MemoryConfig>& memory_config_arg,
     float pad_value = 0.0f) {
     const auto rank = input_tensor.logical_shape().rank();
-    ttnn::SmallVector<int64_t> permutation;
+    ttsl::SmallVector<int64_t> permutation;
     permutation.reserve(rank);
     for (uint32_t i = 0; i < rank; ++i) {
         permutation.push_back(i);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -214,7 +214,7 @@ void UntilizeWithUnpaddingDeviceOperation::validate_on_program_cache_miss(
 
 TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
-    SmallVector<uint32_t> out_shape;
+    ttsl::SmallVector<uint32_t> out_shape;
     const auto& input_tensor_a = input;
     size_t rank = input_tensor_a.logical_shape().rank();
     out_shape.reserve(rank);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -12,7 +12,7 @@ using namespace tt::tt_metal;
 
 static ttnn::Shape squeeze_vector_shape(ttnn::Shape output_shape) {
     if (output_shape.rank() > 4) {
-        ttnn::SmallVector<uint32_t> output_shape_4d(output_shape.rank());
+        ttsl::SmallVector<uint32_t> output_shape_4d(output_shape.rank());
         output_shape_4d[0] = 1;
         int extra_rank = output_shape.size() - 4;
         for (int i = extra_rank; i >= 0; i--) {
@@ -77,7 +77,7 @@ Tensor untilize_with_unpadding(
     const std::optional<CoreRangeSet>& sub_core_grids) {
     bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::FLOAT32;
 
-    ttnn::SmallVector<uint32_t> output_end_vector;
+    ttsl::SmallVector<uint32_t> output_end_vector;
     ttnn::Shape output_end;
     const auto& input_shape = input_tensor.logical_shape();
     if (input_shape.rank() > 4) {

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
@@ -30,7 +30,7 @@ ttnn::Tensor fast_reduce_nc(
     auto kernel_config_val =
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4);
 
-    ttnn::SmallVector<int32_t> sorted_dims(dims.begin(), dims.end());
+    ttsl::SmallVector<int32_t> sorted_dims(dims.begin(), dims.end());
     std::sort(sorted_dims.begin(), sorted_dims.end());
 
     const std::optional<tt::tt_metal::DataType> intermediate_dtype =

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
@@ -21,7 +21,7 @@ namespace {
 
 ttnn::Tensor fast_reduce_nc_wrapper(
     const ttnn::Tensor& input,
-    const ttnn::SmallVector<int32_t>& dims,
+    const ttsl::SmallVector<int32_t>& dims,
     const std::optional<const ttnn::Tensor>& output,
     const ttnn::MemoryConfig& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
@@ -40,7 +40,7 @@ void bind_fast_reduce_nc(nb::module_& mod) {
         fast_reduce_nc_wrapper,
         nb::arg("input").noconvert(),
         nb::kw_only(),
-        nb::arg("dims").noconvert() = ttnn::SmallVector<int32_t>(),
+        nb::arg("dims").noconvert() = ttsl::SmallVector<int32_t>(),
         nb::arg("output").noconvert() = nb::none(),
         nb::arg("memory_config").noconvert() = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         nb::arg("compute_kernel_config").noconvert() = nb::none());

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -23,12 +23,12 @@ ttnn::Tensor view(const ttnn::Tensor& tensor, ttsl::Span<const int32_t> shape_ve
     return tt::tt_metal::view(tensor, shape, shape);
 }
 
-ttnn::Tensor view(const ttnn::Tensor& tensor, const ttnn::SmallVector<int32_t>& shape_vector) {
+ttnn::Tensor view(const ttnn::Tensor& tensor, const ttsl::SmallVector<int32_t>& shape_vector) {
     return ttnn::experimental::view(tensor, ttsl::Span<const int32_t>(shape_vector.data(), shape_vector.size()));
 }
 
 ttnn::Tensor view(const ttnn::Tensor& tensor, int32_t N, int32_t C, int32_t H, int32_t W) {
-    ttnn::SmallVector<int32_t> shape_vec{N, C, H, W};
+    ttsl::SmallVector<int32_t> shape_vec{N, C, H, W};
     return ttnn::experimental::view(tensor, ttsl::Span<const int32_t>(shape_vec.data(), shape_vec.size()));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.hpp
@@ -15,7 +15,7 @@ ttnn::Tensor view(
     const ttnn::Tensor& input_tensor, const ttnn::Shape& logical_shape, const ttnn::Shape& padded_shape);
 
 // Overloads for nanobind (SmallVector has a registered type caster; Span does not)
-ttnn::Tensor view(const ttnn::Tensor& input_tensor, const ttnn::SmallVector<int32_t>& shape_vector);
+ttnn::Tensor view(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<int32_t>& shape_vector);
 ttnn::Tensor view(const ttnn::Tensor& input_tensor, int32_t N, int32_t C, int32_t H, int32_t W);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view_nanobind.cpp
@@ -50,7 +50,7 @@ void bind_view(nb::module_& mod) {
             nb::arg("H"),
             nb::arg("W")),
         ttnn::overload_t(
-            static_cast<ttnn::Tensor (*)(const ttnn::Tensor&, const ttnn::SmallVector<int32_t>&)>(
+            static_cast<ttnn::Tensor (*)(const ttnn::Tensor&, const ttsl::SmallVector<int32_t>&)>(
                 &ttnn::experimental::view),
             nb::arg("input_tensor"),
             nb::arg("shape")));

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -19,9 +19,9 @@ namespace ttnn::experimental {
 ttnn::Tensor slice_write(
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& output_tensor,
-    const ttnn::SmallVector<uint32_t>& begins,
-    const ttnn::SmallVector<uint32_t>& ends,
-    const ttnn::SmallVector<uint32_t>& step) {
+    const ttsl::SmallVector<uint32_t>& begins,
+    const ttsl::SmallVector<uint32_t>& ends,
+    const ttsl::SmallVector<uint32_t>& step) {
     const auto& logical_input_shape = input_tensor.logical_shape();
     const auto& padded_input_shape = input_tensor.padded_shape();
     const auto& padded_output_shape = output_tensor.padded_shape();
@@ -39,7 +39,7 @@ ttnn::Tensor slice_write(
     const bool tiled = input.layout() == Layout::TILE;
     bool on_device = input.storage_type() == StorageType::DEVICE;
 
-    ttnn::SmallVector<uint32_t> padded_ends = ends;
+    ttsl::SmallVector<uint32_t> padded_ends = ends;
     if (tiled && ends.size() >= 2) {
         // Only pad the last two dimensions for tiled layout
         size_t rank = ends.size();
@@ -48,8 +48,8 @@ ttnn::Tensor slice_write(
         padded_ends[rank - 1] =
             std::max(tt::round_up(ends[rank - 1], tt::constants::TILE_WIDTH), tt::constants::TILE_WIDTH);
     }
-    ttnn::SmallVector<uint32_t> actual_shape_vec;
-    ttnn::SmallVector<uint32_t> padded_shape_vec;
+    ttsl::SmallVector<uint32_t> actual_shape_vec;
+    ttsl::SmallVector<uint32_t> padded_shape_vec;
     actual_shape_vec.reserve(ends.size());
     padded_shape_vec.reserve(ends.size());
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -11,8 +11,8 @@ namespace ttnn::experimental {
 ttnn::Tensor slice_write(
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& output_tensor,
-    const ttnn::SmallVector<uint32_t>& begins,
-    const ttnn::SmallVector<uint32_t>& ends,
-    const ttnn::SmallVector<uint32_t>& step);
+    const ttsl::SmallVector<uint32_t>& begins,
+    const ttsl::SmallVector<uint32_t>& ends,
+    const ttsl::SmallVector<uint32_t>& step);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -78,7 +78,7 @@ NlpKVCacheLoadSliceDeviceOperation::spec_return_value_t NlpKVCacheLoadSliceDevic
     const auto& input_tensor_a = tensor_args.input;
     const auto& input_shape = input_tensor_a.padded_shape();
 
-    SmallVector<uint32_t> out_shape;
+    ttsl::SmallVector<uint32_t> out_shape;
     auto rank = input_shape.rank();
     out_shape.reserve(rank);
     for (uint32_t i = 0; i < rank; i++) {

--- a/ttnn/cpp/ttnn/operations/full_like/full_like.cpp
+++ b/ttnn/cpp/ttnn/operations/full_like/full_like.cpp
@@ -17,7 +17,7 @@ Tensor moreh_full_like(
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Full Like: Input must be on device");
     const auto& shape = input.logical_shape();
     return ttnn::prim::full(
-        ttnn::SmallVector<uint32_t>(shape.cbegin(), shape.cend()),
+        ttsl::SmallVector<uint32_t>(shape.cbegin(), shape.cend()),
         fill_value,
         input.device(),
         dtype.value_or(input.dtype()),

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -29,6 +29,32 @@ using tt::tt_metal::TensorLayout;
 using tt::tt_metal::TensorMemoryLayout;
 using tt::tt_metal::distributed::MeshDevice;
 
+namespace detail {
+
+inline TensorLayout legacy_tensor_layout_from_padded_shape(
+    DataType dtype,
+    const PageConfig& page_config,
+    const MemoryConfig& memory_config,
+    const ttnn::Shape& logical_shape,
+    const ttnn::Shape& padded_shape) {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    auto layout = TensorLayout::fromPaddedShape(dtype, page_config, memory_config, logical_shape, padded_shape);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+    return layout;
+}
+
+}  // namespace detail
+
 template <typename T, bool IS_UPPER>
 static Tensor index_trilu(
     const ttnn::Shape& logical_shape,
@@ -63,7 +89,7 @@ static Tensor index_trilu(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -104,7 +130,7 @@ static Tensor index_width(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -145,7 +171,7 @@ static Tensor index_height(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -185,7 +211,7 @@ static Tensor index_all(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -249,7 +275,7 @@ static Tensor fill_first_val_into_tensor(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           input_tensor.logical_shape(),
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type,
                               PageConfig(Layout::ROW_MAJOR),
                               MemoryConfig{},
@@ -284,7 +310,7 @@ static Tensor prod_result_computation_WH_B0(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           ttnn::Shape({}),
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type,
                               PageConfig(Layout::ROW_MAJOR),
                               MemoryConfig{},
@@ -330,7 +356,7 @@ static Tensor index_channel(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -370,7 +396,7 @@ static Tensor index_batch(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -397,7 +423,7 @@ static Tensor manual_insertion(
                       tt::tt_metal::host_buffer::get_host_buffer(input_cpu_tensor),
                       TensorSpec(
                           logical_shape,
-                          TensorLayout::fromPaddedShape(
+                          detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -142,7 +142,7 @@ ttnn::Shape compute_matmul_output_shape(
 
     // Handle the vector matmul case: if a_rank == 1, remove the second-to-last dimension
     if (a_rank == 1 && output_shape.rank() > 1) [[unlikely]] {
-        ttnn::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
+        ttsl::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
         // Copy all elements except the second-to-last dimension
         size_t dst_idx = 0;
         for (size_t src_idx = 0; src_idx < output_shape.rank(); ++src_idx) {
@@ -155,7 +155,7 @@ ttnn::Shape compute_matmul_output_shape(
 
     // Handle the case where b_rank == 1, remove the last dimension
     if (b_rank == 1) [[unlikely]] {
-        ttnn::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
+        ttsl::SmallVector<uint32_t> new_shape(output_shape.rank() - 1);
         for (auto index = 0; index < output_shape.rank() - 1; ++index) {
             new_shape[index] = output_shape[index];
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
@@ -101,7 +101,7 @@ MorehGetItemOperation::spec_return_value_t MorehGetItemOperation::compute_output
         // index_tensor: [(100), (100)]
         // index_dims = 1,2
         // output: (10, 1, 100, 40)
-        SmallVector<uint32_t> output_size_vec;
+        ttsl::SmallVector<uint32_t> output_size_vec;
         for (unsigned int dim : output_shape) {
             output_size_vec.push_back(dim);
         }
@@ -122,7 +122,7 @@ MorehGetItemOperation::spec_return_value_t MorehGetItemOperation::compute_output
         // index_tensor: [(100), (100)]
         // index_dims = 1,2
         // output: (10, 100, 40)
-        SmallVector<uint32_t> output_size_vec;
+        ttsl::SmallVector<uint32_t> output_size_vec;
 
         auto input_shape = input_tensor.logical_shape();
         uint32_t input_rank = input_shape.rank();
@@ -164,7 +164,7 @@ namespace ttnn::prim {
 ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation::tensor_return_value_t moreh_getitem(
     const Tensor& input,
     const std::vector<Tensor>& index_tensors,
-    const ttnn::SmallVector<uint32_t>& index_dims,
+    const ttsl::SmallVector<uint32_t>& index_dims,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config) {
     using OperationType = ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
@@ -16,7 +16,7 @@
 namespace ttnn::operations::moreh::moreh_getitem {
 struct MorehGetItemOperation {
     struct operation_attributes_t {
-        const ttnn::SmallVector<uint32_t> index_dims;
+        const ttsl::SmallVector<uint32_t> index_dims;
         // const CoreRange core_range;
         const MemoryConfig memory_config;
     };
@@ -59,7 +59,7 @@ namespace ttnn::prim {
 ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation::tensor_return_value_t moreh_getitem(
     const Tensor& input,
     const std::vector<Tensor>& index_tensors,
-    const ttnn::SmallVector<uint32_t>& index_dims,
+    const ttsl::SmallVector<uint32_t>& index_dims,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.cpp
@@ -9,7 +9,7 @@ namespace ttnn {
 Tensor moreh_getitem(
     const std::optional<const Tensor>& input,
     const std::vector<Tensor>& index_tensors,
-    const ttnn::SmallVector<uint32_t>& index_dims,
+    const ttsl::SmallVector<uint32_t>& index_dims,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config) {
     if (!input.has_value()) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.hpp
@@ -12,7 +12,7 @@ namespace ttnn {
 Tensor moreh_getitem(
     const std::optional<const Tensor>& input,
     const std::vector<Tensor>& index_tensors,
-    const ttnn::SmallVector<uint32_t>& index_dims,
+    const ttsl::SmallVector<uint32_t>& index_dims,
     const std::optional<Tensor>& output = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -329,7 +329,7 @@ uint32_t compute_outer(const ttnn::Shape& shape, uint32_t dim) {
     return num_outer;
 }
 
-void expand_to_max_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
+void expand_to_max_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -379,10 +379,10 @@ void validate_output_with_keepdim(const Tensor& input, const Tensor& output, con
                 output_rank);
         }
 
-        ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> input_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttsl::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttsl::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttsl::SmallVector<uint32_t> input_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttsl::SmallVector<uint32_t> output_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
         expand_to_max_dim(input_dim, input_shape);
         expand_to_max_dim(output_dim, output_shape);
         expand_to_max_dim(input_dim_wo_padding, input_shape_wo_padding);
@@ -407,14 +407,14 @@ void validate_output_with_keepdim(const Tensor& input, const Tensor& output, con
                 output_dim_wo_padding[i]);
         }
     } else {
-        ttnn::SmallVector<uint32_t> expected_output_shape;
+        ttsl::SmallVector<uint32_t> expected_output_shape;
         for (int i = 0; i < output_shape.rank(); ++i) {
             if (i == padded_dim && !is_tile_dim) {
                 expected_output_shape.push_back(1);
             }
             expected_output_shape.push_back(output_shape[i]);
         }
-        ttnn::SmallVector<uint32_t> expected_output_shape_wo_padding;
+        ttsl::SmallVector<uint32_t> expected_output_shape_wo_padding;
         for (int i = 0; i < output_shape_wo_padding.rank(); ++i) {
             if (i == dim && !is_tile_dim) {
                 expected_output_shape_wo_padding.push_back(1);
@@ -447,21 +447,21 @@ void validate_output_with_keepdim(const Tensor& input, const Tensor& output, con
     }
 }
 
-void initialize_dims_with_range(ttnn::SmallVector<int64_t>& dims, uint32_t input_rank) {
+void initialize_dims_with_range(ttsl::SmallVector<int64_t>& dims, uint32_t input_rank) {
     dims.resize(input_rank);
     std::iota(dims.begin(), dims.end(), 0);
 }
 
-ttnn::SmallVector<int64_t> get_dim(
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim, uint32_t input_rank) {
-    ttnn::SmallVector<int64_t> dims;
+ttsl::SmallVector<int64_t> get_dim(
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim, uint32_t input_rank) {
+    ttsl::SmallVector<int64_t> dims;
     if (!dim.has_value()) {
         initialize_dims_with_range(dims, input_rank);
     } else if (std::holds_alternative<int64_t>(dim.value())) {
         auto d = std::get<int64_t>(dim.value());
         dims.push_back(d);
     } else {
-        dims = std::get<ttnn::SmallVector<int64_t>>(dim.value());
+        dims = std::get<ttsl::SmallVector<int64_t>>(dim.value());
         if (dims.empty()) {
             initialize_dims_with_range(dims, input_rank);
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.hpp
@@ -259,16 +259,16 @@ uint32_t compute_inner(const ttnn::Shape& shape, uint32_t dim);
 
 uint32_t compute_outer(const ttnn::Shape& shape, uint32_t dim);
 
-void expand_to_max_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape);
+void expand_to_max_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape);
 
 void validate_input_with_dim(const Tensor& input, const int64_t& dim);
 
 void validate_output_with_keepdim(const Tensor& input, const Tensor& output, const int64_t& dim, const bool& keepdim);
 
-void initialize_dims_with_range(ttnn::SmallVector<int64_t>& dims, uint32_t input_rank);
+void initialize_dims_with_range(ttsl::SmallVector<int64_t>& dims, uint32_t input_rank);
 
-ttnn::SmallVector<int64_t> get_dim(
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim, uint32_t input_rank);
+ttsl::SmallVector<int64_t> get_dim(
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim, uint32_t input_rank);
 
 std::tuple<uint32_t, uint32_t, uint32_t> extract_spatial_dims(const ttnn::Shape& shape);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
@@ -18,7 +18,7 @@ std::tuple<bool, bool, bool> get_required_outputs(const std::vector<bool>& are_r
     return {are_required_outputs[0], are_required_outputs[1], are_required_outputs[2]};
 }
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
+void get_tensor_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -61,14 +61,14 @@ inline void moreh_linear_backward_validate(
     }
 }
 
-ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape) {
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+ttsl::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape) {
+    ttsl::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
     int32_t rank = std::max(a_shape.rank(), b_shape.rank());
     log_debug(tt::LogOp, "find_reduce_dim :{} rank {} a {} b {}", __LINE__, rank, a_shape.rank(), b_shape.rank());
-    ttnn::SmallVector<int64_t> dims;
+    ttsl::SmallVector<int64_t> dims;
     // batch dims
     for (int i = 0; i < rank - 2; ++i) {
         int idx = rank - 1 - i;
@@ -85,8 +85,8 @@ bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
     // check batch dims
     const auto& a_shape = tensor_a.padded_shape();
     const auto& b_shape = tensor_b.padded_shape();
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
     for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
@@ -159,7 +159,7 @@ std::vector<std::optional<Tensor>> moreh_linear_backward(
             const auto& temp_weight_grad = ttnn::moreh_matmul(
                 output_grad, input, true, false, std::nullopt, std::nullopt, weight_grad_memory_config, compute_kernel);
             TT_FATAL(weight_grad.has_value(), "weight_grad tensor should not be std::nullopt");
-            ttnn::SmallVector<int64_t> dims = operations::moreh::moreh_linear_backward::find_reduce_dim(
+            ttsl::SmallVector<int64_t> dims = operations::moreh::moreh_linear_backward::find_reduce_dim(
                 temp_weight_grad.padded_shape(), weight_grad.value().padded_shape());
             ttnn::moreh_sum(temp_weight_grad, dims, true, weight_grad, weight_grad_memory_config, compute_kernel);
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -41,8 +41,8 @@ void MorehMatmulOperation::validate_inputs(
     TT_FATAL(input_k == other_k, "k must be the same. input_k {}, other_k {}", input_k, other_k);
 
     // check batch dims
-    ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(input_dim, input_shape);
     get_tensor_dim(other_dim, other_shape);
     for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
@@ -64,7 +64,7 @@ void MorehMatmulOperation::validate_inputs(
         TT_FATAL(input_m == output_m, "m must be the same. input_m {}, output_m {}", input_m, output_m);
         TT_FATAL(other_n == output_n, "n must be the same. other_n {}, output_n {}", other_n, output_n);
 
-        ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttsl::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
         get_tensor_dim(output_dim, output_shape);
 
         for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
@@ -120,8 +120,8 @@ MorehMatmulOperation::spec_return_value_t MorehMatmulOperation::compute_output_s
     auto h_wo_padding = (transpose_input) ? (input_shape_wo_padding[-1]) : (input_shape_wo_padding[-2]);
     auto w_wo_padding = (transpose_other) ? (other_shape_wo_padding[-2]) : (other_shape_wo_padding[-1]);
 
-    ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(input_dim, input_shape);
     get_tensor_dim(other_dim, other_shape);
 
@@ -135,7 +135,7 @@ MorehMatmulOperation::spec_return_value_t MorehMatmulOperation::compute_output_s
         other_shape.rank(),
         output_rank);
 
-    ttnn::SmallVector<uint32_t> output_dim(output_rank);
+    ttsl::SmallVector<uint32_t> output_dim(output_rank);
     // batch dims
     for (int i = 0; i < output_rank - 2; ++i) {
         int idx = output_rank - 1 - i;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
@@ -48,8 +48,8 @@ struct MorehMatmulOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape);
-ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape);
+void get_tensor_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape);
+ttsl::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape);
 bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b);
 
 }  // namespace ttnn::operations::moreh::moreh_matmul

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -12,7 +12,7 @@
 
 namespace ttnn::operations::moreh::moreh_matmul {
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
+void get_tensor_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -31,14 +31,14 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) 
     }
 }
 
-ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape) {
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+ttsl::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape) {
+    ttsl::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
     int32_t rank = std::max(a_shape.rank(), b_shape.rank());
     log_debug(tt::LogOp, "find_reduce_dim :{} rank {} a {} b {}", __LINE__, rank, a_shape.rank(), b_shape.rank());
-    ttnn::SmallVector<int64_t> dims;
+    ttsl::SmallVector<int64_t> dims;
     // batch dims
     for (int i = 0; i < rank - 2; ++i) {
         int idx = rank - 1 - i;
@@ -55,8 +55,8 @@ bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
     // check batch dims
     const auto& a_shape = tensor_a.padded_shape();
     const auto& b_shape = tensor_b.padded_shape();
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
     for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
@@ -69,7 +69,7 @@ bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
     return true;
 }
 
-void get_tensor_stride(ttnn::SmallVector<uint32_t>& stride, ttnn::SmallVector<uint32_t>& dim) {
+void get_tensor_stride(ttsl::SmallVector<uint32_t>& stride, ttsl::SmallVector<uint32_t>& dim) {
     stride[0] = 1;
     for (auto i = 1; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
         stride[i] = stride[i - 1] * dim[i - 1];
@@ -81,10 +81,10 @@ void get_tensor_stride(ttnn::SmallVector<uint32_t>& stride, ttnn::SmallVector<ui
 }
 
 void get_not_bcast(
-    ttnn::SmallVector<uint32_t>& input_not_bcast,
-    ttnn::SmallVector<uint32_t>& input_dim,
-    ttnn::SmallVector<uint32_t>& other_not_bcast,
-    ttnn::SmallVector<uint32_t>& other_dim) {
+    ttsl::SmallVector<uint32_t>& input_not_bcast,
+    ttsl::SmallVector<uint32_t>& input_dim,
+    ttsl::SmallVector<uint32_t>& other_not_bcast,
+    ttsl::SmallVector<uint32_t>& other_dim) {
     // first 2-dims are M,K and K,N
     // TODO: refaactoring
     for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
@@ -141,37 +141,37 @@ tt::tt_metal::ProgramDescriptor MorehMatmulOperation::MultiCoreProgramFactory::c
     const auto& input_shape = input.padded_shape();
     const auto& input_shape_wo_padding = input.logical_shape();
     log_debug(tt::LogOp, "input dim");
-    ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(input_dim, input_shape);
 
     log_debug(tt::LogOp, "input stride");
-    ttnn::SmallVector<uint32_t> input_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
+    ttsl::SmallVector<uint32_t> input_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
     get_tensor_stride(input_stride, input_dim);
 
     // other tensor
     const auto& other_shape = other.padded_shape();
     const auto& other_shape_wo_padding = other.logical_shape();
     log_debug(tt::LogOp, "other dim");
-    ttnn::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(other_dim, other_shape);
 
     log_debug(tt::LogOp, "other stride");
-    ttnn::SmallVector<uint32_t> other_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
+    ttsl::SmallVector<uint32_t> other_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
     get_tensor_stride(other_stride, other_dim);
 
     log_debug(tt::LogOp, "not bcast");
-    ttnn::SmallVector<uint32_t> input_not_bcast(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> other_not_bcast(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> input_not_bcast(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> other_not_bcast(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_not_bcast(input_not_bcast, input_dim, other_not_bcast, other_dim);
 
     // output tensor
     const auto& output_shape = output.padded_shape();
     log_debug(tt::LogOp, "output dim");
-    ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttsl::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(output_dim, output_shape);
 
     log_debug(tt::LogOp, "output stride");
-    ttnn::SmallVector<uint32_t> output_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
+    ttsl::SmallVector<uint32_t> output_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
     get_tensor_stride(output_stride, output_dim);
 
     // matrix shape

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
@@ -71,7 +71,7 @@ MorehMeanOperation::spec_return_value_t MorehMeanOperation::compute_output_specs
                 tensor_args.input.dtype(), PageConfig(tensor_args.input.layout()), operation_attributes.memory_config));
     }
 
-    ttnn::SmallVector<uint32_t> shape;
+    ttsl::SmallVector<uint32_t> shape;
     const bool is_tile_dim = (dim == input_rank - 1 || dim == input_rank - 2);
 
     // e.g. (2, 64, 64) with dim 1 to be (2, 1[32], 64)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
@@ -11,13 +11,13 @@ namespace ttnn {
 
 Tensor moreh_mean(
     const Tensor& input,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim,
     const bool keepdim,
     const std::optional<uint32_t>& divisor,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    ttnn::SmallVector<int64_t> dims = operations::get_dim(dim, input.logical_shape().rank());
+    ttsl::SmallVector<int64_t> dims = operations::get_dim(dim, input.logical_shape().rank());
     std::sort(dims.begin(), dims.end());
 
     auto temp_input = input;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
@@ -15,7 +15,7 @@ namespace ttnn {
 
 Tensor moreh_mean(
     const Tensor& input,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim = std::nullopt,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim = std::nullopt,
     bool keepdim = false,
     const std::optional<uint32_t>& divisor = std::nullopt,
     const std::optional<Tensor>& output = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
@@ -53,7 +53,7 @@ MorehMeanBackwardOperation::tensor_return_value_t MorehMeanBackwardOperation::cr
 namespace ttnn::prim {
 ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation::tensor_return_value_t moreh_mean_backward(
     const Tensor& output_grad,
-    const ttnn::SmallVector<int64_t>& dims,
+    const ttsl::SmallVector<int64_t>& dims,
     bool keepdim,
     const std::optional<ttnn::Shape>& input_grad_shape,
     const std::optional<Tensor>& input_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
@@ -16,7 +16,7 @@
 namespace ttnn::operations::moreh::moreh_mean_backward {
 struct MorehMeanBackwardOperation {
     struct operation_attributes_t {
-        const ttnn::SmallVector<int64_t> dims;
+        const ttsl::SmallVector<int64_t> dims;
         const bool keepdim;
         const std::optional<ttnn::Shape> input_grad_shape;
         const MemoryConfig memory_config;
@@ -46,7 +46,7 @@ struct MorehMeanBackwardOperation {
 namespace ttnn::prim {
 ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation::tensor_return_value_t moreh_mean_backward(
     const Tensor& output_grad,
-    const ttnn::SmallVector<int64_t>& dims,
+    const ttsl::SmallVector<int64_t>& dims,
     bool keepdim,
     const std::optional<ttnn::Shape>& input_grad_shape,
     const std::optional<Tensor>& input_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -16,7 +16,7 @@
 
 using namespace tt::tt_metal;
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
+void get_tensor_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -31,7 +31,7 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) 
 }
 
 ttnn::Shape get_output_grad_shape(
-    const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim) {
+    const Tensor& output_grad, const Tensor& input_grad, const ttsl::SmallVector<int64_t>& dims, const bool& keepdim) {
     if (keepdim) {
         return output_grad.logical_shape();
     }
@@ -80,14 +80,14 @@ ProgramDescriptor MorehMeanBackwardOperation::create_descriptor(
     const auto& input_grad_shape = input_grad.logical_shape();
     const uint32_t input_grad_rank = input_grad_shape.rank();
 
-    ttnn::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
+    ttsl::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
     get_tensor_dim(input_grad_dim, input_grad_shape);
     const auto& output_grad_shape = get_output_grad_shape(output_grad, input_grad, dims, keepdim);
 
-    ttnn::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
+    ttsl::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
     get_tensor_dim(output_grad_dim, output_grad_shape);
 
-    ttnn::SmallVector<uint32_t> need_bcast_dim(input_grad_rank, 0);
+    ttsl::SmallVector<uint32_t> need_bcast_dim(input_grad_rank, 0);
     for (auto i = 0; i < input_grad_rank; ++i) {
         auto idx = input_grad_rank - 1 - i;
         need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.cpp
@@ -11,7 +11,7 @@ namespace ttnn {
 
 Tensor moreh_mean_backward(
     const Tensor& output_grad,
-    std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>> dim,
+    std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>> dim,
     const bool keepdim,
     const std::optional<ttnn::Shape>& input_grad_shape,
     const std::optional<Tensor>& input_grad,
@@ -25,11 +25,11 @@ Tensor moreh_mean_backward(
         } else if (std::holds_alternative<int64_t>(dim.value())) {
             input_grad_rank += 1;
         } else {
-            auto dims = std::get<ttnn::SmallVector<int64_t>>(dim.value());
+            auto dims = std::get<ttsl::SmallVector<int64_t>>(dim.value());
             input_grad_rank += dims.size();
         }
     }
-    ttnn::SmallVector<int64_t> dims = ttnn::operations::get_dim(dim, input_grad_rank);
+    ttsl::SmallVector<int64_t> dims = ttnn::operations::get_dim(dim, input_grad_rank);
     return ttnn::prim::moreh_mean_backward(
         output_grad, dims, keepdim, input_grad_shape, input_grad, memory_config, compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp
@@ -10,7 +10,7 @@ namespace ttnn {
 
 Tensor moreh_mean_backward(
     const Tensor& output_grad,
-    std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>> dim = std::nullopt,
+    std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>> dim = std::nullopt,
     bool keepdim = false,
     const std::optional<ttnn::Shape>& input_grad_shape = std::nullopt,
     const std::optional<Tensor>& input_grad = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
@@ -69,7 +69,7 @@ MorehNllLossStep2DeviceOperation::spec_return_value_t MorehNllLossStep2DeviceOpe
     auto dtype = tensor_args.input_tensor.dtype();
     Layout layout{Layout::TILE};
 
-    ttnn::SmallVector<uint32_t> output_shape_vec;
+    ttsl::SmallVector<uint32_t> output_shape_vec;
 
     // Need extend 1d output to 2d, because TT not support 1d tensor
     if (input_rank == 2) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
@@ -80,7 +80,7 @@ MorehNormOperation::spec_return_value_t MorehNormOperation::compute_output_specs
             TensorLayout(tensor_args.input.dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
     }
 
-    ttnn::SmallVector<uint32_t> shape;
+    ttsl::SmallVector<uint32_t> shape;
     for (int i = 0; i < input_rank; ++i) {
         bool is_reduced_dim = (i == dim);
         if (is_reduced_dim && !is_tile_dim) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.cpp
@@ -14,7 +14,7 @@ namespace ttnn {
 Tensor moreh_norm(
     const Tensor& input,
     float p,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim,
     bool keepdim,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.hpp
@@ -12,7 +12,7 @@ namespace ttnn {
 Tensor moreh_norm(
     const Tensor& input,
     float p,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim = std::nullopt,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim = std::nullopt,
     bool keepdim = false,
     const std::optional<Tensor>& output = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
@@ -51,13 +51,13 @@ ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation::tensor
     const Tensor& output,
     const Tensor& output_grad,
     float p,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim,
     bool keepdim,
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation;
-    ttnn::SmallVector<int64_t> dims = ttnn::operations::get_dim(dim, input.logical_shape().rank());
+    ttsl::SmallVector<int64_t> dims = ttnn::operations::get_dim(dim, input.logical_shape().rank());
     std::sort(dims.begin(), dims.end());
     auto operation_attributes = OperationType::operation_attributes_t{
         p,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
@@ -12,14 +12,14 @@
 namespace ttnn::operations::moreh::moreh_norm_backward {
 
 std::tuple<uint32_t, float, bool> get_floored_p_and_decimal_and_p_is_negative(float p);
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape);
+void get_tensor_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape);
 ttnn::Shape get_output_grad_shape(
-    const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim);
+    const Tensor& output_grad, const Tensor& input_grad, const ttsl::SmallVector<int64_t>& dims, const bool& keepdim);
 
 struct MorehNormBackwardOperation {
     struct operation_attributes_t {
         float p;
-        ttnn::SmallVector<int64_t> dims;
+        ttsl::SmallVector<int64_t> dims;
         bool keepdim;
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
@@ -54,7 +54,7 @@ ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation::tensor
     const Tensor& output,
     const Tensor& output_grad,
     float p,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim,
     bool keepdim,
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -21,7 +21,7 @@ std::tuple<uint32_t, float, bool> get_floored_p_and_decimal_and_p_is_negative(fl
     return std::make_tuple(static_cast<uint32_t>(floored_p), decimal, p_is_negative);
 }
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
+void get_tensor_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -34,7 +34,7 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) 
 }
 
 ttnn::Shape get_output_grad_shape(
-    const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim) {
+    const Tensor& output_grad, const Tensor& input_grad, const ttsl::SmallVector<int64_t>& dims, const bool& keepdim) {
     if (keepdim) {
         return output_grad.logical_shape();
     }
@@ -75,15 +75,15 @@ ProgramDescriptor MorehNormBackwardOperation::create_descriptor(
     const auto& input_grad_shape = input_grad.logical_shape();
     const auto input_grad_rank = input_grad_shape.rank();
 
-    ttnn::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
+    ttsl::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
     get_tensor_dim(input_grad_dim, input_grad_shape);
     auto output_grad_shape =
         get_output_grad_shape(output_grad, input_grad, operation_attributes.dims, operation_attributes.keepdim);
 
-    ttnn::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
+    ttsl::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
     get_tensor_dim(output_grad_dim, output_grad_shape);
 
-    ttnn::SmallVector<uint32_t> need_bcast_dim(input_grad_rank, 0);
+    ttsl::SmallVector<uint32_t> need_bcast_dim(input_grad_rank, 0);
     for (auto i = 0; i < input_grad_rank; ++i) {
         auto idx = input_grad_rank - 1 - i;
         need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/moreh_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/moreh_norm_backward.cpp
@@ -13,7 +13,7 @@ Tensor moreh_norm_backward(
     const Tensor& output,
     const Tensor& output_grad,
     float p,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim,
     bool keepdim,
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/moreh_norm_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/moreh_norm_backward.hpp
@@ -14,7 +14,7 @@ Tensor moreh_norm_backward(
     const Tensor& output,
     const Tensor& output_grad,
     float p,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim = std::nullopt,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim = std::nullopt,
     bool keepdim = false,
     const std::optional<Tensor>& input_grad = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
@@ -85,7 +85,7 @@ MorehSumOperation::spec_return_value_t MorehSumOperation::compute_output_specs(
         // e.g. (2, 64, 64) with dim 0 to be (1, 64, 64)
         output_shape[operation_attributes.dim] = 1;
     } else {
-        ttnn::SmallVector<uint32_t> shape;
+        ttsl::SmallVector<uint32_t> shape;
 
         // e.g. (2, 64, 64) with dim 1 to be (2, 1[32], 64)
         // e.g. (2, 64, 64) with dim 0 to be (64, 64)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
@@ -12,12 +12,12 @@ namespace ttnn {
 
 Tensor moreh_sum(
     const Tensor& input,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim,
     const bool keepdim,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    ttnn::SmallVector<int64_t> dims = operations::get_dim(dim, input.logical_shape().rank());
+    ttsl::SmallVector<int64_t> dims = operations::get_dim(dim, input.logical_shape().rank());
     std::sort(dims.begin(), dims.end());
 
     if (input.logical_shape().rank() == 1 && dims.size() == 1 && dims.front() == 0) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.hpp
@@ -15,7 +15,7 @@ namespace ttnn {
 
 Tensor moreh_sum(
     const Tensor& input,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim = std::nullopt,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim = std::nullopt,
     bool keepdim = false,
     const std::optional<Tensor>& output = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -133,10 +133,11 @@ ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation::tensor_r
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation;
     auto operation_attributes = OperationType::operation_attributes_t{
-        ttnn::SmallVector<int64_t>(dims.begin(), dims.end()),
+        ttsl::SmallVector<int64_t>(dims.begin(), dims.end()),
         keepdim,
         memory_config.value_or(output_grad.memory_config()),
-        init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4)};
+        init_device_compute_kernel_config(
+            output_grad.device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{output_grad, input, input_grad};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
@@ -11,7 +11,7 @@
 namespace ttnn::operations::moreh::moreh_sum_backward {
 struct MorehSumBackwardOperation {
     struct operation_attributes_t {
-        const ttnn::SmallVector<int64_t> dims;
+        const ttsl::SmallVector<int64_t> dims;
         const bool keepdim;
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
@@ -14,7 +14,7 @@ namespace ttnn::operations::moreh::moreh_sum_backward {
 
 using namespace tt::tt_metal;
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& padded_shape) {
+void get_tensor_dim(ttsl::SmallVector<uint32_t>& dim, const ttnn::Shape& padded_shape) {
     const auto rank = padded_shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -34,7 +34,7 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& padded_
 }
 
 std::pair<ttnn::Shape, ttnn::Shape> get_output_grad_shape(
-    const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim) {
+    const Tensor& output_grad, const Tensor& input_grad, const ttsl::SmallVector<int64_t>& dims, const bool& keepdim) {
     if (keepdim) {
         return {output_grad.logical_shape(), output_grad.padded_shape()};
     }
@@ -89,17 +89,17 @@ ProgramDescriptor MorehSumBackwardOperation::create_descriptor(
     const auto& input_grad_shape_wo_padding = input_grad.logical_shape();
     const uint32_t input_grad_rank = input_grad_shape.rank();
 
-    ttnn::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
+    ttsl::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
     log_debug(tt::LogOp, "input_grad");
     get_tensor_dim(input_grad_dim, input_grad_shape);
     const auto [output_grad_shape_wo_padding, output_grad_shape] =
         get_output_grad_shape(output_grad, input_grad, dims, keepdim);
 
-    ttnn::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
+    ttsl::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
     log_debug(tt::LogOp, "output_grad");
     get_tensor_dim(output_grad_dim, output_grad_shape);
 
-    ttnn::SmallVector<uint32_t> need_bcast_dim(input_grad_rank, 0);
+    ttsl::SmallVector<uint32_t> need_bcast_dim(input_grad_rank, 0);
     for (auto i = 0; i < input_grad_rank; ++i) {
         auto idx = input_grad_rank - 1 - i;
         bool is_tile_dim = (idx == input_grad_rank - 1 || idx == input_grad_rank - 2);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/moreh_sum_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/moreh_sum_backward.cpp
@@ -12,14 +12,14 @@ namespace ttnn {
 Tensor moreh_sum_backward(
     const Tensor& output_grad,
     const std::optional<Tensor>& input,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim,
     const bool keepdim,
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     TT_FATAL((input.has_value() || input_grad.has_value()), "either input or input_grad must have a value");
     uint32_t rank = input.has_value() ? input->logical_shape().rank() : input_grad->logical_shape().rank();
-    ttnn::SmallVector<int64_t> dims = operations::get_dim(dim, rank);
+    ttsl::SmallVector<int64_t> dims = operations::get_dim(dim, rank);
     std::sort(dims.begin(), dims.end());
     return ttnn::prim::moreh_sum_backward(
         output_grad, input, dims, keepdim, input_grad, memory_config, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/moreh_sum_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/moreh_sum_backward.hpp
@@ -11,7 +11,7 @@ namespace ttnn {
 Tensor moreh_sum_backward(
     const Tensor& output_grad,
     const std::optional<Tensor>& input = std::nullopt,
-    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim = std::nullopt,
+    const std::optional<std::variant<int64_t, ttsl::SmallVector<int64_t>>>& dim = std::nullopt,
     bool keepdim = false,
     const std::optional<Tensor>& input_grad = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -20,7 +20,7 @@ inline Tensor mean_NHW(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     auto output_mem_config = memory_config.value_or(input_tensor.memory_config());
-    ttnn::SmallVector<int> dims = {2, 3};
+    ttsl::SmallVector<int> dims = {2, 3};
     Tensor mean_hw = ttnn::mean(input_tensor, dims, true, output_mem_config, compute_kernel_config);
     return ttnn::mean(mean_hw, 0, true, output_mem_config, compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -249,7 +249,7 @@ static std::vector<Tensor> pool2d_L1(
         // Apply zero padding to channels if needed - we need it in case when output dtype is block float because if we
         // have random values it would affect common exponent calculation
         if (padding_needed > 0 && is_block_float(dtype)) {
-            ttnn::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};
+            ttsl::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};
             input_tensor_flattened = ttnn::pad(input_tensor_flattened, pad_spec, 0.0f);
         }
         input_tensor_sharded = ttnn::to_memory_config(input_tensor_flattened, in_memory_config, std::nullopt);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -26,7 +26,7 @@ Tensor preprocess_input_tensor(
         int32_t final_rank = input_rank;
         int32_t final_cum_axis = cum_axis;
         if (input_rank < FOUR_DIMENSIONS) {
-            ttnn::SmallVector<uint32_t> new_dims = {};
+            ttsl::SmallVector<uint32_t> new_dims = {};
             for (int32_t i = input_rank; i < FOUR_DIMENSIONS; ++i) {
                 new_dims.push_back(1);
             }
@@ -121,7 +121,7 @@ Tensor accumulation_invoke(
     const int32_t cum_axis = (dim < 0) ? (dim + input_rank) : dim;
 
     Tensor wip_tensor = input_tensor;
-    ttnn::SmallVector<int64_t> permutation;
+    ttsl::SmallVector<int64_t> permutation;
     int32_t accumulation_axis;
     wip_tensor = common::preprocess_input_tensor(wip_tensor, cum_axis, permutation, accumulation_axis, dtype);
     wip_tensor = ttnn::prim::accumulation(

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.hpp
@@ -18,7 +18,7 @@ namespace ttnn::operations::reduction::accumulation::common {
 constexpr uint32_t FOUR_DIMENSIONS{4};
 constexpr uint32_t FIRST_DIMENSION{0};
 
-using permutation_t = ttnn::SmallVector<int64_t>;
+using permutation_t = ttsl::SmallVector<int64_t>;
 
 Tensor preprocess_input_tensor(
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -112,7 +112,7 @@ Tensor run_argmax_nc(
         const auto& logical_shape = row_major_out.logical_shape();
         const int32_t rank = static_cast<int32_t>(logical_shape.rank());
         const int32_t normalized_dim = dim < 0 ? dim + rank : dim;
-        ttnn::SmallVector<uint32_t> new_shape;
+        ttsl::SmallVector<uint32_t> new_shape;
         new_shape.reserve(rank - 1);
         for (int32_t i = 0; i < rank; ++i) {
             if (i == normalized_dim) {

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
@@ -36,10 +36,10 @@ bool uses_multicore_path(const ArgmaxParams& args, const ArgmaxInputs& tensor_ar
  * @param keepdim Whether to keep the reduced dimension.
  * @return The output shape.
  */
-ttnn::SmallVector<uint32_t> get_output_shape(const Tensor& input_tensor, const std::optional<int>& dim, bool keepdim) {
+ttsl::SmallVector<uint32_t> get_output_shape(const Tensor& input_tensor, const std::optional<int>& dim, bool keepdim) {
     auto input_shape = input_tensor.logical_shape();
     int rank = input_shape.size();
-    ttnn::SmallVector<uint32_t> output_shape;
+    ttsl::SmallVector<uint32_t> output_shape;
 
     // If no reduction dims are specified, we reduce all dimensions
     auto all_dim_reduce = not dim.has_value();

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_utils.hpp
@@ -23,6 +23,6 @@ inline int32_t normalize_dim(int32_t dim, int32_t rank) noexcept { return dim < 
  * @param keepdim Whether to keep the reduced dimension.
  * @return The output shape.
  */
-ttnn::SmallVector<uint32_t> get_output_shape(const Tensor& input_tensor, const std::optional<int>& dim, bool keepdim);
+ttsl::SmallVector<uint32_t> get_output_shape(const Tensor& input_tensor, const std::optional<int>& dim, bool keepdim);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -53,11 +53,11 @@ Tensor prod_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_co
 Tensor prod_nc(
     const Tensor& input,
     const Tensor& output,
-    ttnn::SmallVector<int64_t>& dims,
+    ttsl::SmallVector<int64_t>& dims,
     const MemoryConfig& output_mem_config) {
     TT_FATAL(!dims.empty(), "prod_nc dims should not be empty");
 
-    ttnn::SmallVector<int64_t> sorted_dims = dims;
+    ttsl::SmallVector<int64_t> sorted_dims = dims;
     std::sort(sorted_dims.begin(), sorted_dims.end());
 
     auto temp_input = input;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
@@ -17,7 +17,7 @@ using namespace tt_metal;
 Tensor prod_nc(
     const Tensor& input,
     const Tensor& output,
-    ttnn::SmallVector<int64_t>& dims,
+    ttsl::SmallVector<int64_t>& dims,
     const MemoryConfig& output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 }  // namespace tt::operations::primary

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -38,7 +38,7 @@ inline Tensor compute_prod_nc(const Tensor& temp, int64_t dim, const MemoryConfi
         formatted_input_tensor = ttnn::tilize_with_val_padding(temp, a_pad_shape, PadValue(1.0f), temp.memory_config());
     }
     // Apply prod
-    ttnn::SmallVector<int64_t> dimension = {(dim == 1 || dim == -3) ? 1 : 0};
+    ttsl::SmallVector<int64_t> dimension = {(dim == 1 || dim == -3) ? 1 : 0};
     const auto& input_shape = formatted_input_tensor.logical_shape();
     std::array<uint32_t, 4> required = {
         ((dim == 1 || dim == -3) ? input_shape[0] : 1),
@@ -89,7 +89,7 @@ Tensor prod_impl(
 
     // For a zero volume tensor, return a zero volume tensor with the shape adjusted for keepdim.
     if (input_a_padded.logical_volume() == 0) {
-        ttnn::SmallVector<int> dim_vector = reduction_common::generate_reduce_dim(input_a_padded, dim);
+        ttsl::SmallVector<int> dim_vector = reduction_common::generate_reduce_dim(input_a_padded, dim);
         return reduction_common::zero_volume_reduce<reduction_common::ReduceType::Prod>(
             input_a_padded, dim_vector, keepdim, output_mem_config);
     }
@@ -103,7 +103,7 @@ Tensor prod_impl(
         Tensor result = compute_prod_all(input_a_padded, output_mem_config);
         if (keepdim) {
             // Reshape to have all dimensions (as many as the input rank) set to 1.
-            ttnn::SmallVector<uint32_t> output_shape(old_rank, 1);
+            ttsl::SmallVector<uint32_t> output_shape(old_rank, 1);
             result = ttnn::reshape(result, ttnn::Shape{output_shape});
         }
         return result;
@@ -123,7 +123,7 @@ Tensor prod_impl(
         const int third_last_dim_idx = input_a_padded.logical_shape().rank() - 3;
         const bool permute_required = third_last_dim_idx != positive_dim;
 
-        ttnn::SmallVector<int64_t> post_permute_dims(input_a_padded.logical_shape().rank());
+        ttsl::SmallVector<int64_t> post_permute_dims(input_a_padded.logical_shape().rank());
         std::iota(post_permute_dims.begin(), post_permute_dims.end(), 0);
         std::swap(post_permute_dims[third_last_dim_idx], post_permute_dims[positive_dim]);
 
@@ -165,32 +165,32 @@ Tensor prod_impl(
     Tensor temp = input_tensor_4d;
     // Permute for dim 2,3
     if (dim_4d == 2 || dim_4d == -2) {
-        ttnn::SmallVector<int64_t> permute_dims = {2, 0, 1, 3};
+        ttsl::SmallVector<int64_t> permute_dims = {2, 0, 1, 3};
         temp = ttnn::permute(input_tensor_4d, permute_dims, output_mem_config);
     } else if (dim_4d == 3 || dim_4d == -1) {
-        ttnn::SmallVector<int64_t> permute_dims = {3, 0, 1, 2};
+        ttsl::SmallVector<int64_t> permute_dims = {3, 0, 1, 2};
         temp = ttnn::permute(input_tensor_4d, permute_dims, output_mem_config);
     }
     Tensor result = compute_prod_nc(temp, dim_4d, output_mem_config);
     // Permute and unpad result for dim 2,3. Don't need to process dim 0,1.
-    auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
+    auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
     if (dim_4d == 0 || dim_4d == 1 || dim_4d == -4 || dim_4d == -3) {
         result = ttnn::squeeze_from_4D(result, old_rank);
     } else if (dim_4d == 2 || dim_4d == -2) {
-        ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
+        ttsl::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
         Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
         const auto& input_shape = input_tensor_4d.logical_shape();
-        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[3]};
+        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[3]};
         result = ttnn::squeeze_from_4D(ttnn::slice(required, start_index, end_index, step, std::nullopt), old_rank);
     } else {  // dim 3
         // permute
-        ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
+        ttsl::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
         Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
         // unpad
         const auto& input_shape = input_tensor_4d.logical_shape();
-        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[2]};
+        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[2]};
         Tensor new_unpad_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
         // permute back
         after_permute_dims = {0, 1, 3, 2};
@@ -203,7 +203,7 @@ Tensor prod_impl(
 Tensor prod_nc_impl(
     const Tensor& input,
     const Tensor& output,
-    ttnn::SmallVector<int64_t>& dims,
+    ttsl::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config) {
     auto mem_cfg = memory_config.value_or(input.memory_config());
     const Tensor input_padded = input.layout() == Layout::TILE ? ttnn::fill_implicit_tile_padding(input, 1.0f) : input;
@@ -226,7 +226,7 @@ Tensor prod(
 Tensor prod(
     const Tensor& input,
     const Tensor& output,
-    SmallVector<int64_t>& dims,
+    ttsl::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config) {
     return operations::reduction::prod_nc_impl(input, output, dims, memory_config);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
@@ -18,7 +18,7 @@ Tensor prod(
 Tensor prod(
     const Tensor& input,
     const Tensor& output,
-    SmallVector<int64_t>& dims,
+    ttsl::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
@@ -91,8 +91,11 @@ void bind_reduction_prod_operation(nb::module_& mod) {
             nb::kw_only(),
             nb::arg("memory_config") = nb::none()),
         ttnn::overload_t(
-            nb::overload_cast<const Tensor&, const Tensor&, SmallVector<int64_t>&, const std::optional<MemoryConfig>&>(
-                &ttnn::prod),
+            nb::overload_cast<
+                const Tensor&,
+                const Tensor&,
+                ttsl::SmallVector<int64_t>&,
+                const std::optional<MemoryConfig>&>(&ttnn::prod),
             nb::arg("input_tensor"),
             nb::arg("output_tensor"),
             nb::kw_only(),

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.cpp
@@ -20,16 +20,16 @@ ttnn::Tensor transform_to_4d_tensor(const ttnn::Tensor& input_tensor, const bool
                          : ttnn::operations::data_movement::squeeze_from_ND_to_4D(input_tensor);
 }
 
-ttnn::SmallVector<int> generate_reduce_dim(
+ttsl::SmallVector<int> generate_reduce_dim(
     const ttnn::Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, ttnn::SmallVector<int>>>& dim_arg) {
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg) {
     const auto& input_shape = input_tensor_arg.logical_shape();
     auto rank = input_shape.rank();
-    ttnn::SmallVector<int> dim{};
+    ttsl::SmallVector<int> dim{};
     if (dim_arg.has_value()) {
         if (std::holds_alternative<int>(dim_arg.value())) {
             auto dim_as_int = std::get<int>(dim_arg.value());
-            dim = ttnn::SmallVector<int>({dim_as_int});
+            dim = ttsl::SmallVector<int>({dim_as_int});
         } else if (std::holds_alternative<int64_t>(dim_arg.value())) {
             auto dim_as_int64 = std::get<int64_t>(dim_arg.value());
             TT_FATAL(
@@ -37,13 +37,13 @@ ttnn::SmallVector<int> generate_reduce_dim(
                 "Dimension must be in the range [{}, {}]",
                 std::numeric_limits<int>::lowest(),
                 std::numeric_limits<int>::max());
-            dim = ttnn::SmallVector<int>({static_cast<int>(dim_as_int64)});
+            dim = ttsl::SmallVector<int>({static_cast<int>(dim_as_int64)});
         } else {
-            dim = std::get<ttnn::SmallVector<int>>(dim_arg.value());
+            dim = std::get<ttsl::SmallVector<int>>(dim_arg.value());
         }
     }
     if (dim.empty()) {
-        dim = ttnn::SmallVector<int>(rank);
+        dim = ttsl::SmallVector<int>(rank);
         for (int i = 0; i < rank; i++) {
             dim[i] = i;
         }

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.hpp
@@ -38,9 +38,9 @@ ttnn::Tensor perform_transpose(
 
 ttnn::Tensor transform_to_4d_tensor(const ttnn::Tensor& input_tensor, bool is_rank_le_4d);
 
-ttnn::SmallVector<int> generate_reduce_dim(
+ttsl::SmallVector<int> generate_reduce_dim(
     const ttnn::Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, ttnn::SmallVector<int>>>& dim_arg);
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg);
 
 constexpr float get_zero_volume_fill_value(const ReduceType type) {
     switch (type) {
@@ -66,7 +66,7 @@ constexpr float get_zero_volume_fill_value(const ReduceType type) {
 template <ReduceType reduce_type>
 ttnn::Tensor zero_volume_reduce(
     const ttnn::Tensor& input_tensor,
-    const ttnn::SmallVector<int>& dim,
+    const ttsl::SmallVector<int>& dim,
     const bool keepdim,
     const ttnn::MemoryConfig& memory_config) {
     auto input_shape = input_tensor.logical_shape();
@@ -83,7 +83,7 @@ ttnn::Tensor zero_volume_reduce(
         }
     }
 
-    ttnn::SmallVector<uint32_t> output_shape;
+    ttsl::SmallVector<uint32_t> output_shape;
 
     const int rank = static_cast<int>(input_shape.rank());
     // Iterate over the input shape and adjust the output shape for keepdim

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -115,9 +115,9 @@ std::vector<Tensor> post_topk_transform_tensor(
     // If we had to round up K for op, slice down to the requested K value
     if (adjusted_k != k) {
         const auto output_shape = result[0].logical_shape();
-        ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
-        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> end_index = {output_shape[0], output_shape[1], output_shape[2], k};
+        ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<uint32_t> end_index = {output_shape[0], output_shape[1], output_shape[2], k};
 
         // Slice both values and indices tensors to remove extra elements beyond requested K
         result[0] = ttnn::slice(result[0], start_index, end_index, step, input_memory_config);
@@ -134,7 +134,7 @@ std::vector<Tensor> post_topk_transform_tensor(
         result[1] = ttnn::squeeze_from_4D(result[1], orig_rank);
     } else if (orig_rank != 4) {
         // For tensors originally > 4D, or 1D, reshape back to original higher-dimensional structure
-        ttnn::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
+        ttsl::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
         result_shape[result_shape.size() - 1] = k;  // Update last dimension to K
         result[0] = ttnn::reshape(result[0], ttnn::Shape{result_shape});
         result[1] = ttnn::reshape(result[1], ttnn::Shape{result_shape});
@@ -156,9 +156,9 @@ std::vector<Tensor> post_topk_transform_tensor(
         int rank = final_lshape.rank();
 
         // Build slice parameters to extract exactly the expected shape
-        ttnn::SmallVector<uint32_t> step;
-        ttnn::SmallVector<uint32_t> start_index;
-        ttnn::SmallVector<uint32_t> end_index;
+        ttsl::SmallVector<uint32_t> step;
+        ttsl::SmallVector<uint32_t> start_index;
+        ttsl::SmallVector<uint32_t> end_index;
 
         for (int i = 0; i < rank; i++) {
             step.push_back(1);                     // No skipping, take every element
@@ -340,7 +340,7 @@ std::vector<Tensor> topk(
     const auto pad_val = largest ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity();
 
     if (pad_amount > 0) {
-        ttnn::SmallVector<std::array<uint32_t, 2>> padding = {{0, 0}, {0, 0}, {0, 0}, {0, pad_amount}};
+        ttsl::SmallVector<std::array<uint32_t, 2>> padding = {{0, 0}, {0, 0}, {0, 0}, {0, pad_amount}};
 
         // Use multicore padding for BFLOAT16 tensors not in L1 memory for better performance
         const bool pad_multicore = transformed_tensor.dtype() == DataType::BFLOAT16 &&

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -483,9 +483,9 @@ void run_sliced_op(
 
         const Tensor sliced_input_tensor = ttnn::experimental::padded_slice(
             input_tensor,
-            ttnn::SmallVector<uint32_t>{0, input_slice_height_start, input_slice_width_start, 0},  // Start
-            ttnn::SmallVector<uint32_t>{batch_size, input_slice_height_end, input_slice_width_end, input_channels},
-            ttnn::SmallVector<uint32_t>{1, 1, 1, 1},  // Step
+            ttsl::SmallVector<uint32_t>{0, input_slice_height_start, input_slice_width_start, 0},  // Start
+            ttsl::SmallVector<uint32_t>{batch_size, input_slice_height_end, input_slice_width_end, input_channels},
+            ttsl::SmallVector<uint32_t>{1, 1, 1, 1},  // Step
             sliced_input_tensor_memory_config);
 
         auto sliced_output_tensors = op_slice_attr->run_L1_op(
@@ -522,10 +522,10 @@ void run_sliced_op(
             ttnn::experimental::slice_write(
                 sliced_output_tensor,
                 output_tensor,
-                ttnn::SmallVector<uint32_t>{0, output_slice_height_start, output_slice_width_start, 0},
-                ttnn::SmallVector<uint32_t>{
+                ttsl::SmallVector<uint32_t>{0, output_slice_height_start, output_slice_width_start, 0},
+                ttsl::SmallVector<uint32_t>{
                     batch_size, output_slice_height_end, output_slice_width_end, output_channels},
-                ttnn::SmallVector<uint32_t>{1, 1, 1, 1});
+                ttsl::SmallVector<uint32_t>{1, 1, 1, 1});
         }
         output_slice_dim_start += output_slice_size;
         slice_index++;


### PR DESCRIPTION
## Summary
A large number of clang-tidy warnings has been flagged when building the `tt-train` target. This PR fixes them.

### Why are most changes outside `tt-train`?
`tt-train` compiles against TTNN/Metalium headers and templates. clang-tidy runs on the `tt-train` target, but the diagnostics originate in the shared `ttnn/` and `tt_metal/` headers that `tt-train` includes. They are all `-Wdeprecated-declarations` on APIs already marked `[[deprecated]]` upstream, so the fix belongs in those shared headers / call sites, not in `tt-train` itself. There is no new "tt-train policy" being pushed onto the repo — this is just migrating already-deprecated APIs to their canonical replacements.

### What changed
- `ttnn::SmallVector` / unqualified `SmallVector` -> `ttsl::SmallVector` (canonical alias).
- `tt::stl::` -> `ttsl::` (`Span`, `SmallVector`).
- Unqualified `CoreCoord` / `CoreRange` / `CoreRangeSet` -> `tt::tt_metal::`-qualified.
- Deprecated `MeshDevice::is_local` / `MeshDevice::get_device` -> access via `MeshDeviceView`.
- Intentional legacy-compat points (`TensorLayout::fromPaddedShape`, nested `MeshCommandQueue::ShardDataTransfer`) kept working and warning-free behind narrow helpers / diagnostic pragmas.

### Scope note for reviewers
This is scoped as "fix deprecations reachable from the `tt-train` clang-tidy build", not "only edit files under `tt-train/`". If TTNN/Metalium owners prefer a smaller PR, I'm happy to narrow it to the exact warnings emitted by the tt-train scan and move the broader cleanup to a follow-up.

### Related
- #49089 — CI change that makes clang-tidy actually fail on these violations (stacked on this PR).

## Test plan
- [x] `cmake --build --preset clang-tidy-fix-parallel --target tt-train` (completes clean, no deprecation warnings)
- [x] Sanity workflow
- [x] Nightly workflow


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/clang-tidy-deprecation-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/clang-tidy-deprecation-warnings)
