### PR TITLE
Fix #48928: descriptor rebuild-on-cache-hit (ResNet50 non-trace, ~12x)

### DIFF
--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -581,22 +581,31 @@ public:
                     apply_dynamic_runtime_args_if_declared(
                         program, attrs, tensor_args, tensor_return_value, coordinate_range);
                 } else {
-                    // ProgramDescriptor variant — simple per-coord factory.  Fast-path only
-                    // when the factory declared rt-arg buffer bindings via
-                    // emplace_runtime_args().  Without those, the factory may be
-                    // mixing `.buffer = ...` CBs with OLD-style raw uint32 rt-args
-                    // that are not registered as bindings; patching CBs alone
-                    // would leave those rt-args pointing at stale addresses.  Fall
-                    // through to the slow-path rebuild instead.
-                    if (!sv.resolved_bindings.rt_args.empty()) {
+                    // ProgramDescriptor variant — simple per-coord factory.  Fast-path when the factory
+                    // declared rt-arg buffer bindings via emplace_runtime_args(), OR the op declares
+                    // get_dynamic_runtime_args() to re-apply its per-dispatch args — in which case the
+                    // framework also patches the op's `.buffer = ...` CB bindings (covers CB-bound sharded
+                    // ops).  With neither, a `.buffer` CB mixed with raw uint32 rt-args could go stale, so
+                    // fall through to the slow-path rebuild instead. (#48928)
+                    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+                    if constexpr (requires {
+                                      DeviceOperation::get_dynamic_runtime_args(
+                                          attrs,
+                                          tensor_args,
+                                          tensor_return_value,
+                                          std::optional<ttnn::MeshCoordinate>{});
+                                  }) {
+                        dynamic_args = DeviceOperation::get_dynamic_runtime_args(
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    }
+                    if (!sv.resolved_bindings.rt_args.empty() || !dynamic_args.empty()) {
                         auto collected =
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
-                        // Fast path doesn't rebuild the descriptor, so re-apply any declared dynamic
-                        // non-Buffer runtime args (the slow-path else-branch below rebuilds
-                        // create_descriptor() and so already re-derives them).
-                        apply_dynamic_runtime_args_if_declared(
-                            program, attrs, tensor_args, tensor_return_value, coordinate_range);
+                        tt::tt_metal::apply_dynamic_runtime_args(program, dynamic_args);
                     } else {
                         const ttnn::MeshCoordinate mesh_coord = coordinate_range.start_coord();
                         const std::optional<ttnn::MeshCoordinate> mesh_dispatch_coordinate(mesh_coord);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -232,6 +232,22 @@ Tensor PadDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, tensor_args.input.device());
 }
 
+std::vector<tt::tt_metal::DynamicRuntimeArg> PadDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Height-sharded RM factory is CB-bound (addresses ride on the sharded CBs; no Buffer* rt-arg). Re-apply
+    // writer arg0 (= output shard height, unchanged) on the first core to trip the fast-path, so the
+    // framework re-patches the sharded CB base addresses instead of rebuilding create_descriptor. (#48928)
+    if (!std::holds_alternative<PadRmShardedHeightOnlyProgramFactory>(
+            select_program_factory(operation_attributes, tensor_args))) {
+        return {};
+    }
+    const auto shard = tensor_return_value.shard_spec().value();  // writer kernel is index 1
+    return {tt::tt_metal::DynamicRuntimeArg{1, shard.grid.bounding_box().start_coord, 0, shard.shape[0]}};
+}
+
 PadDeviceOperation::tensor_return_value_t pad(
     const Tensor& input,
     const ttnn::Shape& output_logical_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
@@ -21,6 +21,8 @@
 #include "ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp"
 #include "ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/distributed/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 struct PadDeviceOperation {
@@ -50,6 +52,12 @@ struct PadDeviceOperation {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors);
 
+    // #48928: the height-sharded RM factory is pure CB-bound; opt into the descriptor fast-path on a cache hit.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 }  // namespace ttnn::prim
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -12,6 +12,8 @@
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/distributed/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 #include <optional>
 #include <variant>
@@ -52,6 +54,14 @@ struct SliceDeviceOperation {
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
+
+    // #48928: opt the CB-bound height-sharded RM factory into the descriptor fast-path. Defined in
+    // slice_program_factory_rm_sharded.cpp so it can reuse that factory's per-core arg builder directly.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 
 SliceDeviceOperation::tensor_return_value_t slice(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -320,4 +320,36 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     return desc;
 }
 
+std::vector<tt::tt_metal::DynamicRuntimeArg> SliceDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Height-sharded RM factory is CB-bound: addresses ride on the sharded CBs, so re-apply reader arg0
+    // (num source cores, from the same per-core walk create_descriptor uses) on core 0 to trip the
+    // fast-path and let the framework re-patch the CB addresses instead of rebuilding. (#48928)
+    if (!std::holds_alternative<SliceRmShardedProgramFactory>(select_program_factory(args, tensor_args))) {
+        return {};
+    }
+    const auto& input = tensor_args.input;
+    const auto sp_padded = input.shard_spec().value();
+    const auto sp_unpadded = output.shard_spec().value();
+    const auto bbox_p = sp_padded.grid.bounding_box();
+    const auto bbox_u = sp_unpadded.grid.bounding_box();
+    // Build only core 0 (num_cores=1); its reader arg0 == what create_descriptor bakes for core 0.
+    const auto core0 = ttnn::operations::data_movement::get_slice_runtime_args_rm_sharded(
+        input,
+        output,
+        args.slice_start,
+        /*num_cores_unpadded=*/1,
+        sp_unpadded.orientation == ShardOrientation::ROW_MAJOR,
+        bbox_u.end_coord.x + 1,
+        bbox_u.end_coord.y + 1,
+        sp_unpadded.shape[0],
+        sp_padded.shape[0],
+        bbox_p.end_coord.x + 1,
+        bbox_p.end_coord.y + 1);
+    return {tt::tt_metal::DynamicRuntimeArg{0, corerange_to_cores(sp_unpadded.grid).front(), 0, core0[0].first[0]}};
+}
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -269,6 +269,26 @@ TilizeDeviceOperation::tensor_return_value_t TilizeDeviceOperation::create_outpu
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
+std::vector<tt::tt_metal::DynamicRuntimeArg> TilizeDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Only the sharded factory is CB-bound (in/out addresses ride on the sharded CBs, no Buffer* rt-arg).
+    // Re-apply reader arg0 (num_tiles_per_shard, unchanged) on the first core to trip the fast-path so
+    // apply_resolved_bindings re-patches the CB base addresses instead of rebuilding create_descriptor.
+    if (!std::holds_alternative<TilizeMultiCoreShardedProgramFactory>(
+            select_program_factory(operation_attributes, tensor_args))) {
+        return {};
+    }
+    const auto& shard_spec = tensor_args.input_tensor.shard_spec().value();
+    return {tt::tt_metal::DynamicRuntimeArg{
+        /*kernel_idx=*/0,
+        corerange_to_cores(shard_spec.grid).front(),
+        /*arg_idx=*/0,
+        shard_spec.shape[0] * shard_spec.shape[1] / tt::constants::TILE_HW}};
+}
+
 ttnn::Tensor tilize(
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
@@ -12,6 +12,8 @@
 #include "tilize_multi_core_sharded_program_factory.hpp"
 #include "tilize_device_operation_types.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/distributed/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 
@@ -34,6 +36,13 @@ struct TilizeDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
+
+    // #48928: the sharded factory is pure CB-bound; opt into the descriptor fast-path on a cache hit.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 
 ttnn::Tensor tilize(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp
@@ -17,6 +17,8 @@
 
 #include <variant>
 #include "ttnn/operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 
@@ -52,6 +54,14 @@ struct TransposeDeviceOperation {
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, const Tensor& output);
+
+    // #48928: opt the CB-bound height-sharded factories into the descriptor fast-path. Defined in
+    // transpose_hc_sharded_program_factory.cpp so it can reuse that factory's per-core arg builders.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_hc_sharded_program_factory.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -280,6 +280,13 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     return ret_val;
 }
 
+// Selects the special-case per-core builder. Shared by create_descriptor and get_dynamic_runtime_args
+// so the reader arg0 value they emit/re-apply cannot drift.
+inline bool hc_rm_sharded_is_special_case(uint32_t shard_height, uint32_t H, uint32_t C) {
+    return (shard_height % H == 0 || H % shard_height == 0) && (shard_height % C == 0 || C % shard_height == 0) &&
+           (C % H == 0 || H % C == 0) && (shard_height <= C * H);
+}
+
 }  // namespace
 
 tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descriptor(
@@ -302,12 +309,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     uint32_t shard_height = shard_spec.shape[0];
     bool row_major_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
-    bool is_special_case = false;
-    if ((shard_spec.shape[0] % H == 0 || H % shard_spec.shape[0] == 0) &&
-        (shard_spec.shape[0] % C == 0 || C % shard_spec.shape[0] == 0) && (C % H == 0 || H % C == 0) &&
-        (shard_height <= C * H)) {
-        is_special_case = true;
-    }
+    bool is_special_case = hc_rm_sharded_is_special_case(shard_height, H, C);
 
     auto& all_cores = shard_spec.grid;
     uint32_t num_cores = shard_spec.num_cores();
@@ -424,6 +426,32 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     }
 
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> TransposeDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    const auto factory = select_program_factory(operation_attributes, tensor_args);
+    const auto& input = tensor_args.input;
+    // HC sharded RM is CB-bound; re-apply reader arg0 (read by the kernel) on core 0 to trip the fast-path.
+    // Build only core 0 via the same per-core builders (and shared is_special_case) create_descriptor uses. (#48928)
+    if (std::holds_alternative<TransposeHCShardedProgramFactory>(factory)) {
+        const auto shard = input.shard_spec().value();
+        const uint32_t H = input.logical_shape()[2], C = input.logical_shape()[1];
+        const bool special = hc_rm_sharded_is_special_case(shard.shape[0], H, C);
+        const auto bbox = shard.grid.bounding_box();
+        const auto a =
+            special ? get_runtime_args_hc_rm_sharded_special_case(input, 1, bbox.end_coord.x + 1, bbox.end_coord.y + 1)
+                    : get_runtime_args_hc_rm_sharded(input, 1, bbox.end_coord.x + 1, bbox.end_coord.y + 1);
+        return {tt::tt_metal::DynamicRuntimeArg{0, corerange_to_cores(shard.grid).front(), 0, a[0].first[0]}};
+    }
+    // WH sharded RM emits one placeholder reader arg the kernel ignores; re-apply 0 to trip the fast-path.
+    if (std::holds_alternative<TransposeWHShardedRMProgramFactory>(factory)) {
+        return {tt::tt_metal::DynamicRuntimeArg{0, corerange_to_cores(input.shard_spec().value().grid).front(), 0, 0u}};
+    }
+    return {};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -243,6 +243,12 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
         .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
     };
 
