### PR TITLE
[normalization] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -84,42 +84,44 @@ void populate_runtime_arguments(
         const auto packed_scalar_eps =
             any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
 
-        // NOTE: do not pass Buffer* here. packed_scalar_eps depends on the eps
-        // operation_attribute and changes between calls; using BufferBinding
-        // would skip create_descriptor() on cache hits and leave eps stale.
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                packed_scalar_eps,
-                input_tensor.buffer()->address(),
-                start_tile_id,
-                num_tiles_per_core,
-                cHtWt,
-                aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
-                aHt * aWt * static_cast<uint32_t>(aC > 1),
-                cN,
-                cC,
-                cHt,
-                cWt});
+            {packed_scalar_eps,
+             input_tensor.buffer(),
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
+             aHt * aWt * static_cast<uint32_t>(aC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
-        const auto weight_addr = weight_has_value ? weight_tensor->buffer()->address() : 0;
-        const auto bias_addr = bias_has_value ? bias_tensor->buffer()->address() : 0;
-        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs writer_runtime_args = {
-            batch_mean_tensor.buffer()->address(),  //  batch mean
-            batch_var_tensor.buffer()->address(),   //  batch var
-            weight_addr,                            // weight
-            bias_addr,                              // bias
-            c.buffer()->address(),                  // output
-            start_tile_id,
-            num_tiles_per_core,
-            cHtWt,
-            bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
-            bHt * bWt * static_cast<uint32_t>(bC > 1),
-            cN,
-            cC,
-            cHt,
-            cWt};
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+        std::variant<uint32_t, tt::tt_metal::Buffer*> weight_arg = 0u;
+        if (weight_has_value) {
+            weight_arg = weight_tensor->buffer();
+        }
+        std::variant<uint32_t, tt::tt_metal::Buffer*> bias_arg = 0u;
+        if (bias_has_value) {
+            bias_arg = bias_tensor->buffer();
+        }
+        writer_desc.emplace_runtime_args(
+            core,
+            {batch_mean_tensor.buffer(),  //  batch mean
+             batch_var_tensor.buffer(),   //  batch var
+             weight_arg,                  // weight
+             bias_arg,                    // bias
+             c.buffer(),                  // output
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
+             bHt * bWt * static_cast<uint32_t>(bC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
         auto counter = start_tile_id % cHtWt;
         auto freq = cHtWt;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -82,42 +82,43 @@ void populate_runtime_arguments(
         const auto scalar = momentum;
         const auto packed_scalar_momentum =
             any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
-        // NOTE: do not pass Buffer* here. packed_scalar_momentum depends on the
-        // momentum operation_attribute and changes between calls; using
-        // BufferBinding would skip create_descriptor() on cache hits and leave
-        // momentum stale.
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                packed_scalar_momentum,
-                batch_mean_tensor.buffer()->address(),
-                start_tile_id,
-                num_tiles_per_core,
-                cHtWt,
-                aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
-                aHt * aWt * static_cast<uint32_t>(aC > 1),
-                cN,
-                cC,
-                cHt,
-                cWt});
+            {packed_scalar_momentum,
+             batch_mean_tensor.buffer(),
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             aHt * aWt * aC * static_cast<uint32_t>(aN > 1),
+             aHt * aWt * static_cast<uint32_t>(aC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
-        const auto running_mean_addr = running_mean_has_value ? running_mean_tensor->buffer()->address() : 0;
-        const auto running_var_addr = running_var_has_value ? running_var_tensor->buffer()->address() : 0;
-        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs writer_runtime_args = {
-            batch_var_tensor.buffer()->address(),  //  batch var
-            running_mean_addr,                     // old running mean
-            running_var_addr,                      // old running var
-            c.buffer()->address(),                 // output
-            start_tile_id,
-            num_tiles_per_core,
-            cHtWt,
-            bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
-            bHt * bWt * static_cast<uint32_t>(bC > 1),
-            cN,
-            cC,
-            cHt,
-            cWt};
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+        std::variant<uint32_t, tt::tt_metal::Buffer*> running_mean_arg = 0u;
+        if (running_mean_has_value) {
+            running_mean_arg = running_mean_tensor->buffer();
+        }
+        std::variant<uint32_t, tt::tt_metal::Buffer*> running_var_arg = 0u;
+        if (running_var_has_value) {
+            running_var_arg = running_var_tensor->buffer();
+        }
+        writer_desc.emplace_runtime_args(
+            core,
+            {batch_var_tensor.buffer(),  //  batch var
+             running_mean_arg,           // old running mean
+             running_var_arg,            // old running var
+             c.buffer(),                 // output
+             start_tile_id,
+             num_tiles_per_core,
+             cHtWt,
+             bHt * bWt * bC * static_cast<uint32_t>(bN > 1),
+             bHt * bWt * static_cast<uint32_t>(bC > 1),
+             cN,
+             cC,
+             cHt,
+             cWt});
 
         auto counter = start_tile_id % cHtWt;
         auto freq = cHtWt;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -283,12 +283,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
             block_wt * tile_width);
     }
 
-    auto in0_dram_addr = a.buffer()->address();
-    auto out_dram_addr = output.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto input_mask_dram_addr = input_mask.has_value() ? input_mask.value().buffer()->address() : 0;
-
     uint32_t in0_block_tiles_group_1 = block_ht_group_1 / num_out_blocks * block_wt;
     uint32_t in0_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
@@ -1085,9 +1079,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                 if (reader_noc == NOC::NOC_1) {
                     std::swap(mcast_start, mcast_end);
                 }
-                std::vector<uint32_t> mcast_sender_args;
-                mcast_sender_args.push_back(in0_dram_addr);
-                mcast_sender_args.push_back(out_dram_addr);
+                tt::tt_metal::KernelDescriptor::RTArgList mcast_sender_args;
+                mcast_sender_args.push_back(a.buffer());
+                mcast_sender_args.push_back(output.buffer());
                 mcast_sender_args.push_back(in0_start_id);
                 mcast_sender_args.push_back(out_tile_start_id);
                 mcast_sender_args.push_back(Wt);
@@ -1139,23 +1133,18 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                     CoreCoord coord = device->worker_core_from_logical_core(gcore);
                     mcast_noc_xy.push_back(coord.y);
                 }
-                mcast_sender_args.insert(mcast_sender_args.end(), mcast_noc_xy.begin(), mcast_noc_xy.end());
-                reader_mcast_sender_desc.runtime_args.emplace_back(core, std::move(mcast_sender_args));
+                mcast_sender_args.append(mcast_noc_xy);
+                reader_mcast_sender_desc.emplace_runtime_args(core, mcast_sender_args);
             } else {  // mcast receiver
-                // NOTE: do not pass Buffer* here. in0_start_id/out_tile_start_id/Wt/mcast
-                // coords are per-core and shape-derived; using BufferBinding would skip
-                // create_descriptor() on cache hits and leave those scalars stale when a
-                // later call collides on the same cache entry with different shape/grid.
-                reader_mcast_receiver_desc.runtime_args.emplace_back(
+                reader_mcast_receiver_desc.emplace_runtime_args(
                     core,
-                    tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
-                        a.buffer()->address(),
-                        output.buffer()->address(),
-                        in0_start_id,
-                        out_tile_start_id,
-                        Wt,
-                        static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).x),
-                        static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).y)});
+                    {a.buffer(),
+                     output.buffer(),
+                     in0_start_id,
+                     out_tile_start_id,
+                     Wt,
+                     static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).x),
+                     static_cast<uint32_t>(device->worker_core_from_logical_core(group.front()).y)});
             }
         }
     }
