### PR TITLE
MINFRA-1081: infra: map CI job card_type to pipeline SKU via sku_config.yaml [skip ci]

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -371,10 +371,65 @@ def _is_sku_name_prefix(prefix: str, sku_name: str) -> bool:
     return sku_name[len(prefix)] in "_-"
 
 
+# Generic runner pools: store the runner label itself as card_type (not a SKU name).
+_GENERIC_RUNNER_LABELS: frozenset[str] = frozenset(
+    {
+        "ubuntu-latest",
+        "tt-ubuntu-2204-large-stable",
+    }
+)
+
+# Longest-first suffixes stripped when promoting a variant SKU to its root name.
+_CARD_TYPE_ROOT_SUFFIXES: tuple[str, ...] = (
+    "_civ2_viommu_prio",
+    "_civ2_viommu",
+    "_civ2_prio",
+    "_merge_gate",
+    "_civ2",
+    "_viommu",
+    "_perf",
+    "_prio",
+    "_iommu",
+    "-blitz",
+    "-mgd",
+)
+
+
+def _uses_generic_runner_labels(label_set: set[str]) -> bool:
+    return bool(label_set) and label_set <= _GENERIC_RUNNER_LABELS
+
+
+def _card_type_from_generic_runner_labels(label_set: set[str]) -> Optional[str]:
+    if not _uses_generic_runner_labels(label_set):
+        return None
+    return sorted(label_set)[0]
+
+
 @functools.lru_cache(maxsize=128)
 def _root_sku_for(sku_name: str) -> str:
-    candidates = [name for name in _sku_config_sku_names() if _is_sku_name_prefix(name, sku_name)]
-    return min(candidates, key=lambda name: (len(name), name))
+    known_skus = set(_sku_config_sku_names())
+    candidate = sku_name
+
+    while True:
+        promoted = False
+        for suffix in _CARD_TYPE_ROOT_SUFFIXES:
+            if not candidate.endswith(suffix):
+                continue
+            stripped = candidate[: -len(suffix)]
+            if stripped in known_skus:
+                candidate = stripped
+                promoted = True
+                break
+        if not promoted:
+            break
+
+    if candidate in known_skus:
+        return candidate
+
+    candidates = [name for name in known_skus if _is_sku_name_prefix(name, sku_name)]
+    if candidates:
+        return min(candidates, key=lambda name: (len(name), name))
+    return sku_name
 
 
 # Runner labels checked in order when strict sku_config matching fails.
@@ -393,9 +448,8 @@ def _card_type_from_sku_config(labels: list[str]) -> Optional[str]:
     Match job labels to a pipeline SKU from sku_config.yaml.
 
     Every SKU whose runs_on labels are present on the job is a match (sim_* SKUs are
-    skipped). When exactly one SKU matches, that SKU name is returned. When multiple
-    SKUs match, each is mapped to its root SKU and the first root alphabetically is
-    returned.
+    skipped). Matches are promoted to their root SKU via suffix stripping / sku_config
+    prefix lookup.
     """
     label_set = set(labels)
     matching_skus: list[str] = []
@@ -413,9 +467,6 @@ def _card_type_from_sku_config(labels: list[str]) -> Optional[str]:
 
     if not matching_skus:
         return None
-
-    if len(matching_skus) == 1:
-        return matching_skus[0]
 
     roots = {_root_sku_for(sku_name) for sku_name in matching_skus}
     return sorted(roots)[0]
@@ -435,6 +486,13 @@ def _card_type_fallback_from_job_labels(labels: list[str]) -> Optional[str]:
 
 
 def _card_type_from_job_labels(labels: list[str]) -> Optional[str]:
+    label_set = set(labels)
+
+    card_type = _card_type_from_generic_runner_labels(label_set)
+    if card_type is not None:
+        logger.info(f"Matched job labels to generic runner label {card_type!r}")
+        return card_type
+
     card_type = _card_type_from_sku_config(labels)
     if card_type is None:
         card_type = _card_type_fallback_from_job_labels(labels)

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -358,16 +358,46 @@ def _load_sku_config_skus() -> dict:
     return config.get("skus") or {}
 
 
-def _card_type_from_job_labels(labels: list[str]) -> Optional[str]:
-    """
-    Map GitHub job runner labels to a pipeline SKU from sku_config.yaml.
+@functools.lru_cache(maxsize=1)
+def _sku_config_sku_names() -> tuple[str, ...]:
+    return tuple(_load_sku_config_skus().keys())
 
