### PR TITLE
[Feature] GroupNorm: Added FP32 support to GroupNorm across interleaved and sharded (Welford and legacy) configurations

### DIFF
--- a/models/demos/vision/generative/stable_diffusion/wormhole/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -278,7 +278,6 @@ class resnetBlock2D:
             epsilon=eps,
             memory_config=ttnn.get_memory_config(hidden_states),
             core_grid=self.first_group_norm_core_grid,
-            dtype=ttnn.bfloat8_b,
         )
         hidden_states = ttnn.reshape(
             hidden_states,
@@ -394,7 +393,6 @@ class resnetBlock2D:
             epsilon=eps,
             memory_config=self.second_gn_expected_input_sharded_memory_config,
             core_grid=self.second_group_norm_core_grid,
-            dtype=ttnn.bfloat8_b,
         )
         hidden_states = ttnn.reshape(
             hidden_states,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -26,21 +26,10 @@ HEIGHT_SHARDED_SHAPES = [
     (1, 320, 32, 32, 16),
 ]
 
-# GroupNorm coverage shapes for the fp32/bf16 all-config tests. Interleaved shapes are
-# (N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x); sharded shapes are
+# GroupNorm coverage shapes for the fp32/bf16 sharded all-config tests. Shapes are
 # (N, C, H, W, num_groups, grid_y, grid_x) where grid_y == 1 is height-sharded and grid_y > 1 is
-# block-sharded. Chosen to cover single-core, sub-tile group widths, batch > 1, and num_out_blocks
-# slicing (see also GN_INTERLEAVED_SHAPES in test_group_norm_DRAM.py).
-GN_INTERLEAVED_SHAPES = [
-    (1, 320, 32, 32, 16, 1, 1, 8),  # base config (original single-shape test)
-    (1, 480, 1, 64, 8, 1, 1, 1),  # single core, last group ends less than max tile span
-    (1, 768, 1, 512, 32, 2, 8, 8),  # group channel count less than tile size
-    (2, 768, 1, 512, 32, 2, 8, 8),  # batch 2 (still multicast), num_out_blocks 2
-    (1, 2560, 1, 512, 32, 2, 8, 8),  # mcast num_out_blocks 2
-    (1, 128, 1, 512, 32, 2, 4, 4),  # all groups on core fit in less than one tile
-    (8, 768, 1, 512, 32, 3, 8, 8),  # batch 8 (no multicast), uneven num_out_blocks divisor
-]
-
+# block-sharded. Chosen to cover single-core, sub-tile group widths, and batch > 1.
+# (Interleaved/DRAM coverage lives in test_group_norm_DRAM.py::GN_INTERLEAVED_SHAPES.)
 GN_SHARDED_SHAPES = [
     (1, 320, 32, 32, 16, 1, 8),  # base config (original single-shape test), height-sharded
     (1, 256, 1, 256, 16, 1, 1),  # single core height-sharded, sub-tile group width (16 ch/group)
@@ -1569,9 +1558,15 @@ def test_group_norm_optional_weight_bias(
 @pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], ids=["row_major", "tile"])
-def test_group_norm_sharded_welford_all_config(
-    device, layout, in_dtype, gb_dtype, N, C, H, W, num_groups, grid_y, grid_x
+@pytest.mark.parametrize("use_welford", [True, False], ids=["welford", "legacy"])
+def test_group_norm_sharded_all_config(
+    device, use_welford, layout, in_dtype, gb_dtype, N, C, H, W, num_groups, grid_y, grid_x
 ):
+    # Sharded group_norm across both reduction paths (welford / legacy two-pass) for the fp32/bf16
+    # input x fp32/bf16 gamma-beta matrix. Sharded supports ROW_MAJOR and TILE in both directions
+    # (TILIZE_IN/UNTILIZE_OUT are gated on layout, not on welford). The welford_reciprocal mode is
+    # DRAM-only (the sharded program factory never consumes a reciprocals tensor), so it is not
+    # exercised here.
     grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
     torch.manual_seed(0)
     x = torch.rand((N, C, H, W), dtype=torch.float32)
@@ -1583,7 +1578,7 @@ def test_group_norm_sharded_welford_all_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=False,
-        fp32_dest_acc_en=True,  # required for FP32 on the Welford path
+        fp32_dest_acc_en=True,  # required for FP32 (Welford path, or legacy fp32 DEST accumulation)
         packer_l1_acc=False,
     )
 
@@ -1619,7 +1614,7 @@ def test_group_norm_sharded_welford_all_config(
         core_grid=grid,
         dtype=in_dtype,
         compute_kernel_config=ck,
-        use_welford=True,
+        use_welford=use_welford,
         output_layout=layout,
         inplace=(layout == ttnn.ROW_MAJOR_LAYOUT),  # in-place only valid for sharded ROW_MAJOR
     )
@@ -1627,156 +1622,18 @@ def test_group_norm_sharded_welford_all_config(
         ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
     )
 
-    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
-    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta/layout matrix.
-    if in_dtype == ttnn.bfloat16:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+    # Thresholds branch on the reduction path and the input dtype (bf16 input is the dominant error
+    # source); each bound sits ~1.4x above the worst observed value across the shape/gamma-beta/layout matrix.
+    if use_welford:
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
     else:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
-    assert_numeric_metrics(
-        ref,
-        out,
-        pcc_threshold=pcc_threshold,
-        rtol=rtol,
-        atol=atol,
-        frobenius_threshold=frobenius_threshold,
-    )
-
-
-@pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_SHAPES)
-@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
-@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
-def test_group_norm_sharded_legacy_all_config(device, in_dtype, gb_dtype, N, C, H, W, num_groups, grid_y, grid_x):
-    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
-    torch.manual_seed(0)
-    x = torch.rand((N, C, H, W), dtype=torch.float32)
-    w = torch.rand((C,), dtype=torch.float32)
-    b = torch.rand((C,), dtype=torch.float32)
-    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
-
-    ck = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=ttnn.MathFidelity.HiFi4,
-        math_approx_mode=False,
-        fp32_dest_acc_en=True,  # required for legacy FP32 (fp32 DEST accumulation)
-        packer_l1_acc=False,
-    )
-
-    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
-    xt = ttnn.from_torch(
-        xt, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-
-    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, ttnn.DataType.BFLOAT8_B), device)
-    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
-    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
-    gt = ttnn.from_torch(
-        gamma, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-    bt = ttnn.from_torch(
-        beta, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
-    shard_shape = N * H * W // grid.x, C // grid.y
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
-    tensor_memory_layout = (
-        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED if grid.y == 1 else ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
-    )
-    mem = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
-    xt = ttnn.to_memory_config(xt, mem)
-
-    out = ttnn.group_norm(
-        xt,
-        num_groups=num_groups,
-        input_mask=mask,
-        weight=gt,
-        bias=bt,
-        memory_config=mem,
-        core_grid=grid,
-        dtype=in_dtype,
-        compute_kernel_config=ck,
-        use_welford=False,
-        output_layout=ttnn.TILE_LAYOUT,
-        inplace=False,
-    )
-    out = (
-        ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
-    )
-
-    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
-    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
-    if in_dtype == ttnn.bfloat16:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
-    else:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
-    assert_numeric_metrics(
-        ref,
-        out,
-        pcc_threshold=pcc_threshold,
-        rtol=rtol,
-        atol=atol,
-        frobenius_threshold=frobenius_threshold,
-    )
-
-
-@pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x", GN_INTERLEAVED_SHAPES)
-@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
-@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
-def test_group_norm_interleaved_legacy_all_config(
-    device, N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x, in_dtype, gb_dtype
-):
-    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
-    torch.manual_seed(0)
-    x = torch.rand((N, C, H, W), dtype=torch.float32)
-    w = torch.rand((C,), dtype=torch.float32)
-    b = torch.rand((C,), dtype=torch.float32)
-    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
-
-    ck = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=ttnn.MathFidelity.HiFi4,
-        math_approx_mode=False,
-        fp32_dest_acc_en=True,  # required for legacy FP32 (fp32 DEST accumulation)
-        packer_l1_acc=False,
-    )
-
-    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
-    xt = ttnn.from_torch(
-        xt, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, ttnn.DataType.BFLOAT8_B), device)
-    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
-    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
-    gt = ttnn.from_torch(
-        gamma, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-    bt = ttnn.from_torch(
-        beta, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-
-    out = ttnn.group_norm(
-        xt,
-        num_groups=num_groups,
-        input_mask=mask,
-        weight=gt,
-        bias=bt,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        core_grid=grid,
-        dtype=in_dtype,
-        compute_kernel_config=ck,
-        use_welford=False,
-        output_layout=ttnn.TILE_LAYOUT,
-        num_out_blocks=num_out_blocks,
-        inplace=False,
-    )
-    out = ttnn.to_torch(ttnn.from_device(out)).float().reshape(ref.shape)
-    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
-    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
-    if in_dtype == ttnn.bfloat16:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.10, 0.03
-    else:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.03, 0.01
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
     assert_numeric_metrics(
         ref,
         out,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1298,8 +1298,47 @@ def test_group_norm_negative_tests(
         )
 
 
+def test_group_norm_rejects_non_tile_aligned_spatial(device, expect_error):
+    # group_norm reduces over the flattened spatial dimension (N*H*W) in 32-row
+    # tiles, so that dimension must be a whole number of tiles -- otherwise the
+    # trailing partial tile would be silently dropped from the mean/variance,
+    # producing wrong results. Here N*H*W = 16, which is not a multiple of 32.
+    #
+    # A TILE input cannot exercise this (TILE pads the row dim up to 32), and a
+    # ROW_MAJOR interleaved input is rejected earlier as unsupported on the
+    # non-sharded path. A sharded input keeps the unpadded row dim and reaches the
+    # invariant check, so use that to cover it.
+    C, HW, num_groups = 320, 16, 32
+    torch_input_tensor = torch.rand((1, 1, HW, C), dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (HW, C), ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    input_tensor = ttnn.to_memory_config(input_tensor, memory_config=sharded_mem_config)
+
+    with expect_error(RuntimeError, "must be divisible by the tile size"):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=num_groups,
+            memory_config=sharded_mem_config,
+            core_grid=ttnn.CoreGrid(y=1, x=1),
+        )
+
+
 def test_group_norm_rejects_host_input_mask(device, expect_error):
-    input_tensor = ttnn.empty((1, 1, 32, 320), device=device)
+    # TILE layout: a ROW_MAJOR interleaved input is rejected earlier (it is unsupported
+    # on the non-sharded path), which would pre-empt the host-input-mask check this test
+    # targets.
+    input_tensor = ttnn.empty((1, 1, 32, 320), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
 
     with expect_error(RuntimeError, "Input mask must be on device"):

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -26,6 +26,31 @@ HEIGHT_SHARDED_SHAPES = [
     (1, 320, 32, 32, 16),
 ]
 
+# GroupNorm coverage shapes for the fp32/bf16 all-config tests. Interleaved shapes are
+# (N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x); sharded shapes are
+# (N, C, H, W, num_groups, grid_y, grid_x) where grid_y == 1 is height-sharded and grid_y > 1 is
+# block-sharded. Chosen to cover single-core, sub-tile group widths, batch > 1, and num_out_blocks
+# slicing (see also GN_INTERLEAVED_SHAPES in test_group_norm_DRAM.py).
+GN_INTERLEAVED_SHAPES = [
+    (1, 320, 32, 32, 16, 1, 1, 8),  # base config (original single-shape test)
+    (1, 480, 1, 64, 8, 1, 1, 1),  # single core, last group ends less than max tile span
+    (1, 768, 1, 512, 32, 2, 8, 8),  # group channel count less than tile size
+    (2, 768, 1, 512, 32, 2, 8, 8),  # batch 2 (still multicast), num_out_blocks 2
+    (1, 2560, 1, 512, 32, 2, 8, 8),  # mcast num_out_blocks 2
+    (1, 128, 1, 512, 32, 2, 4, 4),  # all groups on core fit in less than one tile
+    (8, 768, 1, 512, 32, 3, 8, 8),  # batch 8 (no multicast), uneven num_out_blocks divisor
+]
+
+GN_SHARDED_SHAPES = [
+    (1, 320, 32, 32, 16, 1, 8),  # base config (original single-shape test), height-sharded
+    (1, 256, 1, 256, 16, 1, 1),  # single core height-sharded, sub-tile group width (16 ch/group)
+    (1, 128, 1, 512, 16, 1, 4),  # height-sharded, groups on core fit in less than one tile
+    #   (num_groups <= 16 per core is required by the welford sharded path)
+    (1, 1280, 1, 512, 32, 8, 8),  # block-sharded 8x8
+    (2, 512, 32, 32, 32, 8, 8),  # block-sharded 8x8, batch 2 (C/grid_y = 64, tile-aligned)
+    (1, 1280, 16, 16, 32, 4, 8),  # block-sharded 8x4
+]
+
 BLOCK_SHARDED_V2_8X4_SHAPES = [
     (1, 1280, 16, 16, 32),
     (1, 320, 1, 8192, 32),
@@ -1273,47 +1298,8 @@ def test_group_norm_negative_tests(
         )
 
 
-def test_group_norm_rejects_non_tile_aligned_spatial(device, expect_error):
-    # group_norm reduces over the flattened spatial dimension (N*H*W) in 32-row
-    # tiles, so that dimension must be a whole number of tiles -- otherwise the
-    # trailing partial tile would be silently dropped from the mean/variance,
-    # producing wrong results. Here N*H*W = 16, which is not a multiple of 32.
-    #
-    # A TILE input cannot exercise this (TILE pads the row dim up to 32), and a
-    # ROW_MAJOR interleaved input is rejected earlier as unsupported on the
-    # non-sharded path. A sharded input keeps the unpadded row dim and reaches the
-    # invariant check, so use that to cover it.
-    C, HW, num_groups = 320, 16, 32
-    torch_input_tensor = torch.rand((1, 1, HW, C), dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(
-        torch_input_tensor,
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
-    shard_spec = ttnn.ShardSpec(shard_grid, (HW, C), ttnn.ShardOrientation.ROW_MAJOR)
-    sharded_mem_config = ttnn.MemoryConfig(
-        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
-    )
-    input_tensor = ttnn.to_memory_config(input_tensor, memory_config=sharded_mem_config)
-
-    with expect_error(RuntimeError, "must be divisible by the tile size"):
-        ttnn.group_norm(
-            input_tensor,
-            num_groups=num_groups,
-            memory_config=sharded_mem_config,
-            core_grid=ttnn.CoreGrid(y=1, x=1),
-        )
-
-
 def test_group_norm_rejects_host_input_mask(device, expect_error):
-    # TILE layout: a ROW_MAJOR interleaved input is rejected earlier (it is unsupported
-    # on the non-sharded path), which would pre-empt the host-input-mask check this test
-    # targets.
-    input_tensor = ttnn.empty((1, 1, 32, 320), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.empty((1, 1, 32, 320), device=device)
     input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
 
     with expect_error(RuntimeError, "Input mask must be on device"):
@@ -1533,6 +1519,228 @@ def test_group_norm_optional_weight_bias(
     assert_numeric_metrics(
         torch_output,
         tt_output,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_SHAPES)
+@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], ids=["row_major", "tile"])
+def test_group_norm_sharded_welford_all_config(
+    device, layout, in_dtype, gb_dtype, N, C, H, W, num_groups, grid_y, grid_x
+):
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for FP32 on the Welford path
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(xt, dtype=in_dtype, layout=layout, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, ttnn.DataType.BFLOAT8_B), device)
+    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
+    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
+    gt = ttnn.from_torch(
+        gamma, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bt = ttnn.from_torch(
+        beta, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    shard_shape = N * H * W // grid.x, C // grid.y
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+    tensor_memory_layout = (
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED if grid.y == 1 else ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+    )
+    mem = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+    xt = ttnn.to_memory_config(xt, mem)
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        weight=gt,
+        bias=bt,
+        memory_config=mem,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=True,
+        output_layout=layout,
+        inplace=(layout == ttnn.ROW_MAJOR_LAYOUT),  # in-place only valid for sharded ROW_MAJOR
+    )
+    out = (
+        ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
+    )
+
+    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
+    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta/layout matrix.
+    if in_dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
+    assert_numeric_metrics(
+        ref,
+        out,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_SHAPES)
+@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
+def test_group_norm_sharded_legacy_all_config(device, in_dtype, gb_dtype, N, C, H, W, num_groups, grid_y, grid_x):
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for legacy FP32 (fp32 DEST accumulation)
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(
+        xt, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, ttnn.DataType.BFLOAT8_B), device)
+    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
+    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
+    gt = ttnn.from_torch(
+        gamma, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bt = ttnn.from_torch(
+        beta, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    shard_shape = N * H * W // grid.x, C // grid.y
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+    tensor_memory_layout = (
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED if grid.y == 1 else ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+    )
+    mem = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+    xt = ttnn.to_memory_config(xt, mem)
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        weight=gt,
+        bias=bt,
+        memory_config=mem,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=False,
+        output_layout=ttnn.TILE_LAYOUT,
+        inplace=False,
+    )
+    out = (
+        ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
+    )
+
+    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
+    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
+    if in_dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
+    assert_numeric_metrics(
+        ref,
+        out,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x", GN_INTERLEAVED_SHAPES)
+@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
+def test_group_norm_interleaved_legacy_all_config(
+    device, N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x, in_dtype, gb_dtype
+):
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for legacy FP32 (fp32 DEST accumulation)
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(
+        xt, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, ttnn.DataType.BFLOAT8_B), device)
+    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
+    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
+    gt = ttnn.from_torch(
+        gamma, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bt = ttnn.from_torch(
+        beta, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        weight=gt,
+        bias=bt,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=False,
+        output_layout=ttnn.TILE_LAYOUT,
+        num_out_blocks=num_out_blocks,
+        inplace=False,
+    )
+    out = ttnn.to_torch(ttnn.from_device(out)).float().reshape(ref.shape)
+    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
+    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
+    if in_dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.10, 0.03
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.03, 0.01
+    assert_numeric_metrics(
+        ref,
+        out,
         pcc_threshold=pcc_threshold,
         rtol=rtol,
         atol=atol,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -44,6 +44,20 @@ BLOCK_SHARDED_NON_TILE_ALIGNED_CASES = [
     (1, 256, 1, 100, 32, 2, 2),  # multi-core M-split: 4 tiles across 2 x-cores, padding on last
 ]
 
+# GroupNorm coverage shapes for the fp32/bf16 sharded all-config tests. Shapes are
+# (N, C, H, W, num_groups, grid_y, grid_x) where grid_y == 1 is height-sharded and grid_y > 1 is
+# block-sharded. Chosen to cover single-core, sub-tile group widths, and batch > 1.
+# (Interleaved/DRAM coverage lives in test_group_norm_DRAM.py::GN_INTERLEAVED_SHAPES.)
+GN_SHARDED_SHAPES = [
+    (1, 320, 32, 32, 16, 1, 8),  # base config (original single-shape test), height-sharded
+    (1, 256, 1, 256, 16, 1, 1),  # single core height-sharded, sub-tile group width (16 ch/group)
+    (1, 128, 1, 512, 16, 1, 4),  # height-sharded, groups on core fit in less than one tile
+    #   (num_groups <= 16 per core is required by the welford sharded path)
+    (1, 1280, 1, 512, 32, 8, 8),  # block-sharded 8x8
+    (2, 512, 32, 32, 32, 8, 8),  # block-sharded 8x8, batch 2 (C/grid_y = 64, tile-aligned)
+    (1, 1280, 16, 16, 32, 4, 8),  # block-sharded 8x4
+]
+
 BLOCK_SHARDED_V2_8X4_SHAPES = [
     (1, 1280, 16, 16, 32),
     (1, 320, 1, 8192, 32),
@@ -1781,6 +1795,96 @@ def test_group_norm_optional_weight_bias(
     assert_numeric_metrics(
         torch_output,
         tt_output,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_SHAPES)
+@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], ids=["row_major", "tile"])
+@pytest.mark.parametrize("use_welford", [True, False], ids=["welford", "legacy"])
+def test_group_norm_sharded_all_config(
+    device, use_welford, layout, in_dtype, gb_dtype, N, C, H, W, num_groups, grid_y, grid_x
+):
+    # Sharded group_norm across both reduction paths (welford / legacy two-pass) for the fp32/bf16
+    # input x fp32/bf16 gamma-beta matrix. Sharded supports ROW_MAJOR and TILE in both directions
+    # (TILIZE_IN/UNTILIZE_OUT are gated on layout, not on welford). The welford_reciprocal mode is
+    # DRAM-only (the sharded program factory never consumes a reciprocals tensor), so it is not
+    # exercised here.
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for FP32 (Welford path, or legacy fp32 DEST accumulation)
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(xt, dtype=in_dtype, layout=layout, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, ttnn.DataType.BFLOAT8_B), device)
+    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
+    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
+    gt = ttnn.from_torch(
+        gamma, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bt = ttnn.from_torch(
+        beta, dtype=gb_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    shard_shape = N * H * W // grid.x, C // grid.y
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+    tensor_memory_layout = (
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED if grid.y == 1 else ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+    )
+    mem = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+    xt = ttnn.to_memory_config(xt, mem)
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        weight=gt,
+        bias=bt,
+        memory_config=mem,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=use_welford,
+        output_layout=layout,
+        inplace=(layout == ttnn.ROW_MAJOR_LAYOUT),  # in-place only valid for sharded ROW_MAJOR
+    )
+    out = (
+        ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
+    )
+
+    # Thresholds branch on the reduction path and the input dtype (bf16 input is the dominant error
+    # source); each bound sits ~1.4x above the worst observed value across the shape/gamma-beta/layout matrix.
+    if use_welford:
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
+    else:
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
+    assert_numeric_metrics(
+        ref,
+        out,
         pcc_threshold=pcc_threshold,
         rtol=rtol,
         atol=atol,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -40,6 +40,14 @@ GN_SHARDED_SHAPES = [
     (1, 1280, 16, 16, 32, 4, 8),  # block-sharded 8x4
 ]
 
+# Subset of GN_SHARDED_SHAPES for the negative-mask coverage test: one height-sharded and two
+# block-sharded grids. The negative-mask path only accepts ROW_MAJOR sharded input and output.
+GN_SHARDED_NEGATIVE_MASK_SHAPES = [
+    (1, 320, 32, 32, 16, 1, 8),
+    # (1, 1280, 1, 512, 32, 8, 8),
+    # (1, 1280, 16, 16, 32, 4, 8),
+]
+
 BLOCK_SHARDED_V2_8X4_SHAPES = [
     (1, 1280, 16, 16, 32),
     (1, 320, 1, 8192, 32),
@@ -1634,6 +1642,182 @@ def test_group_norm_sharded_all_config(
             pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
         else:
             pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
+    assert_numeric_metrics(
+        ref,
+        out,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_NEGATIVE_MASK_SHAPES)
+@pytest.mark.parametrize("mask_dtype", [ttnn.bfloat8_b, ttnn.float32], ids=["mask_bfp8", "mask_fp32"])
+@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
+@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+def test_group_norm_sharded_negative_mask(
+    device, use_welford, in_dtype, mask_dtype, N, C, H, W, num_groups, grid_y, grid_x
+):
+    # Negative mask over the fp32/bf16 input x fp32/bfp8 mask matrix, on both reduction paths. The
+    # negative mask overlaps the tilized-in and out CBs, so gamma/beta are applied in place on cb_in
+    # and the mask dtype takes part in the kernel's fp32 unpacker reconfiguration.
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(
+        xt, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, mask_dtype), device)
+    nmask = ttnn.to_device(ttnn.create_group_norm_input_negative_mask(C, num_groups, grid.y, mask_dtype), device)
+
+    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
+    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
+    gt = ttnn.from_torch(
+        gamma, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bt = ttnn.from_torch(
+        beta, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    shard_shape = N * H * W // grid.x, C // grid.y
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+    tensor_memory_layout = (
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED if grid.y == 1 else ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+    )
+    mem = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+    xt = ttnn.to_memory_config(xt, mem)
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        negative_mask=nmask,
+        weight=gt,
+        bias=bt,
+        memory_config=mem,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=use_welford,
+        output_layout=ttnn.ROW_MAJOR_LAYOUT,
+        inplace=True,
+    )
+    out = (
+        ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
+    )
+
+    if in_dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
+    assert_numeric_metrics(
+        ref,
+        out,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_NEGATIVE_MASK_SHAPES)
+@pytest.mark.parametrize(
+    "mask_dtype",
+    [
+        ttnn.bfloat8_b,
+        # ttnn.float32
+    ],
+)
+@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+def test_group_norm_sharded_negative_mask2(
+    device, use_welford, in_dtype, mask_dtype, N, C, H, W, num_groups, grid_y, grid_x
+):
+    # Negative mask over the fp32/bf16 input x fp32/bfp8 mask matrix, on both reduction paths. The
+    # negative mask overlaps the tilized-in and out CBs, so gamma/beta are applied in place on cb_in
+    # and the mask dtype takes part in the kernel's fp32 unpacker reconfiguration.
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(
+        xt, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, mask_dtype), device)
+    nmask = ttnn.to_device(ttnn.create_group_norm_input_negative_mask(C, num_groups, grid.y, mask_dtype), device)
+
+    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
+    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
+    gt = ttnn.from_torch(
+        gamma, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bt = ttnn.from_torch(
+        beta, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    shard_shape = N * H * W // grid.x, C // grid.y
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+    tensor_memory_layout = (
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED if grid.y == 1 else ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+    )
+    mem = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+    xt = ttnn.to_memory_config(xt, mem)
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        negative_mask=nmask,
+        weight=gt,
+        bias=bt,
+        memory_config=mem,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=use_welford,
+        output_layout=ttnn.ROW_MAJOR_LAYOUT,
+        inplace=True,
+    )
+    out = (
+        ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
+    )
+
+    if in_dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
     assert_numeric_metrics(
         ref,
         out,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -40,12 +40,10 @@ GN_SHARDED_SHAPES = [
     (1, 1280, 16, 16, 32, 4, 8),  # block-sharded 8x4
 ]
 
-# Subset of GN_SHARDED_SHAPES for the negative-mask coverage test: one height-sharded and two
-# block-sharded grids. The negative-mask path only accepts ROW_MAJOR sharded input and output.
+# The negative-mask path only accepts ROW_MAJOR sharded input and output.
 GN_SHARDED_NEGATIVE_MASK_SHAPES = [
     (1, 320, 32, 32, 16, 1, 8),
-    # (1, 1280, 1, 512, 32, 8, 8),
-    # (1, 1280, 16, 16, 32, 4, 8),
+    (1, 1280, 1, 512, 32, 8, 8),
 ]
 
 BLOCK_SHARDED_V2_8X4_SHAPES = [
@@ -1655,14 +1653,8 @@ def test_group_norm_sharded_all_config(
 @pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_NEGATIVE_MASK_SHAPES)
 @pytest.mark.parametrize("mask_dtype", [ttnn.bfloat8_b, ttnn.float32], ids=["mask_bfp8", "mask_fp32"])
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
-@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
-def test_group_norm_sharded_negative_mask(
-    device, use_welford, in_dtype, mask_dtype, N, C, H, W, num_groups, grid_y, grid_x
-):
-    # Negative mask over the fp32/bf16 input x fp32/bfp8 mask matrix, on both reduction paths. The
-    # negative mask overlaps the tilized-in and out CBs, so gamma/beta are applied in place on cb_in
-    # and the mask dtype takes part in the kernel's fp32 unpacker reconfiguration.
+def test_group_norm_sharded_negative_mask(device, in_dtype, mask_dtype, N, C, H, W, num_groups, grid_y, grid_x):
     grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
     torch.manual_seed(0)
     x = torch.rand((N, C, H, W), dtype=torch.float32)
@@ -1715,98 +1707,7 @@ def test_group_norm_sharded_negative_mask(
         core_grid=grid,
         dtype=in_dtype,
         compute_kernel_config=ck,
-        use_welford=use_welford,
-        output_layout=ttnn.ROW_MAJOR_LAYOUT,
-        inplace=True,
-    )
-    out = (
-        ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float().reshape(ref.shape)
-    )
-
-    if in_dtype == ttnn.bfloat16:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.09, 0.035
-    else:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.08, 0.035
-    assert_numeric_metrics(
-        ref,
-        out,
-        pcc_threshold=pcc_threshold,
-        rtol=rtol,
-        atol=atol,
-        frobenius_threshold=frobenius_threshold,
-    )
-
-
-@pytest.mark.parametrize("N, C, H, W, num_groups, grid_y, grid_x", GN_SHARDED_NEGATIVE_MASK_SHAPES)
-@pytest.mark.parametrize(
-    "mask_dtype",
-    [
-        ttnn.bfloat8_b,
-        # ttnn.float32
-    ],
-)
-@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16])
-@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
-@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
-def test_group_norm_sharded_negative_mask2(
-    device, use_welford, in_dtype, mask_dtype, N, C, H, W, num_groups, grid_y, grid_x
-):
-    # Negative mask over the fp32/bf16 input x fp32/bfp8 mask matrix, on both reduction paths. The
-    # negative mask overlaps the tilized-in and out CBs, so gamma/beta are applied in place on cb_in
-    # and the mask dtype takes part in the kernel's fp32 unpacker reconfiguration.
-    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
-    torch.manual_seed(0)
-    x = torch.rand((N, C, H, W), dtype=torch.float32)
-    w = torch.rand((C,), dtype=torch.float32)
-    b = torch.rand((C,), dtype=torch.float32)
-    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
-
-    ck = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=ttnn.MathFidelity.HiFi4,
-        math_approx_mode=False,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=False,
-    )
-
-    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
-    xt = ttnn.from_torch(
-        xt, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-
-    mask = ttnn.to_device(ttnn.create_group_norm_input_mask(C, num_groups, grid.y, mask_dtype), device)
-    nmask = ttnn.to_device(ttnn.create_group_norm_input_negative_mask(C, num_groups, grid.y, mask_dtype), device)
-
-    gamma = ttnn.create_group_norm_weight_bias_rm(w, C, grid.y)
-    beta = ttnn.create_group_norm_weight_bias_rm(b, C, grid.y)
-    gt = ttnn.from_torch(
-        gamma, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-    bt = ttnn.from_torch(
-        beta, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
-    shard_shape = N * H * W // grid.x, C // grid.y
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
-    tensor_memory_layout = (
-        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED if grid.y == 1 else ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
-    )
-    mem = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
-    xt = ttnn.to_memory_config(xt, mem)
-
-    out = ttnn.group_norm(
-        xt,
-        num_groups=num_groups,
-        input_mask=mask,
-        negative_mask=nmask,
-        weight=gt,
-        bias=bt,
-        memory_config=mem,
-        core_grid=grid,
-        dtype=in_dtype,
-        compute_kernel_config=ck,
-        use_welford=use_welford,
+        use_welford=False,
         output_layout=ttnn.ROW_MAJOR_LAYOUT,
         inplace=True,
     )

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -523,3 +523,76 @@ def test_group_norm_DRAM_oft(device, N, C, H, W, num_groups, num_out_blocks, cor
         atol=0.09,
         frobenius_threshold=0.03,
     )
+
+
+GN_INTERLEAVED_SHAPES = [
+    (1, 320, 32, 32, 16, 1, 1, 8),  # base config (original single-shape test)
+    (1, 480, 1, 64, 8, 1, 1, 1),  # single core, last group ends less than max tile span
+    (1, 768, 1, 512, 32, 2, 8, 8),  # group channel count less than tile size
+    (2, 768, 1, 512, 32, 2, 8, 8),  # batch 2 (still multicast), num_out_blocks 2
+    (1, 2560, 1, 512, 32, 2, 8, 8),  # mcast num_out_blocks 2
+    (1, 128, 1, 512, 32, 2, 4, 4),  # all groups on core fit in less than one tile
+    (8, 768, 1, 512, 32, 3, 8, 8),  # batch 8 (no multicast), uneven num_out_blocks divisor
+]
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x", GN_INTERLEAVED_SHAPES)
+@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
+def test_group_norm_interleaved_welford_all_config(
+    device, N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x, in_dtype, gb_dtype
+):
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for FP32 on the Welford path
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(
+        xt, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    [gt, bt], mask = ttnn.dram_group_norm_params_from_torch(
+        [w, b], C, num_groups, device, core_grid=grid, return_mask=True, dtype=gb_dtype
+    )
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        weight=gt,
+        bias=bt,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=True,
+        num_out_blocks=num_out_blocks,
+        inplace=False,
+    )
+    out = ttnn.to_torch(ttnn.from_device(out)).float().reshape(ref.shape)
+
+    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
+    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
+    if in_dtype == ttnn.bfloat16:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+    else:
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
+    assert_numeric_metrics(
+        ref,
+        out,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -538,12 +538,22 @@ GN_INTERLEAVED_SHAPES = [
 
 @pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x", GN_INTERLEAVED_SHAPES)
 @pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
-@pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16], ids=["fp32", "bf16"])
-def test_group_norm_interleaved_welford_all_config(
-    device, N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x, in_dtype, gb_dtype
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
+@pytest.mark.parametrize("welford_mode", WELFORD_MODES)
+def test_group_norm_interleaved_all_config(
+    device, N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x, in_dtype, gb_dtype, welford_mode
 ):
+    # Interleaved (DRAM) group_norm across all WELFORD_MODES. The modes differ only in
+    # use_welford/use_reciprocals and the accuracy thresholds; everything else (fp32/bf16 input,
+    # fp32/bf16 gamma-beta, gamma/beta/mask prep via dram_group_norm_params_from_torch) is identical.
+    # Interleaved input/output is TILE-only (ROW_MAJOR is rejected by the op for non-sharded tensors).
     grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
     torch.manual_seed(0)
+
+    # Determine welford and reciprocals settings
+    use_welford = welford_mode in ("welford_normal", "welford_reciprocal")
+    use_reciprocals = welford_mode == "welford_reciprocal"
+
     x = torch.rand((N, C, H, W), dtype=torch.float32)
     w = torch.rand((C,), dtype=torch.float32)
     b = torch.rand((C,), dtype=torch.float32)
@@ -553,7 +563,7 @@ def test_group_norm_interleaved_welford_all_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=False,
-        fp32_dest_acc_en=True,  # required for FP32 on the Welford path
+        fp32_dest_acc_en=True,  # required for FP32 (Welford path, or legacy fp32 DEST accumulation)
         packer_l1_acc=False,
     )
 
@@ -566,6 +576,26 @@ def test_group_norm_interleaved_welford_all_config(
         [w, b], C, num_groups, device, core_grid=grid, return_mask=True, dtype=gb_dtype
     )
 
+    # Create reciprocals tensor if needed (host-precomputed 1/count fed via the reciprocals= arg)
+    reciprocals_tensor = None
+    if use_reciprocals:
+        torch_reciprocals = ttnn.create_group_norm_reciprocals(N, C, H, W, num_groups, grid)
+        reciprocals_tensor = ttnn.from_torch(
+            torch_reciprocals,
+            dtype=ttnn.DataType.FLOAT32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))}),
+                    (torch_reciprocals.shape[0] // (grid.x * grid.y), torch_reciprocals.shape[1]),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+        )
+
     out = ttnn.group_norm(
         xt,
         num_groups=num_groups,
@@ -576,18 +606,25 @@ def test_group_norm_interleaved_welford_all_config(
         core_grid=grid,
         dtype=in_dtype,
         compute_kernel_config=ck,
-        use_welford=True,
+        use_welford=use_welford,
         num_out_blocks=num_out_blocks,
         inplace=False,
+        reciprocals=reciprocals_tensor,
     )
     out = ttnn.to_torch(ttnn.from_device(out)).float().reshape(ref.shape)
 
-    # Thresholds branch on the input dtype (bf16 input is the dominant error source);
-    # each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
-    if in_dtype == ttnn.bfloat16:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+    # Thresholds branch on the reduction path and the input dtype (bf16 input is the dominant error
+    # source); each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
+    if use_welford:
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
     else:
-        pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.10, 0.03
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.03, 0.01
     assert_numeric_metrics(
         ref,
         out,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -900,3 +900,113 @@ def test_group_norm_DRAM_oft(device, N, C, H, W, num_groups, num_out_blocks, cor
         atol=0.09,
         frobenius_threshold=0.03,
     )
+
+
+GN_INTERLEAVED_SHAPES = [
+    (1, 320, 32, 32, 16, 1, 1, 8),  # base config (original single-shape test)
+    (1, 480, 1, 64, 8, 1, 1, 1),  # single core, last group ends less than max tile span
+    (1, 768, 1, 512, 32, 2, 8, 8),  # group channel count less than tile size
+    (2, 768, 1, 512, 32, 2, 8, 8),  # batch 2 (still multicast), num_out_blocks 2
+    (1, 2560, 1, 512, 32, 2, 8, 8),  # mcast num_out_blocks 2
+    (1, 128, 1, 512, 32, 2, 4, 4),  # all groups on core fit in less than one tile
+    (8, 768, 1, 512, 32, 3, 8, 8),  # batch 8 (no multicast), uneven num_out_blocks divisor
+]
+
+
+@pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x", GN_INTERLEAVED_SHAPES)
+@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
+@pytest.mark.parametrize("welford_mode", WELFORD_MODES)
+def test_group_norm_interleaved_all_config(
+    device, N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x, in_dtype, gb_dtype, welford_mode
+):
+    # Interleaved (DRAM) group_norm across all WELFORD_MODES. The modes differ only in
+    # use_welford/use_reciprocals and the accuracy thresholds; everything else (fp32/bf16 input,
+    # fp32/bf16 gamma-beta, gamma/beta/mask prep via dram_group_norm_params_from_torch) is identical.
+    # Interleaved input/output is TILE-only (ROW_MAJOR is rejected by the op for non-sharded tensors).
+    grid = ttnn.CoreGrid(y=grid_y, x=grid_x)
+    torch.manual_seed(0)
+
+    # Determine welford and reciprocals settings
+    use_welford = welford_mode in ("welford_normal", "welford_reciprocal")
+    use_reciprocals = welford_mode == "welford_reciprocal"
+
+    x = torch.rand((N, C, H, W), dtype=torch.float32)
+    w = torch.rand((C,), dtype=torch.float32)
+    b = torch.rand((C,), dtype=torch.float32)
+    ref = torch.nn.functional.group_norm(x, num_groups, weight=w, bias=b).permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    ck = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,  # required for FP32 (Welford path, or legacy fp32 DEST accumulation)
+        packer_l1_acc=False,
+    )
+
+    xt = x.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    xt = ttnn.from_torch(
+        xt, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    [gt, bt], mask = ttnn.dram_group_norm_params_from_torch(
+        [w, b], C, num_groups, device, core_grid=grid, return_mask=True, dtype=gb_dtype
+    )
+
+    # Create reciprocals tensor if needed (host-precomputed 1/count fed via the reciprocals= arg)
+    reciprocals_tensor = None
+    if use_reciprocals:
+        torch_reciprocals = ttnn.create_group_norm_reciprocals(N, C, H, W, num_groups, grid)
+        reciprocals_tensor = ttnn.from_torch(
+            torch_reciprocals,
+            dtype=ttnn.DataType.FLOAT32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))}),
+                    (torch_reciprocals.shape[0] // (grid.x * grid.y), torch_reciprocals.shape[1]),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+        )
+
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        input_mask=mask,
+        weight=gt,
+        bias=bt,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        core_grid=grid,
+        dtype=in_dtype,
+        compute_kernel_config=ck,
+        use_welford=use_welford,
+        num_out_blocks=num_out_blocks,
+        inplace=False,
+        reciprocals=reciprocals_tensor,
+    )
+    out = ttnn.to_torch(ttnn.from_device(out)).float().reshape(ref.shape)
+
+    # Thresholds branch on the reduction path and the input dtype (bf16 input is the dominant error
+    # source); each bound sits ~1.4x above the worst observed value across the shape/gamma-beta matrix.
+    if use_welford:
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.06, 0.015
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.02, 0.004
+    else:
+        if in_dtype == ttnn.bfloat16:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.01, 0.10, 0.03
+        else:
+            pcc_threshold, rtol, atol, frobenius_threshold = 0.999, 0.008, 0.03, 0.01
+    assert_numeric_metrics(
+        ref,
+        out,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -55,7 +55,10 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
     const uint32_t tile_height = a.tensor_spec().tile().get_height();
     const uint32_t tile_width = a.tensor_spec().tile().get_width();
 
-    TT_FATAL(a.dtype() == DataType::BFLOAT16, "Input tensor must be BFLOAT16, got: {}", a.dtype());
+    TT_FATAL(
+        a.dtype() == DataType::BFLOAT16 || a.dtype() == DataType::FLOAT32,
+        "Input tensor must be BFLOAT16 or FLOAT32, got: {}",
+        a.dtype());
     TT_FATAL(a.storage_type() == StorageType::DEVICE, "Operands to groupnorm need to be on device!");
     TT_FATAL(a.buffer() != nullptr, "Operands to groupnorm need to be allocated in buffers on device!");
     TT_FATAL(a.padded_shape()[3] % args.num_groups == 0, "channel must be divisible by num_groups!");
@@ -115,8 +118,8 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to groupnorm need to be allocated in buffers on device!");
             TT_FATAL(
-                gamma.value().dtype() == DataType::BFLOAT16,
-                "Gamma tensor must be BFLOAT16, got: {}",
+                gamma.value().dtype() == DataType::BFLOAT16 || gamma.value().dtype() == DataType::FLOAT32,
+                "Gamma tensor must be BFLOAT16 or FLOAT32, got: {}",
                 gamma.value().dtype());
         }
         if (beta.has_value()) {
@@ -125,6 +128,12 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
                 "Gamma and beta must have the same layout, got gamma: {} vs beta: {}",
                 gamma.value().layout(),
                 beta.value().layout());
+            TT_FATAL(
+                gamma.value().dtype() == beta.value().dtype(),
+                "Gamma and beta must have the same dtype (the program factories use a single gamma/beta "
+                "CB format for both), got gamma: {} vs beta: {}",
+                gamma.value().dtype(),
+                beta.value().dtype());
         }
     }
 
@@ -157,8 +166,8 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to groupnorm need to be allocated in buffers on device!");
             TT_FATAL(
-                beta.value().dtype() == DataType::BFLOAT16,
-                "Beta tensor must be BFLOAT16, got: {}",
+                beta.value().dtype() == DataType::BFLOAT16 || beta.value().dtype() == DataType::FLOAT32,
+                "Beta tensor must be BFLOAT16 or FLOAT32, got: {}",
                 beta.value().dtype());
         }
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -243,6 +243,8 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             output_layout == Layout::ROW_MAJOR,
             "If using negative mask, output tensor must be in ROW_MAJOR layout, but layout is {}",
             output_layout);
+        // The welford sharded kernels have no negative-mask path; the combination hangs the device.
+        TT_FATAL(!args.use_welford, "Negative mask is not supported with use_welford, use the legacy reduction");
     }
 
     // Reciprocals tensor validation

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -263,13 +263,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     // c_0 isn't itself the consumer of the FP32 transpose, i.e. when tilize_in is false).
     const bool welford_fp32_alias = welford_unpack_fp32_active && !tilize_in;
 
-    // True when any reconfig-relevant operand is fp32, so the compute kernel must run its per-tile
-    // reconfig_data_format calls. When all are bf16 they're no-ops and the kernel skips them.
     // cb_reciprocals is excluded: it's fp32 here but the reconfigs never touch it.
-    const bool enable_fp32_reconfig =
-        !(in_data_format == tt::DataFormat::Float16_b && out_data_format == tt::DataFormat::Float16_b &&
-          cb_data_format == tt::DataFormat::Float16_b && gamma_beta_cb_data_format == tt::DataFormat::Float16_b &&
-          in_mask_cb_data_format == tt::DataFormat::Float16_b);
+    const bool enable_fp32_reconfig = groupnorm_needs_fp32_reconfig(
+        {in_data_format, out_data_format, cb_data_format, gamma_beta_cb_data_format, in_mask_cb_data_format});
 
     const uint32_t cb_in0_welford_index =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_19) : static_cast<uint32_t>(tt::CBIndex::c_0);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -263,6 +263,14 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     // c_0 isn't itself the consumer of the FP32 transpose, i.e. when tilize_in is false).
     const bool welford_fp32_alias = welford_unpack_fp32_active && !tilize_in;
 
+    // True when any reconfig-relevant operand is fp32, so the compute kernel must run its per-tile
+    // reconfig_data_format calls. When all are bf16 they're no-ops and the kernel skips them.
+    // cb_reciprocals is excluded: it's fp32 here but the reconfigs never touch it.
+    const bool enable_fp32_reconfig =
+        !(in_data_format == tt::DataFormat::Float16_b && out_data_format == tt::DataFormat::Float16_b &&
+          cb_data_format == tt::DataFormat::Float16_b && gamma_beta_cb_data_format == tt::DataFormat::Float16_b &&
+          in_mask_cb_data_format == tt::DataFormat::Float16_b);
+
     const uint32_t cb_in0_welford_index =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_19) : static_cast<uint32_t>(tt::CBIndex::c_0);
 
@@ -718,10 +726,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     mcast_sender_compute_named_compile_time_args["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_sender_compute_named_compile_time_args["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_sender_compute_named_compile_time_args["enable_fp32_reconfig"] = static_cast<uint32_t>(enable_fp32_reconfig);
     mcast_receiver_compute_named_compile_time_args["welford_fp32_alias"] = static_cast<uint32_t>(welford_fp32_alias);
     mcast_receiver_compute_named_compile_time_args["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_receiver_compute_named_compile_time_args["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_receiver_compute_named_compile_time_args["enable_fp32_reconfig"] =
+        static_cast<uint32_t>(enable_fp32_reconfig);
 
     KernelDescriptor compute_sender_desc;
     compute_sender_desc.kernel_source = compute_kernel_path;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -240,11 +240,14 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     //    UnpackToDestFp32 writes into.
     //  - Legacy (non-welford): intermediates are stored fp32 (im_data_format=Float32) and
     //    accumulated in the fp32 DEST register, which requires fp32_dest_acc_en.
-    // Without fp32 DEST, inputs are silently truncated to TF32 (10 mantissa bits) through SrcA.
+    // Without fp32_dest_acc_en the DEST register is bfloat16, so accumulated/intermediate results are
+    // silently rounded to bf16 (7 mantissa bits) and UnpackToDestFp32 cannot be enabled. (SrcA's TF32
+    // rounding on FPU operands is separate and applies regardless of this flag.)
     TT_FATAL(
         !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
         "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
-        "otherwise precision is silently lost in the unpacker format conversion.");
+        "otherwise the DEST accumulator is bfloat16 and intermediate/accumulated results are silently "
+        "rounded to bf16.");
 
     // welford_unpack_fp32_active is true iff the compute kernel's intake transpose_tile
     // reads from a CB that carries UnpackToDestFp32, regardless of which CB is used: c_29

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -78,6 +78,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(im_data_format);
+    // fp32 stats CBs (welford + fp32 DEST): reader kernels combine mean/variance as fp32, not bf16.
+    const bool stats_is_fp32 = cb_data_format == tt::DataFormat::Float32;
     tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format =
         reciprocals.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(reciprocals.value().dtype())
@@ -91,19 +93,23 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     tt::DataFormat in_mask_cb_data_format =
         input_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(input_mask.value().dtype())
                                : tt::DataFormat::Float16_b;
-    uint32_t datum_size_bytes = 2;
-
     TT_FATAL(
         out_data_format == in_data_format,
         "input: {} and output: {} must be the same data format",
         in_data_format,
         out_data_format);
+    // datum size follows the dtype (out==in, enforced above); a bf16 hardcode would halve fp32 strides.
+    uint32_t datum_size_bytes = output.element_size();
 
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
     uint32_t out_single_tile_size = tt::tile_size(out_data_format);
     uint32_t gamma_beta_single_tile_size = tt::tile_size(gamma_beta_cb_data_format);
     uint32_t in_mask_single_tile_size = tt::tile_size(in_mask_cb_data_format);
+    // eps is delivered as a bf16 scalar (generate_bcast_col_scalar packs the top 16 bits), so its CB
+    // stays bf16 even with fp32 stats; add_tiles(cb_ex_global, cb_eps) then runs mixed fp32/bf16.
+    const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
+    const uint32_t eps_single_tile_size = tt::tile_size(eps_cb_data_format);
 
     IDevice* device = a.device();
 
@@ -228,15 +234,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    // Float32 input on the welford path requires fp32_dest_acc_en=true as a prerequisite for
-    // UnpackToDestFp32 (set below). UnpackToDestFp32 is what bypasses the unpacker's
-    // Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
-    // UnpackToDestFp32 writes into. Without fp32 DEST, UnpackToDestFp32 can't be enabled
-    // and inputs are silently truncated to TF32 (10 mantissa bits) on the way through SrcA.
+    // Float32 input requires fp32_dest_acc_en=true on both GroupNorm paths:
+    //  - Welford: prerequisite for UnpackToDestFp32 (set below), which bypasses the unpacker's
+    //    Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
+    //    UnpackToDestFp32 writes into.
+    //  - Legacy (non-welford): intermediates are stored fp32 (im_data_format=Float32) and
+    //    accumulated in the fp32 DEST register, which requires fp32_dest_acc_en.
+    // Without fp32 DEST, inputs are silently truncated to TF32 (10 mantissa bits) through SrcA.
     TT_FATAL(
-        !(use_welford && in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
-        "group_norm welford with Float32 input requires fp32_dest_acc_en=true in the compute "
-        "kernel config; otherwise precision is silently lost in the unpacker format conversion.");
+        !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
+        "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
+        "otherwise precision is silently lost in the unpacker format conversion.");
 
     // welford_unpack_fp32_active is true iff the compute kernel's intake transpose_tile
     // reads from a CB that carries UnpackToDestFp32, regardless of which CB is used: c_29
@@ -287,7 +295,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     uint32_t in0_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in2_CB_size = single_tile_size;
-    uint32_t in3_CB_size = single_tile_size;
+    uint32_t in3_CB_size = eps_single_tile_size;
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
@@ -435,6 +443,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_mcast_sender_compile_time_args_group_1);
@@ -469,6 +478,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_mcast_receiver_compile_time_args_group_1);
@@ -816,8 +826,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = eps_single_tile_size,
         }}},
     });
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -78,6 +78,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(im_data_format);
+    // fp32 stats CBs (welford + fp32 DEST): reader kernels combine mean/variance as fp32, not bf16.
+    const bool stats_is_fp32 = cb_data_format == tt::DataFormat::Float32;
     tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format =
         reciprocals.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(reciprocals.value().dtype())
