### PR TITLE
Convert smuggled buffer-address runtime args to BufferBindings (~50 descriptor factories)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
@@ -169,24 +169,24 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHProgramFactory::create_descriptor
         }
         const uint32_t num_tensor_tiles_per_core = NC * Ht_per_core * Wt;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),     // 0
-                0,                          // 1
-                0,                          // 2
-                num_tensor_tiles_per_core,  // 3
-                src1_buffer->address(),     // 4
-                0,                          // 5
-                0,                          // 6
-                num_btensor_tiles,          // 7
-                num_tensor_tiles_per_core,  // 8
-                NC,                         // 9
-                Ht_per_core,                // 10
-                Wt,                         // 11
-                bnc1,                       // 12
-                num_Wtiles_read,            // 13
-                Ht * Wt,                    // 14
+            {
+                src0_buffer,
+                0u,
+                0u,
+                num_tensor_tiles_per_core,
+                src1_buffer,
+                0u,
+                0u,
+                num_btensor_tiles,
+                num_tensor_tiles_per_core,
+                NC,
+                Ht_per_core,
+                Wt,
+                bnc1,
+                num_Wtiles_read,
+                Ht * Wt,
             });
 
         compute_desc.runtime_args.emplace_back(
@@ -197,16 +197,16 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHProgramFactory::create_descriptor
                 Wt            // Wt
             });
 
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
-                0,
-                0,
+            {
+                dst_buffer,
+                0u,
+                0u,
                 Ht_per_core,
                 Wt,
                 num_Wtiles_read,
-                0,
+                0u,
                 NC,
                 Ht * Wt,
             });

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
@@ -192,16 +192,15 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHWProgramFactory::create_descripto
             continue;
         }
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),  // 0
-                src1_buffer->address(),
-                num_tensor_tiles_per_core,
-                HtWt,
-                num_tiles_read / HtWt * HtWt,
-                num_tiles_read % HtWt,
-                bnc1 ? 0 : num_tiles_read / HtWt});
+            {src0_buffer,
+             src1_buffer,
+             num_tensor_tiles_per_core,
+             HtWt,
+             num_tiles_read / HtWt * HtWt,
+             num_tiles_read % HtWt,
+             bnc1 ? 0u : num_tiles_read / HtWt});
 
         compute_desc.runtime_args.emplace_back(
             core,
@@ -211,10 +210,10 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHWProgramFactory::create_descripto
                 num_tensor_tiles_per_core  // Wt
             });
 
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
+            {
+                dst_buffer,
                 num_tensor_tiles_per_core,
                 num_tiles_read,
             });

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
@@ -165,25 +165,25 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreWProgramFactory::create_descriptor
         const uint32_t num_tensor_tiles_per_core = NC * Ht * Wt_per_core;
         const uint32_t Wt_skip = Wt - Wt_per_core;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),     // 0
-                0,                          // 1
-                0,                          // 2
-                num_tensor_tiles_per_core,  // 3
-                src1_buffer->address(),     // 4
-                0,                          // 5
-                0,                          // 6
-                num_btensor_tiles,          // 7
-                num_tensor_tiles_per_core,  // 8
-                NC,                         // 9
-                Ht,                         // 10
-                Wt_per_core,                // 11
-                bnc1,                       // 12
-                num_Wtiles_read,            // 13
-                Ht * Wt,                    // 14
-                Wt_skip,                    // 15
+            {
+                src0_buffer,
+                0u,
+                0u,
+                num_tensor_tiles_per_core,
+                src1_buffer,
+                0u,
+                0u,
+                num_btensor_tiles,
+                num_tensor_tiles_per_core,
+                NC,
+                Ht,
+                Wt_per_core,
+                bnc1,
+                num_Wtiles_read,
+                Ht * Wt,
+                Wt_skip,
             });
 
         compute_desc.runtime_args.emplace_back(
@@ -194,12 +194,12 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreWProgramFactory::create_descriptor
                 Wt_per_core  // Wt
             });
 
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
-                0,
-                0,
+            {
+                dst_buffer,
+                0u,
+                0u,
                 Ht,
                 Wt_per_core,
                 num_Wtiles_read,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
@@ -190,16 +190,16 @@ tt::tt_metal::ProgramDescriptor BcastShardedHOptimisedProgramFactory::create_des
             }
         }
         const uint32_t tile_offset = Wt * ncores;  // used in multi batch weight for block sharded
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                b.buffer()->address(),  // (0) src1_addr
-                Ht,                     // (1) Ht
-                Wt,                     // (2) Wt
-                offset,                 // (3) read offset in1
-                tile_offset,            // (4) in1 offset between batches
-                w_blk,                  // (5) block size in w
-                batch_b,                // (6) in1 batch size
+            {
+                b.buffer(),   // (0) src1_addr
+                Ht,           // (1) Ht
+                Wt,           // (2) Wt
+                offset,       // (3) read offset in1
+                tile_offset,  // (4) in1 offset between batches
+                w_blk,        // (5) block size in w
+                batch_b,      // (6) in1 batch size
             });
 
         compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
@@ -187,15 +187,15 @@ tt::tt_metal::ProgramDescriptor BcastShardedHProgramFactory::create_descriptor(
             Ht_per_core = Ht / bN;
         }
         const uint32_t tile_offset = Wt * ncores;  // used in multi batch weight for block sharded
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                b.buffer()->address(),  // 0
-                Ht,                     // 1
-                Wt,                     // 2
-                offset,                 // 3
-                Ht_per_core,            // 4
-                tile_offset,            // 5
+            {
+                b.buffer(),
+                Ht,
+                Wt,
+                offset,
+                Ht_per_core,
+                tile_offset,
             });
 
         compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -135,7 +135,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     const uint32_t num_dims = output.padded_shape().rank();
 
-    std::vector<uint32_t> src_addr(num_input_tensors);
+    std::vector<Buffer*> src_buffers(num_input_tensors);
     std::vector<uint32_t> num_pages_per_block(num_input_tensors);
     std::vector<uint32_t> page_id_per_tensor(num_input_tensors);
     std::vector<uint32_t> page_size_per_tensor(num_input_tensors);
@@ -172,7 +172,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     if (rm_layout) {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
             auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
+            src_buffers[i] = buffer;
             page_size_per_tensor[i] = buffer->page_size();
             if (dim == num_dims - 1) {
                 num_pages_per_block[i] = num_accum_pages;
@@ -188,18 +188,13 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     } else {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
             auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
+            src_buffers[i] = buffer;
             page_size_per_tensor[i] = buffer->page_size();
             uint32_t dim_pages = input_tensors[i].padded_shape()[dim] / scale_factor;
             num_pages_per_block[i] = num_accum_pages * dim_pages;
             num_output_pages_per_block += num_accum_pages * dim_pages;
         }
     }
-    std::vector<uint32_t> common_reader_kernel_args = {0, 0, 0};
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), src_addr.cbegin(), src_addr.cend());
-    common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_pages_per_block.cbegin(), num_pages_per_block.cend());
-
     // Reader compile-time args
     // Data is 32 byte aligned
     KernelDescriptor::CompileTimeArgs reader_compile_time_args = {src0_cb_index, num_input_tensors};
@@ -272,22 +267,28 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
             }
         }
 
-        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        reader_kernel_args[0] = num_pages_per_core;
-        reader_kernel_args[1] = curr_tensor;
-        reader_kernel_args[2] = curr_tensor_id;
-        reader_kernel_args.insert(reader_kernel_args.end(), page_id_per_tensor.begin(), page_id_per_tensor.end());
-
-        std::vector<uint32_t> writer_kernel_args;
-        if (rm_layout) {
-            writer_kernel_args = {
-                dst_buffer->address(), output.buffer()->page_size(), num_pages_per_core, num_pages_written};
-        } else {
-            writer_kernel_args = {dst_buffer->address(), num_pages_per_core, num_pages_written};
+        KernelDescriptor::RTArgList reader_kernel_args;
+        reader_kernel_args.reserve(3 + 3 * num_input_tensors);
+        reader_kernel_args.push_back(num_pages_per_core);
+        reader_kernel_args.push_back(curr_tensor);
+        reader_kernel_args.push_back(curr_tensor_id);
+        for (uint32_t j = 0; j < num_input_tensors; ++j) {
+            reader_kernel_args.push_back(src_buffers[j]);
         }
+        reader_kernel_args.append(num_pages_per_block);
+        reader_kernel_args.append(page_id_per_tensor);
 
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_kernel_args));
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_kernel_args));
+        reader_desc.emplace_runtime_args(core, reader_kernel_args);
+        if (rm_layout) {
+            writer_desc.emplace_runtime_args(
+                core,
+                {dst_buffer,
+                 static_cast<uint32_t>(output.buffer()->page_size()),
+                 num_pages_per_core,
+                 num_pages_written});
+        } else {
+            writer_desc.emplace_runtime_args(core, {dst_buffer, num_pages_per_core, num_pages_written});
+        }
         num_pages_written += num_pages_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
@@ -78,19 +78,20 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
 
         std::vector<uint32_t> reader_runtime_args;
         reader_runtime_args.reserve(num_input_tensors * 2);
-        std::vector<uint32_t> writer_runtime_args = {
-            output.buffer()->address(),
-            core_id,
-            curr_num_output_rows,
-            num_input_tensors * input_shard_spec.shape[0],
-            input_shard_spec.shape[0]};
+        KernelDescriptor::RTArgList writer_runtime_args;
+        writer_runtime_args.reserve(5 + num_input_tensors);
+        writer_runtime_args.push_back(output.buffer());
+        writer_runtime_args.push_back(core_id);
+        writer_runtime_args.push_back(curr_num_output_rows);
+        writer_runtime_args.push_back(num_input_tensors * input_shard_spec.shape[0]);
+        writer_runtime_args.push_back(input_shard_spec.shape[0]);
         for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
             reader_runtime_args.push_back(input_id);
             reader_runtime_args.push_back(input_shard_spec.shape[0]);
             writer_runtime_args.push_back(input_id);
         }
         reader_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
         core_id++;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -206,13 +206,13 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     // we also need the inverse permutation to map back to input tensor
     auto inv_perm = detail::get_inverse_permutation(operation_attributes.dims);
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
 
     reader_runtime_args.insert(reader_runtime_args.end(), output_shape_view.begin(), output_shape_view.end());
     reader_runtime_args.insert(reader_runtime_args.end(), inv_perm.begin(), inv_perm.end());
     reader_runtime_args.insert(reader_runtime_args.end(), input_tile_strides.begin(), input_tile_strides.end());
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u};
 
     std::vector<uint32_t> compute_runtime_args = {0};
 
@@ -240,8 +240,8 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
         writer_runtime_args[1] = num_tiles_per_core;  // for some reason num_tiles comes first in writer unary
         writer_runtime_args[2] = start_tile;          // start tile is second in writer unary
 
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
         if (swap_hw) {
             compute_runtime_args[0] = num_tiles_per_core;  // number of tiles transposed
             compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
@@ -482,9 +482,9 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
 
     auto input_shape_view = input_shape.view();
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0, 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
     writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
     writer_runtime_args.insert(writer_runtime_args.end(), dims.begin(), dims.end());
 
@@ -536,8 +536,8 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
             compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
         }
 
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
         start_tile = end_tile;
         start_tile_padding = end_tile_padding;