-    A SKU matches when every label in its runs_on list is present on the job (the job
-    may have additional labels). When multiple SKUs match, the most specific SKU wins
-    (the one with the largest runs_on list). Ties break lexicographically on SKU name.
+
+def _is_sku_name_prefix(prefix: str, sku_name: str) -> bool:
+    if sku_name == prefix:
+        return True
+    if len(prefix) >= len(sku_name) or not sku_name.startswith(prefix):
+        return False
+    return sku_name[len(prefix)] in "_-"
+
+
+@functools.lru_cache(maxsize=128)
+def _root_sku_for(sku_name: str) -> str:
+    candidates = [name for name in _sku_config_sku_names() if _is_sku_name_prefix(name, sku_name)]
+    return min(candidates, key=lambda name: (len(name), name))
+
+
+# Runner labels checked in order when strict sku_config matching fails.
+_CARD_TYPE_LABEL_FALLBACK: tuple[tuple[str, str], ...] = (
+    ("P300-viommu", "bh_p300"),
+    ("P300", "bh_p300"),
+    ("P150", "bh_p150"),
+    ("P100", "bh_p100"),
+    ("N300", "wh_n300"),
+    ("N150", "wh_n150"),
+)
+
+
+def _card_type_from_sku_config(labels: list[str]) -> Optional[str]:
+    """
+    Match job labels to a root pipeline SKU from sku_config.yaml.
+
+    Every SKU whose runs_on labels are present on the job is a match (sim_* SKUs are
+    skipped). Each match is mapped to the shortest prefix SKU name in sku_config; when
+    multiple roots match, the first root alphabetically is returned.
     """
     label_set = set(labels)
-    matches: list[tuple[int, str]] = []
+    matching_skus: list[str] = []
 
     for sku_name, sku_entry in _load_sku_config_skus().items():
         if sku_name.startswith("sim_"):
@@ -377,18 +407,39 @@ def _card_type_from_job_labels(labels: list[str]) -> Optional[str]:
         if not runs_on:
             continue
 
-        required_labels = frozenset(runs_on)
-        if not required_labels.issubset(label_set):
-            continue
+        if frozenset(runs_on).issubset(label_set):
+            matching_skus.append(sku_name)
 
-        matches.append((len(required_labels), sku_name))
-
-    if not matches:
+    if not matching_skus:
         return None
 
