### PR TITLE
[Cleanup] Migrate normalization + reduction ops to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/chain_llk.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/chain_llk.hpp
@@ -115,17 +115,17 @@ template <uint32_t num_dst_regs, typename cur_llk_type>
 void unroll_inner_loop(uint32_t register_loops) {
     constexpr auto cur_llk = cur_llk_type::node;
     uint32_t wt = register_loops * num_dst_regs;
-    CircularBuffer cb_a_obj(cur_llk.CB_A);
-    CircularBuffer cb_b_obj(cur_llk.CB_B);
-    CircularBuffer cb_out_obj(cur_llk.CB_OUT);
+    CircularBuffer cb_a(cur_llk.CB_A);
+    CircularBuffer cb_b(cur_llk.CB_B);
+    CircularBuffer cb_out(cur_llk.CB_OUT);
     tile_regs_acquire();
-    cb_a_obj.wait_front(num_dst_regs);
+    cb_a.wait_front(num_dst_regs);
     if constexpr (cur_llk.fixed_CB_B_index == 0xFFFF) {
-        cb_b_obj.wait_front(num_dst_regs);
+        cb_b.wait_front(num_dst_regs);
     } else if constexpr (cur_llk.fixed_CB_B_index == 0xDDDD) {
-        cb_b_obj.wait_front(num_dst_regs + (wt));
+        cb_b.wait_front(num_dst_regs + (wt));
     } else {
-        cb_b_obj.wait_front(cur_llk.fixed_CB_B_index + 1);
+        cb_b.wait_front(cur_llk.fixed_CB_B_index + 1);
     }
     for (uint32_t j = 0; j < num_dst_regs; j++) {
         if constexpr (cur_llk.debug_mode == 1) {
@@ -138,16 +138,16 @@ void unroll_inner_loop(uint32_t register_loops) {
             //  dprint_tensix_dest_reg(j);
         }
     }
-    cb_a_obj.pop_front(num_dst_regs);
+    cb_a.pop_front(num_dst_regs);
     if constexpr (cur_llk.fixed_CB_B_index == 0xFFFF) {
-        cb_b_obj.pop_front(num_dst_regs);
+        cb_b.pop_front(num_dst_regs);
     }
     tile_regs_commit();
     tile_regs_wait();
-    cb_out_obj.reserve_back(num_dst_regs);
+    cb_out.reserve_back(num_dst_regs);
     for (uint32_t j = 0; j < num_dst_regs; j++) {
         pack_tile(j, cur_llk.CB_OUT);
     }
-    cb_out_obj.push_back(num_dst_regs);
+    cb_out.push_back(num_dst_regs);
     tile_regs_release();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/chain_llk.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/chain_llk.hpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/constants.hpp>
 #include <functional>
 
+#include "api/dataflow/circular_buffer.h"
 #include "api/debug/dprint_pages.h"
 
 using fn_compute_5 = void(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t);
@@ -114,14 +115,17 @@ template <uint32_t num_dst_regs, typename cur_llk_type>
 void unroll_inner_loop(uint32_t register_loops) {
     constexpr auto cur_llk = cur_llk_type::node;
     uint32_t wt = register_loops * num_dst_regs;
+    CircularBuffer cb_a_obj(cur_llk.CB_A);
+    CircularBuffer cb_b_obj(cur_llk.CB_B);
+    CircularBuffer cb_out_obj(cur_llk.CB_OUT);
     tile_regs_acquire();
-    cb_wait_front(cur_llk.CB_A, num_dst_regs);
+    cb_a_obj.wait_front(num_dst_regs);
     if constexpr (cur_llk.fixed_CB_B_index == 0xFFFF) {
-        cb_wait_front(cur_llk.CB_B, num_dst_regs);
+        cb_b_obj.wait_front(num_dst_regs);
     } else if constexpr (cur_llk.fixed_CB_B_index == 0xDDDD) {
-        cb_wait_front(cur_llk.CB_B, num_dst_regs + (wt));
+        cb_b_obj.wait_front(num_dst_regs + (wt));
     } else {
-        cb_wait_front(cur_llk.CB_B, cur_llk.fixed_CB_B_index + 1);
+        cb_b_obj.wait_front(cur_llk.fixed_CB_B_index + 1);
     }
     for (uint32_t j = 0; j < num_dst_regs; j++) {
         if constexpr (cur_llk.debug_mode == 1) {
@@ -134,16 +138,16 @@ void unroll_inner_loop(uint32_t register_loops) {
             //  dprint_tensix_dest_reg(j);
         }
     }
-    cb_pop_front(cur_llk.CB_A, num_dst_regs);
+    cb_a_obj.pop_front(num_dst_regs);
     if constexpr (cur_llk.fixed_CB_B_index == 0xFFFF) {
-        cb_pop_front(cur_llk.CB_B, num_dst_regs);
+        cb_b_obj.pop_front(num_dst_regs);
     }
     tile_regs_commit();
     tile_regs_wait();
-    cb_reserve_back(cur_llk.CB_OUT, num_dst_regs);
+    cb_out_obj.reserve_back(num_dst_regs);
     for (uint32_t j = 0; j < num_dst_regs; j++) {
         pack_tile(j, cur_llk.CB_OUT);
     }
-    cb_push_back(cur_llk.CB_OUT, num_dst_regs);
+    cb_out_obj.push_back(num_dst_regs);
     tile_regs_release();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -20,6 +20,7 @@
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
+#include "api/dataflow/circular_buffer.h"
 #include "chain_llk.hpp"
 
 constexpr uint32_t cb_inp = tt::CBIndex::c_0;
@@ -120,8 +121,16 @@ void kernel_main() {
 
     binary_op_init_common(cb_inp, cb_inp, cb_stats_reduced);
 
-    cb_wait_front(cb_reduce, 1);  // comes from the reader
-    cb_wait_front(cb_eps, 1);     // comes from the reader
+    CircularBuffer cb_reduce_obj(cb_reduce);
+    CircularBuffer cb_eps_obj(cb_eps);
+    CircularBuffer cb_stats_obj(cb_stats);
+    CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
+    CircularBuffer cb_mean_squared_obj(cb_mean_squared);
+    CircularBuffer cb_var_obj(cb_var);
+    CircularBuffer cb_recip_sqrt_var_obj(cb_recip_sqrt_var);
+
+    cb_reduce_obj.wait_front(1);  // comes from the reader
+    cb_eps_obj.wait_front(1);     // comes from the reader
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         constexpr int onetile = 1;
@@ -136,7 +145,7 @@ void kernel_main() {
          * RMSNorm packs mean(x**2) into cb_var. Layernorm just uses cb_stats_reduced.
          */
         reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_reduce, cb_stats_reduced);
-        cb_wait_front(cb_stats, stats_tiles_cols);
+        cb_stats_obj.wait_front(stats_tiles_cols);
 
         tile_regs_acquire();
         // Reduce sum(x**2) first
@@ -149,16 +158,16 @@ void kernel_main() {
         }
         tile_regs_commit();
 
-        cb_pop_front(cb_stats, stats_tiles_cols);
+        cb_stats_obj.pop_front(stats_tiles_cols);
 
-        cb_reserve_back(cb_stats_reduced, stats_tile_stride);
+        cb_stats_reduced_obj.reserve_back(stats_tile_stride);
 
         tile_regs_wait();
         pack_tile(0, cb_stats_reduced);
         pack_tile(1, cb_stats_reduced);
         tile_regs_release();
 
-        cb_push_back(cb_stats_reduced, stats_tile_stride);
+        cb_stats_reduced_obj.push_back(stats_tile_stride);
 
         reduce_uninit();
 
@@ -168,19 +177,19 @@ void kernel_main() {
         reconfig_data_format(cb_stats_reduced, cb_stats_reduced);
         pack_reconfig_data_format(cb_mean_squared);
         mul_tiles_init(cb_stats_reduced, cb_stats_reduced);
-        cb_wait_front(cb_stats_reduced, stats_tile_stride);
+        cb_stats_reduced_obj.wait_front(stats_tile_stride);
 
         tile_regs_acquire();
         mul_tiles(cb_stats_reduced, cb_stats_reduced, 1, 1, 0);
         tile_regs_commit();
 
-        cb_reserve_back(cb_mean_squared, onetile);
+        cb_mean_squared_obj.reserve_back(onetile);
 
         tile_regs_wait();
         pack_tile(0, cb_mean_squared);
         tile_regs_release();
 
-        cb_push_back(cb_mean_squared, 1);
+        cb_mean_squared_obj.push_back(1);
 
         /*
          * E[x**2] - E[x]**2
@@ -189,26 +198,26 @@ void kernel_main() {
         pack_reconfig_data_format(cb_var);
         sub_tiles_init(cb_stats_reduced, cb_mean_squared);
 
-        cb_wait_front(cb_mean_squared, 1);
+        cb_mean_squared_obj.wait_front(1);
 
         tile_regs_acquire();
         sub_tiles(cb_stats_reduced, cb_mean_squared, 0, 0, 0);
         tile_regs_commit();
 
-        cb_pop_front(cb_mean_squared, 1);
+        cb_mean_squared_obj.pop_front(1);
 
-        cb_reserve_back(cb_var, onetile);
+        cb_var_obj.reserve_back(onetile);
 
         tile_regs_wait();
         pack_tile(0, cb_var);
         tile_regs_release();
 
-        cb_push_back(cb_var, 1);
+        cb_var_obj.push_back(1);
 
         /*
          * 1/sqrt(var + eps)
          */
-        cb_wait_front(cb_var, 1);
+        cb_var_obj.wait_front(1);
         reconfig_data_format(cb_var, cb_eps);
         pack_reconfig_data_format(cb_recip_sqrt_var);
         add_tiles_init(cb_var, cb_eps);
@@ -219,15 +228,15 @@ void kernel_main() {
         rsqrt_tile<LEGACY_RSQRT>(0);
         tile_regs_commit();
 
-        cb_pop_front(cb_var, 1);
+        cb_var_obj.pop_front(1);
 
-        cb_reserve_back(cb_recip_sqrt_var, 1);
+        cb_recip_sqrt_var_obj.reserve_back(1);
 
         tile_regs_wait();
         pack_tile(0, cb_recip_sqrt_var);
         tile_regs_release();
 
-        cb_push_back(cb_recip_sqrt_var, 1);
+        cb_recip_sqrt_var_obj.push_back(1);
 
         if constexpr (do_gamma && do_beta) {
             /*
@@ -245,9 +254,9 @@ void kernel_main() {
         }
 
         // free up CBs
-        cb_pop_front(cb_stats_reduced, stats_tile_stride);
-        cb_pop_front(cb_recip_sqrt_var, 1);
+        cb_stats_reduced_obj.pop_front(stats_tile_stride);
+        cb_recip_sqrt_var_obj.pop_front(1);
     }
-    cb_pop_front(cb_eps, 1);
-    cb_pop_front(cb_reduce, 1);
+    cb_eps_obj.pop_front(1);
+    cb_reduce_obj.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -24,14 +24,14 @@
 #include "chain_llk.hpp"
 
 constexpr uint32_t cb_inp = tt::CBIndex::c_0;
-constexpr uint32_t cb_stats = tt::CBIndex::c_1;
+constexpr uint32_t cb_stats_idx = tt::CBIndex::c_1;
 
-constexpr uint32_t cb_eps = tt::CBIndex::c_4;
+constexpr uint32_t cb_eps_idx = tt::CBIndex::c_4;
 
 constexpr uint32_t cb_out = tt::CBIndex::c_14;
 
-constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_6;    // [E(x**2), E(x)]
-constexpr uint32_t cb_recip_sqrt_var = tt::CBIndex::c_10;  // 1/sqrt(var+eps)
+constexpr uint32_t cb_stats_reduced_idx = tt::CBIndex::c_6;    // [E(x**2), E(x)]
+constexpr uint32_t cb_recip_sqrt_var_idx = tt::CBIndex::c_10;  // 1/sqrt(var+eps)
 constexpr uint32_t cb_x_normed = tt::CBIndex::c_12;        // (x - E(x)) * 1/sqrt(var+eps) or x * 1/sqrt(E(x**2) + eps)
 
 // Layernorm-specific CBs
@@ -45,7 +45,7 @@ struct x_minus_mean_node {
         .llk_init = sub_bcast_cols_init_short,
         .llk = FN_compute(sub_tiles_bcast_cols),
         .CB_A = cb_inp,
-        .CB_B = cb_stats_reduced,
+        .CB_B = cb_stats_reduced_idx,
         .CB_OUT = cb_x_minus_mean,
         .fixed_CB_B_index = 1,
         .fixed_dest_reg = 0xFFFF,
@@ -60,7 +60,7 @@ struct normed_output_node {
         .llk_init = mul_bcast_cols_init_short,
         .llk = FN_compute(mul_tiles_bcast_cols),
         .CB_A = cb_norm_x_input,
-        .CB_B = cb_recip_sqrt_var,
+        .CB_B = cb_recip_sqrt_var_idx,
         .CB_OUT = normed_output_cb,
         .fixed_CB_B_index = 0,
         .fixed_dest_reg = 0xFFFF,
@@ -110,133 +110,133 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr uint32_t cb_reduce = tt::CBIndex::c_5;
+    constexpr uint32_t cb_reduce_idx = tt::CBIndex::c_5;
 
     constexpr uint32_t cb_var_eps = tt::CBIndex::c_9;  // var + epsilon (or E(x**2) + epsilon)
 
-    constexpr uint32_t cb_var = tt::CBIndex::c_8;  // E(x**2) - E(x)**2 or E(x**2)
+    constexpr uint32_t cb_var_idx = tt::CBIndex::c_8;  // E(x**2) - E(x)**2 or E(x**2)
 
     // Layernorm-specific CBs
-    constexpr uint32_t cb_mean_squared = tt::CBIndex::c_7;  // E(x)**2
+    constexpr uint32_t cb_mean_squared_idx = tt::CBIndex::c_7;  // E(x)**2
 
-    binary_op_init_common(cb_inp, cb_inp, cb_stats_reduced);
+    binary_op_init_common(cb_inp, cb_inp, cb_stats_reduced_idx);
 
-    CircularBuffer cb_reduce_obj(cb_reduce);
-    CircularBuffer cb_eps_obj(cb_eps);
-    CircularBuffer cb_stats_obj(cb_stats);
-    CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
-    CircularBuffer cb_mean_squared_obj(cb_mean_squared);
-    CircularBuffer cb_var_obj(cb_var);
-    CircularBuffer cb_recip_sqrt_var_obj(cb_recip_sqrt_var);
+    CircularBuffer cb_reduce(cb_reduce_idx);
+    CircularBuffer cb_eps(cb_eps_idx);
+    CircularBuffer cb_stats(cb_stats_idx);
+    CircularBuffer cb_stats_reduced(cb_stats_reduced_idx);
+    CircularBuffer cb_mean_squared(cb_mean_squared_idx);
+    CircularBuffer cb_var(cb_var_idx);
+    CircularBuffer cb_recip_sqrt_var(cb_recip_sqrt_var_idx);
 
-    cb_reduce_obj.wait_front(1);  // comes from the reader
-    cb_eps_obj.wait_front(1);     // comes from the reader
+    cb_reduce.wait_front(1);  // comes from the reader
+    cb_eps.wait_front(1);     // comes from the reader
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         constexpr int onetile = 1;
         constexpr int dst0 = 0;
 
-        reconfig_data_format(cb_reduce, cb_stats);
-        pack_reconfig_data_format(cb_stats_reduced);
+        reconfig_data_format(cb_reduce_idx, cb_stats_idx);
+        pack_reconfig_data_format(cb_stats_reduced_idx);
 
         /*
          * Reduce stats input.
-         * cb_stats = [sum(x0**2), sum(x0), sum(x1**2), sum(x1), ...]
-         * RMSNorm packs mean(x**2) into cb_var. Layernorm just uses cb_stats_reduced.
+         * cb_stats_idx = [sum(x0**2), sum(x0), sum(x1**2), sum(x1), ...]
+         * RMSNorm packs mean(x**2) into cb_var_idx. Layernorm just uses cb_stats_reduced_idx.
          */
-        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_reduce, cb_stats_reduced);
-        cb_stats_obj.wait_front(stats_tiles_cols);
+        reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats_idx, cb_reduce_idx, cb_stats_reduced_idx);
+        cb_stats.wait_front(stats_tiles_cols);
 
         tile_regs_acquire();
         // Reduce sum(x**2) first
         for (uint32_t i = 0; i < stats_tiles_cols; i += stats_tile_stride) {
-            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_reduce, i, 0, 0);
+            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats_idx, cb_reduce_idx, i, 0, 0);
         }
         // Reduce sum(x) next
         for (uint32_t i = 1; i < stats_tiles_cols; i += stats_tile_stride) {
-            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats, cb_reduce, i, 0, 1);
+            reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_stats_idx, cb_reduce_idx, i, 0, 1);
         }
         tile_regs_commit();
 
-        cb_stats_obj.pop_front(stats_tiles_cols);
+        cb_stats.pop_front(stats_tiles_cols);
 
-        cb_stats_reduced_obj.reserve_back(stats_tile_stride);
+        cb_stats_reduced.reserve_back(stats_tile_stride);
 
         tile_regs_wait();
-        pack_tile(0, cb_stats_reduced);
-        pack_tile(1, cb_stats_reduced);
+        pack_tile(0, cb_stats_reduced_idx);
+        pack_tile(1, cb_stats_reduced_idx);
         tile_regs_release();
 
-        cb_stats_reduced_obj.push_back(stats_tile_stride);
+        cb_stats_reduced.push_back(stats_tile_stride);
 
         reduce_uninit();
 
         /*
          * E[x]**2
          */
-        reconfig_data_format(cb_stats_reduced, cb_stats_reduced);
-        pack_reconfig_data_format(cb_mean_squared);
-        mul_tiles_init(cb_stats_reduced, cb_stats_reduced);
-        cb_stats_reduced_obj.wait_front(stats_tile_stride);
+        reconfig_data_format(cb_stats_reduced_idx, cb_stats_reduced_idx);
+        pack_reconfig_data_format(cb_mean_squared_idx);
+        mul_tiles_init(cb_stats_reduced_idx, cb_stats_reduced_idx);
+        cb_stats_reduced.wait_front(stats_tile_stride);
 
         tile_regs_acquire();
-        mul_tiles(cb_stats_reduced, cb_stats_reduced, 1, 1, 0);
+        mul_tiles(cb_stats_reduced_idx, cb_stats_reduced_idx, 1, 1, 0);
         tile_regs_commit();
 
-        cb_mean_squared_obj.reserve_back(onetile);
+        cb_mean_squared.reserve_back(onetile);
 
         tile_regs_wait();
-        pack_tile(0, cb_mean_squared);
+        pack_tile(0, cb_mean_squared_idx);
         tile_regs_release();
 
-        cb_mean_squared_obj.push_back(1);
+        cb_mean_squared.push_back(1);
 
         /*
          * E[x**2] - E[x]**2
          */
-        reconfig_data_format(cb_stats_reduced, cb_mean_squared);
-        pack_reconfig_data_format(cb_var);
-        sub_tiles_init(cb_stats_reduced, cb_mean_squared);
+        reconfig_data_format(cb_stats_reduced_idx, cb_mean_squared_idx);
+        pack_reconfig_data_format(cb_var_idx);
+        sub_tiles_init(cb_stats_reduced_idx, cb_mean_squared_idx);
 
-        cb_mean_squared_obj.wait_front(1);
+        cb_mean_squared.wait_front(1);
 
         tile_regs_acquire();
-        sub_tiles(cb_stats_reduced, cb_mean_squared, 0, 0, 0);
+        sub_tiles(cb_stats_reduced_idx, cb_mean_squared_idx, 0, 0, 0);
         tile_regs_commit();
 
-        cb_mean_squared_obj.pop_front(1);
+        cb_mean_squared.pop_front(1);
 
-        cb_var_obj.reserve_back(onetile);
+        cb_var.reserve_back(onetile);
 
         tile_regs_wait();
-        pack_tile(0, cb_var);
+        pack_tile(0, cb_var_idx);
         tile_regs_release();
 
-        cb_var_obj.push_back(1);
+        cb_var.push_back(1);
 
         /*
          * 1/sqrt(var + eps)
          */
-        cb_var_obj.wait_front(1);
-        reconfig_data_format(cb_var, cb_eps);
-        pack_reconfig_data_format(cb_recip_sqrt_var);
-        add_tiles_init(cb_var, cb_eps);
+        cb_var.wait_front(1);
+        reconfig_data_format(cb_var_idx, cb_eps_idx);
+        pack_reconfig_data_format(cb_recip_sqrt_var_idx);
+        add_tiles_init(cb_var_idx, cb_eps_idx);
 
         tile_regs_acquire();
-        add_tiles(cb_var, cb_eps, 0, 0, 0);
+        add_tiles(cb_var_idx, cb_eps_idx, 0, 0, 0);
         rsqrt_tile_init<LEGACY_RSQRT>();
         rsqrt_tile<LEGACY_RSQRT>(0);
         tile_regs_commit();
 
-        cb_var_obj.pop_front(1);
+        cb_var.pop_front(1);
 
-        cb_recip_sqrt_var_obj.reserve_back(1);
+        cb_recip_sqrt_var.reserve_back(1);
 
         tile_regs_wait();
-        pack_tile(0, cb_recip_sqrt_var);
+        pack_tile(0, cb_recip_sqrt_var_idx);
         tile_regs_release();
 
-        cb_recip_sqrt_var_obj.push_back(1);
+        cb_recip_sqrt_var.push_back(1);
 
         if constexpr (do_gamma && do_beta) {
             /*
@@ -254,9 +254,9 @@ void kernel_main() {
         }
 
         // free up CBs
-        cb_stats_reduced_obj.pop_front(stats_tile_stride);
-        cb_recip_sqrt_var_obj.pop_front(1);
+        cb_stats_reduced.pop_front(stats_tile_stride);
+        cb_recip_sqrt_var.pop_front(1);
     }
-    cb_eps_obj.pop_front(1);
-    cb_reduce_obj.pop_front(1);
+    cb_eps.pop_front(1);
+    cb_reduce.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
@@ -27,6 +27,7 @@
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/transpose_dest.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t NCHt = get_arg_val<uint32_t>(0);
@@ -59,6 +60,16 @@ void kernel_main() {
 #else
     compute_kernel_hw_startup(cb_inp, cb_inp, cb_scratch);
 #endif
+
+    CircularBuffer cb_out_obj(cb_out);
+    CircularBuffer cb_scratch_obj(cb_scratch);
+    CircularBuffer cb_inp_obj(cb_inp);
+#if FUSE_PRE_ADD
+    CircularBuffer cb_in0_obj(cb_in0);
+    CircularBuffer cb_res_obj(cb_res);
+    CircularBuffer cb_mean_spill_obj(cb_mean_spill);
+    CircularBuffer cb_m2_spill_obj(cb_m2_spill);
+#endif
     // Get pointer to the reciprocal LUT
     using recip_lut_t = std::array<uint32_t, W>;
     auto p_reciprocals = kutil::compute::memory::get_pointer_to_cb_data<recip_lut_t>(cb_reciprocals, 0);
@@ -88,24 +99,24 @@ void kernel_main() {
         welford_init();
         welford_save_state(dst1);
         tile_regs_commit();
-        cb_reserve_back(cb_mean_spill, 1);
-        cb_reserve_back(cb_m2_spill, 1);
+        cb_mean_spill_obj.reserve_back(1);
+        cb_m2_spill_obj.reserve_back(1);
         tile_regs_wait();
         pack_reconfig_data_format(cb_mean_spill);
         pack_tile(dst1, cb_mean_spill);
         pack_tile(dst2, cb_m2_spill);
         tile_regs_release();
-        cb_push_back(cb_mean_spill, 1);
-        cb_push_back(cb_m2_spill, 1);
+        cb_mean_spill_obj.push_back(1);
+        cb_m2_spill_obj.push_back(1);
 
         uint32_t start_N = 0;
         for (auto block : generic::blocks(Wt, blk)) {
             // --- Pre-add: cb_in0 + cb_res -> cb_inp (block tiles in one tile_regs scope) ---
             reconfig_data_format(cb_in0, cb_res);
             pack_reconfig_data_format(cb_inp);
-            cb_wait_front(cb_in0, block.size());
-            cb_wait_front(cb_res, block.size());
-            cb_reserve_back(cb_inp, block.size());
+            cb_in0_obj.wait_front(block.size());
+            cb_res_obj.wait_front(block.size());
+            cb_inp_obj.reserve_back(block.size());
             if constexpr (welford_unpack_fp32_active) {
                 // SFPU path: copy_tile bypasses SrcA via UnpackToDestEn, preserving full FP32
                 copy_tile_to_dst_init_short(cb_in0);
@@ -135,14 +146,14 @@ void kernel_main() {
                 }
                 tile_regs_release();
             }
-            cb_push_back(cb_inp, block.size());
-            cb_pop_front(cb_in0, block.size());
-            cb_pop_front(cb_res, block.size());
+            cb_inp_obj.push_back(block.size());
+            cb_in0_obj.pop_front(block.size());
+            cb_res_obj.pop_front(block.size());
 
             // --- Welford: reload accumulator, update with block tiles, spill back ---
-            cb_wait_front(cb_mean_spill, 1);
-            cb_wait_front(cb_m2_spill, 1);
-            cb_wait_front(cb_inp, block.size());
+            cb_mean_spill_obj.wait_front(1);
+            cb_m2_spill_obj.wait_front(1);
+            cb_inp_obj.wait_front(block.size());
             tile_regs_acquire();
             reconfig_data_format_srca(cb_in0, cb_mean_spill);
             copy_tile_init(cb_mean_spill);
@@ -172,23 +183,23 @@ void kernel_main() {
             }
             welford_save_state(dst1);
             tile_regs_commit();
-            cb_pop_front(cb_mean_spill, 1);
-            cb_pop_front(cb_m2_spill, 1);
-            cb_pop_front(cb_inp, block.size());
-            cb_reserve_back(cb_mean_spill, 1);
-            cb_reserve_back(cb_m2_spill, 1);
+            cb_mean_spill_obj.pop_front(1);
+            cb_m2_spill_obj.pop_front(1);
+            cb_inp_obj.pop_front(block.size());
+            cb_mean_spill_obj.reserve_back(1);
+            cb_m2_spill_obj.reserve_back(1);
             tile_regs_wait();
             pack_reconfig_data_format(cb_inp, cb_mean_spill);
             pack_tile(dst1, cb_mean_spill);
             pack_tile(dst2, cb_m2_spill);
             tile_regs_release();
-            cb_push_back(cb_mean_spill, 1);
-            cb_push_back(cb_m2_spill, 1);
+            cb_mean_spill_obj.push_back(1);
+            cb_m2_spill_obj.push_back(1);
         }
 
         // Finalize: reload accumulator and write mean and variance to cb_scratch.
-        cb_wait_front(cb_mean_spill, 1);
-        cb_wait_front(cb_m2_spill, 1);
+        cb_mean_spill_obj.wait_front(1);
+        cb_m2_spill_obj.wait_front(1);
         tile_regs_acquire();
         reconfig_data_format_srca(cb_inp, cb_mean_spill);
         copy_tile_init(cb_mean_spill);
@@ -198,15 +209,15 @@ void kernel_main() {
         welford_restore_state(dst1);
         welford_finalize_to_row<W>(dst1, W - 1, *p_reciprocals);
         tile_regs_commit();
-        cb_pop_front(cb_mean_spill, 1);
-        cb_pop_front(cb_m2_spill, 1);
+        cb_mean_spill_obj.pop_front(1);
+        cb_m2_spill_obj.pop_front(1);
 
-        cb_reserve_back(cb_scratch, 2);
+        cb_scratch_obj.reserve_back(2);
         tile_regs_wait();
         pack_reconfig_data_format(cb_mean_spill, cb_scratch);
         pack_tile(dst1, cb_scratch);
         pack_tile(dst2, cb_scratch);
-        cb_push_back(cb_scratch, 2);
+        cb_scratch_obj.push_back(2);
         tile_regs_release();
 #else
         reconfig_data_format(cb_inp, cb_inp);
@@ -234,7 +245,7 @@ void kernel_main() {
         // through SrcA without touching the math-thread replay buffer, so the recovery is
         // gated out.
         for (uint32_t wt = 0; wt < (Wt - 1); wt++) {
-            cb_wait_front(cb_inp, 1);  // cumulative wait
+            cb_inp_obj.wait_front(1);  // cumulative wait
             if constexpr (welford_unpack_fp32_active) {
                 transpose_init(cb_inp);
             }
@@ -245,9 +256,9 @@ void kernel_main() {
             // welford_tile<dst0, dst1, dst2, true, 0>((wt) * 32, W, 0, {});
             welford_update<W>(dst0, start_N, *p_reciprocals);
             start_N += 32;
-            cb_pop_front(cb_inp, 1);
+            cb_inp_obj.pop_front(1);
         }
-        cb_wait_front(cb_inp, 1);  // cumulative wait
+        cb_inp_obj.wait_front(1);  // cumulative wait
         if constexpr (welford_unpack_fp32_active) {
             transpose_init(cb_inp);
         }
@@ -256,19 +267,19 @@ void kernel_main() {
             welford_init<WelfordInitMode::PreserveStats>();
         }
         welford_update_rows<W>(dst0, start_N, 0, last_tile_rows, *p_reciprocals);
-        cb_pop_front(cb_inp, 1);
+        cb_inp_obj.pop_front(1);
         welford_finalize_to_row<W>(dst1, W - 1, *p_reciprocals);
         // tt-llk/issues/549
         // BUG: using transpose_dest here causes a bug. where the kernel hangs
         //  transpose_dest_init();
         //  transpose_dest(dst1);
         //  transpose_dest(dst2);
-        cb_reserve_back(cb_scratch, 2);
+        cb_scratch_obj.reserve_back(2);
         tile_regs_commit();
         tile_regs_wait();
         pack_tile(dst1, cb_scratch);
         pack_tile(dst2, cb_scratch);
-        cb_push_back(cb_scratch, 2);
+        cb_scratch_obj.push_back(2);
         tile_regs_release();
 #endif
 
@@ -276,16 +287,16 @@ void kernel_main() {
         pack_reconfig_data_format(cb_out);
         transpose_init(cb_scratch);
         tile_regs_acquire();
-        cb_wait_front(cb_scratch, 2);  // cumulative wait
+        cb_scratch_obj.wait_front(2);  // cumulative wait
         transpose_tile(cb_scratch, 0, dst0);
         transpose_tile(cb_scratch, 1, dst1);
-        cb_pop_front(cb_scratch, 2);
+        cb_scratch_obj.pop_front(2);
 
         tile_regs_commit();
         tile_regs_wait();
         pack_tile(dst0, cb_out);
         pack_tile(dst1, cb_out);
-        cb_push_back(cb_out, 2);
+        cb_out_obj.push_back(2);
         tile_regs_release();
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
@@ -38,37 +38,37 @@ void kernel_main() {
 #if FUSE_PRE_ADD
     constexpr uint32_t blk = get_compile_time_arg_val(2);
 #endif
-    // True iff the factory configured cb_inp with UnpackToDestFp32. Used by the
+    // True iff the factory configured cb_inp_idx with UnpackToDestFp32. Used by the
     // non-FUSE branch to gate the welford state re-establishment after the transpose.
     constexpr bool welford_unpack_fp32_active = get_named_compile_time_arg_val("welford_unpack_fp32_active") != 0;
 
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_out = tt::CBIndex::c_14;
-    constexpr uint32_t cb_scratch = tt::CBIndex::c_1;      // scratch for post-Welford transpose
+    constexpr uint32_t cb_in0_idx = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out_idx = tt::CBIndex::c_14;
+    constexpr uint32_t cb_scratch_idx = tt::CBIndex::c_1;  // scratch for post-Welford transpose
     constexpr uint32_t cb_reciprocals = tt::CBIndex::c_2;  // recip table
 #if FUSE_PRE_ADD
-    constexpr uint32_t cb_res = tt::CBIndex::c_5;         // residual b
-    constexpr uint32_t cb_inp = tt::CBIndex::c_3;         // fused a + b (sized to a few blocks)
-    constexpr uint32_t cb_mean_spill = tt::CBIndex::c_4;  // Welford mean accumulator spill (1 tile)
-    constexpr uint32_t cb_m2_spill = tt::CBIndex::c_6;    // Welford M2 accumulator spill (1 tile)
+    constexpr uint32_t cb_res_idx = tt::CBIndex::c_5;         // residual b
+    constexpr uint32_t cb_inp_idx = tt::CBIndex::c_3;         // fused a + b (sized to a few blocks)
+    constexpr uint32_t cb_mean_spill_idx = tt::CBIndex::c_4;  // Welford mean accumulator spill (1 tile)
+    constexpr uint32_t cb_m2_spill_idx = tt::CBIndex::c_6;    // Welford M2 accumulator spill (1 tile)
 #else
-    constexpr uint32_t cb_inp = cb_in0;
+    constexpr uint32_t cb_inp_idx = cb_in0_idx;
 #endif
 
 #if FUSE_PRE_ADD
-    binary_op_init_common(cb_in0, cb_res, cb_inp);
+    binary_op_init_common(cb_in0_idx, cb_res_idx, cb_inp_idx);
 #else
-    compute_kernel_hw_startup(cb_inp, cb_inp, cb_scratch);
+    compute_kernel_hw_startup(cb_inp_idx, cb_inp_idx, cb_scratch_idx);
 #endif
 
-    CircularBuffer cb_out_obj(cb_out);
-    CircularBuffer cb_scratch_obj(cb_scratch);
-    CircularBuffer cb_inp_obj(cb_inp);
+    CircularBuffer cb_out(cb_out_idx);
+    CircularBuffer cb_scratch(cb_scratch_idx);
+    CircularBuffer cb_inp(cb_inp_idx);
 #if FUSE_PRE_ADD
-    CircularBuffer cb_in0_obj(cb_in0);
-    CircularBuffer cb_res_obj(cb_res);
-    CircularBuffer cb_mean_spill_obj(cb_mean_spill);
-    CircularBuffer cb_m2_spill_obj(cb_m2_spill);
+    CircularBuffer cb_in0(cb_in0_idx);
+    CircularBuffer cb_res(cb_res_idx);
+    CircularBuffer cb_mean_spill(cb_mean_spill_idx);
+    CircularBuffer cb_m2_spill(cb_m2_spill_idx);
 #endif
     // Get pointer to the reciprocal LUT
     using recip_lut_t = std::array<uint32_t, W>;
@@ -86,9 +86,9 @@ void kernel_main() {
 #if FUSE_PRE_ADD
         // Block-interleaved pre-add + Welford. The Welford accumulator lives in the SFPU within a
         // tile_regs scope, but the pre-add must use its own tile_regs scope to pack its result to
-        // cb_inp before the Welford pass can transpose-read it back. To bridge those scopes the
-        // accumulator (mean, M2) is spilled to cb_mean_spill / cb_m2_spill between chunks via
-        // welford_save_state / welford_restore_state. This lets cb_inp stay sized to a small
+        // cb_inp_idx before the Welford pass can transpose-read it back. To bridge those scopes the
+        // accumulator (mean, M2) is spilled to cb_mean_spill_idx / cb_m2_spill_idx between chunks via
+        // welford_save_state / welford_restore_state. This lets cb_inp_idx stay sized to a small
         // number of tiles (blk * 2 for double-buffer) regardless of Wt. Larger blk amortizes the
         // save/restore overhead and accuracy loss across more tiles per spill cycle; blk is
         // chosen by the factory as gcd(Wt, DST capacity) so it always divides Wt.
@@ -99,78 +99,78 @@ void kernel_main() {
         welford_init();
         welford_save_state(dst1);
         tile_regs_commit();
-        cb_mean_spill_obj.reserve_back(1);
-        cb_m2_spill_obj.reserve_back(1);
+        cb_mean_spill.reserve_back(1);
+        cb_m2_spill.reserve_back(1);
         tile_regs_wait();
-        pack_reconfig_data_format(cb_mean_spill);
-        pack_tile(dst1, cb_mean_spill);
-        pack_tile(dst2, cb_m2_spill);
+        pack_reconfig_data_format(cb_mean_spill_idx);
+        pack_tile(dst1, cb_mean_spill_idx);
+        pack_tile(dst2, cb_m2_spill_idx);
         tile_regs_release();
-        cb_mean_spill_obj.push_back(1);
-        cb_m2_spill_obj.push_back(1);
+        cb_mean_spill.push_back(1);
+        cb_m2_spill.push_back(1);
 
         uint32_t start_N = 0;
         for (auto block : generic::blocks(Wt, blk)) {
-            // --- Pre-add: cb_in0 + cb_res -> cb_inp (block tiles in one tile_regs scope) ---
-            reconfig_data_format(cb_in0, cb_res);
-            pack_reconfig_data_format(cb_inp);
-            cb_in0_obj.wait_front(block.size());
-            cb_res_obj.wait_front(block.size());
-            cb_inp_obj.reserve_back(block.size());
+            // --- Pre-add: cb_in0_idx + cb_res_idx -> cb_inp_idx (block tiles in one tile_regs scope) ---
+            reconfig_data_format(cb_in0_idx, cb_res_idx);
+            pack_reconfig_data_format(cb_inp_idx);
+            cb_in0.wait_front(block.size());
+            cb_res.wait_front(block.size());
+            cb_inp.reserve_back(block.size());
             if constexpr (welford_unpack_fp32_active) {
                 // SFPU path: copy_tile bypasses SrcA via UnpackToDestEn, preserving full FP32
-                copy_tile_to_dst_init_short(cb_in0);
+                copy_tile_to_dst_init_short(cb_in0_idx);
                 for (auto i : block.local()) {
                     tile_regs_acquire();
-                    copy_tile(cb_in0, i, 0);
-                    copy_tile_to_dst_init_short_with_dt(cb_in0, cb_res);
-                    copy_tile(cb_res, i, 1);
+                    copy_tile(cb_in0_idx, i, 0);
+                    copy_tile_to_dst_init_short_with_dt(cb_in0_idx, cb_res_idx);
+                    copy_tile(cb_res_idx, i, 1);
                     add_binary_tile_init();
                     add_binary_tile(0, 1, 0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(0, cb_inp);
+                    pack_tile(0, cb_inp_idx);
                     tile_regs_release();
-                    copy_tile_to_dst_init_short_with_dt(cb_res, cb_in0);
+                    copy_tile_to_dst_init_short_with_dt(cb_res_idx, cb_in0_idx);
                 }
             } else {
-                add_tiles_init(cb_in0, cb_res);
+                add_tiles_init(cb_in0_idx, cb_res_idx);
                 tile_regs_acquire();
                 for (auto i : block.local()) {
-                    add_tiles(cb_in0, cb_res, i, i, i);
+                    add_tiles(cb_in0_idx, cb_res_idx, i, i, i);
                 }
                 tile_regs_commit();
                 tile_regs_wait();
                 for (auto i : block.local()) {
-                    pack_tile(i, cb_inp);
+                    pack_tile(i, cb_inp_idx);
                 }
                 tile_regs_release();
             }
-            cb_inp_obj.push_back(block.size());
-            cb_in0_obj.pop_front(block.size());
-            cb_res_obj.pop_front(block.size());
+            cb_inp.push_back(block.size());
+            cb_in0.pop_front(block.size());
+            cb_res.pop_front(block.size());
 
             // --- Welford: reload accumulator, update with block tiles, spill back ---
-            cb_mean_spill_obj.wait_front(1);
-            cb_m2_spill_obj.wait_front(1);
-            cb_inp_obj.wait_front(block.size());
+            cb_mean_spill.wait_front(1);
+            cb_m2_spill.wait_front(1);
+            cb_inp.wait_front(block.size());
             tile_regs_acquire();
-            reconfig_data_format_srca(cb_in0, cb_mean_spill);
-            copy_tile_init(cb_mean_spill);
-            copy_tile(cb_mean_spill, 0, dst1);
-            copy_tile_to_dst_init_short_with_dt(cb_mean_spill, cb_m2_spill);
-            copy_tile(cb_m2_spill, 0, dst2);
+            reconfig_data_format_srca(cb_in0_idx, cb_mean_spill_idx);
+            copy_tile_init(cb_mean_spill_idx);
+            copy_tile(cb_mean_spill_idx, 0, dst1);
+            copy_tile_to_dst_init_short_with_dt(cb_mean_spill_idx, cb_m2_spill_idx);
+            copy_tile(cb_m2_spill_idx, 0, dst2);
             welford_restore_state(dst1);
 
-            reconfig_data_format_srca(cb_m2_spill, cb_inp);
+            reconfig_data_format_srca(cb_m2_spill_idx, cb_inp_idx);
             if constexpr (!welford_unpack_fp32_active) {
-                transpose_init(cb_inp);
+                transpose_init(cb_inp_idx);
             }
             for (auto i : block.local()) {
                 if constexpr (welford_unpack_fp32_active) {
-                    transpose_init(cb_inp);
+                    transpose_init(cb_inp_idx);
                 }
-                transpose_tile(cb_inp, i, dst0);
+                transpose_tile(cb_inp_idx, i, dst0);
                 if constexpr (welford_unpack_fp32_active) {
                     welford_init<WelfordInitMode::PreserveStats>();
                 }
@@ -183,53 +183,53 @@ void kernel_main() {
             }
             welford_save_state(dst1);
             tile_regs_commit();
-            cb_mean_spill_obj.pop_front(1);
-            cb_m2_spill_obj.pop_front(1);
-            cb_inp_obj.pop_front(block.size());
-            cb_mean_spill_obj.reserve_back(1);
-            cb_m2_spill_obj.reserve_back(1);
+            cb_mean_spill.pop_front(1);
+            cb_m2_spill.pop_front(1);
+            cb_inp.pop_front(block.size());
+            cb_mean_spill.reserve_back(1);
+            cb_m2_spill.reserve_back(1);
             tile_regs_wait();
-            pack_reconfig_data_format(cb_inp, cb_mean_spill);
-            pack_tile(dst1, cb_mean_spill);
-            pack_tile(dst2, cb_m2_spill);
+            pack_reconfig_data_format(cb_inp_idx, cb_mean_spill_idx);
+            pack_tile(dst1, cb_mean_spill_idx);
+            pack_tile(dst2, cb_m2_spill_idx);
             tile_regs_release();
-            cb_mean_spill_obj.push_back(1);
-            cb_m2_spill_obj.push_back(1);
+            cb_mean_spill.push_back(1);
+            cb_m2_spill.push_back(1);
         }
 
-        // Finalize: reload accumulator and write mean and variance to cb_scratch.
-        cb_mean_spill_obj.wait_front(1);
-        cb_m2_spill_obj.wait_front(1);
+        // Finalize: reload accumulator and write mean and variance to cb_scratch_idx.
+        cb_mean_spill.wait_front(1);
+        cb_m2_spill.wait_front(1);
         tile_regs_acquire();
-        reconfig_data_format_srca(cb_inp, cb_mean_spill);
-        copy_tile_init(cb_mean_spill);
-        copy_tile(cb_mean_spill, 0, dst1);
-        copy_tile_to_dst_init_short_with_dt(cb_mean_spill, cb_m2_spill);
-        copy_tile(cb_m2_spill, 0, dst2);
+        reconfig_data_format_srca(cb_inp_idx, cb_mean_spill_idx);
+        copy_tile_init(cb_mean_spill_idx);
+        copy_tile(cb_mean_spill_idx, 0, dst1);
+        copy_tile_to_dst_init_short_with_dt(cb_mean_spill_idx, cb_m2_spill_idx);
+        copy_tile(cb_m2_spill_idx, 0, dst2);
         welford_restore_state(dst1);
         welford_finalize_to_row<W>(dst1, W - 1, *p_reciprocals);
         tile_regs_commit();
-        cb_mean_spill_obj.pop_front(1);
-        cb_m2_spill_obj.pop_front(1);
+        cb_mean_spill.pop_front(1);
+        cb_m2_spill.pop_front(1);
 
-        cb_scratch_obj.reserve_back(2);
+        cb_scratch.reserve_back(2);
         tile_regs_wait();
-        pack_reconfig_data_format(cb_mean_spill, cb_scratch);
-        pack_tile(dst1, cb_scratch);
-        pack_tile(dst2, cb_scratch);
-        cb_scratch_obj.push_back(2);
+        pack_reconfig_data_format(cb_mean_spill_idx, cb_scratch_idx);
+        pack_tile(dst1, cb_scratch_idx);
+        pack_tile(dst2, cb_scratch_idx);
+        cb_scratch.push_back(2);
         tile_regs_release();
 #else
-        reconfig_data_format(cb_inp, cb_inp);
-        pack_reconfig_data_format(cb_scratch);
+        reconfig_data_format(cb_inp_idx, cb_inp_idx);
+        pack_reconfig_data_format(cb_scratch_idx);
 
         tile_regs_acquire();
         uint32_t start_N = 0;
-        transpose_init(cb_inp);
+        transpose_init(cb_inp_idx);
         welford_init();
 
         // When the input CB carries Float32 with fp32_dest_acc_en=true, the program factory
-        // sets UnpackToDestFp32 for cb_inp so transpose_tile preserves FP32 precision into DEST.
+        // sets UnpackToDestFp32 for cb_inp_idx so transpose_tile preserves FP32 precision into DEST.
         // Its math-side init (called from transpose_init) records slots [16, 32) of the
         // math-thread replay buffer, clobbering the LREG2 / LREG3 portions of Welford's recurrence
         // (welford records slots [0, 32), which is 4 LREG variants of 8 instructions each, fully unrolled).
@@ -245,58 +245,58 @@ void kernel_main() {
         // through SrcA without touching the math-thread replay buffer, so the recovery is
         // gated out.
         for (uint32_t wt = 0; wt < (Wt - 1); wt++) {
-            cb_inp_obj.wait_front(1);  // cumulative wait
+            cb_inp.wait_front(1);  // cumulative wait
             if constexpr (welford_unpack_fp32_active) {
-                transpose_init(cb_inp);
+                transpose_init(cb_inp_idx);
             }
-            transpose_tile(cb_inp, 0, dst0);
+            transpose_tile(cb_inp_idx, 0, dst0);
             if constexpr (welford_unpack_fp32_active) {
                 welford_init<WelfordInitMode::PreserveStats>();
             }
             // welford_tile<dst0, dst1, dst2, true, 0>((wt) * 32, W, 0, {});
             welford_update<W>(dst0, start_N, *p_reciprocals);
             start_N += 32;
-            cb_inp_obj.pop_front(1);
+            cb_inp.pop_front(1);
         }
-        cb_inp_obj.wait_front(1);  // cumulative wait
+        cb_inp.wait_front(1);  // cumulative wait
         if constexpr (welford_unpack_fp32_active) {
-            transpose_init(cb_inp);
+            transpose_init(cb_inp_idx);
         }
-        transpose_tile(cb_inp, 0, dst0);
+        transpose_tile(cb_inp_idx, 0, dst0);
         if constexpr (welford_unpack_fp32_active) {
             welford_init<WelfordInitMode::PreserveStats>();
         }
         welford_update_rows<W>(dst0, start_N, 0, last_tile_rows, *p_reciprocals);
-        cb_inp_obj.pop_front(1);
+        cb_inp.pop_front(1);
         welford_finalize_to_row<W>(dst1, W - 1, *p_reciprocals);
         // tt-llk/issues/549
         // BUG: using transpose_dest here causes a bug. where the kernel hangs
         //  transpose_dest_init();
         //  transpose_dest(dst1);
         //  transpose_dest(dst2);
-        cb_scratch_obj.reserve_back(2);
+        cb_scratch.reserve_back(2);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(dst1, cb_scratch);
-        pack_tile(dst2, cb_scratch);
-        cb_scratch_obj.push_back(2);
+        pack_tile(dst1, cb_scratch_idx);
+        pack_tile(dst2, cb_scratch_idx);
+        cb_scratch.push_back(2);
         tile_regs_release();
 #endif
 
-        reconfig_data_format(cb_scratch, cb_scratch);
-        pack_reconfig_data_format(cb_out);
-        transpose_init(cb_scratch);
+        reconfig_data_format(cb_scratch_idx, cb_scratch_idx);
+        pack_reconfig_data_format(cb_out_idx);
+        transpose_init(cb_scratch_idx);
         tile_regs_acquire();
-        cb_scratch_obj.wait_front(2);  // cumulative wait
-        transpose_tile(cb_scratch, 0, dst0);
-        transpose_tile(cb_scratch, 1, dst1);
-        cb_scratch_obj.pop_front(2);
+        cb_scratch.wait_front(2);  // cumulative wait
+        transpose_tile(cb_scratch_idx, 0, dst0);
+        transpose_tile(cb_scratch_idx, 1, dst1);
+        cb_scratch.pop_front(2);
 
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(dst0, cb_out);
-        pack_tile(dst1, cb_out);
-        cb_out_obj.push_back(2);
+        pack_tile(dst0, cb_out_idx);
+        pack_tile(dst1, cb_out_idx);
+        cb_out.push_back(2);
         tile_regs_release();
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
@@ -17,6 +17,7 @@
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 ALWI void ACQ() {
@@ -64,8 +65,19 @@ void kernel_main() {
 
     binary_op_init_common(cb_inp, cb_inp, cb_var);
 
-    cb_wait_front(cb_reduce, 1);  // comes from the reader
-    cb_wait_front(cb_eps, 1);     // comes from the reader
+    CircularBuffer cb_reduce_obj(cb_reduce);
+    CircularBuffer cb_eps_obj(cb_eps);
+    CircularBuffer cb_var_obj(cb_var);
+    CircularBuffer cb_recip_sqrt_var_obj(cb_recip_sqrt_var);
+    CircularBuffer cb_norm_x_input_obj(cb_norm_x_input);
+    CircularBuffer cb_gamma_obj(cb_gamma);
+    CircularBuffer cb_x_normed_obj(cb_x_normed);
+    CircularBuffer cb_times_gamma_out_obj(cb_times_gamma_out);
+    CircularBuffer cb_beta_obj(cb_beta);
+    CircularBuffer cb_out_obj(cb_out);
+
+    cb_reduce_obj.wait_front(1);  // comes from the reader
+    cb_eps_obj.wait_front(1);     // comes from the reader
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         constexpr int onetile = 1;
@@ -83,8 +95,8 @@ void kernel_main() {
         /*
          * 1/sqrt(var + eps)
          */
-        cb_wait_front(cb_var, 1);
-        cb_reserve_back(cb_recip_sqrt_var, 1);
+        cb_var_obj.wait_front(1);
+        cb_recip_sqrt_var_obj.reserve_back(1);
         reconfig_data_format(cb_var, cb_eps);
         pack_reconfig_data_format(cb_recip_sqrt_var);
 
@@ -95,8 +107,8 @@ void kernel_main() {
         rsqrt_tile<LEGACY_RSQRT>(0);
         pack_tile(0, cb_recip_sqrt_var);
         REL();
-        cb_push_back(cb_recip_sqrt_var, 1);
-        cb_pop_front(cb_var, 1);
+        cb_recip_sqrt_var_obj.push_back(1);
+        cb_var_obj.pop_front(1);
 
         /*
          * norm x
@@ -107,24 +119,25 @@ void kernel_main() {
         if constexpr (!do_gamma) {
             normed_output_cb = cb_out;
         }
+        CircularBuffer normed_output_cb_obj(normed_output_cb);
 
         reconfig_data_format(cb_norm_x_input, cb_recip_sqrt_var);
         pack_reconfig_data_format(normed_output_cb);
         mul_bcast_cols_init_short(cb_norm_x_input, cb_recip_sqrt_var);
-        cb_wait_front(cb_recip_sqrt_var, 1);
+        cb_recip_sqrt_var_obj.wait_front(1);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            cb_wait_front(cb_norm_x_input, blk);
-            cb_reserve_back(normed_output_cb, blk);
+            cb_norm_x_input_obj.wait_front(blk);
+            normed_output_cb_obj.reserve_back(blk);
             ACQ();
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 mul_tiles_bcast_cols(cb_norm_x_input, cb_recip_sqrt_var, wtr, 0, wtr);
                 pack_tile(wtr, normed_output_cb);
             }
             REL();
-            cb_push_back(normed_output_cb, blk);
-            cb_pop_front(cb_norm_x_input, blk);
+            normed_output_cb_obj.push_back(blk);
+            cb_norm_x_input_obj.pop_front(blk);
         }
-        cb_pop_front(cb_recip_sqrt_var, 1);
+        cb_recip_sqrt_var_obj.pop_front(1);
 
         if constexpr (do_gamma) {
             /*
@@ -132,19 +145,19 @@ void kernel_main() {
              */
             reconfig_data_format(cb_x_normed, cb_gamma);
             pack_reconfig_data_format(cb_times_gamma_out);
-            cb_wait_front(cb_gamma, Wt);
+            cb_gamma_obj.wait_front(Wt);
             mul_bcast_rows_init_short(cb_x_normed, cb_gamma);
             for (uint32_t wt = 0; wt < Wt; wt += blk) {
-                cb_wait_front(cb_x_normed, blk);
-                cb_reserve_back(cb_times_gamma_out, blk);
+                cb_x_normed_obj.wait_front(blk);
+                cb_times_gamma_out_obj.reserve_back(blk);
                 ACQ();
                 for (uint32_t wtr = 0; wtr < blk; wtr++) {
                     mul_tiles_bcast_rows(cb_x_normed, cb_gamma, wtr, wt + wtr, wtr);
                     pack_tile(wtr, cb_times_gamma_out);
                 }
                 REL();
-                cb_push_back(cb_times_gamma_out, blk);
-                cb_pop_front(cb_x_normed, blk);
+                cb_times_gamma_out_obj.push_back(blk);
+                cb_x_normed_obj.pop_front(blk);
             }
 
             if constexpr (do_beta) {
@@ -153,29 +166,29 @@ void kernel_main() {
                  */
                 reconfig_data_format(cb_times_gamma_out, cb_beta);
                 pack_reconfig_data_format(cb_out);
-                cb_wait_front(cb_beta, Wt);
+                cb_beta_obj.wait_front(Wt);
                 add_bcast_rows_init_short(cb_times_gamma_out, cb_beta);
                 for (uint32_t wt = 0; wt < Wt; wt += blk) {
-                    cb_wait_front(cb_times_gamma_out, blk);
-                    cb_reserve_back(cb_out, blk);
+                    cb_times_gamma_out_obj.wait_front(blk);
+                    cb_out_obj.reserve_back(blk);
                     ACQ();
                     for (uint32_t wtr = 0; wtr < blk; wtr++) {
                         add_tiles_bcast_rows(cb_times_gamma_out, cb_beta, wtr, wt + wtr, wtr);
                         pack_tile(wtr, cb_out);
                     }
                     REL();
-                    cb_push_back(cb_out, blk);
-                    cb_pop_front(cb_times_gamma_out, blk);
+                    cb_out_obj.push_back(blk);
+                    cb_times_gamma_out_obj.pop_front(blk);
                 }
             }
         }
     }
-    cb_pop_front(cb_eps, 1);
-    cb_pop_front(cb_reduce, 1);
+    cb_eps_obj.pop_front(1);
+    cb_reduce_obj.pop_front(1);
     if constexpr (do_gamma) {
-        cb_pop_front(cb_gamma, Wt);
+        cb_gamma_obj.pop_front(Wt);
     }
     if constexpr (do_beta) {
-        cb_pop_front(cb_beta, Wt);
+        cb_beta_obj.pop_front(Wt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
@@ -44,40 +44,41 @@ void kernel_main() {
     constexpr uint32_t cb_inp = tt::CBIndex::c_0;
     constexpr uint32_t cb_stats = tt::CBIndex::c_1;
 
-    constexpr uint32_t cb_eps = tt::CBIndex::c_4;
-    constexpr uint32_t cb_reduce = tt::CBIndex::c_5;
+    constexpr uint32_t cb_eps_idx = tt::CBIndex::c_4;
+    constexpr uint32_t cb_reduce_idx = tt::CBIndex::c_5;
 
-    constexpr uint32_t cb_out = tt::CBIndex::c_14;
+    constexpr uint32_t cb_out_idx = tt::CBIndex::c_14;
 
     constexpr uint32_t cb_var_eps = tt::CBIndex::c_9;          // var + epsilon (or E(x**2) + epsilon)
-    constexpr uint32_t cb_recip_sqrt_var = tt::CBIndex::c_10;  // 1/sqrt(var+eps)
-    constexpr uint32_t cb_x_normed = tt::CBIndex::c_12;  // (x - E(x)) * 1/sqrt(var+eps) or x * 1/sqrt(E(x**2) + eps)
+    constexpr uint32_t cb_recip_sqrt_var_idx = tt::CBIndex::c_10;  // 1/sqrt(var+eps)
+    constexpr uint32_t cb_x_normed_idx =
+        tt::CBIndex::c_12;  // (x - E(x)) * 1/sqrt(var+eps) or x * 1/sqrt(E(x**2) + eps)
 
-    constexpr uint32_t cb_var = tt::CBIndex::c_8;  // E(x**2) - E(x)**2 or E(x**2)
-    constexpr uint32_t cb_norm_x_input = cb_inp;
+    constexpr uint32_t cb_var_idx = tt::CBIndex::c_8;  // E(x**2) - E(x)**2 or E(x**2)
+    constexpr uint32_t cb_norm_x_input_idx = cb_inp;
 
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_2;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_3;
-    uint32_t cb_times_gamma_out = cb_out;
+    constexpr uint32_t cb_gamma_idx = tt::CBIndex::c_2;
+    constexpr uint32_t cb_beta_idx = tt::CBIndex::c_3;
+    uint32_t cb_times_gamma_out_idx = cb_out_idx;
     if constexpr (do_gamma and do_beta) {
-        cb_times_gamma_out = tt::CBIndex::c_13;
+        cb_times_gamma_out_idx = tt::CBIndex::c_13;
     }
 
-    binary_op_init_common(cb_inp, cb_inp, cb_var);
+    binary_op_init_common(cb_inp, cb_inp, cb_var_idx);
 
-    CircularBuffer cb_reduce_obj(cb_reduce);
-    CircularBuffer cb_eps_obj(cb_eps);
-    CircularBuffer cb_var_obj(cb_var);
-    CircularBuffer cb_recip_sqrt_var_obj(cb_recip_sqrt_var);
-    CircularBuffer cb_norm_x_input_obj(cb_norm_x_input);
-    CircularBuffer cb_gamma_obj(cb_gamma);
-    CircularBuffer cb_x_normed_obj(cb_x_normed);
-    CircularBuffer cb_times_gamma_out_obj(cb_times_gamma_out);
-    CircularBuffer cb_beta_obj(cb_beta);
-    CircularBuffer cb_out_obj(cb_out);
+    CircularBuffer cb_reduce(cb_reduce_idx);
+    CircularBuffer cb_eps(cb_eps_idx);
+    CircularBuffer cb_var(cb_var_idx);
+    CircularBuffer cb_recip_sqrt_var(cb_recip_sqrt_var_idx);
+    CircularBuffer cb_norm_x_input(cb_norm_x_input_idx);
+    CircularBuffer cb_gamma(cb_gamma_idx);
+    CircularBuffer cb_x_normed(cb_x_normed_idx);
+    CircularBuffer cb_times_gamma_out(cb_times_gamma_out_idx);
+    CircularBuffer cb_beta(cb_beta_idx);
+    CircularBuffer cb_out(cb_out_idx);
 
-    cb_reduce_obj.wait_front(1);  // comes from the reader
-    cb_eps_obj.wait_front(1);     // comes from the reader
+    cb_reduce.wait_front(1);  // comes from the reader
+    cb_eps.wait_front(1);     // comes from the reader
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         constexpr int onetile = 1;
@@ -86,109 +87,109 @@ void kernel_main() {
         /*
          * Reduce stats input.
          * cb_stats = [sum(x0**2), sum(x1**2), ...]
-         * RMSNorm reduces sum(x**2) directly into cb_var for rsqrt computation.
+         * RMSNorm reduces sum(x**2) directly into cb_var_idx for rsqrt computation.
          * Uses auto-batched STREAMING mode - library handles CB lifecycle.
          */
-        compute_kernel_lib::reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, cb_stats, cb_reduce, cb_var>(
+        compute_kernel_lib::reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, cb_stats, cb_reduce_idx, cb_var_idx>(
             compute_kernel_lib::ReduceInputBlockShape::row(stats_tiles_cols));
 
         /*
          * 1/sqrt(var + eps)
          */
-        cb_var_obj.wait_front(1);
-        cb_recip_sqrt_var_obj.reserve_back(1);
-        reconfig_data_format(cb_var, cb_eps);
-        pack_reconfig_data_format(cb_recip_sqrt_var);
+        cb_var.wait_front(1);
+        cb_recip_sqrt_var.reserve_back(1);
+        reconfig_data_format(cb_var_idx, cb_eps_idx);
+        pack_reconfig_data_format(cb_recip_sqrt_var_idx);
 
-        add_tiles_init(cb_var, cb_eps);
+        add_tiles_init(cb_var_idx, cb_eps_idx);
         ACQ();
-        add_tiles(cb_var, cb_eps, 0, 0, 0);
+        add_tiles(cb_var_idx, cb_eps_idx, 0, 0, 0);
         rsqrt_tile_init<LEGACY_RSQRT>();
         rsqrt_tile<LEGACY_RSQRT>(0);
-        pack_tile(0, cb_recip_sqrt_var);
+        pack_tile(0, cb_recip_sqrt_var_idx);
         REL();
-        cb_recip_sqrt_var_obj.push_back(1);
-        cb_var_obj.pop_front(1);
+        cb_recip_sqrt_var.push_back(1);
+        cb_var.pop_front(1);
 
         /*
          * norm x
          * RMSNorm: X * 1/sqrt(E[X**2] + eps)
          */
 
-        uint32_t normed_output_cb = cb_x_normed;
+        uint32_t normed_output_cb_idx = cb_x_normed_idx;
         if constexpr (!do_gamma) {
-            normed_output_cb = cb_out;
+            normed_output_cb_idx = cb_out_idx;
         }
-        CircularBuffer normed_output_cb_obj(normed_output_cb);
+        CircularBuffer normed_output_cb(normed_output_cb_idx);
 
-        reconfig_data_format(cb_norm_x_input, cb_recip_sqrt_var);
-        pack_reconfig_data_format(normed_output_cb);
-        mul_bcast_cols_init_short(cb_norm_x_input, cb_recip_sqrt_var);
-        cb_recip_sqrt_var_obj.wait_front(1);
+        reconfig_data_format(cb_norm_x_input_idx, cb_recip_sqrt_var_idx);
+        pack_reconfig_data_format(normed_output_cb_idx);
+        mul_bcast_cols_init_short(cb_norm_x_input_idx, cb_recip_sqrt_var_idx);
+        cb_recip_sqrt_var.wait_front(1);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            cb_norm_x_input_obj.wait_front(blk);
-            normed_output_cb_obj.reserve_back(blk);
+            cb_norm_x_input.wait_front(blk);
+            normed_output_cb.reserve_back(blk);
             ACQ();
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                mul_tiles_bcast_cols(cb_norm_x_input, cb_recip_sqrt_var, wtr, 0, wtr);
-                pack_tile(wtr, normed_output_cb);
+                mul_tiles_bcast_cols(cb_norm_x_input_idx, cb_recip_sqrt_var_idx, wtr, 0, wtr);
+                pack_tile(wtr, normed_output_cb_idx);
             }
             REL();
-            normed_output_cb_obj.push_back(blk);
-            cb_norm_x_input_obj.pop_front(blk);
+            normed_output_cb.push_back(blk);
+            cb_norm_x_input.pop_front(blk);
         }
-        cb_recip_sqrt_var_obj.pop_front(1);
+        cb_recip_sqrt_var.pop_front(1);
 
         if constexpr (do_gamma) {
             /*
              * x_normed * gamma
              */
-            reconfig_data_format(cb_x_normed, cb_gamma);
-            pack_reconfig_data_format(cb_times_gamma_out);
-            cb_gamma_obj.wait_front(Wt);
-            mul_bcast_rows_init_short(cb_x_normed, cb_gamma);
+            reconfig_data_format(cb_x_normed_idx, cb_gamma_idx);
+            pack_reconfig_data_format(cb_times_gamma_out_idx);
+            cb_gamma.wait_front(Wt);
+            mul_bcast_rows_init_short(cb_x_normed_idx, cb_gamma_idx);
             for (uint32_t wt = 0; wt < Wt; wt += blk) {
-                cb_x_normed_obj.wait_front(blk);
-                cb_times_gamma_out_obj.reserve_back(blk);
+                cb_x_normed.wait_front(blk);
+                cb_times_gamma_out.reserve_back(blk);
                 ACQ();
                 for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                    mul_tiles_bcast_rows(cb_x_normed, cb_gamma, wtr, wt + wtr, wtr);
-                    pack_tile(wtr, cb_times_gamma_out);
+                    mul_tiles_bcast_rows(cb_x_normed_idx, cb_gamma_idx, wtr, wt + wtr, wtr);
+                    pack_tile(wtr, cb_times_gamma_out_idx);
                 }
                 REL();
-                cb_times_gamma_out_obj.push_back(blk);
-                cb_x_normed_obj.pop_front(blk);
+                cb_times_gamma_out.push_back(blk);
+                cb_x_normed.pop_front(blk);
             }
 
             if constexpr (do_beta) {
                 /*
                  * x_normed * gamma + beta
                  */
-                reconfig_data_format(cb_times_gamma_out, cb_beta);
-                pack_reconfig_data_format(cb_out);
-                cb_beta_obj.wait_front(Wt);
-                add_bcast_rows_init_short(cb_times_gamma_out, cb_beta);
+                reconfig_data_format(cb_times_gamma_out_idx, cb_beta_idx);
+                pack_reconfig_data_format(cb_out_idx);
+                cb_beta.wait_front(Wt);
+                add_bcast_rows_init_short(cb_times_gamma_out_idx, cb_beta_idx);
                 for (uint32_t wt = 0; wt < Wt; wt += blk) {
-                    cb_times_gamma_out_obj.wait_front(blk);
-                    cb_out_obj.reserve_back(blk);
+                    cb_times_gamma_out.wait_front(blk);
+                    cb_out.reserve_back(blk);
                     ACQ();
                     for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                        add_tiles_bcast_rows(cb_times_gamma_out, cb_beta, wtr, wt + wtr, wtr);
-                        pack_tile(wtr, cb_out);
+                        add_tiles_bcast_rows(cb_times_gamma_out_idx, cb_beta_idx, wtr, wt + wtr, wtr);
+                        pack_tile(wtr, cb_out_idx);
                     }
                     REL();
-                    cb_out_obj.push_back(blk);
-                    cb_times_gamma_out_obj.pop_front(blk);
+                    cb_out.push_back(blk);
+                    cb_times_gamma_out.pop_front(blk);
                 }
             }
         }
     }
-    cb_eps_obj.pop_front(1);
-    cb_reduce_obj.pop_front(1);
+    cb_eps.pop_front(1);
+    cb_reduce.pop_front(1);
     if constexpr (do_gamma) {
-        cb_gamma_obj.pop_front(Wt);
+        cb_gamma.pop_front(Wt);
     }
     if constexpr (do_beta) {
-        cb_beta_obj.pop_front(Wt);
+        cb_beta.pop_front(Wt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather_2d.cpp
@@ -14,6 +14,7 @@ For rmsnorm it computes E(x**2) and returns it as a one tile wide output
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
 #include "api/debug/dprint.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 ALWI void ACQ() {
@@ -46,6 +47,10 @@ void kernel_main() {
 
     binary_op_init_common(cb_inp, cb_reduce, cb_x2);
 
+    CircularBuffer cb_inp_obj(cb_inp);
+    CircularBuffer cb_reduce_obj(cb_reduce);
+    CircularBuffer cb_x2_obj(cb_x2);
+
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         /*
          * x**2
@@ -55,9 +60,9 @@ void kernel_main() {
         mul_tiles_init(cb_inp, cb_inp);
 
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            cb_wait_front(cb_inp, wt + blk);  // cumulative wait
+            cb_inp_obj.wait_front(wt + blk);  // cumulative wait
 
-            cb_reserve_back(cb_x2, blk);
+            cb_x2_obj.reserve_back(blk);
             ACQ();
 
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
@@ -66,7 +71,7 @@ void kernel_main() {
             }
             REL();
 
-            cb_push_back(cb_x2, blk);
+            cb_x2_obj.push_back(blk);
         }
 
         /*
@@ -80,8 +85,8 @@ void kernel_main() {
             cb_reduce,
             cb_out,
             compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
-        cb_pop_front(cb_inp, Wt);
-        cb_pop_front(cb_reduce, 1);
+        cb_inp_obj.pop_front(Wt);
+        cb_reduce_obj.pop_front(1);
     }
 
     // if merge core, we need to do a final sum on the tile in cb_x2 and then write the result to cb_out_final
@@ -90,12 +95,16 @@ void kernel_main() {
         constexpr uint32_t cb_out_final = tt::CBIndex::c_14;
         constexpr int dst0 = 0;
 
+        CircularBuffer cb_x2_merge_obj(cb_x2_merge);
+        CircularBuffer cb_zero_obj(cb_zero);
+        CircularBuffer cb_out_final_obj(cb_out_final);
+
         // Wait for all num_cores_y tiles
-        cb_wait_front(cb_x2_merge, num_cores_y);
-        cb_wait_front(cb_zero, 1);
+        cb_x2_merge_obj.wait_front(num_cores_y);
+        cb_zero_obj.wait_front(1);
 
         // Reserve output space
-        cb_reserve_back(cb_out_final, onetile);
+        cb_out_final_obj.reserve_back(onetile);
 
         // Initialize accumulation
         binary_op_init_common(cb_x2_merge, cb_zero, cb_out_final);
@@ -116,7 +125,7 @@ void kernel_main() {
         REL();
 
         // Push output and pop input
-        cb_push_back(cb_out_final, onetile);
-        cb_pop_front(cb_x2_merge, num_cores_y);
+        cb_out_final_obj.push_back(onetile);
+        cb_x2_merge_obj.pop_front(num_cores_y);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather_2d.cpp
@@ -37,41 +37,41 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr uint32_t cb_inp = tt::CBIndex::c_0;
-    constexpr uint32_t cb_reduce = tt::CBIndex::c_1;
+    constexpr uint32_t cb_inp_idx = tt::CBIndex::c_0;
+    constexpr uint32_t cb_reduce_idx = tt::CBIndex::c_1;
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
-    constexpr uint32_t cb_x2 = tt::CBIndex::c_6;  // x**2
-    constexpr uint32_t cb_zero = tt::CBIndex::c_13;
+    constexpr uint32_t cb_x2_idx = tt::CBIndex::c_6;  // x**2
+    constexpr uint32_t cb_zero_idx = tt::CBIndex::c_13;
 
-    binary_op_init_common(cb_inp, cb_reduce, cb_x2);
+    binary_op_init_common(cb_inp_idx, cb_reduce_idx, cb_x2_idx);
 
-    CircularBuffer cb_inp_obj(cb_inp);
-    CircularBuffer cb_reduce_obj(cb_reduce);
-    CircularBuffer cb_x2_obj(cb_x2);
+    CircularBuffer cb_inp(cb_inp_idx);
+    CircularBuffer cb_reduce(cb_reduce_idx);
+    CircularBuffer cb_x2(cb_x2_idx);
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         /*
          * x**2
          */
-        reconfig_data_format(cb_inp, cb_inp);
-        pack_reconfig_data_format(cb_x2);
-        mul_tiles_init(cb_inp, cb_inp);
+        reconfig_data_format(cb_inp_idx, cb_inp_idx);
+        pack_reconfig_data_format(cb_x2_idx);
+        mul_tiles_init(cb_inp_idx, cb_inp_idx);
 
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            cb_inp_obj.wait_front(wt + blk);  // cumulative wait
+            cb_inp.wait_front(wt + blk);  // cumulative wait
 
-            cb_x2_obj.reserve_back(blk);
+            cb_x2.reserve_back(blk);
             ACQ();
 
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                mul_tiles(cb_inp, cb_inp, wt + wtr, wt + wtr, wtr);
-                pack_tile(wtr, cb_x2, wt + wtr);
+                mul_tiles(cb_inp_idx, cb_inp_idx, wt + wtr, wt + wtr, wtr);
+                pack_tile(wtr, cb_x2_idx, wt + wtr);
             }
             REL();
 
-            cb_x2_obj.push_back(blk);
+            cb_x2.push_back(blk);
         }
 
         /*
@@ -81,51 +81,51 @@ void kernel_main() {
         compute_kernel_lib::reduce<
             PoolType::AVG,
             ReduceDim::REDUCE_ROW,
-            cb_x2,
-            cb_reduce,
+            cb_x2_idx,
+            cb_reduce_idx,
             cb_out,
             compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
-        cb_inp_obj.pop_front(Wt);
-        cb_reduce_obj.pop_front(1);
+        cb_inp.pop_front(Wt);
+        cb_reduce.pop_front(1);
     }
 
-    // if merge core, we need to do a final sum on the tile in cb_x2 and then write the result to cb_out_final
+    // if merge core, we need to do a final sum on the tile in cb_x2_idx and then write the result to cb_out_final_idx
     if (is_merge_core) {
-        constexpr uint32_t cb_x2_merge = tt::CBIndex::c_15;
-        constexpr uint32_t cb_out_final = tt::CBIndex::c_14;
+        constexpr uint32_t cb_x2_merge_idx = tt::CBIndex::c_15;
+        constexpr uint32_t cb_out_final_idx = tt::CBIndex::c_14;
         constexpr int dst0 = 0;
 
-        CircularBuffer cb_x2_merge_obj(cb_x2_merge);
-        CircularBuffer cb_zero_obj(cb_zero);
-        CircularBuffer cb_out_final_obj(cb_out_final);
+        CircularBuffer cb_x2_merge(cb_x2_merge_idx);
+        CircularBuffer cb_zero(cb_zero_idx);
+        CircularBuffer cb_out_final(cb_out_final_idx);
 
         // Wait for all num_cores_y tiles
-        cb_x2_merge_obj.wait_front(num_cores_y);
-        cb_zero_obj.wait_front(1);
+        cb_x2_merge.wait_front(num_cores_y);
+        cb_zero.wait_front(1);
 
         // Reserve output space
-        cb_out_final_obj.reserve_back(onetile);
+        cb_out_final.reserve_back(onetile);
 
         // Initialize accumulation
-        binary_op_init_common(cb_x2_merge, cb_zero, cb_out_final);
-        reconfig_data_format(cb_x2_merge, cb_zero);
-        pack_reconfig_data_format(cb_out_final);
-        add_tiles_init(cb_x2_merge, cb_zero, true);
+        binary_op_init_common(cb_x2_merge_idx, cb_zero_idx, cb_out_final_idx);
+        reconfig_data_format(cb_x2_merge_idx, cb_zero_idx);
+        pack_reconfig_data_format(cb_out_final_idx);
+        add_tiles_init(cb_x2_merge_idx, cb_zero_idx, true);
 
         // Acquire registers
         ACQ();
 
         // Add all 8 tiles together
         for (uint32_t i = 0; i < num_cores_y; i++) {
-            add_tiles(cb_x2_merge, cb_zero, i, 0, dst0);
+            add_tiles(cb_x2_merge_idx, cb_zero_idx, i, 0, dst0);
         }
 
         // Pack result
-        pack_tile(dst0, cb_out_final);
+        pack_tile(dst0, cb_out_final_idx);
         REL();
 
         // Push output and pop input
-        cb_out_final_obj.push_back(onetile);
-        cb_x2_merge_obj.pop_front(num_cores_y);
+        cb_out_final.push_back(onetile);
+        cb_x2_merge.pop_front(num_cores_y);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -255,7 +255,7 @@ void reduce_cb(bool use_prev_reduce, uint32_t cb_length_t) {
             if (use_prev_reduce) {
                 // At this point, DST[0] contains the current reduce result
                 // Load previous result into DST[1] and accumulate
-                cb_wait_front(cb_prev_out_id, 1);
+                CircularBuffer(cb_prev_out_id).wait_front(1);
                 reconfig_data_format_srca(cb_prev_out_id);
                 copy_tile_init(cb_prev_out_id);
                 copy_tile(cb_prev_out_id, 0, 1);
@@ -270,7 +270,7 @@ void reduce_cb(bool use_prev_reduce, uint32_t cb_length_t) {
                     add_binary_tile(0, 1, 0);  // add(DST[0], DST[1]) -> DST[0]
                 }
 
-                cb_pop_front(cb_prev_out_id, 1);
+                CircularBuffer(cb_prev_out_id).pop_front(1);
             }
             // If !use_prev_reduce, lambda is no-op (compiles away)
         });

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_sharded.cpp
@@ -231,7 +231,7 @@ void kernel_main() {
         // SUM reduce with reciprocal operation using PRELOADED mode
         // PRELOADED is correct for sharded - all tiles loaded at once
         // Auto-detects FP32 mode from ENABLE_FP32_DEST_ACC define
-        cb_wait_front(cb_exps, block_w);
+        cb_exps_obj.wait_front(block_w);
         compute_kernel_lib::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_ROW,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include "api/compute/cb_api.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 void kernel_main() {
@@ -44,5 +45,6 @@ void kernel_main() {
 
     // The reduce helper waits on the scaler CB but never pops it (the single scaler tile is
     // reused for the whole reduction). Pop it here so the CB is left balanced.
-    cb_pop_front(tt::CBIndex::c_2, 1);
+    CircularBuffer cb_scaler(tt::CBIndex::c_2);
+    cb_scaler.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -105,7 +105,7 @@ void kernel_main() {
         PACK((llk_pack_reduce_mask_clear()));
         // The scaler tile is waited once and reused for the whole reduction; pop it at the
         // end so the CB is left balanced.
-        cb_pop_front(cb_scaler, onetile);
+        cb_scaler_obj.pop_front(onetile);
         return;
     }
 


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to #45003. Completes the Device 2.0 kernel data-movement migration for the `normalization/` and `reduction/` operation directories through a mechanical API swap.

### Notes for reviewers

- Kernel-side only, compute kernels
- The swap: CB free-functions to `CircularBuffer` methods.
- `layernorm_post_allgather_welford.cpp` needed no edit — its only 1.x taint was transitive via `chain_llk.hpp`, so fixing the header resolves it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/norm-reduction-d2-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/norm-reduction-d2-cleanup)
