### PR TITLE
[moreh] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -245,26 +245,19 @@ ProgramDescriptor MorehAbsPowOperation::create_descriptor(
         }
 
         // reader
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input.buffer()->address(),
-                static_cast<uint32_t>(is_dram(input)),
-                std::bit_cast<uint32_t>(decimal),
-                num_units_per_core,
-                Wt,
-                tile_offset,
-                origin_w});
+            {input.buffer(),
+             static_cast<uint32_t>(is_dram(input)),
+             std::bit_cast<uint32_t>(decimal),
+             num_units_per_core,
+             Wt,
+             tile_offset,
+             origin_w});
 
         // writer
-        writer_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                output.buffer()->address(),
-                static_cast<uint32_t>(is_dram(output)),
-                num_units_per_core,
-                Wt,
-                tile_offset});
+        writer_desc.emplace_runtime_args(
+            core, {output.buffer(), static_cast<uint32_t>(is_dram(output)), num_units_per_core, Wt, tile_offset});
 
         // compute — runtime args go to the correct kernel descriptor
         KernelDescriptor::CoreRuntimeArgs compute_rt{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
@@ -212,7 +212,6 @@ ProgramDescriptor MorehClipGradNormStep1Operation::create_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto output_addr = tmp_pow_sum.buffer()->address();
     auto cores = grid_to_cores(num_cores_to_be_used, num_cores_x, num_cores_y, false);
 
     uint32_t tile_offset = tile_offset_of_tmp_pow_sum;
@@ -220,18 +219,15 @@ ProgramDescriptor MorehClipGradNormStep1Operation::create_descriptor(
         const CoreCoord& core = cores.at(i);
 
         const auto& input = inputs.at(i);
-        const auto input_addr = input.buffer()->address();
         const auto num_tiles = static_cast<uint32_t>(input.physical_volume()) / tt::constants::TILE_HW;
         const auto [origin_h, origin_w] = origin_hw_vec.at(i);
 
         // reader
-        reader_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input_addr, num_tiles, std::bit_cast<uint32_t>(decimal), origin_h, origin_w});
+        reader_desc.emplace_runtime_args(
+            core, {input.buffer(), num_tiles, std::bit_cast<uint32_t>(decimal), origin_h, origin_w});
 
         // writer
-        writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset});
+        writer_desc.emplace_runtime_args(core, {tmp_pow_sum.buffer(), tile_offset});
 
         // compute
         compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
@@ -151,17 +151,12 @@ ProgramDescriptor MorehClipGradNormStep2Operation::create_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto input_addr = tmp_pow_sum.buffer()->address();
-    const auto output_addr = total_norm.buffer()->address();
-
     // reader
-    reader_desc.runtime_args.emplace_back(
-        single_core,
-        KernelDescriptor::CoreRuntimeArgs{
-            input_addr, static_cast<uint32_t>(num_tiles), std::bit_cast<uint32_t>(decimal)});
+    reader_desc.emplace_runtime_args(
+        single_core, {tmp_pow_sum.buffer(), static_cast<uint32_t>(num_tiles), std::bit_cast<uint32_t>(decimal)});
 
     // writer
-    writer_desc.runtime_args.emplace_back(single_core, KernelDescriptor::CoreRuntimeArgs{output_addr});
+    writer_desc.emplace_runtime_args(single_core, {total_norm.buffer()});
 
     // compute
     compute_desc.runtime_args.emplace_back(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
@@ -133,21 +133,18 @@ ProgramDescriptor MorehClipGradNormStep3Operation::create_descriptor(
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
     auto cores = grid_to_cores(num_cores_to_be_used, num_cores_x, num_cores_y, false);
-    const auto clip_coef_clamped_addr = clip_coef_clamped.buffer()->address();
 
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores.at(i);
 
         const auto& input = inputs.at(i);
-        const auto input_addr = input.buffer()->address();
         const auto num_tiles = static_cast<uint32_t>(input.physical_volume()) / tt::constants::TILE_HW;
 
         // reader
-        reader_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{input_addr, clip_coef_clamped_addr, num_tiles});
+        reader_desc.emplace_runtime_args(core, {input.buffer(), clip_coef_clamped.buffer(), num_tiles});
 
         // writer
-        writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{input_addr, num_tiles});
+        writer_desc.emplace_runtime_args(core, {input.buffer(), num_tiles});
 
         // compute
         compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_tiles});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
@@ -124,10 +124,7 @@ ProgramDescriptor MorehDotOperation::create_descriptor(
     reader_desc.core_ranges = core_set;
     reader_desc.compile_time_args = std::move(reader_ct_args);
     reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.runtime_args.emplace_back(
-        core,
-        KernelDescriptor::CoreRuntimeArgs{
-            src0_buffer->address(), src1_buffer->address(), num_tiles, 0u, mask_h, mask_w});
+    reader_desc.emplace_runtime_args(core, {src0_buffer, src1_buffer, num_tiles, 0u, mask_h, mask_w});
 
     // Writer kernel
     KernelDescriptor::CompileTimeArgs writer_ct_args = {static_cast<uint32_t>(tt::CBIndex::c_16)};
@@ -139,7 +136,7 @@ ProgramDescriptor MorehDotOperation::create_descriptor(
     writer_desc.core_ranges = core_set;
     writer_desc.compile_time_args = std::move(writer_ct_args);
     writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dst_buffer->address(), 1u, 0u});
