### PR TITLE
[LLK] Fix #32285: Need uint8 support in 16bit Dest

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -217,6 +217,28 @@ def test_unary_datacopy(
 
 
 @parametrize(
+    formats=input_output_formats([DataFormat.UInt8]),
+    input_dimensions=[[32, 32], [64, 64]],
+)
+def test_unary_datacopy_uint8_16bit_dest(formats, input_dimensions):
+    """UInt8 datacopy must round-trip through a 16-bit (non-FP32) Dest.
+
+    UInt8 masks to the Int8 ALU format, so math hw-config previously enabled INT8
+    math for it regardless of Dest mode; INT8 math forces an int32 Dest layout and
+    corrupts the MOVA2D copy when Dest is 16-bit, making the copy return zeros. With
+    INT8 math gated on FP32 Dest, the copy uses the normal MOVA2D path and must be
+    bit-exact.
+    """
+    _run_unary_datacopy_test(
+        formats,
+        DestAccumulation.No,
+        num_faces=4,
+        tilize=Tilize.No,
+        input_dimensions=input_dimensions,
+    )
+
+
+@parametrize(
     formats=[
         fmt
         for fmt in input_output_formats(

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -282,6 +282,14 @@ constexpr static bool is_int8_or_int32_format(const std::uint32_t format)
     return (masked_data_format(format) == to_underlying(DataFormat::Int8)) || (format == to_underlying(DataFormat::Int32));
 }
 
+// True if the format requires FP32 (32-bit) Dest to run INT8 math: Int8/Int32, but NOT UInt8.
+// UInt8 masks to the Int8 ALU format yet is a datacopy-only case that is valid in 16-bit Dest (INT8 math stays
+// off), so it is excluded here; genuine signed-Int8/Int32 math still requires FP32 Dest.
+constexpr static bool requires_fp32_dest_for_int8_math(const std::uint32_t format)
+{
+    return is_int8_or_int32_format(format) && (format != to_underlying(DataFormat::UInt8));
+}
+
 #define LOWER_HALFWORD(x) ((x) & 0xFFFF)
 #define UPPER_HALFWORD(x) ((x) >> 16)
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -10,6 +10,7 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "sanitizer/api.h"
 
 using namespace ckernel::math;
@@ -159,9 +160,10 @@ inline void _llk_math_pack_sync_init_()
  * On Blackhole the ALU source format is inferred, so this is a no-op unless the reconfiguration crosses an
  * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
+ * @note Genuine Int8/Int32 math requires FP32 Dest (asserted when to_from_int8 is set); UInt8 datacopy is exempt and runs with INT8 math off in 16-bit Dest.
  */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_format)
@@ -175,6 +177,9 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
         // Gate on FP32 dest: enabling INT8 math in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || !requires_fp32_dest_for_int8_math(srca_data_format),
+            "Reconfiguring math to/from Int8/Int32 formats requires FP32 Dest mode enabled (only UInt8 datacopy is valid in 16-bit Dest)");
         std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srca_data_format);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
@@ -189,9 +194,10 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
  * On Blackhole the ALU source format is inferred, so this is a no-op unless the reconfiguration crosses an
  * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
+ * @note Genuine Int8/Int32 math requires FP32 Dest (asserted when to_from_int8 is set); UInt8 datacopy is exempt and runs with INT8 math off in 16-bit Dest.
  */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_format)
@@ -205,6 +211,9 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
         // Gate on FP32 dest: enabling INT8 math in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || !requires_fp32_dest_for_int8_math(srcb_data_format),
+            "Reconfiguring math to/from Int8/Int32 formats requires FP32 Dest mode enabled (only UInt8 datacopy is valid in 16-bit Dest)");
         std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srcb_data_format);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
@@ -220,10 +229,11 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
  * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit
  * from both source formats.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
+ * @note Genuine Int8/Int32 math requires FP32 Dest (asserted when to_from_int8 is set); UInt8 datacopy is exempt and runs with INT8 math off in 16-bit Dest.
  */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format)
@@ -237,6 +247,9 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
         // Gate on FP32 dest: enabling INT8 math in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || (!requires_fp32_dest_for_int8_math(srca_data_format) && !requires_fp32_dest_for_int8_math(srcb_data_format)),
