### PR TITLE
[DONT REVIEW] [LLK][srcreg] datacopy bcast: clear SrcB dvalid without flipping the bank (F-BH-10, tt-llk#1662)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -156,7 +156,10 @@ inline void _llk_math_eltwise_unary_datacopy_(
 
             cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
 
-            TTI_CLEARDVALID(0b10, 0);
+            // no-switch (reset bit1): SrcB here is math-thread scratch (MOVD2B-fed, not an unpacker fill),
+            // so releasing its dvalid must not flip the bank. The opening SETDVALID does not flip either, so
+            // this keeps the pair net-zero and avoids a tile-count-parity SrcB bank leak. tt-llk#1662
+            TTI_CLEARDVALID(0b10, 0b10);
         }
         else if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
         {
@@ -199,7 +202,10 @@ inline void _llk_math_eltwise_unary_datacopy_(
 
             cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
 
-            TTI_CLEARDVALID(0b10, 0);
+            // no-switch (reset bit1): SrcB here is math-thread scratch (MOVD2B-fed, not an unpacker fill),
+            // so releasing its dvalid must not flip the bank. The opening SETDVALID does not flip either, so
+            // this keeps the pair net-zero and avoids a tile-count-parity SrcB bank leak. tt-llk#1662
+            TTI_CLEARDVALID(0b10, 0b10);
         }
         else if constexpr (src_b_bcast_type == BroadcastType::COL)
         {
@@ -260,7 +266,10 @@ inline void _llk_math_eltwise_unary_datacopy_(
                 cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
             }
 
-            TTI_CLEARDVALID(0b10, 0);
+            // no-switch (reset bit1): SrcB here is math-thread scratch (MOVD2B-fed, not an unpacker fill),
+            // so releasing its dvalid must not flip the bank. The opening SETDVALID does not flip either, so
+            // this keeps the pair net-zero and avoids a tile-count-parity SrcB bank leak. tt-llk#1662
+            TTI_CLEARDVALID(0b10, 0b10);
         }
 
         if constexpr (src_b_bcast_type != BroadcastType::NONE)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -112,7 +112,10 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             TT_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST, tile_base + 48);
             TT_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST, tile_base + 56);
 
-            TTI_CLEARDVALID(0b10, 0);
+            // no-switch (reset bit1): SrcB here is math-thread scratch (MOVD2B-fed, not an unpacker fill),
+            // so releasing its dvalid must not flip the bank. The opening SETDVALID does not flip either, so
+            // this keeps the pair net-zero and avoids a tile-count-parity SrcB bank leak. tt-llk#1662
+            TTI_CLEARDVALID(0b10, 0b10);
         }
         else if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
         {
@@ -143,7 +146,10 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             TT_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST_D0_BRCST, tile_base + 48);
             TT_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_3, p_movb2d::MOV_8_ROW_BRCST_D0_BRCST, tile_base + 56);
 
-            TTI_CLEARDVALID(0b10, 0);
+            // no-switch (reset bit1): SrcB here is math-thread scratch (MOVD2B-fed, not an unpacker fill),
+            // so releasing its dvalid must not flip the bank. The opening SETDVALID does not flip either, so
+            // this keeps the pair net-zero and avoids a tile-count-parity SrcB bank leak. tt-llk#1662
+            TTI_CLEARDVALID(0b10, 0b10);
         }
         else if constexpr (src_b_bcast_type == BroadcastType::COL)
         {
@@ -187,7 +193,10 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
                 TT_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ZERO_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS_D0_BRCST, face_base + 28);
             }
 
-            TTI_CLEARDVALID(0b10, 0);
+            // no-switch (reset bit1): SrcB here is math-thread scratch (MOVD2B-fed, not an unpacker fill),
+            // so releasing its dvalid must not flip the bank. The opening SETDVALID does not flip either, so
+            // this keeps the pair net-zero and avoids a tile-count-parity SrcB bank leak. tt-llk#1662
+            TTI_CLEARDVALID(0b10, 0b10);
         }
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
 


