### PR TITLE
[pool] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -403,14 +403,19 @@ ProgramDescriptor GridSampleBilinearProgramFactory::create_descriptor(
             const CoreCoord& core = logical_cores[i];
 
             // Runtime arguments for sharded reader
-            KernelDescriptor::CoreRuntimeArgs reader_runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                i * grid_nsticks_per_core          // rt_arg[1]: grid_stick_offset
-            };
-
-            reader0_desc.runtime_args.emplace_back(core, reader_runtime_args);
+            reader0_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                    i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                });
             if (enable_split_reader) {
-                reader1_desc.runtime_args.emplace_back(core, reader_runtime_args);
+                reader1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                        i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                    });
             }
         }
     } else {
@@ -424,22 +429,23 @@ ProgramDescriptor GridSampleBilinearProgramFactory::create_descriptor(
             const uint32_t output_sticks = batch_output_channels ? grid_sticks : grid_sticks * grid_batching_factor;
 
             // Runtime arguments for interleaved reader - expanded row by row
-            KernelDescriptor::CoreRuntimeArgs reader_runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                grid_tensor.buffer()->address(),   // rt_arg[1]: grid_buffer_address
-                grid_sticks,                       // rt_arg[2]: grid_sticks
-                grid_processed                     // rt_arg[3]: grid_processed
-            };
+            reader0_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                    grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                    grid_sticks,            // rt_arg[2]: grid_sticks
+                    grid_processed          // rt_arg[3]: grid_processed
+                });
 
             // Runtime arguments for interleaved writer - expanded row by row
-            KernelDescriptor::CoreRuntimeArgs writer_runtime_args = {
-                output_tensor.buffer()->address(),  // rt_arg[0]: output_buffer_address
-                output_sticks,                      // rt_arg[1]: output_sticks
-                output_processed                    // rt_arg[2]: output_processed
-            };
-
-            reader0_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
-            writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    output_tensor.buffer(),  // rt_arg[0]: output_buffer_address
+                    output_sticks,           // rt_arg[1]: output_sticks
+                    output_processed         // rt_arg[2]: output_processed
+                });
 
             grid_processed += grid_sticks;
             output_processed += output_sticks;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
@@ -207,14 +207,19 @@ ProgramDescriptor GridSampleNearestProgramFactory::create_descriptor(
             const CoreCoord& core = logical_cores[i];
 
             // Runtime arguments for sharded reader
-            KernelDescriptor::CoreRuntimeArgs runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                i * grid_nsticks_per_core          // rt_arg[1]: grid_stick_offset
-            };
-
-            writer_desc.runtime_args.emplace_back(core, runtime_args);
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                    i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                });
             if (enable_split_reader) {
-                writer1_desc.runtime_args.emplace_back(core, runtime_args);
+                writer1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                        i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                    });
             }
         }
     } else {
@@ -226,18 +231,25 @@ ProgramDescriptor GridSampleNearestProgramFactory::create_descriptor(
                 core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
 
             // Runtime arguments for interleaved reader - expanded row by row
-            KernelDescriptor::CoreRuntimeArgs runtime_args = {
-                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                grid_tensor.buffer()->address(),   // rt_arg[1]: grid_buffer_address
-                grid_sticks,                       // rt_arg[2]: grid_sticks
-                grid_processed                     // rt_arg[3]: grid_processed
-            };
-
-            writer_desc.runtime_args.emplace_back(core, runtime_args);
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                    grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                    grid_sticks,            // rt_arg[2]: grid_sticks
+                    grid_processed          // rt_arg[3]: grid_processed
+                });
             if (enable_split_reader) {
                 // For split reader in nearest mode, second writer needs same runtime args
                 // The kernel logic handles the split internally via reader_id
-                writer1_desc.runtime_args.emplace_back(core, runtime_args);
+                writer1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                        grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                        grid_sticks,            // rt_arg[2]: grid_sticks
+                        grid_processed          // rt_arg[3]: grid_processed
+                    });
             }
 
             grid_processed += grid_sticks;

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_bilinear_program_factory.cpp
@@ -361,10 +361,10 @@ ProgramDescriptor RotateDeviceOperation::BilinearProgramFactory::create_descript
             start_stick_id = sticks_processed;
         }
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input_tensor.buffer()->address(),
+            {
+                input_tensor.buffer(),
                 num_sticks,
                 start_stick_id,
                 static_cast<uint32_t>(cos_angle_q16),
@@ -375,10 +375,10 @@ ProgramDescriptor RotateDeviceOperation::BilinearProgramFactory::create_descript
             });
 
         if (!any_sharded && writer_desc.has_value()) {
-            writer_desc->runtime_args.emplace_back(
+            writer_desc->emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output_tensor.buffer()->address(),
+                {
+                    output_tensor.buffer(),
                     num_sticks,
                     start_stick_id,
                 });

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
@@ -252,10 +252,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                 start_stick_id = i * input_nsticks_per_core;
             }
 
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    input_tensor.buffer()->address(),
+                {
+                    input_tensor.buffer(),
                     input_nsticks_per_core,
                     start_stick_id,
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(cos_angle)),
@@ -265,10 +265,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                     static_cast<uint32_t>(fill_value_bf16),
                 });
 
