### PR TITLE
Add cold/warm/long scenarios to MLA perf test

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -43,13 +43,22 @@ Two-test pattern (mirrors tests/nightly/blackhole/sdpa):
   * test_mla_chunked_perf_impl  — the work to profile. Builds the v32 ttMLA and, per DS_PERF_SCENARIO,
     either measures one forward over the (zero-init) block-cyclic caches (warm/long) or forwards a chunk
     loop that fills them (cold), wrapping the measured forward(s) in signpost("start"/"stop"). Run under tracy.
-  * test_mla_chunked_perf       — the driver, parametrized over [warm, cold, long]. Spawns the impl
-    under tracy via run_device_profiler (passing DS_PERF_SCENARIO), reads the device ops log for the
-    signposted region, prints a per-op table, and writes a per-scenario CSV.
+  * test_mla_chunked_perf       — the driver, parametrized over [warm, cold, long] × [sparse, dense].
+    Spawns the impl under tracy via run_device_profiler (passing DS_PERF_SCENARIO + DS_PERF_ATTN_MODE),
+    reads the device ops log for the signposted region, prints a per-op table, and writes a per-(scenario,
+    mode) CSV under the per-mode profiler dir.
 
-Run (Blackhole Galaxy/LoudBox/QuietBox) — all three scenarios, or one via -k:
+attn_mode axis — a baseline to compare the sparse impl against:
+  * sparse — v3.2 DSA: indexer builds top-k index keys, sparse_sdpa attends only the top-k=2048 keys.
+  * dense  — v3.1 baseline: has_indexer=False -> NullIndexer + full-prefix ring MLA (ring_joint_sdpa
+    over the whole prefix, no indexer/top-k). Needs no cache fill (ring reads the prefix by logical_n).
+  Each mode writes its own profiler subdir (deepseek_v32_{sparse,dense}_mla_perf) so the runs never
+  clobber and the CSVs stay directly comparable.
+
+Run (Blackhole Galaxy/LoudBox/QuietBox) — all six combos, or narrow via -k:
     pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf -s
-    pytest -m perf ...::test_mla_chunked_perf -k cold -s
+    pytest -m perf ...::test_mla_chunked_perf -k "cold and sparse" -s
+    pytest -m perf ...::test_mla_chunked_perf -k dense -s
 
 Knobs (env): DS_PERF_SCENARIO (warm|cold|long, default warm for a standalone impl run),
 DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120), DS_PERF_LONG_CACHE (default 512000),
@@ -90,10 +99,21 @@ CHUNK_TOKENS = int(os.environ.get("DS_PERF_CHUNK", 5120))  # 5 * 1024 processed 
 # chunk (the rope table requires total = cache + chunk to be a multiple of chunk). Override with
 # DS_PERF_LONG_CACHE (must stay a chunk multiple), e.g. 522240 (=102 chunks ≈ 512*1024).
 LONG_CACHE_TOKENS = int(os.environ.get("DS_PERF_LONG_CACHE", 512000))
-SUBDIR = "deepseek_v32_sparse_mla_perf"
-# Per-op summary filename (one per scenario, suffixed). Written under the tracy profiler dir
-# (PROFILER_ARTIFACTS_DIR / SUBDIR) alongside the raw device reports — see _scenario_csv.
-CSV_NAME = os.environ.get("DS_PERF_CSV", "deepseek_v32_sparse_mla_perf.csv")
+# attn_mode axis: sparse (v3.2 DSA indexer + sparse_sdpa) vs dense (v3.1 full-prefix ring MLA — no
+# indexer, no top-k), a baseline to compare the sparse impl against. Each mode writes its own tracy
+# profiler subdir + per-scenario CSVs so the two runs never clobber and stay directly comparable.
+ATTN_MODES = ("sparse", "dense")
+ATTN_MODE = os.environ.get("DS_PERF_ATTN_MODE", "sparse")  # the impl selects its mode from this
+
+
+def _subdir(mode: str) -> str:
+    """Per-mode tracy profiler subdir (holds the raw device reports + the per-scenario summary CSVs)."""
+    return f"deepseek_v32_{mode}_mla_perf"
+
+
+def _csv_name(mode: str) -> str:
+    return os.environ.get("DS_PERF_CSV" if mode == "sparse" else "DS_DENSE_PERF_CSV", f"{_subdir(mode)}.csv")
+
 
 # Three profiling scenarios (select the impl's via DS_PERF_SCENARIO; the driver sweeps all three):
 #   warm  — the production step: one chunk over a pre-filled `cache` (indexer K-cache populated