+    writer_desc.emplace_runtime_args(core, {dst_buffer, 1u, 0u});
 
     // Compute kernel
     KernelDescriptor compute_desc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
@@ -108,33 +108,30 @@ ProgramDescriptor MorehDotBackwardOperation::create_descriptor(
     reader_desc.core_ranges = core_set;
     reader_desc.compile_time_args = std::move(reader_ct_args);
     reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.runtime_args.emplace_back(
+    reader_desc.emplace_runtime_args(
         core,
-        KernelDescriptor::CoreRuntimeArgs{
-            static_cast<uint32_t>(has_input_grad),
-            static_cast<uint32_t>(has_other_grad),
-            src0_buffer->address(),
-            src1_buffer->address(),
-            src2_buffer->address(),
-            num_tiles,
-            0u});
+        {static_cast<uint32_t>(has_input_grad),
+         static_cast<uint32_t>(has_other_grad),
+         src0_buffer,
+         src1_buffer,
+         src2_buffer,
+         num_tiles,
+         0u});
 
     // Writer kernel
-    uint32_t dst0_address = 0;
-    uint32_t dst1_address = 0;
+    Buffer* dst0_buffer = nullptr;
+    Buffer* dst1_buffer = nullptr;
 
     if (has_input_grad) {
         const auto& input_grad_tensor = input_grad.value();
-        auto* dst0_buffer = input_grad_tensor.buffer();
+        dst0_buffer = input_grad_tensor.buffer();
         TT_ASSERT(dst0_buffer != nullptr, "input_grad buffer should be allocated on device!");
-        dst0_address = dst0_buffer->address();
     }
 
     if (has_other_grad) {
         const auto& other_grad_tensor = other_grad.value();
-        auto* dst1_buffer = other_grad_tensor.buffer();
+        dst1_buffer = other_grad_tensor.buffer();
         TT_ASSERT(dst1_buffer != nullptr, "other_grad buffer should be allocated on device!");
-        dst1_address = dst1_buffer->address();
     }
 
     KernelDescriptor::CompileTimeArgs writer_ct_args = {
@@ -150,15 +147,23 @@ ProgramDescriptor MorehDotBackwardOperation::create_descriptor(
     writer_desc.core_ranges = core_set;
     writer_desc.compile_time_args = std::move(writer_ct_args);
     writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.runtime_args.emplace_back(
-        core,
-        KernelDescriptor::CoreRuntimeArgs{
-            static_cast<uint32_t>(has_input_grad),
-            static_cast<uint32_t>(has_other_grad),
-            dst0_address,
-            dst1_address,
-            num_tiles,
-            0u});
+    KernelDescriptor::RTArgList writer_args;
+    writer_args.push_back(static_cast<uint32_t>(has_input_grad));
+    writer_args.push_back(static_cast<uint32_t>(has_other_grad));
+    // Push the grad buffer when present, 0 when absent (framework treats an absent slot as 0).
+    if (has_input_grad) {
+        writer_args.push_back(dst0_buffer);
+    } else {
+        writer_args.push_back(0u);
+    }
+    if (has_other_grad) {
+        writer_args.push_back(dst1_buffer);
+    } else {
+        writer_args.push_back(0u);
+    }
+    writer_args.push_back(num_tiles);
+    writer_args.push_back(0u);
+    writer_desc.emplace_runtime_args(core, writer_args);
 
     // Compute kernel
     KernelDescriptor compute_desc;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
@@ -169,35 +169,32 @@ ProgramDescriptor MorehFoldOperation::create_descriptor(
         uint32_t aligned = (src_is_dram ? (input_cb_page_size % dram_alignment == 0) : 1);
         aligned = aligned && !is_blackhole;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input.buffer()->address(),
-                N,
-                C,
-                H,
-                W,
-                kernel_size_h,
-                kernel_size_w,
-                stride_h,
-                stride_w,
-                padding_h,
-                padding_w,
-                dilation_h,
-                dilation_w,
-                LH,
-                LW,
-                input_cb_page_size,
-                dram_aligned_input_cb_page_size,
-                aligned_output_cb_page_size,
-                start_id,
-                num_units_per_core,
-                aligned});
+            {input.buffer(),
+             N,
+             C,
+             H,
+             W,
+             kernel_size_h,
+             kernel_size_w,
+             stride_h,
+             stride_w,
+             padding_h,
+             padding_w,
+             dilation_h,
+             dilation_w,
+             LH,
+             LW,
+             input_cb_page_size,
+             dram_aligned_input_cb_page_size,
+             aligned_output_cb_page_size,
+             start_id,
+             num_units_per_core,
+             aligned});
 
-        writer_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                output.buffer()->address(), aligned_output_cb_page_size, start_id, num_units_per_core});
+        writer_desc.emplace_runtime_args(
+            core, {output.buffer(), aligned_output_cb_page_size, start_id, num_units_per_core});
 
         start_id += num_units_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
