### PR TITLE
[LLK][QSR] Mask SRC_ADDR_OFFSET write in _set_packer_dest_registers_ (tt-llk#1659 N1)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -319,13 +319,17 @@ inline void _set_packer_dest_registers_()
     static_assert(DST == ckernel::DstSync::SyncHalf || DST == ckernel::DstSync::SyncFull);
     std::uint32_t dest_buffer_base_offset = (DST == ckernel::DstSync::SyncFull) ? 0 : _get_dest_buffer_base_();
 
+    // Masked write of just SRC_ADDR_OFFSET. On PACKER1 this cfg word (ADDR32 65) also holds the
+    // INSTRN_LOOP_COUNT/COUNT auto-loop bits programmed by _llk_pack_srcs_config_ (llk_srcs.h); a
+    // full-word write would zero them (per-tile in SyncHalf, once the SrcS->Packer1 path is wired).
+    // PACKER0's word has no such siblings today, but keep it masked for symmetry.
     if constexpr (PACK_SEL == p_pacr::PACK0)
     {
-        cfg[THCON_PACKER0_REG0_SRC_ADDR_OFFSET_ADDR32] = dest_buffer_base_offset;
+        cfg_rmw(THCON_PACKER0_REG0_SRC_ADDR_OFFSET_RMW, dest_buffer_base_offset);
     }
     else
     {
-        cfg[THCON_PACKER1_REG0_SRC_ADDR_OFFSET_ADDR32] = dest_buffer_base_offset;
+        cfg_rmw(THCON_PACKER1_REG0_SRC_ADDR_OFFSET_RMW, dest_buffer_base_offset);
     }
 }
 
@@ -403,8 +407,8 @@ inline tdma_descriptor_t construct_tdma_desc(
     {
         buf_desc.f.z_dim = static_cast<std::uint8_t>(compute_square_of_min(tensor_shape.num_faces_r_dim, tensor_shape.num_faces_c_dim));
     }
-    buf_desc.f.l1_addr_16B  = base_l1_16B;
-    buf_desc.f.format       = static_cast<std::uint8_t>(data_format);
+    buf_desc.f.l1_addr_16B = base_l1_16B;
+    buf_desc.f.format      = static_cast<std::uint8_t>(data_format);
 
     tdma_descriptor_t tdma_desc = {buf_desc, buf_desc_id, static_cast<std::uint8_t>(reg_data_format)};
 


### PR DESCRIPTION
## Summary

Issue https://github.com/tenstorrent/tt-llk/issues/1659

Fix N1 from the Quasar race-audit (tt-llk#1659): an **intra-thread cfg-word clobber** in `_set_packer_dest_registers_<PACK1>` (`tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h`).

`_set_packer_dest_registers_<PACK1>` did an **unmasked full-word write** of `SRC_ADDR_OFFSET`:

```cpp
cfg[THCON_PACKER1_REG0_SRC_ADDR_OFFSET_ADDR32] = dest_buffer_base_offset;   // 32-bit write
```

But `THCON_PACKER1_REG0` (cfg word **65**) also holds `INSTRN_LOOP_COUNT` and `INSTRN_COUNT` — the packer auto-loop bits programmed by `_llk_pack_srcs_config_` (`llk_srcs.h:35-36`, masked `cfg_rmw`). `SRC_ADDR_OFFSET` is `SHAMT=0, MASK=0xfffff` (low 20 bits), so the full-word write zeroes the INSTRN bits (bits ≥20). This runs **per-tile in SyncHalf**, so it repeatedly clobbers the auto-loop config.

`THCON_PACKER0_REG0` (word 49) holds only `SRC_ADDR_OFFSET` + an unused field, so the PACK0 write is harmless today.

## Fix

Use a masked `cfg_rmw` that writes only the `SRC_ADDR_OFFSET` field, preserving the sibling INSTRN bits:

```cpp
cfg_rmw(THCON_PACKER1_REG0_SRC_ADDR_OFFSET_RMW, dest_buffer_base_offset);
```

PACK0 is switched to the masked form too, for symmetry and to remove the full-word-write anti-pattern (harmless today, defensive against a future field in word 49). `SRC_ADDR_OFFSET` is `SHAMT=0`, so the masked write places the offset in the same low 20 bits as before — identical result for that field.

## Status / confidence

Currently **latent**: per the audit this bites once the SrcS→Packer1 auto-loop path is actually wired (Packer0 carries no INSTRN bits). The fix is a strictly-safe hardening — a masked RMW of the intended field can't change behavior for the `SRC_ADDR_OFFSET` write while it stops clobbering the siblings. Per the #1659 caveat, Quasar findings are lower-confidence pending RTL/owner confirmation, but this one is a deterministic word-layout overlap (verified against `quasar/cfg_defines.h`), not a HW-timing claim.

## Verification

- Verified word 65 layout (`SRC_ADDR_OFFSET` + `INSTRN_LOOP_COUNT`/`INSTRN_COUNT`) and word 49 (no INSTRN siblings) in `tt_metal/hw/inc/internal/tt-2xx/quasar/cfg_defines.h`.
- Quasar `compile-producer` passes (`test_eltwise_unary_datacopy_quasar`).

Fixes N1 of tt-llk#1659 (sub-issue of tt-llk#1658).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/qsr-set-packer-dest-masked-cfg-rmw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/qsr-set-packer-dest-masked-cfg-rmw)