### PR TITLE
[eltwise] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
@@ -143,23 +143,13 @@ ProgramDescriptor TanhBwProgramFactory::create_descriptor(
             TT_THROW("Core not in specified core ranges");
         }
 
-        reader_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src0_buffer->address(),
-                src1_buffer->address(),
-                num_tiles_per_core,
-                num_tiles_written,
-                0,
-                0,
-                num_cores_y});
+        reader_desc.emplace_runtime_args(
+            core, {src0_buffer, src1_buffer, num_tiles_per_core, num_tiles_written, 0u, 0u, num_cores_y});
 
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{num_tiles_per_core, 1});
 
-        writer_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
 
         num_tiles_written += num_tiles_per_core;
     }


### PR DESCRIPTION
### What
Declare raw `tensor.buffer()->address()` runtime-arg slots in the eltwise factories as `Buffer*` bindings via `emplace_runtime_args` — removing the smuggled-pointer anti-pattern so the framework knows these slots hold buffer addresses instead of opaque uint32s.

### Why
A raw address pushed as a plain uint32 is invisible to the descriptor framework, which then cannot recognize or manage the buffer reference (and falls back to rebuilding the descriptor on every cache hit to refresh it). Declaring it as a binding makes the address framework-tracked and patched directly on cache hits. De-smuggling only — no miss-path behavior change.

### Safety
Only the buffer address slot changes; all other runtime args are untouched. Verified the buffer address is the sole dynamic-on-hit value (work distribution is captured by the program hash; no hash-excluded scalars), so the binding is correct and sufficient.

### Test
Build clean; fast-dispatch unit tests green. Nightly for this family + ttsim: to run in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-eltwise)