### PR TITLE
[data-movement] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <optional>
 #include <utility>
+#include <initializer_list>
 #include <variant>
 #include <vector>
 
@@ -168,15 +169,35 @@ struct KernelDescriptor {
     // auto-register as buffer bindings; uint32_t entries embed their value.
     // The variant type is hidden — callers push typed values directly.
     struct RTArgList {
+        RTArgList() = default;
+        // Build directly from a brace list of uint32_t / Buffer* entries, e.g. {buffer, 0u, 0u}.
+        RTArgList(std::initializer_list<std::variant<uint32_t, Buffer*>> init) {
+            items_.reserve(init.size());
+            for (const auto& v : init) {
+                std::visit([this](auto&& x) { items_.emplace_back(x); }, v);
+            }
+        }
         void push_back(uint32_t v) { items_.emplace_back(v); }
         void push_back(Buffer* b) { items_.emplace_back(b); }
         void push_back(const MeshTensor& t) { items_.emplace_back(t); }
         void reserve(size_t n) { items_.reserve(n); }
+        size_t size() const { return items_.size(); }
         // Append a plain uint32_t range (e.g. from fused-op signaler helpers).
         void append(const std::vector<uint32_t>& v) {
             for (uint32_t x : v) {
                 items_.emplace_back(x);
             }
+        }
+        // Append any iterator range of uint32_t-convertible values.
+        template <typename It>
+        void append(It first, It last) {
+            for (; first != last; ++first) {
+                items_.emplace_back(static_cast<uint32_t>(*first));
+            }
+        }
+        // Mutable access to an existing slot (e.g. to update per-core scalar args in place).
+        std::variant<uint32_t, Buffer*, std::reference_wrapper<const MeshTensor>>& operator[](size_t i) {
+            return items_[i];
         }
 
     private:

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -22,7 +22,6 @@
 #include <filesystem>
 #include <optional>
 #include <utility>
-#include <initializer_list>
 #include <variant>
 #include <vector>
 
@@ -169,35 +168,15 @@ struct KernelDescriptor {
     // auto-register as buffer bindings; uint32_t entries embed their value.
     // The variant type is hidden — callers push typed values directly.
     struct RTArgList {
-        RTArgList() = default;
-        // Build directly from a brace list of uint32_t / Buffer* entries, e.g. {buffer, 0u, 0u}.
-        RTArgList(std::initializer_list<std::variant<uint32_t, Buffer*>> init) {
-            items_.reserve(init.size());
-            for (const auto& v : init) {
-                std::visit([this](auto&& x) { items_.emplace_back(x); }, v);
-            }
-        }
         void push_back(uint32_t v) { items_.emplace_back(v); }
         void push_back(Buffer* b) { items_.emplace_back(b); }
         void push_back(const MeshTensor& t) { items_.emplace_back(t); }
         void reserve(size_t n) { items_.reserve(n); }
-        size_t size() const { return items_.size(); }
         // Append a plain uint32_t range (e.g. from fused-op signaler helpers).
         void append(const std::vector<uint32_t>& v) {
             for (uint32_t x : v) {
                 items_.emplace_back(x);
             }
-        }
-        // Append any iterator range of uint32_t-convertible values.
-        template <typename It>
-        void append(It first, It last) {
-            for (; first != last; ++first) {
-                items_.emplace_back(static_cast<uint32_t>(*first));
-            }
-        }
-        // Mutable access to an existing slot (e.g. to update per-core scalar args in place).
-        std::variant<uint32_t, Buffer*, std::reference_wrapper<const MeshTensor>>& operator[](size_t i) {
-            return items_[i];
         }
 
     private:

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
@@ -169,16 +169,16 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHProgramFactory::create_descriptor
         }
         const uint32_t num_tensor_tiles_per_core = NC * Ht_per_core * Wt;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),     // 0
-                0,                          // 1
-                0,                          // 2
+            {
+                src0_buffer,                // 0
+                0u,                         // 1
+                0u,                         // 2
                 num_tensor_tiles_per_core,  // 3
-                src1_buffer->address(),     // 4
-                0,                          // 5
-                0,                          // 6
+                src1_buffer,                // 4
+                0u,                         // 5
+                0u,                         // 6
                 num_btensor_tiles,          // 7
                 num_tensor_tiles_per_core,  // 8
                 NC,                         // 9
@@ -197,16 +197,16 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHProgramFactory::create_descriptor
                 Wt            // Wt
             });
 
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
-                0,
-                0,
+            {
+                dst_buffer,
+                0u,
+                0u,
                 Ht_per_core,
                 Wt,
                 num_Wtiles_read,
-                0,
+                0u,
                 NC,
                 Ht * Wt,
             });

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
@@ -192,16 +192,15 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHWProgramFactory::create_descripto
             continue;
         }
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),  // 0
-                src1_buffer->address(),
-                num_tensor_tiles_per_core,
-                HtWt,
-                num_tiles_read / HtWt * HtWt,
-                num_tiles_read % HtWt,
-                bnc1 ? 0 : num_tiles_read / HtWt});
+            {src0_buffer,  // 0
+             src1_buffer,
+             num_tensor_tiles_per_core,
+             HtWt,
+             num_tiles_read / HtWt * HtWt,
+             num_tiles_read % HtWt,
+             bnc1 ? 0u : num_tiles_read / HtWt});
 
         compute_desc.runtime_args.emplace_back(
             core,
@@ -211,10 +210,10 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreHWProgramFactory::create_descripto
                 num_tensor_tiles_per_core  // Wt
             });
 
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
+            {
+                dst_buffer,
                 num_tensor_tiles_per_core,
                 num_tiles_read,
             });

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
@@ -165,16 +165,16 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreWProgramFactory::create_descriptor
         const uint32_t num_tensor_tiles_per_core = NC * Ht * Wt_per_core;
         const uint32_t Wt_skip = Wt - Wt_per_core;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),     // 0
