### PR TITLE
[LLK] Apply MX quantization roundtrip in UntilizeGolden for MxInt formats

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3555,7 +3555,9 @@ class UntilizeGolden:
     ):
         from helpers.tilize_untilize import untilize_block
 
-        operand = quantize_input_to_unpack_format(operand, input_format)
+        operand = quantize_input_to_unpack_format(
+            operand, input_format, all_mx_formats=True
+        )
 
         result = untilize_block(
             operand, stimuli_format=data_format, dimensions=dimensions


### PR DESCRIPTION
`UntilizeGolden.__call__` called `quantize_input_to_unpack_format(operand, input_format)` with `all_mx_formats` defaulting to `False`. For MxInt8/MxInt4/MxInt2 stimuli this skips the MX pack->unpack quantization roundtrip and compares the (bit-exact) sim output against the **raw, un-quantized** input -> **392 spurious MxInt4/MxInt2 -> Float16 untilize mismatches**.

Pass `all_mx_formats=True` so MxInt formats go through `quantize_mx_tensor_chunked` (`pack_mxint*`/`unpack_mxint*`), matching hardware/sim behavior. This mirrors the MxInt-capable goldens that already pass `all_mx_formats=True` (`golden_generators.py:1628`, `:1748`) -- `UntilizeGolden` was simply missed.

- **MxFp4** (always quantized) and all **non-MX** formats are unaffected (`all_mx_formats` only gates the `is_mx_format()` MxInt branch).
- Fixes 392 `test_pack_untilize_quasar` MxInt4/MxInt2 failures (392 -> 0), allowing the `pack_untilize-MX` allowlist in craq-sim to be dropped (craq-sim #179).

Closes the golden side of craq-sim #179 (issue tt-metal#49199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/untilize-golden-mxint-quant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:codex/untilize-golden-mxint-quant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:codex/untilize-golden-mxint-quant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/untilize-golden-mxint-quant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:codex/untilize-golden-mxint-quant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/untilize-golden-mxint-quant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/untilize-golden-mxint-quant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/untilize-golden-mxint-quant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/untilize-golden-mxint-quant)