-    matches.sort(key=lambda match: (-match[0], match[1]))
-    card_type = matches[0][1]
-    logger.info(f"Matched job labels to SKU {card_type!r}")
+    roots = {_root_sku_for(sku_name) for sku_name in matching_skus}
+    return sorted(roots)[0]
+
+
+def _card_type_fallback_from_job_labels(labels: list[str]) -> Optional[str]:
+    """
+    Best-effort card type when sku_config has no full runs_on match.
+
+    Maps a single hardware runner label to the corresponding root SKU.
+    """
+    label_set = set(labels)
+    for runner_label, card_type in _CARD_TYPE_LABEL_FALLBACK:
+        if runner_label in label_set:
+            return card_type
+    return None
+
+
+def _card_type_from_job_labels(labels: list[str]) -> Optional[str]:
+    card_type = _card_type_from_sku_config(labels)
+    if card_type is None:
+        card_type = _card_type_fallback_from_job_labels(labels)
+        if card_type is not None:
+            logger.info(f"Matched job labels to SKU {card_type!r} via label fallback")
+            return card_type
+        return None
+
+    logger.info(f"Matched job labels to root SKU {card_type!r}")
     return card_type
 
 

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -390,11 +390,12 @@ _CARD_TYPE_LABEL_FALLBACK: tuple[tuple[str, str], ...] = (
 
 def _card_type_from_sku_config(labels: list[str]) -> Optional[str]:
     """
-    Match job labels to a root pipeline SKU from sku_config.yaml.
+    Match job labels to a pipeline SKU from sku_config.yaml.
 
     Every SKU whose runs_on labels are present on the job is a match (sim_* SKUs are
-    skipped). Each match is mapped to the shortest prefix SKU name in sku_config; when
-    multiple roots match, the first root alphabetically is returned.
+    skipped). When exactly one SKU matches, that SKU name is returned. When multiple
+    SKUs match, each is mapped to its root SKU and the first root alphabetically is
+    returned.
     """
     label_set = set(labels)
     matching_skus: list[str] = []
@@ -412,6 +413,9 @@ def _card_type_from_sku_config(labels: list[str]) -> Optional[str]:
 
     if not matching_skus:
         return None
+
+    if len(matching_skus) == 1:
+        return matching_skus[0]
 
     roots = {_root_sku_for(sku_name) for sku_name in matching_skus}
     return sorted(roots)[0]
@@ -439,7 +443,7 @@ def _card_type_from_job_labels(labels: list[str]) -> Optional[str]:
             return card_type
         return None
 
-    logger.info(f"Matched job labels to root SKU {card_type!r}")
+    logger.info(f"Matched job labels to SKU {card_type!r}")
     return card_type
 
 

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
 import pathlib
 import pickle
 import os
@@ -266,43 +267,7 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         logger.warning(f"{github_job_id} is not completed, skipping this job")
         return None
 
-    # Best effort card type getting
-
-    get_overlap = lambda labels_a, labels_b: set(labels_a) & set(labels_b)
-    labels_have_overlap = lambda labels_a, labels_b: bool(get_overlap(labels_a, labels_b))
-
-    try:
-        detected_config = return_first_string_starts_with("config-", labels).replace("config-", "")
-    except Exception as e:
-        logger.error(e)
-        logger.info("Seems to have no config- label, so assuming no special config requested")
-        detected_config = None
-
-    if labels_have_overlap(["N150", "N300", "wormhole_b0", "arch-wormhole_b0", "config-t3000"], labels):
-        detected_arch = "wormhole_b0"
-    elif labels_have_overlap(["BH", "arch-blackhole"], labels):
-        detected_arch = "blackhole"
-    else:
-        detected_arch = None
-
-    single_cards_list = ("N150", "N300", "BH")
-    single_cards_overlap = get_overlap(single_cards_list, labels)
-
-    # In order of preference
-    if detected_config:
-        if not detected_arch:
-            # This will occur for jobs where runs-on: has a config-* label but doesn't have an arch-* or card-specific label
-            logger.warning(f"No arch label found for config {detected_config} in job label, unable to infer card type")
-            card_type = None
-        else:
-            card_type = f"{detected_config}-{detected_arch}"
-    elif single_cards_overlap:
-        logger.info(f"Detected overlap in single cards: {single_cards_overlap}")
-        card_type = list(single_cards_overlap)[0]
-    elif detected_arch:
-        card_type = detected_arch
-    else:
-        card_type = None
+    card_type = _card_type_from_job_labels(labels)
 
     job_submission_ts = github_job["created_at"]
 
@@ -383,6 +348,48 @@ def get_job_rows_from_github_info(workflow_outputs_dir, github_jobs_json, github
 def _get_repo_root() -> pathlib.Path:
     """Return the repository root directory (parent of infra/)."""
     return pathlib.Path(__file__).resolve().parents[3]
+
+
+@functools.lru_cache(maxsize=1)
+def _load_sku_config_skus() -> dict:
+    sku_config_path = _get_repo_root() / ".github" / "sku_config.yaml"
+    with open(sku_config_path) as f:
+        config = yaml.safe_load(f)
+    return config.get("skus") or {}
+
+
+def _card_type_from_job_labels(labels: list[str]) -> Optional[str]:
+    """
+    Map GitHub job runner labels to a pipeline SKU from sku_config.yaml.
+
+    A SKU matches when every label in its runs_on list is present on the job (the job
+    may have additional labels). When multiple SKUs match, the most specific SKU wins
+    (the one with the largest runs_on list). Ties break lexicographically on SKU name.
+    """
+    label_set = set(labels)
+    matches: list[tuple[int, str]] = []
+
+    for sku_name, sku_entry in _load_sku_config_skus().items():
+        if sku_name.startswith("sim_"):
+            continue
+
+        runs_on = sku_entry.get("runs_on") or []
+        if not runs_on:
+            continue
+
+        required_labels = frozenset(runs_on)
+        if not required_labels.issubset(label_set):
+            continue
+
+        matches.append((len(required_labels), sku_name))
+
+    if not matches:
+        return None
+
+    matches.sort(key=lambda match: (-match[0], match[1]))
+    card_type = matches[0][1]
+    logger.info(f"Matched job labels to SKU {card_type!r}")
+    return card_type
 
 
 def get_github_partial_benchmark_data_filenames():

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -371,14 +371,19 @@ def _is_sku_name_prefix(prefix: str, sku_name: str) -> bool:
     return sku_name[len(prefix)] in "_-"
 
 
-# CPU runner pools shared with sim_* SKUs in sku_config.yaml (sim_wormhole_b0 /
-# sim_blackhole → ubuntu-latest; galaxy sim SKUs → tt-ubuntu-2204-large-stable).
-_GENERIC_RUNNER_LABELS: frozenset[str] = frozenset(
-    {
-        "ubuntu-latest",
-        "tt-ubuntu-2204-large-stable",
-    }
-)
+@functools.lru_cache(maxsize=1)
+def _generic_runner_labels() -> frozenset[str]:
+    """
+    Runner labels from sim_* runs_on entries in sku_config.yaml.
+
+    These are shared CPU pools where strict sku_config matching cannot distinguish
+    sim tests from other jobs on the same label; card_type stores the label itself.
+    """
+    labels: set[str] = set()
+    for sku_name, sku_entry in _load_sku_config_skus().items():
+        if sku_name.startswith("sim_"):
+            labels.update(sku_entry.get("runs_on") or [])
+    return frozenset(labels)
 
 # Longest-first suffixes stripped when promoting a variant SKU to its root name.
 _CARD_TYPE_ROOT_SUFFIXES: tuple[str, ...] = (
@@ -397,17 +402,15 @@ _CARD_TYPE_ROOT_SUFFIXES: tuple[str, ...] = (
 
 
 def _uses_generic_runner_labels(label_set: set[str]) -> bool:
-    return bool(label_set) and label_set <= _GENERIC_RUNNER_LABELS
+    return bool(label_set) and label_set <= _generic_runner_labels()
 
 
 def _card_type_from_generic_runner_labels(label_set: set[str]) -> Optional[str]:
     """
     Map sim_* shared CPU pools back to their runner label for card_type.
 
-    sim_* SKUs run on ubuntu-latest or tt-ubuntu-2204-large-stable; strict
-    sku_config matching cannot distinguish sim tests from other CPU jobs on those
-    pools. When labels are only these pools, return the CPU runner label itself
-    rather than a sim_* SKU name.
+    When job labels are only pools listed on sim_* SKUs in sku_config.yaml, return
+    the CPU runner label itself rather than a sim_* SKU name.
     """
     if not _uses_generic_runner_labels(label_set):
         return None

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -385,6 +385,7 @@ def _generic_runner_labels() -> frozenset[str]:
             labels.update(sku_entry.get("runs_on") or [])
     return frozenset(labels)
 
+
 # Longest-first suffixes stripped when promoting a variant SKU to its root name.
 _CARD_TYPE_ROOT_SUFFIXES: tuple[str, ...] = (
     "_civ2_viommu_prio",

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -371,7 +371,8 @@ def _is_sku_name_prefix(prefix: str, sku_name: str) -> bool:
     return sku_name[len(prefix)] in "_-"
 
 
-# Generic runner pools: store the runner label itself as card_type (not a SKU name).
+# CPU runner pools shared with sim_* SKUs in sku_config.yaml (sim_wormhole_b0 /
+# sim_blackhole → ubuntu-latest; galaxy sim SKUs → tt-ubuntu-2204-large-stable).
 _GENERIC_RUNNER_LABELS: frozenset[str] = frozenset(
     {
         "ubuntu-latest",
@@ -400,6 +401,14 @@ def _uses_generic_runner_labels(label_set: set[str]) -> bool:
 
 
 def _card_type_from_generic_runner_labels(label_set: set[str]) -> Optional[str]:
+    """
+    Map sim_* shared CPU pools back to their runner label for card_type.
+
+    sim_* SKUs run on ubuntu-latest or tt-ubuntu-2204-large-stable; strict
+    sku_config matching cannot distinguish sim tests from other CPU jobs on those
+    pools. When labels are only these pools, return the CPU runner label itself
+    rather than a sim_* SKU name.
+    """
     if not _uses_generic_runner_labels(label_set):
         return None
     return sorted(label_set)[0]

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -340,8 +340,8 @@ def clear_sku_config_cache():
             ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"],
             "bh_p300",
         ),
-        (["P300-viommu", "in-service", "pipeline-yyz2-lfc"], "bh_p300_viommu"),
-        (["tt-ubuntu-2204-N300-viommu-stable"], "wh_n300_civ2"),
+        (["P300-viommu", "in-service", "pipeline-yyz2-lfc"], "bh_p300"),
+        (["tt-ubuntu-2204-N300-viommu-stable"], "wh_n300"),
         (
             ["P150", "arch-blackhole", "in-service", "pipeline-functional"],
             "bh_p150",
@@ -353,7 +353,7 @@ def clear_sku_config_cache():
         ),
         (
             ["arch-wormhole_b0", "topology-6u", "in-service", "pipeline-perf"],
-            "wh_galaxy_perf",
+            "wh_galaxy",
         ),
         # tm-fabric-style runs_on: strict match fails, label fallback applies
         (["P300-viommu", "arch-blackhole", "in-service"], "bh_p300"),
@@ -362,19 +362,20 @@ def clear_sku_config_cache():
         # legacy partial wh_n300 labels
         (["N300", "in-service"], "wh_n300"),
         (["build", "in-service"], None),
-        (["ubuntu-latest"], None),
+        (["ubuntu-latest"], "ubuntu-latest"),
+        (["tt-ubuntu-2204-large-stable"], "tt-ubuntu-2204-large-stable"),
     ],
 )
 def test_card_type_from_job_labels(labels, expected_card_type):
     assert _card_type_from_job_labels(labels) == expected_card_type
 
 
-def test_card_type_groups_p300_variants_under_root_sku_when_multiple_match():
+def test_card_type_groups_p300_variants_under_root_sku():
     labels = ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"]
     assert _card_type_from_job_labels(labels) == "bh_p300"
 
     viommu_only_labels = ["P300-viommu", "in-service", "pipeline-yyz2-lfc"]
-    assert _card_type_from_job_labels(viommu_only_labels) == "bh_p300_viommu"
+    assert _card_type_from_job_labels(viommu_only_labels) == "bh_p300"
 
 
 def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -340,7 +340,8 @@ def clear_sku_config_cache():
             ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"],
             "bh_p300",
         ),
-        (["P300-viommu", "in-service", "pipeline-yyz2-lfc"], "bh_p300"),
+        (["P300-viommu", "in-service", "pipeline-yyz2-lfc"], "bh_p300_viommu"),
+        (["tt-ubuntu-2204-N300-viommu-stable"], "wh_n300_civ2"),
         (
             ["P150", "arch-blackhole", "in-service", "pipeline-functional"],
             "bh_p150",
@@ -352,7 +353,7 @@ def clear_sku_config_cache():
         ),
         (
             ["arch-wormhole_b0", "topology-6u", "in-service", "pipeline-perf"],
-            "wh_galaxy",
+            "wh_galaxy_perf",
         ),
         # tm-fabric-style runs_on: strict match fails, label fallback applies
         (["P300-viommu", "arch-blackhole", "in-service"], "bh_p300"),
@@ -368,12 +369,12 @@ def test_card_type_from_job_labels(labels, expected_card_type):
     assert _card_type_from_job_labels(labels) == expected_card_type
 
 
-def test_card_type_groups_p300_variants_under_root_sku():
+def test_card_type_groups_p300_variants_under_root_sku_when_multiple_match():
     labels = ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"]
     assert _card_type_from_job_labels(labels) == "bh_p300"
 
     viommu_only_labels = ["P300-viommu", "in-service", "pipeline-yyz2-lfc"]
-    assert _card_type_from_job_labels(viommu_only_labels) == "bh_p300"
+    assert _card_type_from_job_labels(viommu_only_labels) == "bh_p300_viommu"
 
 
 def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -4,7 +4,11 @@ import pathlib
 from infra.data_collection.github import workflows
 from infra.data_collection.cicd import create_cicd_json_for_data_analysis
 from infra.data_collection.models import InfraErrorV1, TestErrorV1
-from infra.data_collection.github.utils import get_job_failure_signature_, _card_type_from_job_labels, _load_sku_config_skus
+from infra.data_collection.github.utils import (
+    get_job_failure_signature_,
+    _card_type_from_job_labels,
+    _load_sku_config_skus,
+)
 from infra.data_collection.pydantic_models import JobStatus
 from infra.data_collection.pydantic_models import Step
 from loguru import logger
@@ -316,9 +320,15 @@ def test_non_checkout_git_failure_stays_generic():
 
 @pytest.fixture(autouse=True)
 def clear_sku_config_cache():
+    from infra.data_collection.github.utils import _root_sku_for, _sku_config_sku_names
+
     _load_sku_config_skus.cache_clear()
+    _sku_config_sku_names.cache_clear()
+    _root_sku_for.cache_clear()
     yield
     _load_sku_config_skus.cache_clear()
+    _sku_config_sku_names.cache_clear()
+    _root_sku_for.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -330,7 +340,7 @@ def clear_sku_config_cache():
             ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"],
             "bh_p300",
         ),
-        (["P300-viommu", "in-service", "pipeline-yyz2-lfc"], "bh_p300_viommu"),
+        (["P300-viommu", "in-service", "pipeline-yyz2-lfc"], "bh_p300"),
         (
             ["P150", "arch-blackhole", "in-service", "pipeline-functional"],
             "bh_p150",
@@ -340,8 +350,16 @@ def clear_sku_config_cache():
             ["config-t3000", "arch-wormhole_b0", "in-service", "pipeline-functional"],
             "wh_llmbox",
         ),
-        # tm-fabric-style runs_on is a strict subset of bh_p300 runs_on in sku_config
-        (["P300-viommu", "arch-blackhole", "in-service"], None),
+        (
+            ["arch-wormhole_b0", "topology-6u", "in-service", "pipeline-perf"],
+            "wh_galaxy",
+        ),
+        # tm-fabric-style runs_on: strict match fails, label fallback applies
+        (["P300-viommu", "arch-blackhole", "in-service"], "bh_p300"),
+        # model perf-style runs_on: missing arch-blackhole for bh_p150_perf
+        (["P150", "pipeline-perf", "bare-metal", "in-service"], "bh_p150"),
+        # legacy partial wh_n300 labels
+        (["N300", "in-service"], "wh_n300"),
         (["build", "in-service"], None),
         (["ubuntu-latest"], None),
     ],
@@ -350,9 +368,12 @@ def test_card_type_from_job_labels(labels, expected_card_type):
     assert _card_type_from_job_labels(labels) == expected_card_type
 
 
-def test_card_type_prefers_more_specific_sku():
+def test_card_type_groups_p300_variants_under_root_sku():
     labels = ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"]
     assert _card_type_from_job_labels(labels) == "bh_p300"
+
+    viommu_only_labels = ["P300-viommu", "in-service", "pipeline-yyz2-lfc"]
+    assert _card_type_from_job_labels(viommu_only_labels) == "bh_p300"
 
 
 def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):