-                0,                          // 1
-                0,                          // 2
+            {
+                src0_buffer,                // 0
+                0u,                         // 1
+                0u,                         // 2
                 num_tensor_tiles_per_core,  // 3
-                src1_buffer->address(),     // 4
-                0,                          // 5
-                0,                          // 6
+                src1_buffer,                // 4
+                0u,                         // 5
+                0u,                         // 6
                 num_btensor_tiles,          // 7
                 num_tensor_tiles_per_core,  // 8
                 NC,                         // 9
@@ -194,12 +194,12 @@ tt::tt_metal::ProgramDescriptor BcastMultiCoreWProgramFactory::create_descriptor
                 Wt_per_core  // Wt
             });
 
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
-                0,
-                0,
+            {
+                dst_buffer,
+                0u,
+                0u,
                 Ht,
                 Wt_per_core,
                 num_Wtiles_read,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
@@ -190,16 +190,16 @@ tt::tt_metal::ProgramDescriptor BcastShardedHOptimisedProgramFactory::create_des
             }
         }
         const uint32_t tile_offset = Wt * ncores;  // used in multi batch weight for block sharded
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                b.buffer()->address(),  // (0) src1_addr
-                Ht,                     // (1) Ht
-                Wt,                     // (2) Wt
-                offset,                 // (3) read offset in1
-                tile_offset,            // (4) in1 offset between batches
-                w_blk,                  // (5) block size in w
-                batch_b,                // (6) in1 batch size
+            {
+                b.buffer(),   // (0) src1_addr
+                Ht,           // (1) Ht
+                Wt,           // (2) Wt
+                offset,       // (3) read offset in1
+                tile_offset,  // (4) in1 offset between batches
+                w_blk,        // (5) block size in w
+                batch_b,      // (6) in1 batch size
             });
 
         compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
@@ -187,15 +187,15 @@ tt::tt_metal::ProgramDescriptor BcastShardedHProgramFactory::create_descriptor(
             Ht_per_core = Ht / bN;
         }
         const uint32_t tile_offset = Wt * ncores;  // used in multi batch weight for block sharded
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                b.buffer()->address(),  // 0
-                Ht,                     // 1
-                Wt,                     // 2
-                offset,                 // 3
-                Ht_per_core,            // 4
-                tile_offset,            // 5
+            {
+                b.buffer(),   // 0
+                Ht,           // 1
+                Wt,           // 2
+                offset,       // 3
+                Ht_per_core,  // 4
+                tile_offset,  // 5
             });
 
         compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -135,7 +135,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     const uint32_t num_dims = output.padded_shape().rank();
 
-    std::vector<uint32_t> src_addr(num_input_tensors);
+    std::vector<Buffer*> src_buffers(num_input_tensors);
     std::vector<uint32_t> num_pages_per_block(num_input_tensors);
     std::vector<uint32_t> page_id_per_tensor(num_input_tensors);
     std::vector<uint32_t> page_size_per_tensor(num_input_tensors);
