### PR TITLE
Reject unaligned row-major shard widths instead of returning corrupt data

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
@@ -675,6 +675,88 @@ def test_dram_reshard_with_program_cache(
     assert device.num_program_cache_entries() == 1
 
 
+def _height_sharded_reshard_configs(channels):
+    """Build (input_mem_config, output_mem_config) for a (64,C)->(32,C) HEIGHT_SHARDED reshard."""
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))})
+    output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))})
+
+    input_shard_spec = ttnn.ShardSpec(input_shard_grid, (64, channels), ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    output_shard_spec = ttnn.ShardSpec(output_shard_grid, (32, channels), ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+    return input_mem_config, output_mem_config
+
+
+@pytest.mark.parametrize("channels", [8, 16])
+@pytest.mark.parametrize("tt_dtype", [ttnn.bfloat16])
+def test_reshard_aligned_channels_height_sharded(device, channels, tt_dtype):
+    """
+    Row-major HEIGHT_SHARDED reshard with an L1-aligned shard page size is supported;
+    verify the data round-trips. In bf16 the shard row is channels * 2 bytes, so
+    channels that are multiples of 8 (16-byte aligned) take the aligned same-width path.
+
+    The input is sharded directly on device (interleaved_to_sharded is not used, so the
+    reshard op's height->height same-width path is exercised in isolation).
+    """
+    grid_size = device.compute_with_storage_grid_size()
+    if grid_size.x < 3:
+        pytest.skip("Test requires at least 3 cores in the x dimension")
+
+    input_mem_config, output_mem_config = _height_sharded_reshard_configs(channels)
+
+    torch_tensor = random_torch_tensor(tt_dtype, [1, 1, 64, channels])
+    input_tensor = ttnn.Tensor(
+        torch_tensor, tt_dtype, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    output_tensor = ttnn.reshard(input_tensor, output_mem_config)
+    torch_tensor_after_round_trip = ttnn.to_torch(output_tensor)
+
+    assert torch_tensor.shape == torch_tensor_after_round_trip.shape
+    passing, output = comp_equal(torch_tensor, torch_tensor_after_round_trip)
+    assert passing, output
+
+
+@pytest.mark.xfail(
+    raises=RuntimeError,
+    strict=True,
+    reason="Unaligned row-major HEIGHT_SHARDED reshard is unsupported: the shard row "
+    "(channels * elem_size) is not 16-byte L1-aligned, so reshard's validate rejects it. "
+    "The op's unaligned same-width path is incomplete (silently corrupts data / asserts). "
+    "Remove this xfail once unaligned support lands.",
+)
+@pytest.mark.parametrize("channels", [1, 2, 3, 4, 5, 6, 7])
+@pytest.mark.parametrize("tt_dtype", [ttnn.bfloat16])
+def test_reshard_unaligned_channels_height_sharded(device, channels, tt_dtype):
+    """
+    Row-major HEIGHT_SHARDED reshard requires an L1-aligned shard page size: the shard
+    row (shard_width * elem_size) must be a multiple of the 16-byte L1 alignment.
+
+    Channel counts whose row is not 16-byte aligned -- 1..7 channels in bf16 give
+    2..14-byte rows -- are currently unsupported: reshard's validate rejects them (rather
+    than silently returning corrupt data from the incomplete unaligned path). Marked xfail
+    until unaligned support is implemented. Aligned widths (multiples of 8 channels in
+    bf16, e.g. 8/16) are supported; see test_reshard_aligned_channels_height_sharded.
+    """
+    grid_size = device.compute_with_storage_grid_size()
+    if grid_size.x < 3:
+        pytest.skip("Test requires at least 3 cores in the x dimension")
+
+    input_mem_config, output_mem_config = _height_sharded_reshard_configs(channels)
+
+    torch_tensor = random_torch_tensor(tt_dtype, [1, 1, 64, channels])
+    input_tensor = ttnn.Tensor(
+        torch_tensor, tt_dtype, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    output_tensor = ttnn.reshard(input_tensor, output_mem_config)
+    torch_tensor_after_round_trip = ttnn.to_torch(output_tensor)
+
+    assert torch_tensor.shape == torch_tensor_after_round_trip.shape
+    passing, output = comp_equal(torch_tensor, torch_tensor_after_round_trip)
+    assert passing, output
+
+
 @pytest.mark.parametrize(
     "input_shape, input_layout, input_shard_grid,  input_shard_shape, input_shard_orientation, input_sharding_scheme, output_shard_grid, output_shard_shape, output_shard_orientation, output_sharding_scheme",
     [

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
@@ -723,7 +723,8 @@ def test_reshard_aligned_channels_height_sharded(device, channels, tt_dtype):
     reason="Unaligned row-major HEIGHT_SHARDED reshard is unsupported: the shard row "
     "(channels * elem_size) is not 16-byte L1-aligned, so reshard's validate rejects it. "
     "The op's unaligned same-width path is incomplete (silently corrupts data / asserts). "
-    "Remove this xfail once unaligned support lands.",
+    "Remove this xfail once unaligned support lands. "
+    "See https://github.com/tenstorrent/tt-metal/issues/29514",
 )
 @pytest.mark.parametrize("channels", [1, 2, 3, 4, 5, 6, 7])
 @pytest.mark.parametrize("tt_dtype", [ttnn.bfloat16])

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
@@ -162,47 +162,45 @@ std::pair<bool, std::string> ReshardDeviceOperation::validate_inputs(
         return {false, "output must be sharded"};
     }
 
-    // ReshardSameWidthFactory (height↔height) has explicit unaligned handling,
-    // but all other legacy and ND factories require L1-aligned shard widths for correct NOC transfers.
+    // All reshard program factories require L1-aligned row-major shard page sizes for correct NOC
+    // transfers. The height->height same-width path has partial unaligned handling, but it is
+    // incomplete -- it silently produces corrupt data for some widths and asserts on others -- so
+    // reject unaligned row-major shard widths here for every sharding scheme. Callers get a clear
+    // error instead of wrong results. (Aligned widths pass: page_size == aligned_page_size.)
     if (input_tensor.layout() == Layout::ROW_MAJOR) {
-        bool is_height_to_height = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
-                                   out_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+        const uint32_t alignment = hal::get_l1_alignment();
 
-        if (!is_height_to_height) {
-            const uint32_t alignment = hal::get_l1_alignment();
+        uint32_t input_page_size = input_tensor.buffer()->page_size();
+        uint32_t input_aligned_page_size = input_tensor.buffer()->aligned_page_size();
+        if (input_page_size != input_aligned_page_size) {
+            return {
+                false,
+                fmt::format(
+                    "Input row-major shard width {} with data type {} gives page size {} bytes, "
+                    "which must be aligned to {} bytes for reshard",
+                    input_tensor.memory_config().shard_spec().has_value()
+                        ? input_tensor.memory_config().shard_spec().value().shape[1]
+                        : 0,
+                    input_tensor.dtype(),
+                    input_page_size,
+                    alignment)};
+        }
 
-            uint32_t input_page_size = input_tensor.buffer()->page_size();
-            uint32_t input_aligned_page_size = input_tensor.buffer()->aligned_page_size();
-            if (input_page_size != input_aligned_page_size) {
-                return {
-                    false,
-                    fmt::format(
-                        "Input row-major shard width {} with data type {} gives page size {} bytes, "
-                        "which must be aligned to {} bytes for reshard",
-                        input_tensor.memory_config().shard_spec().has_value()
-                            ? input_tensor.memory_config().shard_spec().value().shape[1]
-                            : 0,
-                        input_tensor.dtype(),
-                        input_page_size,
-                        alignment)};
-            }
-
-            uint32_t output_shard_width = out_mem_config.shard_spec().has_value()
-                                              ? out_mem_config.shard_spec().value().shape[1]
-                                              : out_mem_config.nd_shard_spec().value().shard_shape[-1];
-            uint32_t output_page_size = output_shard_width * input_tensor.element_size();
-            uint32_t output_aligned_page_size = tt::align(output_page_size, alignment);
-            if (output_page_size != output_aligned_page_size) {
-                return {
-                    false,
-                    fmt::format(
-                        "Output row-major shard width {} with data type {} gives page size {} bytes, "
-                        "which must be aligned to {} bytes for reshard",
-                        output_shard_width,
-                        input_tensor.dtype(),
-                        output_page_size,
-                        alignment)};
-            }
+        uint32_t output_shard_width = out_mem_config.shard_spec().has_value()
+                                          ? out_mem_config.shard_spec().value().shape[1]
+                                          : out_mem_config.nd_shard_spec().value().shard_shape[-1];
+        uint32_t output_page_size = output_shard_width * input_tensor.element_size();
+        uint32_t output_aligned_page_size = tt::align(output_page_size, alignment);
+        if (output_page_size != output_aligned_page_size) {
+            return {
+                false,
+                fmt::format(
+                    "Output row-major shard width {} with data type {} gives page size {} bytes, "
+                    "which must be aligned to {} bytes for reshard",
+                    output_shard_width,
+                    input_tensor.dtype(),
+                    output_page_size,
+                    alignment)};
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
@@ -170,6 +170,11 @@ std::pair<bool, std::string> ReshardDeviceOperation::validate_inputs(
     if (input_tensor.layout() == Layout::ROW_MAJOR) {
         const uint32_t alignment = hal::get_l1_alignment();
 
+        const uint32_t input_shard_width =
+            input_tensor.memory_config().shard_spec().has_value()
+                ? input_tensor.memory_config().shard_spec().value().shape[1]
+                : input_tensor.memory_config().nd_shard_spec().value().shard_shape[-1];
+
         uint32_t input_page_size = input_tensor.buffer()->page_size();
         uint32_t input_aligned_page_size = input_tensor.buffer()->aligned_page_size();
         if (input_page_size != input_aligned_page_size) {
@@ -178,9 +183,7 @@ std::pair<bool, std::string> ReshardDeviceOperation::validate_inputs(
                 fmt::format(
                     "Input row-major shard width {} with data type {} gives page size {} bytes, "
                     "which must be aligned to {} bytes for reshard",
-                    input_tensor.memory_config().shard_spec().has_value()
-                        ? input_tensor.memory_config().shard_spec().value().shape[1]
-                        : 0,
+                    input_shard_width,
                     input_tensor.dtype(),
                     input_page_size,
                     alignment)};


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This PR is to reject unaligned row-major shard widths.

Row-major sharded reshard is only correct when each shard row (shard_width × element_size) is 16-byte L1-aligned; the height→height path had unfinished unaligned handling that silently produced corrupt data for some widths and crashed for others, so this PR rejects unaligned row-major shard widths in validate with a clear error for all sharding schemes. Adds a positive test for aligned channels (8/16) and an xfail(strict) test for unaligned channels (1–7) documenting the limitation; no existing tests are affected since all current row-major reshard configs are already aligned.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ronnie/29514-fix_reshard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ronnie/29514-fix_reshard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ronnie/29514-fix_reshard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ronnie/29514-fix_reshard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ronnie/29514-fix_reshard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ronnie/29514-fix_reshard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ronnie/29514-fix_reshard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ronnie/29514-fix_reshard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ronnie/29514-fix_reshard)

Note that all the failing test cases in L2 nightly tests also failed on the latest main branch.