### PR TITLE
[LLK] Fix #11384

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
@@ -29,12 +29,15 @@ inline void apply_activation(sfpi::vFloat& v) {
     ActivationImpl<APPROXIMATION_MODE, ACTIVATION_TYPE>::apply(v);
 }
 
-template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS, bool fp32_dest_acc_en>
 inline void calculate_activation() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::convert<sfpi::vFloat16b>(v, sfpi::RoundMode::Nearest);
+        }
         sfpi::dst_reg[0] = v;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -10,16 +10,16 @@
 
 namespace ckernel::sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en>
 inline void calculate_square() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // Load input from destination into LREG0
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-        // Multiply LREG0 * LREG0, store result in LREG0
-        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        // Store result back to destination
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v = v * v;
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::convert<sfpi::vFloat16b>(v, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
@@ -29,12 +29,15 @@ inline void apply_activation(sfpi::vFloat& v) {
     ActivationImpl<APPROXIMATION_MODE, ACTIVATION_TYPE>::apply(v);
 }
 
-template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS, bool fp32_dest_acc_en>
 inline void calculate_activation() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::convert<sfpi::vFloat16b>(v, sfpi::RoundMode::Nearest);
+        }
         sfpi::dst_reg[0] = v;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -10,12 +10,16 @@
 
 namespace ckernel::sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en>
 inline void calculate_square() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = v * v;
+        v = v * v;
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::convert<sfpi::vFloat16b>(v, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -243,7 +243,8 @@ ALWI void tanh_tile(uint32_t idst) {
 // clang-format on
 ALWI void square_tile(uint32_t idst) {
 #ifndef ARCH_QUASAR
-    MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX), idst, VectorMode::RC));
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX, 8 /*ITERATIONS*/, DST_ACCUM_MODE), idst, VectorMode::RC));
 #else
     MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (SFPU_ITERATIONS), idst, VectorMode::RC));
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
@@ -34,7 +34,7 @@ ALWI void hardsigmoid_tile(uint32_t idst) {
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
         calculate_activation,
-        (APPROX, ckernel::ActivationType::Hardsigmoid, 8 /* ITERATIONS */),
+        (APPROX, ckernel::ActivationType::Hardsigmoid, 8 /* ITERATIONS */, DST_ACCUM_MODE),
         idst,
         VectorMode::RC));
 }
@@ -44,7 +44,7 @@ ALWI void hardsigmoid_tile_pack(uint32_t idst) {
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
         calculate_activation,
-        (APPROX, ckernel::ActivationType::Hardsigmoid, 8 /* ITERATIONS */),
+        (APPROX, ckernel::ActivationType::Hardsigmoid, 8 /* ITERATIONS */, DST_ACCUM_MODE),
         idst,
         VectorMode::RC));
 }

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -596,7 +596,12 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     else if constexpr (OPERATION == SfpuType::hardsigmoid)
     {
         SFPU_UNARY_CALL(
-            DST_SYNC_MODE, DST_ACCUM_MODE, calculate_activation, (APPROX_MODE, ckernel::ActivationType::Hardsigmoid, ITERATIONS), dst_index, vector_mode);
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            calculate_activation,
+            (APPROX_MODE, ckernel::ActivationType::Hardsigmoid, ITERATIONS, is_fp32_dest_acc_en),
+            dst_index,
+            vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::log)
     {
@@ -653,7 +658,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::square)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::tanh)
     {


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Improve SFPU kernel accuracy for fp16b using rounding

Differentiate the SFPU store on is_fp32_dest_acc_en for square and hardsigmoid on
Blackhole (and Wormhole, for the shared arch-agnostic Compute API): round the fp32
LREG result to bf16 (sfpi::convert<vFloat16b>, RoundMode::Nearest) before storing to
a 16-bit DEST instead of truncating. Mirrors the existing sqrt/trig/gelu precedent.
Verified on Blackhole silicon: square+hardsigmoid 216/216 pass (fp16b and fp32 paths).

Fixes #11384

### Notes for reviewers

Diffstat: 7 files changed, 32 insertions(+), 16 deletions(-).

Files touched:
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h`
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h`
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h`
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h`
- `tt_metal/hw/inc/api/compute/compute_kernel_api.h`
- `tt_metal/hw/inc/api/compute/eltwise_unary/activations.h`
- `tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h`

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-11384-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-11384-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-11384-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-11384-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-11384-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-11384-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-11384-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-11384-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-11384-v1)