### PR TITLE
Bug fix: disable submesh program cache in AsyncExecutionWorksCQ0 CCL test (#46982)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -79,6 +79,12 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
         single_meshes[3].get(),
     };
 
+    // https://github.com/tenstorrent/tt-metal/issues/24235
+    // Remove when https://github.com/tenstorrent/tt-metal/issues/25418 is fixed.
+    for (auto& device : single_meshes) {
+        device->disable_and_clear_program_cache();
+    }
+
     const size_t num_devices = devices.size();
     TT_FATAL(
         test_expected_num_devices == num_devices,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #46982.

`MultiCQFabricMeshDevice2x4Fixture.AsyncExecutionWorksCQ0` in `test_ccl_multi_cq_multi_device.cpp` creates four 1x1 submeshes but — unlike the other two fixtures in the same file — never disables/clears their program cache. With program cache enabled, the CQ0 + 1x1 submesh + CCL all-gather sequence reuses stale/unsafe cached program state: after the all-gather, the dummy ops wedge dispatch and the following `read_buffer` hangs in the completion-queue read, tripping the Metal operation timeout and aborting the whole `t3k_ttnn_tests` job.

This applies the same `disable_and_clear_program_cache()` workaround the other two fixtures already carry for the known submesh program-cache issue (refs #24235; remove when #25418 is fixed).

On-device triage (T3000/wh_llmbox) showed the CQ0 `cq_dispatch` kernel spinning on CB page credits with `read_buffer` queued behind it, and worker grids on the line-endpoint devices sitting at `pc=0` — consistent with a bad/stale cached program being dispatched to a 1x1 submesh rather than a hardware fault (all ARC/NOC/eth-link health checks passed).

### Notes for reviewers
- This is a **test-side workaround**, not a fix for the underlying submesh program-cache bug (#25418) — same posture as the two sibling fixtures.
- Verification on T3000/wh_llmbox:
  - `AsyncExecutionWorksCQ0` alone: **5/5 passes** (previously a deterministic hang), completing through `Finished` with all `DeviceN Compare Success` data checks passing.
  - All three fixtures together: **3/3 `[ OK ]`**, `rc=0`.
- Supersedes the auto-triage disable PR #47747 (GTEST_SKIP), which is no longer needed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-ccl-multi-cq-cq0-program-cache-46982)