### PR TITLE
[#47820] Prefill on default sub-device manager (option a) — prefetcher repeat batches

### DIFF
--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -100,7 +100,12 @@ class DistributedNorm(LightweightModule):
                 if self.ag_config_key and mode == "decode"
                 else 2,
                 num_buffers_per_channel=2,
-                subdevice_id=self.prefetcher.worker_sub_device_id if self.prefetcher is not None else None,
+                # The prefetcher's worker sub-device (id 1) only exists on the prefetcher's
+                # decode manager. Prefill runs on the default manager (#47820), so only pin
+                # the all-gather to the worker sub-device in decode.
+                subdevice_id=self.prefetcher.worker_sub_device_id
+                if (self.prefetcher is not None and mode == Mode.DECODE)
+                else None,
             )
         else:
             x = ttnn.to_memory_config(x, input_mem_cfg)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -541,6 +541,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         **kwargs,
     ):
         self.mode = Mode.PREFILL
+        # Prefill runs on the device's default sub-device manager, where its trace is
+        # captured. If a prior decode switched the device to a prefetcher's decode
+        # manager, revert now so the cached prefill trace replays on the same manager
+        # across interleaved repeat batches (#47820). No-op when no prefetcher is active.
+        for i in range(len(self.model)):
+            self.model[i].switch_mode(Mode.PREFILL)
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         else:

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -845,9 +845,19 @@ class Transformer(LightweightModule):
         return tt_logits, None
 
     def switch_mode(self, mode: Mode):
-        if self.prefetcher is not None:
+        if self.prefetcher is None:
+            return
+        if mode == Mode.DECODE:
+            # Create (first time) or re-activate the prefetcher's decode sub-device
+            # manager, then ensure weights are queued for prefetch.
             self.prefetcher.init(mode)
             self.prefetcher.prefetch()