@@ -858,13 +858,13 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
 
     auto input_shape_view = input_shape.view();
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
     reader_runtime_args.insert(reader_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
     reader_runtime_args.insert(reader_runtime_args.end(), dims.begin(), dims.end());
 
     std::vector<uint32_t> compute_runtime_args = {0, 0};
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0, 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
     writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
     writer_runtime_args.insert(writer_runtime_args.end(), dims.begin(), dims.end());
 
@@ -913,8 +913,8 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
             start_tile_padding = end_tile_padding;
         }
 
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
         compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
 
         start_block = end_block;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -73,9 +73,9 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
-    reader_common_args[0] = src0_buffer->address();
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+    // src0 buffer binding is registered separately below; this vector holds only the per-dim values.
+    std::vector<uint32_t> reader_common_dims(num_dims * 2);
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_dims.data();
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
     num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
     num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
@@ -134,7 +134,11 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     reader_kernel_desc.compile_time_args = reader_compile_time_args;
     reader_kernel_desc.named_compile_time_args = {{"cb_in", src0_cb_index}};
     reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
-    reader_kernel_desc.common_runtime_args = std::move(reader_common_args);
+    tt::tt_metal::KernelDescriptor::RTArgList reader_common;
+    reader_common.reserve(1 + (num_dims * 2));
+    reader_common.push_back(src0_buffer);
+    reader_common.append(reader_common_dims);
+    reader_kernel_desc.emplace_common_runtime_args(reader_common);
     reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
@@ -142,26 +146,6 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     // CB index via named compile-time arg (essential for fusion CB remapping).
     std::vector<uint32_t> writer_compile_time_args = {};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
-    tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
-    num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
-            continue;
-        }
-
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
-        num_tiles_written += num_tiles_per_core;
-    }
 
     tt::tt_metal::KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
@@ -171,8 +155,26 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = writer_compile_time_args;
     writer_kernel_desc.named_compile_time_args = {{"cb_out", src0_cb_index}};
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            writer_kernel_desc.emplace_runtime_args(core, {0u, 0u, 0u});
+            continue;
+        }
+
+        writer_kernel_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     return program_descriptor;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -99,11 +99,9 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    std::vector<uint32_t> reader_common_args(3 + (num_dims * 3));
-    reader_common_args[0] = src_buffer->address();
-    reader_common_args[1] = start_buffer->address();
-    reader_common_args[2] = end_buffer->address();
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 3;
+    // src/start/end buffer bindings are registered separately below; this vector holds only the per-dim values.
+    std::vector<uint32_t> reader_common_dims(num_dims * 3);
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_dims.data();
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
     uint32_t* input_shape_args = num_padded_tiles_per_dim + num_dims;
     num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
@@ -125,8 +123,16 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
     // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
     constexpr uint32_t start_offset = 0;
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
     KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
     uint32_t num_tiles_written = 0;
     for (const auto& core : corerange_to_cores(all_cores)) {
         uint32_t num_tiles_per_core;
@@ -138,7 +144,7 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
             // no-op core
             std::vector<uint32_t> reader_args(2 + num_dims, 0);
             reader_runtime_args.emplace_back(core, std::move(reader_args));
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            writer_desc.emplace_runtime_args(core, {0u, 0u, 0u});
             continue;
         }
 
@@ -155,8 +161,7 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
         reader_args[1] = num_tiles_per_core;
 
         reader_runtime_args.emplace_back(core, std::move(reader_args));
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
         num_tiles_written += num_tiles_per_core;
     }
 
@@ -168,18 +173,16 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.runtime_args = std::move(reader_runtime_args);
-    reader_desc.common_runtime_args = std::move(reader_common_args);
+    KernelDescriptor::RTArgList reader_common;
+    reader_common.reserve(3 + (num_dims * 3));
+    reader_common.push_back(src_buffer);
+    reader_common.push_back(start_buffer);
+    reader_common.push_back(end_buffer);
+    reader_common.append(reader_common_dims);
+    reader_desc.emplace_common_runtime_args(reader_common);
     reader_desc.config = ReaderConfigDescriptor{};
     desc.kernels.push_back(std::move(reader_desc));
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.runtime_args = std::move(writer_runtime_args);
-    writer_desc.config = WriterConfigDescriptor{};
     desc.kernels.push_back(std::move(writer_desc));
 
     return desc;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -84,11 +84,8 @@ void emit_runtime_args_hc_tiled_interleaved(
         uint32_t end_idx = start_idx + num_tiles_per_core;
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
 
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{input_buffer->address(), num_tiles_per_core, start_idx});
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
+        reader_desc.emplace_runtime_args(core, {input_buffer, num_tiles_per_core, start_idx});
+        writer_desc.emplace_runtime_args(core, {output_buffer, start_idx, end_idx, padded_start_idx, padded_end_idx});
 
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -62,26 +62,24 @@ void emit_runtime_args_hc_tiled(
         uint32_t h = num_tiles_read / CtWt % H;
         uint32_t ct = num_tiles_read / Wt % Ct;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                input_buffer->address(),
-                Wt,
-                H,
-                Ct,
-                HW_bytes,
-                CHW_bytes,
-                num_tiles_read,
-                num_tiles_per_core,
-                num_tiles_read / CtHWt * CHW_bytes,
-                h,
-                h / TILE_HEIGHT * Wt,
-                ct,
-                ct * TILE_HEIGHT * HW_bytes,
-                num_tiles_read % Wt});
+            {input_buffer,
+             Wt,
+             H,
+             Ct,
+             HW_bytes,
+             CHW_bytes,
+             num_tiles_read,
+             num_tiles_per_core,
+             num_tiles_read / CtHWt * CHW_bytes,
+             h,
+             h / TILE_HEIGHT * Wt,
+             ct,
+             ct * TILE_HEIGHT * HW_bytes,
+             num_tiles_read % Wt});
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_buffer->address(), num_tiles_per_core, num_tiles_read});
+        writer_desc.emplace_runtime_args(core, {output_buffer, num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -290,23 +290,21 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        //  writer runtime args
-        std::vector<uint32_t> writer_rt_args = {
-            dst_buffer->address(),
-            TILE_WIDTH * el_size * single_block_size_row_arg,
-            start_row_id,
-            start_column_id,
-            single_block_size_row_arg,
-            single_block_size_col_arg,
-            TILE_WIDTH * el_size * single_sub_block_size_row_arg,
-            single_sub_block_size_row_arg};
-
         // reader runtime args
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
+            core, {src0_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
+
+        //  writer runtime args
+        writer_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                src0_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_rt_args));
+            {dst_buffer,
+             TILE_WIDTH * el_size * single_block_size_row_arg,
+             start_row_id,
+             start_column_id,
+             single_block_size_row_arg,
+             single_block_size_col_arg,
+             TILE_WIDTH * el_size * single_sub_block_size_row_arg,
+             single_sub_block_size_row_arg});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * el_size);
         start_column_id = end_column_id % padded_row_size_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -163,19 +163,11 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
         uint32_t size_per_row_per_block = nblocks_per_core * TILE_WIDTH * el_size;
 
         //  writer runtime args
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                dst_buffer->address(),
-                i,
-                size_per_row_per_block,
-                number_blocks_per_core,
-                TILE_WIDTH * el_size,
-            });
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, i, size_per_row_per_block, number_blocks_per_core, TILE_WIDTH * el_size});
 
         // reader runtime args
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{src0_buffer->address(), i, num_tiles_per_row, number_blocks_per_core});
+        reader_desc.emplace_runtime_args(core, {src0_buffer, i, num_tiles_per_row, number_blocks_per_core});
     }
 
     // Insert reader+writer at the start so kernel ordering matches the legacy program: reader is

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
@@ -143,23 +143,13 @@ ProgramDescriptor TanhBwProgramFactory::create_descriptor(
             TT_THROW("Core not in specified core ranges");
         }
 
-        reader_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),
-                src1_buffer->address(),
-                num_tiles_per_core,
-                num_tiles_written,
-                0,
-                0,
-                num_cores_y});
+        reader_desc.emplace_runtime_args(
+            core, {src0_buffer, src1_buffer, num_tiles_per_core, num_tiles_written, 0u, 0u, num_cores_y});
 
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{num_tiles_per_core, 1});
 
-        writer_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
 
         num_tiles_written += num_tiles_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
@@ -106,11 +106,9 @@ ProgramDescriptor ExampleDeviceOperation::MultiCore::create_descriptor(
             TT_ASSERT(false, "Core not in specified core ranges");
         }
 
-        reader_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{src_buffer->address(), num_tiles_per_core, num_tiles_written});
+        reader_desc.emplace_runtime_args(core, {src_buffer, num_tiles_per_core, num_tiles_written});
 
-        writer_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
 
         compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_tiles_per_core});
 

--- a/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
@@ -108,11 +108,9 @@ ProgramDescriptor ExampleDeviceOperation::SingleCore::create_descriptor(
             TT_ASSERT(false, "Core not in specified core ranges");
         }
 
-        reader_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{src_buffer->address(), num_tiles_per_core, num_tiles_written});
+        reader_desc.emplace_runtime_args(core, {src_buffer, num_tiles_per_core, num_tiles_written});
 
-        writer_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
 
         compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_tiles_per_core});
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -95,10 +95,6 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
     uint32_t in1_KtNt_stride = transpose_hw_bool ? bshape[2] / TILE_HEIGHT * in1_Kt : in1_Kt * Nt;
     uint32_t in1_KtNt_skip = transpose_hw_bool ? (bshape[2] / TILE_HEIGHT - 1) * in1_Kt : (in1_Kt - Kt) * Nt;
 
-    uint32_t src0_addr = src0_buffer->address();
-    uint32_t src1_addr = src1_buffer->address();
-    uint32_t dst_addr = dst_buffer->address();
-
     // ---- Circular buffers ----
     // cb_src0's total_size = Kt * in0_single_tile_size depends on the input shape;
     // padded_shape is folded into compute_program_hash() so each unique Kt keeps
@@ -234,11 +230,11 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
             continue;
         }
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                src0_addr,
-                src1_addr,
+            {
+                src0_buffer,
+                src1_buffer,
                 Mt,
                 Kt,
                 Nt,
@@ -247,7 +243,7 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
                 in1_KtNt_stride * num_rows_in_one_tile,
                 num_output_blocks_per_core,
                 num_blocks_written * MtKt,  // itileA_start
-                0,                          // itileB_start; always read same in1 per core
+                0u,                         // itileB_start; always read same in1 per core
             });
         compute_desc.runtime_args.emplace_back(
             core,
@@ -257,10 +253,10 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
                 Kt,                                 // Kt
                 num_output_blocks_per_core * MtNt,  // Nt
             });
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                dst_addr,
+            {
+                dst_buffer,
                 num_output_blocks_per_core * MtNt,
                 num_blocks_written * MtNt,
             });

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -355,17 +355,17 @@ tt::tt_metal::ProgramDescriptor GroupAttnMatmulProgramFactory::create_descriptor
         const uint32_t in1_mcast_num_dests =
             Q_HEADS < TILE_HEIGHT ? std::min(mcast_num_cores_for_core, num_active_cores - 1) : mcast_num_dests - 1;
 
