### PR TITLE
Fix CIv2 LFC weight downloads (bypass proxy + retry on connection-refused)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -135,6 +135,11 @@ class CIv2ModelDownloadUtils_:
             subprocess.run(
                 [
                     "wget",
+                    # LFC is an internal cluster service and must be reached directly. The CIv2
+                    # no_proxy entry for it is scheme-prefixed ("http://...") so it never matches
+                    # the target hostname; without --no-proxy, wget sends the request through the
+                    # restricted egress proxy, which returns 503 for internal hosts.
+                    "--no-proxy",
                     "-r",
                     "-nH",
                     "-x",

--- a/conftest.py
+++ b/conftest.py
@@ -140,6 +140,11 @@ class CIv2ModelDownloadUtils_:
                     # the target hostname; without --no-proxy, wget sends the request through the
                     # restricted egress proxy, which returns 503 for internal hosts.
                     "--no-proxy",
+                    # LFC occasionally refuses direct connections; wget does not retry connection
+                    # refusals by default, so opt in and back off a few times before giving up.
+                    "--tries=5",
+                    "--retry-connrefused",
+                    "--waitretry=10",
                     "-r",
                     "-nH",
                     "-x",


### PR DESCRIPTION
## Problem
CIv2 e2e/demo jobs that pull model weights from the internal Large File Cache (e.g. panoptic-deeplab on `bh_p150b_civ2`) failed at setup with `wget ... 503 Service Unavailable`, then `Connection refused`. [Failing run](https://github.com/tenstorrent/tt-metal/actions/runs/28780908882/job/85338624643).

## What changed
Both edits are to the CIv2 LFC `wget` in `conftest.py` (`download_from_ci_v2_cache`):

1. **`--no-proxy`** — the LFC is an internal cluster service, but the container's `no_proxy` entry for it is scheme-prefixed (`http://large-file-cache...`), so it never matches the hostname and wget routed LFC through the restricted egress proxy, which returns 503. Force a direct connection.
2. **`--retry-connrefused --tries=5 --waitretry=10`** — LFC occasionally refuses a direct connection, and wget does not retry connection-refused by default. Retry with backoff.

## Effect
General fix for every CIv2 LFC download (PDL, SDXL-blackhole, etc.). Verified on this branch: panoptic-deeplab e2e + demo now download weights and run. [Passing run](https://github.com/tenstorrent/tt-metal/actions/runs/28803863412).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/pdl-ci-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/pdl-ci-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nmilicevic/pdl-ci-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/pdl-ci-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/pdl-ci-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/pdl-ci-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/pdl-ci-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/pdl-ci-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/pdl-ci-fix)