### PR TITLE
[experimental-matmul] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -95,10 +95,6 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
     uint32_t in1_KtNt_stride = transpose_hw_bool ? bshape[2] / TILE_HEIGHT * in1_Kt : in1_Kt * Nt;
     uint32_t in1_KtNt_skip = transpose_hw_bool ? (bshape[2] / TILE_HEIGHT - 1) * in1_Kt : (in1_Kt - Kt) * Nt;
 
-    uint32_t src0_addr = src0_buffer->address();
-    uint32_t src1_addr = src1_buffer->address();
-    uint32_t dst_addr = dst_buffer->address();
-
     // ---- Circular buffers ----
     // cb_src0's total_size = Kt * in0_single_tile_size depends on the input shape;
     // padded_shape is folded into compute_program_hash() so each unique Kt keeps
@@ -234,11 +230,11 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
             continue;
         }
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                src0_addr,
-                src1_addr,
+            {
+                src0_buffer,
+                src1_buffer,
                 Mt,
                 Kt,
                 Nt,
@@ -247,7 +243,7 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
                 in1_KtNt_stride * num_rows_in_one_tile,
                 num_output_blocks_per_core,
                 num_blocks_written * MtKt,  // itileA_start
-                0,                          // itileB_start; always read same in1 per core
+                0u,                         // itileB_start; always read same in1 per core
             });
         compute_desc.runtime_args.emplace_back(
             core,
@@ -257,10 +253,10 @@ tt::tt_metal::ProgramDescriptor AttnMatmulProgramFactory::create_descriptor(
                 Kt,                                 // Kt
                 num_output_blocks_per_core * MtNt,  // Nt
             });
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                dst_addr,
+            {
+                dst_buffer,
                 num_output_blocks_per_core * MtNt,
                 num_blocks_written * MtNt,
             });

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -355,17 +355,17 @@ tt::tt_metal::ProgramDescriptor GroupAttnMatmulProgramFactory::create_descriptor
         const uint32_t in1_mcast_num_dests =
             Q_HEADS < TILE_HEIGHT ? std::min(mcast_num_cores_for_core, num_active_cores - 1) : mcast_num_dests - 1;
 
-        std::vector<uint32_t> reader_runtime_args = {
+        std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args = {
             has_work_for_mcast_kv_heads,
             has_work_for_q_heads,
-            src1_buffer->address(),
+            src1_buffer,
             Mt,
             Nt,
             KV_HEADS,
             in1_CKtNt,
             in1_CKtNt * TILE_HEIGHT,
             num_output_blocks_per_core,
-            0,  // in1_start_id
+            0u,  // in1_start_id
 
             in0_block_w,
             out_block_w,
@@ -397,30 +397,31 @@ tt::tt_metal::ProgramDescriptor GroupAttnMatmulProgramFactory::create_descriptor
             reader_runtime_args.end(), in1_mcast_sender_noc_x.begin(), in1_mcast_sender_noc_x.end());
         reader_runtime_args.insert(
             reader_runtime_args.end(), in1_mcast_sender_noc_y.begin(), in1_mcast_sender_noc_y.end());
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
 
-        std::vector<uint32_t> writer_runtime_args = {
-            has_work_for_q_heads,
-            src0_buffer->address(),
-            dst_buffer->address(),
-            Mt,
-            Kt,
-            Nt,
-            MtKt,
-            num_output_blocks_per_core,
-            num_blocks_written * MtKt,
-            num_blocks_written * MtNt,
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                has_work_for_q_heads,
+                src0_buffer,
+                dst_buffer,
+                Mt,
+                Kt,
+                Nt,
+                MtKt,
+                num_output_blocks_per_core,
+                num_blocks_written * MtKt,
+                num_blocks_written * MtNt,
 
-            in0_block_w,
-            in1_num_subblocks,
-            in1_num_blocks,
-            MtNt,
+                in0_block_w,
+                in1_num_subblocks,
+                in1_num_blocks,
+                MtNt,
 
-            bfloat16_row_bytes,
-            bfloat16_Nt_bytes,
-            bfloat16_last_row_bytes_read,
-        };
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+                bfloat16_row_bytes,
+                bfloat16_Nt_bytes,
+                bfloat16_last_row_bytes_read,
+            });
 
         std::vector<uint32_t> compute_runtime_args = {
             has_work_for_q_heads,


### PR DESCRIPTION
### What
Declare raw `tensor.buffer()->address()` runtime-arg slots in the experimental-matmul factories as `Buffer*` bindings via `emplace_runtime_args` — removing the smuggled-pointer anti-pattern so the framework knows these slots hold buffer addresses instead of opaque uint32s.

### Why
A raw address pushed as a plain uint32 is invisible to the descriptor framework, which then cannot recognize or manage the buffer reference (and falls back to rebuilding the descriptor on every cache hit to refresh it). Declaring it as a binding makes the address framework-tracked and patched directly on cache hits. De-smuggling only — no miss-path behavior change.

### Safety
Only the buffer address slot changes; all other runtime args are untouched. Verified the buffer address is the sole dynamic-on-hit value (work distribution is captured by the program hash; no hash-excluded scalars), so the binding is correct and sufficient.

### Test
Build clean; fast-dispatch unit tests green. Nightly for this family + ttsim: to run in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-experimental-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-experimental-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-experimental-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-experimental-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-experimental-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-experimental-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-experimental-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-experimental-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-experimental-matmul)