### PR TITLE
[Feature] Merge SFPU accuracy and perf into one harness

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import os
 import shutil
+from enum import Enum
 from pathlib import Path
 from typing import List, Optional
 
@@ -24,21 +25,36 @@ from helpers.llk_params import (
     DestAccumulation,
     FastMode,
     MathOperation,
+    PerfRunType,
+    StableSort,
+    Transpose,
     format_dict,
 )
 from helpers.param_config import get_num_blocks_and_num_tiles_in_block
+from helpers.perf import PerfConfig
 from helpers.sfpu_domains import for_op
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import DistributionKind, StimuliSpec, generate_stimuli
+from helpers.stimuli_generator import (
+    DistributionKind,
+    StimuliSpec,
+    calculate_tile_and_face_counts,
+    generate_stimuli,
+)
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     APPROX_MODE,
     CLAMP_NEGATIVE,
     FAST_MODE,
+    ITERATIONS,
+    LOOP_FACTOR,
     MATH_OP,
     NUM_BLOCKS,
+    NUM_FACES,
     NUM_TILES_IN_BLOCK,
+    STABLE_SORT,
     TILE_COUNT,
+    UNPACK_TRANS_FACES,
+    UNPACK_TRANS_WITHIN_FACE,
     DestSync,
     generate_input_dim,
 )
@@ -314,28 +330,78 @@ def clear_shards() -> None:
     SHARD_DIR.mkdir(parents=True, exist_ok=True)
 
 
+class RunMode(Enum):
+    """Which pipeline a single run_case variant exercises.
+
+    ACCURACY  — functional kernel (eltwise_unary_sfpu_test.cpp); writes the
+                accuracy CSV shard. This is the original, unchanged behavior.
+    PERF      — perf kernel (eltwise_unary_sfpu_perf.cpp) across every perf
+                scenario; captures timings into perf_report only (no CSV).
+    BOTH      — perf kernel restricted to L1_TO_L1; captures timings AND reads
+                the L1 result back to write the accuracy CSV, so the perf
+                kernel's output is checked against the golden in one run.
+    """
+
+    ACCURACY = "accuracy"
+    PERF = "perf"
+    BOTH = "both"
+
+
+# PERF profiles every scenario (matches the standalone perf sweep). BOTH is
+# restricted to L1_TO_L1 — the only run type whose L1 output can be read back
+# and compared to the golden.
+_PERF_ONLY_RUN_TYPES = [
+    PerfRunType.L1_TO_L1,
+    PerfRunType.UNPACK_ISOLATE,
+    PerfRunType.MATH_ISOLATE,
+    PerfRunType.PACK_ISOLATE,
+    PerfRunType.L1_CONGESTION,
+]
+_ACCURACY_CAPABLE_RUN_TYPES = [PerfRunType.L1_TO_L1]
+
+
 def run_case(
     op: MathOperation,
     formats: InputOutputFormat,
     approx_mode: ApproximationMode,
     fast_mode: FastMode,
     dest_acc: DestAccumulation,
+    perf_report=None,
     *,
+    run_mode: RunMode = RunMode.ACCURACY,
+    loop_factor: int = 16,
+    iterations: int = 32,
     points: int = DEFAULT_SWEEP_POINTS,
     distribution: DistributionKind = DistributionKind.RAMP,
     seed: Optional[int] = None,
-) -> Path:
-    """Measure one (op, format, config) on hardware and write its shard CSV.
+) -> Optional[Path]:
+    """Run one (op, format, config) variant in the requested *run_mode*.
 
-    The full pipeline for one variant:
+    RunMode.ACCURACY (default) reproduces the original accuracy sweep exactly:
+    the functional kernel runs, the result is compared to the torch golden, and
+    a shard CSV is written. RunMode.PERF runs the perf kernel for timings only
+    (into *perf_report*, no CSV). RunMode.BOTH runs the perf kernel once in
+    L1_TO_L1 and captures both the timings and the accuracy shard, so the perf
+    kernel's numeric output can be diffed against the accuracy-only run.
+
+    The pipeline for the accuracy-producing modes (ACCURACY, BOTH):
       1. build the input sweep for this op (deterministic RAMP by default;
          pass *distribution* for another, and *seed* for reproducible random ones),
       2. compute the torch "golden" output,
       3. compile + run the op on the device to get the "hw" output,
       4. compute per-element errors and write a shard via rows_dataframe/write_shard.
 