@@ -91,19 +93,23 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     tt::DataFormat in_mask_cb_data_format =
         input_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(input_mask.value().dtype())
                                : tt::DataFormat::Float16_b;
-    uint32_t datum_size_bytes = 2;
-
     TT_FATAL(
         out_data_format == in_data_format,
         "input: {} and output: {} must be the same data format",
         in_data_format,
         out_data_format);
+    // datum size follows the dtype (out==in, enforced above); a bf16 hardcode would halve fp32 strides.
+    uint32_t datum_size_bytes = output.element_size();
 
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
     uint32_t out_single_tile_size = tt::tile_size(out_data_format);
     uint32_t gamma_beta_single_tile_size = tt::tile_size(gamma_beta_cb_data_format);
     uint32_t in_mask_single_tile_size = tt::tile_size(in_mask_cb_data_format);
+    // eps is delivered as a bf16 scalar (generate_bcast_col_scalar packs the top 16 bits), so its CB
+    // stays bf16 even with fp32 stats; add_tiles(cb_ex_global, cb_eps) then runs mixed fp32/bf16.
+    const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
+    const uint32_t eps_single_tile_size = tt::tile_size(eps_cb_data_format);
 
     IDevice* device = a.device();
 
@@ -228,15 +234,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    // Float32 input on the welford path requires fp32_dest_acc_en=true as a prerequisite for
-    // UnpackToDestFp32 (set below). UnpackToDestFp32 is what bypasses the unpacker's
-    // Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
-    // UnpackToDestFp32 writes into. Without fp32 DEST, UnpackToDestFp32 can't be enabled
-    // and inputs are silently truncated to TF32 (10 mantissa bits) on the way through SrcA.
+    // Float32 input requires fp32_dest_acc_en=true on both GroupNorm paths:
+    //  - Welford: prerequisite for UnpackToDestFp32 (set below), which bypasses the unpacker's
+    //    Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
+    //    UnpackToDestFp32 writes into.
+    //  - Legacy (non-welford): intermediates are stored fp32 (im_data_format=Float32) and
+    //    accumulated in the fp32 DEST register, which requires fp32_dest_acc_en.
+    // Without fp32_dest_acc_en the DEST register is bfloat16, so accumulated/intermediate results are
+    // silently rounded to bf16 (7 mantissa bits) and UnpackToDestFp32 cannot be enabled. (SrcA's TF32
+    // rounding on FPU operands is separate and applies regardless of this flag.)
     TT_FATAL(
-        !(use_welford && in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
-        "group_norm welford with Float32 input requires fp32_dest_acc_en=true in the compute "
-        "kernel config; otherwise precision is silently lost in the unpacker format conversion.");
+        !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
+        "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
+        "otherwise the DEST accumulator is bfloat16 and intermediate/accumulated results are silently "
+        "rounded to bf16.");
 
     // welford_unpack_fp32_active is true iff the compute kernel's intake transpose_tile
     // reads from a CB that carries UnpackToDestFp32, regardless of which CB is used: c_29