@@ -360,9 +381,7 @@ def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_
 
     wh_n300_labels = {"N300", "cloud-virtual-machine", "in-service"}
     full_wh_n300_jobs = [
-        job
-        for job in pipeline.jobs
-        if job.job_label and wh_n300_labels.issubset(set(job.job_label.split(",")))
+        job for job in pipeline.jobs if job.job_label and wh_n300_labels.issubset(set(job.job_label.split(",")))
     ]
     assert full_wh_n300_jobs
     assert all(job.card_type == "wh_n300" for job in full_wh_n300_jobs)
@@ -376,4 +395,4 @@ def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_
         and "cloud-virtual-machine" not in job.job_label.split(",")
     ]
     assert partial_n300_jobs
-    assert all(job.card_type is None for job in partial_n300_jobs)
+    assert all(job.card_type == "wh_n300" for job in partial_n300_jobs)

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -370,14 +370,6 @@ def test_card_type_from_job_labels(labels, expected_card_type):
     assert _card_type_from_job_labels(labels) == expected_card_type
 
 
-def test_card_type_groups_p300_variants_under_root_sku():
-    labels = ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"]
-    assert _card_type_from_job_labels(labels) == "bh_p300"
-
-    viommu_only_labels = ["P300-viommu", "in-service", "pipeline-yyz2-lfc"]
-    assert _card_type_from_job_labels(viommu_only_labels) == "bh_p300"
-
-
 def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):
     pipeline = _load_pipeline(workflow_run_gh_environment, "all_post_commit_passing_10662355710")
 

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -4,7 +4,7 @@ import pathlib
 from infra.data_collection.github import workflows
 from infra.data_collection.cicd import create_cicd_json_for_data_analysis
 from infra.data_collection.models import InfraErrorV1, TestErrorV1