-        std::vector<uint32_t> reader_runtime_args = {
+        std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {
             has_work_for_mcast_kv_heads,
             has_work_for_q_heads,
-            src1_buffer->address(),
+            src1_buffer,
             Mt,
             Nt,
             KV_HEADS,
             in1_CKtNt,
             in1_CKtNt * TILE_HEIGHT,
             num_output_blocks_per_core,
-            0,  // in1_start_id
+            0u,  // in1_start_id
 
             in0_block_w,
             out_block_w,
@@ -397,30 +397,31 @@ tt::tt_metal::ProgramDescriptor GroupAttnMatmulProgramFactory::create_descriptor
             reader_runtime_args.end(), in1_mcast_sender_noc_x.begin(), in1_mcast_sender_noc_x.end());
         reader_runtime_args.insert(
             reader_runtime_args.end(), in1_mcast_sender_noc_y.begin(), in1_mcast_sender_noc_y.end());
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
 
-        std::vector<uint32_t> writer_runtime_args = {
-            has_work_for_q_heads,
-            src0_buffer->address(),
-            dst_buffer->address(),
-            Mt,
-            Kt,
-            Nt,
-            MtKt,
-            num_output_blocks_per_core,
-            num_blocks_written * MtKt,
-            num_blocks_written * MtNt,
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                has_work_for_q_heads,
+                src0_buffer,
+                dst_buffer,
+                Mt,
+                Kt,
+                Nt,
+                MtKt,
+                num_output_blocks_per_core,
+                num_blocks_written * MtKt,
+                num_blocks_written * MtNt,
 
-            in0_block_w,
-            in1_num_subblocks,
-            in1_num_blocks,
-            MtNt,
+                in0_block_w,
+                in1_num_subblocks,
+                in1_num_blocks,
+                MtNt,
 
-            bfloat16_row_bytes,
-            bfloat16_Nt_bytes,
-            bfloat16_last_row_bytes_read,
-        };
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+                bfloat16_row_bytes,
+                bfloat16_Nt_bytes,
+                bfloat16_last_row_bytes_read,
+            });
 
         std::vector<uint32_t> compute_runtime_args = {
             has_work_for_q_heads,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -245,26 +245,19 @@ ProgramDescriptor MorehAbsPowOperation::create_descriptor(
         }
 
         // reader
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input.buffer()->address(),
-                static_cast<uint32_t>(is_dram(input)),
-                std::bit_cast<uint32_t>(decimal),
-                num_units_per_core,
-                Wt,
-                tile_offset,
-                origin_w});
+            {input.buffer(),
+             static_cast<uint32_t>(is_dram(input)),
+             std::bit_cast<uint32_t>(decimal),
+             num_units_per_core,
+             Wt,
+             tile_offset,
+             origin_w});
 
         // writer
-        writer_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                output.buffer()->address(),
-                static_cast<uint32_t>(is_dram(output)),
-                num_units_per_core,
-                Wt,
-                tile_offset});
+        writer_desc.emplace_runtime_args(
+            core, {output.buffer(), static_cast<uint32_t>(is_dram(output)), num_units_per_core, Wt, tile_offset});
 
         // compute — runtime args go to the correct kernel descriptor
         KernelDescriptor::CoreRuntimeArgs compute_rt{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
@@ -212,7 +212,6 @@ ProgramDescriptor MorehClipGradNormStep1Operation::create_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto output_addr = tmp_pow_sum.buffer()->address();
     auto cores = grid_to_cores(num_cores_to_be_used, num_cores_x, num_cores_y, false);
 
     uint32_t tile_offset = tile_offset_of_tmp_pow_sum;
@@ -220,18 +219,15 @@ ProgramDescriptor MorehClipGradNormStep1Operation::create_descriptor(
         const CoreCoord& core = cores.at(i);
 
         const auto& input = inputs.at(i);
-        const auto input_addr = input.buffer()->address();
         const auto num_tiles = static_cast<uint32_t>(input.physical_volume()) / tt::constants::TILE_HW;
         const auto [origin_h, origin_w] = origin_hw_vec.at(i);
 
         // reader
-        reader_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input_addr, num_tiles, std::bit_cast<uint32_t>(decimal), origin_h, origin_w});
+        reader_desc.emplace_runtime_args(
+            core, {input.buffer(), num_tiles, std::bit_cast<uint32_t>(decimal), origin_h, origin_w});
 
         // writer
-        writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset});
+        writer_desc.emplace_runtime_args(core, {tmp_pow_sum.buffer(), tile_offset});
 
         // compute
         compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
@@ -151,17 +151,12 @@ ProgramDescriptor MorehClipGradNormStep2Operation::create_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto input_addr = tmp_pow_sum.buffer()->address();
-    const auto output_addr = total_norm.buffer()->address();
-
     // reader
-    reader_desc.runtime_args.emplace_back(
-        single_core,
-        KernelDescriptor::CoreRuntimeArgs{
-            input_addr, static_cast<uint32_t>(num_tiles), std::bit_cast<uint32_t>(decimal)});
+    reader_desc.emplace_runtime_args(
+        single_core, {tmp_pow_sum.buffer(), static_cast<uint32_t>(num_tiles), std::bit_cast<uint32_t>(decimal)});
 
     // writer
-    writer_desc.runtime_args.emplace_back(single_core, KernelDescriptor::CoreRuntimeArgs{output_addr});
+    writer_desc.emplace_runtime_args(single_core, {total_norm.buffer()});
 
     // compute
     compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
@@ -133,21 +133,18 @@ ProgramDescriptor MorehClipGradNormStep3Operation::create_descriptor(
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
     auto cores = grid_to_cores(num_cores_to_be_used, num_cores_x, num_cores_y, false);
-    const auto clip_coef_clamped_addr = clip_coef_clamped.buffer()->address();
 
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores.at(i);
 
         const auto& input = inputs.at(i);
-        const auto input_addr = input.buffer()->address();
         const auto num_tiles = static_cast<uint32_t>(input.physical_volume()) / tt::constants::TILE_HW;
 
         // reader
-        reader_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{input_addr, clip_coef_clamped_addr, num_tiles});
+        reader_desc.emplace_runtime_args(core, {input.buffer(), clip_coef_clamped.buffer(), num_tiles});
 
         // writer
-        writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{input_addr, num_tiles});
+        writer_desc.emplace_runtime_args(core, {input.buffer(), num_tiles});
 
         // compute
         compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_tiles});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
@@ -124,10 +124,7 @@ ProgramDescriptor MorehDotOperation::create_descriptor(
     reader_desc.core_ranges = core_set;
     reader_desc.compile_time_args = std::move(reader_ct_args);
     reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.runtime_args.emplace_back(
-        core,
-        KernelDescriptor::CoreRuntimeArgs{
-            src0_buffer->address(), src1_buffer->address(), num_tiles, 0u, mask_h, mask_w});
+    reader_desc.emplace_runtime_args(core, {src0_buffer, src1_buffer, num_tiles, 0u, mask_h, mask_w});
 
     // Writer kernel
     KernelDescriptor::CompileTimeArgs writer_ct_args = {static_cast<uint32_t>(tt::CBIndex::c_16)};
@@ -139,7 +136,7 @@ ProgramDescriptor MorehDotOperation::create_descriptor(
     writer_desc.core_ranges = core_set;
     writer_desc.compile_time_args = std::move(writer_ct_args);
     writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dst_buffer->address(), 1u, 0u});
+    writer_desc.emplace_runtime_args(core, {dst_buffer, 1u, 0u});
 
     // Compute kernel
     KernelDescriptor compute_desc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
@@ -108,33 +108,30 @@ ProgramDescriptor MorehDotBackwardOperation::create_descriptor(
     reader_desc.core_ranges = core_set;
     reader_desc.compile_time_args = std::move(reader_ct_args);
     reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.runtime_args.emplace_back(
+    reader_desc.emplace_runtime_args(
         core,
-        KernelDescriptor::CoreRuntimeArgs{
-            static_cast<uint32_t>(has_input_grad),
-            static_cast<uint32_t>(has_other_grad),
-            src0_buffer->address(),
-            src1_buffer->address(),
-            src2_buffer->address(),
-            num_tiles,
-            0u});
+        {static_cast<uint32_t>(has_input_grad),
+         static_cast<uint32_t>(has_other_grad),
+         src0_buffer,
+         src1_buffer,
+         src2_buffer,
+         num_tiles,
+         0u});
 
     // Writer kernel
-    uint32_t dst0_address = 0;
-    uint32_t dst1_address = 0;
+    Buffer* dst0_buffer = nullptr;
+    Buffer* dst1_buffer = nullptr;
 
     if (has_input_grad) {
         const auto& input_grad_tensor = input_grad.value();
-        auto* dst0_buffer = input_grad_tensor.buffer();
+        dst0_buffer = input_grad_tensor.buffer();
         TT_ASSERT(dst0_buffer != nullptr, "input_grad buffer should be allocated on device!");
-        dst0_address = dst0_buffer->address();
     }
 
     if (has_other_grad) {
         const auto& other_grad_tensor = other_grad.value();
-        auto* dst1_buffer = other_grad_tensor.buffer();
+        dst1_buffer = other_grad_tensor.buffer();
         TT_ASSERT(dst1_buffer != nullptr, "other_grad buffer should be allocated on device!");
-        dst1_address = dst1_buffer->address();
     }
 
     KernelDescriptor::CompileTimeArgs writer_ct_args = {
@@ -150,15 +147,23 @@ ProgramDescriptor MorehDotBackwardOperation::create_descriptor(
     writer_desc.core_ranges = core_set;
     writer_desc.compile_time_args = std::move(writer_ct_args);
     writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.runtime_args.emplace_back(
-        core,
-        KernelDescriptor::CoreRuntimeArgs{
-            static_cast<uint32_t>(has_input_grad),
-            static_cast<uint32_t>(has_other_grad),
-            dst0_address,
-            dst1_address,
-            num_tiles,
-            0u});
+    KernelDescriptor::RTArgList writer_args;
+    writer_args.push_back(static_cast<uint32_t>(has_input_grad));
+    writer_args.push_back(static_cast<uint32_t>(has_other_grad));
+    // Push the grad buffer when present, 0 when absent (framework treats an absent slot as 0).
+    if (has_input_grad) {
+        writer_args.push_back(dst0_buffer);
+    } else {
+        writer_args.push_back(0u);
+    }
+    if (has_other_grad) {
+        writer_args.push_back(dst1_buffer);
+    } else {
+        writer_args.push_back(0u);
+    }
+    writer_args.push_back(num_tiles);
+    writer_args.push_back(0u);
+    writer_desc.emplace_runtime_args(core, writer_args);
 
     // Compute kernel
     KernelDescriptor compute_desc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
@@ -169,35 +169,32 @@ ProgramDescriptor MorehFoldOperation::create_descriptor(
         uint32_t aligned = (src_is_dram ? (input_cb_page_size % dram_alignment == 0) : 1);
         aligned = aligned && !is_blackhole;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input.buffer()->address(),
-                N,
-                C,
-                H,
-                W,
-                kernel_size_h,
-                kernel_size_w,
-                stride_h,
-                stride_w,
-                padding_h,
-                padding_w,
-                dilation_h,
-                dilation_w,
-                LH,
-                LW,
-                input_cb_page_size,
-                dram_aligned_input_cb_page_size,
-                aligned_output_cb_page_size,
-                start_id,
-                num_units_per_core,
-                aligned});
+            {input.buffer(),
+             N,
+             C,
+             H,
+             W,
+             kernel_size_h,
+             kernel_size_w,
+             stride_h,
+             stride_w,
+             padding_h,
+             padding_w,
+             dilation_h,
+             dilation_w,
+             LH,
+             LW,
+             input_cb_page_size,
+             dram_aligned_input_cb_page_size,
+             aligned_output_cb_page_size,
+             start_id,
+             num_units_per_core,
+             aligned});
 
-        writer_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                output.buffer()->address(), aligned_output_cb_page_size, start_id, num_units_per_core});
+        writer_desc.emplace_runtime_args(
+            core, {output.buffer(), aligned_output_cb_page_size, start_id, num_units_per_core});
 
         start_id += num_units_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