@@ -1187,18 +1176,30 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
             }
         }
 
-        std::vector<uint32_t> writer_mcast_sender_args;
+        tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(eps_u);
-        writer_mcast_sender_args.push_back(out_dram_addr);
-        writer_mcast_sender_args.push_back(gamma_dram_addr);
-        writer_mcast_sender_args.push_back(beta_dram_addr);
-        writer_mcast_sender_args.push_back(input_mask_dram_addr);
+        writer_mcast_sender_args.push_back(output.buffer());
+        if (gamma.has_value()) {
+            writer_mcast_sender_args.push_back(gamma.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (beta.has_value()) {
+            writer_mcast_sender_args.push_back(beta.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (input_mask.has_value()) {
+            writer_mcast_sender_args.push_back(input_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
         writer_mcast_sender_args.push_back(out_tile_start_id);
         writer_mcast_sender_args.push_back(gamma_tile_start_id);
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+        writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
     }
 
     desc.kernels.push_back(std::move(reader_mcast_sender_desc));

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -380,13 +380,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             block_wt * tile_width);
     }
 
-    // get addr
-    auto in0_dram_addr = a.buffer()->address();
-    auto out_dram_addr = output.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto input_mask_dram_addr = input_mask.has_value() ? input_mask.value().buffer()->address() : 0;
-
     // Parameters Setup
     uint32_t in0_block_tiles_group_1 = block_ht_group_1 / num_out_blocks * block_wt;
     uint32_t in0_block_tiles_group_2 = 0;
@@ -1343,9 +1336,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             if (reader_noc == NOC::NOC_1) {
                 std::swap(mcast_start, mcast_end);
             }
-            std::vector<uint32_t> mcast_sender_args;
-            mcast_sender_args.push_back(in0_dram_addr);
-            mcast_sender_args.push_back(out_dram_addr);
+            tt::tt_metal::KernelDescriptor::RTArgList mcast_sender_args;
+            mcast_sender_args.push_back(a.buffer());
+            mcast_sender_args.push_back(output.buffer());
             mcast_sender_args.push_back(in0_start_id);
             mcast_sender_args.push_back(out_tile_start_id);
             mcast_sender_args.push_back(Wt);
@@ -1397,11 +1390,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
                 CoreCoord coord = device->worker_core_from_logical_core(gcore);
                 mcast_noc_xy.push_back(coord.y);
             }
-            mcast_sender_args.insert(mcast_sender_args.end(), mcast_noc_xy.begin(), mcast_noc_xy.end());
+            mcast_sender_args.append(mcast_noc_xy);
             if (equal_batches_per_core || (virtual_core.y <= last_row_with_extra_batch)) {
-                reader_mcast_sender_desc_g1.runtime_args.emplace_back(core, std::move(mcast_sender_args));
+                reader_mcast_sender_desc_g1.emplace_runtime_args(core, mcast_sender_args);
             } else {
-                reader_mcast_sender_desc_g2.runtime_args.emplace_back(core, std::move(mcast_sender_args));
+                reader_mcast_sender_desc_g2.emplace_runtime_args(core, mcast_sender_args);
             }
         }
     }
@@ -1438,21 +1431,33 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             }
         }
 