-            writer_desc.runtime_args.emplace_back(
+            writer_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output_tensor.buffer()->address(),
+                {
+                    output_tensor.buffer(),
                     input_nsticks_per_core,
                     start_stick_id,
                 });
@@ -280,10 +280,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
             const uint32_t num_sticks =
                 core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
 
-            reader_desc.runtime_args.emplace_back(
+            reader_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    input_tensor.buffer()->address(),
+                {
+                    input_tensor.buffer(),
                     num_sticks,
                     sticks_processed,
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(cos_angle)),
@@ -293,10 +293,10 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                     static_cast<uint32_t>(fill_value_bf16),
                 });
 
-            writer_desc.runtime_args.emplace_back(
+            writer_desc.emplace_runtime_args(
                 core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output_tensor.buffer()->address(),
+                {
+                    output_tensor.buffer(),
                     num_sticks,
                     sticks_processed,
                 });

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_nearest_float_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_nearest_float_program_factory.cpp
@@ -133,19 +133,19 @@ ProgramDescriptor UpsampleNearestFloatProgramFactory::create_descriptor(
         const uint32_t num_sticks =
             core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                input.buffer()->address(),  // rt_arg[0]: input_buffer_address
-                num_sticks,                 // rt_arg[1]: num_sticks
-                sticks_processed,           // rt_arg[2]: start_stick_id
+            {
+                input.buffer(),    // rt_arg[0]: input_buffer_address
+                num_sticks,        // rt_arg[1]: num_sticks
+                sticks_processed,  // rt_arg[2]: start_stick_id
             });
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                output_tensor.buffer()->address(),  // rt_arg[0]: output_buffer_address
-                num_sticks,                         // rt_arg[1]: num_sticks
-                sticks_processed,                   // rt_arg[2]: start_stick_id
+            {
+                output_tensor.buffer(),  // rt_arg[0]: output_buffer_address
+                num_sticks,              // rt_arg[1]: num_sticks
+                sticks_processed,        // rt_arg[2]: start_stick_id
             });
 
         sticks_processed += num_sticks;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
@@ -244,17 +244,17 @@ ProgramDescriptor UpsampleMultiCoreInterleavedProgramFactory::create_descriptor(
         const uint32_t reader_units = blocks_per_core * input_cb_required_pages;
         const uint32_t reader_start = blocks_processed * input_cb_required_pages;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src_buffer->address(),
+            {
+                src_buffer,
                 reader_units,
                 reader_start,
             });
-        writer_desc.runtime_args.emplace_back(
+        writer_desc.emplace_runtime_args(
             core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
+            {
+                dst_buffer,
                 blocks_per_core,
                 blocks_processed,
             });


### PR DESCRIPTION
### What
Declare raw `tensor.buffer()->address()` runtime-arg slots in the pool factories as `Buffer*` bindings via `emplace_runtime_args` — removing the smuggled-pointer anti-pattern so the framework knows these slots hold buffer addresses instead of opaque uint32s.

### Why
A raw address pushed as a plain uint32 is invisible to the descriptor framework, which then cannot recognize or manage the buffer reference (and falls back to rebuilding the descriptor on every cache hit to refresh it). Declaring it as a binding makes the address framework-tracked and patched directly on cache hits. De-smuggling only — no miss-path behavior change.

### Safety
Only the buffer address slot changes; all other runtime args are untouched. Verified the buffer address is the sole dynamic-on-hit value (work distribution is captured by the program hash; no hash-excluded scalars), so the binding is correct and sufficient.

### Test
Build clean; fast-dispatch unit tests green. Nightly for this family + ttsim: to run in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-pool)