@@ -228,9 +228,6 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
     auto* const mean_buf = mean.buffer();
     auto* const rstd_buf = rstd.buffer();
 
-    const auto gamma_grad_addr = gamma_grad_has_value ? gamma_grad.value().buffer()->address() : 0u;
-    const auto beta_grad_addr = beta_grad_has_value ? beta_grad.value().buffer()->address() : 0u;
-
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -243,36 +240,37 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // NOTE: do not pass Buffer* here. tile_offset/num_channels_per_core/etc are
-        // per-core shape-derived; using BufferBinding would skip create_descriptor()
-        // on cache hits and leave those scalars stale.
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                output_grad_buf->address(),
-                input_buf->address(),
-                mean_buf->address(),
-                rstd_buf->address(),
-                tile_offset,
-                num_channels_per_core,
-                num_inner_tiles,
-                num_channels,
-                num_groups,
-                origin_h,
-                origin_w,
-            });
+            {output_grad_buf,
+             input_buf,
+             mean_buf,
+             rstd_buf,
+             tile_offset,
+             num_channels_per_core,
+             num_inner_tiles,
+             num_channels,
+             num_groups,
+             origin_h,
+             origin_w});
 
-        // writer (already address-only, no BufferBinding)
-        writer_desc.runtime_args.emplace_back(
-            core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                gamma_grad_addr,
-                beta_grad_addr,
-                tile_offset,
-                num_channels_per_core,
-                num_inner_tiles,
-                batch,
-            });
+        // writer
+        KernelDescriptor::RTArgList writer_args;
+        if (gamma_grad_has_value) {
+            writer_args.push_back(gamma_grad.value().buffer());
+        } else {
+            writer_args.push_back(0u);
+        }
+        if (beta_grad_has_value) {
+            writer_args.push_back(beta_grad.value().buffer());
+        } else {
+            writer_args.push_back(0u);
+        }
+        writer_args.push_back(tile_offset);
+        writer_args.push_back(num_channels_per_core);
+        writer_args.push_back(num_inner_tiles);
+        writer_args.push_back(batch);
+        writer_desc.emplace_runtime_args(core, writer_args);
 
         tile_offset += num_channels_per_core * HtWt;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
@@ -248,8 +248,6 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
 
     auto* const input_grad_buf = input_grad.buffer();
 
-    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
-
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -262,35 +260,28 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // NOTE: do not pass Buffer* here. gamma_addr is an optional-tensor address
-        // and tile_offset/etc are per-core shape-derived; using BufferBinding would
-        // skip create_descriptor() on cache hits and leave those scalars stale.
-        reader_desc.runtime_args.emplace_back(
-            core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                output_grad_buf->address(),
-                input_buf->address(),
-                mean_buf->address(),
-                rstd_buf->address(),
-                gamma_addr,
-                tile_offset,
-                num_rows_per_core,
-                num_inner_tiles,
-                num_channels,
-                num_groups,
-                origin_h,
-                origin_w,
-            });
+        // reader
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(output_grad_buf);
+        reader_args.push_back(input_buf);
+        reader_args.push_back(mean_buf);
+        reader_args.push_back(rstd_buf);
+        if (gamma_has_value) {
+            reader_args.push_back(gamma.value().buffer());
+        } else {
+            reader_args.push_back(0u);
+        }
+        reader_args.push_back(tile_offset);
+        reader_args.push_back(num_rows_per_core);
+        reader_args.push_back(num_inner_tiles);
+        reader_args.push_back(num_channels);
+        reader_args.push_back(num_groups);
+        reader_args.push_back(origin_h);
+        reader_args.push_back(origin_w);
+        reader_desc.emplace_runtime_args(core, reader_args);
 
         // writer
-        writer_desc.runtime_args.emplace_back(
-            core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                input_grad_buf->address(),
-                tile_offset,
-                num_rows_per_core,
-                num_inner_tiles,
-            });
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, tile_offset, num_rows_per_core, num_inner_tiles});
 
         tile_offset += num_rows_per_core * num_inner_tiles;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -84,42 +84,44 @@ void populate_runtime_arguments(
         const auto packed_scalar_eps =
             any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
 
-        // NOTE: do not pass Buffer* here. packed_scalar_eps depends on the eps
-        // operation_attribute and changes between calls; using BufferBinding
-        // would skip create_descriptor() on cache hits and leave eps stale.
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                packed_scalar_eps,
-                input_tensor.buffer()->address(),
-                start_tile_id,
-                num_tiles_per_core,
-                cHtWt,
-                aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
-                aHt * aWt * static_cast<uint32_t>(aC > 1),
-                cN,
-                cC,
-                cHt,
-                cWt});
+            {packed_scalar_eps,
+             input_tensor.buffer(),
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
+             aHt * aWt * static_cast<uint32_t>(aC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
-        const auto weight_addr = weight_has_value ? weight_tensor->buffer()->address() : 0;
-        const auto bias_addr = bias_has_value ? bias_tensor->buffer()->address() : 0;
-        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs writer_runtime_args = {
-            batch_mean_tensor.buffer()->address(),  //  batch mean
-            batch_var_tensor.buffer()->address(),   //  batch var
-            weight_addr,                            // weight
-            bias_addr,                              // bias
-            c.buffer()->address(),                  // output
-            start_tile_id,
-            num_tiles_per_core,
-            cHtWt,
-            bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
-            bHt * bWt * static_cast<uint32_t>(bC > 1),
-            cN,
-            cC,
-            cHt,
-            cWt};
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+        std::variant<uint32_t, tt::tt_metal::Buffer*> weight_arg = 0u;
+        if (weight_has_value) {
+            weight_arg = weight_tensor->buffer();
+        }
+        std::variant<uint32_t, tt::tt_metal::Buffer*> bias_arg = 0u;
+        if (bias_has_value) {
+            bias_arg = bias_tensor->buffer();
+        }
+        writer_desc.emplace_runtime_args(
+            core,
+            {batch_mean_tensor.buffer(),  //  batch mean
+             batch_var_tensor.buffer(),   //  batch var
+             weight_arg,                  // weight
+             bias_arg,                    // bias
+             c.buffer(),                  // output
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
+             bHt * bWt * static_cast<uint32_t>(bC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
         auto counter = start_tile_id % cHtWt;
         auto freq = cHtWt;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -82,42 +82,43 @@ void populate_runtime_arguments(
         const auto scalar = momentum;
         const auto packed_scalar_momentum =
             any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
-        // NOTE: do not pass Buffer* here. packed_scalar_momentum depends on the
-        // momentum operation_attribute and changes between calls; using
-        // BufferBinding would skip create_descriptor() on cache hits and leave
-        // momentum stale.
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                packed_scalar_momentum,
-                batch_mean_tensor.buffer()->address(),
-                start_tile_id,
-                num_tiles_per_core,
-                cHtWt,
-                aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
-                aHt * aWt * static_cast<uint32_t>(aC > 1),
-                cN,
-                cC,
-                cHt,
-                cWt});
+            {packed_scalar_momentum,
+             batch_mean_tensor.buffer(),
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
+             aHt * aWt * static_cast<uint32_t>(aC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
-        const auto running_mean_addr = running_mean_has_value ? running_mean_tensor->buffer()->address() : 0;
-        const auto running_var_addr = running_var_has_value ? running_var_tensor->buffer()->address() : 0;
-        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs writer_runtime_args = {
-            batch_var_tensor.buffer()->address(),  //  batch var
-            running_mean_addr,                     // old running mean
-            running_var_addr,                      // old running var
-            c.buffer()->address(),                 // output
-            start_tile_id,
-            num_tiles_per_core,
-            cHtWt,
-            bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
-            bHt * bWt * static_cast<uint32_t>(bC > 1),
-            cN,
-            cC,
-            cHt,
-            cWt};
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+        std::variant<uint32_t, tt::tt_metal::Buffer*> running_mean_arg = 0u;
+        if (running_mean_has_value) {
+            running_mean_arg = running_mean_tensor->buffer();
+        }
+        std::variant<uint32_t, tt::tt_metal::Buffer*> running_var_arg = 0u;
+        if (running_var_has_value) {
+            running_var_arg = running_var_tensor->buffer();
+        }
+        writer_desc.emplace_runtime_args(
+            core,
+            {batch_var_tensor.buffer(),  //  batch var
+             running_mean_arg,           // old running mean
+             running_var_arg,            // old running var
+             c.buffer(),                 // output
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
+             bHt * bWt * static_cast<uint32_t>(bC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
         auto counter = start_tile_id % cHtWt;
         auto freq = cHtWt;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -283,12 +283,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
             block_wt * tile_width);
     }
 
-    auto in0_dram_addr = a.buffer()->address();
-    auto out_dram_addr = output.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto input_mask_dram_addr = input_mask.has_value() ? input_mask.value().buffer()->address() : 0;
-
     uint32_t in0_block_tiles_group_1 = block_ht_group_1 / num_out_blocks * block_wt;
     uint32_t in0_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
@@ -1085,9 +1079,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                 if (reader_noc == NOC::NOC_1) {
                     std::swap(mcast_start, mcast_end);
                 }
-                std::vector<uint32_t> mcast_sender_args;
-                mcast_sender_args.push_back(in0_dram_addr);
-                mcast_sender_args.push_back(out_dram_addr);
+                tt::tt_metal::KernelDescriptor::RTArgList mcast_sender_args;
+                mcast_sender_args.push_back(a.buffer());
+                mcast_sender_args.push_back(output.buffer());
                 mcast_sender_args.push_back(in0_start_id);
                 mcast_sender_args.push_back(out_tile_start_id);
                 mcast_sender_args.push_back(Wt);
@@ -1139,23 +1133,18 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                     CoreCoord coord = device->worker_core_from_logical_core(gcore);
                     mcast_noc_xy.push_back(coord.y);
                 }
-                mcast_sender_args.insert(mcast_sender_args.end(), mcast_noc_xy.begin(), mcast_noc_xy.end());
-                reader_mcast_sender_desc.runtime_args.emplace_back(core, std::move(mcast_sender_args));
+                mcast_sender_args.append(mcast_noc_xy);
+                reader_mcast_sender_desc.emplace_runtime_args(core, mcast_sender_args);
             } else {  // mcast receiver
-                // NOTE: do not pass Buffer* here. in0_start_id/out_tile_start_id/Wt/mcast
-                // coords are per-core and shape-derived; using BufferBinding would skip
-                // create_descriptor() on cache hits and leave those scalars stale when a
-                // later call collides on the same cache entry with different shape/grid.
-                reader_mcast_receiver_desc.runtime_args.emplace_back(
+                reader_mcast_receiver_desc.emplace_runtime_args(
                     core,
-                    tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                        a.buffer()->address(),
-                        output.buffer()->address(),
-                        in0_start_id,
-                        out_tile_start_id,
-                        Wt,
-                        static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).x),
-                        static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).y)});
+                    {a.buffer(),
+                     output.buffer(),
+                     in0_start_id,
+                     out_tile_start_id,
+                     Wt,
+                     static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).x),
+                     static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).y)});
             }
         }
     }