-    Returns the shard path.
+    *perf_report* (the pytest fixture) is required for PERF and BOTH; ACCURACY
+    ignores it. *loop_factor*/*iterations* apply only to the perf kernel.
+
+    Returns the shard path for ACCURACY/BOTH, or None for PERF (timings only).
     """
+    if run_mode in (RunMode.PERF, RunMode.BOTH) and perf_report is None:
+        raise ValueError(
+            f"run_mode={run_mode.value} needs the pytest perf_report fixture; "
+            "only RunMode.ACCURACY may omit it"
+        )
+
     # Seed the global RNG too (not just spec.seed) so it's consistent with the
     # param: 0 when unseeded (reproducible baseline), else the requested seed.
     torch.manual_seed(0 if seed is None else seed)
@@ -351,6 +417,105 @@ def run_case(
         input_dimensions_B=input_dimensions,
     )
 
+    variant_stimuli = StimuliConfig(
+        src_A,
+        formats.input_format,
+        src_B,
+        formats.input_format,
+        formats.output_format,
+        tile_count_A=tile_cnt_A,
+        tile_count_B=tile_cnt_B,
+        tile_count_res=tile_cnt_A,
+    )
+
+    # A 32-bit input unpacks straight to dest when dest_acc is ON (matches the
+    # functional kernel); shared by both the functional and perf kernel paths.
+    unpack_to_dest = (
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    )
+
+    if run_mode == RunMode.ACCURACY:
+        # ── Functional-kernel path (unchanged legacy behavior) ──────────────
+        num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+            DestSync.Half,
+            dest_acc,
+            formats,
+            input_dimensions,
+            TILE_DIMENSIONS,
+            BlocksCalculationAlgorithm.Standard,
+        )
+        configuration = TestConfig(
+            "sources/eltwise_unary_sfpu_test.cpp",
+            formats,
+            templates=[
+                generate_input_dim(input_dimensions, input_dimensions),
+                APPROX_MODE(approx_mode),
+                FAST_MODE(fast_mode),
+                CLAMP_NEGATIVE(True),
+                MATH_OP(mathop=op),
+            ],
+            runtimes=[
+                TILE_COUNT(tile_cnt_A),
+                NUM_BLOCKS(num_blocks),
+                NUM_TILES_IN_BLOCK(num_tiles_in_block),
+            ],
+            variant_stimuli=variant_stimuli,
+            dest_acc=dest_acc,
+            unpack_to_dest=unpack_to_dest,
+        )
+        res_from_L1 = configuration.run().result
+    else:
+        # ── Perf-kernel path (PERF: timings only; BOTH: timings + readback) ──
+        _, _, faces_to_generate = calculate_tile_and_face_counts(
+            input_dimensions, input_dimensions, face_r_dim=16, num_faces=4
+        )
+        run_types = (
+            _ACCURACY_CAPABLE_RUN_TYPES
+            if run_mode == RunMode.BOTH
+            else _PERF_ONLY_RUN_TYPES
+        )
+        configuration = PerfConfig(
+            "sources/eltwise_unary_sfpu_perf.cpp",
+            formats,
+            run_types=run_types,
+            templates=[
+                MATH_OP(mathop=op),
+                APPROX_MODE(approx_mode),
+                ITERATIONS(iterations),
+                FAST_MODE(fast_mode),
+                STABLE_SORT(StableSort.No),
+                # CLAMP_NEGATIVE must match the functional kernel: for approx exp
+                # it selects the clamped branch in sfpu_operations (omitting it
+                # defaults to false -> a different path -> mismatch).
+                CLAMP_NEGATIVE(True),
+            ],
+            runtimes=[
+                TILE_COUNT(tile_cnt_A),
+                LOOP_FACTOR(loop_factor),
+                NUM_FACES(num_faces=faces_to_generate),
+                UNPACK_TRANS_FACES(Transpose.No),
+                UNPACK_TRANS_WITHIN_FACE(Transpose.No),
+            ],
+            variant_stimuli=variant_stimuli,
+            unpack_to_dest=unpack_to_dest,
+            dest_acc=dest_acc,
+        )
+
+        if run_mode == RunMode.PERF:
+            # Timings only — PerfConfig.run() writes runtime params and collects
+            # timings; it needs no real stimuli written and no result read back.
+            configuration.run(perf_report)
+            return None
+
+        # BOTH: PerfConfig.run() does not write stimuli or read the result, so
+        # bracket it — write the real input to L1 first, read it back after.
+        configuration.variant_stimuli.write(TestConfig.TENSIX_LOCATION)
+        configuration.run(perf_report)
+        res_from_L1 = configuration.variant_stimuli.collect_results(
+            TestConfig.TENSIX_LOCATION
+        )
+
+    # ── Golden + accuracy CSV (ACCURACY and BOTH) ───────────────────────────
     generate_golden = get_golden_generator(UnarySFPUGolden)
     golden_tensor = generate_golden(
         op,
@@ -361,47 +526,6 @@ def run_case(
         input_dimensions,
     )
 
-    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
-        DestSync.Half,
-        dest_acc,
-        formats,
-        input_dimensions,
-        TILE_DIMENSIONS,
-        BlocksCalculationAlgorithm.Standard,
-    )
-
-    configuration = TestConfig(
-        "sources/eltwise_unary_sfpu_test.cpp",
-        formats,
-        templates=[
-            generate_input_dim(input_dimensions, input_dimensions),
-            APPROX_MODE(approx_mode),
-            FAST_MODE(fast_mode),
-            CLAMP_NEGATIVE(True),
-            MATH_OP(mathop=op),
-        ],
-        runtimes=[
-            TILE_COUNT(tile_cnt_A),
-            NUM_BLOCKS(num_blocks),
-            NUM_TILES_IN_BLOCK(num_tiles_in_block),
-        ],
-        variant_stimuli=StimuliConfig(
-            src_A,
-            formats.input_format,
-            src_B,
-            formats.input_format,
-            formats.output_format,
-            tile_count_A=tile_cnt_A,
-            tile_count_B=tile_cnt_B,
-            tile_count_res=tile_cnt_A,
-        ),
-        dest_acc=dest_acc,
-        unpack_to_dest=(
-            formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
-        ),
-    )
-
-    res_from_L1 = configuration.run().result
     assert len(res_from_L1) == len(golden_tensor), (
         f"{op.name}: result length {len(res_from_L1)} != golden "
         f"{len(golden_tensor)}"

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
@@ -331,16 +331,7 @@ def clear_shards() -> None:
 
 
 class RunMode(Enum):
-    """Which pipeline a single run_case variant exercises.
-
-    ACCURACY  — functional kernel (eltwise_unary_sfpu_test.cpp); writes the
-                accuracy CSV shard. This is the original, unchanged behavior.
-    PERF      — perf kernel (eltwise_unary_sfpu_perf.cpp) across every perf
-                scenario; captures timings into perf_report only (no CSV).
-    BOTH      — perf kernel restricted to L1_TO_L1; captures timings AND reads
-                the L1 result back to write the accuracy CSV, so the perf
-                kernel's output is checked against the golden in one run.
-    """
+    """Which pipeline a single run_case variant exercises."""
 
     ACCURACY = "accuracy"
     PERF = "perf"
@@ -377,12 +368,12 @@ def run_case(
 ) -> Optional[Path]:
     """Run one (op, format, config) variant in the requested *run_mode*.
 
-    RunMode.ACCURACY (default) reproduces the original accuracy sweep exactly:
+    RunMode.ACCURACY (default) reproduces the accuracy sweep exactly:
     the functional kernel runs, the result is compared to the torch golden, and
-    a shard CSV is written. RunMode.PERF runs the perf kernel for timings only
-    (into *perf_report*, no CSV). RunMode.BOTH runs the perf kernel once in
-    L1_TO_L1 and captures both the timings and the accuracy shard, so the perf
-    kernel's numeric output can be diffed against the accuracy-only run.
+    a shard CSV is written.
+    RunMode.PERF runs the perf kernel for timings only.
+    RunMode.BOTH runs the perf kernel once in L1_TO_L1 and captures both the timings
+    and the accuracy shard.
 
     The pipeline for the accuracy-producing modes (ACCURACY, BOTH):
       1. build the input sweep for this op (deterministic RAMP by default;
@@ -390,9 +381,6 @@ def run_case(
       2. compute the torch "golden" output,
       3. compile + run the op on the device to get the "hw" output,
       4. compute per-element errors and write a shard via rows_dataframe/write_shard.
-
-    *perf_report* (the pytest fixture) is required for PERF and BOTH; ACCURACY
-    ignores it. *loop_factor*/*iterations* apply only to the perf kernel.
 
     Returns the shard path for ACCURACY/BOTH, or None for PERF (timings only).
     """
@@ -428,14 +416,12 @@ def run_case(
         tile_count_res=tile_cnt_A,
     )
 
-    # A 32-bit input unpacks straight to dest when dest_acc is ON (matches the
-    # functional kernel); shared by both the functional and perf kernel paths.
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
 
     if run_mode == RunMode.ACCURACY:
-        # ── Functional-kernel path (unchanged legacy behavior) ──────────────
+        # ── Functional-kernel path ─────────────────────────────────────────────
         num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
             DestSync.Half,
             dest_acc,
@@ -465,7 +451,7 @@ def run_case(
         )
         res_from_L1 = configuration.run().result
     else:
-        # ── Perf-kernel path (PERF: timings only; BOTH: timings + readback) ──
+        # ── Perf-kernel path ───────────────────────────────────────────────────
         _, _, faces_to_generate = calculate_tile_and_face_counts(
             input_dimensions, input_dimensions, face_r_dim=16, num_faces=4
         )
@@ -508,14 +494,14 @@ def run_case(
             return None
 
         # BOTH: PerfConfig.run() does not write stimuli or read the result, so
-        # bracket it — write the real input to L1 first, read it back after.
+        # write the real input to L1 first and read it back after.
         configuration.variant_stimuli.write(TestConfig.TENSIX_LOCATION)
         configuration.run(perf_report)
         res_from_L1 = configuration.variant_stimuli.collect_results(
             TestConfig.TENSIX_LOCATION
         )
 
-    # ── Golden + accuracy CSV (ACCURACY and BOTH) ───────────────────────────
+    # ── Golden + accuracy CSV ──────────────────────────────────────────────────
     generate_golden = get_golden_generator(UnarySFPUGolden)
     golden_tensor = generate_golden(
         op,

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
@@ -15,13 +15,11 @@ import torch
 from helpers.accuracy_metrics import compute_pointwise_metrics
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
-    TILE_DIMENSIONS,
     UnarySFPUGolden,
     get_golden_generator,
 )
 from helpers.llk_params import (
     ApproximationMode,
-    BlocksCalculationAlgorithm,
     DestAccumulation,
     FastMode,
     MathOperation,
@@ -30,7 +28,6 @@ from helpers.llk_params import (
     Transpose,
     format_dict,
 )
-from helpers.param_config import get_num_blocks_and_num_tiles_in_block
 from helpers.perf import PerfConfig
 from helpers.sfpu_domains import for_op
 from helpers.stimuli_config import StimuliConfig
@@ -48,15 +45,12 @@ from helpers.test_variant_parameters import (
     ITERATIONS,
     LOOP_FACTOR,
     MATH_OP,
-    NUM_BLOCKS,
     NUM_FACES,
-    NUM_TILES_IN_BLOCK,
+    PERF_RUN_TYPE,
     STABLE_SORT,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
     UNPACK_TRANS_WITHIN_FACE,
-    DestSync,
-    generate_input_dim,
 )
 
 _THIS_DIR = Path(__file__).resolve().parent
@@ -368,12 +362,13 @@ def run_case(
 ) -> Optional[Path]:
     """Run one (op, format, config) variant in the requested *run_mode*.
 