@@ -172,7 +172,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     if (rm_layout) {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
             auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
+            src_buffers[i] = buffer;
             page_size_per_tensor[i] = buffer->page_size();
             if (dim == num_dims - 1) {
                 num_pages_per_block[i] = num_accum_pages;
@@ -188,18 +188,13 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     } else {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
             auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
+            src_buffers[i] = buffer;
             page_size_per_tensor[i] = buffer->page_size();
             uint32_t dim_pages = input_tensors[i].padded_shape()[dim] / scale_factor;
             num_pages_per_block[i] = num_accum_pages * dim_pages;
             num_output_pages_per_block += num_accum_pages * dim_pages;
         }
     }
-    std::vector<uint32_t> common_reader_kernel_args = {0, 0, 0};
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), src_addr.cbegin(), src_addr.cend());
-    common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_pages_per_block.cbegin(), num_pages_per_block.cend());
-
     // Reader compile-time args
     // Data is 32 byte aligned
     KernelDescriptor::CompileTimeArgs reader_compile_time_args = {src0_cb_index, num_input_tensors};
@@ -272,22 +267,28 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
             }
         }
 
-        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        reader_kernel_args[0] = num_pages_per_core;
-        reader_kernel_args[1] = curr_tensor;
-        reader_kernel_args[2] = curr_tensor_id;
-        reader_kernel_args.insert(reader_kernel_args.end(), page_id_per_tensor.begin(), page_id_per_tensor.end());
-
-        std::vector<uint32_t> writer_kernel_args;
-        if (rm_layout) {
-            writer_kernel_args = {
-                dst_buffer->address(), output.buffer()->page_size(), num_pages_per_core, num_pages_written};
-        } else {
-            writer_kernel_args = {dst_buffer->address(), num_pages_per_core, num_pages_written};
+        KernelDescriptor::RTArgList reader_kernel_args;
+        reader_kernel_args.reserve(3 + 3 * num_input_tensors);
+        reader_kernel_args.push_back(num_pages_per_core);
+        reader_kernel_args.push_back(curr_tensor);
+        reader_kernel_args.push_back(curr_tensor_id);
+        for (uint32_t j = 0; j < num_input_tensors; ++j) {
+            reader_kernel_args.push_back(src_buffers[j]);
         }
+        reader_kernel_args.append(num_pages_per_block);
+        reader_kernel_args.append(page_id_per_tensor);
 
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_kernel_args));
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_kernel_args));
+        reader_desc.emplace_runtime_args(core, reader_kernel_args);
+        if (rm_layout) {
+            writer_desc.emplace_runtime_args(
+                core,
+                {dst_buffer,
+                 static_cast<uint32_t>(output.buffer()->page_size()),
+                 num_pages_per_core,
+                 num_pages_written});
+        } else {
+            writer_desc.emplace_runtime_args(core, {dst_buffer, num_pages_per_core, num_pages_written});
+        }
         num_pages_written += num_pages_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
@@ -78,19 +78,20 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
 
         std::vector<uint32_t> reader_runtime_args;
         reader_runtime_args.reserve(num_input_tensors * 2);
-        std::vector<uint32_t> writer_runtime_args = {
-            output.buffer()->address(),
-            core_id,
-            curr_num_output_rows,
-            num_input_tensors * input_shard_spec.shape[0],
-            input_shard_spec.shape[0]};
+        KernelDescriptor::RTArgList writer_runtime_args;
+        writer_runtime_args.reserve(5 + num_input_tensors);
+        writer_runtime_args.push_back(output.buffer());
+        writer_runtime_args.push_back(core_id);
+        writer_runtime_args.push_back(curr_num_output_rows);
+        writer_runtime_args.push_back(num_input_tensors * input_shard_spec.shape[0]);
+        writer_runtime_args.push_back(input_shard_spec.shape[0]);
         for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
             reader_runtime_args.push_back(input_id);
             reader_runtime_args.push_back(input_shard_spec.shape[0]);
             writer_runtime_args.push_back(input_id);
         }
         reader_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
         core_id++;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -206,13 +206,13 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     // we also need the inverse permutation to map back to input tensor
     auto inv_perm = detail::get_inverse_permutation(operation_attributes.dims);
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
 
     reader_runtime_args.insert(reader_runtime_args.end(), output_shape_view.begin(), output_shape_view.end());
     reader_runtime_args.insert(reader_runtime_args.end(), inv_perm.begin(), inv_perm.end());
     reader_runtime_args.insert(reader_runtime_args.end(), input_tile_strides.begin(), input_tile_strides.end());
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u};
 
     std::vector<uint32_t> compute_runtime_args = {0};
 