+    // #48928: this reader uses compile-time args only; emit one placeholder rt-arg per core so
+    // get_dynamic_runtime_args has a slot to re-apply, opting this CB-bound factory into the fast-path.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0u});
+    }
+
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));
     desc.kernels.push_back(std::move(compute_desc));


### PR DESCRIPTION
## Summary

Fixes the ResNet50 **non-trace** e2e host regression (#48928): the Metal-2.0 descriptor adapter re-ran `create_descriptor()` on every program-cache **hit** for the pure CB-bound sharded factories in resnet50's fold path (`transpose` HC/WH, `pad`, `slice` rm-sharded, `tilize`). Some of these (notably `slice`) do an expensive per-core stick-walk in `create_descriptor`, so rebuilding on every hit dominates.

**Result (T3000 / 8-chip, resnet50 batch128 non-trace, `test_perf`, min of 3):**

| | inference_time | FPS |
|---|---|---|
| clean main | **0.3203 s** | ~390 |
| this branch | **0.0258 s** | ~4950 |

**~12× faster**, PCC 0.987 (pass).

## Approach — minimal
- **Framework: one small change** in `mesh_device_operation_adapter.hpp` (+22/−13) — the ProgramDescriptor cache-hit fast-path now also triggers when an op declares `get_dynamic_runtime_args()` (previously only on Buffer\* rt-arg bindings). That lets a CB-bound op opt in so the framework patches its sharded CB `.buffer` bindings in place instead of rebuilding.
- **Ops:** each fixed factory declares `get_dynamic_runtime_args` re-applying **one** already-emitted stable arg on the first core, to opt into the fast-path. **No new structs, no wrapper helpers.**
  - `pad`, `tilize`: value is trivial (output shard height / tiles-per-shard) → device-op-only 1-liners, **factories untouched**.
  - `slice`, `transpose`-HC: value is per-core-walk / path-dependent, so `get_dynamic` is defined **in the factory .cpp** and calls that factory's existing per-core builder directly — no wrapper, `create_descriptor` unchanged.
  - `transpose`-WH: emits one placeholder reader arg (zero runtime args otherwise) so there is a slot to re-apply.
- **10 files, +161/−13.** Scoped to resnet's offenders; `binary_ng` (perf-neutral here) and other descriptor-migration families are separate follow-ups.

## Tests
Covered on-device by the existing sharded tests — `test_fold_op.py::test_fold_with_permute_reshape_on_device_sharded` (transpose HC+WH, pad, slice sharded) and the sharded `test_tilize.py` cases — plus the resnet e2e perf test as the regression signal.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-48928-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-48928-descriptor-rebuild)
