### PR TITLE
#30282: fix(creation): ones/zeros/full_like dtype override ignored for TILE-layout device tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
@@ -56,6 +56,121 @@ def test_ones_like(device, input_shape):
 
 @pytest.mark.parametrize(
     "input_shape",
+    [[32, 32], [1, 2, 64, 64]],
+)
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype",
+    [
+        (ttnn.uint32, ttnn.bfloat16),
+        (ttnn.uint32, ttnn.float32),
+        (ttnn.bfloat16, ttnn.float32),
+        (ttnn.float32, ttnn.bfloat16),
+    ],
+)
+def test_ones_like_dtype_override(device, input_shape, input_dtype, output_dtype):
+    """ones_like must honour dtype= even for TILE-layout device tensors (issue #30282)."""
+    torch_input = torch.randint(0, 10, input_shape, dtype=torch.int32)
+    input_tensor = ttnn.from_torch(torch_input, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.ones_like(input_tensor, dtype=output_dtype)
+
+    assert ttnn.is_tensor_storage_on_device(output_tensor)
+    assert (
+        output_tensor.dtype == output_dtype
+    ), f"Expected dtype {output_dtype}, got {output_tensor.dtype} (issue #30282)"
+
+    result = ttnn.to_torch(ttnn.from_device(output_tensor))
+    expected = torch.ones(input_shape)
+    assert torch.allclose(result.float(), expected), "ones_like values are not all 1.0"
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [[32, 32], [1, 2, 64, 64]],
+)
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype",
+    [
+        (ttnn.uint32, ttnn.bfloat16),
+        (ttnn.uint32, ttnn.float32),
+        (ttnn.bfloat16, ttnn.float32),
+        (ttnn.float32, ttnn.bfloat16),
+    ],
+)
+def test_zeros_like_dtype_override(device, input_shape, input_dtype, output_dtype):
+    """zeros_like must honour dtype= even for TILE-layout device tensors (issue #30282)."""
+    torch_input = torch.randint(1, 10, input_shape, dtype=torch.int32)
+    input_tensor = ttnn.from_torch(torch_input, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.zeros_like(input_tensor, dtype=output_dtype)
+
+    assert ttnn.is_tensor_storage_on_device(output_tensor)
+    assert (
+        output_tensor.dtype == output_dtype
+    ), f"Expected dtype {output_dtype}, got {output_tensor.dtype} (issue #30282)"
+
+    result = ttnn.to_torch(ttnn.from_device(output_tensor))
+    expected = torch.zeros(input_shape)
+    assert torch.allclose(result.float(), expected), "zeros_like values are not all 0.0"
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [[32, 32], [1, 2, 64, 64]],
+)
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype, fill_value",
+    [
+        (ttnn.uint32, ttnn.bfloat16, 3.0),
+        (ttnn.uint32, ttnn.float32, -2.5),
+        (ttnn.bfloat16, ttnn.float32, 0.5),
+        (ttnn.float32, ttnn.bfloat16, 7.0),
+    ],
+)
+def test_full_like_dtype_override(device, input_shape, input_dtype, output_dtype, fill_value):
+    """full_like must honour dtype= even for TILE-layout device tensors (issue #30282)."""
+    torch_input = torch.randint(0, 10, input_shape, dtype=torch.int32)
+    input_tensor = ttnn.from_torch(torch_input, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.full_like(input_tensor, fill_value=fill_value, dtype=output_dtype)
+
+    assert ttnn.is_tensor_storage_on_device(output_tensor)
+    assert (
+        output_tensor.dtype == output_dtype
+    ), f"Expected dtype {output_dtype}, got {output_tensor.dtype} (issue #30282)"
+
+    result = ttnn.to_torch(ttnn.from_device(output_tensor))
+    expected = torch.full(input_shape, fill_value)
+    assert torch.allclose(
+        result.float(), expected, atol=1e-2
+    ), f"full_like values mismatch: expected {fill_value}, got {result.float().unique()}"
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [[32, 32], [1, 2, 64, 64]],
+)
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype",
+    [
+        (ttnn.uint32, ttnn.bfloat16),
+        (ttnn.bfloat16, ttnn.float32),
+    ],
+)
+def test_ones_like_dtype_override_row_major(device, input_shape, input_dtype, output_dtype):
+    """Verify dtype override also works with ROW_MAJOR layout (was always correct, kept for coverage)."""
+    torch_input = torch.randint(0, 10, input_shape, dtype=torch.int32)
+    input_tensor = ttnn.from_torch(torch_input, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.ones_like(input_tensor, dtype=output_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    assert output_tensor.dtype == output_dtype
+    result = ttnn.to_torch(ttnn.from_device(output_tensor))
+    assert torch.allclose(result.float(), torch.ones(input_shape)), "ones_like ROW_MAJOR values not all 1.0"
+
+
+@pytest.mark.parametrize(
+    "input_shape",
     [[32, 32], [5, 96, 64], [1, 2, 64, 64], [1, 2, 4, 64, 64]],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/creation/creation.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation.cpp
@@ -225,11 +225,13 @@ Tensor full_like_impl(
         optional_output_tensor.has_value() ? optional_output_tensor.value().dtype() : dtype.value_or(tensor.dtype());
     const bool is_tile_layout = (tensor.layout() == Layout::TILE) && (layout_value == Layout::TILE);
     if (tt::tt_metal::is_device_tensor(tensor)) {
-        // requires reference tensor to be in TILE for device operation fill - this will be changed later
+        // Fast on-device fill via SFPU kernel: only valid when the output dtype matches the input
+        // tensor's dtype. If the caller requested a dtype override, fall through to the host-side
+        // full_impl so that dtype conversion is applied correctly.
         if (is_tile_layout &&
             (dtype_value == DataType::BFLOAT8_B || dtype_value == DataType::BFLOAT16 ||
              dtype_value == DataType::FLOAT32) &&
-            tensor.storage_type() == StorageType::DEVICE) {
+            tensor.storage_type() == StorageType::DEVICE && dtype_value == tensor.dtype()) {
             return ttnn::fill(tensor, fill_value, memory_config, optional_output_tensor);
         }
         return full_impl(


### PR DESCRIPTION
### Ticket
#30282 

### PR Category
Bug fix

### Summary
ttnn.ones_like, ttnn.zeros_like, and ttnn.full_like silently ignored the dtype= argument when the input tensor was a TILE-layout device tensor. The output would always have the same dtype as the input, regardless of what was requested.

### What this PR does
Added one guard condition dtype_value == tensor.dtype() to the fast SFPU path. When dtypes match, the fast SFPU path is taken as before — zero performance regression. When dtypes differ, it falls through to the host-side full_impl which allocates a correctly-typed buffer, fills it, and uploads to device via DMA.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/ones_like_dtype_arg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/ones_like_dtype_arg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abdulla/ones_like_dtype_arg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/ones_like_dtype_arg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/ones_like_dtype_arg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/ones_like_dtype_arg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/ones_like_dtype_arg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/ones_like_dtype_arg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/ones_like_dtype_arg)