-from infra.data_collection.github.utils import get_job_failure_signature_
+from infra.data_collection.github.utils import get_job_failure_signature_, _card_type_from_job_labels, _load_sku_config_skus
 from infra.data_collection.pydantic_models import JobStatus
 from infra.data_collection.pydantic_models import Step
 from loguru import logger
@@ -312,3 +312,68 @@ def test_non_checkout_git_failure_stays_generic():
         mock_job, "The process '/usr/bin/git' failed with exit code 1", workflow_outputs_dir=None
     )
     assert result == str(InfraErrorV1.GENERIC_FAILURE)
+
+
+@pytest.fixture(autouse=True)
+def clear_sku_config_cache():
+    _load_sku_config_skus.cache_clear()
+    yield
+    _load_sku_config_skus.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "labels,expected_card_type",
+    [
+        (["N300", "cloud-virtual-machine", "in-service"], "wh_n300"),
+        (["N150", "cloud-virtual-machine", "in-service"], "wh_n150"),
+        (
+            ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"],
+            "bh_p300",
+        ),
+        (["P300-viommu", "in-service", "pipeline-yyz2-lfc"], "bh_p300_viommu"),
+        (
+            ["P150", "arch-blackhole", "in-service", "pipeline-functional"],
+            "bh_p150",
+        ),
+        (["P100", "cloud-virtual-machine", "in-service"], "bh_p100"),
+        (
+            ["config-t3000", "arch-wormhole_b0", "in-service", "pipeline-functional"],
+            "wh_llmbox",
+        ),
+        # tm-fabric-style runs_on is a strict subset of bh_p300 runs_on in sku_config
+        (["P300-viommu", "arch-blackhole", "in-service"], None),
+        (["build", "in-service"], None),
+        (["ubuntu-latest"], None),
+    ],
+)
+def test_card_type_from_job_labels(labels, expected_card_type):
+    assert _card_type_from_job_labels(labels) == expected_card_type
+
+
+def test_card_type_prefers_more_specific_sku():
+    labels = ["P300-viommu", "arch-blackhole", "in-service", "pipeline-yyz2-lfc"]
+    assert _card_type_from_job_labels(labels) == "bh_p300"
+
+
+def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):
+    pipeline = _load_pipeline(workflow_run_gh_environment, "all_post_commit_passing_10662355710")
+
+    wh_n300_labels = {"N300", "cloud-virtual-machine", "in-service"}
+    full_wh_n300_jobs = [
+        job
+        for job in pipeline.jobs
+        if job.job_label and wh_n300_labels.issubset(set(job.job_label.split(",")))
+    ]
+    assert full_wh_n300_jobs
+    assert all(job.card_type == "wh_n300" for job in full_wh_n300_jobs)
+
+    # Legacy post-commit jobs may only carry a subset of wh_n300 runs_on labels.
+    partial_n300_jobs = [
+        job
+        for job in pipeline.jobs
+        if job.job_label
+        and "N300" in job.job_label.split(",")
+        and "cloud-virtual-machine" not in job.job_label.split(",")
+    ]
+    assert partial_n300_jobs
+    assert all(job.card_type is None for job in partial_n300_jobs)

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -7,6 +7,7 @@ from infra.data_collection.models import InfraErrorV1, TestErrorV1
 from infra.data_collection.github.utils import (
     get_job_failure_signature_,
     _card_type_from_job_labels,
+    _generic_runner_labels,
     _load_sku_config_skus,
 )
 from infra.data_collection.pydantic_models import JobStatus
