### PR TITLE
Fix GIL deadlock

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -94,7 +94,11 @@ void ttnn_device(nb::module_& mod) {
                 <ttnn._ttnn.device.Device object at 0x7fbac5bfc1b0>
         )doc");
 
-    mod.def("close_device", [](ttnn::MeshDevice& device) { ttnn::close_device(device); }, nb::arg("device"));
+    mod.def(
+        "close_device",
+        [](ttnn::MeshDevice& device) { ttnn::close_device(device); },
+        nb::arg("device"),
+        nb::call_guard<nb::gil_scoped_release>());
 
     mod.def(
         "deallocate_buffers",


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`ttnn.close_device()` could deadlock when an RT-profiler Python callback was registered: the binding held the GIL while `close` joined the profiler receiver thread, which could block trying to acquire the GIL to run the callback. Fixed by releasing the GIL for the close call via `nb::call_guard<nb::gil_scoped_release>()`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yusuf/fix-gil-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml/badge.svg?branch=yusuf/fix-gil-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml?query=branch:yusuf/fix-gil-deadlock)