+        elif mode == Mode.PREFILL:
+            # Option (a) for #47820: run prefill on the mesh device's default sub-device
+            # manager (where the prefill trace is captured), reverting the prefetcher's
+            # decode manager if it is currently active. Keeps prefill trace capture and
+            # replay on one manager across interleaved repeat batches.
+            self.prefetcher.revert_to_default_sub_device_manager()
 
     def forward(
         self,

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -224,6 +224,13 @@ class PrefetcherSubDevice:
         self.mesh_device.load_sub_device_manager(self.manager_id)
         self.mesh_device.set_sub_device_stall_group(self.sub_devices_id)
 
+    def load(self):
+        # Re-activate this (already-created) sub-device manager and its stall group.
+        # Used to restore the prefetcher's decode manager after an interleaved prefill
+        # reverted the mesh device to its default sub-device manager (see #47820).
+        self.mesh_device.load_sub_device_manager(self.manager_id)
+        self.mesh_device.set_sub_device_stall_group(self.sub_devices_id)
+
 
 class Prefetcher(LightweightModule):
     def __init__(
@@ -330,6 +337,11 @@ class Prefetcher(LightweightModule):
         self.init_decode_done = False
         self.init_prefill_done = False
         self.prefetch_done = False
+        # Tracks whether the prefetcher's (decode) sub-device manager is the one
+        # currently loaded on the mesh device. Interleaved prefill reverts to the
+        # default manager (where prefill traces are captured); decode restores this
+        # one. See revert_to_default_sub_device_manager() / load() below (#47820).
+        self._decode_manager_loaded = False
 
     # NOTE: DRAM prefetched weights are prefetched in the order of the construction of the module
     def register_callback(self, callback: Callable[[], None]):
@@ -362,8 +374,13 @@ class Prefetcher(LightweightModule):
         NOTE: All DRAM prefetcher APIs can only be called after init() is called for the given mode
         NOTE: Calling init() again for the same mode is a no-op
         """
-        # If the prefetcher has already been initialized for the given mode, we do not need to initialize it again
-        if mode == Mode.DECODE and self.init_decode_done or mode == Mode.PREFILL and self.init_prefill_done:
+        # If the prefetcher has already been initialized for the given mode, we do not
+        # re-create its sub-device manager. For decode we still (re)load it, since an
+        # interleaved prefill may have reverted the device to the default manager (#47820).
+        if mode == Mode.DECODE and self.init_decode_done:
+            self.load()
+            return
+        if mode == Mode.PREFILL and self.init_prefill_done:
             return
         self.mode = mode
         self.sender_cores = self.core_config.sender_cores
@@ -380,6 +397,8 @@ class Prefetcher(LightweightModule):
                 self.prefetcher_sub_device.add_sub_device(self.to_core_range_set(self.sender_cores(active=True)))
                 self.prefetcher_sub_device.add_sub_device(self.all_worker_cores_range_set)
                 self.prefetcher_sub_device.init_sub_device_manager()
+                # init_sub_device_manager() also loads the manager.
+                self._decode_manager_loaded = True
             case Mode.PREFILL:
                 self.prefetcher_sub_device = PrefetcherSubDevice(self.mesh_device)
                 self.prefetcher_sub_device.add_sub_device(self.all_core_range_set)
@@ -400,6 +419,34 @@ class Prefetcher(LightweightModule):
         logger.info("=" * 50)
         self.init_decode_done = True if mode == Mode.DECODE else False
         self.init_prefill_done = True if mode == Mode.PREFILL else False
+
+    @property
+    def is_initialized(self) -> bool:
+        """True once the prefetcher's decode sub-device manager has been created."""
+        return self.init_decode_done
+
+    def load(self) -> None:
+        """
+        Re-activate the prefetcher's decode sub-device manager if it is not currently
+        the loaded manager. Idempotent — safe to call on every decode step; only acts
+        after an interleaved prefill reverted the device to the default manager (#47820).
+        """
+        if self.init_decode_done and not self._decode_manager_loaded:
+            self.prefetcher_sub_device.load()
+            self._decode_manager_loaded = True
+
+    def revert_to_default_sub_device_manager(self) -> None:
+        """
+        Restore the mesh device's default (full-grid) sub-device manager so that prefill
+        runs — and prefill traces are captured/replayed — on the same manager across
+        repeat batches. No-op until the prefetcher's manager has actually been loaded.
+        Note: this does NOT free the prefetcher's global_cb L1 (it persists across the
+        revert); the decode manager is restored by load() on the next decode (#47820).
+        """
+        if self.init_decode_done and self._decode_manager_loaded:
+            self.mesh_device.clear_loaded_sub_device_manager()
+            self.mesh_device.reset_sub_device_stall_group()
+            self._decode_manager_loaded = False
 
     def create_address_tensor(self):
         """


### PR DESCRIPTION
## #47820 — prefill on the default sub-device manager (option a)

Draft fix for the `TT_FATAL @ mesh_device.cpp: trace_buffer != nullptr` in
`Llama 3.1-8B e2e tests [bh_quietbox_2]` (`ci-eval-32`, `repeat_batches=3`, `--use_prefetcher`).

### Root cause
`decode_forward` switches the mesh device to the prefetcher's decode sub-device manager
(id 1) and never reverts; `prefill_forward_text` never touches the manager. The prefill
trace is captured on the **default** manager (0) during the first prefill (before any
decode), then on the next repeat batch it is replayed while manager 1 is active → trace
absent → fatal. (Single-batch `ci-32` passed because it never re-ran prefill after decode.)

### Change (option a)
Make prefill run on the default manager (where its trace lives) and restore the
prefetcher's manager for decode, symmetrically, across the interleaved loop:

- **prefetcher**: `PrefetcherSubDevice.load()` (reload without re-create); `Prefetcher.load()`
  + `revert_to_default_sub_device_manager()` + `is_initialized`, tracked with
  `_decode_manager_loaded` (idempotent — safe to call every decode step); `init(DECODE)`
  now **reloads** on the already-initialized path instead of no-op.
- **model.switch_mode**: symmetric — `DECODE` (re)loads the prefetcher manager; `PREFILL`
  reverts to the default manager.
- **generator.prefill_forward_text**: `switch_mode(Mode.PREFILL)` before trace capture/replay.
- **distributed_norm**: pin the all-gather to the prefetcher worker sub-device only in
  `DECODE` (it does not exist on the default manager used for prefill — fixes the
  "SubDevice index 1 out of bounds" that reverting to default otherwise surfaces).

### Expected result on `bh_quietbox_2`
The `trace_buffer != nullptr` fatal (and the norm sub-device-1 error) should be gone.
This PR does **not** free the prefetcher's persistent `global_cb`, so I expect it to
advance to — and likely stop at — the L1 clash on core (0,0) in the post-prefill
RMSNorm (`program.cpp:1549`), which is the separately-tracked L1-lifecycle blocker in #47820.
This run is to confirm the trace/sub-device/norm layers are cleared on HW.

Refs #47820
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-prefill-default-mgr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/llama8b-prefetcher-prefill-default-mgr)