### PR TITLE
[draft] TT-DiT CI: bump Flux timeouts 20->30 + deselect inapplicable topo cases in common

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -319,7 +319,7 @@ models:
     wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 20
-    bh_quietbox_2: 237  # GPT-OSS-120B 15->22 (host-variance headroom)
+    bh_quietbox_2: 257  # GPT-OSS-120B 15->22; TT-DiT Flux.1-dev/-schnell 20->30 each (+20)
     bh_galaxy: 70
   unit_tier2:
     wh_llmbox: 114

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -319,7 +319,7 @@ models:
     wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 20
-    bh_quietbox_2: 257  # GPT-OSS-120B 15->22; TT-DiT Flux.1-dev/-schnell 20->30 each (+20)
+    bh_quietbox_2: 251  # GPT-OSS-120B 15->22; TT-DiT Flux.1-dev/-schnell 20->27 each (+14)
     bh_galaxy: 70
   unit_tier2:
     wh_llmbox: 114

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -711,7 +711,7 @@
   model: flux.1-schnell
   skus:
     bh_quietbox_2:
-      timeout: 30  # was 20: full Flux pipeline+transformer exceeds 20 min on bh_quietbox_2
+      timeout: 27  # was 20: cold-JIT day (07-06) killed at 20m00s; warm ~4-8m. 27 keeps cold margin.
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
@@ -726,7 +726,7 @@
   model: flux.1-dev
   skus:
     bh_quietbox_2:
-      timeout: 30  # was 20: full Flux pipeline+transformer exceeds 20 min (07-07: 22m50s) on bh_quietbox_2
+      timeout: 27  # was 20: cold-JIT day (07-06) killed at 20m00s (cited peak 22m50s); warm ~9-11m. 27 keeps cold margin.
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -654,7 +654,11 @@
 
 - name: TT-DiT common unit tests, shared amongst all models.
   cmd: |
-    pytest --timeout 10000 models/tt_dit/tests/unit/
+    # Deselect the multi-node topology cases (wh_glx / wh_t3k / bh_glx) that runtime-skip
+    # on bh_quietbox_2 / wh_n150 anyway — ~1100 skips of log spam that push real failures
+    # past GitHub's log-truncation limit (a genuine crash/hang was being hidden). No change
+    # to what actually executes on these SKUs.
+    pytest --timeout 10000 models/tt_dit/tests/unit/ -k "not wh_glx and not wh_t3k and not bh_glx"
   model: dit-common
   skus:
     wh_n150:
@@ -708,7 +712,7 @@
   model: flux.1-schnell
   skus:
     bh_quietbox_2:
-      timeout: 20
+      timeout: 30  # was 20: full Flux pipeline+transformer exceeds 20 min on bh_quietbox_2
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
@@ -723,7 +727,7 @@
   model: flux.1-dev
   skus:
     bh_quietbox_2:
-      timeout: 20
+      timeout: 30  # was 20: full Flux pipeline+transformer exceeds 20 min (07-07: 22m50s) on bh_quietbox_2
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -654,10 +654,9 @@
 
 - name: TT-DiT common unit tests, shared amongst all models.
   cmd: |
-    # Deselect the multi-node topology cases (wh_glx / wh_t3k / bh_glx) that runtime-skip
-    # on bh_quietbox_2 / wh_n150 anyway — ~1100 skips of log spam that push real failures
-    # past GitHub's log-truncation limit (a genuine crash/hang was being hidden). No change
-    # to what actually executes on these SKUs.
+    # Deselect wh_glx / wh_t3k / bh_glx topology cases: they runtime-skip on bh_quietbox_2
+    # and wh_n150 anyway, and their skip lines bloat the log past GitHub truncation, hiding
+    # real failures. No change to what actually runs on these SKUs.
     pytest --timeout 10000 models/tt_dit/tests/unit/ -k "not wh_glx and not wh_t3k and not bh_glx"
   model: dit-common
   skus:


### PR DESCRIPTION
## Summary (draft — for validation + James Lee review)

Two distinct TT-DiT suite issues from the 2026-07-07 scheduled Tier 1 Unit run:

### 1. Flux.1-dev / Flux.1-schnell [bh_quietbox_2] — real timeout
Both hit their **20-min** job budget (Flux.1-dev ran **22m50s**). The full Flux pipeline + transformer test doesn't fit 20 min on bh_quietbox_2. → **bump both to 30 min**; matching `time_budget.yaml` `unit_tier1.bh_quietbox_2` **237 → 257** (verify_time_budget: 254 ≤ 257 ✅).

### 2. TT-DiT common [bh_quietbox_2] — hidden failure, not a timeout
It failed at **~59 min against a 115-min budget** — so **not** the job timeout, as first assumed. Tests were passing (PCC 99.99%), but the **terminal crash/hang cause was pushed past GitHub's log-truncation limit** by ~1100 skipped-case log lines (2122 skips total, mostly `wh_glx`/`wh_t3k`/`bh_glx` topology cases that runtime-skip on bh_quietbox_2 / wh_n150).
→ **Deselect those inapplicable topology cases** with `-k "not wh_glx and not wh_t3k and not bh_glx"`. This changes **nothing** about what executes on these SKUs (those cases already skip) — it just removes the log spam so the **real failure becomes visible** in the re-run.

## Validation
- [x] YAML parses; `verify_time_budget` passes (unit_tier1 bh_quietbox_2 254 ≤ 257).
- [ ] Re-run TT-DiT jobs on bh_quietbox_2: Flux.1-dev/-schnell pass within 30 min; **common surfaces its real terminal failure** (the point of the deselect).

**Note:** change (2) is diagnostic — it does not *fix* the common suite's crash/hang; it makes it visible. Once the re-run shows the terminal cause, that's a separate fix (likely for @jamesleeTT / owner U0ATR08RCQ0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/ttdit-suite-timeout-and-deselect)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/ttdit-suite-timeout-and-deselect)