@@ -1187,18 +1176,30 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
             }
         }
 
-        std::vector<uint32_t> writer_mcast_sender_args;
+        tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(eps_u);
-        writer_mcast_sender_args.push_back(out_dram_addr);
-        writer_mcast_sender_args.push_back(gamma_dram_addr);
-        writer_mcast_sender_args.push_back(beta_dram_addr);
-        writer_mcast_sender_args.push_back(input_mask_dram_addr);
+        writer_mcast_sender_args.push_back(output.buffer());
+        if (gamma.has_value()) {
+            writer_mcast_sender_args.push_back(gamma.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (beta.has_value()) {
+            writer_mcast_sender_args.push_back(beta.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (input_mask.has_value()) {
+            writer_mcast_sender_args.push_back(input_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
         writer_mcast_sender_args.push_back(out_tile_start_id);
         writer_mcast_sender_args.push_back(gamma_tile_start_id);
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+        writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
     }
 
     desc.kernels.push_back(std::move(reader_mcast_sender_desc));

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -380,13 +380,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             block_wt * tile_width);
     }
 
-    // get addr
-    auto in0_dram_addr = a.buffer()->address();
-    auto out_dram_addr = output.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto input_mask_dram_addr = input_mask.has_value() ? input_mask.value().buffer()->address() : 0;
-
     // Parameters Setup
     uint32_t in0_block_tiles_group_1 = block_ht_group_1 / num_out_blocks * block_wt;
     uint32_t in0_block_tiles_group_2 = 0;
@@ -1343,9 +1336,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             if (reader_noc == NOC::NOC_1) {
                 std::swap(mcast_start, mcast_end);
             }
-            std::vector<uint32_t> mcast_sender_args;
-            mcast_sender_args.push_back(in0_dram_addr);
-            mcast_sender_args.push_back(out_dram_addr);
+            tt::tt_metal::KernelDescriptor::RTArgList mcast_sender_args;
+            mcast_sender_args.push_back(a.buffer());
+            mcast_sender_args.push_back(output.buffer());
             mcast_sender_args.push_back(in0_start_id);
             mcast_sender_args.push_back(out_tile_start_id);
             mcast_sender_args.push_back(Wt);
@@ -1397,11 +1390,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
                 CoreCoord coord = device->worker_core_from_logical_core(gcore);
                 mcast_noc_xy.push_back(coord.y);
             }
-            mcast_sender_args.insert(mcast_sender_args.end(), mcast_noc_xy.begin(), mcast_noc_xy.end());
+            mcast_sender_args.append(mcast_noc_xy);
             if (equal_batches_per_core || (virtual_core.y <= last_row_with_extra_batch)) {
-                reader_mcast_sender_desc_g1.runtime_args.emplace_back(core, std::move(mcast_sender_args));
+                reader_mcast_sender_desc_g1.emplace_runtime_args(core, mcast_sender_args);
             } else {
-                reader_mcast_sender_desc_g2.runtime_args.emplace_back(core, std::move(mcast_sender_args));
+                reader_mcast_sender_desc_g2.emplace_runtime_args(core, mcast_sender_args);
             }
         }
     }
@@ -1438,21 +1431,33 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             }
         }
 
