### PR TITLE
#48688: [ttnn][tilize] Fix crash when DRAM-backed sharded tensor routed into zero-copy optimized factory

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -548,6 +548,43 @@ def test_tilize_width_sharded_dram_input_45331(device, shard_shape):
     assert torch.equal(torch_tensor, torch_out), "tilize round-trip mismatch"
 
 
+@pytest.mark.parametrize(
+    "shard_type,shard_shape",
+    [
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, (512, 64)),
+        (ttnn.TensorMemoryLayout.WIDTH_SHARDED, (32, 128)),
+    ],
+    ids=["height_sharded_dram", "width_sharded_dram"],
+)
+def test_tilize_dram_backed_sharded_input(device, shard_type, shard_shape):
+    torch.manual_seed(0)
+    num_cores = 4
+    shard_h, shard_w = shard_shape
+    if shard_type == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+        tensor_shape = (shard_h * num_cores, shard_w)
+    else:
+        tensor_shape = (shard_h, shard_w * num_cores)
+    torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    dram_sharded_cfg = ttnn.MemoryConfig(shard_type, ttnn.BufferType.DRAM, shard_spec)
+
+    tt_rm = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=dram_sharded_cfg,
+        device=device,
+    )
+
+    tt_tile = ttnn.tilize(tt_rm, memory_config=dram_sharded_cfg, use_multicore=True)
+
+    assert tt_tile.layout == ttnn.TILE_LAYOUT
+    torch_out = ttnn.to_torch(tt_tile)
+    assert torch.equal(torch_tensor, torch_out), "tilize round-trip mismatch on DRAM-backed sharded input"
+
+
 # fp8 is a valid tile INPUT (it tilizes to any float TILE output) though ROW_MAJOR-only as a dtype. Even
 # tile-widths only (odd fp8 widths hit a separate reader NoC bug); golden is the host-quantized fp8 source.
 @run_for_blackhole()

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -27,6 +27,12 @@ bool can_use_sharded_optimized_factories(
         return false;
     }
 
+    // The optimized factory aliases the input CB directly to the input shard buffer (zero-copy read).
+    // CBs can only reside in L1, so a DRAM-backed input shard is always incompatible.
+    if (input_tensor.memory_config().buffer_type() != BufferType::L1) {
+        return false;
+    }
+
     auto memory_layout = input_tensor.memory_config().memory_layout();
     if (memory_layout != TensorMemoryLayout::HEIGHT_SHARDED && memory_layout != TensorMemoryLayout::WIDTH_SHARDED &&
         memory_layout != TensorMemoryLayout::BLOCK_SHARDED) {
@@ -67,7 +73,11 @@ bool can_use_sharded_optimized_factories(
                 // so there is no performance benefit from the optimized path. Fall back to the default factory.
                 return false;
             }
-        } else if (out_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
+        } else if (out_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            if (operation_attributes.output_mem_config.buffer_type() == BufferType::DRAM) {
+                return false;  // CBs cannot be backed by DRAM; sharded output must be L1.
+            }
+        } else {
             return false;  // Only same-layout or L1 INTERLEAVED output supported for HEIGHT_SHARDED.
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -27,9 +27,12 @@ bool can_use_sharded_optimized_factories(
         return false;
     }
 
-    // The optimized factory aliases the input CB directly to the input shard buffer (zero-copy read).
-    // CBs can only reside in L1, so a DRAM-backed input shard is always incompatible.
+    // The optimized factory aliases CBs directly to the input and output shard buffers (zero-copy).
+    // CBs can only reside in L1, so any DRAM-backed input or output is always incompatible.
     if (input_tensor.memory_config().buffer_type() != BufferType::L1) {
+        return false;
+    }
+    if (operation_attributes.output_mem_config.buffer_type() != BufferType::L1) {
         return false;
     }
 
@@ -50,12 +53,9 @@ bool can_use_sharded_optimized_factories(
         if (operation_attributes.output_mem_config.shard_spec().value().shape[0] % tt::constants::TILE_HEIGHT != 0) {
             return false;
         }
-        if (operation_attributes.output_mem_config.buffer_type() == BufferType::DRAM) {
-            return false;
-        }
     }
 
-    // HEIGHT_SHARDED supports both same-layout sharded output and INTERLEAVED (L1/DRAM) output.
+    // HEIGHT_SHARDED supports both same-layout sharded output and INTERLEAVED L1 output.
     // The INTERLEAVED output path uses a contiguous tile-start-id assignment, which is only
     // correct for ROW_MAJOR shard orientation (shards are ordered row-wise matching the output).
     if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
@@ -68,26 +68,14 @@ bool can_use_sharded_optimized_factories(
             if (shard.orientation != ShardOrientation::ROW_MAJOR) {
                 return false;
             }
-            if (operation_attributes.output_mem_config.buffer_type() == BufferType::DRAM) {
-                // DRAM interleaved output always requires NoC writes regardless of the factory used,
-                // so there is no performance benefit from the optimized path. Fall back to the default factory.
-                return false;
-            }
-        } else if (out_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-            if (operation_attributes.output_mem_config.buffer_type() == BufferType::DRAM) {
-                return false;  // CBs cannot be backed by DRAM; sharded output must be L1.
-            }
-        } else {
+        } else if (out_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
             return false;  // Only same-layout or L1 INTERLEAVED output supported for HEIGHT_SHARDED.
         }
     }
 
     if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED || memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        // WIDTH_SHARDED and BLOCK_SHARDED only support same-layout sharded L1 output.
+        // WIDTH_SHARDED and BLOCK_SHARDED only support same-layout sharded output.
         if (operation_attributes.output_mem_config.memory_layout() != memory_layout) {
-            return false;
-        }
-        if (operation_attributes.output_mem_config.buffer_type() == BufferType::DRAM) {
             return false;
         }
     }


### PR DESCRIPTION
### Ticket
#48688 #49337

### PR Category
Bug fix

### Summary

**Operation:** `ttnn::tilize` (`tilize_device_operation.cpp`)

**Failing test:** `test_reduce_scatter_async_sharded_to_sharded`
**Failure:**
```
RuntimeError: TT_THROW @ circular_buffer_config.cpp:222:
Only L1 buffers can have an associated circular buffer!
```

### Root cause

PR #48761 optimized `ttnn::tilize` by introducing `TilizeMultiCoreShardedProgramFactory`, which zero-copy aliases Circular Buffers directly to the input/output shard buffers. It also restructured `can_use_sharded_optimized_factories` but inadvertently removed the DRAM guard for HEIGHT_SHARDED outputs. This allowed DRAM-backed sharded tensors to be routed into the optimized factory — but CBs can only reside in L1, not DRAM, so Program construction crashed.

### What this PR does

- Adds an early L1 guard in `can_use_sharded_optimized_factories`: any input whose `buffer_type()` is not `BufferType::L1` immediately falls back to `TilizeMultiCoreDefaultProgramFactory` (the NoC path).
- Restores the HEIGHT_SHARDED output DRAM guard that was removed by #48761.
- Adds `test_tilize_dram_backed_sharded_input_48688` as a direct regression test covering HEIGHT_SHARDED and WIDTH_SHARDED DRAM-backed inputs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/fix_48761)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/fix_48761)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abdulla/fix_48761)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/fix_48761)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/fix_48761)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/fix_48761)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/fix_48761)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/fix_48761)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/fix_48761)