### PR TITLE
[Clean up]: Add total num entries getter on DFB

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -76,8 +76,11 @@ public:
 
     uint16_t get_id() const { return logical_dfb_id_; }
 
+    // Returns the size of each entry in the DFB
     uint32_t get_entry_size() const;
     uint32_t get_stride_size() const;
+    // Returns the total number of entries that can be stored in the DFB
+    uint32_t get_total_num_entries() const;
 
     // Explicit sync APIs
     void reserve_back(uint16_t num_entries) { reserve_back_impl(num_entries); }

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -25,6 +25,8 @@ inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interf
 
 inline uint32_t DataflowBuffer::get_stride_size() const { return local_dfb_interface_.fifo_page_size; }
 
+inline uint32_t DataflowBuffer::get_total_num_entries() const { return local_dfb_interface_.fifo_num_pages; }
+
 inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
 #ifdef COMPILE_FOR_TRISC
     PACK((llk_wait_for_free_tiles<false, false, false>(logical_dfb_id_, num_entries)));

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -25,6 +25,8 @@ inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interf
 
 inline uint32_t DataflowBuffer::get_stride_size() const { return local_dfb_interface_.stride_size; }
 
+inline uint32_t DataflowBuffer::get_total_num_entries() const { return local_dfb_interface_.num_entries; }
+
 inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
     WAYPOINT("RBW");
     dfb::PackedTileCounter packed_tc =

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -81,6 +81,7 @@ struct dfb_initializer_t {  // 36 bytes
     uint32_t entry_size;
     uint32_t stride_in_entries;
     uint16_t capacity;
+    uint16_t num_entries;
     struct {
         uint16_t dm_mask : 8;         // bits 0-7: DM RISC mask
         uint16_t tensix_mask : 4;     // bits 8-11: Neo RISC mask
@@ -91,7 +92,6 @@ struct dfb_initializer_t {  // 36 bytes
     dfb_txn_id_descriptor_t consumer_txn_descriptor;
     uint8_t num_producers;
     uint8_t implicit_sync_configured; // 0: init state, 1: configured
-    uint8_t padding[2];
 } __attribute__((packed));
 
 struct dfb_initializer_per_risc_t {  // 62 bytes

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -116,6 +116,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             dfb_interface.entry_size = static_cast<uint16_t>(init_ptr->entry_size >> cb_addr_shift);
             dfb_interface.stride_size = static_cast<uint16_t>(
                 static_cast<uint32_t>(dfb_interface.entry_size) * static_cast<uint32_t>(init_ptr->stride_in_entries));
+            dfb_interface.num_entries = init_ptr->num_entries;
             dfb_interface.stride_size_tiles = static_cast<uint8_t>(init_ptr->stride_in_entries);
 #if defined(UCK_CHLKC_PACK)
             dfb_interface.wr_entry_ptr = 0;
@@ -125,6 +126,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
 #else
             dfb_interface.entry_size = init_ptr->entry_size >> cb_addr_shift;
             dfb_interface.stride_size = dfb_interface.entry_size * init_ptr->stride_in_entries;
+            dfb_interface.num_entries = init_ptr->num_entries;
 #endif
 
             for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -41,6 +41,7 @@ struct DFBTCSlot {
 struct LocalDFBInterface {
     uint16_t entry_size;
     uint16_t stride_size;
+    uint16_t num_entries;
     uint16_t wr_entry_ptr;
     uint8_t stride_size_tiles;
     uint8_t num_tcs_to_rr;
@@ -49,7 +50,7 @@ struct LocalDFBInterface {
 } __attribute__((packed));
 
 static_assert(sizeof(DFBTCSlot) == 13, "DFBTCSlot (pack TRISC) size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 87, "LocalDFBInterface (pack TRISC) size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 89, "LocalDFBInterface (pack TRISC) size is incorrect");
 
 #elif defined(COMPILE_FOR_TRISC)
 
@@ -65,6 +66,7 @@ struct DFBTCSlot {
 struct LocalDFBInterface {
     uint16_t entry_size;
     uint16_t stride_size;
+    uint16_t num_entries;
     uint8_t stride_size_tiles;
     uint8_t num_tcs_to_rr;
     uint8_t tc_idx;
@@ -73,7 +75,7 @@ struct LocalDFBInterface {
 } __attribute__((packed));
 
 static_assert(sizeof(DFBTCSlot) == 13, "DFBTCSlot (unpack TRISC) size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 86, "LocalDFBInterface (unpack TRISC) size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 88, "LocalDFBInterface (unpack TRISC) size is incorrect");
 
 #else
 
@@ -90,6 +92,7 @@ struct DFBTCSlot {
 struct LocalDFBInterface {
     uint32_t entry_size;
     uint32_t stride_size;
+    uint16_t num_entries;
 
     uint8_t num_tcs_to_rr;
     uint8_t tc_idx;
@@ -106,7 +109,7 @@ struct LocalDFBInterface {
 } __attribute__((packed));
 
 static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 121, "LocalDFBInterface size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 123, "LocalDFBInterface size is incorrect");
 
 #endif
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -420,6 +420,13 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
     init.producer_txn_descriptor = this->producer_txn_descriptor;
     init.consumer_txn_descriptor = this->consumer_txn_descriptor;
     init.implicit_sync_configured = 0;
+    TT_FATAL(
+        this->config.num_entries <= std::numeric_limits<uint16_t>::max(),
+        "DFB {}: num_entries ({}) exceeds the maximum {} representable on device",
+        this->id,
+        this->config.num_entries,
+        std::numeric_limits<uint16_t>::max());
+    init.num_entries = static_cast<uint16_t>(this->config.num_entries);
 
     log_debug(
         tt::LogMetal,


### PR DESCRIPTION
### Summary
Adding getter to get total number of tiles in a DFB. On Quasar this will return the number of entries the data buffer will store, not the capacity of entries in a particular thread


FYI @bbradelTT

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-num-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-num-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/dfb-num-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-num-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-num-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-num-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-num-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-num-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-num-entries)