### PR TITLE
[LLK][QSR] Drop duplicate tensix_sync() in set_dest_fmt(uint32_t,int)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_dest.h
@@ -71,8 +71,7 @@ inline void set_dest_fmt(std::uint32_t fmt, int t)
     {
         set_dest_fmt<2>(fmt);
     }
-
-    tensix_sync();
+    // No tensix_sync() here: the templated set_dest_fmt<t> above already ends with one.
 }
 
 template <int t, bool is_signed>


### PR DESCRIPTION
## Summary

Issue https://github.com/tenstorrent/tt-llk/issues/1659

Remove the duplicate trailing `tensix_sync()` in Quasar `set_dest_fmt(std::uint32_t fmt, int t)` (`tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_dest.h`).

```cpp
 inline void set_dest_fmt(std::uint32_t fmt, int t) {
     if (t == 0)      set_dest_fmt<0>(fmt);
     else if (t == 1) set_dest_fmt<1>(fmt);
     else             set_dest_fmt<2>(fmt);
-
-    tensix_sync();          // <-- redundant
 }
```

The runtime-dispatch wrapper forwards to the templated `set_dest_fmt<t>(fmt)` in **every** branch, and that template already ends with a `tensix_sync()` (`ckernel_dest.h:56`). The wrapper's trailing `tensix_sync()` was therefore a second, redundant drain — no instruction is issued between the two, so the first already fully drains.

## Why it's safe

`tensix_sync()` is the heaviest sync primitive, and this is a pure **perf cleanup** with no behavioral change: removing a back-to-back duplicate drain cannot change ordering or correctness.

## Verification

- Quasar `compile-producer` passes (`test_eltwise_unary_datacopy_quasar`, 384 variants). No runtime behavior change to test.

## Context

Perf cleanup surfaced by the LLK race-audit (tt-llk#1658, "Perf cleanups → REDUNDANT (delete): QSR `ckernel_dest.h` `set_dest_fmt(uint32_t,int)` duplicate trailing `tensix_sync()`").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/qsr-set-dest-fmt-drop-dup-tensix-sync)