@@ -240,8 +240,8 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
         writer_runtime_args[1] = num_tiles_per_core;  // for some reason num_tiles comes first in writer unary
         writer_runtime_args[2] = start_tile;          // start tile is second in writer unary
 
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
         if (swap_hw) {
             compute_runtime_args[0] = num_tiles_per_core;  // number of tiles transposed
             compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
@@ -482,9 +482,9 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
 
     auto input_shape_view = input_shape.view();
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0, 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
     writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
     writer_runtime_args.insert(writer_runtime_args.end(), dims.begin(), dims.end());
 
@@ -536,8 +536,8 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
             compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
         }
 
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
         start_tile = end_tile;
         start_tile_padding = end_tile_padding;
@@ -858,13 +858,13 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
 
     auto input_shape_view = input_shape.view();
 
-    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
     reader_runtime_args.insert(reader_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
     reader_runtime_args.insert(reader_runtime_args.end(), dims.begin(), dims.end());
 
     std::vector<uint32_t> compute_runtime_args = {0, 0};
 
-    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0, 0, 0};
+    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
     writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
     writer_runtime_args.insert(writer_runtime_args.end(), dims.begin(), dims.end());
 
@@ -913,8 +913,8 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
             start_tile_padding = end_tile_padding;
         }
 
-        reader_desc.runtime_args.emplace_back(core, reader_runtime_args);
-        writer_desc.runtime_args.emplace_back(core, writer_runtime_args);
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
         compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
 
         start_block = end_block;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -206,13 +206,12 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     // we also need the inverse permutation to map back to input tensor
     auto inv_perm = detail::get_inverse_permutation(operation_attributes.dims);
 
-    KernelDescriptor::RTArgList reader_runtime_args = {src_buffer, 0u, 0u};
-
-    reader_runtime_args.append(output_shape_view.begin(), output_shape_view.end());
-    reader_runtime_args.append(inv_perm.begin(), inv_perm.end());
-    reader_runtime_args.append(input_tile_strides.begin(), input_tile_strides.end());
-
-    KernelDescriptor::RTArgList writer_runtime_args = {dst_buffer, 0u, 0u};
+    // Constant reader tail shared by every core: output shape, inverse permutation, input strides.
+    // The src buffer binding and per-core scalar slots are prepended per core in the loop below.
+    std::vector<uint32_t> reader_common_args;
+    reader_common_args.insert(reader_common_args.end(), output_shape_view.begin(), output_shape_view.end());
+    reader_common_args.insert(reader_common_args.end(), inv_perm.begin(), inv_perm.end());
+    reader_common_args.insert(reader_common_args.end(), input_tile_strides.begin(), input_tile_strides.end());
 
     std::vector<uint32_t> compute_runtime_args = {0};
 
@@ -234,14 +233,17 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
             num_tiles_per_core = 0;
         }
         uint32_t end_tile = start_tile + num_tiles_per_core;
-        reader_runtime_args[1] = start_tile;
-        reader_runtime_args[2] = end_tile;
 
-        writer_runtime_args[1] = num_tiles_per_core;  // for some reason num_tiles comes first in writer unary
-        writer_runtime_args[2] = start_tile;          // start tile is second in writer unary
-
+        KernelDescriptor::RTArgList reader_runtime_args;
+        reader_runtime_args.reserve(3 + reader_common_args.size());
+        reader_runtime_args.push_back(src_buffer);
+        reader_runtime_args.push_back(start_tile);
+        reader_runtime_args.push_back(end_tile);
+        reader_runtime_args.append(reader_common_args);
         reader_desc.emplace_runtime_args(core, reader_runtime_args);
-        writer_desc.emplace_runtime_args(core, writer_runtime_args);
+
+        // writer unary: num_tiles comes first, then start_tile
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, start_tile});
         if (swap_hw) {
             compute_runtime_args[0] = num_tiles_per_core;  // number of tiles transposed
             compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
@@ -482,11 +484,11 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
 
     auto input_shape_view = input_shape.view();
 
-    KernelDescriptor::RTArgList reader_runtime_args = {src_buffer, 0u, 0u};
-
-    KernelDescriptor::RTArgList writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
-    writer_runtime_args.append(input_shape_view.begin(), input_shape_view.end());
-    writer_runtime_args.append(dims.begin(), dims.end());
+    // Constant writer tail shared by every core: input shape then permutation dims.
+    // The dst buffer binding and per-core scalar slots are prepended per core in the loop below.
+    std::vector<uint32_t> writer_common_args;
+    writer_common_args.insert(writer_common_args.end(), input_shape_view.begin(), input_shape_view.end());
+    writer_common_args.insert(writer_common_args.end(), dims.begin(), dims.end());
 
     std::vector<uint32_t> compute_runtime_args = {0};
 
@@ -521,22 +523,27 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
             }
         }
         uint32_t end_tile = start_tile + num_tiles_per_core;