-    RunMode.ACCURACY (default) reproduces the accuracy sweep exactly:
-    the functional kernel runs, the result is compared to the torch golden, and
-    a shard CSV is written.
-    RunMode.PERF runs the perf kernel for timings only.
-    RunMode.BOTH runs the perf kernel once in L1_TO_L1 and captures both the timings
-    and the accuracy shard.
+    All three modes run the same merged kernel (eltwise_unary_sfpu_perf.cpp).
+    RunMode.ACCURACY (default) runs it through a plain TestConfig — no profiler
+    build, no perf_report — checks the result against the torch golden, and writes
+    a shard CSV.
+    RunMode.PERF runs it through PerfConfig for timings only.
+    RunMode.BOTH runs it through PerfConfig once in L1_TO_L1 and captures both the
+    timings and the accuracy shard.
 
     The pipeline for the accuracy-producing modes (ACCURACY, BOTH):
       1. build the input sweep for this op (deterministic RAMP by default;
@@ -420,30 +415,29 @@ def run_case(
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
 
+    _, _, faces_to_generate = calculate_tile_and_face_counts(
+        input_dimensions, input_dimensions, face_r_dim=16, num_faces=4
+    )
+
     if run_mode == RunMode.ACCURACY:
-        # ── Functional-kernel path ─────────────────────────────────────────────
-        num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
-            DestSync.Half,
-            dest_acc,
-            formats,
-            input_dimensions,
-            TILE_DIMENSIONS,
-            BlocksCalculationAlgorithm.Standard,
-        )
         configuration = TestConfig(
-            "sources/eltwise_unary_sfpu_test.cpp",
+            "sources/eltwise_unary_sfpu_perf.cpp",
             formats,
             templates=[
-                generate_input_dim(input_dimensions, input_dimensions),
-                APPROX_MODE(approx_mode),
-                FAST_MODE(fast_mode),
-                CLAMP_NEGATIVE(True),
+                PERF_RUN_TYPE(PerfRunType.L1_TO_L1),
                 MATH_OP(mathop=op),
+                APPROX_MODE(approx_mode),
+                ITERATIONS(iterations),
+                FAST_MODE(fast_mode),
+                STABLE_SORT(StableSort.No),
+                CLAMP_NEGATIVE(True),
             ],
             runtimes=[
                 TILE_COUNT(tile_cnt_A),
-                NUM_BLOCKS(num_blocks),
-                NUM_TILES_IN_BLOCK(num_tiles_in_block),
+                LOOP_FACTOR(1),
+                NUM_FACES(num_faces=faces_to_generate),
+                UNPACK_TRANS_FACES(Transpose.No),
+                UNPACK_TRANS_WITHIN_FACE(Transpose.No),
             ],
             variant_stimuli=variant_stimuli,
             dest_acc=dest_acc,
@@ -451,10 +445,6 @@ def run_case(
         )
         res_from_L1 = configuration.run().result
     else:
-        # ── Perf-kernel path ───────────────────────────────────────────────────
-        _, _, faces_to_generate = calculate_tile_and_face_counts(
-            input_dimensions, input_dimensions, face_r_dim=16, num_faces=4
-        )
         run_types = (
             _ACCURACY_CAPABLE_RUN_TYPES
             if run_mode == RunMode.BOTH
@@ -470,9 +460,6 @@ def run_case(
                 ITERATIONS(iterations),
                 FAST_MODE(fast_mode),
                 STABLE_SORT(StableSort.No),
-                # CLAMP_NEGATIVE must match the functional kernel: for approx exp
-                # it selects the clamped branch in sfpu_operations (omitting it
-                # defaults to false -> a different path -> mismatch).
                 CLAMP_NEGATIVE(True),
             ],
             runtimes=[

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
@@ -20,6 +20,31 @@ import os
 
 from helpers.logger import logger
 
+_MODE_TO_FUNC = {
+    "accuracy": "test_sfpu_accuracy_sweep",
+    "perf": "test_sfpu_perf_sweep",
+    "both": "test_sfpu_accuracy_and_perf_sweep",
+}
+_SWEEP_FUNCS = set(_MODE_TO_FUNC.values())
+
+
+def pytest_collection_modifyitems(config, items):
+    mode = config.getoption("--mode", default=None)
+    if not mode:
+        return
+    target = _MODE_TO_FUNC[mode]
+    deselected = [
+        it
+        for it in items
+        if getattr(it, "function", None) is not None
+        and it.function.__name__ in _SWEEP_FUNCS
+        and it.function.__name__ != target
+    ]
+    if deselected:
+        drop = {id(it) for it in deselected}
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = [it for it in items if id(it) not in drop]
+
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
@@ -29,6 +29,7 @@ _SWEEP_FUNCS = set(_MODE_TO_FUNC.values())
 
 
 def pytest_collection_modifyitems(config, items):
+    # --mode defaults to "accuracy"
     mode = config.getoption("--mode", default=None)
     if not mode:
         return

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
@@ -78,18 +78,13 @@ ACCURACY_PARAMS = list(
 )
 
 
-@skip_for_coverage
-@pytest.mark.accuracy
-@pytest.mark.parametrize(
-    "formats,approx_mode,mathop,fast_mode,dest_acc", ACCURACY_PARAMS
-)
-def test_sfpu_accuracy_sweep(
-    formats: InputOutputFormat,
-    approx_mode: ApproximationMode,
+def _skip_if_unsupported(
     mathop: MathOperation,
-    fast_mode: FastMode,
+    approx_mode: ApproximationMode,
     dest_acc: DestAccumulation,
-):
+    formats: InputOutputFormat,
+) -> None:
+    """Skip variants the hardware / metal stack does not support."""
     if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
         pytest.skip(reason="Metal tanh does not support approximation mode")
 
@@ -103,6 +98,97 @@ def test_sfpu_accuracy_sweep(
     ):
         pytest.skip(reason="This combination is not supported on BH architecture")
 
+
+# Three ways to run the same op/format/config matrix (RunMode selects which):
+#   -m accuracy          -> functional kernel, accuracy CSV only (unchanged)
+#   -k sfpu_perf_sweep   -> perf kernel, timings only
+#   -k accuracy_and_perf -> perf kernel, timings + accuracy CSV in one L1_TO_L1 run
+# Both perf tests carry @pytest.mark.perf; narrow with -k to pick just one.
+@skip_for_coverage
+@pytest.mark.accuracy
+@pytest.mark.parametrize(
+    "formats,approx_mode,mathop,fast_mode,dest_acc", ACCURACY_PARAMS
+)
+def test_sfpu_accuracy_sweep(
+    formats: InputOutputFormat,
+    approx_mode: ApproximationMode,
+    mathop: MathOperation,
+    fast_mode: FastMode,
+    dest_acc: DestAccumulation,
+):
+    _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
+
     from accuracy.accuracy_harness import run_case
 
     run_case(mathop, formats, approx_mode, fast_mode, dest_acc)
+
+
+@skip_for_coverage
+@pytest.mark.perf
+@pytest.mark.parametrize(
+    "formats,approx_mode,mathop,fast_mode,dest_acc", ACCURACY_PARAMS
+)
+def test_sfpu_perf_sweep(
+    perf_report,
+    formats: InputOutputFormat,
+    approx_mode: ApproximationMode,
+    mathop: MathOperation,
+    fast_mode: FastMode,
+    dest_acc: DestAccumulation,
+):
+    """Perf-only sweep: run the perf kernel across every scenario for timings."""
+    _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
+
+    # Lazy import so collecting under a `not perf` marker filter doesn't pull the
+    # harness's heavy deps (pandas/torch) into every pytest-xdist worker.
+    from accuracy.accuracy_harness import RunMode, run_case
+
+    run_case(
+        mathop,
+        formats,
+        approx_mode,
+        fast_mode,
+        dest_acc,
+        perf_report,
+        run_mode=RunMode.PERF,
+        loop_factor=16,
+    )
+
+
+@skip_for_coverage
+@pytest.mark.perf
+@pytest.mark.parametrize(
+    "formats,approx_mode,mathop,fast_mode,dest_acc", ACCURACY_PARAMS
+)
+def test_sfpu_accuracy_and_perf_sweep(
+    perf_report,
+    formats: InputOutputFormat,
+    approx_mode: ApproximationMode,
+    mathop: MathOperation,
+    fast_mode: FastMode,
+    dest_acc: DestAccumulation,
+):
+    """Merged sweep: one L1_TO_L1 perf run that captures timings AND writes the
+    accuracy shard, so the perf kernel's output is checked against the golden.
+
+    loop_factor=16: realistic perf setting (amortizes profiler overhead). Safe
+    for accuracy because each loop iteration re-copies the input (datacopy
+    srcA->dest) and unpack re-reads buffer_A from L1, so every iteration
+    recomputes op(input) from scratch — the final L1 result is one clean
+    application regardless of loop_factor.
+    """
+    _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
+
+    from accuracy.accuracy_harness import RunMode, run_case
+
+    run_case(
+        mathop,
+        formats,
+        approx_mode,
+        fast_mode,
+        dest_acc,
+        perf_report,
+        run_mode=RunMode.BOTH,
+        loop_factor=16,
+        points=8192,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
@@ -99,11 +99,6 @@ def _skip_if_unsupported(
         pytest.skip(reason="This combination is not supported on BH architecture")
 
 
-# Three ways to run the same op/format/config matrix (RunMode selects which):
-#   -m accuracy          -> functional kernel, accuracy CSV only (unchanged)
-#   -k sfpu_perf_sweep   -> perf kernel, timings only
-#   -k accuracy_and_perf -> perf kernel, timings + accuracy CSV in one L1_TO_L1 run
-# Both perf tests carry @pytest.mark.perf; narrow with -k to pick just one.
 @skip_for_coverage
 @pytest.mark.accuracy
 @pytest.mark.parametrize(
@@ -139,8 +134,6 @@ def test_sfpu_perf_sweep(
     """Perf-only sweep: run the perf kernel across every scenario for timings."""
     _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
 
-    # Lazy import so collecting under a `not perf` marker filter doesn't pull the
-    # harness's heavy deps (pandas/torch) into every pytest-xdist worker.
     from accuracy.accuracy_harness import RunMode, run_case
 
     run_case(
@@ -152,11 +145,13 @@ def test_sfpu_perf_sweep(
         perf_report,
         run_mode=RunMode.PERF,
         loop_factor=16,
+        points=8192,
     )
 
 
 @skip_for_coverage
 @pytest.mark.perf
+@pytest.mark.accuracy
 @pytest.mark.parametrize(
     "formats,approx_mode,mathop,fast_mode,dest_acc", ACCURACY_PARAMS
 )
@@ -168,15 +163,6 @@ def test_sfpu_accuracy_and_perf_sweep(
     fast_mode: FastMode,
     dest_acc: DestAccumulation,
 ):
-    """Merged sweep: one L1_TO_L1 perf run that captures timings AND writes the
-    accuracy shard, so the perf kernel's output is checked against the golden.
-
-    loop_factor=16: realistic perf setting (amortizes profiler overhead). Safe
-    for accuracy because each loop iteration re-copies the input (datacopy
-    srcA->dest) and unpack re-reads buffer_A from L1, so every iteration
-    recomputes op(input) from scratch — the final L1 result is one clean
-    application regardless of loop_factor.
-    """
     _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
 
     from accuracy.accuracy_harness import RunMode, run_case

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
@@ -49,10 +49,18 @@ TRANSCENDENTAL_OPS = [
 
 # Ops that support FastMode.
 SUPPORTED_FAST_MODE_OPS = [
-    MathOperation.Log1p,
-    MathOperation.Exp,
     MathOperation.Rsqrt,
     MathOperation.Sqrt,
+]
+
+APPROX_CAPABLE_OPS = [
+    MathOperation.Exp,
+    MathOperation.Sqrt,
+    MathOperation.Rsqrt,
+    MathOperation.Reciprocal,
+    MathOperation.Sin,
+    MathOperation.Cos,
+    MathOperation.Gelu,
 ]
 
 FORMATS = input_output_formats(
@@ -63,18 +71,30 @@ FORMATS = input_output_formats(
     ]
 )
 
-# (formats, approx, op, fast, dest) — fast varies only for fast-mode ops.
+
+def _get_approx_modes(mathop):
+    # approx=Yes only for ops with a real approx path; every op still runs approx=No.
+    if mathop in APPROX_CAPABLE_OPS:
+        return [ApproximationMode.No, ApproximationMode.Yes]
+    return [ApproximationMode.No]
+
+
+def _get_fast_modes(mathop):
+    if mathop in SUPPORTED_FAST_MODE_OPS:
+        return [FastMode.No, FastMode.Yes]
+    return [FastMode.No]
+
+
+# (formats, approx, op, fast, dest)
 ACCURACY_PARAMS = list(
     (fmt, approx, op, fast, dest)
-    for fmt, approx, op, dest in product(
+    for fmt, op, dest in product(
         FORMATS,
-        [ApproximationMode.No, ApproximationMode.Yes],
         TRANSCENDENTAL_OPS,
         [DestAccumulation.No, DestAccumulation.Yes],
     )
-    for fast in (
-        [FastMode.No, FastMode.Yes] if op in SUPPORTED_FAST_MODE_OPS else [FastMode.No]
-    )
+    for approx in _get_approx_modes(op)
+    for fast in _get_fast_modes(op)
 )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -292,10 +292,11 @@ def pytest_addoption(parser):
     parser.addoption(
         "--mode",
         action="store",
-        default=None,
+        default="accuracy",
         choices=["accuracy", "perf", "both"],
         help="SFPU sweep selector (accuracy | perf | both): keeps only that sweep "
-        "test and deselects the other two. Exact-match shorthand for -k.",
+        "test and deselects the other two. Defaults to 'accuracy'. "
+        "Exact-match shorthand for -k.",
     )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -289,6 +289,15 @@ def pytest_addoption(parser):
         "(case-insensitive, exact). Repeatable: --op=exp --op=log.",
     )
 
+    parser.addoption(
+        "--mode",
+        action="store",
+        default=None,
+        choices=["accuracy", "perf", "both"],
+        help="SFPU sweep selector (accuracy | perf | both): keeps only that sweep "
+        "test and deselects the other two. Exact-match shorthand for -k.",
+    )
+
 
 _RECORD_TEST_ORDER: bool = False
 _UNIFIED_ORDER_FILE: str = "DEFAULT"

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -19,6 +19,7 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import calculate_tile_and_face_counts
 from helpers.test_variant_parameters import (
     APPROX_MODE,
+    CLAMP_NEGATIVE,
     FAST_MODE,
     ITERATIONS,
     LOOP_FACTOR,
@@ -170,6 +171,7 @@ def test_perf_eltwise_unary_sfpu(
             ITERATIONS(iterations),
             FAST_MODE(fast_mode),
             STABLE_SORT(stable_sort),
+            CLAMP_NEGATIVE(True),
         ],
         runtimes=[
             TILE_COUNT(tile_count_A),

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -152,7 +152,7 @@ def test_perf_eltwise_unary_sfpu(
     # If dest_acc is on, we unpack Float32 into 16-bit format in src registers
     # (later copied over in dest reg for SFPU op)
     unpack_to_dest = (
-        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.No
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
 
     configuration = PerfConfig(

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -149,8 +149,9 @@ def test_perf_eltwise_unary_sfpu(
         input_dimensions, input_dimensions, face_r_dim=16, num_faces=4
     )
 
-    # If dest_acc is on, we unpack Float32 into 16-bit format in src registers
-    # (later copied over in dest reg for SFPU op)
+    # A 32-bit (fp32) input with dest_acc ON unpacks straight into the 32-bit Dest
+    # register. With dest_acc OFF it goes through the source registers (converted to 16-bit)
+    # and is copied into Dest for the SFPU op.
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
@@ -171,7 +172,7 @@ def test_perf_eltwise_unary_sfpu(
             ITERATIONS(iterations),
             FAST_MODE(fast_mode),
             STABLE_SORT(stable_sort),
-            CLAMP_NEGATIVE(True),
+            CLAMP_NEGATIVE(False),
         ],
         runtimes=[
             TILE_COUNT(tile_count_A),

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -45,8 +45,6 @@ from helpers.test_variant_parameters import (
 from helpers.utils import passed_test
 
 SUPPORTED_FAST_MODE_OPS = [
-    MathOperation.Log1p,
-    MathOperation.Exp,
     MathOperation.Rsqrt,
     MathOperation.Sqrt,
 ]

--- a/tt_metal/tt-llk/tests/run_llk_perf_blackhole.sh
+++ b/tt_metal/tt-llk/tests/run_llk_perf_blackhole.sh
@@ -45,12 +45,12 @@ while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
   fi
 
   pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
-    -m "perf" --timeout=60 \
+    -m "perf and not accuracy" --timeout=60 \
     $SPLIT_ARGS \
     "$FILE"
   tt-smi -r 0
   pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x \
-    -m "perf" --timeout=60 \
+    -m "perf and not accuracy" --timeout=60 \
     $SPLIT_ARGS \
     --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
     "$FILE"

--- a/tt_metal/tt-llk/tests/run_llk_perf_wormhole.sh
+++ b/tt_metal/tt-llk/tests/run_llk_perf_wormhole.sh
@@ -24,10 +24,10 @@ mkdir -p perf_data
 PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
 PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
 
-pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
+pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf and not accuracy" --timeout=60 \
   --splits "$N_GROUPS" --group "$GROUP" \
   --junitxml="pytest-report-wormhole-${GROUP}-compile.xml" .
-pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
+pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf and not accuracy" --timeout=60 \
   --splits "$N_GROUPS" --group "$GROUP" \
   --junitxml="pytest-report-wormhole-${GROUP}-run.xml" .
 junitparser merge pytest-report-wormhole-${GROUP}-compile.xml pytest-report-wormhole-${GROUP}-run.xml pytest-report-wormhole-${GROUP}.xml

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -52,7 +52,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
-        _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
+        // acc_to_dest must be false to allow unpack_to_dest (the static assert in
+        // llk_unpack_A forbids both together) — matches the functional kernel.
+        _llk_unpack_A_init_<BROADCAST_TYPE, false, reuse_dest_type, unpack_to_dest>(
             UNPACK_TRANSPOSE_FACES,
             UNPACK_TRANSPOSE_WITHIN_FACE,
             ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
@@ -86,8 +88,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_unpack_A_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
-                        PERF_ADDRESS(PERF_INPUT_A, /* tile_idx */ i), formats.unpack_A_src, formats.unpack_A_dst);
+                    // Accuracy-merge: read input from the runtime operand address
+                    // (StimuliConfig layout) instead of the fixed PERF_INPUT_A, so
+                    // the harness's stimuli line up with what the kernel consumes.
+                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest (see init) */, reuse_dest_type, unpack_to_dest>(
+                        L1_ADDRESS(params.buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
                 }
             }
         }
@@ -123,7 +128,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
-        test_utils::call_unary_sfpu_operation_init<SFPU_UNARY_OPERATION, APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS, FAST_MODE, STABLE_SORT>();
+        // CLAMP_NEGATIVE must match the accuracy harness (which passes it): for
+        // approx exp it selects the clamped approx-exp branch in sfpu_operations.
+        // Omitting it defaulted to false -> a different approx path -> mismatch.
+        test_utils::
+            call_unary_sfpu_operation_init<SFPU_UNARY_OPERATION, APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS, FAST_MODE, STABLE_SORT, CLAMP_NEGATIVE>();
         PROFILER_SYNC();
     }
     {
@@ -220,7 +229,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             is_fp32_dest_acc_en,
                             ITERATIONS,
                             FAST_MODE,
-                            STABLE_SORT>(block_tile, formats.math);
+                            STABLE_SORT,
+                            CLAMP_NEGATIVE>(block_tile, formats.math);
                     }
                 }
             }
@@ -254,7 +264,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             is_fp32_dest_acc_en,
                             ITERATIONS,
                             FAST_MODE,
-                            STABLE_SORT>(block_tile, formats.math);
+                            STABLE_SORT,
+                            CLAMP_NEGATIVE>(block_tile, formats.math);
                     }
 
                     _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
@@ -312,7 +323,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                             "block_tile exceeds max dest tiles");
                         _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, ckernel::PackMode::Default>(
-                            block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                            block_tile, L1_ADDRESS(params.buffer_Res[block_start + block_tile]));
                     }
                 }
             }
@@ -332,7 +343,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                             "block_tile exceeds max dest tiles");
                         _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, ckernel::PackMode::Default>(
-                            block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                            block_tile, L1_ADDRESS(params.buffer_Res[block_start + block_tile]));
                     }
                     _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -43,6 +43,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     const bool UNPACK_TRANSPOSE_FACES       = params.UNPACK_TRANSPOSE_FACES;
     const bool UNPACK_TRANSPOSE_WITHIN_FACE = params.UNPACK_TRANSPOSE_WITHIN_FACE;
+
+    const auto& buffer_A = params.buffer_A;
 #endif
     const EltwiseBinaryReuseDestType reuse_dest_type = EltwiseBinaryReuseDestType::NONE;
 
@@ -92,7 +94,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     // (StimuliConfig layout) instead of the fixed PERF_INPUT_A, so
                     // the harness's stimuli line up with what the kernel consumes.
                     _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest (see init) */, reuse_dest_type, unpack_to_dest>(
-                        L1_ADDRESS(params.buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
+                        L1_ADDRESS(buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
                 }
             }
         }
@@ -293,6 +295,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
     const std::uint32_t num_faces   = params.num_faces;
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const auto& buffer_Res          = params.buffer_Res;
 #endif
     {
         START_PERF_MEASURE("INIT")
@@ -323,7 +326,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                             "block_tile exceeds max dest tiles");
                         _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, ckernel::PackMode::Default>(
-                            block_tile, L1_ADDRESS(params.buffer_Res[block_start + block_tile]));
+                            block_tile, L1_ADDRESS(buffer_Res[block_start + block_tile]));
                     }
                 }
             }
@@ -343,7 +346,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             (block_tile < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                             "block_tile exceeds max dest tiles");
                         _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, ckernel::PackMode::Default>(
-                            block_tile, L1_ADDRESS(params.buffer_Res[block_start + block_tile]));
+                            block_tile, L1_ADDRESS(buffer_Res[block_start + block_tile]));
                     }
                     _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }


### PR DESCRIPTION
### Summary
SFPU accuracy and perf were two separate paths — different kernels (`eltwise_unary_sfpu_test.cpp` vs `eltwise_unary_sfpu_perf.cpp`) and different harnesses, so the perf kernel's numeric output was never checked, and accuracy and timings couldn't be captured in one run.

This makes the perf kernel accuracy correct and adds a run-mode selector so the same op/format/config matrix can run three ways:
- ACCURACY (default) — functional kernel + accuracy CSV. Unchanged from before.
- PERF — perf kernel across all scenarios, timings only.
- BOTH — one L1_TO_L1 run capturing timings and the accuracy CSV.

Kernel changes to `eltwise_unary_sfpu_perf.cpp`:
1) read/write the runtime operand buffers (`buffer_A`/`buffer_Res`) instead of the fixed `PERF_INPUT_A/PERF_OUTPUT`,
2) set `acc_to_dest=false` to allow `unpack_to_dest`,
3) properly set CLAMP_NEGATIVE path.


### Notes for reviewers
- The ACCURACY path is behaviorally unchanged — run_case defaults to it and existing callers pass no perf_report.
- BOTH is intentionally restricted to L1_TO_L1 (the only run type whose L1 output can be read back and checked).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/accuracy-perf-merge)