### PR DESCRIPTION
## What

Fix for **srcreg F-BH-10** from the race-audit ([tenstorrent/tt-llk#1662](https://github.com/tenstorrent/tt-llk/issues/1662), sub-issue of [tenstorrent/tt-llk#1658](https://github.com/tenstorrent/tt-llk/issues/1658)).

In the 32-bit unpack-to-dest **broadcast** datacopy path (`llk_math_eltwise_unary_datacopy.h`, ROW/SCALAR/COL branches), SrcB is used purely as math-thread scratch:

```
TTI_SETDVALID(0b10);          // set SrcB dvalid on current bank — does NOT flip (0x57, TDMA)
  MOVD2B ...                  // DEST -> SrcB   (scratch; NOT an unpacker fill)
  MOVB2D ...                  // SrcB -> DEST   (the broadcast)
TTI_CLEARDVALID(0b10, 0);     // clear SrcB dvalid — AND flips the bank (SrcBBank ^= 1)
```

Per the in-tree encoding spec `instructions/assembly.yaml` (WH+BH): `SETDVALID` does not flip, but `CLEARDVALID` with `reset` bit1 = 0 does (bit1 = *"Clear dvalid but dont switch bank"*). With no matching unpacker SrcB fill on the far bank, **each broadcast tile nets one SrcB bank flip**, leaving the math-thread `SrcBBank` pointer in a **tile-count-parity-dependent** state.

## Fix

Use the no-flip encoding at all three sites, in **both** WH and BH (the audit tagged only BH, but WH has the identical construct — verified against WH `assembly.yaml` + `CLEARDVALID.md`):

```cpp
TTI_CLEARDVALID(0b10, 0b10);   // reset bit1 = "Clear dvalid but dont switch bank"
```

Since the opening `SETDVALID` doesn't flip either, the SET/CLEAR pair becomes net-zero on the bank pointer → no parity drift, deterministic post-op bank state. Correct because SrcB is scratch here (fed by `MOVD2B` from DEST, not an unpacker), so the flip served no purpose.

## Severity / caller sweep

- **LATENT-low.** Reachable via `bcast.h` (`init_bcast`/`any_tiles_bcast<bcast_type>`) → `llk_math_eltwise_unary_datacopy<A2D, …, bcast_type, unpack_to_dest=true>` when `dst_format == Float32` — i.e. the **ttnn fp32 `bcast` op** (live path).
- **No consumer depends on the post-op SrcB parity:** the unpacker in this path targets DEST (never fills SrcB), each loop iteration is self-consistent under either encoding, and the next op re-inits. The fix strictly *removes* a state mutation that had no matching producer, so it cannot break a correct unpacker handshake — it only removes the tile-count-parity leak.

## Grounding

- Instruction semantics: `tt_llk_{blackhole,wormhole_b0}/instructions/assembly.yaml` (`CLEARDVALID` reset-bit layout; `SETDVALID` = TDMA, no flip) + WH `CLEARDVALID.md`.
- Live path + survive-to-consumer sweep: `bcast.h`, `llk_math_unary_datacopy_api.h`.

## Draft / validation status

Marking **draft** pending **on-HW regression of the fp32 `bcast` op (ROW/COL/SCALAR) on WH + BH** — the one thing static analysis can't fully close is confirming no caller relies on the current flip in practice (the survive-to-consumer check). clang-format + pre-commit (incl. codespell) pass. Should also be upstreamed to tenstorrent/tt-llk (mainline `llk_lib` file; source of truth).

## Test plan
- [ ] CI build (JIT-compiles the live fp32 bcast path)
- [ ] HW: fp32 `bcast` add/sub/mul, ROW + COL + SCALAR, multi-tile (odd & even tile counts), WH + BH
- [ ] Reviewer confirm the no-switch encoding is desired here (SrcB-as-scratch)

Closes tenstorrent/tt-llk#1662 (pending validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk-srcreg-cleardvalid-noswitch-fbh10)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk-srcreg-cleardvalid-noswitch-fbh10)