### PR TITLE
binary_ng: fix in-place add descriptor rebuild-on-cache-hit (#48928)

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -611,6 +611,70 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_DuplicateBuffer_Retu
     EXPECT_TRUE(resolved.cbs.empty());
 }
 
+// #48928: an OUTPUT buffer that aliases an INPUT (in-place op writing back into its input) is a
+// same-buffer-by-construction alias, not the ambiguous matmul(X, X) case.  With num_input_buffers
+// marking the input/output boundary, resolve_bindings must KEEP the fast path (non-empty bindings).
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasesInput_KeepsFastPath) {
+    auto buf_a = MakeDramBuffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.emplace_runtime_args({0, 0}, {buf_a.get()});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    // [input=buf_a, output=buf_a]; first entry is the input, the second is the in-place output.
+    ResolvedBindings resolved =
+        resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get(), buf_a.get()}, /*num_input_buffers=*/1);
+
+    EXPECT_FALSE(resolved.empty());
+    ASSERT_EQ(resolved.rt_args.size(), 1u);
+    EXPECT_EQ(resolved.rt_args[0].tensor_buffer_idx, 0u);
+}
+
+// #48928: a duplicate purely WITHIN the input region (two distinct input operands that coincide,
+// matmul(X, X)) must still bail even when num_input_buffers is given.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InputRegionDuplicate_ReturnsEmpty) {
+    auto buf_a = MakeDramBuffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.emplace_runtime_args({0, 0}, {buf_a.get(), buf_a.get()});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    // Both entries are inputs (no output region); the repeat is ambiguous → bail.
+    ResolvedBindings resolved =
+        resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get(), buf_a.get()}, /*num_input_buffers=*/2);
+
+    EXPECT_TRUE(resolved.empty());
+}
+
+// #48928: op(X, X, out=X) — X at two genuine input positions plus the in-place output_tensor slot.
+// The output-alias skip is granted ONCE; the extra input occurrence still bails, so a later
+// same-shape op(X, Y, out=X) cache hit can't patch input-b to X's address.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasRepeatedInInputs_ReturnsEmpty) {
+    auto buf_a = MakeDramBuffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.emplace_runtime_args({0, 0}, {buf_a.get()});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    // [input_a=X, input_b=X, output_tensor=X | return=X]; num_input_buffers=3 (tensor_args), 1 output.
+    ResolvedBindings resolved = resolve_bindings(
+        program,
+        desc,
+        std::vector<Buffer*>{buf_a.get(), buf_a.get(), buf_a.get(), buf_a.get()},
+        /*num_input_buffers=*/3);
+
+    EXPECT_TRUE(resolved.empty());
+}
+
 // resolve_bindings fires TT_FATAL when a runtime-arg binding buffer is not in
 // tensor_buffers — RT-arg bindings are the only mechanism that lets the fast
 // path patch a changing input/output address on cache hits, so a missing

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -58,6 +58,16 @@ ResolvedBindings resolve_bindings(
     //
     // tensor_buffers is ordered inputs-first; the first num_input_buffers entries are inputs.
     {
+        // Buffers in the output/workload region. An input-region entry that also appears here is the
+        // op's own output carried inside tensor_args (e.g. an in-place op's optional output_tensor
+        // aliasing an input) — a same-buffer-by-construction alias, NOT the ambiguous matmul(X, X)
+        // case — so it must not bail. (#48928: binary_ng in-place residual add.)
+        std::unordered_set<Buffer*> output_region;
+        for (size_t i = num_input_buffers; i < tensor_buffers.size(); ++i) {
+            if (tensor_buffers[i]) {
+                output_region.insert(tensor_buffers[i]);
+            }
+        }
         std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
         std::unordered_set<Buffer*> output_buffers;  // buffers seen in the output/workload region
         for (size_t i = 0; i < tensor_buffers.size(); ++i) {
@@ -68,6 +78,11 @@ ResolvedBindings resolve_bindings(
             const bool is_input = i < num_input_buffers;
             // An output/workload buffer that aliases an input is the safe in-place case — skip it.
             if (!is_input && input_buffers.contains(buf)) {
+                continue;
+            }
+            // An input-region entry that is also an output buffer is the op's output (an in-place
+            // alias, e.g. output_tensor carried in tensor_args), not a distinct second input — safe.
+            if (is_input && output_region.contains(buf)) {
                 continue;
             }
             // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -70,6 +70,7 @@ ResolvedBindings resolve_bindings(
         }
         std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
         std::unordered_set<Buffer*> output_buffers;  // buffers seen in the output/workload region
+        std::unordered_set<Buffer*> inplace_alias_used;  // output buffers already granted one input-region skip
         for (size_t i = 0; i < tensor_buffers.size(); ++i) {
             Buffer* buf = tensor_buffers[i];
             if (!buf) {
@@ -80,9 +81,11 @@ ResolvedBindings resolve_bindings(
             if (!is_input && input_buffers.contains(buf)) {
                 continue;
             }
-            // An input-region entry that is also an output buffer is the op's output (an in-place
-            // alias, e.g. output_tensor carried in tensor_args), not a distinct second input — safe.
-            if (is_input && output_region.contains(buf)) {
+            // An output buffer carried in the input region (the op's output_tensor) is an in-place
+            // alias, not a distinct input — skip it ONCE. A second input-region occurrence means the
+            // buffer genuinely repeats across input positions (e.g. op(X, X, out=X)); fall through so
+            // it still bails, else a later same-shape op(X, Y, out=X) hit would patch input-b to X.
+            if (is_input && output_region.contains(buf) && inplace_alias_used.insert(buf).second) {
                 continue;
             }
             // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -10,6 +10,8 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/distributed/types.hpp"
 namespace ttnn::operations::binary_ng {
 
 enum class SubtileBroadcastType {
@@ -78,6 +80,15 @@ struct BinaryNgDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+
+    // compute_program_hash EXCLUDES the tensor volume, so one cached program is reused across
+    // differently-shaped calls.  All shape-/work-split-dependent per-core runtime args are therefore
+    // re-applied on every cache hit here.  Mirrors create_descriptor()'s shared builder.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& c,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1128,10 +1128,10 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                         b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
                     }
                 }
-                std::vector<uint32_t> writer_runtime_args;
+                std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args;
                 if (row_major_inputs) {
                     writer_runtime_args = {
-                        c.buffer()->address(),
+                        c.buffer(),
                         common_row_width_elements,
                         c_num_tiles_core,
                         cD,
@@ -1147,19 +1147,9 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                         writer_stride_size_bytes};
                 } else {
                     writer_runtime_args = {
-                        c.buffer()->address(),
-                        c_start_id,
-                        c_num_tiles_core,
-                        c_current_shard_width,
-                        cD,
-                        cN,
-                        cC,
-                        cHt,
-                        cWt,
-                        cND,
-                        0u};
+                        c.buffer(), c_start_id, c_num_tiles_core, c_current_shard_width, cD, cN, cC, cHt, cWt, cND, 0u};
                 }
-                writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+                writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
                 auto [freq, counter] =
                     CMAKE_UNIQUE_NAMESPACE::calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
@@ -1194,10 +1184,10 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 const auto scalar = *operation_attributes.scalar;
                 const auto packed_scalar = pack_scalar_runtime_arg(scalar, a.dtype(), rt_is_quant_op);
                 packed_scalar_for_reader = packed_scalar;
-                std::vector<uint32_t> writer_runtime_args;
+                std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args;
                 if (row_major_inputs) {
                     writer_runtime_args = {
-                        c.buffer()->address(),
+                        c.buffer(),
                         common_row_width_elements,
                         c_num_tiles_core,
                         cD,
@@ -1214,7 +1204,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 } else {
                     writer_runtime_args = {
                         packed_scalar,
-                        c.buffer()->address(),
+                        c.buffer(),
                         c_start_id,
                         c_num_tiles_core,
                         c_current_shard_width,
@@ -1226,15 +1216,16 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                         cND,
                         0u};
                 }
-                writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+                writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
                 std::array compute_runtime_args = {compute_tiles, 0u, 0u, compute_scalar_value};
                 compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
             }
-            std::vector<uint32_t> reader_runtime_args;
+            std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args;
 
             if (row_major_inputs) {
-                const uint32_t b_addr = b.has_value() ? b->buffer()->address() : 0u;
+                const std::variant<uint32_t, Buffer*> b_addr =
+                    b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u};
                 const uint32_t b_page_size = b.has_value() ? static_cast<uint32_t>(b->buffer()->aligned_page_size())
                                                            : static_cast<uint32_t>(a.buffer()->aligned_page_size());
                 const uint32_t bD_arg = b.has_value() ? bD : 1u;
@@ -1242,7 +1233,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 const uint32_t bC_arg = b.has_value() ? bC : 1u;
                 const uint32_t bHt_r_arg = b.has_value() ? bHt_r : 1u;
                 reader_runtime_args = {
-                    a.buffer()->address(),
+                    a.buffer(),
                     c_num_tiles_core,
                     aD,
                     aN,
@@ -1270,7 +1261,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                     packed_scalar_for_reader};
             } else {
                 reader_runtime_args = {
-                    a.buffer()->address(),
+                    a.buffer(),
                     c_start_id,
                     a_num_tiles,
                     c_num_tiles_core,
@@ -1285,7 +1276,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                     cHt,
                     cWt,
                     cND,
-                    b.has_value() ? b->buffer()->address() : 0u,
+                    b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u},
                     bHt * bWt * bC * bN * bD * (bND > 1),
                     bHt * bWt * bC * bN * (bD > 1),
                     bHt * bWt * bC * (bN > 1),
@@ -1294,7 +1285,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 };
             }
 
-            reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{reader_runtime_args.begin(), reader_runtime_args.end()});
+            reader_desc.emplace_runtime_args(core, reader_runtime_args);
 
             start_tile_id += c_num_tiles_core;
             if (row_major_inputs) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1376,9 +1376,12 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> BinaryNgDeviceOperation::get_dynami
     constexpr uint32_t kComputeKernelIdx = 2;
 
     std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    // Reserve hint only: per core we re-emit reader + writer + compute args; each kernel has at most
-    // ~a dozen runtime args, so 40/core is a conservative upper bound that avoids reallocation.
-    dynamic_args.reserve(per_core.cores.size() * 40);
+    // Reserve the exact number of args we're about to emit (reader + writer + compute per core).
+    size_t total_args = 0;
+    for (size_t i = 0; i < per_core.cores.size(); ++i) {
+        total_args += per_core.reader[i].size() + per_core.writer[i].size() + per_core.compute[i].size();
+    }
+    dynamic_args.reserve(total_args);
 
     auto emit = [&](uint32_t kernel_idx,
                     const CoreCoord& core,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1376,6 +1376,8 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> BinaryNgDeviceOperation::get_dynami
     constexpr uint32_t kComputeKernelIdx = 2;
 
     std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    // Reserve hint only: per core we re-emit reader + writer + compute args; each kernel has at most
+    // ~a dozen runtime args, so 40/core is a conservative upper bound that avoids reallocation.
     dynamic_args.reserve(per_core.cores.size() * 40);
 
     auto emit = [&](uint32_t kernel_idx,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -10,8 +10,11 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 #include <algorithm>
+#include <variant>
+#include <vector>
 using namespace tt::tt_metal;
 
 namespace {
@@ -379,6 +382,444 @@ std::optional<AllShardVolumes> get_shard_volumes(
         .c_shard_volume = c_sharded ? shard_specs->c_shard_spec.numel() / tile_hw : std::optional<std::uint32_t>{},
     };
 }
+
+namespace {
+
+// Per-core runtime-arg lists for every core in the worker grid (work AND noop cores), in the same
+// order create_descriptor() populates them.  Each arg list is a vector of variants: Buffer* entries
+// are buffer base addresses (bindings), uint32_t entries are plain values.
+struct BinaryNgPerCoreArgs {
+    std::vector<CoreCoord> cores;
+    std::vector<std::vector<std::variant<uint32_t, Buffer*>>> reader;
+    std::vector<std::vector<std::variant<uint32_t, Buffer*>>> writer;
+    std::vector<std::vector<std::variant<uint32_t, Buffer*>>> compute;
+};
+
+// SINGLE SOURCE OF TRUTH for binary_ng per-core runtime args.  Run by BOTH create_descriptor()
+// (cache miss) and BinaryNgDeviceOperation::get_dynamic_runtime_args() (cache hit).
+//
+// binary_ng's compute_program_hash intentionally EXCLUDES the tensor volume, so one cached program
+// is shared across differently-shaped calls.  On a cache hit the descriptor is NOT rebuilt, so every
+// shape/work-split-dependent per-core arg (c_start_id, per-core tile counts, strides, D/N/C/Ht/Wt,
+// compute_tiles, freq/counter, packed scalar, ...) would otherwise stay frozen at the first-miss
+// shape and corrupt results.  get_dynamic_runtime_args() re-runs THIS builder for the current tensors
+// and re-applies each arg every dispatch.  Because the work-core set itself changes with volume (a
+// core can flip between work and noop across hits), the builder emits args for ALL num_cores_total
+// cores -- noop cores get zero-filled lists sized to match the work-core layout -- and
+// get_dynamic_runtime_args re-applies every slot (buffer slots via their current address), so nothing
+// is left frozen regardless of how the partition shifts.
+BinaryNgPerCoreArgs build_per_core_runtime_args(
+    const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
+    const Tensor& a,
+    const std::optional<Tensor>& b,
+    const Tensor& c) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    BinaryNgPerCoreArgs result;
+
+    const auto& all_device_cores = operation_attributes.worker_grid;
+    const auto op_type = operation_attributes.binary_op_type;
+
+    const auto out_rank = c.logical_shape().rank();
+    auto aND = CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(a, out_rank);
+    auto bND = b.has_value() ? CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(*b, out_rank) : 1;
+    auto cND = CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(c, out_rank);
+    const auto aHt_r = a.padded_shape()[-2];
+    const auto aWt_r = a.padded_shape()[-1];
+    const auto bHt_r = b.has_value() ? b->padded_shape()[-2] : 0;
+    const auto bWt_r = b.has_value() ? b->padded_shape()[-1] : 0;
+    const auto cHt_r = c.padded_shape()[-2];
+    const auto cWt_r = c.padded_shape()[-1];
+
+    const auto [aD, aN, aC, aHt, aWt] = CMAKE_UNIQUE_NAMESPACE::get_shape_dims(a);
+    const auto [bD, bN, bC, bHt, bWt] =
+        b.has_value() ? CMAKE_UNIQUE_NAMESPACE::get_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u, 1u};
+    const auto [cD, cN, cC, cHt, cWt] = CMAKE_UNIQUE_NAMESPACE::get_shape_dims(c);
+
+    const auto shard_specs = CMAKE_UNIQUE_NAMESPACE::get_shard_specs(
+        a.tensor_spec(), b.has_value() ? b->tensor_spec() : std::optional<TensorSpec>{}, c.tensor_spec());
+    const bool rt_has_sharding = shard_specs.has_value();
+    auto grid = rt_has_sharding ? shard_specs->a_shard_spec.grid : CoreRangeSet{};
+
+    const auto row_major =
+        rt_has_sharding ? shard_specs->a_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
+
+    bool zero_start_grid = false;
+    CoreCoord compute_with_storage_grid;
+    if (grid.size() == 1) {
+        const auto& cr = *all_device_cores.ranges().begin();
+        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+            if (rt_has_sharding) {
+                const auto& shard_start_coord = grid.ranges()[0].start_coord;
+                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                    zero_start_grid = true;
+                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            } else {
+                zero_start_grid = true;
+                compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+            }
+        }
+    }
+    const uint32_t num_cores_total =
+        zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
+
+    uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores;
+    std::vector<CoreCoord> cores;
+
+    const bool row_major_inputs =
+        CMAKE_UNIQUE_NAMESPACE::should_use_row_major_path(operation_attributes, b, rt_has_sharding);
+    const uint32_t a_alignment = a.buffer()->alignment();
+    const uint32_t b_alignment = b.has_value() ? b->buffer()->alignment() : a_alignment;
+    const uint32_t c_alignment = c.buffer()->alignment();
+
+    const uint32_t tile_height = c.tensor_spec().tile().get_height();
+    const uint32_t tile_width = c.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = tile_height * tile_width;
+
+    uint32_t rt_c_num_tiles;
+    uint32_t num_rows_per_tile = 0;
+    uint32_t row_blocks_per_channel = 1;
+    uint32_t tiles_per_row_width = 1;
+    uint32_t common_row_width_elements = 0;
+    uint32_t reader_stride_size_bytes = 0;
+    uint32_t writer_stride_size_bytes = 0;
+
+    if (row_major_inputs) {
+        const uint32_t c_aligned_page_size = c.buffer()->aligned_page_size();
+        const uint32_t a_aligned_page_size = a.buffer()->aligned_page_size();
+        const uint32_t b_aligned_page_size = b.has_value() ? b->buffer()->aligned_page_size() : a_aligned_page_size;
+
+        const uint32_t c_row_width_elements_aligned = c_aligned_page_size / c.element_size();
+        const uint32_t a_row_width_elements_aligned = a_aligned_page_size / a.element_size();
+        const uint32_t b_row_width_elements_aligned =
+            b.has_value() ? (b_aligned_page_size / b->element_size()) : a_row_width_elements_aligned;
+
+        common_row_width_elements = c_row_width_elements_aligned;
+        if (aWt_r == cWt_r) {
+            common_row_width_elements = std::min(common_row_width_elements, a_row_width_elements_aligned);
+        }
+        if (b.has_value() && bWt_r == cWt_r) {
+            common_row_width_elements = std::min(common_row_width_elements, b_row_width_elements_aligned);
+        }
+        common_row_width_elements = std::max<uint32_t>(1u, common_row_width_elements);
+
+        num_rows_per_tile = std::max<uint32_t>(1u, tile_hw / common_row_width_elements);
+        const bool aligned_for_a =
+            (aWt_r == cWt_r) ? ((common_row_width_elements * a.element_size()) == a_aligned_page_size) : true;
+        const bool aligned_for_b = (b.has_value() && bWt_r == cWt_r)
+                                       ? ((common_row_width_elements * b->element_size()) == b_aligned_page_size)
+                                       : true;
+        const bool aligned_for_c = (common_row_width_elements * c.element_size()) == c_aligned_page_size;
+        if (!aligned_for_a || !aligned_for_b || !aligned_for_c) {
+            num_rows_per_tile = 1;
+        }
+
+        row_blocks_per_channel = tt::div_up(cHt_r, num_rows_per_tile);
+        const uint32_t total_row_blocks = cND * cD * cN * cC * row_blocks_per_channel;
+        tiles_per_row_width = tt::div_up(common_row_width_elements, tile_hw);
+        const uint32_t a_tile_bytes = tile_hw * a.element_size();
+        const uint32_t a_row_width_bytes = common_row_width_elements * a.element_size();
+        reader_stride_size_bytes =
+            (a_row_width_bytes > a_tile_bytes) ? a_tile_bytes : tt::round_up(a_row_width_bytes, a_alignment);
+        const uint32_t c_tile_bytes = tile_hw * c.element_size();
+        const uint32_t c_row_width_bytes = common_row_width_elements * c.element_size();
+        writer_stride_size_bytes =
+            (c_row_width_bytes > c_tile_bytes) ? c_tile_bytes : tt::round_up(c_row_width_bytes, c_alignment);
+        rt_c_num_tiles = total_row_blocks;
+    } else {
+        rt_c_num_tiles = c.physical_volume() / tile_hw;
+    }
+
+    uint32_t c_shard_height{}, c_shard_width{}, num_shards_per_width{};
+
+    CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator a_shard_shape_generator;
+    CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator b_shard_shape_generator;
+    CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator c_shard_shape_generator;
+
+    bool all_same_shard_spec = rt_has_sharding && a.memory_config().is_sharded() && b.has_value() &&
+                               b->memory_config().is_sharded() && c.memory_config().is_sharded() &&
+                               shard_specs->a_shard_spec == shard_specs->b_shard_spec &&
+                               shard_specs->a_shard_spec == shard_specs->c_shard_spec;
+
+    if (rt_has_sharding) {
+        core_group_1 = grid;
+        a_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->a_shard_spec, a);
+        if (b.has_value()) {
+            b_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->b_shard_spec, *b);
+        }
+        c_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->c_shard_spec, c);
+        c_shard_height = shard_specs->c_shard_spec.shape[0] / tile_height;
+        c_shard_width = shard_specs->c_shard_spec.shape[1] / tile_width;
+        num_shards_per_width = CMAKE_UNIQUE_NAMESPACE::get_shards_per_width(
+            shard_specs->c_shard_spec, CMAKE_UNIQUE_NAMESPACE::get_memory_layout(a, b, c));
+
+        if (zero_start_grid) {
+            auto bbox = core_group_1.bounding_box();
+            cores = grid_to_cores_with_noop(
+                bbox.end_coord.x,
+                bbox.end_coord.y,
+                compute_with_storage_grid.x,
+                compute_with_storage_grid.y,
+                row_major);
+        } else {
+            cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
+        }
+    } else if (zero_start_grid) {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid, rt_c_num_tiles, row_major);
+        cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
+    } else {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(all_device_cores, rt_c_num_tiles, row_major);
+        cores = corerange_to_cores(all_device_cores, {}, row_major);
+    }
+
+    result.cores.reserve(num_cores_total);
+    result.reader.reserve(num_cores_total);
+    result.writer.reserve(num_cores_total);
+    result.compute.reserve(num_cores_total);
+
+    uint32_t current_block = 0;
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+        const auto& core = cores[i];
+
+        std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args;
+        std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args;
+        std::vector<std::variant<uint32_t, Buffer*>> compute_runtime_args;
+
+        uint32_t a_num_tiles = 0;
+        uint32_t b_num_tiles = 0;
+        uint32_t c_num_tiles_core = 0;
+        if (core_group_1.contains(core)) {
+            c_num_tiles_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            c_num_tiles_core = num_tiles_per_core_group_2;
+        } else {
+            // Noop core: zero-filled runtime args, sized to match the active kernel variant so unused
+            // cores neither inflate the per-kernel max runtime-arg allocation nor change slot count when a
+            // core flips between noop and work across differently-shaped cache hits.
+            const size_t reader_len = row_major_inputs ? 26 : 21;
+            const size_t writer_len = row_major_inputs ? 14 : (b.has_value() ? 11 : 12);
+            const size_t compute_len = (op_type == BinaryOpType::ISCLOSE) ? 5 : 4;
+            reader_runtime_args.assign(reader_len, std::variant<uint32_t, Buffer*>{uint32_t{0}});
+            writer_runtime_args.assign(writer_len, std::variant<uint32_t, Buffer*>{uint32_t{0}});
+            compute_runtime_args.assign(compute_len, std::variant<uint32_t, Buffer*>{uint32_t{0}});
+            result.cores.push_back(core);
+            result.reader.push_back(std::move(reader_runtime_args));
+            result.writer.push_back(std::move(writer_runtime_args));
+            result.compute.push_back(std::move(compute_runtime_args));
+            continue;
+        }
+
+        uint32_t c_start_id = 0;
+        uint32_t c_current_shard_width = 0;
+        if (rt_has_sharding) {
+            if (all_same_shard_spec) {
+                c_num_tiles_core = c_shard_height * c_shard_width;
+                c_current_shard_width = c_shard_width;
+                a_num_tiles = c_shard_height * c_shard_width;
+            } else {
+                auto c_shard_shape = c_shard_shape_generator(core);
+                c_num_tiles_core = c_shard_shape[0] * c_shard_shape[1];
+                c_current_shard_width = c_shard_shape[1];
+                auto a_shard_shape = a_shard_shape_generator(core);
+                a_num_tiles = a_shard_shape[0] * a_shard_shape[1];
+            }
+            c_start_id =
+                (i / num_shards_per_width) * (c_shard_height * cWt) + (i % num_shards_per_width) * c_shard_width;
+        } else {
+            c_start_id = start_tile_id;
+        }
+
+        const bool rt_is_quant_op = operation_attributes.is_quant_op;
+        TT_FATAL(
+            rt_is_quant_op ==
+                ((operation_attributes.post_activations.size() == 1) &&
+                 (operation_attributes.post_activations[0].type() == ttnn::operations::unary::UnaryOpType::ZERO_POINT)),
+            "Quantization op needs to exactly one zero-point value as a post activation");
+        const uint32_t quantization_zero_point =
+            rt_is_quant_op ? std::bit_cast<uint32_t>(
+                                 operation_attributes.post_activations[0].get_param_if<float>(0).value_or(0.0f))
+                           : 0u;
+        uint32_t compute_scalar_value = quantization_zero_point;
+
+        uint32_t compute_tiles = row_major_inputs ? (c_num_tiles_core * tiles_per_row_width) : c_num_tiles_core;
+
+        uint32_t packed_scalar_for_reader = 0u;
+        if (b.has_value()) {
+            if (rt_has_sharding) {
+                if (all_same_shard_spec) {
+                    b_num_tiles = c_shard_height * c_shard_width;
+                } else {
+                    auto b_shard_shape = b_shard_shape_generator(core);
+                    b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
+                }
+            }
+            if (row_major_inputs) {
+                writer_runtime_args = {
+                    c.buffer(),
+                    common_row_width_elements,
+                    c_num_tiles_core,
+                    cD,
+                    cN,
+                    cC,
+                    cHt_r,
+                    cND,
+                    current_block,
+                    num_rows_per_tile,
+                    static_cast<uint32_t>(c.buffer()->aligned_page_size()),
+                    c_alignment,
+                    tiles_per_row_width,
+                    writer_stride_size_bytes};
+            } else {
+                writer_runtime_args = {
+                    c.buffer(), c_start_id, c_num_tiles_core, c_current_shard_width, cD, cN, cC, cHt, cWt, cND, 0u};
+            }
+
+            auto [freq, counter] = CMAKE_UNIQUE_NAMESPACE::calculate_compute_kernel_args(
+                operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
+            if (operation_attributes.binary_op_type == BinaryOpType::WHERE_TTS ||
+                operation_attributes.binary_op_type == BinaryOpType::WHERE_TST) {
+                compute_scalar_value = pack_scalar_runtime_arg(
+                    operation_attributes.scalar.value(), b.has_value() ? b->dtype() : a.dtype(), false);
+            }
+            if (row_major_inputs) {
+                freq = 1;
+                counter = 0;
+            }
+            if (operation_attributes.binary_op_type == BinaryOpType::ISCLOSE) {
+                compute_runtime_args = {
+                    compute_tiles,
+                    freq,
+                    counter,
+                    // rtol and atol are float variables
+                    std::bit_cast<uint32_t>(operation_attributes.rtol),
+                    std::bit_cast<uint32_t>(operation_attributes.atol)};
+            } else {
+                compute_runtime_args = {compute_tiles, freq, counter, compute_scalar_value};
+            }
+        } else {
+            const auto scalar = *operation_attributes.scalar;
+            const auto packed_scalar = pack_scalar_runtime_arg(scalar, a.dtype(), rt_is_quant_op);
+            packed_scalar_for_reader = packed_scalar;
+            if (row_major_inputs) {
+                writer_runtime_args = {
+                    c.buffer(),
+                    common_row_width_elements,
+                    c_num_tiles_core,
+                    cD,
+                    cN,
+                    cC,
+                    cHt_r,
+                    cND,
+                    current_block,
+                    num_rows_per_tile,
+                    static_cast<uint32_t>(c.buffer()->aligned_page_size()),
+                    c_alignment,
+                    tiles_per_row_width,
+                    writer_stride_size_bytes};
+            } else {
+                writer_runtime_args = {
+                    packed_scalar,
+                    c.buffer(),
+                    c_start_id,
+                    c_num_tiles_core,
+                    c_current_shard_width,
+                    cD,
+                    cN,
+                    cC,
+                    cHt,
+                    cWt,
+                    cND,
+                    0u};
+            }
+
+            compute_runtime_args = {compute_tiles, 0u, 0u, compute_scalar_value};
+        }
+
+        if (row_major_inputs) {
+            const std::variant<uint32_t, Buffer*> b_addr =
+                b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u};
+            const uint32_t b_page_size = b.has_value() ? static_cast<uint32_t>(b->buffer()->aligned_page_size())
+                                                       : static_cast<uint32_t>(a.buffer()->aligned_page_size());
+            const uint32_t bD_arg = b.has_value() ? bD : 1u;
+            const uint32_t bN_arg = b.has_value() ? bN : 1u;
+            const uint32_t bC_arg = b.has_value() ? bC : 1u;
+            const uint32_t bHt_r_arg = b.has_value() ? bHt_r : 1u;
+            reader_runtime_args = {
+                a.buffer(),
+                c_num_tiles_core,
+                aD,
+                aN,
+                aC,
+                aHt_r,
+                aND,
+                b_addr,
+                bD_arg,
+                bN_arg,
+                bC_arg,
+                bHt_r_arg,
+                bND,
+                cHt_r,
+                cC,
+                cND,
+                current_block,
+                num_rows_per_tile,
+                common_row_width_elements,
+                static_cast<uint32_t>(a.buffer()->aligned_page_size()),
+                b_page_size,
+                a_alignment,
+                b_alignment,
+                tiles_per_row_width,
+                reader_stride_size_bytes,
+                packed_scalar_for_reader};
+        } else {
+            reader_runtime_args = {
+                a.buffer(),
+                c_start_id,
+                a_num_tiles,
+                c_num_tiles_core,
+                c_current_shard_width,
+                aHt * aWt * aC * aN * aD * (aND > 1),
+                aHt * aWt * aC * aN * (aD > 1),
+                aHt * aWt * aC * (aN > 1),
+                aHt * aWt * (aC > 1),
+                cD,
+                cN,
+                cC,
+                cHt,
+                cWt,
+                cND,
+                b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u},
+                bHt * bWt * bC * bN * bD * (bND > 1),
+                bHt * bWt * bC * bN * (bD > 1),
+                bHt * bWt * bC * (bN > 1),
+                bHt * bWt * (bC > 1),
+                b_num_tiles,
+            };
+        }
+
+        result.cores.push_back(core);
+        result.reader.push_back(std::move(reader_runtime_args));
+        result.writer.push_back(std::move(writer_runtime_args));
+        result.compute.push_back(std::move(compute_runtime_args));
+
+        start_tile_id += c_num_tiles_core;
+        if (row_major_inputs) {
+            current_block += c_num_tiles_core;
+        }
+    }
+
+    return result;
+}
+
+}  // namespace
 
 // Implements c = a op b
 tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_descriptor(
@@ -885,412 +1326,15 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = reader_common_runtime_args;
 
-    // === Inline per-core runtime arguments (previously set_or_update_runtime_arguments) ===
+    // === Per-core runtime arguments ===
+    // Built via the shared single-source-of-truth builder so create_descriptor() (cache miss, here)
+    // and BinaryNgDeviceOperation::get_dynamic_runtime_args() (cache hit) stay byte-identical.
     {
-        const auto out_rank = c.logical_shape().rank();
-        auto aND = CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(a, out_rank);
-        auto bND = b.has_value() ? CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(*b, out_rank) : 1;
-        auto cND = CMAKE_UNIQUE_NAMESPACE::extract_nD_dims(c, out_rank);
-        const auto aHt_r = a.padded_shape()[-2];
-        const auto aWt_r = a.padded_shape()[-1];
-        const auto bHt_r = b.has_value() ? b->padded_shape()[-2] : 0;
-        const auto bWt_r = b.has_value() ? b->padded_shape()[-1] : 0;
-        const auto cHt_r = c.padded_shape()[-2];
-        const auto cWt_r = c.padded_shape()[-1];
-
-        const auto [aD, aN, aC, aHt, aWt] = CMAKE_UNIQUE_NAMESPACE::get_shape_dims(a);
-        const auto [bD, bN, bC, bHt, bWt] = b.has_value() ? CMAKE_UNIQUE_NAMESPACE::get_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u, 1u};
-        const auto [cD, cN, cC, cHt, cWt] = CMAKE_UNIQUE_NAMESPACE::get_shape_dims(c);
-
-        const auto shard_specs = CMAKE_UNIQUE_NAMESPACE::get_shard_specs(
-            a.tensor_spec(), b.has_value() ? b->tensor_spec() : std::optional<TensorSpec>{}, c.tensor_spec());
-        const bool rt_has_sharding = shard_specs.has_value();
-        auto grid = rt_has_sharding ? shard_specs->a_shard_spec.grid : CoreRangeSet{};
-
-        const auto row_major = rt_has_sharding ? shard_specs->a_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
-
-        bool zero_start_grid = false;
-        CoreCoord compute_with_storage_grid;
-        if (grid.size() == 1) {
-            const auto& cr = *all_device_cores.ranges().begin();
-            if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
-                if (rt_has_sharding) {
-                    const auto& shard_start_coord = grid.ranges()[0].start_coord;
-                    if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
-                        zero_start_grid = true;
-                        compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
-                    }
-                } else {
-                    zero_start_grid = true;
-                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
-                }
-            }
-        }
-        const uint32_t num_cores_total =
-            zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
-
-        uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
-        CoreRangeSet all_cores, core_group_1, core_group_2;
-        uint32_t num_cores;
-        std::vector<CoreCoord> cores;
-
-        const bool row_major_inputs = CMAKE_UNIQUE_NAMESPACE::should_use_row_major_path(operation_attributes, b, rt_has_sharding);
-        const uint32_t a_alignment = a.buffer()->alignment();
-        const uint32_t b_alignment = b.has_value() ? b->buffer()->alignment() : a_alignment;
-        const uint32_t c_alignment = c.buffer()->alignment();
-
-        const uint32_t tile_height = c.tensor_spec().tile().get_height();
-        const uint32_t tile_width = c.tensor_spec().tile().get_width();
-        const uint32_t tile_hw = tile_height * tile_width;
-
-        uint32_t rt_c_num_tiles;
-        uint32_t num_rows_per_tile = 0;
-        uint32_t row_blocks_per_channel = 1;
-        uint32_t tiles_per_row_width = 1;
-        uint32_t common_row_width_elements = 0;
-        uint32_t reader_stride_size_bytes = 0;
-        uint32_t writer_stride_size_bytes = 0;
-
-        if (row_major_inputs) {
-            const uint32_t c_aligned_page_size = c.buffer()->aligned_page_size();
-            const uint32_t a_aligned_page_size = a.buffer()->aligned_page_size();
-            const uint32_t b_aligned_page_size = b.has_value() ? b->buffer()->aligned_page_size() : a_aligned_page_size;
-
-            const uint32_t c_row_width_elements_aligned = c_aligned_page_size / c.element_size();
-            const uint32_t a_row_width_elements_aligned = a_aligned_page_size / a.element_size();
-            const uint32_t b_row_width_elements_aligned =
-                b.has_value() ? (b_aligned_page_size / b->element_size()) : a_row_width_elements_aligned;
-
-            common_row_width_elements = c_row_width_elements_aligned;
-            if (aWt_r == cWt_r) {
-                common_row_width_elements = std::min(common_row_width_elements, a_row_width_elements_aligned);
-            }
-            if (b.has_value() && bWt_r == cWt_r) {
-                common_row_width_elements = std::min(common_row_width_elements, b_row_width_elements_aligned);
-            }
-            common_row_width_elements = std::max<uint32_t>(1u, common_row_width_elements);
-
-            num_rows_per_tile = std::max<uint32_t>(1u, tile_hw / common_row_width_elements);
-            const bool aligned_for_a =
-                (aWt_r == cWt_r) ? ((common_row_width_elements * a.element_size()) == a_aligned_page_size) : true;
-            const bool aligned_for_b = (b.has_value() && bWt_r == cWt_r)
-                                           ? ((common_row_width_elements * b->element_size()) == b_aligned_page_size)
-                                           : true;
-            const bool aligned_for_c = (common_row_width_elements * c.element_size()) == c_aligned_page_size;
-            if (!aligned_for_a || !aligned_for_b || !aligned_for_c) {
-                num_rows_per_tile = 1;
-            }
-
-            row_blocks_per_channel = tt::div_up(cHt_r, num_rows_per_tile);
-            const uint32_t total_row_blocks = cND * cD * cN * cC * row_blocks_per_channel;
-            tiles_per_row_width = tt::div_up(common_row_width_elements, tile_hw);
-            const uint32_t a_tile_bytes = tile_hw * a.element_size();
-            const uint32_t a_row_width_bytes = common_row_width_elements * a.element_size();
-            reader_stride_size_bytes =
-                (a_row_width_bytes > a_tile_bytes) ? a_tile_bytes : tt::round_up(a_row_width_bytes, a_alignment);
-            const uint32_t c_tile_bytes = tile_hw * c.element_size();
-            const uint32_t c_row_width_bytes = common_row_width_elements * c.element_size();
-            writer_stride_size_bytes =
-                (c_row_width_bytes > c_tile_bytes) ? c_tile_bytes : tt::round_up(c_row_width_bytes, c_alignment);
-            rt_c_num_tiles = total_row_blocks;
-        } else {
-            rt_c_num_tiles = c.physical_volume() / tile_hw;
-        }
-
-        uint32_t c_shard_height{}, c_shard_width{}, num_shards_per_width{};
-
-        CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator a_shard_shape_generator;
-        CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator b_shard_shape_generator;
-        CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator c_shard_shape_generator;
-
-        bool all_same_shard_spec = rt_has_sharding && a.memory_config().is_sharded() && b.has_value() &&
-                                   b->memory_config().is_sharded() && c.memory_config().is_sharded() &&
-                                   shard_specs->a_shard_spec == shard_specs->b_shard_spec &&
-                                   shard_specs->a_shard_spec == shard_specs->c_shard_spec;
-
-        if (rt_has_sharding) {
-            core_group_1 = grid;
-            a_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->a_shard_spec, a);
-            if (b.has_value()) {
-                b_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->b_shard_spec, *b);
-            }
-            c_shard_shape_generator = CMAKE_UNIQUE_NAMESPACE::ShardShapeGenerator(shard_specs->c_shard_spec, c);
-            c_shard_height = shard_specs->c_shard_spec.shape[0] / tile_height;
-            c_shard_width = shard_specs->c_shard_spec.shape[1] / tile_width;
-            num_shards_per_width = CMAKE_UNIQUE_NAMESPACE::get_shards_per_width(shard_specs->c_shard_spec, CMAKE_UNIQUE_NAMESPACE::get_memory_layout(a, b, c));
-
-            if (zero_start_grid) {
-                auto bbox = core_group_1.bounding_box();
-                cores = grid_to_cores_with_noop(
-                    bbox.end_coord.x,
-                    bbox.end_coord.y,
-                    compute_with_storage_grid.x,
-                    compute_with_storage_grid.y,
-                    row_major);
-            } else {
-                cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
-            }
-        } else if (zero_start_grid) {
-            std::tie(
-                num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
-                tt::tt_metal::split_work_to_cores(compute_with_storage_grid, rt_c_num_tiles, row_major);
-            cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
-        } else {
-            std::tie(
-                num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
-                tt::tt_metal::split_work_to_cores(all_device_cores, rt_c_num_tiles, row_major);
-            cores = corerange_to_cores(all_device_cores, {}, row_major);
-        }
-
-        uint32_t current_block = 0;
-        for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
-            const auto& core = cores[i];
-
-            uint32_t a_num_tiles = 0;
-            uint32_t b_num_tiles = 0;
-            uint32_t c_num_tiles_core = 0;
-            if (core_group_1.contains(core)) {
-                c_num_tiles_core = num_tiles_per_core_group_1;
-            } else if (core_group_2.contains(core)) {
-                c_num_tiles_core = num_tiles_per_core_group_2;
-            } else {
-                // Keep dummy runtime-arg sizes aligned with the active kernel variant so unused cores do not
-                // inflate the per-kernel max runtime-arg allocation.
-                if (row_major_inputs) {
-                    std::array<uint32_t, 26> dummy_reader{0};
-                    reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dummy_reader.begin(), dummy_reader.end()});
-                    std::array<uint32_t, 14> dummy_writer{0};
-                    writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dummy_writer.begin(), dummy_writer.end()});
-                } else if (b.has_value()) {
-                    std::array<uint32_t, 21> dummy_reader{0};
-                    reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dummy_reader.begin(), dummy_reader.end()});
-                    std::array<uint32_t, 11> dummy_writer{0};
-                    writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dummy_writer.begin(), dummy_writer.end()});
-                } else {
-                    std::array<uint32_t, 21> dummy_reader{0};
-                    reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dummy_reader.begin(), dummy_reader.end()});
-                    std::array<uint32_t, 12> dummy_writer{0};
-                    writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{dummy_writer.begin(), dummy_writer.end()});
-                }
-                if (op_type == BinaryOpType::ISCLOSE) {
-                    std::array<uint32_t, 5> dummy_compute{0};
-                    compute_desc.runtime_args.emplace_back(
-                        core, KernelDescriptor::CoreRuntimeArgs{dummy_compute.begin(), dummy_compute.end()});
-                } else {
-                    std::array<uint32_t, 4> dummy_compute{0};
-                    compute_desc.runtime_args.emplace_back(
-                        core, KernelDescriptor::CoreRuntimeArgs{dummy_compute.begin(), dummy_compute.end()});
-                }
-                continue;
-            }
-
-            uint32_t c_start_id = 0;
-            uint32_t c_current_shard_width = 0;
-            if (rt_has_sharding) {
-                if (all_same_shard_spec) {
-                    c_num_tiles_core = c_shard_height * c_shard_width;
-                    c_current_shard_width = c_shard_width;
-                    a_num_tiles = c_shard_height * c_shard_width;
-                } else {
-                    auto c_shard_shape = c_shard_shape_generator(core);
-                    c_num_tiles_core = c_shard_shape[0] * c_shard_shape[1];
-                    c_current_shard_width = c_shard_shape[1];
-                    auto a_shard_shape = a_shard_shape_generator(core);
-                    a_num_tiles = a_shard_shape[0] * a_shard_shape[1];
-                }
-                c_start_id =
-                    (i / num_shards_per_width) * (c_shard_height * cWt) + (i % num_shards_per_width) * c_shard_width;
-            } else {
-                c_start_id = start_tile_id;
-            }
-
-            const bool rt_is_quant_op = operation_attributes.is_quant_op;
-            TT_FATAL(
-                rt_is_quant_op ==
-                    ((operation_attributes.post_activations.size() == 1) &&
-                     (operation_attributes.post_activations[0].type() == ttnn::operations::unary::UnaryOpType::ZERO_POINT)),
-                "Quantization op needs to exactly one zero-point value as a post activation");
-            const uint32_t quantization_zero_point =
-                rt_is_quant_op ? std::bit_cast<uint32_t>(
-                                  operation_attributes.post_activations[0].get_param_if<float>(0).value_or(0.0f))
-                            : 0u;
-            uint32_t compute_scalar_value = quantization_zero_point;
-
-            uint32_t compute_tiles = row_major_inputs ? (c_num_tiles_core * tiles_per_row_width) : c_num_tiles_core;
-
-            uint32_t packed_scalar_for_reader = 0u;
-            if (b.has_value()) {
-                if (rt_has_sharding) {
-                    if (all_same_shard_spec) {
-                        b_num_tiles = c_shard_height * c_shard_width;
-                    } else {
-                        auto b_shard_shape = b_shard_shape_generator(core);
-                        b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
-                    }
-                }
-                std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args;
-                if (row_major_inputs) {
-                    writer_runtime_args = {
-                        c.buffer(),
-                        common_row_width_elements,
-                        c_num_tiles_core,
-                        cD,
-                        cN,
-                        cC,
-                        cHt_r,
-                        cND,
-                        current_block,
-                        num_rows_per_tile,
-                        static_cast<uint32_t>(c.buffer()->aligned_page_size()),
-                        c_alignment,
-                        tiles_per_row_width,
-                        writer_stride_size_bytes};
-                } else {
-                    writer_runtime_args = {
-                        c.buffer(), c_start_id, c_num_tiles_core, c_current_shard_width, cD, cN, cC, cHt, cWt, cND, 0u};
-                }
-                writer_desc.emplace_runtime_args(core, writer_runtime_args);
-
-                auto [freq, counter] =
-                    CMAKE_UNIQUE_NAMESPACE::calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
-                if (operation_attributes.binary_op_type == BinaryOpType::WHERE_TTS ||
-                    operation_attributes.binary_op_type == BinaryOpType::WHERE_TST) {
-                    compute_scalar_value = pack_scalar_runtime_arg(
-                        operation_attributes.scalar.value(), b.has_value() ? b->dtype() : a.dtype(), false);
-                }
-                if (row_major_inputs) {
-                    freq = 1;
-                    counter = 0;
-                }
-                if (operation_attributes.binary_op_type == BinaryOpType::ISCLOSE) {
-                    const std::array<uint32_t, 5> compute_runtime_args = {
-                        compute_tiles,
-                        freq,
-                        counter,
-                        // rtol and atol are float variables
-                        std::bit_cast<uint32_t>(operation_attributes.rtol),
-                        std::bit_cast<uint32_t>(operation_attributes.atol)};
-                    compute_desc.runtime_args.emplace_back(
-                        core,
-                        KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
-                } else {
-                    const std::array<uint32_t, 4> compute_runtime_args = {
-                        compute_tiles, freq, counter, compute_scalar_value};
-                    compute_desc.runtime_args.emplace_back(
-                        core,
-                        KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
-                }
-            } else {
-                const auto scalar = *operation_attributes.scalar;
-                const auto packed_scalar = pack_scalar_runtime_arg(scalar, a.dtype(), rt_is_quant_op);
-                packed_scalar_for_reader = packed_scalar;
-                std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args;
-                if (row_major_inputs) {
-                    writer_runtime_args = {
-                        c.buffer(),
-                        common_row_width_elements,
-                        c_num_tiles_core,
-                        cD,
-                        cN,
-                        cC,
-                        cHt_r,
-                        cND,
-                        current_block,
-                        num_rows_per_tile,
-                        static_cast<uint32_t>(c.buffer()->aligned_page_size()),
-                        c_alignment,
-                        tiles_per_row_width,
-                        writer_stride_size_bytes};
-                } else {
-                    writer_runtime_args = {
-                        packed_scalar,
-                        c.buffer(),
-                        c_start_id,
-                        c_num_tiles_core,
-                        c_current_shard_width,
-                        cD,
-                        cN,
-                        cC,
-                        cHt,
-                        cWt,
-                        cND,
-                        0u};
-                }
-                writer_desc.emplace_runtime_args(core, writer_runtime_args);
-
-                std::array compute_runtime_args = {compute_tiles, 0u, 0u, compute_scalar_value};
-                compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
-            }
-            std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args;
-
-            if (row_major_inputs) {
-                const std::variant<uint32_t, Buffer*> b_addr =
-                    b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u};
-                const uint32_t b_page_size = b.has_value() ? static_cast<uint32_t>(b->buffer()->aligned_page_size())
-                                                           : static_cast<uint32_t>(a.buffer()->aligned_page_size());
-                const uint32_t bD_arg = b.has_value() ? bD : 1u;
-                const uint32_t bN_arg = b.has_value() ? bN : 1u;
-                const uint32_t bC_arg = b.has_value() ? bC : 1u;
-                const uint32_t bHt_r_arg = b.has_value() ? bHt_r : 1u;
-                reader_runtime_args = {
-                    a.buffer(),
-                    c_num_tiles_core,
-                    aD,
-                    aN,
-                    aC,
-                    aHt_r,
-                    aND,
-                    b_addr,
-                    bD_arg,
-                    bN_arg,
-                    bC_arg,
-                    bHt_r_arg,
-                    bND,
-                    cHt_r,
-                    cC,
-                    cND,
-                    current_block,
-                    num_rows_per_tile,
-                    common_row_width_elements,
-                    static_cast<uint32_t>(a.buffer()->aligned_page_size()),
-                    b_page_size,
-                    a_alignment,
-                    b_alignment,
-                    tiles_per_row_width,
-                    reader_stride_size_bytes,
-                    packed_scalar_for_reader};
-            } else {
-                reader_runtime_args = {
-                    a.buffer(),
-                    c_start_id,
-                    a_num_tiles,
-                    c_num_tiles_core,
-                    c_current_shard_width,
-                    aHt * aWt * aC * aN * aD * (aND > 1),
-                    aHt * aWt * aC * aN * (aD > 1),
-                    aHt * aWt * aC * (aN > 1),
-                    aHt * aWt * (aC > 1),
-                    cD,
-                    cN,
-                    cC,
-                    cHt,
-                    cWt,
-                    cND,
-                    b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u},
-                    bHt * bWt * bC * bN * bD * (bND > 1),
-                    bHt * bWt * bC * bN * (bD > 1),
-                    bHt * bWt * bC * (bN > 1),
-                    bHt * bWt * (bC > 1),
-                    b_num_tiles,
-                };
-            }
-
-            reader_desc.emplace_runtime_args(core, reader_runtime_args);
-
-            start_tile_id += c_num_tiles_core;
-            if (row_major_inputs) {
-                current_block += c_num_tiles_core;
-            }
+        auto per_core = build_per_core_runtime_args(operation_attributes, a, b, c);
+        for (size_t i = 0; i < per_core.cores.size(); ++i) {
+            reader_desc.emplace_runtime_args(per_core.cores[i], per_core.reader[i]);
+            writer_desc.emplace_runtime_args(per_core.cores[i], per_core.writer[i]);
+            compute_desc.emplace_runtime_args(per_core.cores[i], per_core.compute[i]);
         }
     }
 