@@ -320,15 +321,26 @@ def test_non_checkout_git_failure_stays_generic():
 
 @pytest.fixture(autouse=True)
 def clear_sku_config_cache():
-    from infra.data_collection.github.utils import _root_sku_for, _sku_config_sku_names
+    from infra.data_collection.github.utils import _generic_runner_labels, _root_sku_for, _sku_config_sku_names
 
     _load_sku_config_skus.cache_clear()
     _sku_config_sku_names.cache_clear()
+    _generic_runner_labels.cache_clear()
     _root_sku_for.cache_clear()
     yield
     _load_sku_config_skus.cache_clear()
     _sku_config_sku_names.cache_clear()
+    _generic_runner_labels.cache_clear()
     _root_sku_for.cache_clear()
+
+
+def test_generic_runner_labels_derived_from_sim_skus():
+    expected_labels: set[str] = set()
+    for sku_name, sku_entry in _load_sku_config_skus().items():
+        if sku_name.startswith("sim_"):
+            expected_labels.update(sku_entry.get("runs_on") or [])
+
+    assert _generic_runner_labels() == frozenset(expected_labels)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## PR Category
Bug fix

## Summary
Fixes missing or incorrect `card_type` values in CI metadata (e.g. P300 hosts tagged as blank/unknown) by replacing hardcoded label inference with lookup against `.github/sku_config.yaml`.