@@ -110,9 +130,9 @@ SCENARIOS = {
 SCENARIO = os.environ.get("DS_PERF_SCENARIO", "warm")
 
 
-def _scenario_csv(out_dir, scenario: str) -> str:
-    """Per-scenario summary CSV path under the tracy profiler dir (next to the raw device reports)."""
-    root, ext = os.path.splitext(CSV_NAME)
+def _scenario_csv(out_dir, scenario: str, mode: str) -> str:
+    """Per-(scenario, mode) summary CSV path under the tracy profiler dir (next to the raw reports)."""
+    root, ext = os.path.splitext(_csv_name(mode))
     return os.path.join(out_dir, f"{root}_{scenario}{ext}")
 
 
@@ -232,6 +252,7 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
 
     scenario = SCENARIOS[SCENARIO]
     is_cold = scenario["loop"]
+    has_indexer = ATTN_MODE == "sparse"  # dense baseline drops the indexer -> full-prefix ring MLA
     sp_axis, tp_axis = 0, 1
     sp, tp = mesh_device.shape
     # cache scales per box (sp/GALAXY_SP) like the chunk, so every box profiles the Galaxy per-chip
@@ -269,9 +290,15 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         tp_axis=tp_axis,
         is_chunked=True,
         layer_num=1,
+        has_indexer=has_indexer,  # sparse: DSA indexer + sparse_sdpa; dense: NullIndexer + ring MLA
     )
 
     rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors_indexed(total, chunk)
+    # KVPE cache format is mode-specific. sparse: sparse_sdpa reads it natively and requires an
+    # uncompressed bf16/fp8_e4m3 ROW_MAJOR cache (mla.py asserts) — NOT the init_kvpe_cache bfloat8_b/TILE
+    # default. dense: ring_joint_sdpa wants the default (bfloat8_b TILE) and derives its output dtype from
+    # the cache, so leave dense on the default.
+    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if has_indexer else {}
     kvpe_cache = init_kvpe_cache(
         kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
         mesh_device=mesh_device,
@@ -279,27 +306,28 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         mesh_shape=list(mesh_device.shape),
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
-        # sparse_sdpa reads the KVPE cache natively and only accepts an uncompressed bf16 / fp8_e4m3
-        # ROW_MAJOR cache (mla.py asserts this) — NOT the init_kvpe_cache bfloat8_b/TILE default.
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        **kvpe_dtype_layout,
     )
 
-    # Block-cyclic indexer key cache: allocated externally (same ownership as the KVPE cache) and passed
-    # into forward. warm/long leave it (and the KVPE cache) at zero init — for a profiling proxy the cache
-    # CONTENTS don't affect op shapes/timing (the gather + score always cover the full `total`-length
-    # prefix), so representing the `cache` already-processed tokens needs no warm-up write. cold fills both
-    # caches for real via its own per-chunk block-cyclic slab writes (start=0,chunk,…,cache).
-    index_kv_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=mla._indexer.index_args.index_head_dim,
-        mesh_device=mesh_device,
-        seq_len=total,
-        mesh_shape=list(mesh_device.shape),
-        sp_axis=sp_axis,
-        num_kvpe_cache_layers=1,
-        num_users=1,
-        dtype=ttnn.bfloat8_b,
-    )
+    # Block-cyclic indexer key cache (SPARSE only): allocated externally (same ownership as the KVPE cache)
+    # and passed into forward. warm/long leave it (and the KVPE cache) at zero init — for a profiling proxy
+    # the cache CONTENTS don't affect op shapes/timing (the gather + score always cover the full
+    # `total`-length prefix), so representing the `cache` already-processed tokens needs no warm-up write.
+    # cold fills both caches for real via its own per-chunk block-cyclic slab writes (start=0,chunk,…,cache).
+    # DENSE has no indexer (NullIndexer) — ring MLA reads the prefix by logical_n (= total), not by cached
+    # index data, so it needs no index cache (index_kv_cache stays None).
+    index_kv_cache = None
+    if has_indexer:
+        index_kv_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=mla._indexer.index_args.index_head_dim,
+            mesh_device=mesh_device,
+            seq_len=total,
+            mesh_shape=list(mesh_device.shape),
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=1,
+            num_users=1,
+            dtype=ttnn.bfloat8_b,
+        )
 
     hidden = make_hidden(chunk, config.hidden_size, seed=42)  # one chunk of input (reused per forward)
     shard_dims = [None, None]
@@ -317,9 +345,10 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
     # signpost the WHOLE loop = total cold-start prefill cost. warm/long: one forward at start=cache.
     starts = list(range(0, cache + chunk, chunk)) if is_cold else [cache]
     logger.info(
-        f"profiling {PERF_WORKLOAD.system_name} {SCENARIO} proxy: {len(starts)} × {chunk}-token chunk(s) "
-        f"filling to end_pos={total} on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
-        f"local MLA heads={config.num_attention_heads // tp}, local indexer heads={config.index_n_heads // tp}"
+        f"profiling {PERF_WORKLOAD.system_name} {ATTN_MODE}/{SCENARIO} proxy: {len(starts)} × {chunk}-token "
+        f"chunk(s) filling to end_pos={total} on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
+        f"local MLA heads={config.num_attention_heads // tp}"
+        + (f", local indexer heads={config.index_n_heads // tp}" if has_indexer else " (dense: no indexer)")
     )
     signpost("start")
     for start in starts:
@@ -332,15 +361,18 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
 # ============================================================================
 # Outer: drive the impl under tracy, post-process, print + write CSV
 # ============================================================================
+@pytest.mark.parametrize("attn_mode", list(ATTN_MODES), ids=list(ATTN_MODES))
 @pytest.mark.parametrize("scenario", list(SCENARIOS), ids=list(SCENARIOS))
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test — run locally with tracy")
 @pytest.mark.timeout(0)
