### PR TITLE
emule runner: sysmem NOC hook + umd pin bump (SysmemManager + TLB)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -61,6 +61,7 @@
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include "umd/device/chip/sw_emule_chip.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>  // fabric route table (multi-chip dst resolve)
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>   // FabricNodeId, MeshId, FabricConfig
 #include <tt-metalium/experimental/fabric/fabric.hpp>         // is_2d_fabric_config
@@ -285,7 +286,18 @@ static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
 //     that is the true in-bank offset (already includes
 //     `bank_to_dram_offset[bank_index]`). Masking to 2 MB silently aliases
 //     any DRAM access >= 2 MB to an offset within the first 2 MB of the bank.
+// Route addresses that fall in the host sysmem arena (device_io_addr = pcie_base_
+// + offset, assigned by SimulationSysmemManager) to the mapped host buffer. This
+// is how a kernel's PCIe NOC read/write (H2D/D2H sockets, PinnedMemory) reaches
+// the pinned host region — those targets are not cores in the core_map. Checked
+// before the core decode: the sysmem window sits above the L1/DRAM NOC range.
+// Defined below (needs get_sw_emulated_chip, which is defined later in this TU).
+extern "C" uint8_t* __emule_resolve_sysmem_addr(uint64_t device_io_addr, uint32_t size);
+
 extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
+    if (uint8_t* host = __emule_resolve_sysmem_addr(noc_addr, 1)) {
+        return host;
+    }
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
     uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint64_t local_addr = noc_addr & NOC_LOCAL_MASK;  // 36 bits, raw
@@ -1239,6 +1251,19 @@ static tt::umd::SWEmuleChip* get_sw_emulated_chip(ChipId device_id) {
     }
     auto* chip = umd_cluster->get_chip(device_id);
     return dynamic_cast<tt::umd::SWEmuleChip*>(chip);
+}
+
+extern "C" uint8_t* __emule_resolve_sysmem_addr(uint64_t device_io_addr, uint32_t size) {
+    emule_require_self(__func__);
+    auto* chip = get_sw_emulated_chip(__emule_self->chip_id);
+    if (chip == nullptr) {
+        return nullptr;
+    }
+    tt::umd::SysmemManager* sm = chip->get_sysmem_manager();
+    if (sm == nullptr || device_io_addr < sm->get_pcie_base()) {
+        return nullptr;
+    }
+    return sm->resolve_host_ptr(device_io_addr, size);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Route sysmem NOC addresses to the mapped host buffer in the emule kernel runner, so ops that DMA host↔device (PinnedMemory / H2D-D2H sockets) actually move bytes under emule. Foundation for the blaze migration op bring-up.

Two commits:
1. **runner sysmem hook** — `__emule_resolve_sysmem_addr` reaches the chip's `SysmemManager` via `get_sw_emulated_chip(__emule_self->chip_id)` and, for addresses `>= get_pcie_base()`, resolves to the mapped host buffer (`SimulationSysmemManager::resolve_host_ptr`). Prepended in `__emule_resolve_noc_addr` as a pure fast path — the sysmem window sits above the L1/DRAM NOC range, so all existing L1/DRAM/cross-core resolutions are unchanged (25-line addition).
2. **umd pin bump** — advance `third_party/umd` to `xchin/emule-sysmem-tlb`, the host-memory foundation the hook resolves through.

## Base + dependency

Based on `emule-blaze-metal-main` (the blaze emule pin line; a PR to upstream `main` would be a 63-commit diff). **Depends on** tenstorrent/tt-umd#2990 — the pin-bump commit points the submodule at that branch's HEAD.

## Status

Draft — emule-specific downstream change on the pin line; opened for review/record. Runtime pair to the tt-emule jit_hw socket-shim PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-migration-sysmem-hook)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-migration-sysmem-hook)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/emule-migration-sysmem-hook)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-migration-sysmem-hook)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-migration-sysmem-hook)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-migration-sysmem-hook)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-migration-sysmem-hook)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-migration-sysmem-hook)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-migration-sysmem-hook)