-        std::vector<uint32_t> writer_mcast_sender_args;
+        tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(eps_u);
-        writer_mcast_sender_args.push_back(out_dram_addr);
-        writer_mcast_sender_args.push_back(gamma_dram_addr);
-        writer_mcast_sender_args.push_back(beta_dram_addr);
-        writer_mcast_sender_args.push_back(input_mask_dram_addr);
+        writer_mcast_sender_args.push_back(output.buffer());
+        if (gamma.has_value()) {
+            writer_mcast_sender_args.push_back(gamma.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (beta.has_value()) {
+            writer_mcast_sender_args.push_back(beta.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (input_mask.has_value()) {
+            writer_mcast_sender_args.push_back(input_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
         writer_mcast_sender_args.push_back(out_tile_start_id);
         writer_mcast_sender_args.push_back(gamma_tile_start_id);
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
         if (equal_batches_per_core || (virtual_core.y <= last_row_with_extra_batch)) {
-            writer_desc_g1.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+            writer_desc_g1.emplace_runtime_args(core, writer_mcast_sender_args);
         } else {
-            writer_desc_g2.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+            writer_desc_g2.emplace_runtime_args(core, writer_mcast_sender_args);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -305,13 +305,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             block_wt * tile_width);
     }
 
-    // get sharded addr
-    // gamma, beta addr
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto input_mask_dram_addr = input_mask.has_value() ? input_mask.value().buffer()->address() : 0;
-    auto input_negative_mask_dram_addr = negative_mask.has_value() ? negative_mask.value().buffer()->address() : 0;
-
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -1236,16 +1229,32 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t beta_tile_start_id = 0;
     uint32_t input_mask_tile_start_id = 0;
     for (const auto& core : core_coords) {
-        std::vector<uint32_t> writer_mcast_sender_args;
+        tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(eps_u);
-        writer_mcast_sender_args.push_back(gamma_dram_addr);
-        writer_mcast_sender_args.push_back(beta_dram_addr);
-        writer_mcast_sender_args.push_back(input_mask_dram_addr);
-        writer_mcast_sender_args.push_back(input_negative_mask_dram_addr);
+        if (gamma.has_value()) {
+            writer_mcast_sender_args.push_back(gamma.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (beta.has_value()) {
+            writer_mcast_sender_args.push_back(beta.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (input_mask.has_value()) {
+            writer_mcast_sender_args.push_back(input_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (negative_mask.has_value()) {
+            writer_mcast_sender_args.push_back(negative_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
         writer_mcast_sender_args.push_back(gamma_tile_start_id);
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+        writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
 
         if (gamma.has_value()) {
             gamma_tile_start_id = (gamma_tile_start_id + gamma_beta_num_cols_tile_per_core) %

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -128,7 +128,6 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     //////////////////////////////////////////////////////////////////////////
     // This should allocate a DRAM buffer on the device
     IDevice* device = a.device();
-    auto dst_addr = output.buffer()->address();
 
     ////////////////////////////////////////////////////////////////////////////
     //                Circular Buffer Data Format Setup
@@ -184,10 +183,10 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         inb_single_tile_size = tt::tile_size(inb_data_format);
     }
 
-    auto a_addr = a.buffer()->address();
-    auto b_dram_addr = b ? b.value().buffer()->address() : 0;
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
+    // Optional residual/gamma/beta: bind the Buffer* when present, else nullptr (framework emits 0u).
+    Buffer* b_buffer = b ? b.value().buffer() : nullptr;
+    Buffer* gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    Buffer* beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     uint32_t num_tile_rows = NC * Ht;
 
@@ -553,13 +552,15 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     auto bfloat_one_value = bfloat16(1);
     uint32_t packed_one_value = pack_two_bfloat16_into_uint32({bfloat_one_value, bfloat_one_value});
 
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Buffer base addresses are bound via emplace_runtime_args() so the framework
+    // patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
-    reader_runtime_args.reserve(num_cores);
-    writer_runtime_args.reserve(num_cores);
-    compute_runtime_args.reserve(num_cores);
+    reader_kernel_desc.runtime_args.reserve(num_cores);
+    writer_kernel_desc.runtime_args.reserve(num_cores);
+    compute_kernel_desc.runtime_args.reserve(num_cores);
 
     // Iterate over active cores
     auto all_core_coords = corerange_to_cores(all_cores, num_cores, true);
@@ -583,30 +584,34 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
             (use_welford_and_not_rms_norm && large_tensor_needed) || (use_row_major_kernel && !input_is_row_major);
         const uint32_t reader_start = using_legacy_tile_reader ? tile_offset : curr_row;
 
-        std::vector<uint32_t> reader_args = {
-            a_addr,
-            num_tile_rows_per_core,
-            Wt,
-            reader_start,
-            packed_one_value,
-            std::bit_cast<uint32_t>(eps),
-            gamma_dram_addr,
-            beta_dram_addr,
-            b_dram_addr};
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(a.buffer());
+        reader_args.push_back(num_tile_rows_per_core);
+        reader_args.push_back(Wt);
+        reader_args.push_back(reader_start);
+        reader_args.push_back(packed_one_value);
+        reader_args.push_back(std::bit_cast<uint32_t>(eps));
+        reader_args.push_back(gamma_buffer);
+        reader_args.push_back(beta_buffer);
+        reader_args.push_back(b_buffer);
         if (input_is_row_major) {
             reader_args.push_back(H_logical);
         }
 
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        reader_kernel_desc.emplace_runtime_args(core, reader_args);
         // For the RM output writer arg[3] is start_tile_row (starting tile-row index for this core),
         // not the flat tile offset, because the RM writer computes row addresses directly.
         const uint32_t writer_start = input_is_row_major ? curr_row : tile_offset;
-        std::vector<uint32_t> writer_args = {dst_addr, Wt, num_tile_rows_per_core, writer_start};
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.push_back(output.buffer());
+        writer_args.push_back(Wt);
+        writer_args.push_back(num_tile_rows_per_core);
+        writer_args.push_back(writer_start);
         if (input_is_row_major) {
-            writer_args.push_back(H_logical);  // arg[4]
+            writer_args.push_back(H_logical);
         }
-        writer_runtime_args.emplace_back(core, std::move(writer_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
+        writer_kernel_desc.emplace_runtime_args(core, writer_args);
+        compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
 
         curr_row += num_tile_rows_per_core;
     }
@@ -617,19 +622,16 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     ProgramDescriptor program_descriptor;
 
     // Build KernelDescriptor for reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source = reader_kernel_path;
     reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = reader_compile_time_args;
     reader_kernel_desc.named_compile_time_args = cb_named_args;
     reader_kernel_desc.defines = reader_defines;
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Build KernelDescriptor for writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source = input_is_row_major
                                            ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
                                              "writer_unary_interleaved_start_id_blocked_rm_output.cpp"
@@ -639,19 +641,16 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = writer_compile_time_args;
     writer_kernel_desc.named_compile_time_args = cb_named_args;
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Build KernelDescriptor for compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_path;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = compute_args;
     compute_kernel_desc.named_compile_time_args = cb_named_args;
     compute_kernel_desc.defines = compute_defines;
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -383,6 +383,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     // RMSNorm doesn't use Welford in this kernel path.
     kernel_config.welford_fp32_alias =
         use_welford && !rms_norm && in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en;
+    kernel_config.gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    kernel_config.beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     add_kernel_descriptors(program_descriptor, core_ranges, workers, grid, std::move(kernel_config));
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -779,6 +779,31 @@ CompileTimeArgs CompileTimeArgs::build(const CompileTimeArgsContext& ctx) {
 // Kernel and CB descriptor builders
 //////////////////////////////////////////////////////////////////////////////
 
+namespace {
+
+// build_writer_args() lays out the gamma/beta base addresses at fixed writer arg indices 3 and 4.
+constexpr uint32_t kWriterGammaArgIdx = 3;
+constexpr uint32_t kWriterBetaArgIdx = 4;
+
+// Bind the gamma/beta writer address slots to their Buffer* so the framework patches them on
+// cache hits. A null buffer (absent optional tensor) leaves the baked 0 untouched.
+void bind_writer_gamma_beta(KernelDescriptor& desc, Buffer* gamma_buffer, Buffer* beta_buffer) {
+    if (gamma_buffer == nullptr && beta_buffer == nullptr) {
+        return;
+    }
+    for (const auto& core_args : desc.runtime_args) {
+        const CoreCoord& core = core_args.first;
+        if (gamma_buffer != nullptr) {
+            desc.buffer_bindings.push_back({core, kWriterGammaArgIdx, gamma_buffer});
+        }
+        if (beta_buffer != nullptr) {
+            desc.buffer_bindings.push_back({core, kWriterBetaArgIdx, beta_buffer});
+        }
+    }
+}
+
+}  // namespace
+
 void add_kernel_descriptors(
     ProgramDescriptor& program_descriptor,
     const CoreRanges& core_ranges,
@@ -895,6 +920,7 @@ void add_kernel_descriptors(
     writer_sender_kernel_desc.named_compile_time_args = writer_cb_named_args;
     writer_sender_kernel_desc.defines = kernel_config.writer_defines;
     writer_sender_kernel_desc.runtime_args = std::move(kernel_config.writer_sender_rt_args);
+    bind_writer_gamma_beta(writer_sender_kernel_desc, kernel_config.gamma_buffer, kernel_config.beta_buffer);
     writer_sender_kernel_desc.config = DataMovementConfigDescriptor{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = kernel_config.writer_noc,
@@ -911,6 +937,7 @@ void add_kernel_descriptors(
         writer_receiver_kernel_desc.named_compile_time_args = writer_cb_named_args;
         writer_receiver_kernel_desc.defines = std::move(kernel_config.writer_defines);
         writer_receiver_kernel_desc.runtime_args = std::move(kernel_config.writer_receiver_rt_args);
+        bind_writer_gamma_beta(writer_receiver_kernel_desc, kernel_config.gamma_buffer, kernel_config.beta_buffer);
         writer_receiver_kernel_desc.config = DataMovementConfigDescriptor{
             .processor = DataMovementProcessor::RISCV_1,
             .noc = kernel_config.writer_noc,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -291,6 +291,11 @@ struct KernelConfig {
     KernelDescriptor::RuntimeArgs compute_all_to_all_rt_args;
     KernelDescriptor::RuntimeArgs compute_not_all_to_all_rt_args;
 
+    // Optional gamma/beta writer base-address slots, bound as BufferBindings in
+    // add_kernel_descriptors() (patched on cache hits); null when the tensor is absent.
+    Buffer* gamma_buffer = nullptr;
+    Buffer* beta_buffer = nullptr;
+
     // NOC config
     tt::tt_metal::NOC reader_noc = tt::tt_metal::NOC::NOC_0;
     tt::tt_metal::NOC writer_noc = tt::tt_metal::NOC::NOC_0;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
@@ -100,11 +100,9 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
     log_debug(tt::LogOp, "math_approx_mode: {}", math_approx_mode);
     log_debug(tt::LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
 
-    auto a_addr = a.buffer()->address();
-    auto stats_addr = stats.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto dst_addr = output.buffer()->address();
+    // Optional gamma/beta: bind the Buffer* when present, else nullptr (framework emits 0u).
+    Buffer* gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    Buffer* beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     [[maybe_unused]] uint32_t num_gamma_tiles = gamma.has_value() ? gamma.value().physical_volume() / tile_hw : 0;
     [[maybe_unused]] uint32_t num_beta_tiles = beta.has_value() ? beta.value().physical_volume() / tile_hw : 0;
@@ -286,10 +284,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
 
     uint32_t eps_u = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
     if (use_2d_kernel) {
         for (uint32_t x = 0; x < cores_x; ++x) {
@@ -305,22 +304,21 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
                     core.x,
                     tile_offset,
                     tiles_per_core_y);
-                reader_runtime_args.emplace_back(
+                reader_kernel_desc.emplace_runtime_args(
                     core,
-                    std::vector<uint32_t>{
-                        a_addr,
-                        tiles_per_core_x,
-                        tiles_per_core_y,
-                        tile_offset,
-                        stats_offset,
-                        eps_u,
-                        gamma_dram_addr,
-                        beta_dram_addr,
-                        stats_addr,
-                        y * tiles_per_core_y});
-                compute_runtime_args.emplace_back(core, std::vector<uint32_t>{tiles_per_core_x});
-                writer_runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{dst_addr, tiles_per_core_x * tiles_per_core_y, tile_offset});
+                    {a.buffer(),
+                     tiles_per_core_x,
+                     tiles_per_core_y,
+                     tile_offset,
+                     stats_offset,
+                     eps_u,
+                     gamma_buffer,
+                     beta_buffer,
+                     stats.buffer(),
+                     y * tiles_per_core_y});
+                compute_kernel_desc.emplace_runtime_args(core, {tiles_per_core_x});
+                writer_kernel_desc.emplace_runtime_args(
+                    core, {output.buffer(), tiles_per_core_x * tiles_per_core_y, tile_offset});
             }
         }
     } else {
@@ -341,22 +339,20 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
             uint32_t stats_offset = curr_row * stats_tiles_cols;
             uint32_t y_offset = 0;
 
-            reader_runtime_args.emplace_back(
+            reader_kernel_desc.emplace_runtime_args(
                 core,
-                std::vector<uint32_t>{
-                    a_addr,
-                    num_tile_rows_per_core,
-                    Wt,
-                    tile_offset,
-                    stats_offset,
-                    eps_u,
-                    gamma_dram_addr,
-                    beta_dram_addr,
-                    stats_addr,
-                    y_offset});
-            compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-            writer_runtime_args.emplace_back(
-                core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * Wt, tile_offset});
+                {a.buffer(),
+                 num_tile_rows_per_core,
+                 Wt,
+                 tile_offset,
+                 stats_offset,
+                 eps_u,
+                 gamma_buffer,
+                 beta_buffer,
+                 stats.buffer(),
+                 y_offset});
+            compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+            writer_kernel_desc.emplace_runtime_args(core, {output.buffer(), num_tile_rows_per_core * Wt, tile_offset});
             curr_row += num_tile_rows_per_core;
         }
     }
@@ -367,7 +363,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_post_allgather.cpp";
@@ -375,30 +370,25 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
@@ -121,11 +121,9 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     log_debug(tt::LogOp, "math_approx_mode: {}", math_approx_mode);
     log_debug(tt::LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
 
-    auto a_addr = a.buffer()->address();
-    auto stats_addr = stats.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto dst_addr = output.buffer()->address();
+    // Optional gamma/beta: bind the Buffer* when present, else nullptr (framework emits 0u).
+    Buffer* gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    Buffer* beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     uint32_t cb_length = Wt;
 
@@ -325,10 +323,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
     uint32_t eps = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
     if (use_2d_kernel) {
         for (uint32_t x = 0; x < cores_x; ++x) {
@@ -344,23 +343,22 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
                     core.x,
                     tile_offset,
                     tiles_per_core_y);
-                reader_runtime_args.emplace_back(
+                reader_kernel_desc.emplace_runtime_args(
                     core,
-                    std::vector<uint32_t>{
-                        a_addr,
-                        tiles_per_core_x,
-                        tiles_per_core_y,
-                        tile_offset,
-                        stats_offset,
-                        packed_winv_value,
-                        eps,
-                        gamma_dram_addr,
-                        beta_dram_addr,
-                        stats_addr,
-                        y * tiles_per_core_y});
-                compute_runtime_args.emplace_back(core, std::vector<uint32_t>{tiles_per_core_x});
-                writer_runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{dst_addr, tiles_per_core_x * tiles_per_core_y, tile_offset});
+                    {a.buffer(),
+                     tiles_per_core_x,
+                     tiles_per_core_y,
+                     tile_offset,
+                     stats_offset,
+                     packed_winv_value,
+                     eps,
+                     gamma_buffer,
+                     beta_buffer,
+                     stats.buffer(),
+                     y * tiles_per_core_y});
+                compute_kernel_desc.emplace_runtime_args(core, {tiles_per_core_x});
+                writer_kernel_desc.emplace_runtime_args(
+                    core, {output.buffer(), tiles_per_core_x * tiles_per_core_y, tile_offset});
             }
         }
     } else {
@@ -381,23 +379,21 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
             uint32_t stats_offset = curr_row * stats_tiles_cols;
             uint32_t y_offset = 0;
 
-            reader_runtime_args.emplace_back(
+            reader_kernel_desc.emplace_runtime_args(
                 core,
-                std::vector<uint32_t>{
-                    a_addr,
-                    num_tile_rows_per_core,
-                    Wt,
-                    tile_offset,
-                    stats_offset,
-                    packed_winv_value,
-                    eps,
-                    gamma_dram_addr,
-                    beta_dram_addr,
-                    stats_addr,
-                    y_offset});
-            compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-            writer_runtime_args.emplace_back(
-                core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * Wt, tile_offset});
+                {a.buffer(),
+                 num_tile_rows_per_core,
+                 Wt,
+                 tile_offset,
+                 stats_offset,
+                 packed_winv_value,
+                 eps,
+                 gamma_buffer,
+                 beta_buffer,
+                 stats.buffer(),
+                 y_offset});
+            compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+            writer_kernel_desc.emplace_runtime_args(core, {output.buffer(), num_tile_rows_per_core * Wt, tile_offset});
             curr_row += num_tile_rows_per_core;
         }
     }
@@ -408,7 +404,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_post_allgather.cpp";
@@ -416,19 +411,16 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
@@ -465,13 +457,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
 
     // Compute kernel
     // Welford preserves the math fidelity selection and FP32 dst-acc setting from compute_kernel_config.
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -77,10 +77,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
     log_debug(tt::LogOp, "in_data_format: {}", in_data_format);
     log_debug(tt::LogOp, "out_data_format: {}", out_data_format);
 
-    auto a_addr = a.buffer()->address();
-    auto dst_addr = output.buffer()->address();
-    auto b_addr = fuse_pre_add ? b->buffer()->address() : 0;
-
     const uint32_t double_buffer_constant = 2;
     const uint32_t in0_tiles = Wt * double_buffer_constant;
     const uint32_t in1_tiles = 1;  // reduce scalar
@@ -149,13 +145,14 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
                    : "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/"
                      "layernorm_pre_allgather.cpp";
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
-    reader_runtime_args.reserve(num_cores);
-    writer_runtime_args.reserve(num_cores);
-    compute_runtime_args.reserve(num_cores);
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
+    reader_kernel_desc.runtime_args.reserve(num_cores);
+    writer_kernel_desc.runtime_args.reserve(num_cores);
+    compute_kernel_desc.runtime_args.reserve(num_cores);
 
     uint32_t curr_row = 0;
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -173,14 +170,18 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
         uint32_t in_tile_offset = curr_row * Wt;
         uint32_t out_tile_offset = curr_row * out0_tiles;
 
-        std::vector<uint32_t> reader_args = {a_addr, num_tile_rows_per_core, Wt, in_tile_offset};
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(a.buffer());
+        reader_args.push_back(num_tile_rows_per_core);
+        reader_args.push_back(Wt);
+        reader_args.push_back(in_tile_offset);
         if (fuse_pre_add) {
-            reader_args.push_back(b_addr);
+            reader_args.push_back(b->buffer());
         }
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * out0_tiles, out_tile_offset});
+        reader_kernel_desc.emplace_runtime_args(core, reader_args);
+        compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+        writer_kernel_desc.emplace_runtime_args(
+            core, {output.buffer(), num_tile_rows_per_core * out0_tiles, out_tile_offset});
 
         curr_row += num_tile_rows_per_core;
     }
@@ -191,7 +192,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp";
@@ -199,30 +199,25 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
@@ -340,10 +335,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
     uint32_t scaler_tile_size = tt::tile_size(scaler_cb_data_format);
 
-    auto a_addr = a.buffer()->address();
-    auto dst_addr = output.buffer()->address();
-    auto b_addr = fuse_pre_add ? b->buffer()->address() : 0;
-
     const uint32_t double_buffer_constant = 2;
     const uint32_t in0_tiles = Wt * double_buffer_constant;
     const uint32_t in1_tiles = 1;  // reduce scalar
@@ -417,10 +408,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
 
     std::vector<uint32_t> compute_args = {tiles_per_core_x, tiles_per_core_y, block_size, cores_y};
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
     for (uint32_t x = 0; x < cores_x; ++x) {
         for (uint32_t y = 0; y < cores_y; ++y) {
@@ -433,23 +425,23 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
             uint32_t in_tile_offset = (x * Wt) + (y * tiles_per_core_y);
             uint32_t out_tile_offset = x * out0_tiles;
 
-            std::vector<uint32_t> reader_args = {
-                a_addr,
-                tiles_per_core_x,
-                tiles_per_core_y,
-                in_tile_offset,
-                static_cast<uint32_t>(is_merge_core),
-                static_cast<uint32_t>(merge_core.x),
-                static_cast<uint32_t>(merge_core.y),
-                y};
+            KernelDescriptor::RTArgList reader_args;
+            reader_args.push_back(a.buffer());
+            reader_args.push_back(tiles_per_core_x);
+            reader_args.push_back(tiles_per_core_y);
+            reader_args.push_back(in_tile_offset);
+            reader_args.push_back(static_cast<uint32_t>(is_merge_core));
+            reader_args.push_back(static_cast<uint32_t>(merge_core.x));
+            reader_args.push_back(static_cast<uint32_t>(merge_core.y));
+            reader_args.push_back(y);
             if (fuse_pre_add) {
-                reader_args.push_back(b_addr);
+                reader_args.push_back(b->buffer());
             }
-            reader_runtime_args.emplace_back(core, std::move(reader_args));
-            compute_runtime_args.emplace_back(core, std::vector<uint32_t>{static_cast<uint32_t>(is_merge_core)});
+            reader_kernel_desc.emplace_runtime_args(core, reader_args);
+            compute_kernel_desc.emplace_runtime_args(core, {static_cast<uint32_t>(is_merge_core)});
             if (is_merge_core) {
-                writer_runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * out0_tiles, out_tile_offset});
+                writer_kernel_desc.emplace_runtime_args(
+                    core, {output.buffer(), num_tile_rows_per_core * out0_tiles, out_tile_offset});
             }
         }
     }
@@ -464,7 +456,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
         .id = reducer_semaphore_id, .core_type = tt::CoreType::WORKER, .core_ranges = all_cores, .initial_value = 0});
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_layernorm_preallgather_2d.cpp";
@@ -472,24 +463,20 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel (only on merge cores)
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = merge_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/"
         "layernorm_pre_allgather_2d.cpp";
@@ -497,7 +484,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
@@ -84,10 +84,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     log_debug(tt::LogOp, "in_data_format: {}", in_data_format);
     log_debug(tt::LogOp, "out_data_format: {}", out_data_format);
 
-    auto a_addr = a.buffer()->address();
-    auto dst_addr = output.buffer()->address();
-    auto b_addr = fuse_pre_add ? b->buffer()->address() : 0;
-
     // Sized for double-buffered block-sized chunks: the welford compute kernel waits on
     // block_size tiles at a time, so the reader must be able to fill that many while the
     // compute side processes the previous batch.
@@ -162,13 +158,14 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     const uint32_t reciprocal_CB_size_bytes = recip_tensor.buffer()->aligned_size_per_bank();
     constexpr tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
-    reader_runtime_args.reserve(num_cores);
-    writer_runtime_args.reserve(num_cores);
-    compute_runtime_args.reserve(num_cores);
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
+    reader_kernel_desc.runtime_args.reserve(num_cores);
+    writer_kernel_desc.runtime_args.reserve(num_cores);
+    compute_kernel_desc.runtime_args.reserve(num_cores);
 
     uint32_t curr_row = 0;
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -186,14 +183,18 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
         uint32_t in_tile_offset = curr_row * Wt;
         uint32_t out_tile_offset = curr_row * out0_tiles;
 
-        std::vector<uint32_t> reader_args = {a_addr, num_tile_rows_per_core, Wt, in_tile_offset};
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(a.buffer());
+        reader_args.push_back(num_tile_rows_per_core);
+        reader_args.push_back(Wt);
+        reader_args.push_back(in_tile_offset);
         if (fuse_pre_add) {
-            reader_args.push_back(b_addr);
+            reader_args.push_back(b->buffer());
         }
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * out0_tiles, out_tile_offset});
+        reader_kernel_desc.emplace_runtime_args(core, reader_args);
+        compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+        writer_kernel_desc.emplace_runtime_args(
+            core, {output.buffer(), num_tile_rows_per_core * out0_tiles, out_tile_offset});
 
         curr_row += num_tile_rows_per_core;
     }
@@ -204,7 +205,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp";
@@ -212,19 +212,16 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
@@ -276,14 +273,12 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
 
     // Compute kernel
     // Welford uses fp32 accumulation; preserve fp32_dest_acc_en from compute config
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.named_compile_time_args = std::move(compute_named_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -386,7 +386,7 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryAtt
         });
     }
 
-    uint32_t mask_addr = tensor_args.mask.has_value() ? tensor_args.mask.value().buffer()->address() : 0;
+    Buffer* mask_buffer = tensor_args.mask.has_value() ? tensor_args.mask.value().buffer() : nullptr;
 
     uint32_t curr_row = 0;
     uint32_t scale_value =
@@ -421,59 +421,50 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryAtt
                                ? ((mask_curr_ht * Wt) + mask_offset)
                                : (curr_row / Ht * Wt);  // causal mask start offset + causal mask batch offset
 
-        // NOTE: do not pass Buffer* here. scale_value and mask_addr depend on
-        // operation_attributes (scale + optional mask tensor); BufferBinding's
-        // fast cache-hit path skips create_descriptor() and would leave them stale.
         if (attributes.is_causal_mask) {
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    src0_buffer->address(),
-                    block_size,
-                    scale_value,
-                    num_tile_rows_per_core,
-                    tile_offset,
-                    Wt,
-                    Ht,
-                    mask_addr,
-                    curr_ht,
-                    mask_id,
-                    in0_t,
-                    mask_curr_ht,
-                    mask_offset});
+                {src0_buffer,
+                 block_size,
+                 scale_value,
+                 num_tile_rows_per_core,
+                 tile_offset,
+                 Wt,
+                 Ht,
+                 mask_buffer,
+                 curr_ht,
+                 mask_id,
+                 in0_t,
+                 mask_curr_ht,
+                 mask_offset});
         } else {
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    src0_buffer->address(),
-                    block_size,
-                    scale_value,
-                    num_tile_rows_per_core,
-                    tile_offset,
-                    Wt,
-                    Ht,
-                    mask_addr,
-                    curr_ht,
-                    mask_id,
-                    in0_t});
+                {src0_buffer,
+                 block_size,
+                 scale_value,
+                 num_tile_rows_per_core,
+                 tile_offset,
+                 Wt,
+                 Ht,
+                 mask_buffer,
+                 curr_ht,
+                 mask_id,
+                 in0_t});
         }
 
         softmax_desc.emplace_runtime_args(
             core,
             {num_tile_rows_per_core, Ht, Wt, block_size, curr_ht, static_cast<uint32_t>(mask_padded_data), cb_length});
 
