### PR TITLE
#47381: reconfig_data_format — always derive int8 state + add SrcOrder overload

### DIFF
--- a/.github/deprecations.json
+++ b/.github/deprecations.json
@@ -40,6 +40,14 @@
       "introduced_by_pr": 49070,
       "grace": "30d",
       "owners": ["ncvetkovicTT"]
+    },
+    {
+      "id": "reconfig-data-format-signature-change",
+      "description": "The reconfig_data_format / reconfig_data_format_srca / reconfig_data_format_srcb overloads that take <to_from_int8, is_tile_dim_reconfig_en> are deprecated (tt-metal#34499). int8/unsigned state is now always derived from the format (to_from_int8 is ignored, closing a latent stale-bit bug), and the two-source form gained a SrcOrder tag (added as a same-name overload with no default on src_order) so matmul stops swapping operands by hand. In-repo call sites are already migrated to the current API (reconfig_data_format<SrcOrder>() and reconfig_data_format_skip_int8()); these deprecated bool overloads remain only for external callers during the grace period. The cleanup PR deletes them and the now-vestigial to_from_int8 flag.",
+      "files": ["tt_metal/hw/inc/api/compute/reconfig_data_format.h"],
+      "introduced_by_pr": 49119,
+      "grace": "30d",
+      "owners": ["ncvetkovicTT"]
     }
   ]
 }

--- a/.github/deprecations.json
+++ b/.github/deprecations.json
@@ -43,7 +43,7 @@
     },
     {
       "id": "reconfig-data-format-signature-change",
-      "description": "The reconfig_data_format / reconfig_data_format_srca / reconfig_data_format_srcb overloads that take <to_from_int8, is_tile_dim_reconfig_en> are deprecated (tt-metal#34499). int8/unsigned state is now always derived from the format (to_from_int8 is ignored, closing a latent stale-bit bug), and the two-source form gained a SrcOrder tag (added as a same-name overload with no default on src_order) so matmul stops swapping operands by hand. In-repo call sites are already migrated to the current API (reconfig_data_format<SrcOrder>() and reconfig_data_format_skip_int8()); these deprecated bool overloads remain only for external callers during the grace period. The cleanup PR deletes them and the now-vestigial to_from_int8 flag.",
+      "description": "The reconfig_data_format / reconfig_data_format_srca / reconfig_data_format_srcb overloads that take <to_from_int8, is_tile_dim_reconfig_en> are deprecated (tt-metal#34499). int8/unsigned state is now always derived from the format (to_from_int8 is ignored, closing a latent stale-bit bug), and the two-source form gained a SrcOrder tag (added as a same-name overload; an explicit <bool, ...> call still selects the deprecated bool overloads by type) so matmul stops swapping operands by hand. In-repo call sites are already migrated to the current API (reconfig_data_format<SrcOrder>() and reconfig_data_format_skip_int8()); these deprecated bool overloads remain only for external callers during the grace period. The cleanup PR deletes them and the now-vestigial to_from_int8 flag.",
       "files": ["tt_metal/hw/inc/api/compute/reconfig_data_format.h"],
       "introduced_by_pr": 49119,
       "grace": "30d",

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/reconfig_data_format.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/reconfig_data_format.rst
@@ -2,9 +2,15 @@ reconfig_data_format
 ====================
 
 
-.. doxygenfunction:: reconfig_data_format(const uint32_t srca_new_operand, const uint32_t srcb_new_operand)
-.. doxygenfunction:: reconfig_data_format(const uint32_t srca_old_operand, const uint32_t srca_new_operand, const uint32_t srcb_old_operand, const uint32_t srcb_new_operand)
+.. doxygenfunction:: reconfig_data_format(const uint32_t icb0_new_operand, const uint32_t icb1_new_operand)
+.. doxygenfunction:: reconfig_data_format(const uint32_t icb0_old_operand, const uint32_t icb0_new_operand, const uint32_t icb1_old_operand, const uint32_t icb1_new_operand)
 .. doxygenfunction:: reconfig_data_format_srca(const uint32_t srca_new_operand)
 .. doxygenfunction:: reconfig_data_format_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand)
 .. doxygenfunction:: reconfig_data_format_srcb(const uint32_t srcb_new_operand)
 .. doxygenfunction:: reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand)
