### PR TITLE
[LLK][srcreg] move_d2a_row_broadcast_fixed_face: add SRCA_VLD stall before MOVD2A run (F-WH-13/F-BH-12, tt-llk#1664)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
@@ -139,6 +139,9 @@ inline void move_d2b_fixed_face(const std::uint8_t addrmod)
 
 inline void move_d2a_row_broadcast_fixed_face(const std::uint8_t addrmod)
 {
+    // MOVD2A does not auto-wait for SrcA[MatrixUnit.SrcABank].AllowedClient == MatrixUnit, so gate on SRCA_VLD
+    // before the row moves (mirrors move_d2b_fixed_face's SRCB_VLD wait). See llk_math_transpose_dest.h. tt-llk#1664.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
     // // Seems to make things 200 clocks slower. Really shouldn't though.
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, addrmod, p_movd2a::MOV_1_ROW, 0);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 1, addrmod, p_movd2a::MOV_1_ROW, 0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -56,9 +56,9 @@ enum class SrcZeroFlagState : std::uint8_t
     MOV_OPS        = 3,
 };
 
-static SrcZeroFlagState src_zero_flag_state    = SrcZeroFlagState::UNCONFIGURED;
-static std::uint32_t    src_zero_flag_srca_fmt = 0xff;
-static std::uint32_t    src_zero_flag_srcb_fmt = 0xff;
+static SrcZeroFlagState src_zero_flag_state = SrcZeroFlagState::UNCONFIGURED;
+static std::uint32_t src_zero_flag_srca_fmt = 0xff;
+static std::uint32_t src_zero_flag_srcb_fmt = 0xff;
 
 inline void _configure_src_zero_flag_(const bool disable)
 {
@@ -138,6 +138,9 @@ inline void move_d2b_fixed_face(const std::uint8_t addrmod)
 
 inline void move_d2a_row_broadcast_fixed_face(const std::uint8_t addrmod)
 {
+    // MOVD2A does not auto-wait for SrcA[MatrixUnit.SrcABank].AllowedClient == MatrixUnit, so gate on SRCA_VLD
+    // before the row moves (mirrors move_d2b_fixed_face's SRCB_VLD wait). See llk_math_transpose_dest.h. tt-llk#1664.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
     // // Seems to make things 200 clocks slower. Really shouldn't though.
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, addrmod, p_movd2a::MOV_1_ROW, 0);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 1, addrmod, p_movd2a::MOV_1_ROW, 0);


### PR DESCRIPTION
## What

Fix for **srcreg F-WH-13 / F-BH-12** ([tenstorrent/tt-llk#1664](https://github.com/tenstorrent/tt-llk/issues/1664), sub-issue of [tenstorrent/tt-llk#1658](https://github.com/tenstorrent/tt-llk/issues/1658)).

`move_d2a_row_broadcast_fixed_face` (WH+BH `common/inc/cmath_common.h`) issues 16 back-to-back `MOVD2A` (dest → SrcA) with **no preceding `STALLWAIT`**. `MOVD2A` does not auto-wait for the SrcA bank to be owned by the Matrix Unit (`SrcA[MatrixUnit.SrcABank].AllowedClient == MatrixUnit`), so an explicit `STALLWAIT(STALL_MATH, SRCA_VLD)` is required before the first move — otherwise it can write SrcA before the bank is handed over → wrong-bank / torn write.

## Fix

Prepend the SrcA bank-valid wait, in both WH and BH:

```cpp
TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
```

This mirrors the SrcB twin `move_d2b_fixed_face` (which already does `STALLWAIT(STALL_MATH, SRCB_VLD)`), and matches the requirement documented in `llk_math_transpose_dest.h`:
> *"Wait condition SRCA_VLD is required as MOVD2A doesn't automatically wait for `SrcA[MatrixUnit.SrcABank].AllowedClient == SrcClient::MatrixUnit`."*

## Severity: LATENT (dead code today)

Whole-repo sweep: `move_d2a_row_broadcast_fixed_face` has **zero callers** in WH and BH (and doesn't exist in QSR). So the missing stall never executes today — this is **defensive hardening** so a future caller that resurrects the row-broadcast helper inherits the correct SrcA handshake, symmetric with `move_d2b_fixed_face`. (Deletion of the dead helper was the alternative; per the issue direction we keep + fix it.)

## Grounding & confidence

Unlike some of the other race-audit items, this one is fully code/ISA-grounded and has no hidden double-flip subtlety: the `MOVD2A`+`SRCA_VLD` requirement is stated verbatim in `llk_math_transpose_dest.h`, and the live sibling `move_d2b_fixed_face` already implements the identical pattern for SrcB. No HW confirmation needed.

## Notes
- The old inline note *"Seems to make things 200 clocks slower"* suggests this wait may have been dropped for perf at some point; moot now (dead code), and correctness > perf for a helper that must be correct when reused.
- clang-format (pre-commit) also re-formatted three unrelated declaration lines in the WH file.
- Should be upstreamed to tenstorrent/tt-llk (mainline `common/inc` file).

Closes tenstorrent/tt-llk#1664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk-srcreg-movd2a-srca-vld-fwh13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk-srcreg-movd2a-srca-vld-fwh13)