-        // NOTE: do not pass Buffer* here. mask_padded_data and num_datum_padded
-        // depend on attribute state; BufferBinding fast cache-hit path skips
-        // create_descriptor() and would leave them stale.
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                out0_buffer->address(),
-                num_tile_rows_per_core * Wt,
-                tile_offset,
-                block_size,
-                static_cast<uint32_t>(mask_padded_data),
-                num_datum_padded});
+            {out0_buffer,
+             num_tile_rows_per_core * Wt,
+             tile_offset,
+             block_size,
+             static_cast<uint32_t>(mask_padded_data),
+             num_datum_padded});
 
         curr_row += num_tile_rows_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
@@ -351,7 +351,7 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
     }
 
     // Runtime Args
-    uint32_t mask_addr = tensor_args.mask.has_value() ? tensor_args.mask->buffer()->address() : 0;
+    Buffer* mask_buffer = tensor_args.mask.has_value() ? tensor_args.mask->buffer() : nullptr;
     uint32_t scale_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
     uint32_t mask_start_tile_id = 0;
 
@@ -372,15 +372,15 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
                     static_cast<std::size_t>(start_core_y) + core_idx_y};
 
                 // reader args
-                KernelDescriptor::CoreRuntimeArgs reader_args;
+                std::vector<std::variant<uint32_t, Buffer*>> reader_args;
                 reader_args.push_back(scale_u);
-                reader_args.push_back(mask_addr);
+                reader_args.push_back(mask_buffer);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {
                     reader_args.push_back(num_tiles_in_attn_mask);
                 }
 
-                reader_desc.runtime_args.emplace_back(core, std::move(reader_args));
+                reader_desc.emplace_runtime_args(core, reader_args);
 
                 num_cores_per_batch_index++;
 
@@ -413,15 +413,15 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
                     static_cast<std::size_t>(start_core_y) + core_idx_y};
 
                 // reader args
