### PR TITLE
Capture ttnn auto-selected program config via query_op_constraints

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_query_op_constraints_mock_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_query_op_constraints_mock_device.cpp
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <any>
+#include <optional>
+
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device/mock_allocator.hpp>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
@@ -26,6 +29,7 @@
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/matmul/device/config/matmul_program_config_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
@@ -356,6 +360,157 @@ TEST_F(QueryOpConstraintsMockDevice, Matmul) {
 }
 
 // ============================================================================
+// Capture the ttnn-auto-selected program config through the uniform query API
+// ============================================================================
+
+TEST_F(QueryOpConstraintsMockDevice, MatmulProgramConfigCaptured) {
+    const auto spec_a = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    const auto spec_b = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 128, 64}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+
+    auto initial_state = experimental::extract_mock_allocator_state(*mock_device_);
+    ASSERT_TRUE(initial_state.is_empty(BufferType::L1));
+
+    // Same op-agnostic entry point every op uses. No explicit program config: ttnn auto-selects one
+    // internally, and the query's built-in capture records it into captured_config.
+    auto out = ttnn::graph::query_op_constraints_with_initial_state(
+        ttnn::matmul,
+        mock_device_.get(),
+        initial_state,
+        spec_a,
+        spec_b,
+        false,  // transpose_a
+        false,  // transpose_b
+        ttnn::L1_MEMORY_CONFIG,
+        DataType::BFLOAT16,
+        std::nullopt,   // program_config
+        std::nullopt,   // activation
+        std::nullopt,   // compute_kernel_config
+        std::nullopt,   // core_grid
+        std::nullopt,   // output_tile
+        std::nullopt,   // optional_output_tensor
+        std::nullopt,   // global_cb
+        std::nullopt);  // sub_device_id
+
+    EXPECT_EQ(out.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << out.response.error_message.value_or("none");
+
+    // Captured, and unpacks (above the API) to the concrete matmul config type.
+    ASSERT_TRUE(out.captured_config.has_value());
+    const auto& captured = std::any_cast<const ttnn::operations::matmul::MatmulProgramConfig&>(*out.captured_config);
+
+    // Cross-check: feeding the captured config back in as an explicit program config reproduces the
+    // op's own kernel footprint — i.e. we captured the config the op actually ran, not an
+    // approximation. This round-trip is the contract every op extractor must satisfy.
+    auto verify = ttnn::graph::query_op_constraints_with_initial_state(
+        ttnn::matmul,
+        mock_device_.get(),
+        initial_state,
+        spec_a,
+        spec_b,
+        false,
+        false,
+        ttnn::L1_MEMORY_CONFIG,
+        DataType::BFLOAT16,
+        std::make_optional(captured),  // explicit config = the captured one
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt);
+
+    EXPECT_EQ(verify.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << verify.response.error_message.value_or("none");
+    EXPECT_EQ(verify.response.resource_usage.cb_peak_size_per_core, out.response.resource_usage.cb_peak_size_per_core);
+    EXPECT_EQ(
+        verify.response.resource_usage.l1_buffers_peak_per_core, out.response.resource_usage.l1_buffers_peak_per_core);
+}
+
+// Requesting a width-sharded output drives ttnn to auto-select a 1D (multi-cast) matmul program
+// config — a different variant than the interleaved case — and the query still captures it and
+// round-trips it to the same footprint.
+TEST_F(QueryOpConstraintsMockDevice, MatmulWidthShardedProgramConfigCaptured) {
+    // M=512 (16 tiles), K=256 (8 tiles), N=1024 (32 tiles).
+    const auto spec_a = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 512, 256}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    const auto spec_b = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 256, 1024}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+
+    // Width-shard the [512, 1024] output across an 8-core row: each core holds the full height
+    // (512) and 1024/8 = 128 columns.
+    const auto width_sharded = MemoryConfig{
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec{
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{7, 0}}}},
+            {512, 128},
+            ShardOrientation::ROW_MAJOR}};
+
+    auto initial_state = experimental::extract_mock_allocator_state(*mock_device_);
+    ASSERT_TRUE(initial_state.is_empty(BufferType::L1));
+
+    auto out = ttnn::graph::query_op_constraints_with_initial_state(
+        ttnn::matmul,
+        mock_device_.get(),
+        initial_state,
+        spec_a,
+        spec_b,
+        false,          // transpose_a
+        false,          // transpose_b
+        width_sharded,  // width-sharded output memory config
+        DataType::BFLOAT16,
+        std::nullopt,   // program_config — let ttnn auto-select
+        std::nullopt,   // activation
+        std::nullopt,   // compute_kernel_config
+        std::nullopt,   // core_grid
+        std::nullopt,   // output_tile
+        std::nullopt,   // optional_output_tensor
+        std::nullopt,   // global_cb
+        std::nullopt);  // sub_device_id
+
+    EXPECT_EQ(out.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << out.response.error_message.value_or("none");
+
+    ASSERT_TRUE(out.captured_config.has_value());
+    const auto& captured = std::any_cast<const ttnn::operations::matmul::MatmulProgramConfig&>(*out.captured_config);
+    // A width-sharded output yields the 1D multi-cast config, not the interleaved 2D one.
+    EXPECT_TRUE(
+        std::holds_alternative<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(captured));
+
+    auto verify = ttnn::graph::query_op_constraints_with_initial_state(
+        ttnn::matmul,
+        mock_device_.get(),
+        initial_state,
+        spec_a,
+        spec_b,
+        false,
+        false,
+        width_sharded,
+        DataType::BFLOAT16,
+        std::make_optional(captured),  // explicit config = the captured one
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt);
+
+    EXPECT_EQ(verify.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << verify.response.error_message.value_or("none");
+    EXPECT_EQ(verify.response.resource_usage.cb_peak_size_per_core, out.response.resource_usage.cb_peak_size_per_core);
+    EXPECT_EQ(
+        verify.response.resource_usage.l1_buffers_peak_per_core, out.response.resource_usage.l1_buffers_peak_per_core);
+}
+
+// ============================================================================
 // query_op_constraints_with_initial_state — pure state-in / state-out variant
 // ============================================================================
 
@@ -384,6 +539,10 @@ TEST_F(QueryOpConstraintsMockDevice, WithInitialStateReturnsResponseAndNewState)
 
     // new_state reflects the op output allocated on top of the (empty) initial state.
     EXPECT_GT(out.new_state.total_allocated_size(BufferType::L1), 0u);
+
+    // An op with no registered program-config extractor captures nothing; the always-on capture is
+    // transparent to such ops.
+    EXPECT_FALSE(out.captured_config.has_value());
 }
 
 TEST_F(QueryOpConstraintsMockDevice, WithInitialStateThreadsStateAcrossOps) {

--- a/ttnn/api/ttnn/graph/capture_program_config.hpp
+++ b/ttnn/api/ttnn/graph/capture_program_config.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <any>
+#include <functional>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <utility>
+
+#include <tt-metalium/graph_tracking.hpp>
+
+namespace ttnn::graph {
+
+// An extractor recognizes one op's operation_attributes_t by its concrete type in the
+// type-erased graph-capture attribute stream and copies out an owned program config.
+// Returns nullopt when `attr` is not the attribute type this extractor handles.
+using ProgramConfigExtractor = std::function<std::optional<std::any>(const std::any& attr)>;
+
+// Passive graph-capture listener: is_capture_processor() == false, so it sits at the bottom of the
+// GraphTracker stack and observes every op the query runs without disturbing the query's own capture
+// push/pop. On each call it runs the registered extractors and keeps the last match. The copy
+// happens here, in-callback, because the std::any holds a reference_wrapper to a stack object (the
+// op's operation_attributes_t) that does not outlive the call.
+class ProgramConfigCaptureProcessor : public tt::tt_metal::IGraphProcessor {
+public:
+    explicit ProgramConfigCaptureProcessor(std::span<const ProgramConfigExtractor> extractors) :
+        extractors_(extractors) {}
+
+    bool is_capture_processor() const override { return false; }
+
+    void track_function_start(
+        std::string_view /*function_name*/, std::span<tt::tt_metal::TrackedArgument> input_parameters) override {
+        for (auto& param : input_parameters) {
+            for (const auto& extractor : extractors_) {
+                if (auto captured = extractor(param.value)) {
+                    captured_ = std::move(captured);
+                    break;  // at most one extractor matches a given argument's concrete type
+                }
+            }
+        }
+    }
+
+    const std::optional<std::any>& result() const& { return captured_; }
+
+    // Move the owned config out just before this processor is popped and destroyed, so QueryOutput
+    // takes ownership without a redundant deep copy of the config.
+    std::optional<std::any> take_result() { return std::move(captured_); }
+
+private:
+    std::span<const ProgramConfigExtractor> extractors_;
+    std::optional<std::any> captured_;
+};
+
+// The registered extractors. Defined out of line in the registry hub
+// (cpp/ttnn/graph/capture_program_config_registry.cpp) so this header stays free of op types.
+std::span<const ProgramConfigExtractor> program_config_extractors();
+
+}  // namespace ttnn::graph

--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <any>
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -15,6 +16,7 @@
 #include <tt_stl/reflection.hpp>
 #include <tuple>
 #include <variant>
+#include "ttnn/graph/capture_program_config.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -149,6 +151,10 @@ struct QueryOutput {
     ConstraintQueryResponse response;
     tt::tt_metal::experimental::MockAllocatorState new_state;
     std::vector<tt::tt_metal::experimental::AllocationRecord> output_allocations;
+    // The program config ttnn auto-selected for the queried op, owned here and holding the op's
+    // concrete config type (e.g. MatmulProgramConfig) for the caller to any_cast. nullopt when no
+    // registered extractor matched. See capture_program_config.hpp.
+    std::optional<std::any> captured_config;
 };
 
 namespace detail {
@@ -266,7 +272,7 @@ auto query_op_constraints(Op op, tt::tt_metal::distributed::MeshDevice* device, 
  * @param device A pointer to a mock MeshDevice used for planning.
  * @param initial_state The caller-owned allocator state to evaluate the op against.
  * @param args The arguments that will be passed to the operation.
- * @return QueryOutput { response, new_state }.
+ * @return QueryOutput { response, new_state, output_allocations, captured_config }.
  */
 template <typename Op, typename... Args>
 QueryOutput query_op_constraints_with_initial_state(
@@ -290,6 +296,15 @@ QueryOutput query_op_constraints_with_initial_state(
     // device teardown (tenstorrent/tt-metal#45646).
     tt::tt_metal::experimental::override_mock_allocator_state(*device, initial_state);
 
+    // Install the passive config-capture listener below the phase captures. Popped via RAII; the
+    // local shared_ptr keeps it alive until this function returns, so take_result() below is valid
+    // regardless of pop order.
+    auto capture_listener = std::make_shared<ProgramConfigCaptureProcessor>(program_config_extractors());
+    tt::tt_metal::GraphTracker::instance().push_processor(capture_listener);
+    struct PopGuard {
+        ~PopGuard() { tt::tt_metal::GraphTracker::instance().pop_processor(); }
+    } pop_guard;
+
     // Phase 1: materialize inputs as weightless handles (address=0, allocator untouched).
     auto transformed_args = [&] {
         auto phase1 = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
@@ -311,11 +326,17 @@ QueryOutput query_op_constraints_with_initial_state(
             output_allocations.push_back({buffer->buffer_type(), buffer->address(), buffer->aligned_size_per_bank()});
         }
         return QueryOutput{
-            detail::build_success_response(op_trace, outputs), std::move(new_state), std::move(output_allocations)};
+            detail::build_success_response(op_trace, outputs),
+            std::move(new_state),
+            std::move(output_allocations),
+            capture_listener->take_result()};
     } catch (const std::exception& e) {
         log_debug(tt::LogOp, "Error during stateful graph capture: {}", e.what());
         return QueryOutput{
-            detail::error_response(e.what()), tt::tt_metal::experimental::extract_mock_allocator_state(*device)};
+            detail::error_response(e.what()),
+            tt::tt_metal::experimental::extract_mock_allocator_state(*device),
+            {},
+            capture_listener->take_result()};
     }
 }
 

--- a/ttnn/cpp/ttnn/graph/capture_program_config_registry.cpp
+++ b/ttnn/cpp/ttnn/graph/capture_program_config_registry.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/graph/capture_program_config.hpp"
+
+#include <any>
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+// The single place that knows which ops expose a capturable program config. Add an op by
+// including its operation_attributes_t header and appending one make_extractor<> line below.
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+
+namespace ttnn::graph {
+namespace {
+
+// Build an extractor for attribute type AttrsT. `select` maps the attributes to the optional config
+// to capture; on a type match with a config present, that config is copied into an owned std::any.
+template <typename AttrsT, typename Select>
+ProgramConfigExtractor make_extractor(Select select) {
+    return [select = std::move(select)](const std::any& attr) -> std::optional<std::any> {
+        if (const auto* ref = std::any_cast<std::reference_wrapper<const AttrsT>>(&attr)) {
+            if (auto cfg = select(ref->get()); cfg.has_value()) {
+                return std::any(std::move(*cfg));
+            }
+        }
+        return std::nullopt;
+    };
+}
+
+}  // namespace
+
+std::span<const ProgramConfigExtractor> program_config_extractors() {
+    // Explicit registry (not static self-registration, which is fragile under static-lib dead-code
+    // stripping and static-init ordering). The extractor must copy out a config that is finalized at
+    // the point the op announces its attributes via device_operation::launch; validate that per op
+    // before adding it here.
+    static const std::vector<ProgramConfigExtractor> extractors = {
+        // Matmul: prim::matmul fills normalized_attributes.program_config (the auto-selected config)
+        // before launch, so it is present and final when the attributes are announced.
+        make_extractor<ttnn::prim::MatmulParams>(
+            [](const ttnn::prim::MatmulParams& params) { return params.program_config; }),
+    };
+    return extractors;
+}
+
+}  // namespace ttnn::graph

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -60,6 +60,7 @@ set(TTNNCPP_SRCS
     # FIXME: Move these out to appropriate sub targets
     cpp/ttnn/operations/compute_throttle_utils.cpp
     cpp/ttnn/operations/trace.cpp
+    cpp/ttnn/graph/capture_program_config_registry.cpp
     cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
     cpp/ttnn/operations/generic/generic_op.cpp
     cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -488,6 +489,7 @@ set(TTNNCPP_API_HEADERS
     api/ttnn/events.hpp
     api/ttnn/global_circular_buffer.hpp
     api/ttnn/global_semaphore.hpp
+    api/ttnn/graph/capture_program_config.hpp
     api/ttnn/graph/graph_consts.hpp
     api/ttnn/graph/graph_serialization.hpp
     api/ttnn/graph/graph_operation_queries.hpp


### PR DESCRIPTION
## What
`query_op_constraints_with_initial_state` now captures the program config ttnn auto-selects while running the op and returns it in a new op-agnostic `QueryOutput::captured_config` (`std::optional<std::any>`, owned). A passive graph-capture listener recovers the op's `operation_attributes_t` from the tracker stream; all op-specific knowledge lives in one explicit registry hub (`cpp/ttnn/graph/capture_program_config_registry.cpp`). Matmul is registered today — adding an op is one `make_extractor<>` line. The consumer unpacks with `any_cast<MatmulProgramConfig>`.

## Why
Lets tt-mlir consume the config ttnn actually chose instead of reimplementing (and drifting from) ttnn's selection heuristic.

## Tests
`MatmulProgramConfigCaptured` (interleaved) and `MatmulWidthShardedProgramConfigCaptured` (asserts the 1D multi-cast variant) round-trip the captured config back as an explicit config and confirm an identical CB/L1 footprint — the contract each op extractor must satisfy. A non-registered op (relu) is guarded to capture nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rpavlovic/poc-capture-matmul-program-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/poc-capture-matmul-program-config)