@@ -228,9 +228,6 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
     auto* const mean_buf = mean.buffer();
     auto* const rstd_buf = rstd.buffer();
 
-    const auto gamma_grad_addr = gamma_grad_has_value ? gamma_grad.value().buffer()->address() : 0u;
-    const auto beta_grad_addr = beta_grad_has_value ? beta_grad.value().buffer()->address() : 0u;
-
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -243,36 +240,37 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // NOTE: do not pass Buffer* here. tile_offset/num_channels_per_core/etc are
-        // per-core shape-derived; using BufferBinding would skip create_descriptor()
-        // on cache hits and leave those scalars stale.
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                output_grad_buf->address(),
-                input_buf->address(),
-                mean_buf->address(),
-                rstd_buf->address(),
-                tile_offset,
-                num_channels_per_core,
-                num_inner_tiles,
-                num_channels,
-                num_groups,
-                origin_h,
-                origin_w,
-            });
+            {output_grad_buf,
+             input_buf,
+             mean_buf,
+             rstd_buf,
+             tile_offset,
+             num_channels_per_core,
+             num_inner_tiles,
+             num_channels,
+             num_groups,
+             origin_h,
+             origin_w});
 
-        // writer (already address-only, no BufferBinding)
-        writer_desc.runtime_args.emplace_back(
-            core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                gamma_grad_addr,
-                beta_grad_addr,
-                tile_offset,
-                num_channels_per_core,
-                num_inner_tiles,
-                batch,
-            });
+        // writer
+        KernelDescriptor::RTArgList writer_args;
+        if (gamma_grad_has_value) {
+            writer_args.push_back(gamma_grad.value().buffer());
+        } else {
+            writer_args.push_back(0u);
+        }
+        if (beta_grad_has_value) {
+            writer_args.push_back(beta_grad.value().buffer());
+        } else {
+            writer_args.push_back(0u);
+        }
+        writer_args.push_back(tile_offset);
+        writer_args.push_back(num_channels_per_core);
+        writer_args.push_back(num_inner_tiles);
+        writer_args.push_back(batch);
+        writer_desc.emplace_runtime_args(core, writer_args);
 
         tile_offset += num_channels_per_core * HtWt;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
@@ -248,8 +248,6 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
 
     auto* const input_grad_buf = input_grad.buffer();
 
-    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
-
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -262,35 +260,28 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // NOTE: do not pass Buffer* here. gamma_addr is an optional-tensor address
-        // and tile_offset/etc are per-core shape-derived; using BufferBinding would
-        // skip create_descriptor() on cache hits and leave those scalars stale.
-        reader_desc.runtime_args.emplace_back(
-            core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                output_grad_buf->address(),
-                input_buf->address(),
-                mean_buf->address(),
-                rstd_buf->address(),
-                gamma_addr,
-                tile_offset,
-                num_rows_per_core,
-                num_inner_tiles,
-                num_channels,
-                num_groups,
-                origin_h,
-                origin_w,
-            });
+        // reader
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(output_grad_buf);
+        reader_args.push_back(input_buf);
+        reader_args.push_back(mean_buf);
+        reader_args.push_back(rstd_buf);
+        if (gamma_has_value) {
+            reader_args.push_back(gamma.value().buffer());
+        } else {
+            reader_args.push_back(0u);
+        }
+        reader_args.push_back(tile_offset);
+        reader_args.push_back(num_rows_per_core);
+        reader_args.push_back(num_inner_tiles);
+        reader_args.push_back(num_channels);
+        reader_args.push_back(num_groups);
+        reader_args.push_back(origin_h);
+        reader_args.push_back(origin_w);
+        reader_desc.emplace_runtime_args(core, reader_args);
 
         // writer
-        writer_desc.runtime_args.emplace_back(
-            core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                input_grad_buf->address(),
-                tile_offset,
-                num_rows_per_core,
-                num_inner_tiles,
-            });
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, tile_offset, num_rows_per_core, num_inner_tiles});
 
         tile_offset += num_rows_per_core * num_inner_tiles;
     }


### PR DESCRIPTION
### What
Declare raw `tensor.buffer()->address()` runtime-arg slots in the moreh factories as `Buffer*` bindings via `emplace_runtime_args` — removing the smuggled-pointer anti-pattern so the framework knows these slots hold buffer addresses instead of opaque uint32s.

### Why
A raw address pushed as a plain uint32 is invisible to the descriptor framework, which then cannot recognize or manage the buffer reference (and falls back to rebuilding the descriptor on every cache hit to refresh it). Declaring it as a binding makes the address framework-tracked and patched directly on cache hits. De-smuggling only — no miss-path behavior change.

### Safety
Only the buffer address slot changes; all other runtime args are untouched. Verified the buffer address is the sole dynamic-on-hit value (work distribution is captured by the program hash; no hash-excluded scalars), so the binding is correct and sufficient.

### Test
Build clean; fast-dispatch unit tests green. Nightly for this family + ttsim: to run in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-moreh)