### PR TITLE
[skip ci] Fix Llama-3.3-70B Galaxy demo parametrize mismatch (missing token_accuracy in seqlen-sweep case)

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -767,6 +767,7 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # apc_test
             False,  # pcc_check
+            False,  # token_accuracy
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs


### PR DESCRIPTION
## Summary

`models/demos/llama3_70b_galaxy/demo/text_demo.py::test_demo_text` fails at **pytest collection** because its parametrize declares **20 argnames** but the **`seqlen-sweep`** value tuple has only **19** — it skips `token_accuracy` (the 13th arg, between `pcc_check` and `prefill_profile`). Result: `collected 0 items / 1 error`, exit 2 → the entire **Llama-3.3-70B e2e (Galaxy)** job errors, no tests run.

```
ERROR collecting .../llama3_70b_galaxy/demo/text_demo.py
test_demo_text: in "parametrize" the number of names (20) must be equal to the number of values (19)
```

## Root cause

Introduced by #45862 (seqlen-sweep tests): the `seqlen-sweep` case was added but its value tuple omitted `token_accuracy`. (Note: the CI auto-triage guessed `prefix_cached_ratio` was missing — that value is actually present; the missing one is `token_accuracy`.)

## Fix

Add `False,  # token_accuracy` to the `seqlen-sweep` tuple. Verified via AST that **all 22 value tuples now have 20 values** matching the 20 argnames.

## Why it surfaced on 2026-07-07

Failing job: [run 28838891464](https://github.com/tenstorrent/tt-metal/actions/runs/28838891464/job/85529369957). On earlier days the Galaxy job died in the pre-test `reset.sh` (board-reset infra) before reaching collection, masking this. On 07-07 it reached collection and the mismatch surfaced.

## Validation
- [x] AST check: 20 argnames, 22 tuples, all length 20 (no mismatch).
- [ ] Next Tier 1 E2E (Galaxy) run collects + runs the test (pending healthy Galaxy runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/llama70b-galaxy-parametrize-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/llama70b-galaxy-parametrize-fix)