-        std::vector<uint32_t> writer_mcast_sender_args;
+        tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(eps_u);
-        writer_mcast_sender_args.push_back(out_dram_addr);
-        writer_mcast_sender_args.push_back(gamma_dram_addr);
-        writer_mcast_sender_args.push_back(beta_dram_addr);
-        writer_mcast_sender_args.push_back(input_mask_dram_addr);
+        writer_mcast_sender_args.push_back(output.buffer());
+        if (gamma.has_value()) {
+            writer_mcast_sender_args.push_back(gamma.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (beta.has_value()) {
+            writer_mcast_sender_args.push_back(beta.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (input_mask.has_value()) {
+            writer_mcast_sender_args.push_back(input_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
         writer_mcast_sender_args.push_back(out_tile_start_id);
         writer_mcast_sender_args.push_back(gamma_tile_start_id);
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
         if (equal_batches_per_core || (virtual_core.y <= last_row_with_extra_batch)) {
-            writer_desc_g1.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+            writer_desc_g1.emplace_runtime_args(core, writer_mcast_sender_args);
         } else {
-            writer_desc_g2.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+            writer_desc_g2.emplace_runtime_args(core, writer_mcast_sender_args);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -305,13 +305,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             block_wt * tile_width);
     }
 
-    // get sharded addr
-    // gamma, beta addr
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto input_mask_dram_addr = input_mask.has_value() ? input_mask.value().buffer()->address() : 0;
-    auto input_negative_mask_dram_addr = negative_mask.has_value() ? negative_mask.value().buffer()->address() : 0;
-
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -1236,16 +1229,32 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t beta_tile_start_id = 0;
     uint32_t input_mask_tile_start_id = 0;
     for (const auto& core : core_coords) {
-        std::vector<uint32_t> writer_mcast_sender_args;
+        tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(eps_u);
-        writer_mcast_sender_args.push_back(gamma_dram_addr);
-        writer_mcast_sender_args.push_back(beta_dram_addr);
-        writer_mcast_sender_args.push_back(input_mask_dram_addr);
-        writer_mcast_sender_args.push_back(input_negative_mask_dram_addr);
+        if (gamma.has_value()) {
+            writer_mcast_sender_args.push_back(gamma.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (beta.has_value()) {
+            writer_mcast_sender_args.push_back(beta.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (input_mask.has_value()) {
+            writer_mcast_sender_args.push_back(input_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
+        if (negative_mask.has_value()) {
+            writer_mcast_sender_args.push_back(negative_mask.value().buffer());
+        } else {
+            writer_mcast_sender_args.push_back(0u);
+        }
         writer_mcast_sender_args.push_back(gamma_tile_start_id);
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_mcast_sender_args));
+        writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
 
         if (gamma.has_value()) {
             gamma_tile_start_id = (gamma_tile_start_id + gamma_beta_num_cols_tile_per_core) %

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -128,7 +128,6 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     //////////////////////////////////////////////////////////////////////////
     // This should allocate a DRAM buffer on the device
     IDevice* device = a.device();
-    auto dst_addr = output.buffer()->address();
 
     ////////////////////////////////////////////////////////////////////////////
     //                Circular Buffer Data Format Setup
@@ -184,10 +183,10 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         inb_single_tile_size = tt::tile_size(inb_data_format);
     }
 
-    auto a_addr = a.buffer()->address();
-    auto b_dram_addr = b ? b.value().buffer()->address() : 0;
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
+    // Optional residual/gamma/beta: bind the Buffer* when present, else nullptr (framework emits 0u).
+    Buffer* b_buffer = b ? b.value().buffer() : nullptr;
+    Buffer* gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    Buffer* beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     uint32_t num_tile_rows = NC * Ht;
 
@@ -553,13 +552,15 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     auto bfloat_one_value = bfloat16(1);
     uint32_t packed_one_value = pack_two_bfloat16_into_uint32({bfloat_one_value, bfloat_one_value});
 
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Buffer base addresses are bound via emplace_runtime_args() so the framework
+    // patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
-    reader_runtime_args.reserve(num_cores);
-    writer_runtime_args.reserve(num_cores);
-    compute_runtime_args.reserve(num_cores);
+    reader_kernel_desc.runtime_args.reserve(num_cores);
+    writer_kernel_desc.runtime_args.reserve(num_cores);
+    compute_kernel_desc.runtime_args.reserve(num_cores);
 
     // Iterate over active cores
     auto all_core_coords = corerange_to_cores(all_cores, num_cores, true);
@@ -583,30 +584,34 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
             (use_welford_and_not_rms_norm && large_tensor_needed) || (use_row_major_kernel && !input_is_row_major);
         const uint32_t reader_start = using_legacy_tile_reader ? tile_offset : curr_row;
 
-        std::vector<uint32_t> reader_args = {
-            a_addr,
-            num_tile_rows_per_core,
-            Wt,
-            reader_start,
-            packed_one_value,
-            std::bit_cast<uint32_t>(eps),
-            gamma_dram_addr,
-            beta_dram_addr,
-            b_dram_addr};
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(a.buffer());
+        reader_args.push_back(num_tile_rows_per_core);
+        reader_args.push_back(Wt);
+        reader_args.push_back(reader_start);
+        reader_args.push_back(packed_one_value);
+        reader_args.push_back(std::bit_cast<uint32_t>(eps));
+        reader_args.push_back(gamma_buffer);
+        reader_args.push_back(beta_buffer);
+        reader_args.push_back(b_buffer);
         if (input_is_row_major) {
             reader_args.push_back(H_logical);
         }
 
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        reader_kernel_desc.emplace_runtime_args(core, reader_args);
         // For the RM output writer arg[3] is start_tile_row (starting tile-row index for this core),
         // not the flat tile offset, because the RM writer computes row addresses directly.
         const uint32_t writer_start = input_is_row_major ? curr_row : tile_offset;
-        std::vector<uint32_t> writer_args = {dst_addr, Wt, num_tile_rows_per_core, writer_start};
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.push_back(output.buffer());
+        writer_args.push_back(Wt);
+        writer_args.push_back(num_tile_rows_per_core);
+        writer_args.push_back(writer_start);
         if (input_is_row_major) {
             writer_args.push_back(H_logical);  // arg[4]
         }
-        writer_runtime_args.emplace_back(core, std::move(writer_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
+        writer_kernel_desc.emplace_runtime_args(core, writer_args);
+        compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
 
         curr_row += num_tile_rows_per_core;
     }
@@ -617,19 +622,16 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     ProgramDescriptor program_descriptor;
 
     // Build KernelDescriptor for reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source = reader_kernel_path;
     reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = reader_compile_time_args;
     reader_kernel_desc.named_compile_time_args = cb_named_args;
     reader_kernel_desc.defines = reader_defines;
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Build KernelDescriptor for writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source = input_is_row_major
                                            ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
                                              "writer_unary_interleaved_start_id_blocked_rm_output.cpp"
@@ -639,19 +641,16 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = writer_compile_time_args;
     writer_kernel_desc.named_compile_time_args = cb_named_args;
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Build KernelDescriptor for compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_path;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = compute_args;
     compute_kernel_desc.named_compile_time_args = cb_named_args;
     compute_kernel_desc.defines = compute_defines;
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -430,6 +430,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         kernel_config.writer_defines.emplace_back("DO_COL_MASK", "1");
         kernel_config.logical_K = logical_K;
     }
+    kernel_config.gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    kernel_config.beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     add_kernel_descriptors(program_descriptor, core_ranges, workers, grid, std::move(kernel_config));
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -801,6 +801,31 @@ CompileTimeArgs CompileTimeArgs::build(const CompileTimeArgsContext& ctx) {
 // Kernel and CB descriptor builders
 //////////////////////////////////////////////////////////////////////////////
 
+namespace {
+
+// build_writer_args() lays out the gamma/beta base addresses at fixed writer arg indices 3 and 4.
+constexpr uint32_t kWriterGammaArgIdx = 3;
+constexpr uint32_t kWriterBetaArgIdx = 4;
+
+// Bind the gamma/beta writer address slots to their Buffer* so the framework patches them on
+// cache hits. A null buffer (absent optional tensor) leaves the baked 0 untouched.
+void bind_writer_gamma_beta(KernelDescriptor& desc, Buffer* gamma_buffer, Buffer* beta_buffer) {
+    if (gamma_buffer == nullptr && beta_buffer == nullptr) {
+        return;
+    }
+    for (const auto& core_args : desc.runtime_args) {
+        const CoreCoord& core = core_args.first;
+        if (gamma_buffer != nullptr) {
+            desc.buffer_bindings.push_back({core, kWriterGammaArgIdx, gamma_buffer});
+        }
+        if (beta_buffer != nullptr) {
+            desc.buffer_bindings.push_back({core, kWriterBetaArgIdx, beta_buffer});
+        }
+    }
+}
+
+}  // namespace
+
 void add_kernel_descriptors(
     ProgramDescriptor& program_descriptor,
     const CoreRanges& core_ranges,
@@ -931,6 +956,7 @@ void add_kernel_descriptors(
     writer_sender_kernel_desc.named_compile_time_args = std::move(writer_sender_named_args);
     writer_sender_kernel_desc.defines = kernel_config.writer_defines;
     writer_sender_kernel_desc.runtime_args = std::move(kernel_config.writer_sender_rt_args);
+    bind_writer_gamma_beta(writer_sender_kernel_desc, kernel_config.gamma_buffer, kernel_config.beta_buffer);
     writer_sender_kernel_desc.config = DataMovementConfigDescriptor{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = kernel_config.writer_noc,
@@ -949,6 +975,7 @@ void add_kernel_descriptors(
         writer_receiver_kernel_desc.named_compile_time_args = std::move(writer_receiver_named_args);
         writer_receiver_kernel_desc.defines = std::move(kernel_config.writer_defines);
         writer_receiver_kernel_desc.runtime_args = std::move(kernel_config.writer_receiver_rt_args);
+        bind_writer_gamma_beta(writer_receiver_kernel_desc, kernel_config.gamma_buffer, kernel_config.beta_buffer);
         writer_receiver_kernel_desc.config = DataMovementConfigDescriptor{
             .processor = DataMovementProcessor::RISCV_1,
             .noc = kernel_config.writer_noc,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -294,6 +294,11 @@ struct KernelConfig {
     KernelDescriptor::RuntimeArgs compute_all_to_all_rt_args;
     KernelDescriptor::RuntimeArgs compute_not_all_to_all_rt_args;
 
+    // Optional gamma/beta writer base-address slots, bound as BufferBindings in
+    // add_kernel_descriptors() (patched on cache hits); null when the tensor is absent.
+    Buffer* gamma_buffer = nullptr;
+    Buffer* beta_buffer = nullptr;
+
     // NOC config
     tt::tt_metal::NOC reader_noc = tt::tt_metal::NOC::NOC_0;
     tt::tt_metal::NOC writer_noc = tt::tt_metal::NOC::NOC_0;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
@@ -100,11 +100,9 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
     log_debug(tt::LogOp, "math_approx_mode: {}", math_approx_mode);
     log_debug(tt::LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
 
-    auto a_addr = a.buffer()->address();
-    auto stats_addr = stats.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto dst_addr = output.buffer()->address();
+    // Optional gamma/beta: bind the Buffer* when present, else nullptr (framework emits 0u).
+    Buffer* gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    Buffer* beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     [[maybe_unused]] uint32_t num_gamma_tiles = gamma.has_value() ? gamma.value().physical_volume() / tile_hw : 0;
     [[maybe_unused]] uint32_t num_beta_tiles = beta.has_value() ? beta.value().physical_volume() / tile_hw : 0;
@@ -286,10 +284,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
 
     uint32_t eps_u = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
     if (use_2d_kernel) {
         for (uint32_t x = 0; x < cores_x; ++x) {
@@ -305,22 +304,21 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
                     core.x,
                     tile_offset,
                     tiles_per_core_y);
-                reader_runtime_args.emplace_back(
+                reader_kernel_desc.emplace_runtime_args(
                     core,
-                    std::vector<uint32_t>{
-                        a_addr,
-                        tiles_per_core_x,
-                        tiles_per_core_y,
-                        tile_offset,
-                        stats_offset,
-                        eps_u,
-                        gamma_dram_addr,
-                        beta_dram_addr,
-                        stats_addr,
-                        y * tiles_per_core_y});
-                compute_runtime_args.emplace_back(core, std::vector<uint32_t>{tiles_per_core_x});
-                writer_runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{dst_addr, tiles_per_core_x * tiles_per_core_y, tile_offset});
+                    {a.buffer(),
+                     tiles_per_core_x,
+                     tiles_per_core_y,
+                     tile_offset,
+                     stats_offset,
+                     eps_u,
+                     gamma_buffer,
+                     beta_buffer,
+                     stats.buffer(),
+                     y * tiles_per_core_y});
+                compute_kernel_desc.emplace_runtime_args(core, {tiles_per_core_x});
+                writer_kernel_desc.emplace_runtime_args(
+                    core, {output.buffer(), tiles_per_core_x * tiles_per_core_y, tile_offset});
             }
         }
     } else {
@@ -341,22 +339,20 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
             uint32_t stats_offset = curr_row * stats_tiles_cols;
             uint32_t y_offset = 0;
 
-            reader_runtime_args.emplace_back(
+            reader_kernel_desc.emplace_runtime_args(
                 core,
-                std::vector<uint32_t>{
-                    a_addr,
-                    num_tile_rows_per_core,
-                    Wt,
-                    tile_offset,
-                    stats_offset,
-                    eps_u,
-                    gamma_dram_addr,
-                    beta_dram_addr,
-                    stats_addr,
-                    y_offset});
-            compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-            writer_runtime_args.emplace_back(
-                core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * Wt, tile_offset});
+                {a.buffer(),
+                 num_tile_rows_per_core,
+                 Wt,
+                 tile_offset,
+                 stats_offset,
+                 eps_u,
+                 gamma_buffer,
+                 beta_buffer,
+                 stats.buffer(),
+                 y_offset});
+            compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+            writer_kernel_desc.emplace_runtime_args(core, {output.buffer(), num_tile_rows_per_core * Wt, tile_offset});
             curr_row += num_tile_rows_per_core;
         }
     }
@@ -367,7 +363,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_post_allgather.cpp";
@@ -375,30 +370,25 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherProgramFactory::create_des
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
@@ -121,11 +121,9 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     log_debug(tt::LogOp, "math_approx_mode: {}", math_approx_mode);
     log_debug(tt::LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
 
-    auto a_addr = a.buffer()->address();
-    auto stats_addr = stats.buffer()->address();
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
-    auto dst_addr = output.buffer()->address();
+    // Optional gamma/beta: bind the Buffer* when present, else nullptr (framework emits 0u).
+    Buffer* gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
+    Buffer* beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
 
     uint32_t cb_length = Wt;
 
@@ -325,10 +323,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
     uint32_t eps = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
     if (use_2d_kernel) {
         for (uint32_t x = 0; x < cores_x; ++x) {
@@ -344,23 +343,22 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
                     core.x,
                     tile_offset,
                     tiles_per_core_y);
-                reader_runtime_args.emplace_back(
+                reader_kernel_desc.emplace_runtime_args(
                     core,
-                    std::vector<uint32_t>{
-                        a_addr,
-                        tiles_per_core_x,
-                        tiles_per_core_y,
-                        tile_offset,
-                        stats_offset,
-                        packed_winv_value,
-                        eps,
-                        gamma_dram_addr,
-                        beta_dram_addr,
-                        stats_addr,
-                        y * tiles_per_core_y});
-                compute_runtime_args.emplace_back(core, std::vector<uint32_t>{tiles_per_core_x});
-                writer_runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{dst_addr, tiles_per_core_x * tiles_per_core_y, tile_offset});
+                    {a.buffer(),
+                     tiles_per_core_x,
+                     tiles_per_core_y,
+                     tile_offset,
+                     stats_offset,
+                     packed_winv_value,
+                     eps,
+                     gamma_buffer,
+                     beta_buffer,
+                     stats.buffer(),
+                     y * tiles_per_core_y});
+                compute_kernel_desc.emplace_runtime_args(core, {tiles_per_core_x});
+                writer_kernel_desc.emplace_runtime_args(
+                    core, {output.buffer(), tiles_per_core_x * tiles_per_core_y, tile_offset});
             }
         }
     } else {
@@ -381,23 +379,21 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
             uint32_t stats_offset = curr_row * stats_tiles_cols;
             uint32_t y_offset = 0;
 
-            reader_runtime_args.emplace_back(
+            reader_kernel_desc.emplace_runtime_args(
                 core,
-                std::vector<uint32_t>{
-                    a_addr,
-                    num_tile_rows_per_core,
-                    Wt,
-                    tile_offset,
-                    stats_offset,
-                    packed_winv_value,
-                    eps,
-                    gamma_dram_addr,
-                    beta_dram_addr,
-                    stats_addr,
-                    y_offset});
-            compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-            writer_runtime_args.emplace_back(
-                core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * Wt, tile_offset});
+                {a.buffer(),
+                 num_tile_rows_per_core,
+                 Wt,
+                 tile_offset,
+                 stats_offset,
+                 packed_winv_value,
+                 eps,
+                 gamma_buffer,
+                 beta_buffer,
+                 stats.buffer(),
+                 y_offset});
+            compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+            writer_kernel_desc.emplace_runtime_args(core, {output.buffer(), num_tile_rows_per_core * Wt, tile_offset});
             curr_row += num_tile_rows_per_core;
         }
     }
@@ -408,7 +404,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_post_allgather.cpp";
@@ -416,19 +411,16 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
@@ -465,13 +457,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPostAllGatherWelfordProgramFactory::cre
 
     // Compute kernel
     // Welford preserves the math fidelity selection and FP32 dst-acc setting from compute_kernel_config.
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -77,10 +77,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
     log_debug(tt::LogOp, "in_data_format: {}", in_data_format);
     log_debug(tt::LogOp, "out_data_format: {}", out_data_format);
 
-    auto a_addr = a.buffer()->address();
-    auto dst_addr = output.buffer()->address();
-    auto b_addr = fuse_pre_add ? b->buffer()->address() : 0;
-
     const uint32_t double_buffer_constant = 2;
     const uint32_t in0_tiles = Wt * double_buffer_constant;
     const uint32_t in1_tiles = 1;  // reduce scalar
@@ -149,13 +145,14 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
                    : "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/"
                      "layernorm_pre_allgather.cpp";
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
-    reader_runtime_args.reserve(num_cores);
-    writer_runtime_args.reserve(num_cores);
-    compute_runtime_args.reserve(num_cores);
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
+    reader_kernel_desc.runtime_args.reserve(num_cores);
+    writer_kernel_desc.runtime_args.reserve(num_cores);
+    compute_kernel_desc.runtime_args.reserve(num_cores);
 
     uint32_t curr_row = 0;
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -173,14 +170,18 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
         uint32_t in_tile_offset = curr_row * Wt;
         uint32_t out_tile_offset = curr_row * out0_tiles;
 
-        std::vector<uint32_t> reader_args = {a_addr, num_tile_rows_per_core, Wt, in_tile_offset};
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(a.buffer());
+        reader_args.push_back(num_tile_rows_per_core);
+        reader_args.push_back(Wt);
+        reader_args.push_back(in_tile_offset);
         if (fuse_pre_add) {
-            reader_args.push_back(b_addr);
+            reader_args.push_back(b->buffer());
         }
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * out0_tiles, out_tile_offset});
+        reader_kernel_desc.emplace_runtime_args(core, reader_args);
+        compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+        writer_kernel_desc.emplace_runtime_args(
+            core, {output.buffer(), num_tile_rows_per_core * out0_tiles, out_tile_offset});
 
         curr_row += num_tile_rows_per_core;
     }
@@ -191,7 +192,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp";
@@ -199,30 +199,25 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherProgramFactory::create_desc
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
@@ -340,10 +335,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
     uint32_t scaler_tile_size = tt::tile_size(scaler_cb_data_format);
 
-    auto a_addr = a.buffer()->address();
-    auto dst_addr = output.buffer()->address();
-    auto b_addr = fuse_pre_add ? b->buffer()->address() : 0;
-
     const uint32_t double_buffer_constant = 2;
     const uint32_t in0_tiles = Wt * double_buffer_constant;
     const uint32_t in1_tiles = 1;  // reduce scalar
@@ -417,10 +408,11 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
 
     std::vector<uint32_t> compute_args = {tiles_per_core_x, tiles_per_core_y, block_size, cores_y};
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
 
     for (uint32_t x = 0; x < cores_x; ++x) {
         for (uint32_t y = 0; y < cores_y; ++y) {
@@ -433,23 +425,23 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
             uint32_t in_tile_offset = (x * Wt) + (y * tiles_per_core_y);
             uint32_t out_tile_offset = x * out0_tiles;
 
-            std::vector<uint32_t> reader_args = {
-                a_addr,
-                tiles_per_core_x,
-                tiles_per_core_y,
-                in_tile_offset,
-                static_cast<uint32_t>(is_merge_core),
-                static_cast<uint32_t>(merge_core.x),
-                static_cast<uint32_t>(merge_core.y),
-                y};
+            KernelDescriptor::RTArgList reader_args;
+            reader_args.push_back(a.buffer());
+            reader_args.push_back(tiles_per_core_x);
+            reader_args.push_back(tiles_per_core_y);
+            reader_args.push_back(in_tile_offset);
+            reader_args.push_back(static_cast<uint32_t>(is_merge_core));
+            reader_args.push_back(static_cast<uint32_t>(merge_core.x));
+            reader_args.push_back(static_cast<uint32_t>(merge_core.y));
+            reader_args.push_back(y);
             if (fuse_pre_add) {
-                reader_args.push_back(b_addr);
+                reader_args.push_back(b->buffer());
             }
-            reader_runtime_args.emplace_back(core, std::move(reader_args));
-            compute_runtime_args.emplace_back(core, std::vector<uint32_t>{static_cast<uint32_t>(is_merge_core)});
+            reader_kernel_desc.emplace_runtime_args(core, reader_args);
+            compute_kernel_desc.emplace_runtime_args(core, {static_cast<uint32_t>(is_merge_core)});
             if (is_merge_core) {
-                writer_runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * out0_tiles, out_tile_offset});
+                writer_kernel_desc.emplace_runtime_args(
+                    core, {output.buffer(), num_tile_rows_per_core * out0_tiles, out_tile_offset});
             }
         }
     }
@@ -464,7 +456,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
         .id = reducer_semaphore_id, .core_type = tt::CoreType::WORKER, .core_ranges = all_cores, .initial_value = 0});
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_layernorm_preallgather_2d.cpp";
@@ -472,24 +463,20 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel (only on merge cores)
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = merge_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     // Compute kernel
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/"
         "layernorm_pre_allgather_2d.cpp";
@@ -497,7 +484,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
@@ -84,10 +84,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     log_debug(tt::LogOp, "in_data_format: {}", in_data_format);
     log_debug(tt::LogOp, "out_data_format: {}", out_data_format);
 
-    auto a_addr = a.buffer()->address();
-    auto dst_addr = output.buffer()->address();
-    auto b_addr = fuse_pre_add ? b->buffer()->address() : 0;
-
     // Sized for double-buffered block-sized chunks: the welford compute kernel waits on
     // block_size tiles at a time, so the reader must be able to fill that many while the
     // compute side processes the previous batch.
@@ -162,13 +158,14 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     const uint32_t reciprocal_CB_size_bytes = recip_tensor.buffer()->aligned_size_per_bank();
     constexpr tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
 
-    // Build runtime args per core
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
-    reader_runtime_args.reserve(num_cores);
-    writer_runtime_args.reserve(num_cores);
-    compute_runtime_args.reserve(num_cores);
+    // Build runtime args per core.  Buffer base addresses are bound via
+    // emplace_runtime_args() so the framework patches them on cache hits.
+    KernelDescriptor reader_kernel_desc;
+    KernelDescriptor writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
+    reader_kernel_desc.runtime_args.reserve(num_cores);
+    writer_kernel_desc.runtime_args.reserve(num_cores);
+    compute_kernel_desc.runtime_args.reserve(num_cores);
 
     uint32_t curr_row = 0;
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -186,14 +183,18 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
         uint32_t in_tile_offset = curr_row * Wt;
         uint32_t out_tile_offset = curr_row * out0_tiles;
 
-        std::vector<uint32_t> reader_args = {a_addr, num_tile_rows_per_core, Wt, in_tile_offset};
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(a.buffer());
+        reader_args.push_back(num_tile_rows_per_core);
+        reader_args.push_back(Wt);
+        reader_args.push_back(in_tile_offset);
         if (fuse_pre_add) {
-            reader_args.push_back(b_addr);
+            reader_args.push_back(b->buffer());
         }
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_addr, num_tile_rows_per_core * out0_tiles, out_tile_offset});
+        reader_kernel_desc.emplace_runtime_args(core, reader_args);
+        compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
+        writer_kernel_desc.emplace_runtime_args(
+            core, {output.buffer(), num_tile_rows_per_core * out0_tiles, out_tile_offset});
 
         curr_row += num_tile_rows_per_core;
     }
