### PR TITLE
[REPRO #47820] ci-eval-32 single repeat batch (DO NOT MERGE)

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -712,7 +712,11 @@ def prepare_generator_args(
         (  # ci-eval-32 - 32 users with 3 repeat batches and shifting prompts
             "models/tt_transformers/demo/sample_prompts/eval_repeat_prompts_batch32.json",  # input_prompts
             True,  # instruct mode
-            3,  # repeat_batches
+            # [REPRO EXPERIMENT #47820] Temporarily 1 (was 3) to test whether a single
+            # prefill->decode batch avoids the prefetcher sub-device trace_buffer fatal.
+            # DO NOT MERGE — the shifting-prompt comparison (len(batch32_outputs) > 1) is
+            # skipped at repeat_batches=1, so this only validates the trace/sub-device path.
+            1,  # repeat_batches
             1024,  # max_seq_len
             32,  # batch_size
             200,  # max_generated_tokens


### PR DESCRIPTION
## Purpose — HW repro experiment for #47820 (DO NOT MERGE)

Validates the root-cause hypothesis from #47820 on `bh_quietbox_2`: the
`TT_FATAL @ mesh_device.cpp: trace_buffer != nullptr` fatal in the
`Llama 3.1-8B e2e tests [bh_quietbox_2]` job is triggered specifically by the
**`ci-eval-32` eval loop running `repeat_batches=3`** under `--use_prefetcher`.

The demo loops prefill→decode per batch (`simple_text_demo.py:1145`). On batch 0
the first `decode_forward` calls `prefetcher.init(Mode.DECODE)`, which loads the
prefetcher's sub-device manager (id 1). Batch 1's prefill then replays the prefill
trace (`_easy_trace_prefill` → `ttnn.execute_trace(trace_id=1)`) while manager 1 is
active — but the trace was captured on the default manager (0) → fatal.

The predecessor test (`ci-32`, `repeat_batches=1`) passed on `bh_quietbox_2` on
2026-06-01/02 in the old `(Blackhole) Demo tests` pipeline; the migration (#45300,
2026-06-02) moved `--use_prefetcher` onto `ci-eval-32`, and the job has failed
every run since 2026-06-03.

### Change
`ci-eval-32`: `repeat_batches` 3 → 1 (one prefill→decode, no post-switch replay).
The shifting-prompt comparison is guarded by `len(batch32_outputs) > 1`, so it is
cleanly skipped at 1 batch — this isolates the trace/sub-device path only.

### Expected result
If the hypothesis holds, the `trace_buffer != nullptr` fatal disappears and the
`ci-eval-32` invocation runs to completion (it may still surface the downstream
L1 `global_cb` clash from #47820 on a later step, but the trace fatal should be gone).

### Follow-up
Real fix (make the prefetcher compatible with `repeat_batches > 1`) tracked in #47820.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/llama8b-eval32-single-batch-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/llama8b-eval32-single-batch-repro)