-        reader_runtime_args[1] = num_tiles_per_core;
-        reader_runtime_args[2] = start_tile;
-
-        writer_runtime_args[1] = start_tile;  // for some reason num_tiles comes first in writer unary
-        writer_runtime_args[2] = end_tile;    // start tile is second in writer unary
         if (needs_padding) {
             end_tile_padding = start_tile_padding + num_tiles_per_core_padding;
-            writer_runtime_args[3] = start_tile_padding;
-            writer_runtime_args[4] = end_tile_padding;
         }
         if (swap_hw) {
             compute_runtime_args[0] = num_tiles_per_core;  // number of tiles transposed
             compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
         }
 
-        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        // reader unary: num_tiles comes first, then start_tile
+        reader_desc.emplace_runtime_args(core, {src_buffer, num_tiles_per_core, start_tile});
+
+        // writer unary: {dst, start_tile, end_tile, start_tile_padding, end_tile_padding, <tail>}.
+        // Padding slots stay zero when padding is not needed (matching the legacy layout).
+        KernelDescriptor::RTArgList writer_runtime_args;
+        writer_runtime_args.reserve(5 + writer_common_args.size());
+        writer_runtime_args.push_back(dst_buffer);
+        writer_runtime_args.push_back(start_tile);
+        writer_runtime_args.push_back(end_tile);
+        writer_runtime_args.push_back(start_tile_padding);
+        writer_runtime_args.push_back(end_tile_padding);
+        writer_runtime_args.append(writer_common_args);
         writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
         start_tile = end_tile;
@@ -858,15 +865,13 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
 
     auto input_shape_view = input_shape.view();
 
-    KernelDescriptor::RTArgList reader_runtime_args = {src_buffer, 0u, 0u};
-    reader_runtime_args.append(input_shape_view.begin(), input_shape_view.end());
-    reader_runtime_args.append(dims.begin(), dims.end());
+    // Constant tail shared by reader and writer on every core: input shape then permutation dims.
+    // Each kernel's buffer binding and per-core scalar slots are prepended per core in the loop below.
+    std::vector<uint32_t> common_args;
+    common_args.insert(common_args.end(), input_shape_view.begin(), input_shape_view.end());
+    common_args.insert(common_args.end(), dims.begin(), dims.end());
 
     std::vector<uint32_t> compute_runtime_args = {0, 0};
-
-    KernelDescriptor::RTArgList writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
-    writer_runtime_args.append(input_shape_view.begin(), input_shape_view.end());
-    writer_runtime_args.append(dims.begin(), dims.end());
 
     auto cores = corerange_to_cores(all_cores, std::nullopt);
     uint32_t start_block = 0;
@@ -897,24 +902,37 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
         }
 
         uint32_t end_block = start_block + num_blocks_per_core;
-        reader_runtime_args[1] = start_block;
-        reader_runtime_args[2] = end_block;
 
         compute_runtime_args[0] = start_block;
         compute_runtime_args[1] = end_block;
 
-        writer_runtime_args[1] = start_block;
-        writer_runtime_args[2] = end_block;
-
+        // Padding slots stay zero when padding is not needed (matching the legacy layout).
+        uint32_t start_tile_padding_arg = 0;
+        uint32_t end_tile_padding_arg = 0;
         if (needs_padding) {
-            uint32_t end_tile_padding = start_tile_padding + num_tiles_per_core_padding;
-            writer_runtime_args[3] = start_tile_padding;
-            writer_runtime_args[4] = end_tile_padding;
-            start_tile_padding = end_tile_padding;
+            start_tile_padding_arg = start_tile_padding;
+            end_tile_padding_arg = start_tile_padding + num_tiles_per_core_padding;
+            start_tile_padding = end_tile_padding_arg;
         }
 