@@ -204,7 +205,6 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     ProgramDescriptor program_descriptor;
 
     // Reader kernel
-    KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp";
@@ -212,19 +212,16 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     reader_kernel_desc.core_ranges = all_cores;
     reader_kernel_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_kernel_desc.defines = KernelDescriptor::Defines(reader_defines.begin(), reader_defines.end());
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
     reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
 
     // Writer kernel
-    KernelDescriptor writer_kernel_desc;
     writer_kernel_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
         "writer_unary_interleaved_start_id_blocked.cpp";
     writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_kernel_desc.core_ranges = all_cores;
     writer_kernel_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
     writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
@@ -276,14 +273,12 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
 
     // Compute kernel
     // Welford uses fp32 accumulation; preserve fp32_dest_acc_en from compute config
-    KernelDescriptor compute_kernel_desc;
     compute_kernel_desc.kernel_source = compute_kernel_file;
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = all_cores;
     compute_kernel_desc.compile_time_args = std::move(compute_args);
     compute_kernel_desc.named_compile_time_args = std::move(compute_named_args);
     compute_kernel_desc.defines = KernelDescriptor::Defines(compute_defines.begin(), compute_defines.end());
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
     compute_kernel_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -386,7 +386,7 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryAtt
         });
     }
 
-    uint32_t mask_addr = tensor_args.mask.has_value() ? tensor_args.mask.value().buffer()->address() : 0;
+    Buffer* mask_buffer = tensor_args.mask.has_value() ? tensor_args.mask.value().buffer() : nullptr;
 
     uint32_t curr_row = 0;
     uint32_t scale_value =
