### PR TITLE
[LLK][BH] Write ZEROACC-mode cfg after the drain in _llk_math_hw_configure_ (defensive)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -47,10 +47,10 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     // LLK sanitizer hooks
     llk::san::math_operand_configure(srca_data_format, srcb_data_format);
 
-    // Configure ZEROACC to auto-detect destination bank (non-legacy mode).
-    cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(0);
     // SFPU_Fp32_enabled (written below) is read by SFPLOAD/SFPSTORE (MOD0_FMT_SRCB), so the SFPU must drain too.
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+    // Configure ZEROACC to auto-detect destination bank (non-legacy mode).
+    cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(0);
     std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
 


### PR DESCRIPTION
## Summary

Issue https://github.com/tenstorrent/tt-llk/issues/1658. Point 2

In Blackhole `_llk_math_hw_configure_` (`tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h`), move the `DEST_ACCESS_CFG_zeroacc_absolute_tile_mode` write to **after** the `STALLWAIT(STALL_CFG, MATH | WAIT_SFPU)` drain, instead of before it.

```cpp
-    // Configure ZEROACC to auto-detect destination bank (non-legacy mode).
-    cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(0);
-    // SFPU_Fp32_enabled (written below) is read by SFPLOAD/SFPSTORE ...
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+    // Configure ZEROACC to auto-detect destination bank (non-legacy mode).
+    cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(0);
```

## Why

`DEST_ACCESS_CFG_zeroacc_absolute_tile_mode` selects the dest-bank addressing mode consumed by the TRISC FPU's `ZEROACC` instruction. The issue this guards against: **if the TRISC FPU is executing a `ZEROACC` and this register is changed during that window, the ZEROACC's addressing mode could change out from under the in-flight op.** We currently do not know the exact sampling behavior of this register (whether `ZEROACC` latches it at decode or samples it at execution), so this is a **defensive** change — writing it after the drain guarantees no `ZEROACC` is in flight when the mode changes, which is the write-after-drain idiom the rest of this function already uses for the SFPU-read config regs.

## Scope / impact

Not a live bug today, purely hardening:
- This call site is **init-only** — `_llk_math_hw_configure_`'s only caller is the one-time `llk_math_hw_configure` at kernel setup, before the compute loop issues any math op — and it is the **sole writer** of this register in the BH tree, so no `ZEROACC` is in flight when it runs.
- The change is a **pure statement reorder** (no new symbols, no dependency change), so it is compile-safe by construction.

## Context

Surfaced while reviewing tt-llk#1658 finding #2 (the reconfig-stall `WAIT_SFPU` fix landed in #48360). That fix added the SFPU drain for the `Fp32`/`SFPU_Fp32` writes but left this `zeroacc` write ahead of the stall; the original audit had also suggested moving it below the drain.

## Verification

- Compile-safe statement reorder; Blackhole `compile-producer` passes for `test_eltwise_unary_datacopy` (exercises `_llk_math_hw_configure_`).
- **Not** runtime-verified on Blackhole silicon (this was developed on a Wormhole machine, and the change is a defensive reorder with no behavioral change today) — Blackhole CI is the gate.
- No regression test added: there is no observable behavioral change today (init-only, single writer), and the guarded condition is a HW-timing hazard that cannot be deterministically reproduced without first knowing the register's sampling behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/bh-math-hw-configure-zeroacc-after-stall)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/bh-math-hw-configure-zeroacc-after-stall)