### PR TITLE
Add CODEOWNERS entry for tt_metal/impl/experimental/offline_kernel_compile.cpp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,6 +187,7 @@ tt_metal/hw/inc/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-by
 tt_metal/api/tt-metalium/experimental/noc_estimator/ @nstamatovicTT @atatuzunerTT @tenstorrent/codeowner-bypass
 tt_metal/impl/experimental/noc_estimator/ @nstamatovicTT @atatuzunerTT @tenstorrent/codeowner-bypass
 tt_metal/impl/experimental/noc_estimator/**/CMakeLists.txt @nstamatovicTT @atatuzunerTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+tt_metal/impl/experimental/offline_kernel_compile.cpp @ruizhangTT @abhullar-tt @tenstorrent/codeowner-bypass
 tt_metal/impl/emulation/ @xanderchin @arminaleTT @sgholamiTT @tenstorrent/codeowner-bypass
 
 # metal misc


### PR DESCRIPTION
### Summary
Wilder noticed in #43851 that `tt_metal/impl/experimental/offline_kernel_compile.cpp` shows as owned by `@tenstorrent/metalium-developers-infra`. That's because the file has no directory- or file-specific CODEOWNERS rule, so it falls through to the top-level `tt_metal/` catch-all:

```
tt_metal/ @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass # nothing should be caught by this, if so, someone added a path somewhere
```

The sibling `tt_metal/impl/experimental/{disaggregation,udm,noc_estimator}/` subdirs each have their own owners; this file just never got one when it was added in #43851.

### Owners chosen
- `git log`/`git blame` on the file (on the `ruizhang/offline-kernel-compile` branch, pre-merge) show it's 100% authored by **@ruizhangTT**.
- **@abhullar-tt** co-owns the predecessor file it was factored out of (`tt_metal/tools/precompile_fw`) alongside ruizhangTT, and approved #43851.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/fix-offline-kernel-compile-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/fix-offline-kernel-compile-codeowners)