@@ -421,59 +421,50 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryAtt
                                ? ((mask_curr_ht * Wt) + mask_offset)
                                : (curr_row / Ht * Wt);  // causal mask start offset + causal mask batch offset
 
-        // NOTE: do not pass Buffer* here. scale_value and mask_addr depend on
-        // operation_attributes (scale + optional mask tensor); BufferBinding's
-        // fast cache-hit path skips create_descriptor() and would leave them stale.
         if (attributes.is_causal_mask) {
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    src0_buffer->address(),
-                    block_size,
-                    scale_value,
-                    num_tile_rows_per_core,
-                    tile_offset,
-                    Wt,
-                    Ht,
-                    mask_addr,
-                    curr_ht,
-                    mask_id,
-                    in0_t,
-                    mask_curr_ht,
-                    mask_offset});
+                {src0_buffer,
+                 block_size,
+                 scale_value,
+                 num_tile_rows_per_core,
+                 tile_offset,
+                 Wt,
+                 Ht,
+                 mask_buffer,
+                 curr_ht,
+                 mask_id,
+                 in0_t,
+                 mask_curr_ht,
+                 mask_offset});
         } else {
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    src0_buffer->address(),
-                    block_size,
-                    scale_value,
-                    num_tile_rows_per_core,
-                    tile_offset,
-                    Wt,
-                    Ht,
-                    mask_addr,
-                    curr_ht,
-                    mask_id,
-                    in0_t});
+                {src0_buffer,
+                 block_size,
+                 scale_value,
+                 num_tile_rows_per_core,
+                 tile_offset,
+                 Wt,
+                 Ht,
+                 mask_buffer,
+                 curr_ht,
+                 mask_id,
+                 in0_t});
         }
 
         softmax_desc.emplace_runtime_args(
             core,
             {num_tile_rows_per_core, Ht, Wt, block_size, curr_ht, static_cast<uint32_t>(mask_padded_data), cb_length});
 
