### PR TITLE
[DONT REVIEW] [LLK] reconfig-stall: drain before experimental reduce fp32 reconfig & fast_untilize base bump (tt-llk#1658 pt5)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -257,6 +257,10 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the FPU/SFPU before rewriting the SrcA ALU format + zero-substitution flag: the column-reduce
+        // MOP issued just above samples these at execute time, so a config write with no preceding stall would
+        // race an in-flight pool op. Mirrors _llk_math_set_fp32_dest_acc_ / mainline reduce. tt-llk #1658 (point 5).
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
@@ -267,6 +271,8 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the transpose replay (MOVD2B/TRNSPSRCB/MOVB2D) before restoring the format/flag it reads.
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -282,6 +282,10 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the FPU/SFPU before rewriting the SrcA ALU format + zero-substitution flag: the column-reduce
+        // MOP issued just above samples these at execute time, so a config write with no preceding stall would
+        // race an in-flight pool op. Mirrors _llk_math_set_fp32_dest_acc_ / mainline reduce. tt-llk #1658 (point 5).
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
@@ -292,6 +296,8 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the transpose replay (MOVD2B/TRNSPSRCB/MOVB2D) before restoring the format/flag it reads.
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
@@ -137,6 +137,11 @@ inline void _llk_unpack_fast_untilize_bfp_block_(const std::uint32_t address, co
 
         if (tile + 1 < unit_dim)
         {
+            // Drain the unpacker before shifting the base-address register: the current tile's UNPACR MOP
+            // (issued just above) reads THCON_SEC0_REG3_Base_address at execute time, so the CFGSHIFTMASK
+            // below must not overwrite it while that UNPACR is still in flight. A NOP bubble alone does not
+            // retire the in-flight UNPACR. tt-llk #1658 (point 5). ISA: CFGSHIFTMASK.md.
+            TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK0);
             if (use_context_0)
             {
                 TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC0_REG3_Base_address_ADDR32);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -204,6 +204,10 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the FPU/SFPU before rewriting the SrcA ALU format override + zero-substitution flag: the
+        // column-reduce MOP issued just above samples these at execute time, so a config write with no preceding
+        // stall would race an in-flight pool op. Mirrors _llk_math_set_fp32_dest_acc_. tt-llk #1658 (point 5).
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
@@ -214,6 +218,8 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the transpose replay (MOVD2B/TRNSPSRCB/MOVB2D) before restoring the format/flag it reads.
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -191,6 +191,10 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the FPU/SFPU before rewriting the SrcA ALU format override + zero-substitution flag: the
+        // column-reduce MOP issued just above samples these at execute time, so a config write with no preceding
+        // stall would race an in-flight pool op. Mirrors _llk_math_set_fp32_dest_acc_. tt-llk #1658 (point 5).
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
@@ -201,6 +205,8 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 
     if constexpr (is_fp32_dest_acc_en)
     {
+        // Drain the transpose replay (MOVD2B/TRNSPSRCB/MOVB2D) before restoring the format/flag it reads.
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
     }


### PR DESCRIPTION
THIS PR DEPENDS ON SAMPLING / LATCHING BEHAVIOR WE DONT KNOW ABOUT. THUS DRAFT DONT REVIEW

## What

Draft fix for **point 5** of the tt-llk race-audit issue [tenstorrent/tt-llk#1658](https://github.com/tenstorrent/tt-llk/issues/1658) — the *reconfig-stall* findings in the **experimental** LLK headers. These sites rewrite a config register that a Tensix backend instruction reads at execute time, without first draining the unit that reads it, so a RISC config write can land on top of an in-flight op and silently corrupt results.

All edit sites live in the tt-metal vendored `tt_metal/tt-llk/` tree (BH `llk_unpack_fast_untilize.h` does not exist upstream), so a single PR covers all of point 5.

### Sub-finding A — fp32 ALU-format reconfig in the custom block-reduce (WH + BH)

`_llk_math_reduce_block_max_row_` (and its `_runtime_` twin) flips the **SrcA ALU format** to Tf32 and disables the **src zero-substitution flag** around the transpose replay, with **no stall on either edge**:

- **Entry edge:** the preceding column-reduce MOP (`ckernel_template::run()`) may still be draining GMPOOL ops in the FPU backend when the format/flag are rewritten.
- **Exit edge:** the transpose replay (`MOVD2B` / `TRNSPSRCB` / `MOVB2D`) may still be in flight when the restore writes execute.

**Fix:** bracket both edges with `TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU)`, mirroring the canonical `_llk_math_set_fp32_dest_acc_` / mainline `llk_math_reduce.h` idiom.

### Sub-finding B — per-tile `CFGSHIFTMASK` base-address bump in fast_untilize (BH)

In the BFP block loop, the per-tile `CFGSHIFTMASK` that bumps `THCON_SEC0_REG3_Base_address` for the next tile was separated from the current tile's in-flight `UNPACR` by only a `TTI_NOP` bubble — a fixed bubble does not *retire* the in-flight unpack that still reads that base register.

**Fix:** add `TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK0)` **before** the `CFGSHIFTMASK` to drain the unpacker first. The trailing `NOP` is kept — it guards the *next* `UNPACR` against the two-cycle config-write latency (a separate edge).

## Live-vs-latent (the caller sweep the finding asked for)

- **Sub-finding A is currently LATENT.** The only in-tree consumer, `ttnn indexer_score`, hard-asserts `fp32_dest_acc_en == false` (`indexer_score_device_operation.cpp:218`: *"the custom LLK is not validated for fp32 DEST"*). No caller instantiates the `is_fp32_dest_acc_en=true` branch today — this **hardens the fp32 fallback before it is enabled**.
- **Sub-finding B is on a live path** (BFP fast-untilize block).

## Why draft / validation status

- The fp32 branches (sub-finding A) are **not instantiated by any current caller**, so neither a host build nor any in-tree test JIT-compiles them. The added lines are an exact mirror of the validated `_llk_math_set_fp32_dest_acc_` idiom, but they have **not been HW-validated** and, per the issue, the WH/BH stall choice (`MATH | WAIT_SFPU`) still merits HW confirmation.
- No regression test is included: the fp32 hazard can't be exercised without a caller that enables fp32 DEST, which the op layer currently forbids. A follow-up that enables the fp32 path + adds a targeted test is the natural place to lock this in.

Marking **draft** pending: (1) HW validation, (2) reviewer sign-off on the stall masks, (3) decision on upstreaming the reduce-custom changes to tenstorrent/tt-llk (source of truth; `fast_untilize` is tt-metal-only).

## Test plan
- [ ] CI build (JIT-compiles the live fast_untilize path)
- [ ] HW validation of the fp32 reduce path once a caller enables `fp32_dest_acc_en`
- [ ] Reviewer confirm `STALL_CFG, MATH|WAIT_SFPU` (reduce) and `STALL_UNPACK, UNPACK0` (untilize) masks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk-reconfig-stall-point5-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk-reconfig-stall-point5-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk-reconfig-stall-point5-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk-reconfig-stall-point5-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk-reconfig-stall-point5-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk-reconfig-stall-point5-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk-reconfig-stall-point5-experimental)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk-reconfig-stall-point5-experimental)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk-reconfig-stall-point5-experimental)