+            "Reconfiguring math to/from Int8/Int32 formats requires FP32 Dest mode enabled (only UInt8 datacopy is valid in 16-bit Dest)");
         std::uint32_t int8_math_enabled =
             is_fp32_dest_acc_en && (is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format));
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -30,9 +30,10 @@ inline void _llk_math_set_fp32_dest_acc_(bool enable)
 /**
  * @brief Configure the math (FPU) thread's ALU control registers for the given source data formats.
  *
- * Sets ZEROACC bank auto-detect, enables INT8 math when either source is Int8/Int32, and programs FP32 dest
- * accumulation mode. Applies HW-bug workarounds (disables debug feature bit 11) for INT8 math and for the
- * UInt16-with-FP32-dest combination.
+ * Sets ZEROACC bank auto-detect, enables INT8 math when either source is Int8/Int32 and FP32 dest accumulation
+ * is enabled, and programs FP32 dest accumulation mode. INT8 math is gated on FP32 dest because enabling it in
+ * 16-bit dest mode corrupts (u)int8 copies through MOVA2D (the FPU forces an int32 dest layout). Applies
+ * HW-bug workarounds (disables debug feature bit 11) for INT8 math and for the UInt16-with-FP32-dest combination.
  *
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @param srca_data_format: Data format of source A (DataFormat enum underlying value).
@@ -51,7 +52,9 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
     // Configure ZEROACC to auto-detect destination bank (non-legacy mode).
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(0);
-    std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
+    // Only enable INT8 math in 32-bit dest mode; enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
+    std::uint32_t int8_math_enabled =
+        is_fp32_dest_acc_en && (is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format));
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
@@ -156,7 +159,7 @@ inline void _llk_math_pack_sync_init_()
  * On Blackhole the ALU source format is inferred, so this is a no-op unless the reconfiguration crosses an
  * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  */
@@ -167,12 +170,12 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
 
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
+        // Gate on FP32 dest: enabling INT8 math in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
-        std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format);
+        std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srca_data_format);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 
@@ -186,7 +189,7 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
  * On Blackhole the ALU source format is inferred, so this is a no-op unless the reconfiguration crosses an
  * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
  */
@@ -197,12 +200,12 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
 
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
+        // Gate on FP32 dest: enabling INT8 math in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
-        std::uint32_t int8_math_enabled = is_int8_or_int32_format(srcb_data_format);
+        std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srcb_data_format);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 
@@ -217,7 +220,7 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
  * Int8/Int32 boundary (to_from_int8), in which case it re-evaluates and programs the INT8 math enable bit
  * from both source formats.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
@@ -229,12 +232,13 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
 
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
         // Only INT8_math_enabled is written here; it is FPU-only (the SFPU never reads it, and on Blackhole SrcB
         // format is inferred rather than rewritten here), so draining the FPU (MATH) suffices -- no WAIT_SFPU.
         // (Wormhole's twin uses WAIT_SFPU because there the reconfig also rewrites the SFPU-read SrcB format.)