@@ -1299,6 +1343,61 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     desc.kernels.push_back(std::move(writer_desc));
     desc.kernels.push_back(std::move(compute_desc));
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> BinaryNgDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& c,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // binary_ng's compute_program_hash EXCLUDES the tensor volume, so one cached program is reused
+    // across differently-shaped calls.  On a cache hit the descriptor is never rebuilt, so every
+    // shape-/work-split-dependent per-core arg baked at the first miss would stay frozen and corrupt a
+    // later, differently-shaped call.  Re-run the SAME builder create_descriptor() uses and re-apply
+    // every per-core arg for the CURRENT tensors.
+    //
+    // Kernel push order in create_descriptor(): reader(0), writer(1), compute(2).
+    //
+    // The work-core partition itself shifts with the volume (a core can flip between work and noop), so
+    // we re-apply ALL cores' args, not just the work cores: noop cores get zero-filled lists (harmless,
+    // they do no work), and any core that becomes a work core on this hit gets its full args here.  For
+    // that reason we ALSO re-apply the buffer-address slots (via the current Buffer address) rather than
+    // relying solely on the Buffer* bindings: bindings are resolved once at cache-miss time and only
+    // cover the cores that were work cores THEN, so a core promoted to a work core on a later hit would
+    // otherwise be left with a stale/zero base address.  Indices match create_descriptor() by
+    // construction because both walk the identical builder output.
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+
+    auto per_core = build_per_core_runtime_args(operation_attributes, a, b, c);
+
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    constexpr uint32_t kComputeKernelIdx = 2;
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(per_core.cores.size() * 40);
+
+    auto emit = [&](uint32_t kernel_idx,
+                    const CoreCoord& core,
+                    const std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>>& args) {
+        for (uint32_t arg_idx = 0; arg_idx < args.size(); ++arg_idx) {
+            const auto& slot = args[arg_idx];
+            uint32_t value = std::holds_alternative<tt::tt_metal::Buffer*>(slot)
+                                 ? static_cast<uint32_t>(std::get<tt::tt_metal::Buffer*>(slot)->address())
+                                 : std::get<uint32_t>(slot);
+            dynamic_args.push_back({kernel_idx, core, arg_idx, value});
+        }
+    };
+
+    for (size_t i = 0; i < per_core.cores.size(); ++i) {
+        const auto& core = per_core.cores[i];
+        emit(kReaderKernelIdx, core, per_core.reader[i]);
+        emit(kWriterKernelIdx, core, per_core.writer[i]);
+        emit(kComputeKernelIdx, core, per_core.compute[i]);
+    }
+
+    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_device_operation.cpp
@@ -56,7 +56,19 @@ ProgramDescriptor FusionDispatchOpDeviceOperation::create_descriptor(
     // Python entry points in fusion_dispatch_op_nanobind.cpp).
     const auto& mesh_programs = operation_attributes.mesh_programs;
     TT_FATAL(!mesh_programs.empty(), "fusion_dispatch_op: mesh_programs must not be empty");
-    return mesh_programs.front().second;
+    ProgramDescriptor desc = mesh_programs.front().second;
+
+    // Sub-op descriptors stitched into the fused program may carry framework BufferBindings (declared
+    // via emplace_runtime_args({buffer, ...}) in the source ops). The fusion renumbers runtime args
+    // when stitching and patches every IO address itself via its own address_slots mechanism (see
+    // compute_address_slots / apply_*), so those inherited bindings are both redundant and carry a
+    // now-stale arg_idx. Left in place, resolve_bindings would validate a binding against the wrong
+    // slot and TT_FATAL. Drop them; address_slots remains the sole (correct) addressing mechanism.
+    for (auto& kd : desc.kernels) {
+        kd.buffer_bindings.clear();
+        kd.common_buffer_bindings.clear();
+    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::experimental::fusion


### PR DESCRIPTION
### What

Fixes the binary_ng contribution to the ResNet50 non-trace host regression (#48928): the in-place
residual add re-ran `create_descriptor()` on every program-cache hit (~x252 per inference).

Two commits:

1. **`resolve_bindings` treats an in-place output alias as safe.** When an op carries its own output
   inside `tensor_args` (e.g. an in-place op's optional `output_tensor`), that buffer appears in both
   the input and output regions. The dedup used to treat the repeat as the ambiguous `matmul(X, X)`
   case and bail to the slow rebuild path. It is a same-buffer-by-construction alias, not a distinct
   second input, so it is now skipped. A genuine repeated *input* (real `matmul(X, X)`) still bails.

2. **binary_ng emits a/b/c as `Buffer*` runtime-arg bindings** (`emplace_runtime_args`) instead of raw
   addresses, so the descriptor adapter can patch them on a cache hit and skip the rebuild.

### Validation (local, 8-chip T3000)

- binary_ng now resolves bindings on the cache path: `rt_args=168/192` (was `rt_args=0`).
- ResNet50 non-trace PCC = 0.987 (unchanged).
- Framework-wide `resolve_bindings` change verified safe: `matmul(X, X)` still bails (`rt_args=0`,
  PCC 0.9999); `test_fold_op.py -k sharded` 9 passed.

Note: binary_ng is perf-neutral for ResNet50 on its own (the wall-clock offenders transpose/tilize/
slice/pad are addressed in #49159); this removes its x252 host rebuilds and the framework over-bail.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-binaryng-inplace-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-binaryng-inplace-descriptor)