-                KernelDescriptor::CoreRuntimeArgs reader_args;
+                std::vector<std::variant<uint32_t, Buffer*>> reader_args;
                 reader_args.push_back(scale_u);
-                reader_args.push_back(mask_addr);
+                reader_args.push_back(mask_buffer);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {
                     reader_args.push_back(num_tiles_in_attn_mask);
                 }
 
-                reader_desc.runtime_args.emplace_back(core, std::move(reader_args));
+                reader_desc.emplace_runtime_args(core, reader_args);
 
                 num_cores_per_batch_index++;
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -403,14 +403,19 @@ ProgramDescriptor GridSampleBilinearProgramFactory::create_descriptor(
             const CoreCoord& core = logical_cores[i];
 
             // Runtime arguments for sharded reader
-            KernelDescriptor::CoreRuntimeArgs reader_runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                i * grid_nsticks_per_core          // rt_arg[1]: grid_stick_offset
-            };
-
-            reader0_desc.runtime_args.emplace_back(core, reader_runtime_args);
+            reader0_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                    i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                });
             if (enable_split_reader) {
-                reader1_desc.runtime_args.emplace_back(core, reader_runtime_args);
+                reader1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                        i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                    });
             }
         }
     } else {
@@ -424,22 +429,23 @@ ProgramDescriptor GridSampleBilinearProgramFactory::create_descriptor(
             const uint32_t output_sticks = batch_output_channels ? grid_sticks : grid_sticks * grid_batching_factor;
 
             // Runtime arguments for interleaved reader - expanded row by row
-            KernelDescriptor::CoreRuntimeArgs reader_runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                grid_tensor.buffer()->address(),   // rt_arg[1]: grid_buffer_address
-                grid_sticks,                       // rt_arg[2]: grid_sticks
-                grid_processed                     // rt_arg[3]: grid_processed
-            };
+            reader0_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                    grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                    grid_sticks,            // rt_arg[2]: grid_sticks
+                    grid_processed          // rt_arg[3]: grid_processed
+                });
 
             // Runtime arguments for interleaved writer - expanded row by row
-            KernelDescriptor::CoreRuntimeArgs writer_runtime_args = {
-                output_tensor.buffer()->address(),  // rt_arg[0]: output_buffer_address
-                output_sticks,                      // rt_arg[1]: output_sticks
-                output_processed                    // rt_arg[2]: output_processed
-            };
-
-            reader0_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
-            writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    output_tensor.buffer(),  // rt_arg[0]: output_buffer_address
+                    output_sticks,           // rt_arg[1]: output_sticks
+                    output_processed         // rt_arg[2]: output_processed
+                });
 
             grid_processed += grid_sticks;
             output_processed += output_sticks;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
@@ -207,14 +207,19 @@ ProgramDescriptor GridSampleNearestProgramFactory::create_descriptor(
             const CoreCoord& core = logical_cores[i];
 
             // Runtime arguments for sharded reader
-            KernelDescriptor::CoreRuntimeArgs runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                i * grid_nsticks_per_core          // rt_arg[1]: grid_stick_offset
-            };
-
-            writer_desc.runtime_args.emplace_back(core, runtime_args);
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                    i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                });
             if (enable_split_reader) {
-                writer1_desc.runtime_args.emplace_back(core, runtime_args);
+                writer1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                        i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                    });
             }
         }
     } else {
@@ -226,18 +231,25 @@ ProgramDescriptor GridSampleNearestProgramFactory::create_descriptor(
                 core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
 
             // Runtime arguments for interleaved reader - expanded row by row
-            KernelDescriptor::CoreRuntimeArgs runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                grid_tensor.buffer()->address(),   // rt_arg[1]: grid_buffer_address
-                grid_sticks,                       // rt_arg[2]: grid_sticks
-                grid_processed                     // rt_arg[3]: grid_processed
-            };
-
-            writer_desc.runtime_args.emplace_back(core, runtime_args);
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                    grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                    grid_sticks,            // rt_arg[2]: grid_sticks
+                    grid_processed          // rt_arg[3]: grid_processed
+                });
             if (enable_split_reader) {
                 // For split reader in nearest mode, second writer needs same runtime args
                 // The kernel logic handles the split internally via reader_id
-                writer1_desc.runtime_args.emplace_back(core, runtime_args);
+                writer1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                        grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                        grid_sticks,            // rt_arg[2]: grid_sticks
+                        grid_processed          // rt_arg[3]: grid_processed
+                    });
             }
 
             grid_processed += grid_sticks;

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_bilinear_program_factory.cpp
@@ -361,10 +361,10 @@ ProgramDescriptor RotateDeviceOperation::BilinearProgramFactory::create_descript
             start_stick_id = sticks_processed;
         }
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input_tensor.buffer()->address(),
+            {
+                input_tensor.buffer(),
                 num_sticks,
                 start_stick_id,
                 static_cast<uint32_t>(cos_angle_q16),
@@ -375,10 +375,10 @@ ProgramDescriptor RotateDeviceOperation::BilinearProgramFactory::create_descript
             });
 
         if (!any_sharded && writer_desc.has_value()) {
-            writer_desc->runtime_args.emplace_back(
+            writer_desc->emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output_tensor.buffer()->address(),
+                {
+                    output_tensor.buffer(),
                     num_sticks,
                     start_stick_id,
                 });

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
@@ -252,10 +252,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                 start_stick_id = i * input_nsticks_per_core;
             }
 
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    input_tensor.buffer()->address(),
+                {
+                    input_tensor.buffer(),
                     input_nsticks_per_core,
                     start_stick_id,
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(cos_angle)),
@@ -265,10 +265,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                     static_cast<uint32_t>(fill_value_bf16),
                 });
 
-            writer_desc.runtime_args.emplace_back(
+            writer_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output_tensor.buffer()->address(),
+                {
+                    output_tensor.buffer(),
                     input_nsticks_per_core,
                     start_stick_id,
                 });
@@ -280,10 +280,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
             const uint32_t num_sticks =
                 core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
 
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    input_tensor.buffer()->address(),
+                {
+                    input_tensor.buffer(),
                     num_sticks,
                     sticks_processed,
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(cos_angle)),
@@ -293,10 +293,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                     static_cast<uint32_t>(fill_value_bf16),
                 });
 
-            writer_desc.runtime_args.emplace_back(
+            writer_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output_tensor.buffer()->address(),
+                {
+                    output_tensor.buffer(),
                     num_sticks,
                     sticks_processed,
                 });

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_nearest_float_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_nearest_float_program_factory.cpp
@@ -133,19 +133,19 @@ ProgramDescriptor UpsampleNearestFloatProgramFactory::create_descriptor(
         const uint32_t num_sticks =
             core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                num_sticks,                 // rt_arg[1]: num_sticks
-                sticks_processed,           // rt_arg[2]: start_stick_id
+            {
+                input.buffer(),    // rt_arg[0]: input_buffer_address
+                num_sticks,        // rt_arg[1]: num_sticks
+                sticks_processed,  // rt_arg[2]: start_stick_id
             });
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                output_tensor.buffer()->address(),  // rt_arg[0]: output_buffer_address
-                num_sticks,                         // rt_arg[1]: num_sticks
-                sticks_processed,                   // rt_arg[2]: start_stick_id
+            {
+                output_tensor.buffer(),  // rt_arg[0]: output_buffer_address
+                num_sticks,              // rt_arg[1]: num_sticks
+                sticks_processed,        // rt_arg[2]: start_stick_id
             });
 
         sticks_processed += num_sticks;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
@@ -244,17 +244,17 @@ ProgramDescriptor UpsampleMultiCoreInterleavedProgramFactory::create_descriptor(
         const uint32_t reader_units = blocks_per_core * input_cb_required_pages;
         const uint32_t reader_start = blocks_processed * input_cb_required_pages;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src_buffer->address(),
+            {
+                src_buffer,
                 reader_units,
                 reader_start,
             });
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
+            {
+                dst_buffer,
                 blocks_per_core,
                 blocks_processed,
             });

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -502,8 +502,11 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
                 0u,                                    // Height offset (no height parallelism currently)
                 core_id * Wt_local,                    // Width offset for this core's chunk
                 static_cast<uint32_t>(is32_bit_data),  // Flag indicating if data is 32-bit
-                input_indices_tensor.has_value() ? static_cast<uint32_t>(input_indices_tensor->address())
-                                                 : 0u,  // DRAM address of input indices tensor (if provided)
+                input_indices_tensor.has_value()
+                    ? std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>{std::cref(*input_indices_tensor)}
+                    : std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>{0u},  // DRAM address of input
+                                                                                             // indices tensor (if
+                                                                                             // provided)
             });
 
         // Local writer

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -263,8 +263,10 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
                         id,
                         work_per_core,
                         tensor_args.indices.has_value()
-                            ? static_cast<uint32_t>(tensor_args.indices->mesh_tensor().address())
-                            : 0u,  // Optional indices tensor
+                            ? std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>{std::cref(
+                                  tensor_args.indices->mesh_tensor())}
+                            : std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>{0u},  // Optional indices
+                                                                                                     // tensor
                     });
                 writer_desc.emplace_runtime_args(
                     core,


### PR DESCRIPTION
### What

Convert raw buffer base addresses that were pushed into kernel runtime args as plain `uint32_t`
(`tensor.buffer()->address()`) into declared `BufferBinding`s via
`KernelDescriptor::emplace_runtime_args(core, {buffer, ...})` / `emplace_common_runtime_args`, across
~50 ProgramDescriptor-variant factories in 24 op families.

### Why

A raw address in a runtime-arg slot is opaque to the descriptor framework: it can't tell the slot holds
a buffer address, so on a program-cache **hit** it can't O(1)-patch the new address and instead falls
back to rebuilding the whole descriptor every dispatch. Declaring the slot as a `Buffer*` registers a
`BufferBinding` the framework patches directly on hits — turning rebuild-on-hit into an O(1) patch.
These ops were verified to have the buffer address as their **only** dynamic-on-hit value (work
distribution is captured by the program hash, no hash-excluded scalars), so the binding alone is
correct and sufficient — no `get_dynamic_runtime_args` needed.

### Scope

Families: data_movement (bcast, concat, permute, slice[tile], transpose, untilize_with_unpadding),
normalization (batch_norm, groupnorm, layernorm, layernorm_distributed, softmax), pool (grid_sample,
rotate, upsample), moreh (abs_pow, dot, dot_backward, fold, clip_grad_norm ×3, group_norm_backward ×2),
reduction (topk), eltwise (unary_backward/tanh_bw), experimental/matmul (attn_matmul,
group_attn_matmul), examples/example.

Not included (deliberately): ops whose cache hit changes a hash-excluded scalar (kv_cache, moreh_adam,
binary_ng) or shares one program across work-distributions (unary, roll) — those need a dynamic-arg
re-apply and are handled separately.

### Test

Build clean (`build_metal.sh --build-ttnn-tests`). Fast-dispatch unit tests green (9781 passed / 0
failed) across all touched families, incl. the softmax and batch_norm program-cache tests that
exercise the cache-hit patch path. Nightly suites for the affected families (data_movement, fused,
pool, moreh, reduction, eltwise, matmul, docs_examples) running — results posted below as they land.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-mechanical)