### PR TITLE
[skip ci] Fix CODEOWNERS: tt_metal/tools CMakeLists.txt catch-all clobbering per-tool owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,7 +177,11 @@ tt_metal/tools/profiler/event_metadata.hpp @sohaibnadeemTT @tenstorrent/codeowne
 tt_metal/tools/profiler/fabric_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/noc_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/noc_event_profiler_utils.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
-tt_metal/tools/**/CMakeLists.txt @kmabeeTT @mo-tenstorrent @ihamer-tt @tenstorrent/metalium-developers-infra
+tt_metal/tools/**/CMakeLists.txt @tenstorrent/metalium-developers-infra
+tt_metal/tools/precompile_fw/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
+tt_metal/tools/jit_compile_server/**/CMakeLists.txt @ruizhangTT @tenstorrent/metalium-runtime @tenstorrent/metalium-developers-infra
+tt_metal/tools/dispatch_telemetry_dump/**/CMakeLists.txt @anashTT @jbaumanTT @sidnadTT @tenstorrent/metalium-developers-infra
+tt_metal/tools/profiler/**/CMakeLists.txt @mo-tenstorrent @akerteszTT @tenstorrent/metalium-developers-infra
 tt_metal/api/tt-metalium/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental APIs
 tt_metal/impl/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental impl
 tt_metal/api/tt-metalium/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,7 +177,6 @@ tt_metal/tools/profiler/event_metadata.hpp @sohaibnadeemTT @tenstorrent/codeowne
 tt_metal/tools/profiler/fabric_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/noc_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/noc_event_profiler_utils.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
-tt_metal/tools/**/CMakeLists.txt @tenstorrent/metalium-developers-infra
 tt_metal/tools/precompile_fw/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
 tt_metal/tools/jit_compile_server/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
 tt_metal/tools/dispatch_telemetry_dump/**/CMakeLists.txt @anashTT @jbaumanTT @sidnadTT @tenstorrent/metalium-developers-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -181,7 +181,6 @@ tt_metal/tools/**/CMakeLists.txt @tenstorrent/metalium-developers-infra
 tt_metal/tools/precompile_fw/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
 tt_metal/tools/jit_compile_server/**/CMakeLists.txt @ruizhangTT @tenstorrent/metalium-runtime @tenstorrent/metalium-developers-infra
 tt_metal/tools/dispatch_telemetry_dump/**/CMakeLists.txt @anashTT @jbaumanTT @sidnadTT @tenstorrent/metalium-developers-infra
-tt_metal/tools/profiler/**/CMakeLists.txt @mo-tenstorrent @akerteszTT @tenstorrent/metalium-developers-infra
 tt_metal/api/tt-metalium/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental APIs
 tt_metal/impl/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental impl
 tt_metal/api/tt-metalium/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -179,7 +179,7 @@ tt_metal/tools/profiler/noc_event_profiler.hpp @sohaibnadeemTT @tenstorrent/code
 tt_metal/tools/profiler/noc_event_profiler_utils.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/**/CMakeLists.txt @tenstorrent/metalium-developers-infra
 tt_metal/tools/precompile_fw/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
-tt_metal/tools/jit_compile_server/**/CMakeLists.txt @ruizhangTT @tenstorrent/metalium-runtime @tenstorrent/metalium-developers-infra
+tt_metal/tools/jit_compile_server/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
 tt_metal/tools/dispatch_telemetry_dump/**/CMakeLists.txt @anashTT @jbaumanTT @sidnadTT @tenstorrent/metalium-developers-infra
 tt_metal/api/tt-metalium/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental APIs
 tt_metal/impl/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental impl


### PR DESCRIPTION
## Problem

\`tt_metal/tools/**/CMakeLists.txt\` was listed *after* the per-tool-directory owner rules (precompile_fw, jit_compile_server, dispatch_telemetry_dump, profiler, etc). Since CODEOWNERS resolves overlapping patterns by last-match-wins, this catch-all silently overrode the real directory owners for any \`CMakeLists.txt\` file, leaving \`@kmabeeTT @mo-tenstorrent @ihamer-tt\` (inherited from the top-level \`tt_metal/tools/*\` rule) as owners of CMake files in tool directories they don't otherwise own.

## Fix

- Narrowed the catch-all to \`@tenstorrent/metalium-developers-infra\` only — it now serves purely as the shared build-file reviewer / fallback for any tool subdirectory without a dedicated CMake rule.
- Added explicit per-directory overrides (listed after the catch-all so they win) pairing each tool's actual owners with infra:
  - \`precompile_fw\` → \`@abhullar-tt @ruizhangTT\`
  - \`jit_compile_server\` → \`@ruizhangTT @tenstorrent/metalium-runtime\`
  - \`dispatch_telemetry_dump\` → \`@anashTT @jbaumanTT @sidnadTT\`
  - \`profiler\` → \`@mo-tenstorrent @akerteszTT\`

This mirrors the existing pattern already used elsewhere in the file (e.g. \`tests/tt_metal/tools/**/CMakeLists.txt\` + \`tests/tt_metal/tools/profiler/**/CMakeLists.txt\`).

## Open question for follow-up

\`lightmetal_runner\` (owned by \`@kmabeeTT\`) and \`mem_bench\` (owned by \`@abhullar-tt\`) don't have explicit CMake overrides here, so their CMakeLists.txt files fall to the infra-only catch-all. Happy to add explicit overrides for those too if desired — raising this as an initial proposal to iterate on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/codeowners-tools-cmake)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/codeowners-tools-cmake)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:wilder/codeowners-tools-cmake)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/codeowners-tools-cmake)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/codeowners-tools-cmake)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/codeowners-tools-cmake)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/codeowners-tools-cmake)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/codeowners-tools-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/codeowners-tools-cmake)