### PR TITLE
Bug Fix: Resolve failing TTNN comparison test

### DIFF
--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -903,7 +903,7 @@ class Operation:
                 global_tensor_comparison_records = []
                 global_golden_function_output = []
 
-                ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+                ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL, _internal=True)
 
                 try:
                     if cq_id is None:

--- a/ttnn/ttnn/graph.py
+++ b/ttnn/ttnn/graph.py
@@ -206,7 +206,7 @@ def _collect_tensor_ids(value) -> list:
     return ids
 
 
-def begin_graph_capture(run_mode=None):
+def begin_graph_capture(run_mode=None, *, _internal=False):
     """Wrapper that clears Python I/O state before starting C++ capture.
 
     Automatically enables Python I/O recording so that
@@ -240,9 +240,15 @@ def begin_graph_capture(run_mode=None):
         import ttnn
 
         _python_io_data = []
-        # Preserve comparison records across per-op capture sessions (comparison mode
-        # without enable_graph_report). Only initialize once per test run.
-        if not _comparison_records_data:
+        # A user-initiated (non-internal) outermost capture starts a fresh comparison
+        # sidecar scope: any records left over from earlier comparison-mode activity
+        # in this process must not leak into this capture's sidecar. The per-op
+        # auto-capture inside the operation wrapper passes _internal=True so that
+        # comparison records still accumulate across per-op sessions (comparison mode
+        # without enable_graph_report, later drained by flush_comparison_records_to_db).
+        if not _internal:
+            _comparison_records_data = _new_comparison_records_data()
+        elif not _comparison_records_data:
             _comparison_records_data = _new_comparison_records_data()
         _python_io_recording_enabled = True
         _configure_python_stack_traces_for_outer_graph_capture(ttnn)


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary

https://github.com/tenstorrent/tt-metal/issues/48464

There is a test that runs successfully when you call it like this:

```
pytest tests/ttnn/unit_tests/base_functionality/test_graph_report.py::TestGraphReportImport::test_import_populates_comparison_records_from_runtime_sidecar
```

But when the full test suite runs in the CI build, it fails intermittently.

### Notes for reviewers

Comparison-mode records accumulate in a process-global buffer that was only cleared when a capture was flushed to file. Records leaked from earlier comparison-mode tests in the same process contaminated later captures' sidecars, causing `test_import_populates_comparison_records_from_runtime_sidecar` to fail in CI (a stale `matches=False` record) while passing in isolation.

Fix: a user-initiated (outermost) `begin_graph_capture` now starts a clean comparison-records buffer, while per-op auto-captures still accumulate as before (via an `_internal` flag), so `flush_comparison_records_to_db` is unaffected.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smountenay-tt/comparison_test_failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smountenay-tt/comparison_test_failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:smountenay-tt/comparison_test_failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smountenay-tt/comparison_test_failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smountenay-tt/comparison_test_failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smountenay-tt/comparison_test_failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smountenay-tt/comparison_test_failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smountenay-tt/comparison_test_failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smountenay-tt/comparison_test_failure)