+        // Gate on FP32 dest: enabling INT8 math in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);
-        std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
+        std::uint32_t int8_math_enabled =
+            is_fp32_dest_acc_en && (is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format));
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_INT8_math_enabled_RMW>(int8_math_enabled);
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -415,7 +415,7 @@ inline void eltwise_unary_configure_addrmod(const std::uint32_t dst_format)
 /**
  * @brief Program the datacopy MOP, selecting the move instruction (MOVA2D/MOVB2D/ELWADD) per direction, format, and broadcast.
  *
- * A2D normally uses MOVA2D but falls back to ELWADD when dest is FP32/INT (except UInt16, which stays on MOVA2D) or the datum is UInt8; B2D uses
+ * A2D normally uses MOVA2D but falls back to ELWADD when dest is FP32/INT (except UInt16, which stays on MOVA2D); B2D uses
  * MOVB2D (or ELWADD for non-UInt16 column broadcast) with loop counts derived from the broadcast type.
  *
  * @tparam type: Datacopy direction, values = <A2D/B2D>
@@ -438,9 +438,10 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
         std::uint32_t innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         std::uint32_t outerloop = tilize ? 1 : num_faces;
 
-        if (((is_fp32_dest_acc_en || is_int_fpu_en) && !(dst_format == to_underlying(DataFormat::UInt16))) || (dst_format == to_underlying(DataFormat::UInt8)))
+        if ((is_fp32_dest_acc_en || is_int_fpu_en) && !(dst_format == to_underlying(DataFormat::UInt16)))
         {
-            // use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode OR to handle uint8 datums
+            // use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode.
+            // uint8 into a 16-bit dest takes the MOVA2D path below (INT8 math stays disabled).
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -127,7 +127,7 @@ inline void _llk_unpack_configure_stoch_rnd_()
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format; reprograms the Src unsigned flag for UInt8.
  * @param unpack_src_format: New source data format of operand A in L1.
  * @param unpack_dst_format: New destination data format operand A is converted to.
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
@@ -164,7 +164,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // SrcAUnsigned selects unsigned unpacking for UInt8; it is correct in any dest mode (no FP32-dest requirement).
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 
@@ -206,7 +206,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format; reprograms the Src unsigned flag for UInt8.
  * @param unpack_src_format: New source data format of operand B in L1.
  * @param unpack_dst_format: New destination data format operand B is converted to.
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
@@ -243,7 +243,7 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // SrcBUnsigned selects unsigned unpacking for UInt8; it is correct in any dest mode (no FP32-dest requirement).
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -264,6 +264,14 @@ constexpr static bool is_int8_or_int32_format(const std::uint32_t format)
     return (masked_data_format(format) == to_underlying(DataFormat::Int8)) || (format == to_underlying(DataFormat::Int32));
 }
 
+// True if the format requires FP32 (32-bit) Dest to run INT8 math: Int8/Int32, but NOT UInt8.
+// UInt8 masks to the Int8 ALU format yet is a datacopy-only case that is valid in 16-bit Dest (INT8 math stays
+// off), so it is excluded here; genuine signed-Int8/Int32 math still requires FP32 Dest.
+constexpr static bool requires_fp32_dest_for_int8_math(const std::uint32_t format)
+{
+    return is_int8_or_int32_format(format) && (format != to_underlying(DataFormat::UInt8));
+}
+
 #define LOWER_HALFWORD(x) ((x) & 0xFFFF)
 #define UPPER_HALFWORD(x) ((x) >> 16)
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -29,8 +29,10 @@ inline void _llk_math_set_fp32_dest_acc_(bool enable)
 /**
  * @brief Configure the math (FPU) thread's ALU control registers for the given source data formats.
  *
- * Programs the source A/B ALU formats, enables INT8 math when either source is Int8/Int32, and sets FP32 dest
- * accumulation mode. Always clears debug feature bit 11 (32-bit dest mode workaround) to establish a known-good
+ * Programs the source A/B ALU formats, enables INT8 math when either source is Int8/Int32 and FP32 dest
+ * accumulation is enabled, and sets FP32 dest accumulation mode. INT8 math is gated on FP32 dest because
+ * enabling it in 16-bit dest mode corrupts (u)int8 copies through MOVA2D (the FPU forces an int32 dest layout).
+ * Always clears debug feature bit 11 (32-bit dest mode workaround) to establish a known-good
  * baseline; bit 11 is never set by any math/SFPU path (tt-llk#1568).
  *
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
@@ -45,7 +47,9 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     llk::san::math_operand_configure(srca_data_format, srcb_data_format);
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-    std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
+    // Only enable INT8 math in 32-bit dest mode; enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
+    std::uint32_t int8_math_enabled =
+        is_fp32_dest_acc_en && (is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format));
     std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                 (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
     constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
@@ -128,7 +132,7 @@ inline void _llk_math_pack_sync_init_()
  * Programs the ALU source A format register. When the reconfiguration crosses an Int8/Int32 boundary
  * (to_from_int8), it also re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  */
@@ -139,9 +143,9 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
 
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        // Gate INT8 math on FP32 dest: enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-        std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srca_data_format);
+        std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srca_data_format);
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
@@ -162,7 +166,7 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
  * Programs the ALU source B format register. When the reconfiguration crosses an Int8/Int32 boundary
  * (to_from_int8), it also re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
  */
