### PR TITLE
[Feature] Enable trace capture and replay on Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/sources.cmake
+++ b/tests/tt_metal/tt_metal/sources.cmake
@@ -30,6 +30,7 @@ set(UNIT_TESTS_LEGACY_SRC
     test_quasar_mesh_buffers.cpp
     test_quasar_mesh_workloads.cpp
     test_quasar_semaphores.cpp
+    test_quasar_trace.cpp
     test_sdpa_reduce_c.cpp
     test_single_dm_l1_write.cpp
     test_stress_noc_mcast.cpp

--- a/tests/tt_metal/tt_metal/test_quasar_trace.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_trace.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/device_fixture.hpp"
+#include "context/metal_context.hpp"
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceSingleReplay) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto mesh_device = devices_[0];
+    const experimental::NodeCoord node{0, 0};
+
+    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t value = 0xcafe1234;
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    const experimental::KernelSpecName DM_KERNEL{"dm_kernel"};
+    experimental::KernelSpec dm_kernel_spec{
+        .unique_id = DM_KERNEL,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+        .num_threads = 2,
+        .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+    };
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
+    experimental::ProgramSpec spec{.name = "trace_test", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, experimental::MakeProgramFromSpec(*mesh_device, spec));
+    Program& prog = workload.get_programs().at(device_range);
+
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = DM_KERNEL,
+        .runtime_arg_values = {{node, {{"address", address}}}},
+        .common_runtime_arg_values = {{"value", value}},
+    }};
+    experimental::SetProgramRunArgs(prog, params);
+
+    // Warm up
+    std::vector<uint32_t> zeros(1, 0);
+    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+    std::vector<uint32_t> warm_up_result(1, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), warm_up_result);
+    ASSERT_EQ(warm_up_result[0], value);
+
+    // Capture trace
+    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+    distributed::MeshTraceId trace_id = distributed::BeginTraceCapture(mesh_device.get(), 0);
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    mesh_device->end_mesh_trace(0, trace_id);
+
+    // Replay trace
+    mesh_device->replay_mesh_trace(0, trace_id, true);
+    std::vector<uint32_t> trace_result(1, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), trace_result);
+    ASSERT_EQ(trace_result[0], value);
+
+    mesh_device->release_mesh_trace(trace_id);
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceMultipleReplays) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto mesh_device = devices_[0];
+    const experimental::NodeCoord node{0, 0};
+
+    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t value = 0x5a5a5a5a;
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    const experimental::KernelSpecName DM_KERNEL{"dm_kernel"};
+    experimental::KernelSpec dm_kernel_spec{
+        .unique_id = DM_KERNEL,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+        .num_threads = 2,
+        .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{}},
+    };
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
+    experimental::ProgramSpec spec{
+        .name = "trace_multi_replay_test", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, experimental::MakeProgramFromSpec(*mesh_device, spec));
+    Program& prog = workload.get_programs().at(device_range);
+
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = DM_KERNEL,
+        .runtime_arg_values = {{node, {{"address", address}}}},
+        .common_runtime_arg_values = {{"value", value}},
+    }};
+    experimental::SetProgramRunArgs(prog, params);
+
+    // Warm up
+    std::vector<uint32_t> zeros(1, 0);
+    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+    std::vector<uint32_t> warm_up_result(1, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), warm_up_result);
+    ASSERT_EQ(warm_up_result[0], value);
+
+    // Capture trace
+    distributed::MeshTraceId trace_id = distributed::BeginTraceCapture(mesh_device.get(), 0);
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    mesh_device->end_mesh_trace(0, trace_id);
+
+    // Replay trace
+    constexpr uint32_t num_replays = 5;
+    for (uint32_t i = 0; i < num_replays; i++) {
+        std::vector<uint32_t> zeros(1, 0);
+        tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+
+        mesh_device->replay_mesh_trace(0, trace_id, true);
+
+        std::vector<uint32_t> result(1, 0);
+        tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), result);
+        ASSERT_EQ(result[0], value);
+    }
+
+    mesh_device->release_mesh_trace(trace_id);
+}

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -338,7 +338,8 @@ extern "C" uint32_t _start1() {
                 WAYPOINT("R");
                 if (enables & (1u << index)) {
                     uintptr_t kernel_lma =
-                        (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
+                        (static_cast<uint32_t>(kernel_config_base) +
+                         launch_msg_address->kernel_config.kernel_text_offset[index]);
                     // Invalidate the i$ now the kernels have loaded and before running
                     invalidate_kernel_binary_l2_cache(kernel_lma, launch_msg_address, index);
                     invalidate_l1_icache();
@@ -416,7 +417,7 @@ extern "C" uint32_t _start1() {
         int index = hartid;
 
         uintptr_t kernel_lma =
-            kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index];
+            static_cast<uint32_t>(kernel_config_base) + launch_msg->kernel_config.kernel_text_offset[index];
 
         uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
                                                                 launch_msg->kernel_config.local_cb_offset);

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -85,8 +85,6 @@ void issue_trace_commands(
     uint8_t cq_id,
     const DispatchArray<uint32_t>& expected_num_workers_completed,
     CoreCoord dispatch_core) {
-    TT_FATAL(mesh_device->arch() != tt::ARCH::QUASAR, "Trace commands are currently not supported on Quasar");
-
     void* cmd_region = sysmem_manager.issue_queue_reserve(dispatch_md.cmd_sequence_sizeB, cq_id);
 
     HugepageDeviceCommand command_sequence(cmd_region, dispatch_md.cmd_sequence_sizeB);


### PR DESCRIPTION
### PR Category
Feature

### Summary
Enables trace capture/replay on Quasar. This required two changes: removing the guard that blocked trace commands on Quasar, and fixing a tt-2xx DM firmware bug where a negative `kernel_text_offset` added to the 64-bit `kernel_config_base` overflowed the 32-bit L1 address space instead of wrapping.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/quasar_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/quasar_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sagarwal/quasar_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/quasar_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/quasar_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/quasar_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/quasar_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/quasar_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/quasar_trace)