+        KernelDescriptor::RTArgList reader_runtime_args;
+        reader_runtime_args.reserve(3 + common_args.size());
+        reader_runtime_args.push_back(src_buffer);
+        reader_runtime_args.push_back(start_block);
+        reader_runtime_args.push_back(end_block);
+        reader_runtime_args.append(common_args);
         reader_desc.emplace_runtime_args(core, reader_runtime_args);
+
+        KernelDescriptor::RTArgList writer_runtime_args;
+        writer_runtime_args.reserve(5 + common_args.size());
+        writer_runtime_args.push_back(dst_buffer);
+        writer_runtime_args.push_back(start_block);
+        writer_runtime_args.push_back(end_block);
+        writer_runtime_args.push_back(start_tile_padding_arg);
+        writer_runtime_args.push_back(end_tile_padding_arg);
+        writer_runtime_args.append(common_args);
         writer_desc.emplace_runtime_args(core, writer_runtime_args);
+
         compute_desc.runtime_args.emplace_back(core, compute_runtime_args);
 
         start_block = end_block;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -206,13 +206,13 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     // we also need the inverse permutation to map back to input tensor
     auto inv_perm = detail::get_inverse_permutation(operation_attributes.dims);
 
-    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
+    KernelDescriptor::RTArgList reader_runtime_args = {src_buffer, 0u, 0u};
 
-    reader_runtime_args.insert(reader_runtime_args.end(), output_shape_view.begin(), output_shape_view.end());
-    reader_runtime_args.insert(reader_runtime_args.end(), inv_perm.begin(), inv_perm.end());
-    reader_runtime_args.insert(reader_runtime_args.end(), input_tile_strides.begin(), input_tile_strides.end());
+    reader_runtime_args.append(output_shape_view.begin(), output_shape_view.end());
+    reader_runtime_args.append(inv_perm.begin(), inv_perm.end());
+    reader_runtime_args.append(input_tile_strides.begin(), input_tile_strides.end());
 
-    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u};
+    KernelDescriptor::RTArgList writer_runtime_args = {dst_buffer, 0u, 0u};
 
     std::vector<uint32_t> compute_runtime_args = {0};
 
@@ -482,11 +482,11 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
 
     auto input_shape_view = input_shape.view();
 
-    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
+    KernelDescriptor::RTArgList reader_runtime_args = {src_buffer, 0u, 0u};
 
-    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
-    writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
-    writer_runtime_args.insert(writer_runtime_args.end(), dims.begin(), dims.end());
+    KernelDescriptor::RTArgList writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
+    writer_runtime_args.append(input_shape_view.begin(), input_shape_view.end());
+    writer_runtime_args.append(dims.begin(), dims.end());
 
     std::vector<uint32_t> compute_runtime_args = {0};
 
@@ -858,15 +858,15 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
 
     auto input_shape_view = input_shape.view();
 
-    std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {src_buffer, 0u, 0u};
-    reader_runtime_args.insert(reader_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
-    reader_runtime_args.insert(reader_runtime_args.end(), dims.begin(), dims.end());
+    KernelDescriptor::RTArgList reader_runtime_args = {src_buffer, 0u, 0u};
+    reader_runtime_args.append(input_shape_view.begin(), input_shape_view.end());
+    reader_runtime_args.append(dims.begin(), dims.end());
 
     std::vector<uint32_t> compute_runtime_args = {0, 0};
 
-    std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
-    writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
-    writer_runtime_args.insert(writer_runtime_args.end(), dims.begin(), dims.end());
+    KernelDescriptor::RTArgList writer_runtime_args = {dst_buffer, 0u, 0u, 0u, 0u};
+    writer_runtime_args.append(input_shape_view.begin(), input_shape_view.end());
+    writer_runtime_args.append(dims.begin(), dims.end());
 
     auto cores = corerange_to_cores(all_cores, std::nullopt);
     uint32_t start_block = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -73,9 +73,9 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
-    reader_common_args[0] = src0_buffer->address();
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+    // src0 buffer binding is registered separately below; this vector holds only the per-dim values.
+    std::vector<uint32_t> reader_common_dims(num_dims * 2);
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_dims.data();
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
     num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
     num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
@@ -134,7 +134,11 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     reader_kernel_desc.compile_time_args = reader_compile_time_args;
     reader_kernel_desc.named_compile_time_args = {{"cb_in", src0_cb_index}};
     reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
-    reader_kernel_desc.common_runtime_args = std::move(reader_common_args);
+    tt::tt_metal::KernelDescriptor::RTArgList reader_common;
+    reader_common.reserve(1 + (num_dims * 2));
+    reader_common.push_back(src0_buffer);
+    reader_common.append(reader_common_dims);
+    reader_kernel_desc.emplace_common_runtime_args(reader_common);
     reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
@@ -142,26 +146,6 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     // CB index via named compile-time arg (essential for fusion CB remapping).
     std::vector<uint32_t> writer_compile_time_args = {};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
-    tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
-    num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
-            continue;
-        }
-
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
-        num_tiles_written += num_tiles_per_core;
-    }
 
     tt::tt_metal::KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
