### PR TITLE
[LLK] Fix #46474: [LLK Perf] perf_pack_untilize: Bfp8_b × tile_cnt ≥ 32 rows bimodal on Blackhole post-#44596

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -123,16 +123,24 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
     */
     tmp.set_start_op(TT_OP_ADDRCRZW(p_setadc::PAC, 0, 0, 0, 0, 0b0010 /*CH0_W*/)); // W = W_Cr (restore W to start of block)
 
-    const std::uint32_t replay_buf_len = 2;
+    const std::uint32_t replay_buf_len = 3;
     load_replay_buf(
         ckernel::packer::replay_buf_offset,
         replay_buf_len,
         []
         {
+            // Serialize the per-row L1-dest-address update against the packer. The row-closing
+            // PACR (ADDR_MOD_1) still reads the OLD THCON_SEC0_REG1_L1_Dest_addr; hold this config
+            // RMW at the Wait Gate until THCON drains so the write is ordered after that read
+            // deterministically. Without this fence the config-write->PACR ordering rests on the
+            // implicit interlock whose stall length tracks pack-pipe occupancy, which made Bfp8_b
+            // pack_untilize cycle counts bimodal at tile_cnt >= 32. This restores the barrier the
+            // CFGSHIFTMASK fusion dropped while keeping that fusion (3 instrs/row vs the old 4).
+            // Mirrors the guard idiom in _llk_pack_untilize_init_ and _llk_unpack_tilize_init_.
+            TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
             // THCON_SEC0_REG1_L1_Dest_addr_ADDR32 += SCRATCH_SEC[CurrentThread].val
             // Scratch slot loaded in _llk_pack_untilize_init_ holds the per-row L1 stride.
-            // Replaces ADDDMAREG + STALLWAIT + WRCFG + NOP — saves ~3 cyc + 1 STALLWAIT per row.
-            // Mirrors llk_unpack_tilize.h:285 precedent.
+            // Mirrors llk_unpack_tilize.h precedent.
             TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
             TTI_NOP;
         });


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

[LLK Perf] perf_pack_untilize: Bfp8_b × tile_cnt ≥ 32 rows bimodal on Blackhole post-#44596

Fixes #46474

### Notes for reviewers

Diffstat: 1 file changed, 11 insertions(+), 3 deletions(-).

Files touched:
- `tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h`

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-46474-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-46474-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-46474-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-46474-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-46474-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-46474-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-46474-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-46474-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-46474-v1)