@@ -251,6 +262,10 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     // welford_fp32_alias is the non-TILIZE_IN sub-case (c_19 alias is only useful when
     // c_0 isn't itself the consumer of the FP32 transpose, i.e. when tilize_in is false).
     const bool welford_fp32_alias = welford_unpack_fp32_active && !tilize_in;
+
+    // cb_reciprocals is excluded: it's fp32 here but the reconfigs never touch it.
+    const bool enable_fp32_reconfig = groupnorm_needs_fp32_reconfig(
+        {in_data_format, out_data_format, cb_data_format, gamma_beta_cb_data_format, in_mask_cb_data_format});
 
     const uint32_t cb_in0_welford_index =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_19) : static_cast<uint32_t>(tt::CBIndex::c_0);
@@ -287,7 +302,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     uint32_t in0_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in2_CB_size = single_tile_size;
-    uint32_t in3_CB_size = single_tile_size;
+    uint32_t in3_CB_size = eps_single_tile_size;
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
@@ -437,6 +452,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_mcast_sender_compile_time_args_group_1);
@@ -471,6 +487,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_mcast_receiver_compile_time_args_group_1);
@@ -720,10 +737,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     mcast_sender_compute_named_compile_time_args["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_sender_compute_named_compile_time_args["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_sender_compute_named_compile_time_args["enable_fp32_reconfig"] = static_cast<uint32_t>(enable_fp32_reconfig);
     mcast_receiver_compute_named_compile_time_args["welford_fp32_alias"] = static_cast<uint32_t>(welford_fp32_alias);
     mcast_receiver_compute_named_compile_time_args["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_receiver_compute_named_compile_time_args["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_receiver_compute_named_compile_time_args["enable_fp32_reconfig"] =
+        static_cast<uint32_t>(enable_fp32_reconfig);
 
     KernelDescriptor compute_sender_desc;
     compute_sender_desc.kernel_source = compute_kernel_path;
@@ -831,8 +851,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = eps_single_tile_size,
         }}},
     });
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -313,13 +313,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     // c_0 isn't itself the consumer of the FP32 transpose, i.e. when tilize_in is false).
     const bool welford_fp32_alias = welford_unpack_fp32_active && !tilize_in;
 
-    // True when any reconfig-relevant operand is fp32, so the compute kernel must run its per-tile
-    // reconfig_data_format calls. When all are bf16 they're no-ops and the kernel skips them.
     // cb_reciprocals is excluded: it's fp32 here but the reconfigs never touch it.
-    const bool enable_fp32_reconfig =
-        !(in_data_format == tt::DataFormat::Float16_b && out_data_format == tt::DataFormat::Float16_b &&
-          cb_data_format == tt::DataFormat::Float16_b && gamma_beta_cb_data_format == tt::DataFormat::Float16_b &&
-          in_mask_cb_data_format == tt::DataFormat::Float16_b);
+    const bool enable_fp32_reconfig = groupnorm_needs_fp32_reconfig(
+        {in_data_format, out_data_format, cb_data_format, gamma_beta_cb_data_format, in_mask_cb_data_format});
 
     const uint32_t cb_in0_welford_index =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_19) : static_cast<uint32_t>(tt::CBIndex::c_0);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -290,11 +290,14 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     //    UnpackToDestFp32 writes into.
     //  - Legacy (non-welford): intermediates are stored fp32 (im_data_format=Float32) and
     //    accumulated in the fp32 DEST register, which requires fp32_dest_acc_en.
-    // Without fp32 DEST, inputs are silently truncated to TF32 (10 mantissa bits) through SrcA.
+    // Without fp32_dest_acc_en the DEST register is bfloat16, so accumulated/intermediate results are
+    // silently rounded to bf16 (7 mantissa bits) and UnpackToDestFp32 cannot be enabled. (SrcA's TF32
+    // rounding on FPU operands is separate and applies regardless of this flag.)
     TT_FATAL(
         !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
         "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
-        "otherwise precision is silently lost in the unpacker format conversion.");
+        "otherwise the DEST accumulator is bfloat16 and intermediate/accumulated results are silently "
+        "rounded to bf16.");
 
     // welford_unpack_fp32_active is true iff the compute kernel's intake transpose_tile
     // reads from a CB that carries UnpackToDestFp32, regardless of which CB is used: c_29

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -79,6 +79,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(im_data_format);
+    // fp32 stats CBs (welford + fp32 DEST): reader kernels combine mean/variance as fp32, not bf16.
+    const bool stats_is_fp32 = cb_data_format == tt::DataFormat::Float32;
     tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format =
         reciprocals.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(reciprocals.value().dtype())
@@ -92,13 +94,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     tt::DataFormat in_mask_cb_data_format =
         input_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(input_mask.value().dtype())
                                : tt::DataFormat::Float16_b;
-    uint32_t datum_size_bytes = 2;  // bfloat16
-
     TT_FATAL(
         out_data_format == in_data_format,
         "input: {} and output: {} must be the same data format",
         in_data_format,
         out_data_format);
+    // datum size follows the dtype (out==in, enforced above); a bf16 hardcode would halve fp32 strides.
+    uint32_t datum_size_bytes = output.element_size();
 
     // tile sizes
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
@@ -106,6 +108,10 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t out_single_tile_size = tt::tile_size(out_data_format);
     uint32_t gamma_beta_single_tile_size = tt::tile_size(gamma_beta_cb_data_format);
     uint32_t in_mask_single_tile_size = tt::tile_size(in_mask_cb_data_format);
+    // eps is delivered as a bf16 scalar (generate_bcast_col_scalar packs the top 16 bits), so its CB
+    // stays bf16 even with fp32 stats; add_tiles(cb_ex_global, cb_eps) then runs mixed fp32/bf16.
+    const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
+    const uint32_t eps_single_tile_size = tt::tile_size(eps_cb_data_format);
 
     IDevice* device = a.device();
 
@@ -278,15 +284,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    // Float32 input on the welford path requires fp32_dest_acc_en=true as a prerequisite for
-    // UnpackToDestFp32 (set below). UnpackToDestFp32 is what bypasses the unpacker's
-    // Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
-    // UnpackToDestFp32 writes into. Without fp32 DEST, UnpackToDestFp32 can't be enabled
-    // and inputs are silently truncated to TF32 (10 mantissa bits) on the way through SrcA.
+    // Float32 input requires fp32_dest_acc_en=true on both GroupNorm paths:
+    //  - Welford: prerequisite for UnpackToDestFp32 (set below), which bypasses the unpacker's
+    //    Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
+    //    UnpackToDestFp32 writes into.
+    //  - Legacy (non-welford): intermediates are stored fp32 (im_data_format=Float32) and
+    //    accumulated in the fp32 DEST register, which requires fp32_dest_acc_en.
+    // Without fp32 DEST, inputs are silently truncated to TF32 (10 mantissa bits) through SrcA.
     TT_FATAL(
-        !(use_welford && in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
-        "group_norm welford with Float32 input requires fp32_dest_acc_en=true in the compute "
-        "kernel config; otherwise precision is silently lost in the unpacker format conversion.");
+        !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
+        "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
+        "otherwise precision is silently lost in the unpacker format conversion.");
 
     // welford_unpack_fp32_active is true iff the compute kernel's intake transpose_tile
     // reads from a CB that carries UnpackToDestFp32, regardless of which CB is used: c_29
@@ -388,7 +396,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t in_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in_CB_size_group_2 = 0;
     uint32_t in2_CB_size = single_tile_size;
-    uint32_t in3_CB_size = single_tile_size;
+    uint32_t in3_CB_size = eps_single_tile_size;
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
@@ -556,6 +564,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     std::unordered_map<std::string, uint32_t> reader_mcast_sender_named_compile_time_args_group_2 = {
@@ -589,6 +598,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     std::vector<uint32_t> reader_mcast_sender_compile_time_args_group_1 = {};
@@ -1047,8 +1057,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = eps_single_tile_size,
         }}},
     });
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -313,6 +313,14 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     // c_0 isn't itself the consumer of the FP32 transpose, i.e. when tilize_in is false).
     const bool welford_fp32_alias = welford_unpack_fp32_active && !tilize_in;
 
+    // True when any reconfig-relevant operand is fp32, so the compute kernel must run its per-tile
+    // reconfig_data_format calls. When all are bf16 they're no-ops and the kernel skips them.
+    // cb_reciprocals is excluded: it's fp32 here but the reconfigs never touch it.
+    const bool enable_fp32_reconfig =
+        !(in_data_format == tt::DataFormat::Float16_b && out_data_format == tt::DataFormat::Float16_b &&
+          cb_data_format == tt::DataFormat::Float16_b && gamma_beta_cb_data_format == tt::DataFormat::Float16_b &&
+          in_mask_cb_data_format == tt::DataFormat::Float16_b);
+
     const uint32_t cb_in0_welford_index =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_19) : static_cast<uint32_t>(tt::CBIndex::c_0);
 
@@ -902,11 +910,15 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     mcast_sender_compute_named_compile_time_args_group_1["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_sender_compute_named_compile_time_args_group_1["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_sender_compute_named_compile_time_args_group_1["enable_fp32_reconfig"] =
+        static_cast<uint32_t>(enable_fp32_reconfig);
     mcast_sender_compute_named_compile_time_args_group_2["welford_fp32_alias"] =
         static_cast<uint32_t>(welford_fp32_alias);
     mcast_sender_compute_named_compile_time_args_group_2["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_sender_compute_named_compile_time_args_group_2["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_sender_compute_named_compile_time_args_group_2["enable_fp32_reconfig"] =
+        static_cast<uint32_t>(enable_fp32_reconfig);
 
     KernelDescriptor compute_desc_g1;
     compute_desc_g1.kernel_source = compute_kernel_path;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -79,6 +79,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(im_data_format);
+    // fp32 stats CBs (welford + fp32 DEST): reader kernels combine mean/variance as fp32, not bf16.
+    const bool stats_is_fp32 = cb_data_format == tt::DataFormat::Float32;
     tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format =
         reciprocals.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(reciprocals.value().dtype())
@@ -92,13 +94,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     tt::DataFormat in_mask_cb_data_format =
         input_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(input_mask.value().dtype())
                                : tt::DataFormat::Float16_b;
-    uint32_t datum_size_bytes = 2;  // bfloat16
-
     TT_FATAL(
         out_data_format == in_data_format,
         "input: {} and output: {} must be the same data format",
         in_data_format,
         out_data_format);
+    // datum size follows the dtype (out==in, enforced above); a bf16 hardcode would halve fp32 strides.
+    uint32_t datum_size_bytes = output.element_size();
 
     // tile sizes
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
@@ -106,6 +108,10 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t out_single_tile_size = tt::tile_size(out_data_format);
     uint32_t gamma_beta_single_tile_size = tt::tile_size(gamma_beta_cb_data_format);
     uint32_t in_mask_single_tile_size = tt::tile_size(in_mask_cb_data_format);
+    // eps is delivered as a bf16 scalar (generate_bcast_col_scalar packs the top 16 bits), so its CB
+    // stays bf16 even with fp32 stats; add_tiles(cb_ex_global, cb_eps) then runs mixed fp32/bf16.
+    const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
+    const uint32_t eps_single_tile_size = tt::tile_size(eps_cb_data_format);
 
     IDevice* device = a.device();
 
@@ -278,15 +284,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    // Float32 input on the welford path requires fp32_dest_acc_en=true as a prerequisite for
-    // UnpackToDestFp32 (set below). UnpackToDestFp32 is what bypasses the unpacker's
-    // Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
-    // UnpackToDestFp32 writes into. Without fp32 DEST, UnpackToDestFp32 can't be enabled
-    // and inputs are silently truncated to TF32 (10 mantissa bits) on the way through SrcA.
+    // Float32 input requires fp32_dest_acc_en=true on both GroupNorm paths:
+    //  - Welford: prerequisite for UnpackToDestFp32 (set below), which bypasses the unpacker's
+    //    Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
+    //    UnpackToDestFp32 writes into.
+    //  - Legacy (non-welford): intermediates are stored fp32 (im_data_format=Float32) and
+    //    accumulated in the fp32 DEST register, which requires fp32_dest_acc_en.
+    // Without fp32_dest_acc_en the DEST register is bfloat16, so accumulated/intermediate results are
+    // silently rounded to bf16 (7 mantissa bits) and UnpackToDestFp32 cannot be enabled. (SrcA's TF32
+    // rounding on FPU operands is separate and applies regardless of this flag.)
     TT_FATAL(
-        !(use_welford && in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
-        "group_norm welford with Float32 input requires fp32_dest_acc_en=true in the compute "
-        "kernel config; otherwise precision is silently lost in the unpacker format conversion.");
+        !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
+        "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
+        "otherwise the DEST accumulator is bfloat16 and intermediate/accumulated results are silently "
+        "rounded to bf16.");
 
     // welford_unpack_fp32_active is true iff the compute kernel's intake transpose_tile
     // reads from a CB that carries UnpackToDestFp32, regardless of which CB is used: c_29
@@ -301,6 +312,10 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     // welford_fp32_alias is the non-TILIZE_IN sub-case (c_19 alias is only useful when
     // c_0 isn't itself the consumer of the FP32 transpose, i.e. when tilize_in is false).
     const bool welford_fp32_alias = welford_unpack_fp32_active && !tilize_in;
+
+    // cb_reciprocals is excluded: it's fp32 here but the reconfigs never touch it.
+    const bool enable_fp32_reconfig = groupnorm_needs_fp32_reconfig(
+        {in_data_format, out_data_format, cb_data_format, gamma_beta_cb_data_format, in_mask_cb_data_format});
 
     const uint32_t cb_in0_welford_index =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_19) : static_cast<uint32_t>(tt::CBIndex::c_0);
@@ -388,7 +403,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t in_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in_CB_size_group_2 = 0;
     uint32_t in2_CB_size = single_tile_size;
-    uint32_t in3_CB_size = single_tile_size;
+    uint32_t in3_CB_size = eps_single_tile_size;
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
@@ -558,6 +573,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     std::unordered_map<std::string, uint32_t> reader_mcast_sender_named_compile_time_args_group_2 = {
@@ -591,6 +607,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         // cb_in0_welford_index == c_0 and the reader's gated push is skipped.
         {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
         {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
     };
 
     std::vector<uint32_t> reader_mcast_sender_compile_time_args_group_1 = {};
@@ -909,11 +926,15 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     mcast_sender_compute_named_compile_time_args_group_1["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_sender_compute_named_compile_time_args_group_1["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_sender_compute_named_compile_time_args_group_1["enable_fp32_reconfig"] =
+        static_cast<uint32_t>(enable_fp32_reconfig);
     mcast_sender_compute_named_compile_time_args_group_2["welford_fp32_alias"] =
         static_cast<uint32_t>(welford_fp32_alias);
     mcast_sender_compute_named_compile_time_args_group_2["welford_unpack_fp32_active"] =
         static_cast<uint32_t>(welford_unpack_fp32_active);
     mcast_sender_compute_named_compile_time_args_group_2["cb_in0_welford"] = cb_in0_welford_index;
+    mcast_sender_compute_named_compile_time_args_group_2["enable_fp32_reconfig"] =
+        static_cast<uint32_t>(enable_fp32_reconfig);
 
     KernelDescriptor compute_desc_g1;
     compute_desc_g1.kernel_source = compute_kernel_path;
@@ -1067,8 +1088,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = eps_single_tile_size,
         }}},
     });
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -9,6 +9,12 @@
 
 namespace ttnn::prim {
 
+bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfig_formats) {
+    return std::any_of(reconfig_formats.begin(), reconfig_formats.end(), [](tt::DataFormat format) {
+        return format != tt::DataFormat::Float16_b;
+    });
+}
+
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {
     if (n <= max_subblock_w) {
         return n;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -54,6 +54,12 @@ void append_group_norm_pad_correction_cbs(
     }
 }
 
+bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfig_formats) {
+    return std::any_of(reconfig_formats.begin(), reconfig_formats.end(), [](tt::DataFormat format) {
+        return format != tt::DataFormat::Float16_b;
+    });
+}
+
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {
     if (n <= max_subblock_w) {
         return n;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -10,8 +10,11 @@
 namespace ttnn::prim {
 
 bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfig_formats) {
+    // Only Float32 CBs need the extra reconfig_data_format path. Do not use
+    // `!= Float16_b`: Bfp8_b masks (common in SDXL/VAE sharded group_norm) are also
+    // non-Float16_b and must keep the legacy bf16 reconfig behavior.
     return std::any_of(reconfig_formats.begin(), reconfig_formats.end(), [](tt::DataFormat format) {
-        return format != tt::DataFormat::Float16_b;
+        return format == tt::DataFormat::Float32;
     });
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -6,12 +6,18 @@
 
 #include <vector>
 #include <cstdint>
+#include <initializer_list>
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace ttnn::prim {
 
 enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
+
+// True when any reconfig-relevant CB format is fp32, so the compute kernel must run its
+// reconfig_data_format calls. When all are bf16 those calls are no-ops and the kernel skips them.
+bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfig_formats);
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -7,9 +7,11 @@
 #include <array>
 #include <vector>
 #include <cstdint>
+#include <initializer_list>
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace ttnn::prim {
 
@@ -49,6 +51,10 @@ void append_group_norm_pad_correction_cbs(
     const tt::tt_metal::CoreRangeSet& core_ranges,
     tt::DataFormat data_format,
     uint32_t single_tile_size);
+
+// True when any reconfig-relevant CB format is fp32, so the compute kernel must run its
+// reconfig_data_format calls. When all are bf16 those calls are no-ops and the kernel skips them.
+bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfig_formats);
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -15,8 +15,9 @@ namespace ttnn::prim {
 
 enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
 
-// True when any reconfig-relevant CB format is fp32, so the compute kernel must run its
-// reconfig_data_format calls. When all are bf16 those calls are no-ops and the kernel skips them.
+// True when any reconfig-relevant CB format is Float32, so the compute kernel must run its
+// fp32 reconfig_data_format calls. Non-fp32 formats (Float16_b, Bfp8_b masks, etc.) must not
+// enable this path — Bfp8 != Float16_b is not a reason to take the fp32 reconfig branch.
 bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfig_formats);
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -780,13 +780,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_29) : static_cast<uint32_t>(tt::CBIndex::c_0);
     const uint32_t cb_in_welford_arg =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_31) : static_cast<uint32_t>(tt::CBIndex::c_1);
-    // True when any reconfig-relevant operand is fp32, so the compute kernel must run its per-group
-    // reconfig_data_format calls. When all are bf16 they're no-ops and the kernel skips them.
-    const bool enable_fp32_reconfig =
-        !(in_data_format == tt::DataFormat::Float16_b && out_data_format == tt::DataFormat::Float16_b &&
-          cb_data_format == tt::DataFormat::Float16_b && gamma_beta_cb_data_format == tt::DataFormat::Float16_b &&
-          in_mask_cb_data_format == tt::DataFormat::Float16_b &&
-          in_negative_mask_cb_data_format == tt::DataFormat::Float16_b);
+    const bool enable_fp32_reconfig = groupnorm_needs_fp32_reconfig(
+        {in_data_format,
+         out_data_format,
+         cb_data_format,
+         gamma_beta_cb_data_format,
+         in_mask_cb_data_format,
+         in_negative_mask_cb_data_format});
     // enable_fp32_reconfig is read by both compute kernels; the alias args only by the welford one.
     KernelDescriptor::NamedCompileTimeArgs compute_named_compile_time_args = {
         {"enable_fp32_reconfig", static_cast<uint32_t>(enable_fp32_reconfig)},

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -731,11 +731,14 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     //    UnpackToDestFp32 writes into.
     //  - Legacy (non-welford): the reduction is accumulated in the fp32 DEST register, which requires
     //    fp32_dest_acc_en.
-    // Without fp32 DEST, inputs are silently truncated to TF32 (10 mantissa bits) through SrcA.
+    // Without fp32_dest_acc_en the DEST register is bfloat16, so accumulated/intermediate results are
+    // silently rounded to bf16 (7 mantissa bits) and UnpackToDestFp32 cannot be enabled. (SrcA's TF32
+    // rounding on FPU operands is separate and applies regardless of this flag.)
     TT_FATAL(
         !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
         "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
-        "otherwise precision is silently lost in the unpacker format conversion.");
+        "otherwise the DEST accumulator is bfloat16 and intermediate/accumulated results are silently "
+        "rounded to bf16.");
 
     // UnpackToDestFp32 only helps for CBs whose only consumer is an op that supports the
     // unpack-to-DEST path (copy_tile or transpose_tile in fp32 mode).

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -66,6 +66,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(im_data_format);
+    // Tells the welford reader kernels to combine mean/variance as fp32 (see welford_reader_*_sharded_gn_v2.cpp).
+    const bool stats_is_fp32 = cb_data_format == tt::DataFormat::Float32;
     tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
     if (gamma.has_value()) {
         gamma_beta_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(gamma.value().dtype());
@@ -79,7 +81,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     tt::DataFormat in_negative_mask_cb_data_format =
         negative_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(negative_mask.value().dtype())
                                   : tt::DataFormat::Float16_b;
-    uint32_t datum_size_bytes = 2;  // bfloat16
+    uint32_t datum_size_bytes = output.element_size();  // output datum size (out==in format, enforced below)
 
     TT_FATAL(
         out_data_format == in_data_format,
@@ -317,10 +319,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t in0_block_tiles = per_core_Nt * per_core_Mt;
     uint32_t in0_CB_size = a.buffer()->aligned_size_per_bank();  // use buffer size to handle both RM and Tile
     uint32_t in_CB_size = in0_block_tiles * in_single_tile_size;
-    // in2 - scaler
-    uint32_t in2_CB_size = single_tile_size * (use_welford ? 3 : 1);
-    // in3 - eps
-    uint32_t in3_CB_size = single_tile_size;
+    // Scalar CBs (scaler c_2, scaler-c c_4, eps c_3, ones c_26) are written as bf16 bit patterns, so
+    // they stay bf16 even on the legacy fp32 path where cb_data_format is Float32.
+    const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t eps_single_tile_size = tt::tile_size(eps_cb_data_format);
+    uint32_t scalar_single_tile_size = eps_single_tile_size;
+    // Welford repurposes c_2 as the fp32 cb_xmm intermediate (3 tile slots); legacy uses it as the bf16 scaler.
+    const tt::DataFormat in2_cb_data_format = use_welford ? cb_data_format : eps_cb_data_format;
+    const uint32_t in2_single_tile_size = use_welford ? single_tile_size : scalar_single_tile_size;
+    uint32_t in2_CB_size = in2_single_tile_size * (use_welford ? 3 : 1);
+    // in3 - eps.
+    uint32_t in3_CB_size = eps_single_tile_size;
     // gamma
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
@@ -506,6 +515,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         reader_mcast_sender_compile_time_args.push_back(block_ht * block_wt);
         reader_mcast_sender_compile_time_args.push_back(num_groups_per_core);
         reader_mcast_sender_compile_time_args.push_back(tile_width);
+        reader_mcast_sender_compile_time_args.push_back(static_cast<uint32_t>(stats_is_fp32));
     }
     std::vector<uint32_t> reader_mcast_receiver_compile_time_args = {
         reduce_receiver_semaphore_id,
@@ -520,6 +530,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         reader_mcast_receiver_compile_time_args.push_back(block_ht * block_wt);
         reader_mcast_receiver_compile_time_args.push_back(num_groups_per_core);
         reader_mcast_receiver_compile_time_args.push_back(tile_width);
+        reader_mcast_receiver_compile_time_args.push_back(static_cast<uint32_t>(stats_is_fp32));
     }
     tt::tt_metal::NOC writer_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt::tt_metal::NOC reader_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
@@ -714,15 +725,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
     eltwise_binary_defines["FP32_DEST_ACC"] = fp32_dest_acc_en ? "true" : "false";
 
-    // Float32 input on the welford path requires fp32_dest_acc_en=true as a prerequisite for
-    // UnpackToDestFp32 (set below). UnpackToDestFp32 is what bypasses the unpacker's
-    // Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
-    // UnpackToDestFp32 writes into. Without fp32 DEST, UnpackToDestFp32 can't be enabled
-    // and inputs are silently truncated to TF32 (10 mantissa bits) on the way through SrcA.
+    // Float32 input requires fp32_dest_acc_en=true on both GroupNorm paths:
+    //  - Welford: prerequisite for UnpackToDestFp32 (set below), which bypasses the unpacker's
+    //    Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
+    //    UnpackToDestFp32 writes into.
+    //  - Legacy (non-welford): the reduction is accumulated in the fp32 DEST register, which requires
+    //    fp32_dest_acc_en.
+    // Without fp32 DEST, inputs are silently truncated to TF32 (10 mantissa bits) through SrcA.
     TT_FATAL(
-        !(use_welford && in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
-        "group_norm welford with Float32 input requires fp32_dest_acc_en=true in the compute "
-        "kernel config; otherwise precision is silently lost in the unpacker format conversion.");
+        !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
+        "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
+        "otherwise precision is silently lost in the unpacker format conversion.");
 
     // UnpackToDestFp32 only helps for CBs whose only consumer is an op that supports the
     // unpack-to-DEST path (copy_tile or transpose_tile in fp32 mode).
@@ -925,8 +938,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in2_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = in2_cb_data_format,
+            .page_size = in2_single_tile_size,
         }}},
     });
     // in3 eps
