### PR TITLE
[LLK] Fix #44910: [LLK Perf] Perf Infra speed-of-light perf test variant produces unstable perf results

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/src/brisc.cpp
+++ b/tt_metal/tt-llk/tests/helpers/src/brisc.cpp
@@ -25,6 +25,19 @@ static const mailbox_t mailboxes_arr = reinterpret_cast<mailbox_t>(0x1FFB8U);
 #define ARCH_CYCLE_MICRO_SECOND 1350
 #endif
 
+// Command-mailbox poll cadence. While idle (waiting for the host to issue the
+// next START/RESET) BRISC polls every microsecond so command acknowledgement
+// stays snappy. Once BRISC has released the TRISCs to run a profiled kernel it
+// polls far less often: every command-mailbox load is an L1 access that contends
+// with the TRISCs' unpack/pack traffic and skews the perf measurement running on
+// them. Polling coarsely during the measurement window removes almost all of
+// that periodic contention, so measurements converge to their contention-free
+// value and stop drifting run-to-run. RESET_TRISCS is still
+// observed within one coarse interval (~64us) — orders of magnitude below the
+// host's command timeout — so TRISC hang-recovery is unaffected.
+constexpr std::uint32_t IDLE_POLL_CYCLES        = ARCH_CYCLE_MICRO_SECOND;
+constexpr std::uint32_t MEASUREMENT_POLL_CYCLES = 64 * ARCH_CYCLE_MICRO_SECOND;
+
 static const mailbox_t mailbox_unpack = mailboxes_arr;
 static const mailbox_t mailbox_math   = mailboxes_arr + 1;
 static const mailbox_t mailbox_pack   = mailboxes_arr + 2;
@@ -85,6 +98,10 @@ int main()
     std::uint32_t TRISC_ADDR_CACHE[3] = {};
 #endif
 
+    // Coarse while a profiled kernel is running (set on START), fast while idle
+    // (set on RESET). See IDLE_POLL_CYCLES / MEASUREMENT_POLL_CYCLES above.
+    std::uint32_t poll_cycles = IDLE_POLL_CYCLES;
+
     while (true)
     {
         ckernel::invalidate_data_cache();
@@ -134,6 +151,11 @@ int main()
 
                 reset_state(counter);
                 commit_store(brisc_bread0, counter);
+
+                // TRISCs are now running the profiled kernel: back off to coarse
+                // polling so BRISC stays quiescent on L1 during the measurement
+                // window. The next command will be RESET_TRISCS.
+                poll_cycles = MEASUREMENT_POLL_CYCLES;
                 break;
 
             case BriscCommandState::RESET_TRISCS:
@@ -141,14 +163,19 @@ int main()
 
                 reset_state(counter);
                 commit_store(brisc_bread1, counter);
+
+                // Idle again: poll frequently so the next START is acknowledged
+                // with minimal latency.
+                poll_cycles = IDLE_POLL_CYCLES;
                 break;
 
             default:
                 break;
         }
 
-        // Wait for 1us before polling again
-        ckernel::wait(ARCH_CYCLE_MICRO_SECOND);
+        // Wait before polling the command mailbox again: coarse while a profiled
+        // kernel is running (quiescent BRISC), fine while idle.
+        ckernel::wait(poll_cycles);
     }
 }
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

[LLK Perf] speed-of-light perf test variant produces unstable perf results

Make the BRISC command-loop poll the command mailbox coarsely (~64us) while a
profiled kernel is running, instead of every 1us. The persistent BRISC polling
loop runs concurrently with the TRISC kernels being profiled; each 1us
command-mailbox load is an L1 access that arbitrates against the TRISCs'
unpack/pack traffic and perturbs the TILE_LOOP x L1_TO_L1 measurement, causing
the observed run-to-run drift under --speed-of-light. Polling coarsely during
the measurement window (fast again when idle) makes BRISC quiescent on L1 so
measurements converge to their contention-free value. RESET_TRISCS is still
observed within one coarse interval (<< the host 1s command timeout), so TRISC
hang-recovery is unaffected.

Verified on WH silicon: test_eltwise_unary_datacopy.py 654 passed / 162 skipped.

Fixes #44910

### Notes for reviewers

Diffstat: 1 file changed, 29 insertions(+), 2 deletions(-).

Files touched:
- `tt_metal/tt-llk/tests/helpers/src/brisc.cpp`

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-44910-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-44910-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-44910-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-44910-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-44910-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-44910-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-44910-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-44910-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-44910-v1)