-def test_mla_chunked_perf(scenario):
+def test_mla_chunked_perf(scenario, attn_mode):
     from tracy.common import PROFILER_ARTIFACTS_DIR
     from tracy.process_model_log import run_device_profiler
 
     if PERF_SKIP_REASON:
         pytest.skip(PERF_SKIP_REASON)
+
+    subdir = _subdir(attn_mode)  # per-mode profiler dir (sparse/dense never clobber each other)
 
     # merge_device_rows: the deepseek_v3_d_p / tt_transformers convention for collapsing the device
     # dimension of a multi-chip Tracy ops log (see models/demos/deepseek_v3_d_p/utils/perf_utils.py).
@@ -362,8 +394,8 @@ def test_mla_chunked_perf(scenario):
     # run_device_profiler defaults op_support_count to ~1333 ops/device — the tracy device-profiler
     # ring buffer silently drops ops beyond it. cold forwards ~11 chunks (~800 ops); raise the cap so a
     # future op-count bump can't silently truncate the log (which would corrupt the per-op totals).
-    with mock.patch.dict(os.environ, {"CI": "false", "DS_PERF_SCENARIO": scenario}):
-        run_device_profiler(command, SUBDIR, device_analysis_types=["device_kernel_duration"], op_support_count=5000)
+    with mock.patch.dict(os.environ, {"CI": "false", "DS_PERF_SCENARIO": scenario, "DS_PERF_ATTN_MODE": attn_mode}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"], op_support_count=5000)
 
     dur_col = "DEVICE KERNEL DURATION [ns]"
     # Rows between signpost("start") and signpost("stop") = the measured chunk's device ops, with ONE
@@ -374,7 +406,7 @@ def test_mla_chunked_perf(scenario):
     #   * collectives -> AVG duration across chips (all chips run the same collective together)
     # region = the sliced signpost("start")..signpost("stop") window, still holding the per-forward
     # MLA_START/MLA_END signpost rows (used below to split cold into per-iteration segments).
-    region = post_process_ops_log(SUBDIR, has_signposts=True)
+    region = post_process_ops_log(subdir, has_signposts=True)
     region[dur_col] = pd.to_numeric(region[dur_col], errors="coerce")
     df = merge_device_rows(region)  # aggregate; filters to tt_dnn_device rows internally
     assert len(df), "no device ops in the signposted region — was the impl skipped (wrong device count)?"
@@ -396,7 +428,7 @@ def test_mla_chunked_perf(scenario):
     span = f"full cold prefill 0→{cache}-tok cache" if is_cold else f"one chunk @ {cache}-tok cache"
     table = "\n".join(
         [
-            f"DeepSeek V3.2 MLA chunked perf [{scenario}] — {PERF_WORKLOAD.system_name} proxy "
+            f"DeepSeek V3.2 MLA chunked perf [{attn_mode}/{scenario}] — {PERF_WORKLOAD.system_name} proxy "
             f"{PERF_WORKLOAD.chunk_tokens}-tok chunk, {span}, SP={PERF_WORKLOAD.sp}×TP={PERF_WORKLOAD.tp}",
             f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {galaxy_cache}-tok cache, SP=8×TP=4; "
             f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={GALAXY_NUM_HEADS // GALAXY_TP}",
@@ -411,7 +443,7 @@ def test_mla_chunked_perf(scenario):
     logger.info("\n" + table)
     print("\n" + table)  # ensure full table reaches stdout even if logging is filtered
 
-    csv_out = _scenario_csv(PROFILER_ARTIFACTS_DIR / SUBDIR, scenario)
+    csv_out = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, scenario, attn_mode)
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
 
@@ -458,6 +490,6 @@ def test_mla_chunked_perf(scenario):
         )
         logger.info("\n" + iter_table)
         print("\n" + iter_table)
-        iter_csv = _scenario_csv(PROFILER_ARTIFACTS_DIR / SUBDIR, f"{scenario}_by_iter")
+        iter_csv = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, f"{scenario}_by_iter", attn_mode)
         by_iter_op.to_csv(iter_csv, index=False)
         logger.info(f"per-op×iteration CSV written to {os.path.abspath(iter_csv)}")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -7,36 +7,61 @@ Tracy perf harness for the DeepSeek V3.2 MLA (DSA) chunked-prefill layer.
 Production scenario (defaults): process one **5k-token chunk** with **50k tokens already cached**,
 on the Galaxy **SP=8 × TP=4** mesh.
 
-The test can also run on smaller Blackhole boxes by profiling a per-chip Galaxy slice:
-  * Galaxy   (32 chips): SP=8 × TP=4, chunk=5120, heads=128
-  * LoudBox  (8 chips):  SP=2 × TP=4, chunk=1280, heads=128
-  * QuietBox (4 chips):  SP=1 × TP=4, chunk=640,  heads=128
+The test can also run on smaller Blackhole boxes by profiling a per-chip Galaxy slice. BOTH the chunk
+and the cache scale by SP/8, so smaller boxes run a proportionally shorter sequence — the per-chip
+workload mirrors Galaxy rather than a heavier one:
+  * Galaxy   (32 chips): SP=8 × TP=4, chunk=5120, cache=50k,   heads=128 (full workload)
+  * LoudBox  (8 chips):  SP=2 × TP=4, chunk=1280, cache=12.5k, heads=128 (1/4 sequence length)
+  * QuietBox (4 chips):  SP=1 × TP=4, chunk=640,  cache=6.25k, heads=128 (1/8 sequence length)
 
 That keeps the per-chip COMPUTE shapes equal to Galaxy: local query rows/chip (640), MLA heads/chip
-(32), indexer heads/chip (16). The indexer K-cache is replicated full-depth (50k) on every chip and the
-sparse SDPA is top-k-gated, so kernel timing is a faithful Galaxy proxy. CAVEAT: the KVPE cache is
-SP-sharded, so its per-chip depth is 50k/SP (50k on QuietBox, 25k on LoudBox, 6.25k on Galaxy) — per-chip
-KVPE footprint and any op that scales with KVPE depth are heavier on smaller boxes.
+(32), indexer heads/chip (16), the per-chip KVPE depth (cache/SP = 6.25k on every box), AND the number
+of chunks-to-fill in `cold` (11 on every box, not 41 on LoudBox). CAVEAT: the indexer K-cache is
+replicated full-depth (= the box-local cache), so on smaller boxes it holds a proportionally SHORTER
+prefix than Galaxy — only Galaxy exercises the true 50k (or 0.5M) indexer/top-k depth; smaller boxes
+under-represent any op that scales with the replicated key-cache length.
 No reference values: this just runs the real device forward and reports per-op device-kernel time.
 Multi-chip rows are device-collapsed (compute=max, collectives=avg across chips) via merge_device_rows
 so the reported time is per-step critical path, not the ~8× over-count of summing parallel device rows.
 
+Three scenarios (DS_PERF_SCENARIO; the driver sweeps all three):
+  * warm — production step: one `chunk`-token forward at start=cache over a `cache`-length prefix. Both
+    block-cyclic caches (indexer index_kv_cache + KVPE) are left at init — no warm-up forwards; for a perf
+    proxy only op shapes/timing matter, and those are set by the full `total` prefix width the gather+score
+    span, not the cache contents. Measures a single steady-state chunk.
+  * cold — full cold prefill: forward chunks start=0,chunk,…,cache with real forwards that grow both
+    caches (both by per-chunk block-cyclic slab writes). The signposted region spans ALL chunks = the
+    total cold-start prefill cost; the final chunk (start=cache) is exactly the `warm` step. Besides the
+    aggregate per-op table, cold also emits a per-cache-fill-iteration breakdown (…_cold_by_iter.csv:
+    iteration, cache_depth_tokens, total_ns, op_count) showing how the per-chunk critical path grows as
+    the cache fills — recovered by splitting the ops log on each forward's MLA_START marker.
+  * long — like `warm` but with a 0.5M-token Galaxy cache (512000 = 100 chunks), to profile a single
+    chunk over a long prefix. Like the others the cache scales by SP/8, so per-chip depth stays
+    Galaxy-equal on every box (LoudBox=128k, QuietBox=64k box-local cache).
+
 Two-test pattern (mirrors tests/nightly/blackhole/sdpa):
-  * test_mla_chunked_perf_impl  — the work to profile. Builds the v32 ttMLA, populates the index/KV
-    caches directly to stand in for the cached prefix (no warm-up forwards), then wraps a SINGLE
-    `chunk`-token forward in signpost("start"/"stop"). Run this under tracy.
-  * test_mla_chunked_perf       — the driver. Spawns the impl under tracy via run_device_profiler,
-    reads the device ops log for the signposted region, prints a per-op table, and writes a CSV.
+  * test_mla_chunked_perf_impl  — the work to profile. Builds the v32 ttMLA and, per DS_PERF_SCENARIO,
+    either measures one forward over the (zero-init) block-cyclic caches (warm/long) or forwards a chunk
+    loop that fills them (cold), wrapping the measured forward(s) in signpost("start"/"stop"). Run under tracy.
+  * test_mla_chunked_perf       — the driver, parametrized over [warm, cold, long]. Spawns the impl
+    under tracy via run_device_profiler (passing DS_PERF_SCENARIO), reads the device ops log for the
+    signposted region, prints a per-op table, and writes a per-scenario CSV.
 
-Run (Blackhole Galaxy/LoudBox/QuietBox):
+Run (Blackhole Galaxy/LoudBox/QuietBox) — all three scenarios, or one via -k:
     pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf -s
+    pytest -m perf ...::test_mla_chunked_perf -k cold -s
 
-Knobs (env): DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120), DS_PERF_CSV.
-DS_PERF_CHUNK is the Galaxy-global target chunk; smaller boxes scale the measured chunk by SP/8.
+Knobs (env): DS_PERF_SCENARIO (warm|cold|long, default warm for a standalone impl run),
+DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120), DS_PERF_LONG_CACHE (default 512000),
+DS_PERF_CSV (summary filename, per-scenario suffix appended; written under the tracy profiler dir
+generated/profiler/deepseek_v32_sparse_mla_perf/). DS_PERF_CHUNK is the Galaxy-global target chunk; smaller
+boxes scale BOTH the measured chunk and the cache by SP/8; cache must stay a whole chunk multiple.
 