-        // NOTE: do not pass Buffer* here. mask_padded_data and num_datum_padded
-        // depend on attribute state; BufferBinding fast cache-hit path skips
-        // create_descriptor() and would leave them stale.
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                out0_buffer->address(),
-                num_tile_rows_per_core * Wt,
-                tile_offset,
-                block_size,
-                static_cast<uint32_t>(mask_padded_data),
-                num_datum_padded});
+            {out0_buffer,
+             num_tile_rows_per_core * Wt,
+             tile_offset,
+             block_size,
+             static_cast<uint32_t>(mask_padded_data),
+             num_datum_padded});
 
         curr_row += num_tile_rows_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
@@ -351,7 +351,7 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
     }
 
     // Runtime Args
-    uint32_t mask_addr = tensor_args.mask.has_value() ? tensor_args.mask->buffer()->address() : 0;
+    Buffer* mask_buffer = tensor_args.mask.has_value() ? tensor_args.mask->buffer() : nullptr;
     uint32_t scale_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
     uint32_t mask_start_tile_id = 0;
 
@@ -372,15 +372,15 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
                     static_cast<std::size_t>(start_core_y) + core_idx_y};
 
                 // reader args
-                KernelDescriptor::CoreRuntimeArgs reader_args;
+                std::vector<std::variant<uint32_t, Buffer*>> reader_args;
                 reader_args.push_back(scale_u);
