### PR TITLE
Fix PCC assertion failures for single-element bfloat8_b tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -9,9 +9,14 @@ import ttnn
 from models.common.utility_functions import torch_random
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_div_by_zero_outputs
+from tests.ttnn.utils_for_testing import assert_allclose, assert_with_pcc, assert_with_ulp, assert_div_by_zero_outputs
 
 pytestmark = pytest.mark.use_module_device
+
+# Looser than assert_quality bf8 defaults (rtol=0.05, atol=0.025): golden is full float on
+# bf8-rounded input while device output is bf8-quantized; squared_difference worst case ~31%.
+_BF8_SINGLE_ELEM_RTOL = 0.4
+_BF8_SINGLE_ELEM_ATOL = 0.35
 
 
 binary_fns = [
@@ -775,8 +780,25 @@ def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
     golden_fn = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_fn(torch_input_tensor_a, scalar)
 
-    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
-    assert status >= 0.999
+    if output_tensor.numel() == 1:
+        if ttnn_fn == "divide" and scalar == 0.0:
+            # No zero-replacement here (unlike test_edgecase_dims); also ensure inf-vs-NaN classification matches.
+            assert torch.equal(
+                torch.isinf(torch_output_tensor),
+                torch.isinf(output_tensor),
+            ), "Inf positions differ between golden and device"
+            assert_div_by_zero_outputs(torch_output_tensor, output_tensor)
+        elif ttnn_fn in ("gt", "lt", "le", "ge", "eq", "ne"):
+            assert torch.equal(torch_output_tensor, output_tensor)
+        else:
+            assert_allclose(
+                torch_output_tensor,
+                output_tensor,
+                rtol=_BF8_SINGLE_ELEM_RTOL,
+                atol=_BF8_SINGLE_ELEM_ATOL,
+            )
+    else:
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize("input_shape", [(1, 1, 1, 1), (3, 3, 15, 15), (3, 3, 17, 17), (3, 3, 33, 33)])


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/49482

### PR Category
Test Only

### Summary
`test_opt_output_scalar` was failing with `AssertionError: 0.0 >= 0.999` for 23 parametrized cases after #48276. All failures were `shape=(1,1,1,1)` + arithmetic op (`add`, `sub`, `mul`, `divide`, `rsub`, `squared_difference`).
PCC is unreliable for N=1 single-element outputs: it can false-fail (e.g. zero vs non-zero → 0.0) or false-pass (other mismatches → 1.0 via MaskedConstant). Comparison ops were unaffected because outputs are exactly 0/1 in bf8.
### Changes
- N=1: bypass PCC and use `assert_allclose` with bf8-tuned tolerances (`_BF8_SINGLE_ELEM_RTOL=0.4`, `_BF8_SINGLE_ELEM_ATOL=0.35`) — looser than `assert_quality` defaults (0.05/0.025) because golden is full float on bf8-rounded input while device output is bf8-quantized; worst case ~31% on `squared_difference`.
- N=1 divide + `scalar==0.0`: use shared `assert_div_by_zero_outputs` (non-finite mask + inf sign), not plain allclose.
- Multi-element outputs: unchanged PCC check (`>= 0.999`).

### Pipeline status

- [x] Sanity
- [x] BH Sanity

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/pcc_ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/pcc_ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/pcc_ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/pcc_ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/pcc_ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/pcc_ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/pcc_ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/pcc_ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/pcc_ng)