Relates to https://tenstorrent.atlassian.net/browse/MINFRA-1081

- Replace legacy if-elif-else `card_type` logic in `get_job_row_from_github_job` with `_card_type_from_job_labels()`
- **Generic runners:** if job labels are only pools listed on `sim_*` SKUs in `sku_config.yaml` (currently `ubuntu-latest` and/or `tt-ubuntu-2204-large-stable`), store the runner label itself as `card_type` (e.g. `"ubuntu-latest"`), not a `sim_*` SKU; generic pools are derived from `sim_*` `runs_on` so they stay in sync when simulator runner pools change
- **Strict match:** find all SKUs whose full `runs_on` list is present on the job (skip `sim_*` SKUs)
- **Root grouping:** promote matched SKUs to a root via postfix suffix stripping (`_perf`, `_civ2`, `_viommu`, `-blitz`, etc.); if multiple roots match, pick first alphabetically — collapses 36 non-sim SKUs to 16 roots (e.g. `wh_n300_civ2` → `wh_n300`, `bh_p300_viommu` → `bh_p300`, `wh_galaxy_perf` → `wh_galaxy`)
- **Letter variants stay separate:** `bh_p150b_civ2`, `bh_p100a_civ2_viommu` are not rolled into `bh_p150` / `bh_p100` for naming consistency and reliability
- **Label fallback:** when strict match fails, map hardware runner labels to root SKUs (`N150` → `wh_n150`, `N300` → `wh_n300`, `P100` → `bh_p100`, `P150` → `bh_p150`, `P300`/`P300-viommu` → `bh_p300`) — covers TM-Fabric, model perf, and legacy partial-label jobs
- Add 17 new tests in `infra/tests/data_collection/test_cicd.py` (15 parametrized unit cases + 1 generic-runner derivation test + 1 post-commit fixture integration test)
- **Behavior change:** `card_type` now uses root SKU names from `sku_config.yaml` (e.g. `wh_n300`, `bh_p300`) instead of legacy values (`N300`, `blackhole`, `bh_p300_viommu`). Jobs with no SKU match and no fallback label still get `None`.