@@ -936,8 +949,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = eps_single_tile_size,
         }}},
     });
     // in4 scaler-c
@@ -948,8 +961,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in4_cb_index),
-                .data_format = cb_data_format,
-                .page_size = single_tile_size,
+                .data_format = eps_cb_data_format,
+                .page_size = scalar_single_tile_size,
             }}},
         });
     }
@@ -1095,12 +1108,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
 
     constexpr uint32_t cb_ones_index = tt::CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = single_tile_size,
+        .total_size = scalar_single_tile_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(cb_ones_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = scalar_single_tile_size,
         }}},
     });
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -775,18 +775,26 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     }
 
     // Welford-fp32 alias args. Only attached on the welford compute kernel; the non-welford
-    // groupnorm_sharded_v2.cpp never references these names. Read by welford_groupnorm_sharded_v2.cpp.
+    // groupnorm_sharded_v2.cpp never references these alias names. Read by welford_groupnorm_sharded_v2.cpp.
     const uint32_t cb_in0_welford_arg =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_29) : static_cast<uint32_t>(tt::CBIndex::c_0);
     const uint32_t cb_in_welford_arg =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_31) : static_cast<uint32_t>(tt::CBIndex::c_1);
-    KernelDescriptor::NamedCompileTimeArgs welford_named_compile_time_args;
+    // True when any reconfig-relevant operand is fp32, so the compute kernel must run its per-group
+    // reconfig_data_format calls. When all are bf16 they're no-ops and the kernel skips them.
+    const bool enable_fp32_reconfig =
+        !(in_data_format == tt::DataFormat::Float16_b && out_data_format == tt::DataFormat::Float16_b &&
+          cb_data_format == tt::DataFormat::Float16_b && gamma_beta_cb_data_format == tt::DataFormat::Float16_b &&
+          in_mask_cb_data_format == tt::DataFormat::Float16_b &&
+          in_negative_mask_cb_data_format == tt::DataFormat::Float16_b);
+    // enable_fp32_reconfig is read by both compute kernels; the alias args only by the welford one.
+    KernelDescriptor::NamedCompileTimeArgs compute_named_compile_time_args = {
+        {"enable_fp32_reconfig", static_cast<uint32_t>(enable_fp32_reconfig)},
+    };
     if (use_welford) {
-        welford_named_compile_time_args = {
-            {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
-            {"cb_in0_welford", cb_in0_welford_arg},
-            {"cb_in_welford", cb_in_welford_arg},
-        };
+        compute_named_compile_time_args.push_back({"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)});
+        compute_named_compile_time_args.push_back({"cb_in0_welford", cb_in0_welford_arg});
+        compute_named_compile_time_args.push_back({"cb_in_welford", cb_in_welford_arg});
     }
 
     KernelDescriptor compute_sender_desc;
@@ -798,7 +806,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     compute_sender_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_sender_desc.core_ranges = mcast_sender_cores;
     compute_sender_desc.compile_time_args = mcast_sender_compute_compile_time_args;
-    compute_sender_desc.named_compile_time_args = welford_named_compile_time_args;
+    compute_sender_desc.named_compile_time_args = compute_named_compile_time_args;
     compute_sender_desc.defines =
         KernelDescriptor::Defines(eltwise_binary_defines.begin(), eltwise_binary_defines.end());
     compute_sender_desc.config = ComputeConfigDescriptor{
@@ -818,7 +826,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     compute_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_receiver_desc.core_ranges = mcast_receiver_cores;
     compute_receiver_desc.compile_time_args = mcast_receiver_compute_compile_time_args;
-    compute_receiver_desc.named_compile_time_args = std::move(welford_named_compile_time_args);
+    compute_receiver_desc.named_compile_time_args = std::move(compute_named_compile_time_args);
     compute_receiver_desc.defines =
         KernelDescriptor::Defines(eltwise_binary_defines.begin(), eltwise_binary_defines.end());
     compute_receiver_desc.config = ComputeConfigDescriptor{

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -66,6 +66,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(im_data_format);
+    // Tells the welford reader kernels to combine mean/variance as fp32 (see welford_reader_*_sharded_gn_v2.cpp).
+    const bool stats_is_fp32 = cb_data_format == tt::DataFormat::Float32;
     tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
     if (gamma.has_value()) {
         gamma_beta_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(gamma.value().dtype());
@@ -79,7 +81,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     tt::DataFormat in_negative_mask_cb_data_format =
         negative_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(negative_mask.value().dtype())
                                   : tt::DataFormat::Float16_b;
-    uint32_t datum_size_bytes = 2;  // bfloat16
+    uint32_t datum_size_bytes = output.element_size();  // output datum size (out==in format, enforced below)
 
     TT_FATAL(
         out_data_format == in_data_format,
@@ -317,10 +319,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t in0_block_tiles = per_core_Nt * per_core_Mt;
     uint32_t in0_CB_size = a.buffer()->aligned_size_per_bank();  // use buffer size to handle both RM and Tile
     uint32_t in_CB_size = in0_block_tiles * in_single_tile_size;
-    // in2 - scaler
-    uint32_t in2_CB_size = single_tile_size * (use_welford ? 3 : 1);
-    // in3 - eps
-    uint32_t in3_CB_size = single_tile_size;
+    // Scalar CBs (scaler c_2, scaler-c c_4, eps c_3, ones c_26) are written as bf16 bit patterns, so
+    // they stay bf16 even on the legacy fp32 path where cb_data_format is Float32.
+    const tt::DataFormat eps_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t eps_single_tile_size = tt::tile_size(eps_cb_data_format);
+    uint32_t scalar_single_tile_size = eps_single_tile_size;
+    // Welford repurposes c_2 as the fp32 cb_xmm intermediate (3 tile slots); legacy uses it as the bf16 scaler.
+    const tt::DataFormat in2_cb_data_format = use_welford ? cb_data_format : eps_cb_data_format;
+    const uint32_t in2_single_tile_size = use_welford ? single_tile_size : scalar_single_tile_size;
+    uint32_t in2_CB_size = in2_single_tile_size * (use_welford ? 3 : 1);
+    // in3 - eps.
+    uint32_t in3_CB_size = eps_single_tile_size;
     // gamma
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
@@ -509,6 +518,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         reader_mcast_sender_compile_time_args.push_back(block_ht * block_wt);
         reader_mcast_sender_compile_time_args.push_back(num_groups_per_core);
         reader_mcast_sender_compile_time_args.push_back(tile_width);
+        reader_mcast_sender_compile_time_args.push_back(static_cast<uint32_t>(stats_is_fp32));
     }
     std::vector<uint32_t> reader_mcast_receiver_compile_time_args = {
         reduce_receiver_semaphore_id,
@@ -523,6 +533,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         reader_mcast_receiver_compile_time_args.push_back(block_ht * block_wt);
         reader_mcast_receiver_compile_time_args.push_back(num_groups_per_core);
         reader_mcast_receiver_compile_time_args.push_back(tile_width);
+        reader_mcast_receiver_compile_time_args.push_back(static_cast<uint32_t>(stats_is_fp32));
     }
     tt::tt_metal::NOC writer_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt::tt_metal::NOC reader_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
@@ -733,15 +744,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
     eltwise_binary_defines["FP32_DEST_ACC"] = fp32_dest_acc_en ? "true" : "false";
 
-    // Float32 input on the welford path requires fp32_dest_acc_en=true as a prerequisite for
-    // UnpackToDestFp32 (set below). UnpackToDestFp32 is what bypasses the unpacker's
-    // Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
-    // UnpackToDestFp32 writes into. Without fp32 DEST, UnpackToDestFp32 can't be enabled
-    // and inputs are silently truncated to TF32 (10 mantissa bits) on the way through SrcA.
+    // Float32 input requires fp32_dest_acc_en=true on both GroupNorm paths:
+    //  - Welford: prerequisite for UnpackToDestFp32 (set below), which bypasses the unpacker's
+    //    Float32 → TF32 truncation in SrcA; fp32_dest_acc_en provides the 32-bit DEST that
+    //    UnpackToDestFp32 writes into.
+    //  - Legacy (non-welford): the reduction is accumulated in the fp32 DEST register, which requires
+    //    fp32_dest_acc_en.
+    // Without fp32_dest_acc_en the DEST register is bfloat16, so accumulated/intermediate results are
+    // silently rounded to bf16 (7 mantissa bits) and UnpackToDestFp32 cannot be enabled. (SrcA's TF32
+    // rounding on FPU operands is separate and applies regardless of this flag.)
     TT_FATAL(
-        !(use_welford && in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
-        "group_norm welford with Float32 input requires fp32_dest_acc_en=true in the compute "
-        "kernel config; otherwise precision is silently lost in the unpacker format conversion.");
+        !(in_data_format == tt::DataFormat::Float32 && !fp32_dest_acc_en),
+        "group_norm with Float32 input requires fp32_dest_acc_en=true in the compute kernel config; "
+        "otherwise the DEST accumulator is bfloat16 and intermediate/accumulated results are silently "
+        "rounded to bf16.");
 
     // UnpackToDestFp32 only helps for CBs whose only consumer is an op that supports the
     // unpack-to-DEST path (copy_tile or transpose_tile in fp32 mode).
@@ -778,18 +794,26 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     }
 
     // Welford-fp32 alias args. Only attached on the welford compute kernel; the non-welford
-    // groupnorm_sharded_v2.cpp never references these names. Read by welford_groupnorm_sharded_v2.cpp.
+    // groupnorm_sharded_v2.cpp never references these alias names. Read by welford_groupnorm_sharded_v2.cpp.
     const uint32_t cb_in0_welford_arg =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_29) : static_cast<uint32_t>(tt::CBIndex::c_0);
     const uint32_t cb_in_welford_arg =
         welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_31) : static_cast<uint32_t>(tt::CBIndex::c_1);
-    KernelDescriptor::NamedCompileTimeArgs welford_named_compile_time_args;
+    const bool enable_fp32_reconfig = groupnorm_needs_fp32_reconfig(
+        {in_data_format,
+         out_data_format,
+         cb_data_format,
+         gamma_beta_cb_data_format,
+         in_mask_cb_data_format,
+         in_negative_mask_cb_data_format});
+    // enable_fp32_reconfig is read by both compute kernels; the alias args only by the welford one.
+    KernelDescriptor::NamedCompileTimeArgs compute_named_compile_time_args = {
+        {"enable_fp32_reconfig", static_cast<uint32_t>(enable_fp32_reconfig)},
+    };
     if (use_welford) {
-        welford_named_compile_time_args = {
-            {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
-            {"cb_in0_welford", cb_in0_welford_arg},
-            {"cb_in_welford", cb_in_welford_arg},
-        };
+        compute_named_compile_time_args.push_back({"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)});
+        compute_named_compile_time_args.push_back({"cb_in0_welford", cb_in0_welford_arg});
+        compute_named_compile_time_args.push_back({"cb_in_welford", cb_in_welford_arg});
     }
 
     KernelDescriptor compute_sender_desc;
@@ -801,7 +825,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     compute_sender_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_sender_desc.core_ranges = mcast_sender_cores;
     compute_sender_desc.compile_time_args = mcast_sender_compute_compile_time_args;
-    compute_sender_desc.named_compile_time_args = welford_named_compile_time_args;
+    compute_sender_desc.named_compile_time_args = compute_named_compile_time_args;
     compute_sender_desc.defines =
         KernelDescriptor::Defines(eltwise_binary_defines.begin(), eltwise_binary_defines.end());
     compute_sender_desc.config = ComputeConfigDescriptor{
@@ -821,7 +845,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     compute_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_receiver_desc.core_ranges = mcast_receiver_cores;
     compute_receiver_desc.compile_time_args = mcast_receiver_compute_compile_time_args;
-    compute_receiver_desc.named_compile_time_args = std::move(welford_named_compile_time_args);
+    compute_receiver_desc.named_compile_time_args = std::move(compute_named_compile_time_args);
     compute_receiver_desc.defines =
         KernelDescriptor::Defines(eltwise_binary_defines.begin(), eltwise_binary_defines.end());
     compute_receiver_desc.config = ComputeConfigDescriptor{
@@ -944,8 +968,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in2_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = in2_cb_data_format,
+            .page_size = in2_single_tile_size,
         }}},
     });
     // in3 eps
@@ -955,8 +979,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = eps_single_tile_size,
         }}},
     });
     // in4 scaler-c
@@ -967,8 +991,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in4_cb_index),
-                .data_format = cb_data_format,
-                .page_size = single_tile_size,
+                .data_format = eps_cb_data_format,
+                .page_size = scalar_single_tile_size,
             }}},
         });
     }
@@ -1114,12 +1138,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
 
     constexpr uint32_t cb_ones_index = tt::CBIndex::c_26;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = single_tile_size,
+        .total_size = scalar_single_tile_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(cb_ones_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = eps_cb_data_format,
+            .page_size = scalar_single_tile_size,
         }}},
     });
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -94,6 +94,9 @@ void kernel_main() {
     constexpr uint32_t do_gamma = get_named_compile_time_arg_val("do_gamma");
     constexpr uint32_t do_beta = get_named_compile_time_arg_val("do_beta");
     constexpr uint32_t num_cores_per_mcast_group = get_named_compile_time_arg_val("num_cores_per_mcast_group");
+    // True when a reconfig-relevant operand is fp32: the per-group reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
 
     constexpr uint32_t batch = get_named_compile_time_arg_val("batch");
     constexpr uint32_t group = get_named_compile_time_arg_val("group");
@@ -409,6 +412,11 @@ void kernel_main() {
                 dfb_in0.wait_front(out_block_hw_normal);
                 // x - E[x]
                 sub_bcast_scalar_init(dfb_in0_id, dfb_ex_global_id);
+                // fp32: reset both srcs so fp32 input/mean aren't read through the stale bf16 scaler format.
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_in0_id);
+                    reconfig_data_format_srcb(dfb_ex_global_id);
+                }
 
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex_global.wait_front(1);
@@ -575,6 +583,11 @@ void kernel_main() {
             // (Var + eps)
             tile_regs_acquire();
             add_init(dfb_var_src_id, dfb_eps_id);
+            // fp32: reset both srcs so fp32 variance / bf16 eps aren't read through the stale square/reduce format.
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_var_src_id);
+                reconfig_data_format_srcb(dfb_eps_id);
+            }
             add_tiles(dfb_var_src_id, dfb_eps_id, 0, 0, dst0);
             tile_regs_wait();
             // 1/[sqrt(Var + eps)]
@@ -610,6 +623,11 @@ void kernel_main() {
                 dfb_in0.wait_front(out_block_hw_normal);
                 // x - E[x]
                 sub_bcast_scalar_init(dfb_in0_id, dfb_ex_global_id);
+                // fp32: reset both srcs so fp32 input/mean aren't read through the stale rsqrt/eps format.
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_in0_id);
+                    reconfig_data_format_srcb(dfb_ex_global_id);
+                }
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex_global.wait_front(1);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
@@ -668,6 +686,11 @@ void kernel_main() {
                 // (x - Ex) * 1/[sqrt(Var + eps)]
                 index_h_offset = 0;
                 mul_bcast_scalar_init(dfb_x_id, dfb_ex2pe_id);
+                // fp32: reset both srcs so fp32 x/rstd aren't read through the stale mask/eps format.
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_x_id);
+                    reconfig_data_format_srcb(dfb_ex2pe_id);
+                }
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex2pe.wait_front(1);
                 dfb_x.wait_front(out_block_hw_normal);
