### PR TITLE
[skip ci] GPT-OSS-120B unit [bh_quietbox_2]: bump timeout 15 -> 22 min (host variance)

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -318,7 +318,7 @@ models:
     wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 20
-    bh_quietbox_2: 230
+    bh_quietbox_2: 237  # GPT-OSS-120B 15->22 (host-variance headroom)
     bh_galaxy: 70
   unit_tier2:
     wh_llmbox: 114

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -507,8 +507,12 @@
     bh_quietbox_2:
       # 10 min was too tight: the suite runs to ~12 min and got wall-clock
       # killed mid-"Full MLP Pipeline" on the prefill_4096 test_decoder while
-      # all components were still passing (PCC 0.96-0.99). Bump to 15.
-      timeout: 15
+      # all components were still passing (PCC 0.96-0.99). 15 also proved too
+      # tight on slower hosts (07-06: killed at the 15-min limit having done 52
+      # of ~64 tests on p03t05, vs 11.4 min for the full 64 on p02t07 — host
+      # variance, not a hang; firmware pre-compiled, all sub-tests pass). Bump to
+      # 22; suite is long (test_rope seq sweep to 131k) and may want sharding.
+      timeout: 22
       tier: 1
     bh_galaxy:
       timeout: 10


### PR DESCRIPTION
## Summary

Bump the GPT-OSS-120B unit `bh_quietbox_2` job timeout **15 → 22 min** (+ matching `time_budget.yaml` `unit_tier1.bh_quietbox_2` 230 → 237). Follow-up to #48790.

## Why

The 15-min budget (from #48790) held on a fast host but the **2026-07-06 scheduled run was wall-clock-killed at 15 min** having completed only 52 of ~64 tests on the slower runner `p03t05` — **host variance, not a hang**: firmware is pre-compiled and every sub-test passes. (For reference, a fast host `p02t07` did the full 64-test suite in 11.4 min.)

## Validation

Dispatched a targeted unit run on this branch ([run 28807099624](https://github.com/tenstorrent/tt-metal/actions/runs/28807099624)):
- **GPT-OSS-120B unit [bh_quietbox_2] → success** on `qb2-120-p03t04` (a p03 host, same slow-host class). Completed the **full suite including `test_rope` seq-131072** in **16m26s job-time** (test step ~13–14 min, well inside 22).
- `verify_time_budget` passes: `models.unit_tier1.bh_quietbox_2` requested 234 ≤ budget 237.

## Note

This is the second bump on this job — the underlying cause is a long parametrized suite (`test_rope` seq sweep to 131072 + `test_decoder` configs, ~28 fabric reinits). A durable fix would be to **shard or trim** the suite rather than keep raising the timeout; flagging for the GPT-OSS owner (Harry Andrews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gptoss-120b-bh-quietbox-timeout-22)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gptoss-120b-bh-quietbox-timeout-22)