### PR TITLE
[#47820] DRAM prefetcher + repeat batches on Blackhole (Llama-3.1-8B)

### DIFF
--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -100,7 +100,12 @@ class DistributedNorm(LightweightModule):
                 if self.ag_config_key and mode == "decode"
                 else 2,
                 num_buffers_per_channel=2,
-                subdevice_id=self.prefetcher.worker_sub_device_id if self.prefetcher is not None else None,
+                # The prefetcher's worker sub-device (id 1) only exists on the prefetcher's
+                # decode manager. Prefill runs on the default manager (#47820), so only pin
+                # the all-gather to the worker sub-device in decode.
+                subdevice_id=self.prefetcher.worker_sub_device_id
+                if (self.prefetcher is not None and mode == Mode.DECODE)
+                else None,
             )
         else:
             x = ttnn.to_memory_config(x, input_mem_cfg)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -541,6 +541,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         **kwargs,
     ):
         self.mode = Mode.PREFILL
+        # Prefill runs on the device's default sub-device manager, where its trace is
+        # captured. If a prior decode switched the device to a prefetcher's decode
+        # manager, revert now so the cached prefill trace replays on the same manager
+        # across interleaved repeat batches (#47820). No-op when no prefetcher is active.
+        for i in range(len(self.model)):
+            self.model[i].switch_mode(Mode.PREFILL)
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         else:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -541,6 +541,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         **kwargs,
     ):
         self.mode = Mode.PREFILL
+        # If a prefetcher is active, its global_cb is torn down for prefill and rebuilt
+        # (at a possibly different L1 address) on the next decode. The cached decode trace
+        # baked the old global_cb address, so it must be released and re-captured — else
+        # replay reads freed L1 and hangs the device. Release it *before* reverting the
+        # sub-device manager below, while the prefetcher's (decode) manager — where the
+        # decode trace lives — is still the active one (#47820).
+        if any(getattr(m, "prefetcher", None) is not None and m.prefetcher.is_initialized for m in self.model):
+            self._invalidate_decode_traces()
         # Prefill runs on the device's default sub-device manager, where its trace is
         # captured. If a prior decode switched the device to a prefetcher's decode
         # manager, revert now so the cached prefill trace replays on the same manager
@@ -1497,6 +1505,28 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs
+
+    def _invalidate_decode_traces(self):
+        """
+        Release and clear cached decode traces so they are re-captured on the next decode.
+
+        Needed when a prefetcher tears down + rebuilds its global_cb across a prefill/decode
+        switch: the decode trace bakes the global_cb's L1 address at capture time, and a
+        rebuilt CB may land at a different address, so replaying the stale trace would read
+        freed L1 and hang the device. Must be called while the prefetcher's (decode)
+        sub-device manager is still active, since traces are stored per manager (#47820).
+        """
+        for trace_ids in self.trace_ids_decode.values():
+            if not trace_ids:
+                continue
+            for i, trace_id in trace_ids.items():
+                try:
+                    ttnn.release_trace(self.model_args[i].mesh_device, trace_id)
+                except Exception as e:
+                    logger.warning(f"Failed to release decode trace {trace_id} for model {i}: {e}")
+        self.trace_ids_decode = defaultdict(lambda: None)
+        self.trace_inputs_decode = defaultdict(lambda: None)
+        self.trace_output_decode = defaultdict(lambda: None)
 
     def _decode_forward_trace_text(
         self,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -541,18 +541,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         **kwargs,
     ):
         self.mode = Mode.PREFILL
-        # If a prefetcher is active, its global_cb is torn down for prefill and rebuilt
-        # (at a possibly different L1 address) on the next decode. The cached decode trace
-        # baked the old global_cb address, so it must be released and re-captured — else
-        # replay reads freed L1 and hangs the device. Release it *before* reverting the
-        # sub-device manager below, while the prefetcher's (decode) manager — where the
-        # decode trace lives — is still the active one (#47820).
-        if any(getattr(m, "prefetcher", None) is not None and m.prefetcher.is_initialized for m in self.model):
-            self._invalidate_decode_traces()
         # Prefill runs on the device's default sub-device manager, where its trace is
-        # captured. If a prior decode switched the device to a prefetcher's decode
-        # manager, revert now so the cached prefill trace replays on the same manager
-        # across interleaved repeat batches (#47820). No-op when no prefetcher is active.
+        # captured. If a prior decode switched the device to a prefetcher's decode manager,
+        # revert now so the cached prefill trace replays on the same manager across
+        # interleaved repeat batches, and free the prefetcher's global CB for prefill. The
+        # decode trace is intentionally KEPT and reused (the prefetcher's manager is kept);
+        # the next decode re-allocates the global CB at the same address and replays it.
+        # No-op when no prefetcher is active (#47820).
         for i in range(len(self.model)):
             self.model[i].switch_mode(Mode.PREFILL)
         if page_table is not None:
