### PR TITLE
[Bug fix] Health check test fix

### DIFF
--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -11,7 +11,31 @@
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
 
+#include <unordered_set>
+
 namespace tt::tt_metal {
+
+// Returns the device's active ethernet cores whose link stays *within* the opened
+// cluster. Cores whose link leaves the cluster to a remote MMIO device (another host /
+// an unopened chip) are excluded: they are derived from get_ethernet_connections(),
+// which only tracks intra-cluster links. Calling get_connected_ethernet_core() on an
+// off-cluster core TT_FATALs ("connects to a remote mmio device") even though the link
+// is up, so callers must iterate this set instead of get_active_ethernet_cores(). Reserved
+// dispatch/tunnel cores stay excluded via get_active_ethernet_cores(true).
+static inline std::unordered_set<CoreCoord> get_intra_cluster_active_eth_cores(IDevice* device) {
+    const auto& cluster = MetalContext::instance().get_cluster();
+    std::unordered_set<CoreCoord> intra_cluster;
+    for (const auto& [peer_chip, cores] : cluster.get_ethernet_cores_grouped_by_connected_chips(device->id())) {
+        intra_cluster.insert(cores.begin(), cores.end());
+    }
+    std::unordered_set<CoreCoord> result;
+    for (const auto& core : device->get_active_ethernet_cores(true)) {
+        if (intra_cluster.contains(core)) {
+            result.insert(core);
+        }
+    }
+    return result;
+}
 
 static inline void prepare_sender(
     tt::tt_metal::IDevice* const send_device,

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
@@ -101,7 +101,7 @@ TEST_F(UnitMeshCQProgramFixture, TensixDeploymentEthernetBandwidth) {
                 sender_device->id(),
                 receiver_device->id());
 
-            for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+            for (const auto& sender_core : get_intra_cluster_active_eth_cores(sender_device)) {
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
@@ -212,7 +212,7 @@ TEST_F(UnitMeshCQProgramFixture, TensixDeploymentEthernetBandwidthBidir) {
                 sender_device->id(),
                 receiver_device->id());
 
-            for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+            for (const auto& sender_core : get_intra_cluster_active_eth_cores(sender_device)) {
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
@@ -214,7 +214,7 @@ TEST_F(UnitMeshCQProgramFixture, TensixDeploymentEthernetDataIntegrityDram) {
                 sender_device->id(),
                 receiver_device->id());
 
-            for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+            for (const auto& sender_core : get_intra_cluster_active_eth_cores(sender_device)) {
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
@@ -9,6 +9,8 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 
+#include <unordered_set>
+
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
@@ -85,8 +87,22 @@ TEST_F(UnitMeshCQProgramFixture, TensixDeploymentEthernetLinkUp) {
 
     SignalGuard g(SIGINT, handle_sigint);
 
+    const auto& cluster = MetalContext::instance().get_cluster();
+
     for (const auto& sender_mesh_device : devices_) {
         auto* const sender_device = sender_mesh_device->get_devices()[0];
+
+        // Active eth cores whose link stays *within* the opened cluster. This is
+        // derived from get_ethernet_connections(), so cores whose link leaves the
+        // cluster to a remote MMIO device (another host / an unopened chip) are
+        // excluded. Calling get_connected_ethernet_core() on such a core TT_FATALs
+        // ("connects to a remote mmio device", tt_cluster.cpp), even though the link
+        // is up, so those cores must be skipped rather than tested.
+        std::unordered_set<CoreCoord> intra_cluster_cores;
+        for (const auto& [peer_chip, cores] : cluster.get_ethernet_cores_grouped_by_connected_chips(sender_device->id())) {
+            intra_cluster_cores.insert(cores.begin(), cores.end());
+        }
+
         for (const auto& receiver_mesh_device : devices_) {
             auto* const receiver_device = receiver_mesh_device->get_devices()[0];
 
@@ -97,6 +113,10 @@ TEST_F(UnitMeshCQProgramFixture, TensixDeploymentEthernetLinkUp) {
                 receiver_device->id());
 
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+                if (!intra_cluster_cores.contains(sender_core)) {
+                    continue;
+                }
+
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
 
                 if (receiver_device->id() != device_id) {

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
@@ -9,8 +9,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 
-#include <unordered_set>
-
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
@@ -87,21 +85,8 @@ TEST_F(UnitMeshCQProgramFixture, TensixDeploymentEthernetLinkUp) {
 
     SignalGuard g(SIGINT, handle_sigint);
 
-    const auto& cluster = MetalContext::instance().get_cluster();
-
     for (const auto& sender_mesh_device : devices_) {
         auto* const sender_device = sender_mesh_device->get_devices()[0];
-
-        // Active eth cores whose link stays *within* the opened cluster. This is
-        // derived from get_ethernet_connections(), so cores whose link leaves the
-        // cluster to a remote MMIO device (another host / an unopened chip) are
-        // excluded. Calling get_connected_ethernet_core() on such a core TT_FATALs
-        // ("connects to a remote mmio device", tt_cluster.cpp), even though the link
-        // is up, so those cores must be skipped rather than tested.
-        std::unordered_set<CoreCoord> intra_cluster_cores;
-        for (const auto& [peer_chip, cores] : cluster.get_ethernet_cores_grouped_by_connected_chips(sender_device->id())) {
-            intra_cluster_cores.insert(cores.begin(), cores.end());
-        }
 
         for (const auto& receiver_mesh_device : devices_) {
             auto* const receiver_device = receiver_mesh_device->get_devices()[0];
@@ -112,11 +97,7 @@ TEST_F(UnitMeshCQProgramFixture, TensixDeploymentEthernetLinkUp) {
                 sender_device->id(),
                 receiver_device->id());
 
-            for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
-                if (!intra_cluster_cores.contains(sender_core)) {
-                    continue;
-                }
-
+            for (const auto& sender_core : get_intra_cluster_active_eth_cores(sender_device)) {
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
 
                 if (receiver_device->id() != device_id) {


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The ethernet deployment tests abort with a `TT_FATAL` when a chip has an active ethernet link that leaves the opened cluster:

```
2026-07-07 08:28:31.012 | critical |          Always | TT_FATAL: Chip 0 logical eth core 0-9 connects to a remote mmio device (assert.hpp:104)
unknown file: Failure
C++ exception with description "TT_FATAL @ /data/local-syseng-manual/tt-metal-mgajewski/tt_metal/llrt/tt_cluster.cpp:1399: ethernet_connections_within_cluster.contains(std::get<0>(eth_core)) and ethernet_connections_within_cluster.at(std::get<0>(eth_core)).contains(eth_chan)
info:
Chip 0 logical eth core 0-9 connects to a remote mmio device
backtrace:
```

Each test iterated `get_active_ethernet_cores()` and called `get_connected_ethernet_core()` unconditionally. That call only resolves peers **within** the opened cluster; when a core's link is up but terminates on a remote MMIO device (another host / an unopened chip), it fatals and takes down the whole test. The usual `is_ethernet_link_up()` guard other eth tests use does **not** help here — the link is up; the problem is that the peer is off-cluster. The same unguarded pattern was copy-pasted across the suite, so `eth_link_up`, `eth_bandwidth`, `eth_bandwidth_bidir`, and `eth_data_integrity_dram` all crashed the same way.

#### What changed

- Added a shared `get_intra_cluster_active_eth_cores()` helper in `eth/common.hpp` that returns a device's active eth cores filtered to those whose peer is inside the cluster. It intersects `get_active_ethernet_cores(true)` (reserved dispatch/tunnel cores stay excluded) with the intra-cluster set from `Cluster::get_ethernet_cores_grouped_by_connected_chips()` (built from `get_ethernet_connections()`, so remote-MMIO links are excluded by construction).
- Switched `test_eth_link_up`, `test_eth_bandwidth`, `test_eth_bandwidth_bidir`, and `test_eth_data_integrity_dram` to iterate this helper instead of calling `get_connected_ethernet_core()` on every active core. Off-cluster links are skipped; in-cluster links are tested exactly as before.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/#0-Health-check-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/#0-Health-check-test-fix)