+.. doxygenfunction:: reconfig_data_format_skip_int8(const uint32_t icb0_new_operand, const uint32_t icb1_new_operand)
+.. doxygenfunction:: reconfig_data_format_skip_int8(const uint32_t icb0_old_operand, const uint32_t icb0_new_operand, const uint32_t icb1_old_operand, const uint32_t icb1_new_operand)
+.. doxygenfunction:: reconfig_data_format_srca_skip_int8(const uint32_t srca_new_operand)
+.. doxygenfunction:: reconfig_data_format_srca_skip_int8(const uint32_t srca_old_operand, const uint32_t srca_new_operand)
+.. doxygenfunction:: reconfig_data_format_srcb_skip_int8(const uint32_t srcb_new_operand)
+.. doxygenfunction:: reconfig_data_format_srcb_skip_int8(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand)

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul_custom_compressed/kernels/matmul_custom_compressed_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul_custom_compressed/kernels/matmul_custom_compressed_kernel.cpp
@@ -56,7 +56,7 @@ void kernel_main() {
     deepseek_compute_kernel_init();
 
     // Initial HW config (in1→srcA bfp8, in0→srcB bf16)
-    reconfig_data_format<false, true>(cb_in1, cb_in0);
+    reconfig_data_format<SrcOrder::Reverse, true>(cb_in0, cb_in1);
     pack_reconfig_data_format<true>(cb_out);
 
     // Wait for inputs

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_reduce.hpp
@@ -452,7 +452,7 @@ private:
         // TODO: Fix this to account for actual dst size
         static_assert(CTArgs::num_tiles <= 8, "num_tiles must be less than or equal to 8");
 
-        reconfig_data_format<false, true>(CTArgs::cb_local, CTArgs::cb_remote);
+        reconfig_data_format<SrcOrder::Regular, true>(CTArgs::cb_local, CTArgs::cb_remote);
         pack_reconfig_data_format<true>(CTArgs::cb_out);
         pack_block_contiguous_init(CTArgs::cb_out);
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
@@ -313,7 +313,7 @@ struct CreateQHeads {
             // This ensures proper hardware state between tilize_block calls.
             constexpr uint32_t nope_num_chunks = 2;
             uint32_t nope_chunk = args.nope_tiles / nope_num_chunks;
-            reconfig_data_format_srca<false, true>(args.receiver_in_cb);
+            reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(args.receiver_in_cb);
             pack_reconfig_data_format<true>(args.out_cb);
             tilize_init(args.receiver_in_cb, args.nope_tiles, args.out_cb);
             // For safety

--- a/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
@@ -110,7 +110,7 @@ struct DeepseekMoeGate {
             // ================================================================
 
             // Input indices CB should have the same tile shape as the input CB
-            reconfig_data_format<false, true>(CTArgs::input_indices_cb, CTArgs::bias_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::input_indices_cb, CTArgs::bias_cb);
             // Output indices CB should have the same tile shape as the output CB
             pack_reconfig_data_format<true>(CTArgs::output_cb);
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
@@ -277,7 +277,8 @@ struct DRAMStreamingExpertsMatmul {
                 custom_mm_block_init<transpose, split_acc, dense_packing, CTArgs::fp32_dest_acc_en>(
                     CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             } else {
-                reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+                reconfig_data_format<SrcOrder::Reverse, /*is_tile_dim_reconfig_en=*/true>(
+                    CTArgs::cb_in0, CTArgs::cb_in1);
                 pack_reconfig_data_format<true>(CTArgs::cb_out);
                 custom_mm_block_init_short<transpose, split_acc, dense_packing>(
                     CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
@@ -274,7 +274,7 @@ struct DRAMStreamingMatmul {
                 custom_mm_block_init<transpose, split_acc, dense_packing, CTArgs::fp32_dest_acc_en>(
                     CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             } else {
-                reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+                reconfig_data_format<SrcOrder::Reverse, true>(CTArgs::cb_in0, CTArgs::cb_in1);
                 pack_reconfig_data_format<true>(CTArgs::cb_out);
                 custom_mm_block_init_short<transpose, split_acc, dense_packing>(
                     CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -249,7 +249,7 @@ struct DRAMStreamingMatmulCompressed {
             constexpr bool split_acc = true;
             constexpr bool dense_packing = false;
 
-            reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+            reconfig_data_format<SrcOrder::Reverse, true>(CTArgs::cb_in0, CTArgs::cb_in1);
             pack_reconfig_data_format<true>(CTArgs::cb_out);
             compressed::custom_mm_compressed_block_init_short<true, 1, split_acc, dense_packing>(
                 CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);

--- a/models/demos/deepseek_v3_b1/unified_kernels/eltwise_add.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/eltwise_add.hpp
@@ -122,7 +122,7 @@ struct EltwiseAdd {
             // ================================================================
             constexpr uint32_t num_tiles = CTArgs::num_tiles;
 
-            reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_in1);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::cb_in0, CTArgs::cb_in1);
             pack_reconfig_data_format<true>(CTArgs::cb_out);
             add_tiles_init(CTArgs::cb_in0, CTArgs::cb_in1);
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/eltwise_add_or_copy.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/eltwise_add_or_copy.hpp
@@ -120,7 +120,7 @@ struct EltwiseAddOrCopy {
 
             if (args.do_add) {
                 cb_wait_front(cb_in0_wait, cb_in0_wait_tiles);
-                reconfig_data_format<false, true>(cb_in0, cb_in1);
+                reconfig_data_format<SrcOrder::Regular, true>(cb_in0, cb_in1);
                 pack_reconfig_data_format<true>(cb_out);
                 add_tiles_init(cb_in0, cb_in1);
                 tile_regs_acquire();
@@ -135,7 +135,7 @@ struct EltwiseAddOrCopy {
                 tile_regs_release();
                 cb_pop_front(cb_in0_wait, cb_in0_wait_tiles);
             } else {
-                reconfig_data_format<false, true>(cb_in1, cb_in1);
+                reconfig_data_format<SrcOrder::Regular, true>(cb_in1, cb_in1);
                 pack_reconfig_data_format<true>(cb_out);
                 copy_tile_to_dst_init_short(cb_in1);
                 tile_regs_acquire();

--- a/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
@@ -191,7 +191,7 @@ struct EltwiseMul {
                     deepseek_compute_kernel_hw_startup<CTArgs::fp32_dest_acc_en>(
                         CTArgs::cb_in0, CTArgs::cb_scalar, CTArgs::cb_out);
                 } else {
-                    reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_scalar);
+                    reconfig_data_format<SrcOrder::Regular, true>(CTArgs::cb_in0, CTArgs::cb_scalar);
                     pack_reconfig_data_format<true>(CTArgs::cb_out);
                 }
                 deepseek_mul_tiles_bcast_scalar_init_short(CTArgs::cb_in0, CTArgs::cb_scalar);
@@ -215,7 +215,7 @@ struct EltwiseMul {
                 }
             } else {
                 // ---- Simple binary multiply: in0 * in1 -> dest ----
-                reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_in1);
+                reconfig_data_format<SrcOrder::Regular, true>(CTArgs::cb_in0, CTArgs::cb_in1);
                 pack_reconfig_data_format<true>(CTArgs::cb_out);
                 mul_tiles_init(CTArgs::cb_in0, CTArgs::cb_in1);
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -743,7 +743,7 @@ struct FlashMLADecode {
             constexpr bool transpose_k = true;
             constexpr bool transpose_v = false;
 
-            reconfig_data_format<false, true>(cb_k_in, cb_q_in);
+            reconfig_data_format<SrcOrder::Regular, true>(cb_k_in, cb_q_in);
             pack_reconfig_data_format<true>(cb_out_o);
             PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
             PACK(SFPU_UNARY_INIT_FN(
@@ -863,7 +863,7 @@ struct FlashMLADecode {
             constexpr uint32_t block_size = vDHt / num_blocks;
 
             if (do_reduce && num_cores_to_wait > 0) {
-                reconfig_data_format_srca<false, true>(cb_ms_in);
+                reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(cb_ms_in);
                 exp_tile_init<exp_approx_mode, scale_fp32>();
                 for (uint32_t i = 0; i < num_cores_to_wait - 1; i++) {
                     sdpa_tail<exp_approx_mode, false, block_size, num_blocks, scale_fp32, VectorMode::C>(

--- a/models/demos/deepseek_v3_b1/unified_kernels/gated_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gated_reduce.hpp
@@ -126,7 +126,7 @@ struct GatedReduce {
             // Init once before the loop
             // Assumes all input cbs are configured the same, and the intermediate cb is configured the same as the
             // output cb
-            reconfig_data_format<false, true>(args.group1_cb, args.group1_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(args.group1_cb, args.group1_cb);
             pack_reconfig_data_format<true>(args.out_cb);
             silu_tile_init();
             for (uint32_t k = 0; k < k_num_tiles; k++) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
@@ -93,7 +93,7 @@ struct GatherReduce {
     // number of 32x32 tiles so the half boundary is tile-aligned.
     // num_tiles is the 32x32 tile count per half (e.g. 2 for 56 rows).
     static inline void add_half_tiles(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
-        reconfig_data_format<false, true>(in_cb, in_cb);
+        reconfig_data_format<SrcOrder::Regular, true>(in_cb, in_cb);
         pack_reconfig_data_format<true>(out_cb);
         pack_block_contiguous_init(out_cb);
         add_tiles_init(in_cb, in_cb);

--- a/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
@@ -108,7 +108,7 @@ struct KNSlicedMatmul {
             constexpr bool finalize = true;
             constexpr uint32_t out_w = CTArgs::out_w;
 
-            reconfig_data_format<false, true>(args.weights_cb, args.act_cb);
+            reconfig_data_format<SrcOrder::Reverse, true>(args.act_cb, args.weights_cb);
             pack_reconfig_data_format<true>(args.out_cb);
 
             custom_mm_block_init_short<transpose, split_acc, dense_packing>(

--- a/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
@@ -351,7 +351,7 @@ struct KVCacheUpdate {
                 constexpr uint32_t NUM_CHUNKS = kv_cache_num_tiles / CHUNK_SIZE;
 
                 // Phase 1: Untilize into intermed_cb, pushing each chunk of CHUNK_SIZE
-                reconfig_data_format_srca<false, true>(kv_cache_input_cb);
+                reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(kv_cache_input_cb);
                 pack_reconfig_data_format<true>(kv_cache_intermed_cb);
                 pack_untilize_init<CHUNK_SIZE, CHUNK_SIZE>(kv_cache_input_cb, kv_cache_intermed_cb);
                 for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
@@ -364,7 +364,7 @@ struct KVCacheUpdate {
                 pack_untilize_uninit(kv_cache_intermed_cb);
 
                 // Phase 2: Tilize each chunk after NCRISC signals via sync CB
-                reconfig_data_format_srca<false, true>(kv_cache_intermed_sync_cb);
+                reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(kv_cache_intermed_sync_cb);
                 pack_reconfig_data_format<true>(kv_cache_output_cb);
                 tilize_init(kv_cache_intermed_sync_cb, CHUNK_SIZE, kv_cache_output_cb);
                 for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/local_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/local_reduce.hpp
@@ -67,7 +67,7 @@ struct LocalReduce {
             constexpr bool apply_silu = CTArgs::apply_silu;
 
             // Initialize operations before waiting for data
-            reconfig_data_format<false, true>(args.in_cb, args.in_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(args.in_cb, args.in_cb);
             pack_reconfig_data_format<true>(args.out_cb);
             add_tiles_init(args.in_cb, args.in_cb, true /* acc_to_dest */);
             if constexpr (apply_silu) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -125,7 +125,7 @@ struct Matmul {
             constexpr bool read_transposed = transpose && true;
             constexpr bool fuse_activation = CTArgs::fuse_sigmoid || CTArgs::fuse_silu;
             if constexpr (!skip_reconfig) {
-                reconfig_data_format<false, true>(args.in1, args.in0);
+                reconfig_data_format<SrcOrder::Reverse, true>(args.in0, args.in1);
                 pack_reconfig_data_format<true>(args.out);
             }
             custom_mm_block_init_short<transpose, split_acc, dense_packing>(args.in0, args.in1, args.out, out_w);

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
@@ -640,7 +640,7 @@ struct MatmulExpertCompressedDRAM {
             } else {
                 cb_wait_front(CTArgs::cb_in0, num_tiles_k);
             }
-            reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+            reconfig_data_format<SrcOrder::Reverse, true>(CTArgs::cb_in0, CTArgs::cb_in1);
             pack_reconfig_data_format<true>(CTArgs::cb_out);
             compressed_custom_mm_block_init_short<false, true, false>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
 
@@ -975,7 +975,7 @@ struct MatmulExpertCompressedDRAM {
                         // as silu_tile) so the tile_regs commit/wait flow is clean.
                         constexpr uint32_t silu_iterations = CTArgs::silu_tile_h / 2;
 
-                        reconfig_data_format_srca<false, true>(CTArgs::cb_out_silu);
+                        reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(CTArgs::cb_out_silu);
                         pack_reconfig_data_format<true>(CTArgs::cb_out_silu);
                         copy_tile_to_dst_init_short(CTArgs::cb_out_silu);
                         silu_tile_init();

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_sram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_sram.hpp
@@ -171,7 +171,7 @@ struct MatmulExpertCompressedSRAM {
                 reinterpret_cast<const volatile uint32_t*>(CTArgs::sram_base_addrs_l1_addr);
             const volatile uint32_t* fmt_base = reinterpret_cast<const volatile uint32_t*>(fmt_l1_addr_base);
 
-            reconfig_data_format<false, true>(cb_in1, cb_in0);
+            reconfig_data_format<SrcOrder::Reverse, true>(cb_in0, cb_in1);
             pack_reconfig_data_format<true>(cb_out);
             // cb_in0 metadata always advances by the full num_active_experts ×
             // num_tiles_k pages per iter (producer pads if data is compact). This

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
@@ -503,7 +503,7 @@ struct ReduceToAllB1 {
                 return;
             }
 
-            reconfig_data_format<false, true>(CTArgs::local_cb, CTArgs::received_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::local_cb, CTArgs::received_cb);
             pack_reconfig_data_format<true>(CTArgs::scratch_cb);
 
             // R1: local + received_R1

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
@@ -593,7 +593,7 @@ struct ReduceToOneB1 {
             }
 
             // Initialize for binary operations
-            reconfig_data_format<false, true>(CTArgs::local_cb, CTArgs::received_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::local_cb, CTArgs::received_cb);
             pack_reconfig_data_format<true>(CTArgs::scratch_cb);
             pack_block_contiguous_init(CTArgs::scratch_cb);
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
@@ -67,7 +67,7 @@ struct ResidualAdd {
 
             if constexpr (SkipAdd) {
                 // Pass-through: copy in0 to out, discard in1
-                reconfig_data_format<false, true>(args.in0_cb, args.in0_cb);
+                reconfig_data_format<SrcOrder::Regular, true>(args.in0_cb, args.in0_cb);
                 pack_reconfig_data_format<true>(args.out_cb);
                 pack_block_contiguous_init(args.out_cb);
                 copy_tile_to_dst_init_short(args.in0_cb);
@@ -84,7 +84,7 @@ struct ResidualAdd {
                 tile_regs_release();
             } else {
                 // Normal: matmul_out + shard(residual)
-                reconfig_data_format<false, true>(args.in0_cb, args.in1_cb);
+                reconfig_data_format<SrcOrder::Regular, true>(args.in0_cb, args.in1_cb);
                 pack_reconfig_data_format<true>(args.out_cb);
                 pack_block_contiguous_init(args.out_cb);
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
@@ -124,7 +124,7 @@ struct RMSNorm {
 #if defined(COMPILE_FOR_TRISC)
         void compute_rmsnorm(const ComputeArgs& args) {
             constexpr uint32_t num_tiles = CTArgs::num_tiles;
-            reconfig_data_format<false, true>(CTArgs::input_cb, CTArgs::input_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::input_cb, CTArgs::input_cb);
             pack_reconfig_data_format<true>(CTArgs::output_cb);
             pack_block_contiguous_init(CTArgs::output_cb);
             {

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -144,7 +144,7 @@ struct Rope {
             constexpr uint32_t Wt = CTArgs::Wt;
             constexpr uint32_t Ht = CTArgs::Ht;
             // Assumes all intermediate and output CBs are configured the same
-            reconfig_data_format_srcb<false, true>(args.in_cb);
+            reconfig_data_format_srcb</*is_tile_dim_reconfig_en=*/true>(args.in_cb);
             pack_reconfig_data_format<true>(args.out_cb);
 
             // ================================================================
@@ -161,7 +161,7 @@ struct Rope {
             // Main loop: process Ht heads, each head consumes Wt tiles
             // ================================================================
             for (uint32_t ht = 0; ht < Ht; ht++) {
-                reconfig_data_format_srca<false, true>(args.trans_mat_cb);
+                reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(args.trans_mat_cb);
                 matmul_init(args.in_cb, args.trans_mat_cb);
 
                 // Reserve intermediate and output buffers
@@ -191,7 +191,7 @@ struct Rope {
                 // ============================================================
                 // Step 2: cos_interm = input * cos (broadcast multiply)
                 // ============================================================
-                reconfig_data_format_srca<false, true>(args.in_cb);
+                reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(args.in_cb);
                 mul_bcast_rows_init_short(args.in_cb, args.cos_sin_cb);
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < Wt; ++j) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -354,7 +354,7 @@ void trisc_fused_softmax_top_p_sampling_block() {
         pack_tile(0, probs_cb);
         cb_push_back(probs_cb, 1);
         tile_regs_release();
-        reconfig_data_format_srca<false, true>(exp_cb, probs_cb);
+        reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(exp_cb, probs_cb);
         cb_wait_front(probs_cb, 1);
         cb_wait_front(p_cb, 1);
         tile_regs_acquire();

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -817,7 +817,7 @@ struct SdpaReduceWorker {
         void compute_impl([[maybe_unused]] const ComputeArgs& args) {
             constexpr VectorMode vector_mode = VectorMode::RC_custom;
 
-            reconfig_data_format<false, true>(CTArgs::cb_local_l, CTArgs::cb_local_l);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::cb_local_l, CTArgs::cb_local_l);
             pack_reconfig_data_format<true>(CTArgs::cb_l_out);
             exp_tile_init<EXP_APPROX_MODE>();
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -47,28 +47,28 @@ inline void llk_math_pack_sync_init() {
     _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, skip_int8>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, skip_int8>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, skip_int8>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -81,33 +81,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<is_fp32_dest_acc_en, skip_int8>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, skip_int8>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, skip_int8>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, skip_int8>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, skip_int8>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -98,11 +98,11 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_new_operand    New operand id to configure srcA for.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
@@ -111,7 +111,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size, face_r_dim, num_faces);
 }
 
@@ -122,11 +122,11 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srcb_new_operand    New operand id to configure srcB for.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
@@ -135,7 +135,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size, face_r_dim, num_faces);
 }
 
@@ -146,25 +146,25 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_old_operand    Currently configured srcA operand id.
  * @param  srca_new_operand    New srcA operand id to switch to.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srca_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srca_new_operand);
     } else if (
         get_operand_face_r_dim(old_srca_operand_id) != get_operand_face_r_dim(new_srca_operand_id) ||
         get_operand_num_faces(old_srca_operand_id) != get_operand_num_faces(new_srca_operand_id)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, skip_int8>(
             srca_new_operand);
     }
 }
@@ -176,25 +176,25 @@ inline void llk_unpack_reconfig_data_format_srca(
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srcb_old_operand    Currently configured srcB operand id.
  * @param  srcb_new_operand    New srcB operand id to switch to.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srcb_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srcb_new_operand);
     } else if (
         get_operand_face_r_dim(old_srcb_operand_id) != get_operand_face_r_dim(new_srcb_operand_id) ||
         get_operand_num_faces(old_srcb_operand_id) != get_operand_num_faces(new_srcb_operand_id)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, skip_int8>(
             srcb_new_operand);
     }
 }
@@ -204,16 +204,16 @@ inline void llk_unpack_reconfig_data_format_srcb(
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_new_operand    New srcA operand id.
  * @param  srcb_new_operand    New srcB operand id.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srcb_new_operand);
 }
 
 /**
@@ -222,22 +222,22 @@ inline void llk_unpack_reconfig_data_format(
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_old_operand    Currently configured srcA operand id.
  * @param  srca_new_operand    New srcA operand id.
  * @param  srcb_old_operand    Currently configured srcB operand id.
  * @param  srcb_new_operand    New srcB operand id.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         srcb_old_operand, srcb_new_operand);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -47,28 +47,28 @@ inline void llk_math_pack_sync_init() {
     _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, skip_int8>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, skip_int8>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, skip_int8>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -81,33 +81,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<is_fp32_dest_acc_en, skip_int8>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, skip_int8>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, skip_int8>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, skip_int8>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, skip_int8>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -98,11 +98,11 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_new_operand    New operand id to configure srcA for.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
@@ -111,7 +111,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size, face_r_dim, num_faces);
 }
 
@@ -122,11 +122,11 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srcb_new_operand    New operand id to configure srcB for.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
@@ -135,7 +135,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size, face_r_dim, num_faces);
 }
 
@@ -146,25 +146,25 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_old_operand    Currently configured srcA operand id.
  * @param  srca_new_operand    New srcA operand id to switch to.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srca_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srca_new_operand);
     } else if (
         get_operand_face_r_dim(old_srca_operand_id) != get_operand_face_r_dim(new_srca_operand_id) ||
         get_operand_num_faces(old_srca_operand_id) != get_operand_num_faces(new_srca_operand_id)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, skip_int8>(
             srca_new_operand);
     }
 }
@@ -176,25 +176,25 @@ inline void llk_unpack_reconfig_data_format_srca(
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srcb_old_operand    Currently configured srcB operand id.
  * @param  srcb_new_operand    New srcB operand id to switch to.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srcb_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srcb_new_operand);
     } else if (
         get_operand_face_r_dim(old_srcb_operand_id) != get_operand_face_r_dim(new_srcb_operand_id) ||
         get_operand_num_faces(old_srcb_operand_id) != get_operand_num_faces(new_srcb_operand_id)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, skip_int8>(
             srcb_new_operand);
     }
 }
@@ -204,16 +204,16 @@ inline void llk_unpack_reconfig_data_format_srcb(
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_new_operand    New srcA operand id.
  * @param  srcb_new_operand    New srcB operand id.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(srcb_new_operand);
 }
 
 /**
@@ -222,22 +222,22 @@ inline void llk_unpack_reconfig_data_format(
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
+ * @tparam skip_int8           Skip re-deriving the SrcUnsigned bit from the new format; leave false unless the
+ *                             caller guarantees no Int8/UInt8/Int32 boundary is crossed (tt-metal#34499).
  * @param  srca_old_operand    Currently configured srcA operand id.
  * @param  srca_new_operand    New srcA operand id.
  * @param  srcb_old_operand    Currently configured srcB operand id.
  * @param  srcb_new_operand    New srcB operand id.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, skip_int8>(
         srcb_old_operand, srcb_new_operand);
 }
 

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "api/compute/common.h"
+#include "api/compute/src_order.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
 
 #ifdef TRISC_UNPACK
@@ -16,28 +17,6 @@
 #endif
 
 namespace ckernel {
-
-// clang-format off
-/**
- * Describes how the two input circular buffers map onto the source registers (SrcA/SrcB) of the
- * compute engine. This matters because compute_kernel_hw_startup() programs per-source-register
- * state (data formats, tile/face dimensions, tile sizes) and that state must match the operand
- * ordering of the operation that follows.
- *
- *  - SrcOrder::Regular : icb0 -> SrcA, icb1 -> SrcB. This is the natural ordering used by virtually
- *                        every operation (e.g. eltwise binary, where in0 -> SrcA and in1 -> SrcB).
- *  - SrcOrder::Reverse : icb0 -> SrcB, icb1 -> SrcA. The operands are mapped onto the source registers
- *                        in reverse. Matmul is the operation that needs this today: in0 (the "A" /
- *                        activations operand) is loaded into SrcB, while in1 (the "B" / weights operand)
- *                        is loaded into SrcA. Passing this tag lets the kernel keep calling startup with
- *                        the natural (in0, in1) argument order while startup programs the source
- *                        registers in the reversed order such an operation requires.
- */
-// clang-format on
-enum class SrcOrder : uint8_t {
-    Regular = 0,  // icb0 -> SrcA, icb1 -> SrcB
-    Reverse = 1,  // icb0 -> SrcB, icb1 -> SrcA
-};
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -90,7 +90,7 @@ ALWI void reconfig_df_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_
 // SrcOrder is added as a same-name overload with no default on src_order, so a plain reconfig_data_format(a, b) call
 // resolves to the functions below while an explicit reconfig_data_format<false, true>(...) still resolves to the
 // deprecated bool overloads (further down). Those bool overloads carry the removed to_from_int8 flag, are deprecated,
-// and work until 2026-08-15; the cleanup PR deletes them and their now-vestigial flag.
+// and work until 2026-08-20; the cleanup PR deletes them and their now-vestigial flag.
 //
 // NOTE(ARCH_QUASAR): On Quasar, buffer descriptors are programmed into the unpack MOP at op init. reconfig_data_format
 // only reprograms THCON data formats (gasket), not the MOP. When operands or buffer descriptors change, call the op
@@ -239,7 +239,7 @@ ALWI void reconfig_data_format_srcb_skip_int8(const uint32_t srcb_old_operand, c
 
 // -------------------------------------------------------------------------------------------------------------------
 // Deprecated (tt-metal#34499). These keep the old <to_from_int8, is_tile_dim_reconfig_en> signature and work until
-// 2026-08-15. to_from_int8 is now ignored: the int8/unsigned state is always re-derived from the format, so callers
+// 2026-08-20. to_from_int8 is now ignored: the int8/unsigned state is always re-derived from the format, so callers
 // get the fix for free. Move to reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8() when you know
 // no int8 boundary is crossed). The cleanup PR removes these overloads and the now-vestigial to_from_int8 flag.
 //
@@ -252,12 +252,12 @@ ALWI void reconfig_data_format_srcb_skip_int8(const uint32_t srcb_old_operand, c
 // -------------------------------------------------------------------------------------------------------------------
 
 /// \cond DEPRECATED_RECONFIG_DATA_FORMAT (excluded from published docs; overloads the current API by template only)
-#define RECONFIG_DF_DEPRECATED(new_fn)                                                                             \
-    [[deprecated("reconfig_data_format signature is changing (SrcOrder support; int8 state always derived). Use " \
-                 new_fn "() or the *_skip_int8 variant. This overload works until 2026-08-15. See tt-metal#34499.")]]
+#define RECONFIG_DF_DEPRECATED(new_fn)                                                                              \
+    [[deprecated("This call to reconfig_data_format_* will be removed after August 20th 2026 (tt-metal#34499). Use " \
+                 new_fn "() or the *_skip_int8 variant; int8/unsigned state is now always derived from the format.")]]
 
 /**
- * @deprecated Use reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8()). Kept until 2026-08-15;
+ * @deprecated Use reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8()). Kept until 2026-08-20;
  * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
 template <bool to_from_int8, bool is_tile_dim_reconfig_en>
@@ -273,7 +273,7 @@ ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t s
 }
 
 /**
- * @deprecated Use reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8()). Kept until 2026-08-15;
+ * @deprecated Use reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8()). Kept until 2026-08-20;
  * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
 template <bool to_from_int8, bool is_tile_dim_reconfig_en>
@@ -294,7 +294,7 @@ ALWI void reconfig_data_format(
 }
 
 /**
- * @deprecated Use reconfig_data_format_srca() (or reconfig_data_format_srca_skip_int8()). Kept until 2026-08-15;
+ * @deprecated Use reconfig_data_format_srca() (or reconfig_data_format_srca_skip_int8()). Kept until 2026-08-20;
  * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
 template <bool to_from_int8, bool is_tile_dim_reconfig_en>
@@ -310,7 +310,7 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
 }
 
 /**
- * @deprecated Use reconfig_data_format_srca() (or reconfig_data_format_srca_skip_int8()). Kept until 2026-08-15;
+ * @deprecated Use reconfig_data_format_srca() (or reconfig_data_format_srca_skip_int8()). Kept until 2026-08-20;
  * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
 template <bool to_from_int8, bool is_tile_dim_reconfig_en>
@@ -326,7 +326,7 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint3
 }
 
 /**
- * @deprecated Use reconfig_data_format_srcb() (or reconfig_data_format_srcb_skip_int8()). Kept until 2026-08-15;
+ * @deprecated Use reconfig_data_format_srcb() (or reconfig_data_format_srcb_skip_int8()). Kept until 2026-08-20;
  * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
 template <bool to_from_int8, bool is_tile_dim_reconfig_en>
@@ -342,7 +342,7 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
 }
 
 /**
- * @deprecated Use reconfig_data_format_srcb() (or reconfig_data_format_srcb_skip_int8()). Kept until 2026-08-15;
+ * @deprecated Use reconfig_data_format_srcb() (or reconfig_data_format_srcb_skip_int8()). Kept until 2026-08-20;
  * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
 template <bool to_from_int8, bool is_tile_dim_reconfig_en>

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -87,10 +87,11 @@ ALWI void reconfig_df_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_
 //   2. SrcOrder: the two-source reconfig now takes operands in natural (icb0, icb1) order and maps them onto
 //      SrcA/SrcB from a SrcOrder tag, so matmul no longer swaps operands by hand (mirrors compute_kernel_hw_startup).
 //
-// SrcOrder is added as a same-name overload with no default on src_order, so a plain reconfig_data_format(a, b) call
-// resolves to the functions below while an explicit reconfig_data_format<false, true>(...) still resolves to the
-// deprecated bool overloads (further down). Those bool overloads carry the removed to_from_int8 flag, are deprecated,
-// and work until 2026-08-20; the cleanup PR deletes them and their now-vestigial flag.
+// SrcOrder is added as a same-name overload whose template params all default, so a plain reconfig_data_format(a, b)
+// call resolves to the functions below -- the deprecated bool overloads (further down) have no template defaults, so
+// they cannot win a bare call. An explicit reconfig_data_format<false, true>(...) instead selects those deprecated
+// overloads because a bool cannot bind to the SrcOrder first param. Those bool overloads carry the removed to_from_int8
+// flag, are deprecated, and work until 2026-08-20; the cleanup PR deletes them and their now-vestigial flag.
 //
 // NOTE(ARCH_QUASAR): On Quasar, buffer descriptors are programmed into the unpack MOP at op init. reconfig_data_format
 // only reprograms THCON data formats (gasket), not the MOP. When operands or buffer descriptors change, call the op

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -242,6 +242,13 @@ ALWI void reconfig_data_format_srcb_skip_int8(const uint32_t srcb_old_operand, c
 // 2026-08-15. to_from_int8 is now ignored: the int8/unsigned state is always re-derived from the format, so callers
 // get the fix for free. Move to reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8() when you know
 // no int8 boundary is crossed). The cleanup PR removes these overloads and the now-vestigial to_from_int8 flag.
+//
+// MIGRATION CAVEAT (srca/srcb): the new reconfig_data_format_srca/_srcb take ONE bool template arg
+// (is_tile_dim_reconfig_en), the old ones took two (to_from_int8, is_tile_dim_reconfig_en). A one-arg call like
+// reconfig_data_format_srca<true>(...) now binds true to is_tile_dim_reconfig_en (new), not to_from_int8 (old) --
+// it compiles with no deprecation warning and reprograms tile/face geometry. The [[deprecated]] shim cannot catch
+// this (the two-arg form still binds to the deprecated overload and warns). All in-repo call sites are migrated;
+// external callers must drop the leading to_from_int8 arg (int8 state is derived regardless).
 // -------------------------------------------------------------------------------------------------------------------
 
 /// \cond DEPRECATED_RECONFIG_DATA_FORMAT (excluded from published docs; overloads the current API by template only)

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -6,6 +6,7 @@
 
 #include "common_globals.h"
 #include "sanitizer/api.h"
+#include "api/compute/src_order.h"
 
 #ifdef TRISC_PACK
 #include "llk_pack_common_api.h"
@@ -14,15 +15,246 @@
 
 namespace ckernel {
 
+namespace detail {
+
+// Shared implementation for the reconfig_data_format family. The public entry points pick is_tile_dim_reconfig_en
+// (threaded through from the caller) and skip_int8 (hardcoded per public function: false to re-derive the int8/unsigned
+// state from the format, true to skip it); every public function funnels through these helpers so the primary,
+// deprecated, and _skip_int8 surfaces stay in lockstep.
+
+// p_dim_stride_target is declared only on the unpack thread (via the unpack API header). This helper, and every other
+// reference to that type, therefore lives under TRISC_UNPACK and is called only inside UNPACK((...)) -- which expands to
+// nothing on the math/pack threads, so the type is never named there (naming it unconditionally breaks the math build).
+#ifdef TRISC_UNPACK
+constexpr p_dim_stride_target dim_stride_of(bool is_tile_dim_reconfig_en) {
+    return is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE;
+}
+#endif
+
+template <bool is_tile_dim_reconfig_en, bool skip_int8>
+ALWI void reconfig_df_both(const uint32_t src_a_operand, const uint32_t src_b_operand) {
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, dim_stride_of(is_tile_dim_reconfig_en), skip_int8>(
+        src_a_operand, src_b_operand)));
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, skip_int8>(src_a_operand, src_b_operand)));
+}
+
+template <bool is_tile_dim_reconfig_en, bool skip_int8>
+ALWI void reconfig_df_both(
+    const uint32_t src_a_old_operand,
+    const uint32_t src_a_new_operand,
+    const uint32_t src_b_old_operand,
+    const uint32_t src_b_new_operand) {
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, dim_stride_of(is_tile_dim_reconfig_en), skip_int8>(
+        src_a_old_operand, src_a_new_operand, src_b_old_operand, src_b_new_operand)));
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, skip_int8>(
+        src_a_old_operand, src_a_new_operand, src_b_old_operand, src_b_new_operand)));
+}
+
+template <bool is_tile_dim_reconfig_en, bool skip_int8>
+ALWI void reconfig_df_srca(const uint32_t srca_new_operand) {
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, dim_stride_of(is_tile_dim_reconfig_en), skip_int8>(
+        srca_new_operand)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, skip_int8>(srca_new_operand)));
+}
+
+template <bool is_tile_dim_reconfig_en, bool skip_int8>
+ALWI void reconfig_df_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand) {
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, dim_stride_of(is_tile_dim_reconfig_en), skip_int8>(
+        srca_old_operand, srca_new_operand)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, skip_int8>(srca_old_operand, srca_new_operand)));
+}
+
+template <bool is_tile_dim_reconfig_en, bool skip_int8>
+ALWI void reconfig_df_srcb(const uint32_t srcb_new_operand) {
+    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE, dim_stride_of(is_tile_dim_reconfig_en), skip_int8>(
+        srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, skip_int8>(srcb_new_operand)));
+}
+
+template <bool is_tile_dim_reconfig_en, bool skip_int8>
+ALWI void reconfig_df_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand) {
+    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE, dim_stride_of(is_tile_dim_reconfig_en), skip_int8>(
+        srcb_old_operand, srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, skip_int8>(srcb_old_operand, srcb_new_operand)));
+}
+
+}  // namespace detail
+
+// The reconfig_data_format signature is changing (tt-metal#34499). Two things move at once:
+//   1. int8 fix: the reconfig now always re-derives the int8/unsigned state (Src{A,B}Unsigned on unpack,
+//      INT8_math_enabled on math) from the new format. The old to_from_int8 flag defaulted to false and was never
+//      set, so those bits went stale when a reconfig crossed an int8 boundary and the math was wrong.
+//   2. SrcOrder: the two-source reconfig now takes operands in natural (icb0, icb1) order and maps them onto
+//      SrcA/SrcB from a SrcOrder tag, so matmul no longer swaps operands by hand (mirrors compute_kernel_hw_startup).
+//
+// SrcOrder is added as a same-name overload with no default on src_order, so a plain reconfig_data_format(a, b) call
+// resolves to the functions below while an explicit reconfig_data_format<false, true>(...) still resolves to the
+// deprecated bool overloads (further down). Those bool overloads carry the removed to_from_int8 flag, are deprecated,
+// and work until 2026-08-15; the cleanup PR deletes them and their now-vestigial flag.
+//
+// NOTE(ARCH_QUASAR): On Quasar, buffer descriptors are programmed into the unpack MOP at op init. reconfig_data_format
+// only reprograms THCON data formats (gasket), not the MOP. When operands or buffer descriptors change, call the op
+// init again for the new operand pair before the next unpack operation.
+
 /**
- * Helper function to reconfigure srca and srcb data formats.
- *
- * NOTE(ARCH_QUASAR): On Quasar, buffer descriptors are programmed into the unpack MOP at op init.
- * reconfig_data_format only reprograms THCON data formats (gasket), not the MOP. When operands or
- * DFB/buffer descriptors change, call the op init again for the new
- * operand pair before the next unpack operation.
+ * Reconfigures the srcA and srcB unpacker/math data formats for new operands, always re-deriving the int8/unsigned
+ * state from the new formats. Operands are passed in natural (icb0, icb1) order; src_order selects how they map onto
+ * SrcA/SrcB (SrcOrder::Reverse maps icb0 -> SrcB and icb1 -> SrcA, so matmul can pass its operands unswapped, matching
+ * compute_kernel_hw_startup). Set is_tile_dim_reconfig_en when the new tile/face geometry differs from the current one.
  */
-template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <SrcOrder src_order = SrcOrder::Regular, bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format(const uint32_t icb0_new_operand, const uint32_t icb1_new_operand) {
+    LLK_SAN_FUNCTION();
+    constexpr bool reverse = (src_order == SrcOrder::Reverse);
+    detail::reconfig_df_both<is_tile_dim_reconfig_en, false>(
+        reverse ? icb1_new_operand : icb0_new_operand, reverse ? icb0_new_operand : icb1_new_operand);
+}
+
+/**
+ * Conditional variant of reconfig_data_format: reconfigures only the sources whose format differs between the old
+ * and new operand. Operands are in natural (icb0, icb1) order and honor src_order as above.
+ */
+template <SrcOrder src_order = SrcOrder::Regular, bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format(
+    const uint32_t icb0_old_operand,
+    const uint32_t icb0_new_operand,
+    const uint32_t icb1_old_operand,
+    const uint32_t icb1_new_operand) {
+    LLK_SAN_FUNCTION();
+    constexpr bool reverse = (src_order == SrcOrder::Reverse);
+    detail::reconfig_df_both<is_tile_dim_reconfig_en, false>(
+        reverse ? icb1_old_operand : icb0_old_operand,
+        reverse ? icb1_new_operand : icb0_new_operand,
+        reverse ? icb0_old_operand : icb1_old_operand,
+        reverse ? icb0_new_operand : icb1_new_operand);
+}
+
+/**
+ * Reconfigures the srcA data format for a new operand, always re-deriving the int8/unsigned state from the new format.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srca<is_tile_dim_reconfig_en, false>(srca_new_operand);
+}
+
+/**
+ * Reconfigures the srcA data format only if the new operand's format differs from the old one.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srca<is_tile_dim_reconfig_en, false>(srca_old_operand, srca_new_operand);
+}
+
+/**
+ * Reconfigures the srcB data format for a new operand, always re-deriving the int8/unsigned state from the new format.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srcb<is_tile_dim_reconfig_en, false>(srcb_new_operand);
+}
+
+/**
+ * Reconfigures the srcB data format only if the new operand's format differs from the old one.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srcb<is_tile_dim_reconfig_en, false>(srcb_old_operand, srcb_new_operand);
+}
+
+// Perf variant: skips re-deriving the int8/unsigned state (the old to_from_int8 == false behavior). Use it only when
+// the caller knows the reconfig never crosses an Int8/UInt8/Int32 boundary and wants to avoid the extra register write.
+// The two-source overloads take operands in natural (icb0, icb1) order and honor SrcOrder like reconfig_data_format.
+
+/**
+ * Same as reconfig_data_format, but skips re-deriving the int8/unsigned state (the old to_from_int8 == false
+ * behavior). Use only when the caller knows the reconfig never crosses an Int8/UInt8/Int32 boundary and wants to
+ * avoid the extra register write.
+ */
+template <SrcOrder src_order = SrcOrder::Regular, bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_skip_int8(const uint32_t icb0_new_operand, const uint32_t icb1_new_operand) {
+    LLK_SAN_FUNCTION();
+    constexpr bool reverse = (src_order == SrcOrder::Reverse);
+    detail::reconfig_df_both<is_tile_dim_reconfig_en, true>(
+        reverse ? icb1_new_operand : icb0_new_operand, reverse ? icb0_new_operand : icb1_new_operand);
+}
+
+/**
+ * Conditional variant of reconfig_data_format_skip_int8: reconfigures only sources whose format differs, without
+ * re-deriving the int8/unsigned state.
+ */
+template <SrcOrder src_order = SrcOrder::Regular, bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_skip_int8(
+    const uint32_t icb0_old_operand,
+    const uint32_t icb0_new_operand,
+    const uint32_t icb1_old_operand,
+    const uint32_t icb1_new_operand) {
+    LLK_SAN_FUNCTION();
+    constexpr bool reverse = (src_order == SrcOrder::Reverse);
+    detail::reconfig_df_both<is_tile_dim_reconfig_en, true>(
+        reverse ? icb1_old_operand : icb0_old_operand,
+        reverse ? icb1_new_operand : icb0_new_operand,
+        reverse ? icb0_old_operand : icb1_old_operand,
+        reverse ? icb0_new_operand : icb1_new_operand);
+}
+
+/**
+ * reconfig_data_format_srca without re-deriving the int8/unsigned state. See reconfig_data_format_skip_int8.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srca_skip_int8(const uint32_t srca_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srca<is_tile_dim_reconfig_en, true>(srca_new_operand);
+}
+
+/**
+ * Conditional srcA reconfig without re-deriving the int8/unsigned state. See reconfig_data_format_skip_int8.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srca_skip_int8(const uint32_t srca_old_operand, const uint32_t srca_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srca<is_tile_dim_reconfig_en, true>(srca_old_operand, srca_new_operand);
+}
+
+/**
+ * reconfig_data_format_srcb without re-deriving the int8/unsigned state. See reconfig_data_format_skip_int8.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srcb_skip_int8(const uint32_t srcb_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srcb<is_tile_dim_reconfig_en, true>(srcb_new_operand);
+}
+
+/**
+ * Conditional srcB reconfig without re-deriving the int8/unsigned state. See reconfig_data_format_skip_int8.
+ */
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void reconfig_data_format_srcb_skip_int8(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand) {
+    LLK_SAN_FUNCTION();
+    detail::reconfig_df_srcb<is_tile_dim_reconfig_en, true>(srcb_old_operand, srcb_new_operand);
+}
+
+// -------------------------------------------------------------------------------------------------------------------
+// Deprecated (tt-metal#34499). These keep the old <to_from_int8, is_tile_dim_reconfig_en> signature and work until
+// 2026-08-15. to_from_int8 is now ignored: the int8/unsigned state is always re-derived from the format, so callers
+// get the fix for free. Move to reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8() when you know
+// no int8 boundary is crossed). The cleanup PR removes these overloads and the now-vestigial to_from_int8 flag.
+// -------------------------------------------------------------------------------------------------------------------
+
+/// \cond DEPRECATED_RECONFIG_DATA_FORMAT (excluded from published docs; overloads the current API by template only)
+#define RECONFIG_DF_DEPRECATED(new_fn)                                                                             \
+    [[deprecated("reconfig_data_format signature is changing (SrcOrder support; int8 state always derived). Use " \
+                 new_fn "() or the *_skip_int8 variant. This overload works until 2026-08-15. See tt-metal#34499.")]]
+
+/**
+ * @deprecated Use reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8()). Kept until 2026-08-15;
+ * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
+ */
+template <bool to_from_int8, bool is_tile_dim_reconfig_en>
+RECONFIG_DF_DEPRECATED("reconfig_data_format<SrcOrder::Regular>")
 ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t srcb_new_operand) {
     LLK_SAN_FUNCTION();
 #ifdef ARCH_QUASAR
@@ -30,20 +262,15 @@ ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t s
     // math reconfig is a no-op.
     static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
 #endif
-    // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
-    UNPACK((llk_unpack_reconfig_data_format<
-            DST_ACCUM_MODE,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
-            to_from_int8>(srca_new_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(srca_new_operand, srcb_new_operand)));
+    detail::reconfig_df_both<is_tile_dim_reconfig_en, false>(srca_new_operand, srcb_new_operand);
 }
 
 /**
- * Helper function to reconfigure srca/srcb data formats, only if they differ from existing formats.
- *
- * NOTE(ARCH_QUASAR): See reconfig_data_format(srca_new_operand, srcb_new_operand).
+ * @deprecated Use reconfig_data_format<SrcOrder::Regular>() (or reconfig_data_format_skip_int8()). Kept until 2026-08-15;
+ * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
-template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool to_from_int8, bool is_tile_dim_reconfig_en>
+RECONFIG_DF_DEPRECATED("reconfig_data_format<SrcOrder::Regular>")
 ALWI void reconfig_data_format(
     const uint32_t srca_old_operand,
     const uint32_t srca_new_operand,
@@ -55,19 +282,16 @@ ALWI void reconfig_data_format(
     // math reconfig is a no-op.
     static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
 #endif
-    // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
-    UNPACK((llk_unpack_reconfig_data_format<
-            DST_ACCUM_MODE,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
-            to_from_int8>(srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(
-        srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
+    detail::reconfig_df_both<is_tile_dim_reconfig_en, false>(
+        srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand);
 }
 
 /**
- * Helper function to reconfigure srca data format.
+ * @deprecated Use reconfig_data_format_srca() (or reconfig_data_format_srca_skip_int8()). Kept until 2026-08-15;
+ * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
-template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool to_from_int8, bool is_tile_dim_reconfig_en>
+RECONFIG_DF_DEPRECATED("reconfig_data_format_srca")
 ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
     LLK_SAN_FUNCTION();
 #ifdef ARCH_QUASAR
@@ -75,18 +299,15 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
     // math reconfig is a no-op.
     static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
 #endif
-    // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
-    UNPACK((llk_unpack_reconfig_data_format_srca<
-            DST_ACCUM_MODE,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
-            to_from_int8>(srca_new_operand)));
-    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_new_operand)));
+    detail::reconfig_df_srca<is_tile_dim_reconfig_en, false>(srca_new_operand);
 }
 
 /**
- * Helper function to reconfigure srca input data format, only if it differs from existing format.
+ * @deprecated Use reconfig_data_format_srca() (or reconfig_data_format_srca_skip_int8()). Kept until 2026-08-15;
+ * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
-template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool to_from_int8, bool is_tile_dim_reconfig_en>
+RECONFIG_DF_DEPRECATED("reconfig_data_format_srca")
 ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand) {
     LLK_SAN_FUNCTION();
 #ifdef ARCH_QUASAR
@@ -94,18 +315,15 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint3
     // math reconfig is a no-op.
     static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
 #endif
-    // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
-    UNPACK((llk_unpack_reconfig_data_format_srca<
-            DST_ACCUM_MODE,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
-            to_from_int8>(srca_old_operand, srca_new_operand)));
-    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_old_operand, srca_new_operand)));
+    detail::reconfig_df_srca<is_tile_dim_reconfig_en, false>(srca_old_operand, srca_new_operand);
 }
 
 /**
- * Helper function to reconfigure srcb input data format.
+ * @deprecated Use reconfig_data_format_srcb() (or reconfig_data_format_srcb_skip_int8()). Kept until 2026-08-15;
+ * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
-template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool to_from_int8, bool is_tile_dim_reconfig_en>
+RECONFIG_DF_DEPRECATED("reconfig_data_format_srcb")
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
     LLK_SAN_FUNCTION();
 #ifdef ARCH_QUASAR
@@ -113,18 +331,15 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
     // math reconfig is a no-op.
     static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
 #endif
-    // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
-    UNPACK((llk_unpack_reconfig_data_format_srcb<
-            DST_ACCUM_MODE,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
-            to_from_int8>(srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_new_operand)));
+    detail::reconfig_df_srcb<is_tile_dim_reconfig_en, false>(srcb_new_operand);
 }
 
 /**
- * Helper function to reconfigure srcb input data format, only if it differs from existing format.
+ * @deprecated Use reconfig_data_format_srcb() (or reconfig_data_format_srcb_skip_int8()). Kept until 2026-08-15;
+ * to_from_int8 is ignored and the int8/unsigned state is always re-derived from the format. See tt-metal#34499.
  */
-template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool to_from_int8, bool is_tile_dim_reconfig_en>
+RECONFIG_DF_DEPRECATED("reconfig_data_format_srcb")
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand) {
     LLK_SAN_FUNCTION();
 #ifdef ARCH_QUASAR
@@ -132,13 +347,11 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint3
     // math reconfig is a no-op.
     static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
 #endif
-    // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
-    UNPACK((llk_unpack_reconfig_data_format_srcb<
-            DST_ACCUM_MODE,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
-            to_from_int8>(srcb_old_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_old_operand, srcb_new_operand)));
+    detail::reconfig_df_srcb<is_tile_dim_reconfig_en, false>(srcb_old_operand, srcb_new_operand);
 }
+
+#undef RECONFIG_DF_DEPRECATED
+/// \endcond
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
+++ b/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
@@ -186,9 +186,9 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
         if (m_enabled) {
 #ifdef ARCH_QUASAR
             // Quasar unpack reconfig does not support stride/tile-dim changes; force is_tile_dim_reconfig_en=false.
-            reconfig_data_format_srca<false /* to_from_int8 */, false /* is_tile_dim_reconfig_en */>(m_srca_cb, cb);
+            reconfig_data_format_srca<false /* is_tile_dim_reconfig_en */>(m_srca_cb, cb);
 #else
-            reconfig_data_format_srca<false /* to_from_int8 */, true /* is_tile_dim_reconfig_en */>(m_srca_cb, cb);
+            reconfig_data_format_srca<true /* is_tile_dim_reconfig_en */>(m_srca_cb, cb);
 #endif
         }
 
@@ -201,9 +201,9 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
         if (m_enabled) {
 #ifdef ARCH_QUASAR
             // Quasar unpack reconfig does not support stride/tile-dim changes; force is_tile_dim_reconfig_en=false.
-            reconfig_data_format_srcb<false /* to_from_int8 */, false /* is_tile_dim_reconfig_en */>(m_srcb_cb, cb);
+            reconfig_data_format_srcb<false /* is_tile_dim_reconfig_en */>(m_srcb_cb, cb);
 #else
-            reconfig_data_format_srcb<false /* to_from_int8 */, true /* is_tile_dim_reconfig_en */>(m_srcb_cb, cb);
+            reconfig_data_format_srcb<true /* is_tile_dim_reconfig_en */>(m_srcb_cb, cb);
 #endif
         }
 

--- a/tt_metal/hw/inc/api/compute/src_order.h
+++ b/tt_metal/hw/inc/api/compute/src_order.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Describes how the two input circular buffers map onto the source registers (SrcA/SrcB) of the
+ * compute engine. This matters because both compute_kernel_hw_startup() and reconfig_data_format()
+ * program per-source-register state (data formats, tile/face dimensions, tile sizes) and that state
+ * must match the operand ordering of the operation that follows.
+ *
+ *  - SrcOrder::Regular : icb0 -> SrcA, icb1 -> SrcB. This is the natural ordering used by virtually
+ *                        every operation (e.g. eltwise binary, where in0 -> SrcA and in1 -> SrcB).
+ *  - SrcOrder::Reverse : icb0 -> SrcB, icb1 -> SrcA. The operands are mapped onto the source registers
+ *                        in reverse. Matmul is the operation that needs this today: in0 (the "A" /
+ *                        activations operand) is loaded into SrcB, while in1 (the "B" / weights operand)
+ *                        is loaded into SrcA. Passing this tag lets the kernel keep calling with the
+ *                        natural (in0, in1) argument order while the source registers are programmed in
+ *                        the reversed order such an operation requires.
+ */
+// clang-format on
+enum class SrcOrder : uint8_t {
+    Regular = 0,  // icb0 -> SrcA, icb1 -> SrcB
+    Reverse = 1,  // icb0 -> SrcB, icb1 -> SrcA
+};
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -324,7 +324,7 @@ ALWI void fast_tilize_init_with_dt_impl(uint32_t icb, uint32_t full_dim, uint32_
     // leave SrcB in a prior matmul-weights config that's incompatible with the
     // fast-tilize path, producing garbage output.
     UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(icb, icb)));
-    MATH((llk_math_reconfig_data_format<true, true>(icb, icb)));
+    MATH((llk_math_reconfig_data_format<true /*is_fp32_dest_acc_en*/, false /*skip_int8: derive int8 state*/>(icb, icb)));
 
     fast_tilize_init_impl<configure_remap>(icb, full_dim, ocb);
 }

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -124,6 +124,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/sentinel/sentinel_core.h
     inc/api/compute/sentinel/testing_spy.h
     inc/api/compute/softmax.h
+    inc/api/compute/src_order.h
     inc/api/compute/sub_int_sfpu.h
     inc/api/compute/tile_move_copy.h
     inc/api/compute/tilize.h

--- a/tt_metal/tt-llk/tests/python_tests/helpers/tensix.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/tensix.py
@@ -41,3 +41,12 @@ class TensixState:
         msg = f"Assertion FAILED: Tensix state mismatch:\n{''.join(diff)}"
         logger.error(msg)
         raise AssertionError(msg)
+
+    @classmethod
+    def assert_not_equal(cls, left: dict, right: dict) -> None:
+        if left != right:
+            return
+
+        msg = "Assertion FAILED: Tensix states are equal but were expected to differ"
+        logger.error(msg)
+        raise AssertionError(msg)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -450,6 +450,14 @@ class ADD_TOP_ROW(TemplateParameter):
 
 
 @dataclass
+class TO_FROM_INT8(TemplateParameter):
+    to_from_int8: bool
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool TO_FROM_INT8 = {str(self.to_from_int8).lower()};"
+
+
+@dataclass
 class IS_MAX_OP(TemplateParameter):
     """Compile-time flag: true for element-wise max, false for min."""
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -450,14 +450,6 @@ class ADD_TOP_ROW(TemplateParameter):
 
 
 @dataclass
-class TO_FROM_INT8(TemplateParameter):
-    to_from_int8: bool
-
-    def convert_to_cpp(self) -> str:
-        return f"constexpr bool TO_FROM_INT8 = {str(self.to_from_int8).lower()};"
-
-
-@dataclass
 class IS_MAX_OP(TemplateParameter):
     """Compile-time flag: true for element-wise max, false for min."""
 

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
@@ -10,7 +10,7 @@ from helpers.llk_params import (
 from helpers.param_config import parametrize
 from helpers.tensix import TensixState
 from helpers.test_config import TestConfig
-from helpers.test_variant_parameters import CONFIGURE_TEST_RUN_IDX, TO_FROM_INT8
+from helpers.test_variant_parameters import CONFIGURE_TEST_RUN_IDX
 
 
 def generate_valid_formats(
@@ -30,16 +30,14 @@ def generate_valid_formats(
     ]
 
 
-def get_valid_to_from_int8(
+def get_valid_dest_acc(
     formats: tuple[DataFormat, DataFormat, DataFormat, DataFormat],
-) -> bool:
-    return any(f.is_integer() for f in formats)
-
-
-def get_valid_dest_acc(to_from_int8: bool) -> bool:
+) -> list[DestAccumulation]:
+    # int8/int32 math requires FP32 dest accumulation (tt-metal#34499): the reconfig path now asserts
+    # this at runtime keyed on the format, so only exercise dest_acc=Yes when an integer format is involved.
     return (
         [DestAccumulation.Yes]
-        if to_from_int8
+        if any(f.is_integer() for f in formats)
         else [DestAccumulation.No, DestAccumulation.Yes]
     )
 
@@ -60,24 +58,22 @@ def get_valid_dest_acc(to_from_int8: bool) -> bool:
             DataFormat.UInt8,
         ]
     ),
-    to_from_int8=lambda formats: get_valid_to_from_int8(formats),
-    dest_acc=lambda to_from_int8: get_valid_dest_acc(to_from_int8),
+    dest_acc=lambda formats: get_valid_dest_acc(formats),
 )
 def test_math_reconfig(
     formats,
-    to_from_int8,
     dest_acc,
 ):
     prev_a, prev_b, next_a, next_b = formats
 
+    # tt-metal#34499: reconfig now always re-derives INT8_math_enabled from the new format, so a reconfig
+    # (run idx 1) must land in the same ALU state as a fresh hw_configure for the new formats (run idx 0),
+    # with no to_from_int8 opt-in flag -- including across an int8 boundary.
     configuration = TestConfig(
         "sources/state/reconfig/math_reconfig_test.cpp",
         FormatConfig(
             prev_a, prev_b, next_a, next_b, DataFormat.Float32
         ),  # ikr, but there is no less painful way to do this right now
-        templates=[
-            TO_FROM_INT8(to_from_int8),
-        ],
         runtimes=[
             CONFIGURE_TEST_RUN_IDX(0),
         ],

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
@@ -106,9 +106,13 @@ def generate_int8_boundary_formats() -> (
 
 @parametrize(
     formats=generate_int8_boundary_formats(),
+    dest_acc=lambda formats: [
+        DestAccumulation.Yes
+    ],  # int8/int32 math requires FP32 dest accumulation
 )
 def test_math_reconfig_skip_int8(
     formats,
+    dest_acc,
 ):
     prev_a, prev_b, next_a, next_b = formats
 
@@ -119,7 +123,7 @@ def test_math_reconfig_skip_int8(
         "sources/state/reconfig/math_reconfig_test.cpp",
         FormatConfig(prev_a, prev_b, next_a, next_b, DataFormat.Float32),
         runtimes=[CONFIGURE_TEST_RUN_IDX(1)],
-        dest_acc=DestAccumulation.Yes,  # int8/int32 math requires FP32 dest accumulation
+        dest_acc=dest_acc,
     )
 
     configuration.run()

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
@@ -106,13 +106,9 @@ def generate_int8_boundary_formats() -> (
 
 @parametrize(
     formats=generate_int8_boundary_formats(),
-    dest_acc=lambda formats: [
-        DestAccumulation.Yes
-    ],  # int8/int32 math requires FP32 dest accumulation
 )
 def test_math_reconfig_skip_int8(
     formats,
-    dest_acc,
 ):
     prev_a, prev_b, next_a, next_b = formats
 
@@ -123,7 +119,7 @@ def test_math_reconfig_skip_int8(
         "sources/state/reconfig/math_reconfig_test.cpp",
         FormatConfig(prev_a, prev_b, next_a, next_b, DataFormat.Float32),
         runtimes=[CONFIGURE_TEST_RUN_IDX(1)],
-        dest_acc=dest_acc,
+        dest_acc=DestAccumulation.Yes,  # int8/int32 math requires FP32 dest accumulation
     )
 
     configuration.run()

--- a/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/z_state/reconfig/test_math_reconfig.py
@@ -90,3 +90,47 @@ def test_math_reconfig(
     actual = TensixState.fetch(TestConfig.TENSIX_LOCATION)
 
     TensixState.assert_equal(expected, actual)
+
+
+def generate_int8_boundary_formats() -> (
+    list[tuple[DataFormat, DataFormat, DataFormat, DataFormat]]
+):
+    # Reconfigs that cross the INT8_math_enabled boundary: a float side (bit = 0) <-> an Int8/Int32 side (bit = 1).
+    # These are the cases where skip_int8 is observable -- it leaves the bit stale instead of re-deriving it.
+    floats = [DataFormat.Float16_b, DataFormat.Float16]
+    ints = [DataFormat.Int8, DataFormat.Int32]
+    return [(f, f, i, i) for f in floats for i in ints] + [
+        (i, i, f, f) for f in floats for i in ints
+    ]
+
+
+@parametrize(
+    formats=generate_int8_boundary_formats(),
+    dest_acc=lambda formats: [
+        DestAccumulation.Yes
+    ],  # int8/int32 math requires FP32 dest accumulation
+)
+def test_math_reconfig_skip_int8(
+    formats,
+    dest_acc,
+):
+    prev_a, prev_b, next_a, next_b = formats
+
+    # tt-metal#34499: the _skip_int8 path (run idx 2) leaves INT8_math_enabled untouched, whereas the default
+    # path (run idx 1) re-derives it. Across an int8 boundary the two must therefore land in different ALU
+    # states -- this is the coverage that pins the skip_int8=true branch and its "do not re-derive" contract.
+    configuration = TestConfig(
+        "sources/state/reconfig/math_reconfig_test.cpp",
+        FormatConfig(prev_a, prev_b, next_a, next_b, DataFormat.Float32),
+        runtimes=[CONFIGURE_TEST_RUN_IDX(1)],
+        dest_acc=dest_acc,
+    )
+
+    configuration.run()
+    derived = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    configuration.runtimes = [CONFIGURE_TEST_RUN_IDX(2)]
+    configuration.run()
+    skipped = TensixState.fetch(TestConfig.TENSIX_LOCATION)
+
+    TensixState.assert_not_equal(derived, skipped)

--- a/tt_metal/tt-llk/tests/sources/state/reconfig/math_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/state/reconfig/math_reconfig_test.cpp
@@ -29,6 +29,25 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "llk_math_common.h"
 #include "params.h"
 
+// Reconfigure only the source(s) whose format actually changes, at the requested skip_int8 setting.
+template <bool skip_int8>
+inline void reconfig_math(
+    const std::uint32_t prev_a, const std::uint32_t prev_b, const std::uint32_t next_a, const std::uint32_t next_b)
+{
+    if (prev_a != next_a && prev_b != next_b)
+    {
+        _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, skip_int8>(next_a, next_b);
+    }
+    else if (prev_a != next_a)
+    {
+        _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, skip_int8>(next_a);
+    }
+    else if (prev_b != next_b)
+    {
+        _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, skip_int8>(next_b);
+    }
+}
+
 void run_kernel(RUNTIME_PARAMETERS params)
 {
     const std::uint32_t prev_a = (std::uint32_t)params.formats.unpack_A_src;
@@ -48,24 +67,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
             /* srca_data_format */ prev_a,
             /* srcb_data_format */ prev_b);
 
-        // tt-metal#34499: the reconfig path now always re-derives INT8_math_enabled from the new format
-        // (skip_int8 defaults to false), so a reconfig must land in the same ALU state as a fresh
-        // hw_configure for the new formats -- including across an int8 boundary -- with no opt-in flag.
-        if (prev_a != next_a && prev_b != next_b)
+        // tt-metal#34499: run idx 1 uses the default (skip_int8 = false), which re-derives INT8_math_enabled
+        // from the new format, so the reconfig lands in the same ALU state as a fresh hw_configure -- even
+        // across an int8 boundary. Run idx 2 uses skip_int8 = true, which leaves INT8_math_enabled untouched,
+        // so across an int8 boundary it deliberately diverges from run idx 1 (the state stays stale).
+        if (params.CONFIGURE_TEST_RUN_IDX == 1)
         {
-            _llk_math_reconfig_data_format_<is_fp32_dest_acc_en>(
-                /* srca_data_format */ next_a,
-                /* srcb_data_format */ next_b);
+            reconfig_math</* skip_int8 */ false>(prev_a, prev_b, next_a, next_b);
         }
-        else if (prev_a != next_a)
+        else
         {
-            _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en>(
-                /* srca_data_format */ next_a);
-        }
-        else if (prev_b != next_b)
-        {
-            _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en>(
-                /* srcb_data_format */ next_b);
+            reconfig_math</* skip_int8 */ true>(prev_a, prev_b, next_a, next_b);
         }
     }
 }

--- a/tt_metal/tt-llk/tests/sources/state/reconfig/math_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/state/reconfig/math_reconfig_test.cpp
@@ -48,20 +48,23 @@ void run_kernel(RUNTIME_PARAMETERS params)
             /* srca_data_format */ prev_a,
             /* srcb_data_format */ prev_b);
 
+        // tt-metal#34499: the reconfig path now always re-derives INT8_math_enabled from the new format
+        // (skip_int8 defaults to false), so a reconfig must land in the same ALU state as a fresh
+        // hw_configure for the new formats -- including across an int8 boundary -- with no opt-in flag.
         if (prev_a != next_a && prev_b != next_b)
         {
-            _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, TO_FROM_INT8>(
+            _llk_math_reconfig_data_format_<is_fp32_dest_acc_en>(
                 /* srca_data_format */ next_a,
                 /* srcb_data_format */ next_b);
         }
         else if (prev_a != next_a)
         {
-            _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, TO_FROM_INT8>(
+            _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en>(
                 /* srca_data_format */ next_a);
         }
         else if (prev_b != next_b)
         {
-            _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, TO_FROM_INT8>(
+            _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en>(
                 /* srcb_data_format */ next_b);
         }
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -169,8 +169,7 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     if constexpr (!skip_int8)
     {
         LLK_ASSERT(
-            is_fp32_dest_acc_en || !(masked_data_format(srca_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
-                                     srca_data_format == ckernel::to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(srca_data_format),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
@@ -203,8 +202,7 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     if constexpr (!skip_int8)
     {
         LLK_ASSERT(
-            is_fp32_dest_acc_en || !(masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
-                                     srcb_data_format == ckernel::to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(srcb_data_format),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
@@ -238,10 +236,7 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     if constexpr (!skip_int8)
     {
         LLK_ASSERT(
-            is_fp32_dest_acc_en ||
-                !(masked_data_format(srca_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
-                  masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
-                  srca_data_format == ckernel::to_underlying(DataFormat::Int32) || srcb_data_format == ckernel::to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !(is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format)),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -153,21 +153,25 @@ inline void _llk_math_pack_sync_init_()
 /**
  * @brief Reconfigure the math thread for a new source A data format.
  *
- * On Blackhole the ALU source format is inferred, so this is a no-op unless the reconfiguration crosses an
- * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit.
+ * On Blackhole the ALU source format is inferred, so this only re-derives the INT8 math enable bit from the new
+ * format. It does so by default so an int8-boundary reconfig cannot leave the bit stale (tt-metal#34499); pass
+ * skip_int8 = true (making it a no-op) only when the caller guarantees no Int8/UInt8/Int32 boundary is crossed.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
- * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when the new format is Int8/UInt8/Int32).
+ * @tparam skip_int8: Skip re-deriving the INT8 math enable bit from the new format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  */
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_format)
 {
     llk::san::math_operand_configure<true>(srca_data_format, llk::san::IGNORE);
 
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || !(masked_data_format(srca_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
+                                     srca_data_format == ckernel::to_underlying(DataFormat::Int32)),
+            "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
@@ -183,21 +187,25 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
 /**
  * @brief Reconfigure the math thread for a new source B data format.
  *
- * On Blackhole the ALU source format is inferred, so this is a no-op unless the reconfiguration crosses an
- * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit.
+ * On Blackhole the ALU source format is inferred, so this only re-derives the INT8 math enable bit from the new
+ * format. It does so by default so an int8-boundary reconfig cannot leave the bit stale (tt-metal#34499); pass
+ * skip_int8 = true (making it a no-op) only when the caller guarantees no Int8/UInt8/Int32 boundary is crossed.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
- * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when the new format is Int8/UInt8/Int32).
+ * @tparam skip_int8: Skip re-deriving the INT8 math enable bit from the new format.
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
  */
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_format)
 {
     llk::san::math_operand_configure<true>(llk::san::IGNORE, srcb_data_format);
 
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || !(masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
+                                     srcb_data_format == ckernel::to_underlying(DataFormat::Int32)),
+            "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
@@ -213,23 +221,28 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
 /**
  * @brief Reconfigure the math thread for new source A and source B data formats.
  *
- * On Blackhole the ALU source format is inferred, so this is a no-op unless the reconfiguration crosses an
- * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit
- * from both source formats.
+ * On Blackhole the ALU source format is inferred, so this only re-derives the INT8 math enable bit from both new
+ * formats. It does so by default so an int8-boundary reconfig cannot leave the bit stale (tt-metal#34499); pass
+ * skip_int8 = true (making it a no-op) only when the caller guarantees no Int8/UInt8/Int32 boundary is crossed.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
- * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when either new format is Int8/UInt8/Int32).
+ * @tparam skip_int8: Skip re-deriving the INT8 math enable bit from the new formats.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
  */
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format)
 {
     llk::san::math_operand_configure<true>(srca_data_format, srcb_data_format);
 
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        LLK_ASSERT(
+            is_fp32_dest_acc_en ||
+                !(masked_data_format(srca_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
+                  masked_data_format(srcb_data_format) == ckernel::to_underlying(DataFormat::Int8) ||
+                  srca_data_format == ckernel::to_underlying(DataFormat::Int32) || srcb_data_format == ckernel::to_underlying(DataFormat::Int32)),
+            "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -127,7 +127,9 @@ inline void _llk_unpack_configure_stoch_rnd_()
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam skip_int8: Skip re-deriving the SrcA signedness bit from the new format. Leave false (the default)
+ *                    unless the caller guarantees the reconfig never crosses an Int8/UInt8/Int32 boundary and
+ *                    wants to avoid the extra RMW; skipping it can leave a stale SrcAUnsigned bit (tt-metal#34499).
  * @param unpack_src_format: New source data format of operand A in L1.
  * @param unpack_dst_format: New destination data format operand A is converted to.
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
@@ -139,8 +141,7 @@ inline void _llk_unpack_configure_stoch_rnd_()
  *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
  *       state is left stale and the next op misinterprets the operand.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
@@ -167,9 +168,16 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         llk::san::IGNORE);
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // Always re-derive SrcAUnsigned from the new format so a reconfig cannot leave a stale signedness bit
+        // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
+        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
+        // so gate the assertion on the format value rather than at compile time.
+        LLK_ASSERT(
+            is_fp32_dest_acc_en ||
+                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 
@@ -211,7 +219,9 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam skip_int8: Skip re-deriving the SrcB signedness bit from the new format. Leave false (the default)
+ *                    unless the caller guarantees the reconfig never crosses an Int8/UInt8/Int32 boundary and
+ *                    wants to avoid the extra RMW; skipping it can leave a stale SrcBUnsigned bit (tt-metal#34499).
  * @param unpack_src_format: New source data format of operand B in L1.
  * @param unpack_dst_format: New destination data format operand B is converted to.
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
@@ -223,8 +233,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
  *       state is left stale and the next op misinterprets the operand.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
@@ -251,9 +260,16 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         llk::san::IGNORE);
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // Always re-derive SrcBUnsigned from the new format so a reconfig cannot leave a stale signedness bit
+        // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
+        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
+        // so gate the assertion on the format value rather than at compile time.
+        LLK_ASSERT(
+            is_fp32_dest_acc_en ||
+                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -172,11 +172,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     {
         // Always re-derive SrcAUnsigned from the new format so a reconfig cannot leave a stale signedness bit
         // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
-        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
-        // so gate the assertion on the format value rather than at compile time.
+        // from UInt8 needs. FP32 dest is required only when the new register (dst) format drives int8/int32 math,
+        // so key the assertion on unpack_dst_format (matching math-side reconfig), not the L1 source: a supported
+        // dequant like Int8->Float16_b needs no FP32 dest.
         LLK_ASSERT(
-            is_fp32_dest_acc_en ||
-                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(unpack_dst_format),
             "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
@@ -264,11 +264,11 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     {
         // Always re-derive SrcBUnsigned from the new format so a reconfig cannot leave a stale signedness bit
         // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
-        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
-        // so gate the assertion on the format value rather than at compile time.
+        // from UInt8 needs. FP32 dest is required only when the new register (dst) format drives int8/int32 math,
+        // so key the assertion on unpack_dst_format (matching math-side reconfig), not the L1 source: a supported
+        // dequant like Int8->Float16_b needs no FP32 dest.
         LLK_ASSERT(
-            is_fp32_dest_acc_en ||
-                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(unpack_dst_format),
             "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -135,11 +135,11 @@ inline void _llk_unpack_configure_stoch_rnd_()
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
- * @note Caller contract: the SrcA-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcAUnsigned), and the math-side
- *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srca_, are only reprogrammed when
- *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
- *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
- *       state is left stale and the next op misinterprets the operand.
+ * @note The SrcA-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcAUnsigned), and the math-side INT8 math-enable in
+ *       @ref _llk_math_reconfig_data_format_srca_, are re-derived from the new format by default, so a reconfig
+ *       that transitions to OR from an 8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float) is handled
+ *       automatically. Set skip_int8 = true only when the caller guarantees no such boundary is crossed;
+ *       skipping leaves the previous unsigned/INT8 state, which the next op would then misinterpret.
  */
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
@@ -227,11 +227,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
- * @note Caller contract: the SrcB-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcBUnsigned), and the math-side
- *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srcb_, are only reprogrammed when
- *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
- *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
- *       state is left stale and the next op misinterprets the operand.
+ * @note The SrcB-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcBUnsigned), and the math-side INT8 math-enable in
+ *       @ref _llk_math_reconfig_data_format_srcb_, are re-derived from the new format by default, so a reconfig
+ *       that transitions to OR from an 8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float) is handled
+ *       automatically. Set skip_int8 = true only when the caller guarantees no such boundary is crossed;
+ *       skipping leaves the previous unsigned/INT8 state, which the next op would then misinterpret.
  */
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -141,8 +141,7 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     if constexpr (!skip_int8)
     {
         LLK_ASSERT(
-            is_fp32_dest_acc_en ||
-                !(masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8) || srca_data_format == to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(srca_data_format),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srca_data_format);
@@ -179,8 +178,7 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     if constexpr (!skip_int8)
     {
         LLK_ASSERT(
-            is_fp32_dest_acc_en ||
-                !(masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8) || srcb_data_format == to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(srcb_data_format),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srcb_data_format);
@@ -218,9 +216,7 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     if constexpr (!skip_int8)
     {
         LLK_ASSERT(
-            is_fp32_dest_acc_en || !(masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8) ||
-                                     masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8) ||
-                                     srca_data_format == to_underlying(DataFormat::Int32) || srcb_data_format == to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !(is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format)),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -125,21 +125,25 @@ inline void _llk_math_pack_sync_init_()
 /**
  * @brief Reconfigure the math thread for a new source A data format.
  *
- * Programs the ALU source A format register. When the reconfiguration crosses an Int8/Int32 boundary
- * (to_from_int8), it also re-evaluates and programs the INT8 math enable bit.
+ * Programs the ALU source A format register and, by default, re-derives the INT8 math enable bit from the new
+ * format so an int8-boundary reconfig cannot leave it stale (tt-metal#34499). Pass skip_int8 = true only when the
+ * caller guarantees no Int8/UInt8/Int32 boundary is crossed and wants to avoid the extra RMW.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
- * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when the new format is Int8/UInt8/Int32).
+ * @tparam skip_int8: Skip re-deriving the INT8 math enable bit from the new format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  */
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_format)
 {
     llk::san::math_operand_configure<true>(srca_data_format, llk::san::IGNORE);
 
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        LLK_ASSERT(
+            is_fp32_dest_acc_en ||
+                !(masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8) || srca_data_format == to_underlying(DataFormat::Int32)),
+            "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srca_data_format);
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
@@ -159,21 +163,25 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
 /**
  * @brief Reconfigure the math thread for a new source B data format.
  *
- * Programs the ALU source B format register. When the reconfiguration crosses an Int8/Int32 boundary
- * (to_from_int8), it also re-evaluates and programs the INT8 math enable bit.
+ * Programs the ALU source B format register and, by default, re-derives the INT8 math enable bit from the new
+ * format so an int8-boundary reconfig cannot leave it stale (tt-metal#34499). Pass skip_int8 = true only when the
+ * caller guarantees no Int8/UInt8/Int32 boundary is crossed and wants to avoid the extra RMW.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
- * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when the new format is Int8/UInt8/Int32).
+ * @tparam skip_int8: Skip re-deriving the INT8 math enable bit from the new format.
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
  */
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_format)
 {
     llk::san::math_operand_configure<true>(llk::san::IGNORE, srcb_data_format);
 
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        LLK_ASSERT(
+            is_fp32_dest_acc_en ||
+                !(masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8) || srcb_data_format == to_underlying(DataFormat::Int32)),
+            "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srcb_data_format);
         std::uint32_t config_data = (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
@@ -193,22 +201,27 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
 /**
  * @brief Reconfigure the math thread for new source A and source B data formats.
  *
- * Programs the ALU source A and source B format registers. When the reconfiguration crosses an Int8/Int32
- * boundary (to_from_int8), it also re-evaluates and programs the INT8 math enable bit from both source formats.
+ * Programs the ALU source A and source B format registers and, by default, re-derives the INT8 math enable bit
+ * from both new formats so an int8-boundary reconfig cannot leave it stale (tt-metal#34499). Pass skip_int8 = true
+ * only when the caller guarantees no Int8/UInt8/Int32 boundary is crossed and wants to avoid the extra RMW.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
- * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when either new format is Int8/UInt8/Int32).
+ * @tparam skip_int8: Skip re-deriving the INT8 math enable bit from the new formats.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
  */
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, bool skip_int8 = false>
 inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format)
 {
     llk::san::math_operand_configure<true>(srca_data_format, srcb_data_format);
 
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || !(masked_data_format(srca_data_format) == to_underlying(DataFormat::Int8) ||
+                                     masked_data_format(srcb_data_format) == to_underlying(DataFormat::Int8) ||
+                                     srca_data_format == to_underlying(DataFormat::Int32) || srcb_data_format == to_underlying(DataFormat::Int32)),
+            "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -132,7 +132,9 @@ inline void _llk_unpack_configure_stoch_rnd_()
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam skip_int8: Skip re-deriving the SrcA signedness bit from the new format. Leave false (the default)
+ *                    unless the caller guarantees the reconfig never crosses an Int8/UInt8/Int32 boundary and
+ *                    wants to avoid the extra RMW; skipping it can leave a stale SrcAUnsigned bit (tt-metal#34499).
  * @param unpack_src_format: New source data format of operand A in L1.
  * @param unpack_dst_format: New destination data format operand A is converted to.
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
@@ -144,8 +146,7 @@ inline void _llk_unpack_configure_stoch_rnd_()
  *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
  *       state is left stale and the next op misinterprets the operand.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
@@ -172,9 +173,16 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         llk::san::IGNORE);
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // Always re-derive SrcAUnsigned from the new format so a reconfig cannot leave a stale signedness bit
+        // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
+        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
+        // so gate the assertion on the format value rather than at compile time.
+        LLK_ASSERT(
+            is_fp32_dest_acc_en ||
+                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 
@@ -213,7 +221,9 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam skip_int8: Skip re-deriving the SrcB signedness bit from the new format. Leave false (the default)
+ *                    unless the caller guarantees the reconfig never crosses an Int8/UInt8/Int32 boundary and
+ *                    wants to avoid the extra RMW; skipping it can leave a stale SrcBUnsigned bit (tt-metal#34499).
  * @param unpack_src_format: New source data format of operand B in L1.
  * @param unpack_dst_format: New destination data format operand B is converted to.
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
@@ -225,8 +235,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
  *       state is left stale and the next op misinterprets the operand.
  */
-// TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
@@ -253,9 +262,16 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         llk::san::IGNORE);
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
-    if constexpr (to_from_int8)
+    if constexpr (!skip_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // Always re-derive SrcBUnsigned from the new format so a reconfig cannot leave a stale signedness bit
+        // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
+        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
+        // so gate the assertion on the format value rather than at compile time.
+        LLK_ASSERT(
+            is_fp32_dest_acc_en ||
+                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -177,11 +177,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     {
         // Always re-derive SrcAUnsigned from the new format so a reconfig cannot leave a stale signedness bit
         // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
-        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
-        // so gate the assertion on the format value rather than at compile time.
+        // from UInt8 needs. FP32 dest is required only when the new register (dst) format drives int8/int32 math,
+        // so key the assertion on unpack_dst_format (matching math-side reconfig), not the L1 source: a supported
+        // dequant like Int8->Float16_b needs no FP32 dest.
         LLK_ASSERT(
-            is_fp32_dest_acc_en ||
-                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(unpack_dst_format),
             "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
@@ -266,11 +266,11 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     {
         // Always re-derive SrcBUnsigned from the new format so a reconfig cannot leave a stale signedness bit
         // (tt-metal#34499). For non-int8 formats this simply writes 0, which is exactly what a reconfig away
-        // from UInt8 needs. FP32 dest is required only when the new format actually drives int8/int32 math,
-        // so gate the assertion on the format value rather than at compile time.
+        // from UInt8 needs. FP32 dest is required only when the new register (dst) format drives int8/int32 math,
+        // so key the assertion on unpack_dst_format (matching math-side reconfig), not the L1 source: a supported
+        // dequant like Int8->Float16_b needs no FP32 dest.
         LLK_ASSERT(
-            is_fp32_dest_acc_en ||
-                !(masked_data_format(unpack_src_format) == to_underlying(DataFormat::Int8) || unpack_src_format == to_underlying(DataFormat::Int32)),
+            is_fp32_dest_acc_en || !is_int8_or_int32_format(unpack_dst_format),
             "Reconfiguring unpack to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -140,11 +140,11 @@ inline void _llk_unpack_configure_stoch_rnd_()
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
- * @note Caller contract: the SrcA-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcAUnsigned), and the math-side
- *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srca_, are only reprogrammed when
- *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
- *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
- *       state is left stale and the next op misinterprets the operand.
+ * @note The SrcA-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcAUnsigned), and the math-side INT8 math-enable in
+ *       @ref _llk_math_reconfig_data_format_srca_, are re-derived from the new format by default, so a reconfig
+ *       that transitions to OR from an 8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float) is handled
+ *       automatically. Set skip_int8 = true only when the caller guarantees no such boundary is crossed;
+ *       skipping leaves the previous unsigned/INT8 state, which the next op would then misinterpret.
  */
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
@@ -229,11 +229,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
  * @param unpack_face_r_dim: Rows per face, used when reprogramming dim/stride.
  * @param unpack_num_faces: Number of faces, valid values = <1, 2, 4>.
- * @note Caller contract: the SrcB-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcBUnsigned), and the math-side
- *       INT8 math-enable in @ref _llk_math_reconfig_data_format_srcb_, are only reprogrammed when
- *       to_from_int8 is set. Set to_from_int8 = true for ANY reconfig that transitions to OR from an
- *       8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float); otherwise the previous unsigned/INT8
- *       state is left stale and the next op misinterprets the operand.
+ * @note The SrcB-unsigned ALU bit (ALU_FORMAT_SPEC_REG0_SrcBUnsigned), and the math-side INT8 math-enable in
+ *       @ref _llk_math_reconfig_data_format_srcb_, are re-derived from the new format by default, so a reconfig
+ *       that transitions to OR from an 8-bit-integer / Int8 / Int32 format (e.g. UInt8 -> float) is handled
+ *       automatically. Set skip_int8 = true only when the caller guarantees no such boundary is crossed;
+ *       skipping leaves the previous unsigned/INT8 state, which the next op would then misinterpret.
  */
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool skip_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/unified_kernels/deepseek_moe_gate.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/unified_kernels/deepseek_moe_gate.hpp
@@ -112,7 +112,7 @@ struct DeepseekMoeGate {
             // ================================================================
 
             // Input indices CB should have the same tile shape as the input CB
-            reconfig_data_format<false, true>(CTArgs::input_indices_cb, CTArgs::bias_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::input_indices_cb, CTArgs::bias_cb);
             // Output indices CB should have the same tile shape as the output CB
             pack_reconfig_data_format<true>(CTArgs::output_cb);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/unified_kernels/generalized_moe_gate.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/unified_kernels/generalized_moe_gate.hpp
@@ -203,7 +203,7 @@ struct GeneralizedMoeGate {
             // ================================================================
 
             // Input indices CB should have the same tile shape as the input CB
-            reconfig_data_format<false, true>(CTArgs::input_indices_cb, CTArgs::bias_cb);
+            reconfig_data_format<SrcOrder::Regular, true>(CTArgs::input_indices_cb, CTArgs::bias_cb);
             // Output indices CB should have the same tile shape as the output CB
             pack_reconfig_data_format<true>(CTArgs::output_cb);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
@@ -120,7 +120,7 @@ void kernel_main() {
                 // (is_tile_dim_reconfig_en=true): the default reconfig keeps the prior element
                 // stride, so after a bf16 tilize the fp32 cb_tile would be read with a 2-byte
                 // stride and copy_tile would misread it (corrupting the amax for bf16 input).
-                reconfig_data_format_srca<false, true>(cb_tile_id);
+                reconfig_data_format_srca</*is_tile_dim_reconfig_en=*/true>(cb_tile_id);
                 pack_reconfig_data_format(cb_abs_id);
                 copy_tile_init(cb_tile_id);
                 cb_abs.reserve_back(block_wt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -121,7 +121,7 @@ void kernel_main() {
                 /*num_blocks=*/Skt, /*total_input_pages=*/Skt * tt::constants::TILE_HEIGHT);
             // QK reads K (transposed -> srcA) and Q (srcB). Reconfigure both formats and the tiled descriptor
             // geometry/strides; mm_no_mop_init_short only programs the matmul MOP.
-            reconfig_data_format<false /* to_from_int8 */, true /* is_tile_dim_reconfig_en */>(cb_k_in, cb_q_in);
+            reconfig_data_format<SrcOrder::Regular, /*is_tile_dim_reconfig_en=*/true>(cb_k_in, cb_q_in);
             // K tilize also leaves the packer in cb_k_in's format+strides (bfp8 for fp8). Restore bf16 once per
             // chunk for the downstream packs (cb_qk_im/max/sum/out share its geometry); configure_pack_width in
             // the qg loop refreshes only the MOP. No-op for bf16.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -231,7 +231,7 @@ void kernel_main() {
         // are both full tiles), so the per-chunk reconfig can stay IGNORE. Without this, SrcA stays
         // at num_faces=2 and the matmul reads K wrong -> Top-1 0%. (Full-tile Q: this is a no-op
         // re-assert of num_faces=4.)
-        reconfig_data_format</*to_from_int8=*/false, /*is_tile_dim_reconfig_en=*/true>(cb_k_in, cb_q_in);
+        reconfig_data_format<SrcOrder::Regular, /*is_tile_dim_reconfig_en=*/true>(cb_k_in, cb_q_in);
     } else {
         compute_kernel_hw_startup<SrcOrder::Reverse>(cb_q_in, cb_k_in, cb_qk_im);
         matmul_init(cb_q_in, cb_k_in);


### PR DESCRIPTION
Closes #47381. Part of the reconfig cleanup umbrella (#34499).

It changes how `reconfig_data_format` works on Wormhole and Blackhole.

## The bug it fixes

When you reconfigure a data format, the code has to update the int8 state on the unpacker and on the math unit. It only did that when the caller passed `to_from_int8 = true`. No kernel ever passed it, so the state went stale. When a reconfigure crossed into or out of an int8 format, the math was wrong.

Now the reconfigure always reads the int8 state from the new format. Every caller gets the fix without changing anything. The old compile time assert became a runtime assert that only fires for Int8, UInt8 and Int32, which are the formats that need fp32 dest.

## The new API

`reconfig_data_format` also gained a `SrcOrder` tag on the version that takes two operands. Matmul can now pass its operands in the natural order instead of swapping them by hand. This matches how `compute_kernel_hw_startup` already behaves.

The old functions keep their names until we retire them, so the new functions carry a temporary `_v2` name for now:

- `reconfig_data_format_v2<SrcOrder>`, plus `reconfig_data_format_srca_v2` and `reconfig_data_format_srcb_v2`.
- `reconfig_data_format_skip_int8` for callers that know they never cross an int8 format and want to skip the extra register write.

## Deprecation

The old `reconfig_data_format`, `reconfig_data_format_srca` and `reconfig_data_format_srcb` are now deprecated. They still work until August 15th. They ignore `to_from_int8` and always derive the int8 state, so they stay correct while you migrate.

## The cleanup PR

After the grace period a follow up PR will delete the deprecated functions, rename the `_v2` functions back to `reconfig_data_format`, and swap the call sites onto the new signatures.

## Validation

I updated the math reconfigure test for the new behavior. All 2425 cases pass on a Wormhole card. The new overloads and the deprecation compile cleanly.

## Notes

- `deprecations.json` tracks the removal.
- Next in the umbrella: #47382 and #34495.

## CI sweep — updated 2026-07-22 (rebased head 56ec4c4a)

Ran the full set before merge. Every red is either already failing on main or a runner failure where the test never ran, so none come from this change. Device Perf passes, and the repo has zero old signature reconfig calls.

| Workflow | Result | Why |
|---|---|---|
| Sanity | red, matches main | `runtime_sim_cpp_unit_tests` (WH and BH) fails on main too. |
| Blackhole Sanity | red, matches main | `sdpa QB2` fails on main with the exact same PCC. |
| Blackhole e2e | red, matches main | `ccl nightly` and `DeepSeek_DSA` fail on every recent main run. |
| Device Perf (single card) | green | Clean. |
| LLK Perf | red, flake | `perf_eltwise_typecast` hangs on the perf box; that kernel never calls reconfig, and LLK Perf fails on about half of main runs. |
| Nightly L2 | red, matches main | Baseline spread: tt-train, ccl, sdxl, experimental, reduction, moreh. None touch reconfig, no matmul red. |
| All Models Tier 1 and 2 | red, justified | 68 pass, 19 fail on the rebased head. See below. |

### Why the 19 model failures are justified

Re-ran All Models Tier 1 and 2 on the rebased head after the copy_block build break was fixed on main. 68 pass, 19 fail, and not one is an accuracy failure:

- 12 of 19 also fail on recent main runs for the same model and tier. These are already flaky on main.
- 7 of 19 are runner failures where the kernel never ran: five container start failures with `Value cannot be null (ContainerId)` (Whisper e2e, Mistral 7B unit, SDXL base e2e, SDXL img2img e2e, SDXL refiner unit), one checkout timeout (Shallow UNet e2e), and one download timeout (Qwen2.5 VL 72B unit).

A wrong signature swap would show up as a numeric or PCC failure, because the model would run and compute a wrong result. There are zero such failures, so the migration is not implicated. Note: the six workflows above ran on the pre rebase sweep and their reds are unchanged main baseline failures or flakes; All Models was re run on the rebased head.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkc/47381-reconfig-data-format-srcorder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkc/47381-reconfig-data-format-srcorder)