## Notes for reviewers
- `sim_*` SKUs are skipped during strict matching to avoid false positives from generic labels like `ubuntu-latest`
- Generic runner pools are collected from `sim_*` `runs_on` in `sku_config.yaml` (not hardcoded in Python); if a sim SKU moves to a new shared pool, generic detection picks it up automatically
- Generic check runs before strict match so shared-pool jobs are not mis-tagged as another SKU (e.g. `cpu_medium`) when labels are only the pool label; jobs with extra labels (e.g. `in-service`) can still strict-match their SKU
- Root grouping uses postfix suffix stripping, not a hardcoded family dict; no `root_sku` field in yaml yet
- Fallback is intentionally narrow — only single-card hardware labels; BH/BH-LLMBox, multi-host tags, partial galaxy labels, etc. remain `None` unless strict match works
- **Future direction:** fallback is a bridge for legacy/hardcoded workflows; long-term we want all pipelines to use full `runs_on` from `sku_config` (via `prepare_test_matrix`) so strict match covers everything and fallback can be removed
- **Downstream impact** — new root SKU values will appear in Snowflake going forward; historical rows keyed on old values may need a separate backfill
- `_get_device_type_from_runner_environment` is unchanged — still uses `RUNNER_NAME` / arch inference for benchmark enrichment
- Test file refactor (`_load_pipeline`, parametrized gtest/timeout cases) is from [Test Only] Parametrize infra CICD data collection tests #49174 (`yiyiwu/test-refact`), not this PR

## Test plan
- [x] `pytest infra/tests/data_collection/test_cicd.py::test_card_type_from_job_labels`
- [x] `pytest infra/tests/data_collection/test_cicd.py::test_generic_runner_labels_derived_from_sim_skus`
- [x] `pytest infra/tests/data_collection/test_cicd.py::test_create_pipeline_json_assigns_sku_card_type_to_n300_job`
- [x] `pytest infra/tests/data_collection/test_cicd.py` (43 passed; 17 new card_type cases from this PR)

**Automated CI:** `[internal] Infra tools unit tests` (`.github/workflows/_unit-tests-infra.yaml`) runs on PRs touching `infra/**`, `workflow_dispatch`, and cron every 6 hours. `ubuntu-latest` only — no Tenstorrent hardware. This PR adds 17 host-only tests (~2s); remaining 26 tests are pre-existing (including refactor from #49174). No new scheduled hardware pipelines.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yiyiwu-card-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yiyiwu-card-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yiyiwu-card-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yiyiwu-card-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yiyiwu-card-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yiyiwu-card-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yiyiwu-card-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yiyiwu-card-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yiyiwu-card-fix)