@@ -171,8 +155,26 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = writer_compile_time_args;
     writer_kernel_desc.named_compile_time_args = {{"cb_out", src0_cb_index}};
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            writer_kernel_desc.emplace_runtime_args(core, {0u, 0u, 0u});
+            continue;
+        }
+
+        writer_kernel_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     return program_descriptor;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
 
 #include <optional>
+#include <span>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -75,8 +76,9 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
 
     // src0 buffer binding is registered separately below; this vector holds only the per-dim values.
     std::vector<uint32_t> reader_common_dims(num_dims * 2);
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_dims.data();
-    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    std::span<uint32_t> reader_common_dims_view{reader_common_dims};
+    auto num_unpadded_tiles_per_dim = reader_common_dims_view.subspan(0, num_dims);
+    auto num_padded_tiles_per_dim = reader_common_dims_view.subspan(num_dims, num_dims);
     num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
     num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
     num_padded_tiles_per_dim[0] = num_padded_Xt;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -99,11 +99,9 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    std::vector<uint32_t> reader_common_args(3 + (num_dims * 3));
-    reader_common_args[0] = src_buffer->address();
-    reader_common_args[1] = start_buffer->address();
-    reader_common_args[2] = end_buffer->address();
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 3;
+    // src/start/end buffer bindings are registered separately below; this vector holds only the per-dim values.
+    std::vector<uint32_t> reader_common_dims(num_dims * 3);
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_dims.data();
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
     uint32_t* input_shape_args = num_padded_tiles_per_dim + num_dims;
     num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
@@ -125,8 +123,16 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
     // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
     constexpr uint32_t start_offset = 0;
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
     KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
     uint32_t num_tiles_written = 0;
     for (const auto& core : corerange_to_cores(all_cores)) {
         uint32_t num_tiles_per_core;
@@ -138,7 +144,7 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
             // no-op core
             std::vector<uint32_t> reader_args(2 + num_dims, 0);
             reader_runtime_args.emplace_back(core, std::move(reader_args));
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            writer_desc.emplace_runtime_args(core, {0u, 0u, 0u});
             continue;
         }
 
@@ -155,8 +161,7 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
         reader_args[1] = num_tiles_per_core;
 
         reader_runtime_args.emplace_back(core, std::move(reader_args));
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
         num_tiles_written += num_tiles_per_core;
     }
 
@@ -168,18 +173,16 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.runtime_args = std::move(reader_runtime_args);
-    reader_desc.common_runtime_args = std::move(reader_common_args);
+    KernelDescriptor::RTArgList reader_common;
+    reader_common.reserve(3 + (num_dims * 3));
+    reader_common.push_back(src_buffer);
+    reader_common.push_back(start_buffer);
+    reader_common.push_back(end_buffer);
+    reader_common.append(reader_common_dims);
+    reader_desc.emplace_common_runtime_args(reader_common);
     reader_desc.config = ReaderConfigDescriptor{};
     desc.kernels.push_back(std::move(reader_desc));
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.runtime_args = std::move(writer_runtime_args);
-    writer_desc.config = WriterConfigDescriptor{};
     desc.kernels.push_back(std::move(writer_desc));
 
     return desc;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp"
 
 #include <optional>