-                reader_args.push_back(mask_addr);
+                reader_args.push_back(mask_buffer);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {
                     reader_args.push_back(num_tiles_in_attn_mask);
                 }
 
-                reader_desc.runtime_args.emplace_back(core, std::move(reader_args));
+                reader_desc.emplace_runtime_args(core, reader_args);
 
                 num_cores_per_batch_index++;
 
@@ -413,15 +413,15 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
                     static_cast<std::size_t>(start_core_y) + core_idx_y};
 
                 // reader args
-                KernelDescriptor::CoreRuntimeArgs reader_args;
+                std::vector<std::variant<uint32_t, Buffer*>> reader_args;
                 reader_args.push_back(scale_u);
-                reader_args.push_back(mask_addr);
+                reader_args.push_back(mask_buffer);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {
                     reader_args.push_back(num_tiles_in_attn_mask);
                 }
 
-                reader_desc.runtime_args.emplace_back(core, std::move(reader_args));
+                reader_desc.emplace_runtime_args(core, reader_args);
 
                 num_cores_per_batch_index++;
 


### PR DESCRIPTION
### What
Declare raw `tensor.buffer()->address()` runtime-arg slots in the normalization factories as `Buffer*` bindings via `emplace_runtime_args` — removing the smuggled-pointer anti-pattern so the framework knows these slots hold buffer addresses instead of opaque uint32s.

### Why
A raw address pushed as a plain uint32 is invisible to the descriptor framework, which then cannot recognize or manage the buffer reference (and falls back to rebuilding the descriptor on every cache hit to refresh it). Declaring it as a binding makes the address framework-tracked and patched directly on cache hits. De-smuggling only — no miss-path behavior change.

### Safety
Only the buffer address slot changes; all other runtime args are untouched. Verified the buffer address is the sole dynamic-on-hit value (work distribution is captured by the program hash; no hash-excluded scalars), so the binding is correct and sufficient.

### Test
Build clean; fast-dispatch unit tests green. Nightly for this family + ttsim: to run in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-normalization)