### PR TITLE
[CI] Disable [WH-T3K] Gemma4-26B-A4B vLLM nightly test (DRAM OOM)

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
           # Re-enable once hybrid KV cache is enabled (which will size the
           # sliding-window layers' KV cache to the window instead of the full
           # sequence length, freeing the DRAM needed to fit the full model).
-          # https://github.com/tenstorrent/tt-metal/issues/48680
+          # Tracked in https://github.com/tenstorrent/tt-metal/issues/49257
           #
           # Disabled entry preserved verbatim for the re-enable:
           #

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -84,6 +84,31 @@ jobs:
           #     "owner_id": "U08TJ70UFRT"
           #   },
           #
+          # The WH-T3K Gemma4-26B-A4B entry below is temporarily disabled —
+          # DRAM OOM during KV cache allocation (layer 25/30) causes EngineCore
+          # init failure on WH-T3K. Full unquantized KV cache no longer fits.
+          # Re-enable once hybrid KV cache is enabled (which will size the
+          # sliding-window layers' KV cache to the window instead of the full
+          # sequence length, freeing the DRAM needed to fit the full model).
+          # https://github.com/tenstorrent/tt-metal/issues/48680
+          #
+          # Disabled entry preserved verbatim for the re-enable:
+          #
+          #   {
+          #     "name": "[WH-T3K] Gemma4-26B-A4B",
+          #     "model": "google/gemma-4-26B-A4B-it",
+          #     "coherence-test": true,
+          #     "server-timeout": 30,
+          #     "benchmark-timeout": 10,
+          #     "runner-label": "config-t3000",
+          #     "arch": "arch-wormhole_b0",
+          #     "mesh-device": "T3K",
+          #     "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 200000000}",
+          #     "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+          #     "multimodal": false,
+          #     "owner_id": "U08TJ70UFRT"
+          #   },
+          #
           # Disabled due to Metal timeout in reduce-scatter async tests
           # https://github.com/tenstorrent/vllm/issues/416
           # Originally disabled in:
@@ -157,20 +182,6 @@ jobs:
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 400000000}",
-              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
-              "multimodal": false,
-              "owner_id": "U08TJ70UFRT"
-            },
-            {
-              "name": "[WH-T3K] Gemma4-26B-A4B",
-              "model": "google/gemma-4-26B-A4B-it",
-              "coherence-test": true,
-              "server-timeout": 30,
-              "benchmark-timeout": 10,
-              "runner-label": "config-t3000",
-              "arch": "arch-wormhole_b0",
-              "mesh-device": "T3K",
-              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 200000000}",
               "additional-server-args": "--max_num_seqs 1 --async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"


### PR DESCRIPTION
### Problem

The `vllm-tests / [WH-T3K] Gemma4-26B-A4B` nightly job fails deterministically with a DRAM OOM during KV cache allocation (layer 25/30), causing `EngineCore` init failure:

```
TT_FATAL: Out of Memory: Not enough space to allocate 67141632 B DRAM buffer across 12 banks,
where each bank needs to store 5595136 B, but bank size is 1056022464 B
(allocated: 1055726816 B, free: 295648 B, largest free block: 293888 B)
```

Hybrid KV cache is currently disabled for Gemma 4 (temp fix in #48283), so every layer allocates a full-length KV buffer. On WH-T3K the resulting single-pool KV cache no longer fits in DRAM.

### Change

- Remove `[WH-T3K] Gemma4-26B-A4B` from the active `all_tests` matrix in `.github/workflows/vllm-nightly-tests-impl.yaml`.
- Preserve the entry verbatim in the disabled-entries comment block (matching the existing Gemma4-31B convention), noting that re-enabling depends on **hybrid KV cache** being enabled — which will size the sliding-window layers' KV cache to the window instead of the full sequence length, freeing the DRAM needed to fit the full model.
- `[BH-QB-2] Gemma4-26B-A4B` is left untouched — the reported failure is WH-T3K only.

### Verification

- Embedded JSON matrix parses (18 entries; WH-T3K removed, BH-QB-2 retained).
- Overall workflow YAML parses.
- Will confirm end-to-end by running vLLM nightly.

### Re-enable tracking

Re-enabling this matrix entry is tracked in #49257 (enable hybrid KV cache via token-chunked prefill). The OOM was reported in #48680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dwadhwani/disable-gemma4-26b-vllm-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dwadhwani/disable-gemma4-26b-vllm-nightly)