+#include <span>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -101,9 +102,10 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
 
     // src/start/end buffer bindings are registered separately below; this vector holds only the per-dim values.
     std::vector<uint32_t> reader_common_dims(num_dims * 3);
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_dims.data();
-    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
-    uint32_t* input_shape_args = num_padded_tiles_per_dim + num_dims;
+    std::span<uint32_t> reader_common_dims_view{reader_common_dims};
+    auto num_unpadded_tiles_per_dim = reader_common_dims_view.subspan(0, num_dims);
+    auto num_padded_tiles_per_dim = reader_common_dims_view.subspan(num_dims, num_dims);
+    auto input_shape_args = reader_common_dims_view.subspan(num_dims * 2, num_dims);
     num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
     num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
     num_padded_tiles_per_dim[0] = num_padded_Xt;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -84,11 +84,8 @@ void emit_runtime_args_hc_tiled_interleaved(
         uint32_t end_idx = start_idx + num_tiles_per_core;
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
 
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{input_buffer->address(), num_tiles_per_core, start_idx});
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
+        reader_desc.emplace_runtime_args(core, {input_buffer, num_tiles_per_core, start_idx});
+        writer_desc.emplace_runtime_args(core, {output_buffer, start_idx, end_idx, padded_start_idx, padded_end_idx});
 
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -62,26 +62,24 @@ void emit_runtime_args_hc_tiled(
         uint32_t h = num_tiles_read / CtWt % H;
         uint32_t ct = num_tiles_read / Wt % Ct;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                input_buffer->address(),
-                Wt,
-                H,
-                Ct,
-                HW_bytes,
-                CHW_bytes,
-                num_tiles_read,
-                num_tiles_per_core,
-                num_tiles_read / CtHWt * CHW_bytes,
-                h,
-                h / TILE_HEIGHT * Wt,
-                ct,
-                ct * TILE_HEIGHT * HW_bytes,
-                num_tiles_read % Wt});
+            {input_buffer,
+             Wt,
+             H,
+             Ct,
+             HW_bytes,
+             CHW_bytes,
+             num_tiles_read,
+             num_tiles_per_core,
+             num_tiles_read / CtHWt * CHW_bytes,
+             h,
+             h / TILE_HEIGHT * Wt,
+             ct,
+             ct * TILE_HEIGHT * HW_bytes,
+             num_tiles_read % Wt});
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_buffer->address(), num_tiles_per_core, num_tiles_read});
+        writer_desc.emplace_runtime_args(core, {output_buffer, num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -290,23 +290,21 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        //  writer runtime args
-        std::vector<uint32_t> writer_rt_args = {
-            dst_buffer->address(),
-            TILE_WIDTH * el_size * single_block_size_row_arg,
-            start_row_id,
-            start_column_id,
-            single_block_size_row_arg,
-            single_block_size_col_arg,
-            TILE_WIDTH * el_size * single_sub_block_size_row_arg,
-            single_sub_block_size_row_arg};
-
         // reader runtime args
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
+            core, {src0_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
+
+        //  writer runtime args
+        writer_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                src0_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_rt_args));
+            {dst_buffer,
+             TILE_WIDTH * el_size * single_block_size_row_arg,
+             start_row_id,
+             start_column_id,
+             single_block_size_row_arg,
+             single_block_size_col_arg,
+             TILE_WIDTH * el_size * single_sub_block_size_row_arg,
+             single_sub_block_size_row_arg});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * el_size);
         start_column_id = end_column_id % padded_row_size_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -163,19 +163,11 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
         uint32_t size_per_row_per_block = nblocks_per_core * TILE_WIDTH * el_size;
 
         //  writer runtime args
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                dst_buffer->address(),
-                i,
-                size_per_row_per_block,
-                number_blocks_per_core,
-                TILE_WIDTH * el_size,
-            });
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, i, size_per_row_per_block, number_blocks_per_core, TILE_WIDTH * el_size});
 
         // reader runtime args
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{src0_buffer->address(), i, num_tiles_per_row, number_blocks_per_core});
+        reader_desc.emplace_runtime_args(core, {src0_buffer, i, num_tiles_per_row, number_blocks_per_core});
     }
 
     // Insert reader+writer at the start so kernel ordering matches the legacy program: reader is


### PR DESCRIPTION
### What
Declare raw `tensor.buffer()->address()` runtime-arg slots in the data-movement factories as `Buffer*` bindings via `emplace_runtime_args` — removing the smuggled-pointer anti-pattern so the framework knows these slots hold buffer addresses instead of opaque uint32s.

### Why
A raw address pushed as a plain uint32 is invisible to the descriptor framework, which then cannot recognize or manage the buffer reference (and falls back to rebuilding the descriptor on every cache hit to refresh it). Declaring it as a binding makes the address framework-tracked and patched directly on cache hits. De-smuggling only — no miss-path behavior change.

### Safety
Only the buffer address slot changes; all other runtime args are untouched. Verified the buffer address is the sole dynamic-on-hit value (work distribution is captured by the program hash; no hash-excluded scalars), so the binding is correct and sufficient.

### Test
Build clean; fast-dispatch unit tests green. Nightly for this family + ttsim: to run in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-data-movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-data-movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-data-movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-data-movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-data-movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-data-movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-data-movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-data-movement)