@@ -767,6 +790,12 @@ void kernel_main() {
                         for (uint32_t j = 0; j < block_w_curr; ++j) {
                             if (apply_gamma_beta[j]) {
                                 mul_bcast_rows_init(dfb_reread_write_out_id, dfb_gamma_id);
+                                // fp32: reset both srcs so bf16 gamma isn't read through the reread stage's fp32
+                                // format.
+                                if constexpr (enable_fp32_reconfig) {
+                                    reconfig_data_format_srca(dfb_reread_write_out_id);
+                                    reconfig_data_format_srcb(dfb_gamma_id);
+                                }
                             } else {
                                 copy_tile_init(dfb_reread_write_out_id);
                             }
@@ -800,6 +829,11 @@ void kernel_main() {
                         for (uint32_t j = 0; j < block_w_curr; ++j) {
                             if (apply_gamma_beta[j]) {
                                 add_bcast_rows_init(dfb_inbeta_id, dfb_beta_id);
+                                // fp32: reset both srcs so bf16 beta isn't read through the fp32 dfb_inbeta format.
+                                if constexpr (enable_fp32_reconfig) {
+                                    reconfig_data_format_srca(dfb_inbeta_id);
+                                    reconfig_data_format_srcb(dfb_beta_id);
+                                }
                             } else {
                                 copy_tile_init(dfb_inbeta_id);
                             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -94,6 +94,9 @@ void kernel_main() {
     constexpr uint32_t do_gamma = get_named_compile_time_arg_val("do_gamma");
     constexpr uint32_t do_beta = get_named_compile_time_arg_val("do_beta");
     constexpr uint32_t num_cores_per_mcast_group = get_named_compile_time_arg_val("num_cores_per_mcast_group");
+    // True when a reconfig-relevant operand is fp32: the per-group reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
 
     constexpr uint32_t batch = get_named_compile_time_arg_val("batch");
     constexpr uint32_t group = get_named_compile_time_arg_val("group");
@@ -394,10 +397,11 @@ void kernel_main() {
                 dfb_in0.wait_front(out_block_hw_normal);
                 // x - E[x]
                 sub_tiles_bcast_scalar_init_short(dfb_in0_id, dfb_ex_global_id);
-                // fp32: reset both srcs so fp32 input/mean aren't read through the stale bf16 scaler format; no-op for
-                // bf16.
-                reconfig_data_format_srca(dfb_in0_id);
-                reconfig_data_format_srcb(dfb_ex_global_id);
+                // fp32: reset both srcs so fp32 input/mean aren't read through the stale bf16 scaler format.
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_in0_id);
+                    reconfig_data_format_srcb(dfb_ex_global_id);
+                }
 
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex_global.wait_front(1);
@@ -521,8 +525,10 @@ void kernel_main() {
             tile_regs_acquire();
             add_tiles_init(dfb_ex2_global_id, dfb_eps_id);
             // fp32: reset both srcs so fp32 variance / bf16 eps aren't read through the stale square/reduce format.
-            reconfig_data_format_srca(dfb_ex2_global_id);
-            reconfig_data_format_srcb(dfb_eps_id);
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_ex2_global_id);
+                reconfig_data_format_srcb(dfb_eps_id);
+            }
             add_tiles(dfb_ex2_global_id, dfb_eps_id, 0, 0, dst0);
             tile_regs_wait();
             // 1/[sqrt(Var + eps)]
@@ -556,8 +562,10 @@ void kernel_main() {
                 // x - E[x]
                 sub_tiles_bcast_scalar_init_short(dfb_in0_id, dfb_ex_global_id);
                 // fp32: reset both srcs so fp32 input/mean aren't read through the stale rsqrt/eps format.
-                reconfig_data_format_srca(dfb_in0_id);
-                reconfig_data_format_srcb(dfb_ex_global_id);
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_in0_id);
+                    reconfig_data_format_srcb(dfb_ex_global_id);
+                }
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex_global.wait_front(1);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
@@ -617,8 +625,10 @@ void kernel_main() {
                 index_h_offset = 0;
                 mul_tiles_bcast_scalar_init_short(dfb_x_id, dfb_ex2pe_id);
                 // fp32: reset both srcs so fp32 x/rstd aren't read through the stale mask/eps format.
-                reconfig_data_format_srca(dfb_x_id);
-                reconfig_data_format_srcb(dfb_ex2pe_id);
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_x_id);
+                    reconfig_data_format_srcb(dfb_ex2pe_id);
+                }
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex2pe.wait_front(1);
                 dfb_x.wait_front(out_block_hw_normal);
@@ -720,8 +730,10 @@ void kernel_main() {
                                 mul_bcast_rows_init_short(dfb_reread_write_out_id, dfb_gamma_id);
                                 // fp32: reset both srcs so bf16 gamma isn't read through the reread stage's fp32
                                 // format.
-                                reconfig_data_format_srca(dfb_reread_write_out_id);
-                                reconfig_data_format_srcb(dfb_gamma_id);
+                                if constexpr (enable_fp32_reconfig) {
+                                    reconfig_data_format_srca(dfb_reread_write_out_id);
+                                    reconfig_data_format_srcb(dfb_gamma_id);
+                                }
                             } else {
                                 copy_tile_init(dfb_reread_write_out_id);
                             }
@@ -756,8 +768,10 @@ void kernel_main() {
                             if (apply_gamma_beta[j]) {
                                 add_bcast_rows_init_short(dfb_inbeta_id, dfb_beta_id);
                                 // fp32: reset both srcs so bf16 beta isn't read through the fp32 cb_inbeta format.
-                                reconfig_data_format_srca(dfb_inbeta_id);
-                                reconfig_data_format_srcb(dfb_beta_id);
+                                if constexpr (enable_fp32_reconfig) {
+                                    reconfig_data_format_srca(dfb_inbeta_id);
+                                    reconfig_data_format_srcb(dfb_beta_id);
+                                }
                             } else {
                                 copy_tile_init(dfb_inbeta_id);
                             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -394,6 +394,10 @@ void kernel_main() {
                 dfb_in0.wait_front(out_block_hw_normal);
                 // x - E[x]
                 sub_tiles_bcast_scalar_init_short(dfb_in0_id, dfb_ex_global_id);
+                // fp32: reset both srcs so fp32 input/mean aren't read through the stale bf16 scaler format; no-op for
+                // bf16.
+                reconfig_data_format_srca(dfb_in0_id);
+                reconfig_data_format_srcb(dfb_ex_global_id);
 
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex_global.wait_front(1);
@@ -516,6 +520,9 @@ void kernel_main() {
             // (Var + eps)
             tile_regs_acquire();
             add_tiles_init(dfb_ex2_global_id, dfb_eps_id);
+            // fp32: reset both srcs so fp32 variance / bf16 eps aren't read through the stale square/reduce format.
+            reconfig_data_format_srca(dfb_ex2_global_id);
+            reconfig_data_format_srcb(dfb_eps_id);
             add_tiles(dfb_ex2_global_id, dfb_eps_id, 0, 0, dst0);
             tile_regs_wait();
             // 1/[sqrt(Var + eps)]
@@ -548,6 +555,9 @@ void kernel_main() {
                 dfb_in0.wait_front(out_block_hw_normal);
                 // x - E[x]
                 sub_tiles_bcast_scalar_init_short(dfb_in0_id, dfb_ex_global_id);
+                // fp32: reset both srcs so fp32 input/mean aren't read through the stale rsqrt/eps format.
+                reconfig_data_format_srca(dfb_in0_id);
+                reconfig_data_format_srcb(dfb_ex_global_id);
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex_global.wait_front(1);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
@@ -606,6 +616,9 @@ void kernel_main() {
                 // (x - Ex) * 1/[sqrt(Var + eps)]
                 index_h_offset = 0;
                 mul_tiles_bcast_scalar_init_short(dfb_x_id, dfb_ex2pe_id);
+                // fp32: reset both srcs so fp32 x/rstd aren't read through the stale mask/eps format.
+                reconfig_data_format_srca(dfb_x_id);
+                reconfig_data_format_srcb(dfb_ex2pe_id);
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex2pe.wait_front(1);
                 dfb_x.wait_front(out_block_hw_normal);
@@ -705,6 +718,10 @@ void kernel_main() {
                         for (uint32_t j = 0; j < block_w_curr; ++j) {
                             if (apply_gamma_beta[j]) {
                                 mul_bcast_rows_init_short(dfb_reread_write_out_id, dfb_gamma_id);
+                                // fp32: reset both srcs so bf16 gamma isn't read through the reread stage's fp32
+                                // format.
+                                reconfig_data_format_srca(dfb_reread_write_out_id);
+                                reconfig_data_format_srcb(dfb_gamma_id);
                             } else {
                                 copy_tile_init(dfb_reread_write_out_id);
                             }
@@ -738,6 +755,9 @@ void kernel_main() {
                         for (uint32_t j = 0; j < block_w_curr; ++j) {
                             if (apply_gamma_beta[j]) {
                                 add_bcast_rows_init_short(dfb_inbeta_id, dfb_beta_id);
+                                // fp32: reset both srcs so bf16 beta isn't read through the fp32 cb_inbeta format.
+                                reconfig_data_format_srca(dfb_inbeta_id);
+                                reconfig_data_format_srcb(dfb_beta_id);
                             } else {
                                 copy_tile_init(dfb_inbeta_id);
                             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -25,6 +25,9 @@ void kernel_main() {
     constexpr uint32_t do_gamma = get_compile_time_arg_val(1);
     constexpr uint32_t do_beta = get_compile_time_arg_val(2);
     constexpr uint32_t num_cores_per_mcast_group = get_compile_time_arg_val(3);
+    // True when a reconfig-relevant operand is fp32: the per-group reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
 
     constexpr uint32_t batch = get_compile_time_arg_val(4);
     constexpr uint32_t group = get_compile_time_arg_val(5);
@@ -341,6 +344,11 @@ void kernel_main() {
 
             // x - E[x]
             sub_bcast_scalar_init(dfb_x_id, dfb_ex_global_id);
+            // fp32: reset both srcs so fp32 x/mean aren't read through the partial-E[x] bf16 dfb_ones format.
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_x_id);
+                reconfig_data_format_srcb(dfb_ex_global_id);
+            }
             for (uint32_t i = 0; i < block_h; i++) {
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -468,6 +476,11 @@ void kernel_main() {
             // (Var + eps)
             tile_regs_acquire();
             add_init(dfb_var_src_id, dfb_eps_id);
+            // fp32: reset both srcs so bf16 eps isn't read through the (x-Ex)^2 fp32 format (else garbage var+eps).
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_var_src_id);
+                reconfig_data_format_srcb(dfb_eps_id);
+            }
             add_tiles(dfb_var_src_id, dfb_eps_id, 0, 0, dst0);
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
@@ -484,6 +497,11 @@ void kernel_main() {
             //  (x - Ex) * 1/[sqrt(Var + eps)]
             index_h_offset = 0;
             mul_bcast_scalar_init(dfb_x_id, dfb_ex2pe_id);
+            // fp32: reset both srcs so fp32 x/rstd aren't read through the (var+eps) bf16 dfb_eps format.
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_x_id);
+                reconfig_data_format_srcb(dfb_ex2pe_id);
+            }
 
             dfb_ex2pe.wait_front(1);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -662,6 +680,11 @@ void kernel_main() {
         index_h_offset = 0;
         if constexpr (use_negative_mask == false) {
             mul_bcast_rows_init(dfb_out_id, dfb_gamma_id);
+            // fp32: reset both srcs so bf16 gamma isn't read through the normalization loop's fp32 format.
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_out_id);
+                reconfig_data_format_srcb(dfb_gamma_id);
+            }
             dfb_outgamma.reserve_back(per_core_MN);
             dfb_gamma.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
@@ -683,6 +706,11 @@ void kernel_main() {
         } else {
             // cb in has data required for gamma, so we do it inplace
             mul_bcast_rows_init(dfb_in_id, dfb_gamma_id);
+            // fp32: see non-negative-mask branch above.
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_in_id);
+                reconfig_data_format_srcb(dfb_gamma_id);
+            }
             dfb_gamma.wait_front(per_core_N);
             dfb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {
@@ -705,6 +733,11 @@ void kernel_main() {
         if constexpr (use_negative_mask == false) {
             index_h_offset = 0;
             add_bcast_rows_init(dfb_inbeta_id, dfb_beta_id);
+            // fp32: reset both srcs so bf16 beta isn't read as fp32 (matters especially when do_gamma=false).
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_inbeta_id);
+                reconfig_data_format_srcb(dfb_beta_id);
+            }
             dfb_outbeta.reserve_back(per_core_MN);
             dfb_beta.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
@@ -725,6 +758,11 @@ void kernel_main() {
         } else {
             // cb_in_id has data required for beta, so we do it inplace
             add_bcast_rows_init(dfb_in_id, dfb_beta_id);
+            // fp32: see non-negative-mask branch above.
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_in_id);
+                reconfig_data_format_srcb(dfb_beta_id);
+            }
             dfb_beta.wait_front(per_core_N);
             dfb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -298,6 +298,10 @@ void kernel_main() {
             }
             // x - E[x]
             sub_tiles_bcast_scalar_init_short(dfb_x_id, dfb_ex_global_id);
+            // fp32: reset both srcs (1-arg) so fp32 x/mean aren't read through the partial-E[x] bf16 cb_ones format;
+            // no-op for bf16.
+            reconfig_data_format_srca(dfb_x_id);
+            reconfig_data_format_srcb(dfb_ex_global_id);
 
             dfb_ex_global.wait_front(1);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -410,6 +414,9 @@ void kernel_main() {
             // (Var + eps)
             tile_regs_acquire();
             add_tiles_init(dfb_ex_global_id, dfb_eps_id);
+            // fp32: reset both srcs so bf16 eps isn't read through the (x-Ex)^2 fp32 format (else garbage var+eps).
+            reconfig_data_format_srca(dfb_ex_global_id);
+            reconfig_data_format_srcb(dfb_eps_id);
             add_tiles(dfb_ex_global_id, dfb_eps_id, 0, 0, dst0);
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
@@ -423,6 +430,9 @@ void kernel_main() {
             //  (x - Ex) * 1/[sqrt(Var + eps)]
             index_h_offset = 0;
             mul_tiles_bcast_scalar_init_short(dfb_x_id, dfb_ex2pe_id);
+            // fp32: reset both srcs so fp32 x/rstd aren't read through the (var+eps) bf16 cb_eps format.
+            reconfig_data_format_srca(dfb_x_id);
+            reconfig_data_format_srcb(dfb_ex2pe_id);
 
             dfb_ex2pe.wait_front(1);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -601,6 +611,9 @@ void kernel_main() {
         index_h_offset = 0;
         if constexpr (use_negative_mask == false) {
             mul_bcast_rows_init_short(dfb_out_id, dfb_gamma_id);
+            // fp32: reset both srcs so bf16 gamma isn't read through the normalization loop's fp32 format.
+            reconfig_data_format_srca(dfb_out_id);
+            reconfig_data_format_srcb(dfb_gamma_id);
             dfb_outgamma.reserve_back(per_core_MN);
             dfb_gamma.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
@@ -622,6 +635,9 @@ void kernel_main() {
         } else {
             // cb in has data required for gamma, so we do it inplace
             mul_bcast_rows_init_short(dfb_in_id, dfb_gamma_id);
+            // fp32: see non-negative-mask branch above.
+            reconfig_data_format_srca(dfb_in_id);
+            reconfig_data_format_srcb(dfb_gamma_id);
             dfb_gamma.wait_front(per_core_N);
             dfb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {
@@ -644,6 +660,9 @@ void kernel_main() {
         if constexpr (use_negative_mask == false) {
             index_h_offset = 0;
             add_bcast_rows_init_short(dfb_inbeta_id, dfb_beta_id);
+            // fp32: reset both srcs so bf16 beta isn't read as fp32 (matters especially when do_gamma=false).
+            reconfig_data_format_srca(dfb_inbeta_id);
+            reconfig_data_format_srcb(dfb_beta_id);
             dfb_outbeta.reserve_back(per_core_MN);
             dfb_beta.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
@@ -664,6 +683,9 @@ void kernel_main() {
         } else {
             // cb_in_id has data required for beta, so we do it inplace
             add_bcast_rows_init_short(dfb_in_id, dfb_beta_id);
+            // fp32: see non-negative-mask branch above.
+            reconfig_data_format_srca(dfb_in_id);
+            reconfig_data_format_srcb(dfb_beta_id);
             dfb_beta.wait_front(per_core_N);
             dfb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -25,6 +25,9 @@ void kernel_main() {
     constexpr uint32_t do_gamma = get_compile_time_arg_val(1);
     constexpr uint32_t do_beta = get_compile_time_arg_val(2);
     constexpr uint32_t num_cores_per_mcast_group = get_compile_time_arg_val(3);
+    // True when a reconfig-relevant operand is fp32: the per-group reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
 
     constexpr uint32_t batch = get_compile_time_arg_val(4);
     constexpr uint32_t group = get_compile_time_arg_val(5);
@@ -298,10 +301,11 @@ void kernel_main() {
             }
             // x - E[x]
             sub_tiles_bcast_scalar_init_short(dfb_x_id, dfb_ex_global_id);
-            // fp32: reset both srcs (1-arg) so fp32 x/mean aren't read through the partial-E[x] bf16 cb_ones format;
-            // no-op for bf16.
-            reconfig_data_format_srca(dfb_x_id);
-            reconfig_data_format_srcb(dfb_ex_global_id);
+            // fp32: reset both srcs so fp32 x/mean aren't read through the partial-E[x] bf16 cb_ones format.
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_x_id);
+                reconfig_data_format_srcb(dfb_ex_global_id);
+            }
 
             dfb_ex_global.wait_front(1);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -415,8 +419,10 @@ void kernel_main() {
             tile_regs_acquire();
             add_tiles_init(dfb_ex_global_id, dfb_eps_id);
             // fp32: reset both srcs so bf16 eps isn't read through the (x-Ex)^2 fp32 format (else garbage var+eps).
-            reconfig_data_format_srca(dfb_ex_global_id);
-            reconfig_data_format_srcb(dfb_eps_id);
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_ex_global_id);
+                reconfig_data_format_srcb(dfb_eps_id);
+            }
             add_tiles(dfb_ex_global_id, dfb_eps_id, 0, 0, dst0);
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
@@ -431,8 +437,10 @@ void kernel_main() {
             index_h_offset = 0;
             mul_tiles_bcast_scalar_init_short(dfb_x_id, dfb_ex2pe_id);
             // fp32: reset both srcs so fp32 x/rstd aren't read through the (var+eps) bf16 cb_eps format.
-            reconfig_data_format_srca(dfb_x_id);
-            reconfig_data_format_srcb(dfb_ex2pe_id);
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_x_id);
+                reconfig_data_format_srcb(dfb_ex2pe_id);
+            }
 
             dfb_ex2pe.wait_front(1);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -612,8 +620,10 @@ void kernel_main() {
         if constexpr (use_negative_mask == false) {
             mul_bcast_rows_init_short(dfb_out_id, dfb_gamma_id);
             // fp32: reset both srcs so bf16 gamma isn't read through the normalization loop's fp32 format.
-            reconfig_data_format_srca(dfb_out_id);
-            reconfig_data_format_srcb(dfb_gamma_id);
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_out_id);
+                reconfig_data_format_srcb(dfb_gamma_id);
+            }
             dfb_outgamma.reserve_back(per_core_MN);
             dfb_gamma.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
@@ -636,8 +646,10 @@ void kernel_main() {
             // cb in has data required for gamma, so we do it inplace
             mul_bcast_rows_init_short(dfb_in_id, dfb_gamma_id);
             // fp32: see non-negative-mask branch above.
-            reconfig_data_format_srca(dfb_in_id);
-            reconfig_data_format_srcb(dfb_gamma_id);
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_in_id);
+                reconfig_data_format_srcb(dfb_gamma_id);
+            }
             dfb_gamma.wait_front(per_core_N);
             dfb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {
@@ -661,8 +673,10 @@ void kernel_main() {
             index_h_offset = 0;
             add_bcast_rows_init_short(dfb_inbeta_id, dfb_beta_id);
             // fp32: reset both srcs so bf16 beta isn't read as fp32 (matters especially when do_gamma=false).
-            reconfig_data_format_srca(dfb_inbeta_id);
-            reconfig_data_format_srcb(dfb_beta_id);
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_inbeta_id);
+                reconfig_data_format_srcb(dfb_beta_id);
+            }
             dfb_outbeta.reserve_back(per_core_MN);
             dfb_beta.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
@@ -684,8 +698,10 @@ void kernel_main() {
             // cb_in_id has data required for beta, so we do it inplace
             add_bcast_rows_init_short(dfb_in_id, dfb_beta_id);
             // fp32: see non-negative-mask branch above.
-            reconfig_data_format_srca(dfb_in_id);
-            reconfig_data_format_srcb(dfb_beta_id);
+            if constexpr (enable_fp32_reconfig) {
+                reconfig_data_format_srca(dfb_in_id);
+                reconfig_data_format_srcb(dfb_beta_id);
+            }
             dfb_beta.wait_front(per_core_N);
             dfb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -134,6 +134,9 @@ void kernel_main() {
     // transpose. For bf16 input, transpose routes through SrcA without touching the
     // math-thread replay buffer, so no re-init is needed.
     constexpr bool welford_unpack_fp32_active = get_named_compile_time_arg_val("welford_unpack_fp32_active") != 0;
+    // True when a reconfig-relevant operand is fp32: the per-tile reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
     constexpr uint32_t dfb_eps_id = tt::CBIndex::c_3;
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
@@ -385,7 +388,12 @@ void kernel_main() {
         dfb_ex_global.wait_front(2 * num_groups);
         dfb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
+        // fp32: dfb_ex_global is fp32 (var), dfb_eps is bf16; the welford intake left SrcA on the fp32 input alias.
+        // Reset both srcs so they match the operands read below. no-op for bf16.
         add_init(dfb_ex_global_id, dfb_eps_id);
+        if constexpr (enable_fp32_reconfig) {
+            reconfig_data_format_srca(dfb_ex_global_id);
+        }
         reconfig_data_format_srcb(dfb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
@@ -444,8 +452,16 @@ void kernel_main() {
 
                         // // Now let us do the actual computation for the current group here
                         // // a. x-u
+                        // fp32: SrcA needs dfb_in0 (fp32 input), SrcB needs dfb_ex_global (fp32 mean); the prior
+                        // group's mul_tiles(dfb_xmm) left SrcA on dfb_xmm. Use the unconditional 1-arg form: the old
+                        // 2-arg srcb(dfb_eps -> dfb_ex_global) never reset SrcA at all.
                         sub_bcast_scalar_init(dfb_in0_id, dfb_ex_global_id);
-                        reconfig_data_format_srcb(dfb_eps_id, dfb_ex_global_id);
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_in0_id);
+                            reconfig_data_format_srcb(dfb_ex_global_id);
+                        } else {
+                            reconfig_data_format_srcb(dfb_eps_id, dfb_ex_global_id);
+                        }
 
                         tile_regs_acquire();
                         sub_tiles_bcast_scalar(dfb_in0_id, dfb_ex_global_id, 0, 0 + (g << 1), dst0);
@@ -458,7 +474,12 @@ void kernel_main() {
                         const uint32_t mask_offset = g * block_w;
                         const uint32_t mask_index = mask_offset + block_w_index;
 
+                        // fp32: reset SrcA to the mask format before reading dfb_input_mask (prior step left it on fp32
+                        // dfb_in0).
                         mul_bcast_scalar_init(dfb_input_mask_id, dfb_ex2pe_id);
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_in0_id, dfb_input_mask_id);
+                        }
                         reconfig_data_format_srcb(dfb_ex_global_id, dfb_ex2pe_id);
                         tile_regs_acquire();
                         mul_tiles_bcast_scalar(dfb_input_mask_id, dfb_ex2pe_id, mask_index, g, dst0);
@@ -471,6 +492,10 @@ void kernel_main() {
                         // // c. a * b
                         dfb_xmm.wait_front(2);
                         mul_init(dfb_xmm_id, dfb_xmm_id);
+                        // fp32: reset SrcA to dfb_xmm (fp32); step b above left SrcA on the bf16 input mask.
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_xmm_id);
+                        }
                         reconfig_data_format_srcb(dfb_ex2pe_id, dfb_xmm_id);
                         tile_regs_acquire();
                         mul_tiles(dfb_xmm_id, dfb_xmm_id, 0, 1, dst0);
@@ -548,8 +573,15 @@ void kernel_main() {
                     }
 
                     if constexpr (do_gamma) {
-                        mul_bcast_rows_init(dfb_x_id, dfb_gamma_id);
-                        reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
+                        // fp32: reset SrcA to dfb_x (fp32); the prior mask/accumulate step left SrcA on a bf16 format.
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_x_id);
+                            reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
+                            mul_bcast_rows_init(dfb_x_id, dfb_gamma_id);
+                        } else {
+                            mul_bcast_rows_init(dfb_x_id, dfb_gamma_id);
+                            reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
+                        }
 
                         dfb_x.wait_front(1);
                         tile_regs_acquire();
@@ -564,8 +596,15 @@ void kernel_main() {
                     }
 
                     if constexpr (do_beta) {
-                        add_bcast_rows_init(dfb_x_id, dfb_beta_id);
-                        reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
+                        // fp32: reset SrcA to dfb_x (fp32), same as the gamma step above.
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_x_id);
+                            reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
+                            add_bcast_rows_init(dfb_x_id, dfb_beta_id);
+                        } else {
+                            add_bcast_rows_init(dfb_x_id, dfb_beta_id);
+                            reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
+                        }
 
                         dfb_x.wait_front(1);
                         tile_regs_acquire();
@@ -581,6 +620,9 @@ void kernel_main() {
 
                     // Write out the final output
                     copy_tile_init(dfb_x_id);
+                    if constexpr (enable_fp32_reconfig) {
+                        reconfig_data_format_srca(dfb_x_id);
+                    }
                     reconfig_data_format_srcb(do_beta ? dfb_beta_id : dfb_xmm_id, dfb_x_id);
 
                     dfb_x.wait_front(1);
@@ -590,7 +632,19 @@ void kernel_main() {
                     dfb_x.pop_front(1);
                     dfb_out.reserve_back(1);
                     tile_regs_wait();
+#ifndef UNTILIZE_OUT
+                    // Packer was last set for bf16 dfb_x; reconfigure to dfb_out_id (may be fp32) before pack, restore
+                    // after. Only needed when out differs from dfb_x (fp32 path); no-op gated out for bf16.
+                    if constexpr (enable_fp32_reconfig) {
+                        pack_reconfig_data_format(dfb_out_id);
+                    }
+#endif
                     pack_tile(dst0, dfb_out_id);
+#ifndef UNTILIZE_OUT
+                    if constexpr (enable_fp32_reconfig) {
+                        pack_reconfig_data_format(dfb_x_id);
+                    }
+#endif
                     tile_regs_release();
                     dfb_out.push_back(1);
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -125,15 +125,13 @@ void kernel_main() {
     constexpr uint32_t dfb_in0_welford_id = get_named_compile_time_arg_val("cb_in0_welford");
     // Boolean indicating whether the welford kernel uses the alias CB.
     constexpr bool welford_fp32_alias = get_named_compile_time_arg_val("welford_fp32_alias") != 0;
-    // True when the welford intake CB is configured with UnpackToDestFp32, i.e. the FP32
-    // path. Covers both the TILIZE_IN branch (intake CB is c_29) and the non-TILIZE_IN
-    // alias branch (intake CB is dfb_in0_welford, see welford_fp32_alias). On this path,
-    // transpose_tile routes through llk_math_transpose_dest, whose math-side init
-    // records slots [16, 32) of the math-thread replay buffer, clobbering welford's
-    // LREG2 / LREG3 portions, so the welford SFPU state must be re-initialized after each
-    // transpose. For bf16 input, transpose routes through SrcA without touching the
-    // math-thread replay buffer, so no re-init is needed.
+    // True on the fp32 intake path (transpose reads an UnpackToDestFp32 CB). transpose_tile then
+    // clobbers welford's LREG2/LREG3, so welford SFPU state must be re-inited after each transpose.
+    // bf16 transposes via SrcA and needs no re-init.
     constexpr bool welford_unpack_fp32_active = get_named_compile_time_arg_val("welford_unpack_fp32_active") != 0;
+    // True when a reconfig-relevant operand is fp32: the per-tile reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
     constexpr uint32_t dfb_eps_id = tt::CBIndex::c_3;
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
@@ -388,7 +386,9 @@ void kernel_main() {
         // fp32: cb_ex_global is fp32 (var), cb_eps is bf16; the welford intake left SrcA on the fp32 input alias.
         // Reset both srcs so they match the operands read below. no-op for bf16.
         add_tiles_init(dfb_ex_global_id, dfb_eps_id);
-        reconfig_data_format_srca(dfb_ex_global_id);
+        if constexpr (enable_fp32_reconfig) {
+            reconfig_data_format_srca(dfb_ex_global_id);
+        }
         reconfig_data_format_srcb(dfb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
@@ -449,10 +449,14 @@ void kernel_main() {
                         // // a. x-u
                         // fp32: SrcA needs cb_in0 (fp32 input), SrcB needs cb_ex_global (fp32 mean); the prior group's
                         // mul_tiles(cb_xmm) left SrcA on cb_xmm. Use the unconditional 1-arg form: the old 2-arg
-                        // srcb(cb_eps -> cb_ex_global) never reset SrcA at all. no-op for bf16.
+                        // srcb(cb_eps -> cb_ex_global) never reset SrcA at all.
                         sub_tiles_bcast_scalar_init_short(dfb_in0_id, dfb_ex_global_id);
-                        reconfig_data_format_srca(dfb_in0_id);
-                        reconfig_data_format_srcb(dfb_ex_global_id);
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_in0_id);
+                            reconfig_data_format_srcb(dfb_ex_global_id);
+                        } else {
+                            reconfig_data_format_srcb(dfb_eps_id, dfb_ex_global_id);
+                        }
 
                         tile_regs_acquire();
                         sub_tiles_bcast_scalar(dfb_in0_id, dfb_ex_global_id, 0, 0 + (g << 1), dst0);
@@ -468,7 +472,9 @@ void kernel_main() {
                         // fp32: reset SrcA to the mask format before reading cb_input_mask (prior step left it on fp32
                         // cb_in0).
                         mul_tiles_bcast_scalar_init_short(dfb_input_mask_id, dfb_ex2pe_id);
-                        reconfig_data_format_srca(dfb_in0_id, dfb_input_mask_id);
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_in0_id, dfb_input_mask_id);
+                        }
                         reconfig_data_format_srcb(dfb_ex_global_id, dfb_ex2pe_id);
                         tile_regs_acquire();
                         mul_tiles_bcast_scalar(dfb_input_mask_id, dfb_ex2pe_id, mask_index, g, dst0);
@@ -481,9 +487,10 @@ void kernel_main() {
                         // // c. a * b
                         dfb_xmm.wait_front(2);
                         mul_tiles_init(dfb_xmm_id, dfb_xmm_id);
-                        // fp32: reset SrcA to cb_xmm (fp32); step b above left SrcA on the bf16 input mask. no-op for
-                        // bf16.
-                        reconfig_data_format_srca(dfb_xmm_id);
+                        // fp32: reset SrcA to cb_xmm (fp32); step b above left SrcA on the bf16 input mask.
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_xmm_id);
+                        }
                         reconfig_data_format_srcb(dfb_ex2pe_id, dfb_xmm_id);
                         tile_regs_acquire();
                         mul_tiles(dfb_xmm_id, dfb_xmm_id, 0, 1, dst0);
@@ -562,10 +569,14 @@ void kernel_main() {
 
                     if constexpr (do_gamma) {
                         // fp32: reset SrcA to cb_x (fp32); the prior mask/accumulate step left SrcA on a bf16 format.
-                        // no-op for bf16.
-                        reconfig_data_format_srca(dfb_x_id);
-                        reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
-                        mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_x_id);
+                            reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
+                            mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
+                        } else {
+                            mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
+                            reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
+                        }
 
                         dfb_x.wait_front(1);
                         tile_regs_acquire();
@@ -581,9 +592,14 @@ void kernel_main() {
 
                     if constexpr (do_beta) {
                         // fp32: reset SrcA to cb_x (fp32), same as the gamma step above.
-                        reconfig_data_format_srca(dfb_x_id);
-                        reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
-                        add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);
+                        if constexpr (enable_fp32_reconfig) {
+                            reconfig_data_format_srca(dfb_x_id);
+                            reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
+                            add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);
+                        } else {
+                            add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);
+                            reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
+                        }
 
                         dfb_x.wait_front(1);
                         tile_regs_acquire();
@@ -599,7 +615,9 @@ void kernel_main() {
 
                     // Write out the final output
                     copy_tile_init(dfb_x_id);
-                    reconfig_data_format_srca(dfb_x_id);
+                    if constexpr (enable_fp32_reconfig) {
+                        reconfig_data_format_srca(dfb_x_id);
+                    }
                     reconfig_data_format_srcb(do_beta ? dfb_beta_id : dfb_xmm_id, dfb_x_id);
 
                     dfb_x.wait_front(1);
@@ -611,12 +629,16 @@ void kernel_main() {
                     tile_regs_wait();
 #ifndef UNTILIZE_OUT
                     // Packer was last set for bf16 cb_x; reconfigure to cb_out_id (may be fp32) before pack, restore
-                    // after.
-                    pack_reconfig_data_format(dfb_out_id);
+                    // after. Only needed when out differs from cb_x (fp32 path); no-op gated out for bf16.
+                    if constexpr (enable_fp32_reconfig) {
+                        pack_reconfig_data_format(dfb_out_id);
+                    }
 #endif
                     pack_tile(dst0, dfb_out_id);
 #ifndef UNTILIZE_OUT
-                    pack_reconfig_data_format(dfb_x_id);
+                    if constexpr (enable_fp32_reconfig) {
+                        pack_reconfig_data_format(dfb_x_id);
+                    }
 #endif
                     tile_regs_release();
                     dfb_out.push_back(1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -385,7 +385,8 @@ void kernel_main() {
         dfb_ex_global.wait_front(2 * num_groups);
         dfb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
-        // fp32: reset SrcA to cb_ex_global (bf16 var) else the fp32-configured SrcA misreads it; no-op for bf16.
+        // fp32: cb_ex_global is fp32 (var), cb_eps is bf16; the welford intake left SrcA on the fp32 input alias.
+        // Reset both srcs so they match the operands read below. no-op for bf16.
         add_tiles_init(dfb_ex_global_id, dfb_eps_id);
         reconfig_data_format_srca(dfb_ex_global_id);
         reconfig_data_format_srcb(dfb_eps_id);
@@ -446,8 +447,9 @@ void kernel_main() {
 
                         // // Now let us do the actual computation for the current group here
                         // // a. x-u
-                        // fp32: reset SrcA to cb_in0 and SrcB to cb_ex_global (unconditional 1-arg; a 2-arg reset off
-                        // the bf16 stats would no-op) so fp32 input and bf16 mean aren't misread.
+                        // fp32: SrcA needs cb_in0 (fp32 input), SrcB needs cb_ex_global (fp32 mean); the prior group's
+                        // mul_tiles(cb_xmm) left SrcA on cb_xmm. Use the unconditional 1-arg form: the old 2-arg
+                        // srcb(cb_eps -> cb_ex_global) never reset SrcA at all. no-op for bf16.
                         sub_tiles_bcast_scalar_init_short(dfb_in0_id, dfb_ex_global_id);
                         reconfig_data_format_srca(dfb_in0_id);
                         reconfig_data_format_srcb(dfb_ex_global_id);
@@ -479,7 +481,8 @@ void kernel_main() {
                         // // c. a * b
                         dfb_xmm.wait_front(2);
                         mul_tiles_init(dfb_xmm_id, dfb_xmm_id);
-                        // fp32 mask: reset SrcA to bf16 cb_xmm else the fp32-mask-configured SrcA misreads it.
+                        // fp32: reset SrcA to cb_xmm (fp32); step b above left SrcA on the bf16 input mask. no-op for
+                        // bf16.
                         reconfig_data_format_srca(dfb_xmm_id);
                         reconfig_data_format_srcb(dfb_ex2pe_id, dfb_xmm_id);
                         tile_regs_acquire();
@@ -558,7 +561,8 @@ void kernel_main() {
                     }
 
                     if constexpr (do_gamma) {
-                        // fp32 mask: reset SrcA to bf16 cb_x else the fp32-configured SrcA misreads it.
+                        // fp32: reset SrcA to cb_x (fp32); the prior mask/accumulate step left SrcA on a bf16 format.
+                        // no-op for bf16.
                         reconfig_data_format_srca(dfb_x_id);
                         reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
                         mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
@@ -576,7 +580,7 @@ void kernel_main() {
                     }
 
                     if constexpr (do_beta) {
-                        // fp32 mask: reset SrcA to bf16 cb_x, same as the gamma step above.
+                        // fp32: reset SrcA to cb_x (fp32), same as the gamma step above.
                         reconfig_data_format_srca(dfb_x_id);
                         reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
                         add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -385,7 +385,9 @@ void kernel_main() {
         dfb_ex_global.wait_front(2 * num_groups);
         dfb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
+        // fp32: reset SrcA to cb_ex_global (bf16 var) else the fp32-configured SrcA misreads it; no-op for bf16.
         add_tiles_init(dfb_ex_global_id, dfb_eps_id);
+        reconfig_data_format_srca(dfb_ex_global_id);
         reconfig_data_format_srcb(dfb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
@@ -444,8 +446,11 @@ void kernel_main() {
 
                         // // Now let us do the actual computation for the current group here
                         // // a. x-u
+                        // fp32: reset SrcA to cb_in0 and SrcB to cb_ex_global (unconditional 1-arg; a 2-arg reset off
+                        // the bf16 stats would no-op) so fp32 input and bf16 mean aren't misread.
                         sub_tiles_bcast_scalar_init_short(dfb_in0_id, dfb_ex_global_id);
-                        reconfig_data_format_srcb(dfb_eps_id, dfb_ex_global_id);
+                        reconfig_data_format_srca(dfb_in0_id);
+                        reconfig_data_format_srcb(dfb_ex_global_id);
 
                         tile_regs_acquire();
                         sub_tiles_bcast_scalar(dfb_in0_id, dfb_ex_global_id, 0, 0 + (g << 1), dst0);
@@ -458,7 +463,10 @@ void kernel_main() {
                         const uint32_t mask_offset = g * block_w;
                         const uint32_t mask_index = mask_offset + block_w_index;
 
+                        // fp32: reset SrcA to the mask format before reading cb_input_mask (prior step left it on fp32
+                        // cb_in0).
                         mul_tiles_bcast_scalar_init_short(dfb_input_mask_id, dfb_ex2pe_id);
+                        reconfig_data_format_srca(dfb_in0_id, dfb_input_mask_id);
                         reconfig_data_format_srcb(dfb_ex_global_id, dfb_ex2pe_id);
                         tile_regs_acquire();
                         mul_tiles_bcast_scalar(dfb_input_mask_id, dfb_ex2pe_id, mask_index, g, dst0);
@@ -471,6 +479,8 @@ void kernel_main() {
                         // // c. a * b
                         dfb_xmm.wait_front(2);
                         mul_tiles_init(dfb_xmm_id, dfb_xmm_id);
+                        // fp32 mask: reset SrcA to bf16 cb_xmm else the fp32-mask-configured SrcA misreads it.
+                        reconfig_data_format_srca(dfb_xmm_id);
                         reconfig_data_format_srcb(dfb_ex2pe_id, dfb_xmm_id);
                         tile_regs_acquire();
                         mul_tiles(dfb_xmm_id, dfb_xmm_id, 0, 1, dst0);
@@ -548,8 +558,10 @@ void kernel_main() {
                     }
 
                     if constexpr (do_gamma) {
-                        mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
+                        // fp32 mask: reset SrcA to bf16 cb_x else the fp32-configured SrcA misreads it.
+                        reconfig_data_format_srca(dfb_x_id);
                         reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
+                        mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
 
                         dfb_x.wait_front(1);
                         tile_regs_acquire();
@@ -564,8 +576,10 @@ void kernel_main() {
                     }
 
                     if constexpr (do_beta) {
-                        add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);
+                        // fp32 mask: reset SrcA to bf16 cb_x, same as the gamma step above.
+                        reconfig_data_format_srca(dfb_x_id);
                         reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
+                        add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);
 
                         dfb_x.wait_front(1);
                         tile_regs_acquire();
@@ -581,6 +595,7 @@ void kernel_main() {
 
                     // Write out the final output
                     copy_tile_init(dfb_x_id);
+                    reconfig_data_format_srca(dfb_x_id);
                     reconfig_data_format_srcb(do_beta ? dfb_beta_id : dfb_xmm_id, dfb_x_id);
 
                     dfb_x.wait_front(1);
@@ -590,7 +605,15 @@ void kernel_main() {
                     dfb_x.pop_front(1);
                     dfb_out.reserve_back(1);
                     tile_regs_wait();
+#ifndef UNTILIZE_OUT
+                    // Packer was last set for bf16 cb_x; reconfigure to cb_out_id (may be fp32) before pack, restore
+                    // after.
+                    pack_reconfig_data_format(dfb_out_id);
+#endif
                     pack_tile(dst0, dfb_out_id);
+#ifndef UNTILIZE_OUT
+                    pack_reconfig_data_format(dfb_x_id);
+#endif
                     tile_regs_release();
                     dfb_out.push_back(1);
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -56,6 +56,9 @@ void kernel_main() {
     constexpr bool welford_fp32_alias = get_named_compile_time_arg_val("welford_fp32_alias") != 0;
     constexpr uint32_t dfb_in0_welford_id = get_named_compile_time_arg_val("cb_in0_welford");
     constexpr uint32_t dfb_in_welford_id = get_named_compile_time_arg_val("cb_in_welford");
+    // True when a reconfig-relevant operand is fp32: the per-tile reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
 
     // dst regs
     constexpr uint32_t dst0 = 0;
@@ -287,6 +290,10 @@ void kernel_main() {
         dfb_ex_global.wait_front(2 * num_groups);
         dfb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
+        // fp32: dfb_ex_global is fp32 (var), dfb_eps is bf16; the welford intake left SrcA on the fp32 input alias.
+        if constexpr (enable_fp32_reconfig) {
+            reconfig_data_format_srca(dfb_ex_global_id);
+        }
         reconfig_data_format_srcb(dfb_eps_id);
         add_init(dfb_ex_global_id, dfb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
@@ -439,6 +446,10 @@ void kernel_main() {
                 ++tile_id;
 
                 if constexpr (do_gamma) {
+                    // fp32: reset SrcA to dfb_x (fp32).
+                    if constexpr (enable_fp32_reconfig) {
+                        reconfig_data_format_srca(dfb_x_id);
+                    }
                     reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
                     mul_bcast_rows_init(dfb_x_id, dfb_gamma_id);
 
@@ -455,6 +466,10 @@ void kernel_main() {
                 }
 
                 if constexpr (do_beta) {
+                    // fp32: reset SrcA to dfb_x (fp32).
+                    if constexpr (enable_fp32_reconfig) {
+                        reconfig_data_format_srca(dfb_x_id);
+                    }
                     reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
                     add_bcast_rows_init(dfb_x_id, dfb_beta_id);
 
@@ -471,6 +486,10 @@ void kernel_main() {
                 }
 
                 // Write out the final output
+                // fp32: reset SrcA to dfb_x (fp32).
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_x_id);
+                }
                 reconfig_data_format_srcb(do_beta ? dfb_beta_id : dfb_xmm_id, dfb_x_id);
                 copy_tile_init(dfb_x_id);
 
@@ -487,7 +506,19 @@ void kernel_main() {
                 DataflowBuffer write_dfb(write_dfb_id);
                 write_dfb.reserve_back(1);
                 tile_regs_wait();
+#ifndef UNTILIZE_OUT
+                // Packer was last set for bf16 dfb_xmm; reconfigure to write_dfb_id (may be fp32) before pack, restore
+                // after. Gated out for bf16 (no format change).
+                if constexpr (enable_fp32_reconfig) {
+                    pack_reconfig_data_format(write_dfb_id);
+                }
+#endif
                 pack_tile(dst0, write_dfb_id);
+#ifndef UNTILIZE_OUT
+                if constexpr (enable_fp32_reconfig) {
+                    pack_reconfig_data_format(dfb_xmm_id);
+                }
+#endif
                 tile_regs_release();
                 write_dfb.push_back(1);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -287,6 +287,8 @@ void kernel_main() {
         dfb_ex_global.wait_front(2 * num_groups);
         dfb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
+        // fp32: reset SrcA to cb_ex_global (bf16 var) else the fp32-configured SrcA misreads it; no-op for bf16.
+        reconfig_data_format_srca(dfb_ex_global_id);
         reconfig_data_format_srcb(dfb_eps_id);
         add_tiles_init(dfb_ex_global_id, dfb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
@@ -487,7 +489,15 @@ void kernel_main() {
                 DataflowBuffer write_dfb(write_dfb_id);
                 write_dfb.reserve_back(1);
                 tile_regs_wait();
+#ifndef UNTILIZE_OUT
+                // Packer was last set for bf16 cb_xmm; reconfigure to write_cb_id (may be fp32) before pack, restore
+                // after.
+                pack_reconfig_data_format(write_dfb_id);
+#endif
                 pack_tile(dst0, write_dfb_id);
+#ifndef UNTILIZE_OUT
+                pack_reconfig_data_format(dfb_xmm_id);
+#endif
                 tile_regs_release();
                 write_dfb.push_back(1);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -56,6 +56,9 @@ void kernel_main() {
     constexpr bool welford_fp32_alias = get_named_compile_time_arg_val("welford_fp32_alias") != 0;
     constexpr uint32_t dfb_in0_welford_id = get_named_compile_time_arg_val("cb_in0_welford");
     constexpr uint32_t dfb_in_welford_id = get_named_compile_time_arg_val("cb_in_welford");
+    // True when a reconfig-relevant operand is fp32: the per-tile reconfig_data_format calls below
+    // are then required. All-bf16 compiles them out (no-ops). See program factory.
+    constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
 
     // dst regs
     constexpr uint32_t dst0 = 0;
@@ -288,8 +291,9 @@ void kernel_main() {
         dfb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
         // fp32: cb_ex_global is fp32 (var), cb_eps is bf16; the welford intake left SrcA on the fp32 input alias.
-        // Reset both srcs so they match the operands read below. no-op for bf16.
-        reconfig_data_format_srca(dfb_ex_global_id);
+        if constexpr (enable_fp32_reconfig) {
+            reconfig_data_format_srca(dfb_ex_global_id);
+        }
         reconfig_data_format_srcb(dfb_eps_id);
         add_tiles_init(dfb_ex_global_id, dfb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
@@ -442,8 +446,10 @@ void kernel_main() {
                 ++tile_id;
 
                 if constexpr (do_gamma) {
-                    // fp32: reset SrcA to cb_x (fp32); no-op for bf16.
-                    reconfig_data_format_srca(dfb_x_id);
+                    // fp32: reset SrcA to cb_x (fp32).
+                    if constexpr (enable_fp32_reconfig) {
+                        reconfig_data_format_srca(dfb_x_id);
+                    }
                     reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
                     mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
 
@@ -460,8 +466,10 @@ void kernel_main() {
                 }
 
                 if constexpr (do_beta) {
-                    // fp32: reset SrcA to cb_x (fp32); no-op for bf16.
-                    reconfig_data_format_srca(dfb_x_id);
+                    // fp32: reset SrcA to cb_x (fp32).
+                    if constexpr (enable_fp32_reconfig) {
+                        reconfig_data_format_srca(dfb_x_id);
+                    }
                     reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
                     add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);
 
@@ -478,8 +486,10 @@ void kernel_main() {
                 }
 
                 // Write out the final output
-                // fp32: reset SrcA to cb_x (fp32); no-op for bf16.
-                reconfig_data_format_srca(dfb_x_id);
+                // fp32: reset SrcA to cb_x (fp32).
+                if constexpr (enable_fp32_reconfig) {
+                    reconfig_data_format_srca(dfb_x_id);
+                }
                 reconfig_data_format_srcb(do_beta ? dfb_beta_id : dfb_xmm_id, dfb_x_id);
                 copy_tile_init(dfb_x_id);
 
@@ -498,12 +508,16 @@ void kernel_main() {
                 tile_regs_wait();
 #ifndef UNTILIZE_OUT
                 // Packer was last set for bf16 cb_xmm; reconfigure to write_cb_id (may be fp32) before pack, restore
-                // after.
-                pack_reconfig_data_format(write_dfb_id);
+                // after. Gated out for bf16 (no format change).
+                if constexpr (enable_fp32_reconfig) {
+                    pack_reconfig_data_format(write_dfb_id);
+                }
 #endif
                 pack_tile(dst0, write_dfb_id);
 #ifndef UNTILIZE_OUT
-                pack_reconfig_data_format(dfb_xmm_id);
+                if constexpr (enable_fp32_reconfig) {
+                    pack_reconfig_data_format(dfb_xmm_id);
+                }
 #endif
                 tile_regs_release();
                 write_dfb.push_back(1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -287,7 +287,8 @@ void kernel_main() {
         dfb_ex_global.wait_front(2 * num_groups);
         dfb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
-        // fp32: reset SrcA to cb_ex_global (bf16 var) else the fp32-configured SrcA misreads it; no-op for bf16.
+        // fp32: cb_ex_global is fp32 (var), cb_eps is bf16; the welford intake left SrcA on the fp32 input alias.
+        // Reset both srcs so they match the operands read below. no-op for bf16.
         reconfig_data_format_srca(dfb_ex_global_id);
         reconfig_data_format_srcb(dfb_eps_id);
         add_tiles_init(dfb_ex_global_id, dfb_eps_id);
@@ -441,6 +442,8 @@ void kernel_main() {
                 ++tile_id;
 
                 if constexpr (do_gamma) {
+                    // fp32: reset SrcA to cb_x (fp32); no-op for bf16.
+                    reconfig_data_format_srca(dfb_x_id);
                     reconfig_data_format_srcb(dfb_xmm_id, dfb_gamma_id);
                     mul_bcast_rows_init_short(dfb_x_id, dfb_gamma_id);
 
@@ -457,6 +460,8 @@ void kernel_main() {
                 }
 
                 if constexpr (do_beta) {
+                    // fp32: reset SrcA to cb_x (fp32); no-op for bf16.
+                    reconfig_data_format_srca(dfb_x_id);
                     reconfig_data_format_srcb(do_gamma ? dfb_gamma_id : dfb_xmm_id, dfb_beta_id);
                     add_bcast_rows_init_short(dfb_x_id, dfb_beta_id);
 
@@ -473,6 +478,8 @@ void kernel_main() {
                 }
 
                 // Write out the final output
+                // fp32: reset SrcA to cb_x (fp32); no-op for bf16.
+                reconfig_data_format_srca(dfb_x_id);
                 reconfig_data_format_srcb(do_beta ? dfb_beta_id : dfb_xmm_id, dfb_x_id);
                 copy_tile_init(dfb_x_id);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -245,15 +245,18 @@ void kernel_main() {
 
                         for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                             for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                noc.async_read(
-                                    dst_a,
-                                    CoreLocalMem<uint32_t>(l1_write_addr),
-                                    single_tile_size_bytes,
-                                    {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                        index_b_offset + index_g_offset},
-                                    {});
+                                // Skip tiles the writer never wrote; rereading them pulls uninitialized DRAM (fp32 = huge garbage). Keep advancing l1_write_addr to stay aligned.
+                                if ((index_g_offset + nt) < per_core_N) {
+                                    noc.async_read(
+                                        dst_a,
+                                        CoreLocalMem<uint32_t>(l1_write_addr),
+                                        single_tile_size_bytes,
+                                        {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                            index_b_offset + index_g_offset},
+                                        {});
+                                    noc.async_read_barrier();
+                                }
                                 l1_write_addr += dst_tile_bytes;
-                                noc.async_read_barrier();
                             }
                         }
                         dfb_reread_out.push_back(out_block_hw_normal);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -249,15 +249,18 @@ void kernel_main() {
 
                         for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                             for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                noc.async_read(
-                                    dst_a,
-                                    CoreLocalMem<uint32_t>(l1_write_addr),
-                                    single_tile_size_bytes,
-                                    {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                        index_b_offset + index_g_offset},
-                                    {});
+                                // Skip tiles the writer never wrote; rereading them pulls uninitialized DRAM (fp32 = huge garbage). Keep advancing l1_write_addr to stay aligned.
+                                if ((index_g_offset + nt) < per_core_N) {
+                                    noc.async_read(
+                                        dst_a,
+                                        CoreLocalMem<uint32_t>(l1_write_addr),
+                                        single_tile_size_bytes,
+                                        {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                            index_b_offset + index_g_offset},
+                                        {});
+                                    noc.async_read_barrier();
+                                }
                                 l1_write_addr += dst_tile_bytes;
-                                noc.async_read_barrier();
                             }
                         }
                         dfb_reread_out.push_back(out_block_hw_normal);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -427,15 +427,18 @@ void kernel_main() {
 
                             for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                                 for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                    noc.async_read(
-                                        dst_a,
-                                        CoreLocalMem<uint32_t>(l1_write_addr),
-                                        single_tile_size_bytes,
-                                        {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                            index_b_offset + index_g_offset},
-                                        {});
+                                    // Skip tiles the writer never wrote; rereading them pulls uninitialized DRAM (fp32 = huge garbage). Keep advancing l1_write_addr to stay aligned.
+                                    if ((index_g_offset + nt) < per_core_N) {
+                                        noc.async_read(
+                                            dst_a,
+                                            CoreLocalMem<uint32_t>(l1_write_addr),
+                                            single_tile_size_bytes,
+                                            {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                                index_b_offset + index_g_offset},
+                                            {});
+                                        noc.async_read_barrier();
+                                    }
                                     l1_write_addr += dst_tile_bytes;
-                                    noc.async_read_barrier();
                                 }
                             }
                             dfb_reread_out.push_back(out_block_hw_normal);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -429,15 +429,18 @@ void kernel_main() {
 
                             for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                                 for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                    noc.async_read(
-                                        dst_a,
-                                        CoreLocalMem<uint32_t>(l1_write_addr),
-                                        single_tile_size_bytes,
-                                        {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                            index_b_offset + index_g_offset},
-                                        {});
+                                    // Skip tiles the writer never wrote; rereading them pulls uninitialized DRAM (fp32 = huge garbage). Keep advancing l1_write_addr to stay aligned.
+                                    if ((index_g_offset + nt) < per_core_N) {
+                                        noc.async_read(
+                                            dst_a,
+                                            CoreLocalMem<uint32_t>(l1_write_addr),
+                                            single_tile_size_bytes,
+                                            {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                                index_b_offset + index_g_offset},
+                                            {});
+                                        noc.async_read_barrier();
+                                    }
                                     l1_write_addr += dst_tile_bytes;
-                                    noc.async_read_barrier();
                                 }
                             }
                             dfb_reread_out.push_back(out_block_hw_normal);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -11,6 +11,7 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/groupnorm_constants.hpp"
+#include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_zero_fill.hpp"
 
 // split REDUCE across cores
 void kernel_main() {
@@ -154,6 +155,13 @@ void kernel_main() {
     }
 #endif
 
+    // fp32 breaks the full-tile self-read's REDUCE_SCALAR packer-zero contract, so zero dfb_ex_external up front and
+    // read each scalar at datum width; bf16 keeps the cheaper full-tile trick.
+    constexpr bool stats_fp32_zero_fill = (datum_size_bytes >= 4);
+    if constexpr (stats_fp32_zero_fill) {
+        zero_whole_cb(dfb_ex_external_id, noc);
+    }
+
     if constexpr (num_mcast_cores > 1) {
         for (uint32_t m = 0; m < num_batch_group; ++m) {
             for (uint32_t n = 0; n < 2; ++n) {
@@ -185,10 +193,12 @@ void kernel_main() {
                 // the downstream reduce_tile sum on dfb_ex_external is not
                 // polluted.
                 UnicastEndpoint remote_ep;
+                // fp32: read self at datum width (gaps zeroed up front); bf16: full-tile self-read zero-inits the
+                // reserved tile.
                 noc.async_read(
                     remote_ep,
                     CoreLocalMem<uint32_t>(l1_write_addr_external),
-                    single_tile_size_bytes,
+                    stats_fp32_zero_fill ? num_bytes_read : single_tile_size_bytes,
                     {.noc_x = noc_coord_x[0], .noc_y = noc_coord_y[0], .addr = l1_read_addr_ex_par},
                     {});
                 l1_write_addr_external += dfb_ex_external_slot_pitch_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -11,6 +11,7 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/groupnorm_constants.hpp"
+#include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_zero_fill.hpp"
 
 // split REDUCE across cores
 void kernel_main() {
@@ -154,6 +155,13 @@ void kernel_main() {
     }
 #endif
 
+    // fp32 breaks the full-tile self-read's REDUCE_SCALAR packer-zero contract, so zero cb_ex_external up front and
+    // read each scalar at datum width; bf16 keeps the cheaper full-tile trick.
+    constexpr bool stats_fp32_zero_fill = (datum_size_bytes >= 4);
+    if constexpr (stats_fp32_zero_fill) {
+        zero_whole_cb(dfb_ex_external_id, noc);
+    }
+
     if constexpr (num_mcast_cores > 1) {
         for (uint32_t m = 0; m < num_batch_group; ++m) {
             for (uint32_t n = 0; n < 2; ++n) {
@@ -185,10 +193,12 @@ void kernel_main() {
                 // the downstream reduce_tile sum on dfb_ex_external is not
                 // polluted.
                 UnicastEndpoint remote_ep;
+                // fp32: read self at datum width (gaps zeroed up front); bf16: full-tile self-read zero-inits the
+                // reserved tile.
                 noc.async_read(
                     remote_ep,
                     CoreLocalMem<uint32_t>(l1_write_addr_external),
-                    single_tile_size_bytes,
+                    stats_fp32_zero_fill ? num_bytes_read : single_tile_size_bytes,
                     {.noc_x = noc_coord_x[0], .noc_y = noc_coord_y[0], .addr = l1_read_addr_ex_par},
                     {});
                 l1_write_addr_external += dfb_ex_external_slot_pitch_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -61,6 +61,8 @@ void kernel_main() {
     // == cb_in0_id and the gated pushes below are skipped.
     constexpr uint32_t dfb_in0_welford_id = get_named_compile_time_arg_val("cb_in0_welford");
     constexpr bool welford_fp32_alias = get_named_compile_time_arg_val("welford_fp32_alias") != 0;
+    // When set, stats CBs hold fp32; the Welford combine reads/writes them as float not bf16.
+    constexpr bool stats_is_fp32 = get_named_compile_time_arg_val("stats_is_fp32") != 0;
 
     Noc noc;
     Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
@@ -80,6 +82,10 @@ void kernel_main() {
     constexpr uint32_t local_stride = 2;
     constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tile_height;
     constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
+
+    // Combine overload picked by pointer type: const float* -> fp32 combine, volatile uint16_t* -> bf16.
+    using stats_read_t = std::conditional_t<stats_is_fp32, const float, volatile uint16_t>;
+    using stats_write_t = std::conditional_t<stats_is_fp32, float, uint16_t>;
 
     const auto src_a = TensorAccessor(src0_args, src_addr);
 
@@ -163,8 +169,8 @@ void kernel_main() {
 
         for (uint32_t m = 0; m < num_groups; ++m) {
             // Read mean and variance arrays from dfb_ex_partial, then combine using Welford
-            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_means_ptr);
-            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_vars_ptr);
+            auto p_local_means = reinterpret_cast<stats_read_t*>(local_means_ptr);
+            auto p_local_vars = reinterpret_cast<stats_read_t*>(local_vars_ptr);
 
             auto local_result = combine_welford_stats<
                 tile_width,
@@ -172,8 +178,8 @@ void kernel_main() {
                 local_stride>(p_local_means, p_local_vars);
 
             // Write this to dfb_ex_global
-            auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
-            auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            auto p_global_means = reinterpret_cast<volatile stats_write_t*>(global_means_ptr);
+            auto p_global_vars = reinterpret_cast<volatile stats_write_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -28,6 +28,8 @@ void kernel_main() {
     constexpr uint32_t block_hw = get_compile_time_arg_val(8);
     constexpr uint32_t num_groups = get_compile_time_arg_val(9);
     constexpr uint32_t tile_width = get_compile_time_arg_val(10);
+    // When set, stats CBs hold fp32; the Welford combine reads/writes them as float not bf16.
+    constexpr bool stats_is_fp32 = get_compile_time_arg_val(11) != 0;
 
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(0);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(1);
@@ -55,6 +57,9 @@ void kernel_main() {
     constexpr uint32_t local_stride = 2;
     constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tile_height;
     constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
+    // Combine overload picked by pointer type: const float* -> fp32 combine, volatile uint16_t* -> bf16.
+    using stats_read_t = std::conditional_t<stats_is_fp32, const float, volatile uint16_t>;
+    using stats_write_t = std::conditional_t<stats_is_fp32, float, uint16_t>;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = dfb_in0.get_read_ptr();
@@ -90,15 +95,15 @@ void kernel_main() {
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
-            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_means_ptr);
-            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_vars_ptr);
+            auto p_local_means = reinterpret_cast<stats_read_t*>(local_means_ptr);
+            auto p_local_vars = reinterpret_cast<stats_read_t*>(local_vars_ptr);
 
             auto local_result =
                 combine_welford_stats<tile_width, block_hw * tile_width, local_stride>(p_local_means, p_local_vars);
 
             // Write this to dfb_ex_global
-            auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
-            auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            auto p_global_means = reinterpret_cast<volatile stats_write_t*>(global_means_ptr);
+            auto p_global_vars = reinterpret_cast<volatile stats_write_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -135,6 +135,9 @@ void kernel_main() {
     // == cb_in0_id and the gated pushes below are skipped.
     constexpr uint32_t dfb_in0_welford_id = get_named_compile_time_arg_val("cb_in0_welford");
     constexpr bool welford_fp32_alias = get_named_compile_time_arg_val("welford_fp32_alias") != 0;
+    // When set, stats CBs hold fp32; the Welford combine reads/writes them as float not bf16, and the cross-core stride
+    // is in fp32 elements.
+    constexpr bool stats_is_fp32 = get_named_compile_time_arg_val("stats_is_fp32") != 0;
 
     DataflowBuffer dfb_ex_partial(dfb_ex_partial_id);
     DataflowBuffer dfb_ex_global(dfb_ex_global_id);
@@ -148,7 +151,13 @@ void kernel_main() {
     constexpr uint32_t src0_tile_bytes = get_tile_size(dfb_in0_id);
 
     constexpr uint32_t local_stride = 2;
-    constexpr uint32_t global_stride = NOC_L1_READ_ALIGNMENT_BYTES / 2;
+    // Cross-core stats packed at NOC alignment; element stride = byte gap / element size.
+    constexpr uint32_t stats_elem_size = stats_is_fp32 ? 4 : 2;
+    constexpr uint32_t global_stride = NOC_L1_READ_ALIGNMENT_BYTES / stats_elem_size;
+
+    // Combine overload picked by pointer type: const float* -> fp32 combine, volatile uint16_t* -> bf16.
+    using stats_read_t = std::conditional_t<stats_is_fp32, const float, volatile uint16_t>;
+    using stats_write_t = std::conditional_t<stats_is_fp32, float, uint16_t>;
     constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tile_height;
     constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
 
@@ -234,8 +243,8 @@ void kernel_main() {
 
         for (uint32_t m = 0; m < num_groups; ++m) {
             // Read mean and variance arrays from dfb_ex_partial, then combine using Welford
-            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_means_ptr);
-            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_vars_ptr);
+            auto p_local_means = reinterpret_cast<stats_read_t*>(local_means_ptr);
+            auto p_local_vars = reinterpret_cast<stats_read_t*>(local_vars_ptr);
 
             auto local_result = combine_welford_stats<
                 tile_width,
@@ -243,8 +252,8 @@ void kernel_main() {
                 local_stride>(p_local_means, p_local_vars);
 
             // Write this to dfb_ex_global
-            auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
-            auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            auto p_global_means = reinterpret_cast<volatile stats_write_t*>(global_means_ptr);
+            auto p_global_vars = reinterpret_cast<volatile stats_write_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
 
@@ -271,10 +280,13 @@ void kernel_main() {
                 noc.async_read_barrier();
             }
 
-            // Read mean and variance arrays from dfb_ex_global, then combine using Welford
+            // Read dfb_ex_global through read-typed views; the writes below reuse the write-typed pointers (same L1
+            // addresses).
+            auto p_global_means_read = reinterpret_cast<stats_read_t*>(global_means_ptr);
+            auto p_global_vars_read = reinterpret_cast<stats_read_t*>(global_vars_ptr);
             auto global_result =
                 combine_welford_stats<num_mcast_cores, num_channels_per_group * num_rows_per_group, global_stride>(
-                    p_global_means, p_global_vars);
+                    p_global_means_read, p_global_vars_read);
 
             // Write this to dfb_ex_global
             p_global_means[0] = global_result.mean;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -29,6 +29,9 @@ void kernel_main() {
     constexpr uint32_t block_hw = get_compile_time_arg_val(10);
     constexpr uint32_t num_groups = get_compile_time_arg_val(11);
     constexpr uint32_t tile_width = get_compile_time_arg_val(12);
+    // When set, stats CBs hold fp32; the Welford combine reads/writes them as float not bf16, and the cross-core stride
+    // is in fp32 elements.
+    constexpr bool stats_is_fp32 = get_compile_time_arg_val(13) != 0;
 
     const bool has_mcast_first_group = get_arg_val<uint32_t>(0);
     const bool has_mcast_last_group = get_arg_val<uint32_t>(1);
@@ -123,7 +126,12 @@ void kernel_main() {
     constexpr uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial_id);
     // This is the stride between two consecutive local means/variances in the dfb_ex_partial
     constexpr uint32_t local_stride = 2;
-    constexpr uint32_t global_stride = NOC_L1_READ_ALIGNMENT_BYTES / 2;
+    // Cross-core stats packed at NOC alignment; element stride = byte gap / element size.
+    constexpr uint32_t stats_elem_size = stats_is_fp32 ? 4 : 2;
+    constexpr uint32_t global_stride = NOC_L1_READ_ALIGNMENT_BYTES / stats_elem_size;
+    // Combine overload picked by pointer type: const float* -> fp32 combine, volatile uint16_t* -> bf16.
+    using stats_read_t = std::conditional_t<stats_is_fp32, const float, volatile uint16_t>;
+    using stats_write_t = std::conditional_t<stats_is_fp32, float, uint16_t>;
     constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tile_height;
     constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
 
@@ -162,15 +170,15 @@ void kernel_main() {
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
-            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_means_ptr);
-            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_vars_ptr);
+            auto p_local_means = reinterpret_cast<stats_read_t*>(local_means_ptr);
+            auto p_local_vars = reinterpret_cast<stats_read_t*>(local_vars_ptr);
 
             auto local_result =
                 combine_welford_stats<tile_width, block_hw * tile_width, local_stride>(p_local_means, p_local_vars);
 
             // Write this to dfb_ex_global
-            auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
-            auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            auto p_global_means = reinterpret_cast<volatile stats_write_t*>(global_means_ptr);
+            auto p_global_vars = reinterpret_cast<volatile stats_write_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
 
@@ -197,10 +205,13 @@ void kernel_main() {
                 noc.async_read_barrier();
             }
 
-            // Read mean and variance arrays from dfb_ex_global, then combine using Welford
+            // Read dfb_ex_global through read-typed views; the writes below reuse the write-typed pointers (same L1
+            // addresses).
+            auto p_global_means_read = reinterpret_cast<stats_read_t*>(global_means_ptr);
+            auto p_global_vars_read = reinterpret_cast<stats_read_t*>(global_vars_ptr);
             auto global_result =
                 combine_welford_stats<num_mcast_cores, block_hw * tile_width * tile_height, global_stride>(
-                    p_global_means, p_global_vars);
+                    p_global_means_read, p_global_vars_read);
 
             // Write this to dfb_ex_global
             p_global_means[0] = global_result.mean;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
@@ -12,6 +13,28 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+
+// Queue the DRAM read of a gamma/beta row (TILE_WIDTH datums) into face 0; byte offsets scale with
+// datum size (2B bf16 / 4B fp32). Full row goes to face 0 (Blackhole DRAM reads need 64B granularity).
+template <typename AccessorType>
+void async_read_row_face0(
+    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t row_bytes = tt::constants::TILE_WIDTH * element_bytes;
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
+}
+
+// L1->L1-copy the row's second half into face 1. Only legal after the face-0 read barrier.
+void copy_row_half_to_face1(const Noc& noc, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
+    const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
+    UnicastEndpoint self;
+    noc.async_read(
+        self,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_dst_addr + half_row_bytes},
+        {});
+}
 
 void kernel_main() {
     constexpr bool is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender") == 1;
@@ -125,82 +148,48 @@ void kernel_main() {
 
     if constexpr (fuse_gamma) {
         constexpr uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+        constexpr uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
         const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
         dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
-
         const uint32_t base_l1_write_addr_gamma = dfb_gamma.get_write_ptr();
+
         uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-        // We want this data to appear as the first row of the tile.
-        // This is 32B at the start of the first face, 32B at the start of the second face
-        // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
-        // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
-        // Then later, copy the second set of 32 bytes into the start of the second face
-        // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
-        // to L1
-
-        // Read the first 64 bytes of the tile into the first face
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint32_t tile_id = gamma_tile_start_id + w;
-            noc.async_read(
-                gamma, CoreLocalMem<uint32_t>(l1_write_addr_gamma), 64, {.page_id = tile_id}, {});
+            async_read_row_face0(noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
         noc.async_read_barrier();
 
-        // Copy the second set of 32 bytes into the second face
         l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-        UnicastEndpoint self_ep_gamma;
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            noc.async_read(
-                self_ep_gamma,
-                CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                32,
-                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
-                {});
+            copy_row_half_to_face1(noc, l1_write_addr_gamma, gamma_element_bytes);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
-
         noc.async_read_barrier();
         dfb_gamma.push_back(num_cols_tile_gamma_beta);
     }
 
     if constexpr (fuse_beta) {
-        // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
-        // Then copy the second set of 32 bytes into the second face
         constexpr uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+        constexpr uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
         const auto beta = TensorAccessor(beta_args, beta_addr);
 
         dfb_beta.reserve_back(num_cols_tile_gamma_beta);
-
         const uint32_t base_l1_write_addr_beta = dfb_beta.get_write_ptr();
-        uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
 
-        // Read the first 64 bytes of the tile into the first face
+        uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint32_t tile_id = beta_tile_start_id + w;
-            noc.async_read(
-                beta, CoreLocalMem<uint32_t>(l1_write_addr_beta), 64, {.page_id = tile_id}, {});
+            async_read_row_face0(noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
             l1_write_addr_beta += beta_tile_bytes;
         }
         noc.async_read_barrier();
 
-        // Copy the second set of 32 bytes into the second face
         l1_write_addr_beta = base_l1_write_addr_beta;
-
-        UnicastEndpoint self_ep_beta;
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            noc.async_read(
-                self_ep_beta,
-                CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                32,
-                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
-                {});
+            copy_row_half_to_face1(noc, l1_write_addr_beta, beta_element_bytes);
             l1_write_addr_beta += beta_tile_bytes;
         }
-
         noc.async_read_barrier();
         dfb_beta.push_back(num_cols_tile_gamma_beta);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -14,19 +14,19 @@
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
 
-// Load one row-major gamma/beta stick (TILE_WIDTH datums) into the first row of a tile's two 16x16 faces;
-// byte offsets scale with datum size (2B bf16 / 4B fp32). Read the full row into face 0 (Blackhole DRAM
-// needs 64B-granular reads), then L1->L1-copy its second half-row into face 1.
+// Queue the DRAM read of a gamma/beta row (TILE_WIDTH datums) into face 0; byte offsets scale with
+// datum size (2B bf16 / 4B fp32). Full row goes to face 0 (Blackhole DRAM reads need 64B granularity).
 template <typename AccessorType>
-void async_read_row_to_tile(
+void async_read_row_face0(
     const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
     const uint32_t row_bytes = tt::constants::TILE_WIDTH * element_bytes;
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
+}
+
+// L1->L1-copy the row's second half into face 1. Only legal after the face-0 read barrier.
+void copy_row_half_to_face1(const Noc& noc, uint32_t l1_dst_addr, uint32_t element_bytes) {
     const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
     const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
-
-    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
-    noc.async_read_barrier();
-
     UnicastEndpoint self;
     noc.async_read(
         self,
@@ -152,10 +152,18 @@ void kernel_main() {
         const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
         dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
-        uint32_t l1_write_addr_gamma = dfb_gamma.get_write_ptr();
+        const uint32_t base_l1_write_addr_gamma = dfb_gamma.get_write_ptr();
 
+        uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            async_read_row_to_tile(noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
+            async_read_row_face0(noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
+            l1_write_addr_gamma += gamma_tile_bytes;
+        }
+        noc.async_read_barrier();
+
+        l1_write_addr_gamma = base_l1_write_addr_gamma;
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            copy_row_half_to_face1(noc, l1_write_addr_gamma, gamma_element_bytes);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
         noc.async_read_barrier();
@@ -168,10 +176,18 @@ void kernel_main() {
         const auto beta = TensorAccessor(beta_args, beta_addr);
 
         dfb_beta.reserve_back(num_cols_tile_gamma_beta);
-        uint32_t l1_write_addr_beta = dfb_beta.get_write_ptr();
+        const uint32_t base_l1_write_addr_beta = dfb_beta.get_write_ptr();
 
+        uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            async_read_row_to_tile(noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
+            async_read_row_face0(noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
+            l1_write_addr_beta += beta_tile_bytes;
+        }
+        noc.async_read_barrier();
+
+        l1_write_addr_beta = base_l1_write_addr_beta;
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            copy_row_half_to_face1(noc, l1_write_addr_beta, beta_element_bytes);
             l1_write_addr_beta += beta_tile_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
@@ -12,6 +13,28 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+
+// Load one row-major gamma/beta stick (TILE_WIDTH datums) into the first row of a tile's two 16x16 faces;
+// byte offsets scale with datum size (2B bf16 / 4B fp32). Read the full row into face 0 (Blackhole DRAM
+// needs 64B-granular reads), then L1->L1-copy its second half-row into face 1.
+template <typename AccessorType>
+void async_read_row_to_tile(
+    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t row_bytes = tt::constants::TILE_WIDTH * element_bytes;
+    const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
+    const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
+
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
+    noc.async_read_barrier();
+
+    UnicastEndpoint self;
+    noc.async_read(
+        self,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_dst_addr + half_row_bytes},
+        {});
+}
 
 void kernel_main() {
     constexpr bool is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender") == 1;
@@ -125,82 +148,32 @@ void kernel_main() {
 
     if constexpr (fuse_gamma) {
         constexpr uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+        constexpr uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
         const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
         dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
+        uint32_t l1_write_addr_gamma = dfb_gamma.get_write_ptr();
 
-        const uint32_t base_l1_write_addr_gamma = dfb_gamma.get_write_ptr();
-        uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-        // We want this data to appear as the first row of the tile.
-        // This is 32B at the start of the first face, 32B at the start of the second face
-        // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
-        // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
-        // Then later, copy the second set of 32 bytes into the start of the second face
-        // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
-        // to L1
-
-        // Read the first 64 bytes of the tile into the first face
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint32_t tile_id = gamma_tile_start_id + w;
-            noc.async_read(
-                gamma, CoreLocalMem<uint32_t>(l1_write_addr_gamma), 64, {.page_id = tile_id}, {});
+            async_read_row_to_tile(noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
-        noc.async_read_barrier();
-
-        // Copy the second set of 32 bytes into the second face
-        l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-        UnicastEndpoint self_ep_gamma;
-        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            noc.async_read(
-                self_ep_gamma,
-                CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                32,
-                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
-                {});
-            l1_write_addr_gamma += gamma_tile_bytes;
-        }
-
         noc.async_read_barrier();
         dfb_gamma.push_back(num_cols_tile_gamma_beta);
     }
 
     if constexpr (fuse_beta) {
-        // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
-        // Then copy the second set of 32 bytes into the second face
         constexpr uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+        constexpr uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
         const auto beta = TensorAccessor(beta_args, beta_addr);
 
         dfb_beta.reserve_back(num_cols_tile_gamma_beta);
+        uint32_t l1_write_addr_beta = dfb_beta.get_write_ptr();
 
-        const uint32_t base_l1_write_addr_beta = dfb_beta.get_write_ptr();
-        uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
-
-        // Read the first 64 bytes of the tile into the first face
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint32_t tile_id = beta_tile_start_id + w;
-            noc.async_read(
-                beta, CoreLocalMem<uint32_t>(l1_write_addr_beta), 64, {.page_id = tile_id}, {});
+            async_read_row_to_tile(noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
             l1_write_addr_beta += beta_tile_bytes;
         }
-        noc.async_read_barrier();
-
-        // Copy the second set of 32 bytes into the second face
-        l1_write_addr_beta = base_l1_write_addr_beta;
-
-        UnicastEndpoint self_ep_beta;
-        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            noc.async_read(
-                self_ep_beta,
-                CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                32,
-                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
-                {});
-            l1_write_addr_beta += beta_tile_bytes;
-        }
-
         noc.async_read_barrier();
         dfb_beta.push_back(num_cols_tile_gamma_beta);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -13,6 +14,28 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+
+// Queue the DRAM read of a gamma/beta row (TILE_WIDTH datums) into face 0; byte offsets scale with
+// datum size (2B bf16 / 4B fp32). Full row goes to face 0 (Blackhole DRAM reads need 64B granularity).
+template <typename AccessorType>
+void async_read_row_face0(
+    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t row_bytes = tt::constants::TILE_WIDTH * element_bytes;
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
+}
+
+// L1->L1-copy the row's second half into face 1. Only legal after the face-0 read barrier.
+void copy_row_half_to_face1(const Noc& noc, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
+    const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
+    UnicastEndpoint self;
+    noc.async_read(
+        self,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_dst_addr + half_row_bytes},
+        {});
+}
 
 void kernel_main() {
     constexpr bool is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender") == 1;
@@ -175,90 +198,49 @@ void kernel_main() {
 
                 if constexpr (fuse_gamma) {
                     const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+                    const uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
                     dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
-
                     const uint32_t base_l1_write_addr_gamma = dfb_gamma.get_write_ptr();
+
                     uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-                    // We want this data to appear as the first row of the tile.
-                    // This is 32B at the start of the first face, 32B at the start of the second face
-                    // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
-                    // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
-                    // Then later, copy the second set of 32 bytes into the start of the second face
-                    // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
-                    // to L1
-
-                    // Read the first 64 bytes of the tile into the first face
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = gamma_tile_start_id + w;
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma),
-                            64,
-                            {.page_id = tile_id},
-                            {});
+                        async_read_row_face0(
+                            noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc.async_read_barrier();
 
-                    // Copy the second set of 32 bytes into the second face
                     l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-                    UnicastEndpoint self_ep_gamma;
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        noc.async_read(
-                            self_ep_gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
-                            {});
+                        copy_row_half_to_face1(noc, l1_write_addr_gamma, gamma_element_bytes);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
-
                     noc.async_read_barrier();
                     dfb_gamma.push_back(num_cols_tile_gamma_beta);
                 }
 
                 if constexpr (fuse_beta) {
-                    // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
-                    // Then copy the second set of 32 bytes into the second face
                     const uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+                    const uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
                     const auto beta = TensorAccessor(beta_args, beta_addr);
 
                     dfb_beta.reserve_back(num_cols_tile_gamma_beta);
-
                     const uint32_t base_l1_write_addr_beta = dfb_beta.get_write_ptr();
-                    uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
 
-                    // Read the first 64 bytes of the tile into the first face
+                    uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = beta_tile_start_id + w;
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta),
-                            64,
-                            {.page_id = tile_id},
-                            {});
+                        async_read_row_face0(noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
                     noc.async_read_barrier();
 
-                    // Copy the second set of 32 bytes into the second face
                     l1_write_addr_beta = base_l1_write_addr_beta;
-
-                    UnicastEndpoint self_ep_beta;
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        noc.async_read(
-                            self_ep_beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
-                            {});
+                        copy_row_half_to_face1(noc, l1_write_addr_beta, beta_element_bytes);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
-
                     noc.async_read_barrier();
                     dfb_beta.push_back(num_cols_tile_gamma_beta);
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -13,6 +14,28 @@
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
+
+// Load one row-major gamma/beta stick (TILE_WIDTH datums) into the first row of a tile's two 16x16 faces;
+// byte offsets scale with datum size (2B bf16 / 4B fp32). Read the full row into face 0 (Blackhole DRAM
+// needs 64B-granular reads), then L1->L1-copy its second half-row into face 1.
+template <typename AccessorType>
+void async_read_row_to_tile(
+    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t row_bytes = tt::constants::TILE_WIDTH * element_bytes;
+    const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
+    const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
+
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
+    noc.async_read_barrier();
+
+    UnicastEndpoint self;
+    noc.async_read(
+        self,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_dst_addr + half_row_bytes},
+        {});
+}
 
 void kernel_main() {
     constexpr bool is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender") == 1;
@@ -157,90 +180,34 @@ void kernel_main() {
 
                 if constexpr (fuse_gamma) {
                     const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+                    const uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
                     dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
+                    uint32_t l1_write_addr_gamma = dfb_gamma.get_write_ptr();
 
-                    const uint32_t base_l1_write_addr_gamma = dfb_gamma.get_write_ptr();
-                    uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-                    // We want this data to appear as the first row of the tile.
-                    // This is 32B at the start of the first face, 32B at the start of the second face
-                    // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
-                    // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
-                    // Then later, copy the second set of 32 bytes into the start of the second face
-                    // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
-                    // to L1
-
-                    // Read the first 64 bytes of the tile into the first face
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = gamma_tile_start_id + w;
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma),
-                            64,
-                            {.page_id = tile_id},
-                            {});
+                        async_read_row_to_tile(
+                            noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
-                    noc.async_read_barrier();
-
-                    // Copy the second set of 32 bytes into the second face
-                    l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-                    UnicastEndpoint self_ep_gamma;
-                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        noc.async_read(
-                            self_ep_gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
-                            {});
-                        l1_write_addr_gamma += gamma_tile_bytes;
-                    }
-
                     noc.async_read_barrier();
                     dfb_gamma.push_back(num_cols_tile_gamma_beta);
                 }
 
                 if constexpr (fuse_beta) {
-                    // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
-                    // Then copy the second set of 32 bytes into the second face
                     const uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+                    const uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
                     const auto beta = TensorAccessor(beta_args, beta_addr);
 
                     dfb_beta.reserve_back(num_cols_tile_gamma_beta);
+                    uint32_t l1_write_addr_beta = dfb_beta.get_write_ptr();
 
-                    const uint32_t base_l1_write_addr_beta = dfb_beta.get_write_ptr();
-                    uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
-
-                    // Read the first 64 bytes of the tile into the first face
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = beta_tile_start_id + w;
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta),
-                            64,
-                            {.page_id = tile_id},
-                            {});
+                        async_read_row_to_tile(
+                            noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
-                    noc.async_read_barrier();
-
-                    // Copy the second set of 32 bytes into the second face
-                    l1_write_addr_beta = base_l1_write_addr_beta;
-
-                    UnicastEndpoint self_ep_beta;
-                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        noc.async_read(
-                            self_ep_beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
-                            {});
-                        l1_write_addr_beta += beta_tile_bytes;
-                    }
-
                     noc.async_read_barrier();
                     dfb_beta.push_back(num_cols_tile_gamma_beta);
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -15,19 +15,19 @@
 #include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
 
-// Load one row-major gamma/beta stick (TILE_WIDTH datums) into the first row of a tile's two 16x16 faces;
-// byte offsets scale with datum size (2B bf16 / 4B fp32). Read the full row into face 0 (Blackhole DRAM
-// needs 64B-granular reads), then L1->L1-copy its second half-row into face 1.
+// Queue the DRAM read of a gamma/beta row (TILE_WIDTH datums) into face 0; byte offsets scale with
+// datum size (2B bf16 / 4B fp32). Full row goes to face 0 (Blackhole DRAM reads need 64B granularity).
 template <typename AccessorType>
-void async_read_row_to_tile(
+void async_read_row_face0(
     const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
     const uint32_t row_bytes = tt::constants::TILE_WIDTH * element_bytes;
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
+}
+
+// L1->L1-copy the row's second half into face 1. Only legal after the face-0 read barrier.
+void copy_row_half_to_face1(const Noc& noc, uint32_t l1_dst_addr, uint32_t element_bytes) {
     const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
     const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
-
-    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), row_bytes, {.page_id = page_id}, {});
-    noc.async_read_barrier();
-
     UnicastEndpoint self;
     noc.async_read(
         self,
@@ -184,11 +184,19 @@ void kernel_main() {
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
                     dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
-                    uint32_t l1_write_addr_gamma = dfb_gamma.get_write_ptr();
+                    const uint32_t base_l1_write_addr_gamma = dfb_gamma.get_write_ptr();
 
+                    uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        async_read_row_to_tile(
+                        async_read_row_face0(
                             noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
+                        l1_write_addr_gamma += gamma_tile_bytes;
+                    }
+                    noc.async_read_barrier();
+
+                    l1_write_addr_gamma = base_l1_write_addr_gamma;
+                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                        copy_row_half_to_face1(noc, l1_write_addr_gamma, gamma_element_bytes);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc.async_read_barrier();
@@ -201,11 +209,18 @@ void kernel_main() {
                     const auto beta = TensorAccessor(beta_args, beta_addr);
 
                     dfb_beta.reserve_back(num_cols_tile_gamma_beta);
-                    uint32_t l1_write_addr_beta = dfb_beta.get_write_ptr();
+                    const uint32_t base_l1_write_addr_beta = dfb_beta.get_write_ptr();
 
+                    uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        async_read_row_to_tile(
-                            noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
+                        async_read_row_face0(noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
+                        l1_write_addr_beta += beta_tile_bytes;
+                    }
+                    noc.async_read_barrier();
+
+                    l1_write_addr_beta = base_l1_write_addr_beta;
+                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                        copy_row_half_to_face1(noc, l1_write_addr_beta, beta_element_bytes);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
                     noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -22,6 +23,38 @@ void generate_tile_with_packed_bfloat16_values(uint32_t dfb_id, uint32_t packed_
         *ptr++ = packed_bf16_value;
     }
     dfb.push_back(1);
+}
+
+// Load one row-major gamma/beta stick (TILE_WIDTH datums) into the first row of a tile's two 16x16 faces;
+// byte offsets scale with datum size (2B bf16 / 4B fp32). Blackhole (64B-granular DRAM reads): read the full
+// row into face 0 then L1->L1-copy its second half-row into face 1; else two direct reads, one per face.
+template <typename AccessorType>
+void async_read_row_to_tile(
+    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
+    const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
+#ifdef ARCH_BLACKHOLE
+    // Blackhole DRAM reads need 64B granularity: read both face-rows into face 0, then rearrange the
+    // second face-row into face 1 with an L1->L1 copy (legal at 16B alignment on BH once resident in L1).
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), 2 * half_row_bytes, {.page_id = page_id}, {});
+    noc.async_read_barrier();
+    UnicastEndpoint self;
+    noc.async_read(
+        self,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_dst_addr + half_row_bytes},
+        {});
+#else
+    // Two direct DRAM reads: face-row 0 -> face 0, face-row 1 -> face 1.
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), half_row_bytes, {.page_id = page_id}, {});
+    noc.async_read(
+        accessor,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.page_id = page_id, .offset_bytes = half_row_bytes},
+        {});
+#endif
 }
 
 void kernel_main() {
@@ -161,41 +194,14 @@ void kernel_main() {
 
                 if constexpr (fuse_gamma) {
                     const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+                    const uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
                     dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
                     uint32_t l1_write_addr_gamma = dfb_gamma.get_write_ptr();
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = gamma_tile_start_id + w;
-#ifdef ARCH_BLACKHOLE
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma),
-                            32 * 2,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read_barrier();
-                        UnicastEndpoint self_ep;
-                        noc.async_read(
-                            self_ep,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
-                            {});
-#else
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma),
-                            32,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                            32,
-                            {.page_id = tile_id, .offset_bytes = 32},
-                            {});
-#endif
+                        async_read_row_to_tile(
+                            noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc.async_read_barrier();
@@ -204,41 +210,14 @@ void kernel_main() {
 
                 if constexpr (fuse_beta) {
                     const uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+                    const uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
                     const auto beta = TensorAccessor(beta_args, beta_addr);
 
                     uint32_t l1_write_addr_beta = dfb_beta.get_write_ptr();
                     dfb_beta.reserve_back(num_cols_tile_gamma_beta);
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = beta_tile_start_id + w;
-#ifdef ARCH_BLACKHOLE
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta),
-                            32 * 2,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read_barrier();
-                        UnicastEndpoint self_ep;
-                        noc.async_read(
-                            self_ep,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
-                            {});
-#else
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta),
-                            32,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                            32,
-                            {.page_id = tile_id, .offset_bytes = 32},
-                            {});
-#endif
+                        async_read_row_to_tile(
+                            noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
                     noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -22,6 +23,38 @@ void generate_tile_with_packed_bfloat16_values(uint32_t dfb_id, uint32_t packed_
         *ptr++ = packed_bf16_value;
     }
     dfb.push_back(1);
+}
+
+// Load one row-major gamma/beta stick (TILE_WIDTH datums) into the first row of a tile's two 16x16 faces;
+// byte offsets scale with datum size (2B bf16 / 4B fp32). Blackhole (64B-granular DRAM reads): read the full
+// row into face 0 then L1->L1-copy its second half-row into face 1; else two direct reads, one per face.
+template <typename AccessorType>
+void async_read_row_to_tile(
+    const Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t l1_dst_addr, uint32_t element_bytes) {
+    const uint32_t face_bytes = tt::constants::FACE_HW * element_bytes;
+    const uint32_t half_row_bytes = tt::constants::FACE_WIDTH * element_bytes;
+#ifdef ARCH_BLACKHOLE
+    // Blackhole DRAM reads need 64B granularity: read both face-rows into face 0, then rearrange the
+    // second face-row into face 1 with an L1->L1 copy (legal at 16B alignment on BH once resident in L1).
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), 2 * half_row_bytes, {.page_id = page_id}, {});
+    noc.async_read_barrier();
+    UnicastEndpoint self;
+    noc.async_read(
+        self,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_dst_addr + half_row_bytes},
+        {});
+#else
+    // Two direct DRAM reads: face-row 0 -> face 0, face-row 1 -> face 1.
+    noc.async_read(accessor, CoreLocalMem<uint32_t>(l1_dst_addr), half_row_bytes, {.page_id = page_id}, {});
+    noc.async_read(
+        accessor,
+        CoreLocalMem<uint32_t>(l1_dst_addr + face_bytes),
+        half_row_bytes,
+        {.page_id = page_id, .offset_bytes = half_row_bytes},
+        {});
+#endif
 }
 
 void kernel_main() {
@@ -149,41 +182,14 @@ void kernel_main() {
 
                 if constexpr (fuse_gamma) {
                     const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+                    const uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
                     dfb_gamma.reserve_back(num_cols_tile_gamma_beta);
                     uint32_t l1_write_addr_gamma = dfb_gamma.get_write_ptr();
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = gamma_tile_start_id + w;
-#ifdef ARCH_BLACKHOLE
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma),
-                            32 * 2,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read_barrier();
-                        UnicastEndpoint self_ep;
-                        noc.async_read(
-                            self_ep,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
-                            {});
-#else
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma),
-                            32,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read(
-                            gamma,
-                            CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
-                            32,
-                            {.page_id = tile_id, .offset_bytes = 32},
-                            {});
-#endif
+                        async_read_row_to_tile(
+                            noc, gamma, gamma_tile_start_id + w, l1_write_addr_gamma, gamma_element_bytes);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc.async_read_barrier();
@@ -192,41 +198,14 @@ void kernel_main() {
 
                 if constexpr (fuse_beta) {
                     const uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+                    const uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
                     const auto beta = TensorAccessor(beta_args, beta_addr);
 
                     uint32_t l1_write_addr_beta = dfb_beta.get_write_ptr();
                     dfb_beta.reserve_back(num_cols_tile_gamma_beta);
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = beta_tile_start_id + w;
-#ifdef ARCH_BLACKHOLE
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta),
-                            32 * 2,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read_barrier();
-                        UnicastEndpoint self_ep;
-                        noc.async_read(
-                            self_ep,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                            32,
-                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
-                            {});
-#else
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta),
-                            32,
-                            {.page_id = tile_id},
-                            {});
-                        noc.async_read(
-                            beta,
-                            CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
-                            32,
-                            {.page_id = tile_id, .offset_bytes = 32},
-                            {});
-#endif
+                        async_read_row_to_tile(
+                            noc, beta, beta_tile_start_id + w, l1_write_addr_beta, beta_element_bytes);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
                     noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -15,6 +15,11 @@ namespace {
 using ttnn::operations::normalization::compute_num_virtual_cols;
 using ttnn::operations::normalization::find_expected_dram_grid;
 
+// Stats/intermediate CB format: fp32 input uses fp32 stats, bf16 input uses bf16.
+ttnn::DataType group_norm_im_data_format(ttnn::DataType input_dtype) {
+    return input_dtype == ttnn::DataType::FLOAT32 ? ttnn::DataType::FLOAT32 : ttnn::DataType::BFLOAT16;
+}
+
 // Validates that the requested core grid satisfies the DRAM group-norm constraints.
 // If the requested grid is invalid, fatals with an error suggesting the largest valid sub-grid.
 void validate_dram_grid(
@@ -260,8 +265,6 @@ Tensor group_norm(
     const auto fp32_acc = use_welford || (input_tensor.dtype() == DataType::FLOAT32);
     auto kernel_config_val =
         init_device_compute_kernel_config(arch, compute_kernel_config, math_fidelity, approx_mode, fp32_acc);
-    // When DEST is fp32, keep the stats/intermediate CBs fp32 instead of round-tripping through bf16.
-    const bool fp32_dest_acc_en = get_fp32_dest_acc_en(kernel_config_val);
 
     // Reciprocals must be sharded to L1 via the legacy ShardSpec representation:
     // the program factory reads shard_spec().value().numel() as the compile-time
@@ -381,11 +384,7 @@ Tensor group_norm(
     if (input_tensor.is_sharded()) {
         const ttnn::prim::GroupNormShardedMultiCoreProgramConfig program_config = {
             .compute_with_storage_grid_size = core_grid.value().to_CoreCoord(),
-            // fp32 stats when the fp32 intake path is active: legacy fp32 always, welford fp32-input
-            // with fp32 DEST. bf16 input keeps bf16 stats (bf16-input + fp32-stats needs a retune).
-            .im_data_format = (input_tensor.dtype() == DataType::FLOAT32 && (!use_welford || fp32_dest_acc_en))
-                                  ? DataType::FLOAT32
-                                  : DataType::BFLOAT16,
+            .im_data_format = group_norm_im_data_format(input_tensor.dtype()),
             .out_data_format = out_dtype,
             .inplace = inplace.value_or(false),
             .output_layout = output_layout.value_or(input_tensor.layout())};
@@ -408,11 +407,7 @@ Tensor group_norm(
     // Otherwise honor the explicit num_out_blocks (defaulting to 1 = no chunking).
     const ttnn::prim::GroupNormMultiCoreProgramConfig program_config = {
         .compute_with_storage_grid_size = core_grid.value().to_CoreCoord(),
-        // fp32 stats when the fp32 intake path is active (mirrors the sharded branch): legacy fp32
-        // always, welford fp32-input with fp32 DEST. bf16 input keeps bf16 stats (fp32-stats needs a retune).
-        .im_data_format = (input_tensor.dtype() == DataType::FLOAT32 && (!use_welford || fp32_dest_acc_en))
-                              ? DataType::FLOAT32
-                              : DataType::BFLOAT16,
+        .im_data_format = group_norm_im_data_format(input_tensor.dtype()),
         .out_data_format = out_dtype,
         .inplace = inplace.value_or(false),
         .output_layout = output_layout.value_or(input_tensor.layout()),

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -153,7 +153,7 @@ Tensor group_norm(
     const std::optional<Tensor>& bias,
     const std::optional<Tensor>& reciprocals,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DataType> /*dtype*/,
+    const std::optional<DataType> dtype,
     std::optional<CoreGrid> core_grid,
     std::optional<bool> inplace,
     std::optional<Layout> output_layout,
@@ -246,9 +246,13 @@ Tensor group_norm(
     const auto arch = input_tensor.device()->arch();
     const auto math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     const auto approx_mode = true;
-    const auto fp32_acc = use_welford;
+    // fp32 input accumulates in the fp32 DEST (like LayerNorm); welford already forces it. A
+    // user-supplied compute_kernel_config still overrides this default.
+    const auto fp32_acc = use_welford || (input_tensor.dtype() == DataType::FLOAT32);
     auto kernel_config_val =
         init_device_compute_kernel_config(arch, compute_kernel_config, math_fidelity, approx_mode, fp32_acc);
+    // When DEST is fp32, keep the stats/intermediate CBs fp32 instead of round-tripping through bf16.
+    const bool fp32_dest_acc_en = get_fp32_dest_acc_en(kernel_config_val);
 
     // Reciprocals must be sharded to L1 via the legacy ShardSpec representation:
     // the program factory reads shard_spec().value().numel() as the compile-time
@@ -368,8 +372,12 @@ Tensor group_norm(
     if (input_tensor.is_sharded()) {
         const ttnn::prim::GroupNormShardedMultiCoreProgramConfig program_config = {
             .compute_with_storage_grid_size = core_grid.value().to_CoreCoord(),
-            .im_data_format = DataType::BFLOAT16,
-            .out_data_format = DataType::BFLOAT16,
+            // fp32 stats when the fp32 intake path is active: legacy fp32 always, welford fp32-input
+            // with fp32 DEST. bf16 input keeps bf16 stats (bf16-input + fp32-stats needs a retune).
+            .im_data_format = (input_tensor.dtype() == DataType::FLOAT32 && (!use_welford || fp32_dest_acc_en))
+                                  ? DataType::FLOAT32
+                                  : DataType::BFLOAT16,
+            .out_data_format = dtype.value_or(input_tensor.dtype()),
             .inplace = inplace.value_or(false),
             .output_layout = output_layout.value_or(input_tensor.layout())};
         return ttnn::prim::group_norm(
@@ -391,8 +399,12 @@ Tensor group_norm(
     // Otherwise honor the explicit num_out_blocks (defaulting to 1 = no chunking).
     const ttnn::prim::GroupNormMultiCoreProgramConfig program_config = {
         .compute_with_storage_grid_size = core_grid.value().to_CoreCoord(),
-        .im_data_format = DataType::BFLOAT16,
-        .out_data_format = DataType::BFLOAT16,
+        // fp32 stats when the fp32 intake path is active (mirrors the sharded branch): legacy fp32
+        // always, welford fp32-input with fp32 DEST. bf16 input keeps bf16 stats (fp32-stats needs a retune).
+        .im_data_format = (input_tensor.dtype() == DataType::FLOAT32 && (!use_welford || fp32_dest_acc_en))
+                              ? DataType::FLOAT32
+                              : DataType::BFLOAT16,
+        .out_data_format = dtype.value_or(input_tensor.dtype()),
         .inplace = inplace.value_or(false),
         .output_layout = output_layout.value_or(input_tensor.layout()),
         .num_out_blocks = core_grid_auto_selected ? -1 : num_out_blocks.value_or(1)};

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -243,6 +243,15 @@ Tensor group_norm(
         TT_FATAL(input_mask->buffer() != nullptr, "Input mask must be allocated in buffers on device!");
         TT_FATAL(input_tensor.device() == input_mask->device(), "Input and input mask tensors must be on same device");
     }
+
+    // Program factories require output dtype == input dtype.
+    const auto out_dtype = dtype.value_or(input_tensor.dtype());
+    TT_FATAL(
+        out_dtype == input_tensor.dtype(),
+        "group_norm output dtype must match input dtype ({}), got dtype={}",
+        input_tensor.dtype(),
+        out_dtype);
+
     const auto arch = input_tensor.device()->arch();
     const auto math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     const auto approx_mode = true;
@@ -377,7 +386,7 @@ Tensor group_norm(
             .im_data_format = (input_tensor.dtype() == DataType::FLOAT32 && (!use_welford || fp32_dest_acc_en))
                                   ? DataType::FLOAT32
                                   : DataType::BFLOAT16,
-            .out_data_format = dtype.value_or(input_tensor.dtype()),
+            .out_data_format = out_dtype,
             .inplace = inplace.value_or(false),
             .output_layout = output_layout.value_or(input_tensor.layout())};
         return ttnn::prim::group_norm(
@@ -404,7 +413,7 @@ Tensor group_norm(
         .im_data_format = (input_tensor.dtype() == DataType::FLOAT32 && (!use_welford || fp32_dest_acc_en))
                               ? DataType::FLOAT32
                               : DataType::BFLOAT16,
-        .out_data_format = dtype.value_or(input_tensor.dtype()),
+        .out_data_format = out_dtype,
         .inplace = inplace.value_or(false),
         .output_layout = output_layout.value_or(input_tensor.layout()),
         .num_out_blocks = core_grid_auto_selected ? -1 : num_out_blocks.value_or(1)};

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -18,6 +18,11 @@ namespace {
 using ttnn::operations::normalization::compute_num_virtual_cols;
 using ttnn::operations::normalization::find_expected_dram_grid;
 
+// Stats/intermediate CB format: fp32 input uses fp32 stats, bf16 input uses bf16.
+ttnn::DataType group_norm_im_data_format(ttnn::DataType input_dtype) {
+    return input_dtype == ttnn::DataType::FLOAT32 ? ttnn::DataType::FLOAT32 : ttnn::DataType::BFLOAT16;
+}
+
 // Validates that the requested core grid satisfies the DRAM group-norm constraints.
 // If the requested grid is invalid, fatals with an error suggesting the largest valid sub-grid.
 void validate_dram_grid(
@@ -156,7 +161,7 @@ Tensor group_norm(
     const std::optional<Tensor>& bias,
     const std::optional<Tensor>& reciprocals,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DataType> /*dtype*/,
+    const std::optional<DataType> dtype,
     std::optional<CoreGrid> core_grid,
     std::optional<bool> inplace,
     std::optional<Layout> output_layout,
@@ -268,10 +273,21 @@ Tensor group_norm(
         TT_FATAL(input_mask->buffer() != nullptr, "Input mask must be allocated in buffers on device!");
         TT_FATAL(input_tensor.device() == input_mask->device(), "Input and input mask tensors must be on same device");
     }
+
+    // Program factories require output dtype == input dtype.
+    const auto out_dtype = dtype.value_or(input_tensor.dtype());
+    TT_FATAL(
+        out_dtype == input_tensor.dtype(),
+        "group_norm output dtype must match input dtype ({}), got dtype={}",
+        input_tensor.dtype(),
+        out_dtype);
+
     const auto arch = input_tensor.device()->arch();
     const auto math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     const auto approx_mode = true;
-    const auto fp32_acc = use_welford;
+    // fp32 input accumulates in the fp32 DEST (like LayerNorm); welford already forces it. A
+    // user-supplied compute_kernel_config still overrides this default.
+    const auto fp32_acc = use_welford || (input_tensor.dtype() == DataType::FLOAT32);
     auto kernel_config_val =
         init_device_compute_kernel_config(arch, compute_kernel_config, math_fidelity, approx_mode, fp32_acc);
 
@@ -393,8 +409,8 @@ Tensor group_norm(
     if (input_tensor.is_sharded()) {
         const ttnn::prim::GroupNormShardedMultiCoreProgramConfig program_config = {
             .compute_with_storage_grid_size = core_grid.value().to_CoreCoord(),
-            .im_data_format = DataType::BFLOAT16,
-            .out_data_format = DataType::BFLOAT16,
+            .im_data_format = group_norm_im_data_format(input_tensor.dtype()),
+            .out_data_format = out_dtype,
             .inplace = inplace.value_or(false),
             .output_layout = output_layout.value_or(input_tensor.layout())};
         return ttnn::prim::group_norm(
@@ -416,8 +432,8 @@ Tensor group_norm(
     // Otherwise honor the explicit num_out_blocks (defaulting to 1 = no chunking).
     const ttnn::prim::GroupNormMultiCoreProgramConfig program_config = {
         .compute_with_storage_grid_size = core_grid.value().to_CoreCoord(),
-        .im_data_format = DataType::BFLOAT16,
-        .out_data_format = DataType::BFLOAT16,
+        .im_data_format = group_norm_im_data_format(input_tensor.dtype()),
+        .out_data_format = out_dtype,
         .inplace = inplace.value_or(false),
         .output_layout = output_layout.value_or(input_tensor.layout()),
         .num_out_blocks = core_grid_auto_selected ? -1 : num_out_blocks.value_or(1)};

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -58,7 +58,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 weight (ttnn.Tensor, optional): Gamma (scale) parameter for the affine transformation. When omitted, no scaling is applied. Defaults to `None`.
                 bias (ttnn.Tensor, optional): Beta (shift) parameter for the affine transformation. When omitted, no shift is applied. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                dtype (ttnn.DataType, optional): Defaults to `None`.
+                dtype (ttnn.DataType, optional): Output data type. When provided, it must equal the :attr:`input_tensor` dtype; a mismatch is rejected. Defaults to `None` (output dtype matches the input).
                 core_grid (CoreGrid, optional): Defaults to `None`.
                 inplace (bool, optional): Defaults to `True`.
                 output_layout (ttnn.Layout, optional): Defaults to `None`.
@@ -79,7 +79,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT16
+                    * - BFLOAT16, FLOAT32
                       - TILE, ROW_MAJOR
 
                 ROW_MAJOR input is supported only for sharded inputs. An interleaved
@@ -92,8 +92,10 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT16
+                    * - BFLOAT16, FLOAT32
                       - ROW_MAJOR
+
+                weight (gamma) and bias (beta) must share the same dtype.
 
                 .. list-table:: input_mask
                     :header-rows: 1
@@ -103,7 +105,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                     * - BFLOAT16, BFLOAT8_B
                       - TILE
 
-                The output will be BFLOAT16, and both the layout and the memory configuration will match the :attr:`input_tensor`.
+                The output dtype matches the :attr:`input_tensor` dtype (BFLOAT16 or FLOAT32); an explicit :attr:`dtype` must equal it. Both the layout and the memory configuration also match the :attr:`input_tensor`.
 
             Memory Support:
               - Interleaved: DRAM and L1


### PR DESCRIPTION
## PR Category

Feature — FP32 support for GroupNorm (interleaved + block-sharded, legacy + Welford), issue #44650.

## Summary

GroupNorm rejected FP32 input, stats, and gamma/beta — it was hardwired to BFLOAT16 end-to-end. This PR accepts FP32 across all three program factories (mcast / no-mcast interleaved and block-sharded) for both the legacy and Welford compute flavors, and adds comprehensive FP32 test coverage across the full config matrix.

FPU path (TF32-class): FP32 CB data is read through SrcA/SrcB as TF32 (8-bit exp, 10-bit mantissa). With fp32_dest_acc_en=True, results accumulate in 32-bit DEST. 

SFPU path (true FP32): With UnpackToDestFp32, the unpacker writes full 32-bit values straight into DEST, bypassing SrcA/SrcB, so the vector engine runs at full FP32.

## Changes Made

**Device op — `layernorm`… → `groupnorm_device_operation.cpp`**

- Accept `BFLOAT16 || FLOAT32` for input, gamma, and beta 
- New `TT_FATAL` requiring gamma/beta to share a dtype (the factories use a single gamma/beta CB format for both).
- Reciprocals (Welford) validated as `FLOAT32`.
- `compute_output_specs` stamps the output tensor with `program_config.out_data_format`, so FP32 input round-trips to FP32 output.

**Program factories — `groupnorm_mcast_` / `groupnorm_no_mcast_` / `groupnorm_sharded_program_factory.cpp`**

- `TT_FATAL` rejecting FP32 input when `fp32_dest_acc_en=False` 
- FP32 intermediate/stats data format (`im_data_format`) enabled on the FP32 intake path (legacy always; Welford when fp32 DEST is on); BFLOAT16 input keeps BFLOAT16 stats.
- Welford `UnpackToDestFp32` aliasing: register alias buffer indices (`c_29` / `c_31`) on the intake CBs' SRAM and set `UnpackToDestMode` on the aliases so the Welford transpose intake preserves the full 23-bit mantissa into DEST, while the final FPU normalization stage stays on the primary (SrcA) index. Other candidate CBs were evaluated and deliberately left in Default mode (documented inline — their downstream FPU consumer truncates to TF32 regardless, so the flag would cost without improving precision).
- `reconfig_data_format` inserts to keep SrcA/SrcB formats consistent when FP32 and BFLOAT16 CBs are interleaved across compute stages.

**Gamma/beta writer kernels — `writer_unary_gn_rm_gb.cpp`, `welford_writer_unary_gn_rm_gb.cpp`, `writer_unary_sharded_gn_rm_gb_v2.cpp`**

- Made the ROW_MAJOR gamma/beta stick reader datum-size-aware (byte offsets scale with datum size = tile_bytes / TILE_HW). It previously hardcoded 64-byte (bf16) reads, so FP32 gamma/beta read garbage (NaN). Reads the full row into face 0 (Blackhole needs 64B-granular DRAM reads), then L1→L1-copies its second half-row into face 1.
- In the legacy + Welford RM writers, the reader is async_read_row_face0 + copy_row_half_to_face1, issued in two batched phases (all reads → one barrier → all copies → one trailing barrier). The sharded v2 writer uses a single arch-conditional helper.

**Welford reader kernels (mcast sender/receiver, sharded)**

- FP32-aware stats pointer views and byte strides (`global_stride`); skip-guard barrier placement preserved for the FP32 path.

**Compute kernels — `groupnorm.cpp`, `groupnorm_sharded_v2.cpp`, `welford_groupnorm.cpp`, `welford_groupnorm_sharded_v2.cpp`**

- FP32 stats combine path and reconfig discipline for the FP32 DEST accumulation; `eps`/scaler CBs remain BFLOAT16 while stats go FP32.

**Model fix — `ttnn_functional_resnetblock2d_new_conv.py`**

- Dropped `dtype=ttnn.bfloat8_b` from two SD `group_norm` call sites; a bf8_b output against a bf16 input is now rejected by the new `out_dtype == input_dtype` FATAL.

**Tests — `test_group_norm.py`, `test_group_norm_DRAM.py`**

- two `*_all_config` tests covering {interleaved, block-sharded} × {legacy, Welford} across **input** {fp32, bf16} × **gamma/beta** {fp32, bf16} × **layout** {TILE, ROW_MAJOR}:
  - `test_group_norm_sharded_all_config`
  - `test_group_norm_interleaved_all_config`

- Asserted against torch at **PCC ≥ 0.999** with dtype-tuned rtol/atol/frobenius bounds (tighter for fp32 than bf16).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/44650_fp32_groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/44650_fp32_groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/44650_fp32_groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/44650_fp32_groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/44650_fp32_groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/44650_fp32_groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/44650_fp32_groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/44650_fp32_groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/44650_fp32_groupnorm)