@@ -173,9 +177,9 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
 
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        // Gate INT8 math on FP32 dest: enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-        std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srcb_data_format);
+        std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srcb_data_format);
         std::uint32_t config_data = (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_ADDR32, 0, config_mask>(config_data);
@@ -196,7 +200,7 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
  * Programs the ALU source A and source B format registers. When the reconfiguration crosses an Int8/Int32
  * boundary (to_from_int8), it also re-evaluates and programs the INT8 math enable bit from both source formats.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when to_from_int8 is set).
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
@@ -208,9 +212,10 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
 
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring math to/from Int8 formats requires FP32 Dest mode enabled");
+        // Gate INT8 math on FP32 dest: enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-        std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
+        std::uint32_t int8_math_enabled =
+            is_fp32_dest_acc_en && (is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format));
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                     (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -10,6 +10,7 @@
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "sanitizer/api.h"
 
 using namespace ckernel::math;
@@ -132,9 +133,10 @@ inline void _llk_math_pack_sync_init_()
  * Programs the ALU source A format register. When the reconfiguration crosses an Int8/Int32 boundary
  * (to_from_int8), it also re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
+ * @note Genuine Int8/Int32 math requires FP32 Dest (asserted when to_from_int8 is set); UInt8 datacopy is exempt and runs with INT8 math off in 16-bit Dest.
  */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_format)
@@ -145,6 +147,9 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     {
         // Gate INT8 math on FP32 dest: enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || !requires_fp32_dest_for_int8_math(srca_data_format),
+            "Reconfiguring math to/from Int8/Int32 formats requires FP32 Dest mode enabled (only UInt8 datacopy is valid in 16-bit Dest)");
         std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srca_data_format);
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
@@ -166,9 +171,10 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
  * Programs the ALU source B format register. When the reconfiguration crosses an Int8/Int32 boundary
  * (to_from_int8), it also re-evaluates and programs the INT8 math enable bit.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
+ * @note Genuine Int8/Int32 math requires FP32 Dest (asserted when to_from_int8 is set); UInt8 datacopy is exempt and runs with INT8 math off in 16-bit Dest.
  */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_format)
@@ -179,6 +185,9 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     {
         // Gate INT8 math on FP32 dest: enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || !requires_fp32_dest_for_int8_math(srcb_data_format),
+            "Reconfiguring math to/from Int8/Int32 formats requires FP32 Dest mode enabled (only UInt8 datacopy is valid in 16-bit Dest)");
         std::uint32_t int8_math_enabled = is_fp32_dest_acc_en && is_int8_or_int32_format(srcb_data_format);
         std::uint32_t config_data = (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
@@ -200,10 +209,11 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
  * Programs the ALU source A and source B format registers. When the reconfiguration crosses an Int8/Int32
  * boundary (to_from_int8), it also re-evaluates and programs the INT8 math enable bit from both source formats.
  *
- * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled; INT8 math is enabled only when this is set.
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
  * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
  * @param srca_data_format: New data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: New data format of source B (DataFormat enum underlying value).
+ * @note Genuine Int8/Int32 math requires FP32 Dest (asserted when to_from_int8 is set); UInt8 datacopy is exempt and runs with INT8 math off in 16-bit Dest.
  */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format)