@@ -1505,28 +1500,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs
-
-    def _invalidate_decode_traces(self):
-        """
-        Release and clear cached decode traces so they are re-captured on the next decode.
-
-        Needed when a prefetcher tears down + rebuilds its global_cb across a prefill/decode
-        switch: the decode trace bakes the global_cb's L1 address at capture time, and a
-        rebuilt CB may land at a different address, so replaying the stale trace would read
-        freed L1 and hang the device. Must be called while the prefetcher's (decode)
-        sub-device manager is still active, since traces are stored per manager (#47820).
-        """
-        for trace_ids in self.trace_ids_decode.values():
-            if not trace_ids:
-                continue
-            for i, trace_id in trace_ids.items():
-                try:
-                    ttnn.release_trace(self.model_args[i].mesh_device, trace_id)
-                except Exception as e:
-                    logger.warning(f"Failed to release decode trace {trace_id} for model {i}: {e}")
-        self.trace_ids_decode = defaultdict(lambda: None)
-        self.trace_inputs_decode = defaultdict(lambda: None)
-        self.trace_output_decode = defaultdict(lambda: None)
 
     def _decode_forward_trace_text(
         self,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -857,6 +857,13 @@ class Transformer(LightweightModule):
             # manager (where the prefill trace is captured), reverting the prefetcher's
             # decode manager if it is currently active. Keeps prefill trace capture and
             # replay on one manager across interleaved repeat batches.
+            #
+            # Also free the persistent global CB L1: on repeat batches the decode global
+            # CB stays resident and clashes with the prefill sharded RMSNorm CBs on core
+            # (0,0). Freeing it here lets prefill use those cores; it is rebuilt on the
+            # next decode run(). Order: tear down the CB while the prefetcher's manager is
+            # still active, then revert to the default manager for prefill.
+            self.prefetcher.teardown_global_cb()
             self.prefetcher.revert_to_default_sub_device_manager()
 
     def forward(

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -849,20 +849,21 @@ class Transformer(LightweightModule):
             return
         if mode == Mode.DECODE:
             # Create (first time) or re-activate the prefetcher's decode sub-device
-            # manager, then ensure weights are queued for prefetch.
+            # manager, ensure weights are queued, and re-allocate the global CB (freed
+            # for the preceding prefill) at its original L1 address so the cached decode
+            # trace can be replayed without re-capture (#47820).
             self.prefetcher.init(mode)
             self.prefetcher.prefetch()
+            self.prefetcher.ensure_global_cb_allocated()
         elif mode == Mode.PREFILL:
             # #47820: run prefill on the mesh device's default sub-device manager (where
-            # the prefill trace is captured), and fully tear down the prefetcher's
-            # decode-time state so the NEXT decode re-inits from scratch. This frees the
-            # persistent global CB L1 (which otherwise clashes with the prefill sharded
-            # RMSNorm on core (0,0)) and, crucially, removes the prefetcher's sub-device
-            # manager + resets init/prefetch state so the next decode re-captures its
-            # trace cleanly — re-capturing against a reused manager + rebuilt CB hangs
-            # trace capture on repeat batches. The generator releases the (per-manager)
-            # decode traces just before this call, while this manager is still active.
-            self.prefetcher.reset_for_reinit()
+            # the prefill trace is captured). Free the persistent global CB L1 — it
+            # otherwise clashes with the prefill sharded RMSNorm on core (0,0) — but KEEP
+            # the prefetcher's sub-device manager and the cached decode trace. The next
+            # decode re-allocates the global CB at the same address and replays the trace
+            # (no re-capture; re-capturing the async prefetcher op hangs on repeat batches).
+            self.prefetcher.teardown_global_cb()
+            self.prefetcher.revert_to_default_sub_device_manager()
 
     def forward(
         self,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -853,18 +853,16 @@ class Transformer(LightweightModule):
             self.prefetcher.init(mode)
             self.prefetcher.prefetch()
         elif mode == Mode.PREFILL:
-            # Option (a) for #47820: run prefill on the mesh device's default sub-device
-            # manager (where the prefill trace is captured), reverting the prefetcher's
-            # decode manager if it is currently active. Keeps prefill trace capture and
-            # replay on one manager across interleaved repeat batches.
-            #
-            # Also free the persistent global CB L1: on repeat batches the decode global
-            # CB stays resident and clashes with the prefill sharded RMSNorm CBs on core
-            # (0,0). Freeing it here lets prefill use those cores; it is rebuilt on the
-            # next decode run(). Order: tear down the CB while the prefetcher's manager is
-            # still active, then revert to the default manager for prefill.
-            self.prefetcher.teardown_global_cb()
-            self.prefetcher.revert_to_default_sub_device_manager()
+            # #47820: run prefill on the mesh device's default sub-device manager (where
+            # the prefill trace is captured), and fully tear down the prefetcher's
+            # decode-time state so the NEXT decode re-inits from scratch. This frees the
+            # persistent global CB L1 (which otherwise clashes with the prefill sharded
+            # RMSNorm on core (0,0)) and, crucially, removes the prefetcher's sub-device
+            # manager + resets init/prefetch state so the next decode re-captures its
+            # trace cleanly — re-capturing against a reused manager + rebuilt CB hangs
+            # trace capture on repeat batches. The generator releases the (per-manager)
+            # decode traces just before this call, while this manager is still active.
+            self.prefetcher.reset_for_reinit()
 
     def forward(
         self,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -845,9 +845,19 @@ class Transformer(LightweightModule):
         return tt_logits, None
 
     def switch_mode(self, mode: Mode):
-        if self.prefetcher is not None:
+        if self.prefetcher is None:
+            return
+        if mode == Mode.DECODE:
+            # Create (first time) or re-activate the prefetcher's decode sub-device
+            # manager, then ensure weights are queued for prefetch.
             self.prefetcher.init(mode)
             self.prefetcher.prefetch()
+        elif mode == Mode.PREFILL:
+            # Option (a) for #47820: run prefill on the mesh device's default sub-device
+            # manager (where the prefill trace is captured), reverting the prefetcher's
+            # decode manager if it is currently active. Keeps prefill trace capture and
+            # replay on one manager across interleaved repeat batches.
+            self.prefetcher.revert_to_default_sub_device_manager()
 
     def forward(
         self,

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -461,16 +461,11 @@ class Prefetcher(LightweightModule):
         occupies — notably core (0,0), where the origin-anchored sharded RMSNorm's CBs
         otherwise clash with the resident global CB (program.cpp L1 clash, #47820).
 
-        Rebuilt lazily on the next decode run() (global_cb + address tensor are None ->
-        re-created and the dram_prefetcher op re-run). The prefetched weight tensors are
-        DRAM-resident and kept (their addresses are stable), so the rebuild re-prefetches
-        weights into a fresh global CB — a perf cost accepted to make repeat batches
-        correct. No-op if the global CB was never created.
-
-        We reset the full runtime allocation set (global CB, its op output, and the L1
-        address tensor) so the next decode's rebuild is identical to the very first build
-        — a partial reset left device/trace state that hung the following decode's trace
-        capture (#47820).
+        Only the global CB is freed; the prefetcher's sub-device manager, the L1 address
+        tensor, and the cached decode trace are all kept. The next decode re-allocates the
+        global CB at the same L1 address (ensure_global_cb_allocated) and replays the
+        cached trace — we do NOT re-capture, because re-capturing the async dram_prefetcher
+        op hangs trace capture on repeat batches (#47820). No-op if the CB was never made.
         """
         if self.global_cb is None:
             return
@@ -485,53 +480,42 @@ class Prefetcher(LightweightModule):
         # while the device still references it, corrupting NOC state and hanging the next
         # op (observed as a device timeout in the following prefill) (#47820).
         ttnn.synchronize_device(self.mesh_device)
+        self._prev_global_cb_address = self.global_cb.buffer_address()
         self.global_cb.deallocate()
         self.global_cb = None
-        # Also drop the L1 address tensor so run() recreates it, making the next decode's
-        # rebuild path identical to the first-time build (which captures cleanly). Kept in
-        # DRAM/L1, so free it explicitly. prefetched_tensor_addr (host list) persists, so
-        # create_address_tensor() can rebuild it.
-        if getattr(self, "prefetched_tt_addr_tensor", None) is not None:
-            ttnn.deallocate(self.prefetched_tt_addr_tensor)
-            self.prefetched_tt_addr_tensor = None
+        # NOTE: the L1 address tensor is intentionally KEPT allocated (small, on the sender
+        # cores) so its address stays stable across the prefill — the decode trace bakes it
+        # too, so freeing + reallocating it would add a second same-address dependency.
 
-    def reset_for_reinit(self) -> None:
+    def ensure_global_cb_allocated(self) -> None:
         """
-        Fully tear down decode-time prefetcher state on a prefill switch so the NEXT decode
-        re-initializes from scratch: fresh sub-device manager, re-inserted prefetch queue,
-        re-created global CB, and a re-captured decode trace.
+        Re-allocate the global CB (freed for the preceding prefill by teardown_global_cb)
+        so the cached decode trace — which baked the CB's L1 address at capture — can be
+        replayed without re-capture. Called on the decode switch, after the prefetcher's
+        sub-device manager is reloaded, so allocation happens in the same manager context
+        as the original capture. The replayed trace's dram_prefetcher op fills the CB.
 
-        Re-capturing a decode trace against half-stale prefetcher state (reused manager +
-        rebuilt CB) hangs trace capture on repeat batches — the workers park at Go-Wait
-        while host-side capture never completes. A clean reinit makes batch N's decode
-        setup identical to batch 0's first-time setup, which captures cleanly (#47820).
-
-        The caller must release any decode traces (which live on this manager) BEFORE
-        calling this; here we free the global CB / op / address tensor, revert to the
-        default manager, remove the prefetcher's manager, and reset all decode init state
-        (init flags, worker sub-device, prefetch queue) so init()/prefetch()/run() rebuild
-        everything on the next decode.
+        The rebuilt CB must land at the SAME L1 address as at capture; we log it (and the
+        previous address) so a mismatch is visible. No-op on the first decode (the CB is
+        created by run() during the compile pass) and when no CB was ever freed (#47820).
         """
-        if not self.init_decode_done:
-            # Nothing to tear down yet (first prefill, before any decode init).
-            self.mode = Mode.PREFILL
+        if not self.init_decode_done or self.global_cb is not None:
             return
-        # 1. Free the global CB, its op output, and the L1 address tensor (drains device).
-        self.teardown_global_cb()
-        # 2. Revert to the default (full-grid) manager for prefill.
-        self.revert_to_default_sub_device_manager()
-        # 3. Remove the prefetcher's (now inactive) sub-device manager and reset decode
-        #    init state so the next switch_mode(DECODE) rebuilds from scratch and
-        #    prefetch() re-inserts the weight queue.
-        if self.prefetcher_sub_device is not None:
-            self.mesh_device.remove_sub_device_manager(self.prefetcher_sub_device.manager_id)
-            self.prefetcher_sub_device = None
-        self.init_decode_done = False
-        self.init_prefill_done = False
-        self.prefetch_done = False
-        self.worker_sub_device_id = None
-        self.prefetched_tensors = []
-        self.prefetched_tensor_addr = []
+        self.global_cb_size = self.max_tensor_block_size
+        self.global_cb = ttnn.create_global_circular_buffer(
+            self.mesh_device,
+            self.sender_receiver_mapping,
+            self.global_cb_size,
+        )
+        new_addr = self.global_cb.buffer_address()
+        prev_addr = getattr(self, "_prev_global_cb_address", None)
+        if prev_addr is not None and new_addr != prev_addr:
+            logger.warning(
+                f"[DRAM Prefetcher] global CB re-allocated at {new_addr} but decode trace baked {prev_addr} "
+                f"— address mismatch will corrupt trace replay (#47820)"
+            )
+        else:
+            logger.info(f"[DRAM Prefetcher] Re-allocated global CB at {new_addr} (matches capture)")
 
     def create_address_tensor(self):
         """

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -495,6 +495,44 @@ class Prefetcher(LightweightModule):
             ttnn.deallocate(self.prefetched_tt_addr_tensor)
             self.prefetched_tt_addr_tensor = None
 
+    def reset_for_reinit(self) -> None:
+        """
+        Fully tear down decode-time prefetcher state on a prefill switch so the NEXT decode
+        re-initializes from scratch: fresh sub-device manager, re-inserted prefetch queue,
+        re-created global CB, and a re-captured decode trace.
+
+        Re-capturing a decode trace against half-stale prefetcher state (reused manager +
+        rebuilt CB) hangs trace capture on repeat batches — the workers park at Go-Wait
+        while host-side capture never completes. A clean reinit makes batch N's decode
+        setup identical to batch 0's first-time setup, which captures cleanly (#47820).
+
+        The caller must release any decode traces (which live on this manager) BEFORE
+        calling this; here we free the global CB / op / address tensor, revert to the
+        default manager, remove the prefetcher's manager, and reset all decode init state
+        (init flags, worker sub-device, prefetch queue) so init()/prefetch()/run() rebuild
+        everything on the next decode.
+        """
+        if not self.init_decode_done:
+            # Nothing to tear down yet (first prefill, before any decode init).
+            self.mode = Mode.PREFILL
+            return
+        # 1. Free the global CB, its op output, and the L1 address tensor (drains device).
+        self.teardown_global_cb()
+        # 2. Revert to the default (full-grid) manager for prefill.
+        self.revert_to_default_sub_device_manager()
+        # 3. Remove the prefetcher's (now inactive) sub-device manager and reset decode
+        #    init state so the next switch_mode(DECODE) rebuilds from scratch and
+        #    prefetch() re-inserts the weight queue.
+        if self.prefetcher_sub_device is not None:
+            self.mesh_device.remove_sub_device_manager(self.prefetcher_sub_device.manager_id)
+            self.prefetcher_sub_device = None
+        self.init_decode_done = False
+        self.init_prefill_done = False
+        self.prefetch_done = False
+        self.worker_sub_device_id = None
+        self.prefetched_tensors = []
+        self.prefetched_tensor_addr = []
+
     def create_address_tensor(self):
         """
         Creates a ttnn tensor which holds the addresses of the tensors to be prefetched

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -475,6 +475,11 @@ class Prefetcher(LightweightModule):
         if garbage is not None:
             ttnn.deallocate(garbage)
             self.garbage = None
+        # Drain all in-flight device work (the async dram_prefetcher op and any decode
+        # ops) before freeing the global CB's L1. Without this the buffer can be freed
+        # while the device still references it, corrupting NOC state and hanging the next
+        # op (observed as a device timeout in the following prefill) (#47820).
+        ttnn.synchronize_device(self.mesh_device)
         self.global_cb.deallocate()
         self.global_cb = None
 

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -461,11 +461,16 @@ class Prefetcher(LightweightModule):
         occupies — notably core (0,0), where the origin-anchored sharded RMSNorm's CBs
         otherwise clash with the resident global CB (program.cpp L1 clash, #47820).
 
-        Rebuilt lazily on the next decode run() (global_cb is None -> re-created and the
-        dram_prefetcher op re-run). The prefetched weight tensors and the address tensor
-        are DRAM/L1-resident and kept, so only the global CB is freed and rebuilt (this
-        does mean weights are re-prefetched on the next decode — a perf cost accepted to
-        make repeat batches correct). No-op if the global CB was never created.
+        Rebuilt lazily on the next decode run() (global_cb + address tensor are None ->
+        re-created and the dram_prefetcher op re-run). The prefetched weight tensors are
+        DRAM-resident and kept (their addresses are stable), so the rebuild re-prefetches
+        weights into a fresh global CB — a perf cost accepted to make repeat batches
+        correct. No-op if the global CB was never created.
+
+        We reset the full runtime allocation set (global CB, its op output, and the L1
+        address tensor) so the next decode's rebuild is identical to the very first build
+        — a partial reset left device/trace state that hung the following decode's trace
+        capture (#47820).
         """
         if self.global_cb is None:
             return
@@ -482,6 +487,13 @@ class Prefetcher(LightweightModule):
         ttnn.synchronize_device(self.mesh_device)
         self.global_cb.deallocate()
         self.global_cb = None
+        # Also drop the L1 address tensor so run() recreates it, making the next decode's
+        # rebuild path identical to the first-time build (which captures cleanly). Kept in
+        # DRAM/L1, so free it explicitly. prefetched_tensor_addr (host list) persists, so
+        # create_address_tensor() can rebuild it.
+        if getattr(self, "prefetched_tt_addr_tensor", None) is not None:
+            ttnn.deallocate(self.prefetched_tt_addr_tensor)
+            self.prefetched_tt_addr_tensor = None
 
     def create_address_tensor(self):
         """

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -224,6 +224,13 @@ class PrefetcherSubDevice:
         self.mesh_device.load_sub_device_manager(self.manager_id)
         self.mesh_device.set_sub_device_stall_group(self.sub_devices_id)
 
+    def load(self):
+        # Re-activate this (already-created) sub-device manager and its stall group.
+        # Used to restore the prefetcher's decode manager after an interleaved prefill
+        # reverted the mesh device to its default sub-device manager (see #47820).
+        self.mesh_device.load_sub_device_manager(self.manager_id)
+        self.mesh_device.set_sub_device_stall_group(self.sub_devices_id)
+
 
 class Prefetcher(LightweightModule):
     def __init__(
@@ -330,6 +337,11 @@ class Prefetcher(LightweightModule):
         self.init_decode_done = False
         self.init_prefill_done = False
         self.prefetch_done = False
+        # Tracks whether the prefetcher's (decode) sub-device manager is the one
+        # currently loaded on the mesh device. Interleaved prefill reverts to the
+        # default manager (where prefill traces are captured); decode restores this
+        # one. See revert_to_default_sub_device_manager() / load() below (#47820).
+        self._decode_manager_loaded = False
 
     # NOTE: DRAM prefetched weights are prefetched in the order of the construction of the module
     def register_callback(self, callback: Callable[[], None]):
@@ -362,8 +374,13 @@ class Prefetcher(LightweightModule):
         NOTE: All DRAM prefetcher APIs can only be called after init() is called for the given mode
         NOTE: Calling init() again for the same mode is a no-op
         """
-        # If the prefetcher has already been initialized for the given mode, we do not need to initialize it again
-        if mode == Mode.DECODE and self.init_decode_done or mode == Mode.PREFILL and self.init_prefill_done:
+        # If the prefetcher has already been initialized for the given mode, we do not
+        # re-create its sub-device manager. For decode we still (re)load it, since an
+        # interleaved prefill may have reverted the device to the default manager (#47820).
+        if mode == Mode.DECODE and self.init_decode_done:
+            self.load()
+            return
+        if mode == Mode.PREFILL and self.init_prefill_done:
             return
         self.mode = mode
         self.sender_cores = self.core_config.sender_cores
@@ -380,6 +397,8 @@ class Prefetcher(LightweightModule):
                 self.prefetcher_sub_device.add_sub_device(self.to_core_range_set(self.sender_cores(active=True)))
                 self.prefetcher_sub_device.add_sub_device(self.all_worker_cores_range_set)
                 self.prefetcher_sub_device.init_sub_device_manager()
+                # init_sub_device_manager() also loads the manager.
+                self._decode_manager_loaded = True
             case Mode.PREFILL:
                 self.prefetcher_sub_device = PrefetcherSubDevice(self.mesh_device)
                 self.prefetcher_sub_device.add_sub_device(self.all_core_range_set)
@@ -400,6 +419,34 @@ class Prefetcher(LightweightModule):
         logger.info("=" * 50)
         self.init_decode_done = True if mode == Mode.DECODE else False
         self.init_prefill_done = True if mode == Mode.PREFILL else False
+
+    @property
+    def is_initialized(self) -> bool:
+        """True once the prefetcher's decode sub-device manager has been created."""
+        return self.init_decode_done
+
+    def load(self) -> None:
+        """
+        Re-activate the prefetcher's decode sub-device manager if it is not currently
+        the loaded manager. Idempotent — safe to call on every decode step; only acts
+        after an interleaved prefill reverted the device to the default manager (#47820).
+        """
+        if self.init_decode_done and not self._decode_manager_loaded:
+            self.prefetcher_sub_device.load()
+            self._decode_manager_loaded = True
+
+    def revert_to_default_sub_device_manager(self) -> None:
+        """
+        Restore the mesh device's default (full-grid) sub-device manager so that prefill
+        runs — and prefill traces are captured/replayed — on the same manager across
+        repeat batches. No-op until the prefetcher's manager has actually been loaded.
+        Note: this does NOT free the prefetcher's global_cb L1 (it persists across the
+        revert); the decode manager is restored by load() on the next decode (#47820).
+        """
+        if self.init_decode_done and self._decode_manager_loaded:
+            self.mesh_device.clear_loaded_sub_device_manager()
+            self.mesh_device.reset_sub_device_stall_group()
+            self._decode_manager_loaded = False
 
     def create_address_tensor(self):
         """

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -431,6 +431,9 @@ class Prefetcher(LightweightModule):
         the loaded manager. Idempotent — safe to call on every decode step; only acts
         after an interleaved prefill reverted the device to the default manager (#47820).
         """
+        # Restore decode as the prefetcher's current mode so mode-gated consumers
+        # (e.g. lm_head's use_prefetcher, prefetch()) behave correctly again (#47820).
+        self.mode = Mode.DECODE
         if self.init_decode_done and not self._decode_manager_loaded:
             self.prefetcher_sub_device.load()
             self._decode_manager_loaded = True
@@ -443,6 +446,10 @@ class Prefetcher(LightweightModule):
         Note: this does NOT free the prefetcher's global_cb L1 (it persists across the
         revert); the decode manager is restored by load() on the next decode (#47820).
         """
+        # Mark the prefetcher as being in prefill so mode-gated consumers (e.g. lm_head's
+        # use_prefetcher, which pins the worker sub-device that only exists on the decode
+        # manager) do not reference decode-only state during prefill (#47820).
+        self.mode = Mode.PREFILL
         if self.init_decode_done and self._decode_manager_loaded:
             self.mesh_device.clear_loaded_sub_device_manager()
             self.mesh_device.reset_sub_device_stall_group()

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -448,6 +448,29 @@ class Prefetcher(LightweightModule):
             self.mesh_device.reset_sub_device_stall_group()
             self._decode_manager_loaded = False
 
+    def teardown_global_cb(self) -> None:
+        """
+        Free the persistent global CB L1 so an interleaved prefill can use the cores it
+        occupies — notably core (0,0), where the origin-anchored sharded RMSNorm's CBs
+        otherwise clash with the resident global CB (program.cpp L1 clash, #47820).
+
+        Rebuilt lazily on the next decode run() (global_cb is None -> re-created and the
+        dram_prefetcher op re-run). The prefetched weight tensors and the address tensor
+        are DRAM/L1-resident and kept, so only the global CB is freed and rebuilt (this
+        does mean weights are re-prefetched on the next decode — a perf cost accepted to
+        make repeat batches correct). No-op if the global CB was never created.
+        """
+        if self.global_cb is None:
+            return
+        # decode normally stop()s the prefetcher op before switching to prefill; be
+        # defensive in case a live op output is still around.
+        garbage = getattr(self, "garbage", None)
+        if garbage is not None:
+            ttnn.deallocate(garbage)
+            self.garbage = None
+        self.global_cb.deallocate()
+        self.global_cb = None
+
     def create_address_tensor(self):
         """
         Creates a ttnn tensor which holds the addresses of the tensors to be prefetched

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -56,6 +56,12 @@ public:
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping() const;
     IDevice* get_device() const { return this->device_; }
 
+    // Free the L1 backing this GCB (data + config buffers). Copies of this GCB share the
+    // same underlying buffers, so callers must not use any copy after deallocate() until
+    // the GCB is rebuilt. Added for the DRAM-prefetcher prefill/decode teardown (#47820).
+    void deallocate();
+    bool is_allocated() const;
+
     static constexpr auto attribute_names =
         std::forward_as_tuple("sender_receiver_core_mapping", "size", "buffer_type");
     auto attribute_values() const {

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -394,6 +394,29 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
 }
 
+void GlobalCircularBuffer::deallocate() {
+    // Free the L1 backing this GCB (data + config buffers). Used so the DRAM prefetcher
+    // can release its persistent global CB across a prefill/decode switch and rebuild it
+    // later; the buffers are re-created by a subsequent create_global_circular_buffer.
+    // Copies of this GCB share the same underlying buffers, so callers must not use any
+    // copy after deallocate() until the GCB is rebuilt (see #47820).
+    if (auto mesh_buffer = cb_buffer_.get_mesh_buffer()) {
+        if (mesh_buffer->is_allocated()) {
+            mesh_buffer->deallocate();
+        }
+    }
+    if (auto mesh_buffer = cb_config_buffer_.get_mesh_buffer()) {
+        if (mesh_buffer->is_allocated()) {
+            mesh_buffer->deallocate();
+        }
+    }
+}
+
+bool GlobalCircularBuffer::is_allocated() const {
+    auto mesh_buffer = cb_buffer_.get_mesh_buffer();
+    return mesh_buffer != nullptr && mesh_buffer->is_allocated();
+}
+
 const Buffer& GlobalCircularBuffer::cb_buffer() const { return *cb_buffer_.get_buffer(); }
 
 const CoreRangeSet& GlobalCircularBuffer::sender_cores() const { return sender_cores_; }

--- a/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
+++ b/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
@@ -21,6 +21,7 @@ void py_module_types(nb::module_& mod) {
         .def("size", &GlobalCircularBuffer::size)
         .def("deallocate", &GlobalCircularBuffer::deallocate)
         .def("is_allocated", &GlobalCircularBuffer::is_allocated)
+        .def("buffer_address", &GlobalCircularBuffer::buffer_address)
         .def("sender_cores", &GlobalCircularBuffer::sender_cores, nb::rv_policy::reference_internal)
         .def("receiver_cores", &GlobalCircularBuffer::receiver_cores, nb::rv_policy::reference_internal)
         .def("sender_core_type", [](const GlobalCircularBuffer& gcb) {

--- a/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
+++ b/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
@@ -19,6 +19,8 @@ namespace ttnn::global_circular_buffer {
 void py_module_types(nb::module_& mod) {
     nb::class_<GlobalCircularBuffer>(mod, "global_circular_buffer")
         .def("size", &GlobalCircularBuffer::size)
+        .def("deallocate", &GlobalCircularBuffer::deallocate)
+        .def("is_allocated", &GlobalCircularBuffer::is_allocated)
         .def("sender_cores", &GlobalCircularBuffer::sender_cores, nb::rv_policy::reference_internal)
         .def("receiver_cores", &GlobalCircularBuffer::receiver_cores, nb::rv_policy::reference_internal)
         .def("sender_core_type", [](const GlobalCircularBuffer& gcb) {


### PR DESCRIPTION
## #47820 — DRAM prefetcher + repeat batches on Blackhole (Llama-3.1-8B, `bh_quietbox_2`)

Single PR for the whole fix (previously split as #49124 + #49139, now condensed here). Lets the `ci-eval-32 --use_prefetcher` demo run interleaved prefill/decode across repeat batches (`repeat_batches=3`) on Blackhole instead of dying on the first cross-mode boundary.

### Background / root cause
The scheduled `Llama 3.1-8B e2e tests [bh_quietbox_2]` job has failed every run since **2026-06-03** — the first run after #45300 migrated BH models into the Tier-2 pipeline and moved `--use_prefetcher` from the old `ci-32` (`repeat_batches=1`) onto **`ci-eval-32` (`repeat_batches=3`)**. The demo loops prefill→decode per batch (`simple_text_demo.py:1145`). With >1 batch, batch 0's decode switches the device to the prefetcher's sub-device manager, and batch 1's prefill trace replays under the wrong manager → the original `trace_buffer != nullptr` fatal. Behind that sat a stack of latent cross-mode bugs (this demo has never passed on BH). Full CI history + root cause in the issue thread.

### The fix (each layer HW-validated on `bh_quietbox_2`, peeling one fatal at a time)

**Sub-device coordination — prefill on the default manager (option a)**
- `prefetcher`: `PrefetcherSubDevice.load()` (reload without re-create); `Prefetcher.load()` / `revert_to_default_sub_device_manager()` / `is_initialized`, tracked via an idempotent `_decode_manager_loaded` flag; `init(DECODE)` reloads the manager on the already-initialized path instead of no-op; `mode` kept accurate across the switch.
- `model.switch_mode`: symmetric — `DECODE` (re)loads the prefetcher manager; `PREFILL` reverts to the default manager.
- `generator.prefill_forward_text`: `switch_mode(Mode.PREFILL)` before trace capture/replay.
- `distributed_norm`: pin the all-gather to the prefetcher worker sub-device only in `DECODE`.
- Cleared: `trace_buffer != nullptr`, `SubDevice index out of bounds` (norm), `num_intersections == num_cores`.

**`global_cb` teardown/rebuild + decode-trace lifecycle**
- `tt_metal` `GlobalCircularBuffer::deallocate()` + `is_allocated()` (frees the data + config L1 via their `MeshBuffer`s), exposed via nanobind — the deallocate primitive that didn't exist.
- `prefetcher.teardown_global_cb()`: on the prefill switch, `synchronize_device` then free the global CB (and its op output + L1 address tensor) so prefill can use core (0,0); rebuilt lazily on the next decode `run()` (weights re-prefetched).
- `prefetcher.mode` tracked across the switch so `lm_head` (`use_prefetcher = prefetcher.mode == Mode.DECODE`) doesn't pin the decode-only worker sub-device during prefill.
- `generator._invalidate_decode_traces()`: release + clear cached decode traces on teardown (while the prefetcher's manager is still active, since traces are per-manager), so decode re-captures against the rebuilt CB instead of replaying a trace that baked the old (freed) global CB address.
- Cleared: the core-(0,0) L1 clash (`program.cpp` static-CB clash), the lm_head sub-device pin, and the batch-1 prefill device hang.

### HW iteration results (`bh_quietbox_2`)
| # | Change | Outcome |
|---|--------|---------|
| baseline | `ci-eval-32` `repeat_batches` 3→1 (repro only, PR #49120) | ✅ passes — confirms `repeat_batches>1` is the trigger |
| 1 | sub-device fix (option a) | 3 sub-device/trace/norm fatals cleared → hit L1 `global_cb` clash |
| 2 | `global_cb` teardown | L1 clash cleared → hit lm_head sub-device pin |
| 3 | track `prefetcher.mode` | lm_head passes → device hang in batch-1 prefill |
| 4 | `synchronize_device` before free | **all of batch-1 prefill works** → hang early in batch-1 decode |
| 5 | invalidate decode trace on teardown | batch-1 decode compile run succeeds (CB rebuilt) → hang in decode **trace capture** |
| 6 | reset address tensor on teardown | no change — still hangs in decode trace capture |

**Net: batch-1 prefill fully works; batch-1 decode compute works; the remaining failure is re-capturing the async DRAM-prefetcher op into the decode trace on the 2nd batch (device NOC timeout).**

### Remaining blocker
Re-capturing the decode trace (which contains the persistent async `dram_prefetcher` op) hangs on the 2nd batch — batch 0's first capture succeeds, batch 1's re-capture NOC-hangs. Two allocation-state fixes (device sync, address-tensor reset) did not move it, so it is not model-layer state — it's trace ⇄ async-prefetcher-op internals (the area #47820 flagged for the trace / DRAM-prefetcher owners). A watcher-enabled diagnostic run is in progress to pinpoint the stuck kernel; results and next direction to follow.

### Notes
- Tradeoff of the teardown approach: weights are re-prefetched (and the decode trace re-captured) on every prefill→decode switch — a perf cost accepted for correctness; needs evaluation against the eval-loop time budget.
- The job may still show red on the unrelated `--use_hf_rope` token-matching step (read-only `/mnt/MLPerf` cache) — a separate CI-infra issue.

_Supersedes #49124 (option-a), now closed and folded into this PR._
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/llama8b-prefetcher-global-cb-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/llama8b-prefetcher-global-cb-teardown)