### PR TITLE
Add unsigned integer support for relu and reglu

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -243,6 +243,181 @@ def test_relu(device, h, w, layout):
     run_unary_test(device, h, w, ttnn.relu, layout=layout, ulp=0)
 
 
+def create_banded_range_tensor(input_shape, value_ranges, dtype=torch.uint32):
+    num_elements = torch.prod(torch.tensor(input_shape)).item()
+    per_range = num_elements // len(value_ranges)
+    remainder = num_elements % len(value_ranges)
+
+    segments = []
+    for i, (low, high) in enumerate(value_ranges):
+        n = per_range + (1 if i < remainder else 0)
+        segments.append(torch.linspace(low, high, steps=n, dtype=torch.float64))
+    return torch.cat(segments).to(dtype).reshape(input_shape)
+
+
+@pytest.mark.parametrize("input_shapes", [torch.Size([1, 2, 32, 128])])
+@pytest.mark.parametrize(
+    "value_ranges",
+    [
+        [
+            (0, 300),
+            (300, 1000),
+            (1000, 1e4),
+            (1e4, 1e5),
+            (1e5, 1e6),
+            (1e6, 1e7),
+            (1e7, 1e8),
+            (1e8, 1e9),
+            (1e9, 2147483647),
+            (2147483648, 4294967295),
+        ]
+    ],
+)
+def test_relu_uint32_full_range(device, input_shapes, value_ranges):
+    torch_input_tensor = create_banded_range_tensor(input_shapes, value_ranges, dtype=torch.uint32)
+
+    golden_function = ttnn.get_golden_function(ttnn.relu)
+    torch_output_tensor = golden_function(torch_input_tensor.to(torch.int64), device=device).to(torch.uint32)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.to_torch(ttnn.relu(input_tensor), dtype=torch.uint32)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+def test_relu_reglu_uint32_edge_cases(device):
+    values = [0, 1, 35, 41, 600, 2147483647, 2147483648, 4294967295]
+    torch_input_tensor = torch.tensor([values], dtype=torch.int64).to(torch.uint32)
+
+    golden_function = ttnn.get_golden_function(ttnn.relu)
+    torch_output_tensor = golden_function(torch_input_tensor.to(torch.int64), device=device).to(torch.uint32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint32, device=device, layout=ttnn.TILE_LAYOUT)
+
+    relu_out = ttnn.to_torch(ttnn.relu(input_tensor), dtype=torch.uint32)
+    assert torch.equal(relu_out, torch_output_tensor)
+
+    chain_out = ttnn.to_torch(
+        ttnn.unary_chain(input_tensor, [ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)]), dtype=torch.uint32
+    )
+
+    assert torch.equal(chain_out, torch_output_tensor)
+
+    multiplier = torch.ones((1, 1, 32, 32), dtype=torch.int64).to(torch.uint32)
+    gate_values = [0, 1, 600, 2147483647, 2147483648, 4294967295]
+    gate = torch.tensor((gate_values * 171)[: 32 * 32], dtype=torch.int64).to(torch.uint32).reshape(1, 1, 32, 32)
+    torch_reglu_input = torch.cat([multiplier, gate], dim=-1)
+
+    reglu_golden = ttnn.get_golden_function(ttnn.reglu)
+    torch_reglu_output = reglu_golden(torch_reglu_input.to(torch.int64), -1).to(torch.uint32)
+
+    reglu_input = ttnn.from_torch(torch_reglu_input, dtype=ttnn.uint32, device=device, layout=ttnn.TILE_LAYOUT)
+    reglu_out = ttnn.to_torch(ttnn.reglu(reglu_input, -1), dtype=torch.uint32)
+
+    assert torch.equal(reglu_out, torch_reglu_output)
+
+
+@pytest.mark.parametrize("input_shapes", [torch.Size([1, 2, 32, 128])])
+@pytest.mark.parametrize(
+    "value_ranges",
+    [
+        [
+            (0, 300),
+            (300, 1000),
+            (1000, 1e4),
+            (1e4, 1e5),
+            (1e5, 1e6),
+            (1e6, 1e7),
+            (1e7, 1e8),
+            (1e8, 1e9),
+            (1e9, 2147483647),
+            (2147483648, 4294967295),
+        ]
+    ],
+)
+def test_reglu_uint32_full_range(device, input_shapes, value_ranges):
+    gate = create_banded_range_tensor(input_shapes, value_ranges, dtype=torch.uint32)
+    multiplier = torch.ones(input_shapes, dtype=torch.int64).to(torch.uint32)
+    torch_reglu_input = torch.cat([multiplier, gate], dim=-1)
+
+    reglu_golden = ttnn.get_golden_function(ttnn.reglu)
+    torch_reglu_output = reglu_golden(torch_reglu_input.to(torch.int64), -1).to(torch.uint32)
+
+    reglu_input = ttnn.from_torch(
+        torch_reglu_input,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    reglu_out = ttnn.to_torch(ttnn.reglu(reglu_input, -1), dtype=torch.uint32)
+
+    assert torch.equal(reglu_out, torch_reglu_output)
+
+
+def test_reglu_uint16_full_range(device):
+    # UINT8 is not supported since multiply has no uint8 path.
+    gate = create_banded_range_tensor((1, 1, 256, 256), [(0, 65535)], dtype=torch.uint16)
+    multiplier = torch.ones((1, 1, 256, 256), dtype=torch.int64).to(torch.uint16)
+    torch_reglu_input = torch.cat([multiplier, gate], dim=-1)
+
+    reglu_golden = ttnn.get_golden_function(ttnn.reglu)
+    torch_reglu_output = reglu_golden(torch_reglu_input.to(torch.int64), -1).to(torch.uint16)
+
+    reglu_input = ttnn.from_torch(
+        torch_reglu_input,
+        dtype=ttnn.uint16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    reglu_out = ttnn.to_torch(ttnn.reglu(reglu_input, -1), dtype=torch.uint16)
+
+    assert torch.equal(reglu_out, torch_reglu_output)
+
+
+def test_relu_uint8_full_range(device):
+    torch_input_tensor = torch.arange(256, dtype=torch.uint8).reshape(1, 1, 8, 32)
+
+    golden_function = ttnn.get_golden_function(ttnn.relu)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.uint8,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.to_torch(ttnn.relu(input_tensor), dtype=torch.uint8)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+def test_relu_uint16_full_range(device):
+    torch_input_tensor = create_banded_range_tensor((1, 1, 256, 256), [(0, 65535)], dtype=torch.uint16)
+
+    golden_function = ttnn.get_golden_function(ttnn.relu)
+    torch_output_tensor = golden_function(torch_input_tensor.to(torch.int64), device=device).to(torch.uint16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.uint16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.to_torch(ttnn.relu(input_tensor), dtype=torch.uint16)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -343,11 +343,11 @@ def test_relu_reglu_uint32_edge_cases(device):
 )
 def test_reglu_uint32_full_range(device, input_shapes, value_ranges):
     gate = create_banded_range_tensor(input_shapes, value_ranges, dtype=torch.uint32)
-    multiplier = torch.ones(input_shapes, dtype=torch.int64).to(torch.uint32)
+    multiplier = (gate.to(torch.int64) // 2).to(torch.uint32)
     torch_reglu_input = torch.cat([multiplier, gate], dim=-1)
 
     reglu_golden = ttnn.get_golden_function(ttnn.reglu)
-    torch_reglu_output = reglu_golden(torch_reglu_input.to(torch.int64), -1).to(torch.uint32)
+    torch_reglu_output = (reglu_golden(torch_reglu_input.to(torch.int64), -1) % (2**32)).to(torch.uint32)
 
     reglu_input = ttnn.from_torch(
         torch_reglu_input,
@@ -362,13 +362,12 @@ def test_reglu_uint32_full_range(device, input_shapes, value_ranges):
 
 
 def test_reglu_uint16_full_range(device):
-    # UINT8 is not supported since multiply has no uint8 path.
     gate = create_banded_range_tensor((1, 1, 256, 256), [(0, 65535)], dtype=torch.uint16)
-    multiplier = torch.ones((1, 1, 256, 256), dtype=torch.int64).to(torch.uint16)
+    multiplier = (gate.to(torch.int64) // 2).to(torch.uint16)
     torch_reglu_input = torch.cat([multiplier, gate], dim=-1)
 
     reglu_golden = ttnn.get_golden_function(ttnn.reglu)
-    torch_reglu_output = reglu_golden(torch_reglu_input.to(torch.int64), -1).to(torch.uint16)
+    torch_reglu_output = (reglu_golden(torch_reglu_input.to(torch.int64), -1) % (2**16)).to(torch.uint16)
 
     reglu_input = ttnn.from_torch(
         torch_reglu_input,
@@ -383,10 +382,10 @@ def test_reglu_uint16_full_range(device):
 
 
 def test_relu_uint8_full_range(device):
-    torch_input_tensor = torch.arange(256, dtype=torch.uint8).reshape(1, 1, 8, 32)
+    torch_input_tensor = create_banded_range_tensor((1, 1, 32, 32), [(0, 255)], dtype=torch.uint8)
 
     golden_function = ttnn.get_golden_function(ttnn.relu)
-    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+    torch_output_tensor = golden_function(torch_input_tensor.to(torch.int64), device=device).to(torch.uint8)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -674,10 +674,14 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
         case UnaryOpType::RELU:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            // For unsigned inputs, relu is the identity. Emit an empty op so the tile is just copied.
+            if (input_dtype == DataType::UINT32 || input_dtype == DataType::UINT16 || input_dtype == DataType::UINT8) {
+                return {};
+            }
             if (input_dtype == DataType::INT32) {
                 return {"relu_tile_init();", fmt::format("relu_tile_int32({});", idst)};
             }
-            return {"relu_tile_init();", fmt::format("        relu_tile({});", idst)};
+            return {"relu_tile_init();", fmt::format("relu_tile({});", idst)};
 
         case UnaryOpType::SIGNBIT:
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -1793,7 +1793,7 @@ void py_module(nb::module_& mod) {
         &ttnn::relu,
         R"doc(\mathrm{{output\_tensor}}_i = \verb|relu|(\mathrm{{input\_tensor}}_i))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16, UINT8)doc");
     bind_unary_operation_subcoregrids<"relu6">(
         mod,
         &ttnn::relu6,
@@ -2022,7 +2022,7 @@ void py_module(nb::module_& mod) {
         "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)",
         "Split the tensor into two parts, apply the ReLU function on the second tensor, and then perform "
         "multiplication with the first tensor.",
-        R"doc(BFLOAT16, BFLOAT8_B)doc",
+        R"doc(BFLOAT16, BFLOAT8_B, UINT32, UINT16)doc",
         R"doc(System memory is not supported.
 
            Last dimension of input tensor should be divisible by 64.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/48763
https://github.com/tenstorrent/tt-metal/issues/27621

### Problem
Unsigned-int ReLU returned 0 for every positive input (relu, unary_chain, reglu on uint32/uint8). 

### Fix
- relu(x) = x for any unsigned value, so unsigned ReLU is just an identity copy. In unary_op_utils.cpp, route UINT8/UINT16/UINT32 ReLU to an empty init pair.
- Since reglu = multiply(split[0], relu(split[1])), it also supports u32, u16.
- Reglu doesn't support u8 since its internal ttnn::multiply does not support u8.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/relu_unsigned)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/relu_unsigned)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anasuya/relu_unsigned)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/relu_unsigned)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/relu_unsigned)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/relu_unsigned)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/relu_unsigned)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/relu_unsigned)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/relu_unsigned)