@@ -214,6 +224,9 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     {
         // Gate INT8 math on FP32 dest: enabling it in 16-bit dest corrupts (u)int8 copies through MOVA2D.
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+        LLK_ASSERT(
+            is_fp32_dest_acc_en || (!requires_fp32_dest_for_int8_math(srca_data_format) && !requires_fp32_dest_for_int8_math(srcb_data_format)),
+            "Reconfiguring math to/from Int8/Int32 formats requires FP32 Dest mode enabled (only UInt8 datacopy is valid in 16-bit Dest)");
         std::uint32_t int8_math_enabled =
             is_fp32_dest_acc_en && (is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format));
         std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -344,7 +344,7 @@ inline void eltwise_unary_configure_addrmod(const std::uint32_t dst_format)
 /**
  * @brief Program the datacopy MOP, selecting the move instruction (MOVA2D/MOVB2D/ELWADD) per direction, format, and broadcast.
  *
- * A2D normally uses MOVA2D but falls back to ELWADD when dest is FP32/INT (except UInt16, which stays on MOVA2D) or the datum is UInt8; B2D uses
+ * A2D normally uses MOVA2D but falls back to ELWADD when dest is FP32/INT (except UInt16, which stays on MOVA2D); B2D uses
  * MOVB2D (or ELWADD for non-UInt16 column broadcast) with loop counts derived from the broadcast type.
  *
  * @tparam type: Datacopy direction, values = <A2D/B2D>
@@ -366,9 +366,10 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
         std::uint32_t innerloop = (rows_per_inst == p_mova2d::MOV_1_ROW) ? total_rows : (total_rows >> 3);
         std::uint32_t outerloop = num_faces;
 
-        if (((is_fp32_dest_acc_en || is_int_fpu_en) && !(dst_format == to_underlying(DataFormat::UInt16))) || (dst_format == to_underlying(DataFormat::UInt8)))
+        if ((is_fp32_dest_acc_en || is_int_fpu_en) && !(dst_format == to_underlying(DataFormat::UInt16)))
         {
-            // use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode OR to handle uint8 datums
+            // use elwadd to handle unpacking data into src A as fp16, but dest is in fp32 mode.
+            // uint8 into a 16-bit dest takes the MOVA2D path below (INT8 math stays disabled).
             ckernel_template tmp(outerloop, innerloop, TT_OP_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -132,7 +132,7 @@ inline void _llk_unpack_configure_stoch_rnd_()
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format; reprograms the Src unsigned flag for UInt8.
  * @param unpack_src_format: New source data format of operand A in L1.
  * @param unpack_dst_format: New destination data format operand A is converted to.
  * @param tile_size: New tile size of operand A stored to the tile-size GPR.
@@ -169,7 +169,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // SrcAUnsigned selects unsigned unpacking for UInt8; it is correct in any dest mode (no FP32-dest requirement).
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcAUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 
@@ -208,7 +208,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
  *
  * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
- * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format; reprograms the Src unsigned flag for UInt8.
  * @param unpack_src_format: New source data format of operand B in L1.
  * @param unpack_dst_format: New destination data format operand B is converted to.
  * @param tile_size: New tile size of operand B stored to the tile-size GPR.
@@ -245,7 +245,7 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK1);
     if constexpr (to_from_int8)
     {
-        static_assert(is_fp32_dest_acc_en, "Reconfiguring unpack to/from Int8 formats requires FP32 Dest mode enabled");
+        // SrcBUnsigned selects unsigned unpacking for UInt8; it is correct in any dest mode (no FP32-dest requirement).
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcBUnsigned_RMW>((unpack_src_format == to_underlying(DataFormat::UInt8)) ? 1 : 0);
     }
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

[LLK] Enable uint8 in 16-bit Dest: gate INT8 math on FP32 dest (BH+WH)

UInt8 masks to the Int8 ALU format, so _llk_math_hw_configure_ enabled INT8 math
for it regardless of Dest mode. INT8 math forces an int32 Dest layout and corrupts
the MOVA2D copy of uint8 into a 16-bit Dest (returns zeros/garbage). Gate INT8 math
on is_fp32_dest_acc_en in hw_configure and the math reconfig paths, let uint8 take
the normal MOVA2D datacopy path in 16-bit Dest, and drop the FP32-dest static_assert
from the (u)int8 reconfig paths. Verified on-card (BH+WH): uint8->uint8 16-bit-dest
datacopy round-trips bit-exactly (fails without the fix).

Resolves tenstorrent/tt-metal#32285

Fixes #32285

### Notes for reviewers

Diffstat: 7 files changed, 72 insertions(+), 39 deletions(-).

Files touched:
- `tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy.py`
- `tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h`
- `tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h`
- `tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h`
- `tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h`
- `tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h`
- `tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h`

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-32285-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-32285-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-32285-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-32285-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-32285-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-32285-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-32285-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-32285-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-32285-v1)