-NOTE: caches are POPULATED directly (random index keys; KVPE left at init) rather than warmed with
-real chunks — only op shapes/timing matter here, not values. The indexer rope now scales from the HF
-config (mla.py), so `config.max_seq_len = total` is enough for a 50k+ context (no manual rope bump).
+NOTE: warm/long leave both block-cyclic caches at zero init rather than warming with real chunks — only
+op shapes/timing matter here, not values, and those come from the full `total` prefix width (allocation),
+not the cache contents; cold instead runs real chunk forwards that fill the caches. The indexer rope
+scales from the HF config (mla.py), so `config.max_seq_len = total` is enough for a 50k+ (and 0.5M)
+context (no manual rope bump).
 """
 
 import copy
@@ -61,8 +86,45 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 
 CACHE_TOKENS = int(os.environ.get("DS_PERF_CACHE", 51200))  # 50 * 1024 already cached
 CHUNK_TOKENS = int(os.environ.get("DS_PERF_CHUNK", 5120))  # 5 * 1024 processed this step
+# Long-sequence cache (Galaxy target). 512000 = 100 * 5120 == "0.5M" — a whole multiple of the 5k
+# chunk (the rope table requires total = cache + chunk to be a multiple of chunk). Override with
+# DS_PERF_LONG_CACHE (must stay a chunk multiple), e.g. 522240 (=102 chunks ≈ 512*1024).
+LONG_CACHE_TOKENS = int(os.environ.get("DS_PERF_LONG_CACHE", 512000))
 SUBDIR = "deepseek_v32_sparse_mla_perf"
-CSV_OUT = os.environ.get("DS_PERF_CSV", "deepseek_v32_sparse_mla_perf.csv")
+# Per-op summary filename (one per scenario, suffixed). Written under the tracy profiler dir
+# (PROFILER_ARTIFACTS_DIR / SUBDIR) alongside the raw device reports — see _scenario_csv.
+CSV_NAME = os.environ.get("DS_PERF_CSV", "deepseek_v32_sparse_mla_perf.csv")
+
+# Three profiling scenarios (select the impl's via DS_PERF_SCENARIO; the driver sweeps all three):
+#   warm  — the production step: one chunk over a pre-filled `cache` (indexer K-cache populated
+#           directly, no warm-up forwards). Measures a single steady-state chunk.
+#   cold  — full cold prefill: iteratively forward chunks start=0,chunk,…,cache (real forwards that
+#           grow the caches). The signposted region spans ALL chunks = total cold-start prefill cost;
+#           the final chunk (start=cache) is exactly the `warm` case.
+#   long  — like `warm` but with a 0.5M-token cache, to profile a single chunk over a long prefix.
+SCENARIOS = {
+    "warm": {"cache": CACHE_TOKENS, "loop": False},
+    "cold": {"cache": CACHE_TOKENS, "loop": True},
+    "long": {"cache": LONG_CACHE_TOKENS, "loop": False},
+}
+SCENARIO = os.environ.get("DS_PERF_SCENARIO", "warm")
+
+
+def _scenario_csv(out_dir, scenario: str) -> str:
+    """Per-scenario summary CSV path under the tracy profiler dir (next to the raw device reports)."""
+    root, ext = os.path.splitext(CSV_NAME)
+    return os.path.join(out_dir, f"{root}_{scenario}{ext}")
+
+
+def _local_cache_tokens(galaxy_cache: int, sp: int) -> int:
+    """Box-local cached sequence length: scale the Galaxy-global cache by SP/GALAXY_SP exactly like the
+    chunk, so every box profiles the Galaxy per-chip workload rather than a heavier one. This keeps the
+    number of chunks-to-fill constant (Galaxy=11, LoudBox=11, QuietBox=11 — NOT 41) and the per-chip
+    KVPE depth Galaxy-equal (cache/SP = galaxy_cache/GALAXY_SP on every box). LoudBox runs 1/4 the
+    sequence length, QuietBox 1/8. CACHE_TOKENS/LONG_CACHE_TOKENS are multiples of GALAXY_SP and of the
+    per-box chunk, so the result stays an exact chunk multiple (required by the indexed rope table)."""
+    return galaxy_cache * sp // GALAXY_SP
+
 
 pytestmark = pytest.mark.perf
 
@@ -78,7 +140,6 @@ class PerfWorkload:
     system_name: str
     num_devices: int
     mesh_shape: tuple[int, int]
-    cache_tokens: int
     chunk_tokens: int
     num_attention_heads: int
     index_n_heads: int
@@ -113,7 +174,7 @@ def _detect_perf_workload() -> tuple[PerfWorkload, str | None]:
     num_devices = detect_num_devices()
     system = _SYSTEM_BY_DEVICE_COUNT.get(num_devices)
     if system is None:
-        placeholder = PerfWorkload("unsupported", num_devices, (1, 1), CACHE_TOKENS, CHUNK_TOKENS, 32, 16)
+        placeholder = PerfWorkload("unsupported", num_devices, (1, 1), CHUNK_TOKENS, 32, 16)
         return placeholder, (
             "DeepSeek V3.2 sparse MLA perf supports Blackhole QuietBox/LoudBox/Galaxy only "
             f"(detected {num_devices} chips)"
@@ -128,7 +189,6 @@ def _detect_perf_workload() -> tuple[PerfWorkload, str | None]:
         system_name=system_name,
         num_devices=num_devices,
         mesh_shape=mesh_shape,
-        cache_tokens=CACHE_TOKENS,
         chunk_tokens=local_chunk * sp,
         num_attention_heads=local_heads * tp,
         index_n_heads=local_index_heads * tp,
@@ -170,11 +230,17 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
     if PERF_SKIP_REASON:
         pytest.skip(PERF_SKIP_REASON)
 
-    cache, chunk = PERF_WORKLOAD.cache_tokens, PERF_WORKLOAD.chunk_tokens
-    total = cache + chunk
+    scenario = SCENARIOS[SCENARIO]
+    is_cold = scenario["loop"]
     sp_axis, tp_axis = 0, 1
     sp, tp = mesh_device.shape
+    # cache scales per box (sp/GALAXY_SP) like the chunk, so every box profiles the Galaxy per-chip
+    # workload: constant chunks-to-fill and Galaxy-equal per-chip depth (see _local_cache_tokens).
+    cache, chunk = _local_cache_tokens(scenario["cache"], sp), PERF_WORKLOAD.chunk_tokens
+    total = cache + chunk
     assert (sp, tp) == PERF_WORKLOAD.mesh_shape, f"expected mesh {PERF_WORKLOAD.mesh_shape}, got {(sp, tp)}"
+    # cache must be a whole number of chunks: the cold loop steps by `chunk`, and the indexed rope
+    # table (get_rope_tensors_indexed) requires total = cache + chunk to be a multiple of chunk.
     assert cache % chunk == 0, f"cache {cache} must be a whole number of {chunk}-token chunks"
     assert total % sp == 0 and (total // sp) % 32 == 0, f"total {total} must be tile-aligned per SP={sp} chip"
     assert (
@@ -213,12 +279,17 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         mesh_shape=list(mesh_device.shape),
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
+        # sparse_sdpa reads the KVPE cache natively and only accepts an uncompressed bf16 / fp8_e4m3
+        # ROW_MAJOR cache (mla.py asserts this) — NOT the init_kvpe_cache bfloat8_b/TILE default.
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
     # Block-cyclic indexer key cache: allocated externally (same ownership as the KVPE cache) and passed
-    # into forward. Left at its zero init — for a profiling proxy the cache CONTENTS don't affect op
-    # shapes/timing (the gather + score always cover the full `total`-length prefix), so representing the
-    # `cache` already-processed tokens needs no warm-up write. The KVPE cache is likewise left at init.
+    # into forward. warm/long leave it (and the KVPE cache) at zero init — for a profiling proxy the cache
+    # CONTENTS don't affect op shapes/timing (the gather + score always cover the full `total`-length
+    # prefix), so representing the `cache` already-processed tokens needs no warm-up write. cold fills both
+    # caches for real via its own per-chunk block-cyclic slab writes (start=0,chunk,…,cache).
     index_kv_cache = init_kvpe_cache(
         kvpe_cache_head_dim=mla._indexer.index_args.index_head_dim,
         mesh_device=mesh_device,
@@ -230,7 +301,7 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         dtype=ttnn.bfloat8_b,
     )
 
-    hidden = make_hidden(chunk, config.hidden_size, seed=42)  # only the measured chunk
+    hidden = make_hidden(chunk, config.hidden_size, seed=42)  # one chunk of input (reused per forward)
     shard_dims = [None, None]
     shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
     tt_x = ttnn.from_torch(
@@ -242,14 +313,18 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
 
+    # cold: forward every chunk start=0,chunk,…,cache (the last, start=cache, is the warm step) and
+    # signpost the WHOLE loop = total cold-start prefill cost. warm/long: one forward at start=cache.
+    starts = list(range(0, cache + chunk, chunk)) if is_cold else [cache]
     logger.info(
-        f"profiling {PERF_WORKLOAD.system_name} proxy: one {chunk}-token chunk @ {cache}-token cache "
-        f"(end_pos={total}) on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
+        f"profiling {PERF_WORKLOAD.system_name} {SCENARIO} proxy: {len(starts)} × {chunk}-token chunk(s) "
+        f"filling to end_pos={total} on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
         f"local MLA heads={config.num_attention_heads // tp}, local indexer heads={config.index_n_heads // tp}"
     )
     signpost("start")
-    out = mla.forward(tt_x, rope, kvpe_cache, actual_start=cache, index_kv_cache=index_kv_cache)
-    ttnn.deallocate(out)
+    for start in starts:
+        out = mla.forward(tt_x, rope, kvpe_cache, actual_start=start, index_kv_cache=index_kv_cache)
+        ttnn.deallocate(out)
     ttnn.synchronize_device(mesh_device)
     signpost("stop")
 
@@ -257,9 +332,11 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
 # ============================================================================
 # Outer: drive the impl under tracy, post-process, print + write CSV
 # ============================================================================
+@pytest.mark.parametrize("scenario", list(SCENARIOS), ids=list(SCENARIOS))
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test — run locally with tracy")
 @pytest.mark.timeout(0)
-def test_mla_chunked_perf():
+def test_mla_chunked_perf(scenario):
+    from tracy.common import PROFILER_ARTIFACTS_DIR
     from tracy.process_model_log import run_device_profiler
 
     if PERF_SKIP_REASON:
@@ -270,15 +347,23 @@ def test_mla_chunked_perf():
     from models.tt_transformers.tests.test_utils import merge_device_rows
     from tests.nightly.sdpa_perf_utils import post_process_ops_log
 
+    galaxy_cache = SCENARIOS[scenario]["cache"]
+    cache = _local_cache_tokens(galaxy_cache, PERF_WORKLOAD.sp)  # box-scaled (matches the impl)
+    is_cold = SCENARIOS[scenario]["loop"]
+
     # The impl is skipif(CI=="true"); CI=false in the subprocess lets it run there (mirrors the
-    # tests/nightly/blackhole/sdpa perf pattern). The driver itself opens no device, so when the gate is
-    # run by node-id only the tracy subprocess opens the board — no parent CHIP_IN_USE lock contention.
+    # tests/nightly/blackhole/sdpa perf pattern). DS_PERF_SCENARIO selects which scenario the impl runs.
+    # The driver itself opens no device, so when the gate is run by node-id only the tracy subprocess
+    # opens the board — no parent CHIP_IN_USE lock contention.
     command = (
         "pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py"
         "::test_mla_chunked_perf_impl"
     )
-    with mock.patch.dict(os.environ, {"CI": "false"}):
-        run_device_profiler(command, SUBDIR, device_analysis_types=["device_kernel_duration"])
+    # run_device_profiler defaults op_support_count to ~1333 ops/device — the tracy device-profiler
+    # ring buffer silently drops ops beyond it. cold forwards ~11 chunks (~800 ops); raise the cap so a
+    # future op-count bump can't silently truncate the log (which would corrupt the per-op totals).
+    with mock.patch.dict(os.environ, {"CI": "false", "DS_PERF_SCENARIO": scenario}):
+        run_device_profiler(command, SUBDIR, device_analysis_types=["device_kernel_duration"], op_support_count=5000)
 
     dur_col = "DEVICE KERNEL DURATION [ns]"
     # Rows between signpost("start") and signpost("stop") = the measured chunk's device ops, with ONE
@@ -287,9 +372,11 @@ def test_mla_chunked_perf():
     # the device dimension to one row per logical op call with the standard merge_device_rows rule:
     #   * compute ops -> MAX duration across chips (the slowest chip gates the step = critical path)
     #   * collectives -> AVG duration across chips (all chips run the same collective together)
-    df = post_process_ops_log(SUBDIR, has_signposts=True)
-    df[dur_col] = pd.to_numeric(df[dur_col], errors="coerce")
-    df = merge_device_rows(df)  # filters to tt_dnn_device rows internally
+    # region = the sliced signpost("start")..signpost("stop") window, still holding the per-forward
+    # MLA_START/MLA_END signpost rows (used below to split cold into per-iteration segments).
+    region = post_process_ops_log(SUBDIR, has_signposts=True)
+    region[dur_col] = pd.to_numeric(region[dur_col], errors="coerce")
+    df = merge_device_rows(region)  # aggregate; filters to tt_dnn_device rows internally
     assert len(df), "no device ops in the signposted region — was the impl skipped (wrong device count)?"
 
     total_ns = df[dur_col].sum()
@@ -306,15 +393,16 @@ def test_mla_chunked_perf():
         f"{op:<44}{int(r['count']):>7}{r['total_ns']/1e6:>12.3f}{r['avg_ns']/1e3:>12.1f}{r['pct']:>7.1f}%"
         for op, r in by_op.iterrows()
     ]
+    span = f"full cold prefill 0→{cache}-tok cache" if is_cold else f"one chunk @ {cache}-tok cache"
     table = "\n".join(
         [
-            f"DeepSeek V3.2 MLA chunked perf — {PERF_WORKLOAD.system_name} proxy "
-            f"{PERF_WORKLOAD.chunk_tokens}-tok chunk @ {PERF_WORKLOAD.cache_tokens}-tok cache, "
-            f"SP={PERF_WORKLOAD.sp}×TP={PERF_WORKLOAD.tp}",
-            f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {CACHE_TOKENS}-tok cache, SP=8×TP=4; "
+            f"DeepSeek V3.2 MLA chunked perf [{scenario}] — {PERF_WORKLOAD.system_name} proxy "
+            f"{PERF_WORKLOAD.chunk_tokens}-tok chunk, {span}, SP={PERF_WORKLOAD.sp}×TP={PERF_WORKLOAD.tp}",
+            f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {galaxy_cache}-tok cache, SP=8×TP=4; "
             f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={GALAXY_NUM_HEADS // GALAXY_TP}",
-            f"critical-path device-kernel time over the chunk (device-collapsed: compute=max, "
-            f"collectives=avg across chips): {total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} op calls",
+            f"critical-path device-kernel time over the {'prefill' if is_cold else 'chunk'} "
+            f"(device-collapsed: compute=max, collectives=avg across chips): "
+            f"{total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} op calls",
             header,
             "-" * len(header),
             *rows,
@@ -323,5 +411,53 @@ def test_mla_chunked_perf():
     logger.info("\n" + table)
     print("\n" + table)  # ensure full table reaches stdout even if logging is filtered
 
-    by_op.reset_index().to_csv(CSV_OUT, index=False)
-    logger.info(f"per-op CSV written to {os.path.abspath(CSV_OUT)}")
+    csv_out = _scenario_csv(PROFILER_ARTIFACTS_DIR / SUBDIR, scenario)
+    by_op.reset_index().to_csv(csv_out, index=False)
+    logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
+
+    # cold only: per-cache-fill-iteration breakdown. The aggregate above sums all chunks; this shows
+    # how the per-chunk critical path grows as the cache fills (the point of the cold scenario). Each
+    # forward emits its own MLA_START marker, so split the region on those and device-collapse each
+    # segment independently (merge_device_rows drops the interleaved signpost rows internally).
+    if is_cold:
+        ri = region.reset_index(drop=True)
+        starts = list(ri.index[ri["OP CODE"] == "MLA_START"])
+        bounds = starts + [len(ri)]
+        chunk = PERF_WORKLOAD.chunk_tokens
+        # Per-op × per-iteration: the SAME per-op table as the aggregate above (OP CODE, count,
+        # total_ns, avg_ns, pct — sorted desc), but computed for each iteration's segment and tagged
+        # with iteration + cache_depth_tokens, so each op's time can be tracked as the cache fills.
+        per_op_rows, totals = [], []
+        for i in range(len(starts)):
+            seg = merge_device_rows(ri.iloc[bounds[i] + 1 : bounds[i + 1]])
+            tot = seg[dur_col].sum()
+            g = (
+                seg.groupby("OP CODE")[dur_col]
+                .agg(count="count", total_ns="sum", avg_ns="mean")
+                .sort_values("total_ns", ascending=False)
+            )
+            g["pct"] = 100.0 * g["total_ns"] / tot
+            g = g.reset_index()
+            g.insert(0, "cache_depth_tokens", i * chunk)  # tokens already cached when this chunk ran
+            g.insert(0, "iteration", i)
+            per_op_rows.append(g)
+            totals.append((i, i * chunk, tot, len(g)))
+        by_iter_op = pd.concat(per_op_rows, ignore_index=True)
+
+        # stdout: compact per-iteration totals (the full per-op×iteration detail goes to the CSV — too
+        # many rows to print). pivot the CSV to a per-op-by-iteration matrix for charting an op's growth.
+        iter_header = f"{'iter':>4}{'cache_depth':>12}{'total_ms':>12}{'ops':>6}"
+        iter_table = "\n".join(
+            [
+                f"cold per-iteration critical path [{PERF_WORKLOAD.system_name}] "
+                f"(device-collapsed; last iter == the `warm` step):",
+                iter_header,
+                "-" * len(iter_header),
+                *(f"{i:>4}{d:>12}{t/1e6:>12.3f}{n:>6}" for i, d, t, n in totals),
+            ]
+        )
+        logger.info("\n" + iter_table)
+        print("\n" + iter_table)
+        iter_csv = _scenario_csv(PROFILER_ARTIFACTS_DIR / SUBDIR, f"{scenario}_by_iter")
+        by_iter_op.to_csv(iter_csv, index=False)
+        logger.info(f"per-op×iteration CSV written to {os.path.abspath(iter_csv)}")


### PR DESCRIPTION
Add cold/warm/long scenarios  + per-iteration breakdown to sparse to MLA perf harness.
Add option to run dense attention mode which is perf baseline.

Extend test_sparse_mla_perf.py from the single "warm" scenario to three, selected via DS_PERF_SCENARIO (the driver sweeps all three):
  * warm — one chunk over a pre-filled cache (existing behavior)
  * cold — full cold prefill: real chunk forwards start=0..cache; the signpost region spans all chunks (total cold-start cost). Also emits a per-op x per-iteration breakdown (..._cold_by_iter.csv, same columns as the aggregate) showing how each op grows as the cache fills, recovered by splitting the ops log on each forward's MLA_START marker.
  * long — one chunk over a 0.5M-token cache (512000 = 100 chunks).

The cache now scales per box (sp/GALAXY_SP) like the chunk already did, so smaller boxes run a proportionally shorter sequence: constant chunks-to-fill (11 on every box, not 41 on LoudBox) and Galaxy-equal per-chip KVPE depth.

Also fixes two latent issues surfaced by the cold loop:
  * raise run_device_profiler op_support_count (default ~1333 silently drops device-log ops beyond the cap; cold emits ~800) so the log can't truncate.
  * write the per-op summary CSVs under the tracy profiler dir (generated/profiler/deepseek_v32_sparse_mla_perf/) instead of the repo root.

Validated on Blackhole LoudBox (SP=2xTP=4): all three scenarios pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/ds_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasilijevic/ds_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvasilijevic/ds_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/ds_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasilijevic/ds_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/ds_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/ds_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/ds_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/ds_perf)