### PR TITLE
[LLK] 16x32 tiny-tile support for SDPA reduce_block_max_row + sub_bcast_col_custom

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -41,44 +41,57 @@ namespace tt::tt_metal::unit_tests::compute::mul_reduce_scalar {
 
 struct MulReduceScalarConfig {
     uint32_t num_tiles = 1;
+    // Tile row height. 32 -> standard 32x32 tiles (4 faces); 16 -> 16x32 "tiny
+    // tiles" (2 faces, one face-row). Column dimension is always 32.
+    uint32_t tile_height = 32;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
     uint32_t seed = 12345;
 };
 
-constexpr uint32_t TILE_BYTE_SIZE = 2 * 32 * 32;  // bfloat16: 2 bytes * 32 * 32 elements
+constexpr uint32_t TILE_WIDTH = 32;
 
 bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulReduceScalarConfig& config) {
     IDevice* device = mesh_device.get_devices()[0];
     tt_metal::Program program = tt_metal::CreateProgram();
     CoreCoord core = {0, 0};
 
-    uint32_t input_buffer_size = config.num_tiles * TILE_BYTE_SIZE;
+    // bfloat16: 2 bytes per element; a 16x32 tiny tile is half a full tile.
+    const uint32_t tile_byte_size = 2 * config.tile_height * TILE_WIDTH;
+    const tt::tt_metal::Tile cb_tile({config.tile_height, TILE_WIDTH});
+    const bool tiny_tile = (config.tile_height != 32);
+
+    uint32_t input_buffer_size = config.num_tiles * tile_byte_size;
     tt_metal::InterleavedBufferConfig dram_config = {
         .device = device,
         .size = input_buffer_size,
-        .page_size = TILE_BYTE_SIZE,
+        .page_size = tile_byte_size,
         .buffer_type = tt_metal::BufferType::DRAM};
     auto src0_dram_buffer = CreateBuffer(dram_config);
     auto src1_dram_buffer = CreateBuffer(dram_config);
 
-    dram_config.size = TILE_BYTE_SIZE;
+    dram_config.size = tile_byte_size;
     auto dst_dram_buffer = CreateBuffer(dram_config);
 
     uint32_t cb_tiles = std::max(8u, config.num_tiles);
-    uint32_t cb_size = cb_tiles * TILE_BYTE_SIZE;
+    uint32_t cb_size = cb_tiles * tile_byte_size;
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_0, tt::DataFormat::Float16_b}})
-            .set_page_size(tt::CBIndex::c_0, TILE_BYTE_SIZE);
-    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
-
+            .set_page_size(tt::CBIndex::c_0, tile_byte_size);
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, tt::DataFormat::Float16_b}})
-            .set_page_size(tt::CBIndex::c_1, TILE_BYTE_SIZE);
-    tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
-
+            .set_page_size(tt::CBIndex::c_1, tile_byte_size);
     tt_metal::CircularBufferConfig cb_out_config =
         tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_16, tt::DataFormat::Float16_b}})
-            .set_page_size(tt::CBIndex::c_16, TILE_BYTE_SIZE);
+            .set_page_size(tt::CBIndex::c_16, tile_byte_size);
+    if (tiny_tile) {
+        // Advertise the 16x32 tile geometry so the compute kernel derives
+        // num_faces=2 from the operand CBs via get_operand_num_faces().
+        cb_src0_config.set_tile_dims(tt::CBIndex::c_0, cb_tile);
+        cb_src1_config.set_tile_dims(tt::CBIndex::c_1, cb_tile);
+        cb_out_config.set_tile_dims(tt::CBIndex::c_16, cb_tile);
+    }
+    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
     tt_metal::CreateCircularBuffer(program, core, cb_out_config);
 
     // Set up compile-time arguments for the reader kernel using TensorAccessor
@@ -118,7 +131,7 @@ bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulR
 
     SetRuntimeArgs(program, mul_reduce_kernel, core, {config.num_tiles});
 
-    uint32_t byte_size = config.num_tiles * TILE_BYTE_SIZE;
+    uint32_t byte_size = config.num_tiles * tile_byte_size;
     auto packed_input0 = test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         0, 1.0f, byte_size / sizeof(bfloat16), config.seed);
 
@@ -178,14 +191,15 @@ bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulR
 
 using namespace tt::tt_metal::unit_tests::compute::mul_reduce_scalar;
 
-// Test fixture that automatically skips if not on Blackhole
-class MulReduceScalarTest : public LLKBlackholeSingleCardFixture, public testing::WithParamInterface<int> {};
+// Runs on any single card (Wormhole or Blackhole); mul_reduce_scalar is
+// supported on both architectures.
+class MulReduceScalarTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
 
-// Single parametrized test
+// Standard 32x32-tile suite parametrized by tile count.
 TEST_P(MulReduceScalarTest, MulReduceScalar) {
     auto& mesh_device = *devices_[0];
     int num_tiles = GetParam();
-    ASSERT_TRUE(run_mul_reduce_scalar_test(mesh_device, {.num_tiles = num_tiles}));
+    ASSERT_TRUE(run_mul_reduce_scalar_test(mesh_device, {.num_tiles = num_tiles, .tile_height = 32}));
 }
 
 // Instantiate the test suite with different tile counts
@@ -194,3 +208,20 @@ INSTANTIATE_TEST_SUITE_P(
     MulReduceScalarTest,
     testing::Values(1, 2, 3, 7, 8),
     [](const testing::TestParamInfo<int>& info) { return "MulReduceScalar_" + std::to_string(info.param) + "_Tiles"; });
+
+// 16x32 "tiny tile" (num_faces=2) suite parametrized by tile count.
+class MulReduceScalarTinyTileTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
+
+TEST_P(MulReduceScalarTinyTileTest, MulReduceScalarTinyTile) {
+    auto& mesh_device = *devices_[0];
+    int num_tiles = GetParam();
+    ASSERT_TRUE(run_mul_reduce_scalar_test(mesh_device, {.num_tiles = num_tiles, .tile_height = 16}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MulReduceScalarTinyTileTests,
+    MulReduceScalarTinyTileTest,
+    testing::Values(1, 2, 3, 7, 8),
+    [](const testing::TestParamInfo<int>& info) {
+        return "MulReduceScalar_16x32_" + std::to_string(info.param) + "_Tiles";
+    });

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
@@ -48,17 +49,15 @@ struct MulReduceScalarConfig {
     uint32_t seed = 12345;
 };
 
-constexpr uint32_t TILE_WIDTH = 32;
-
 bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulReduceScalarConfig& config) {
     IDevice* device = mesh_device.get_devices()[0];
     tt_metal::Program program = tt_metal::CreateProgram();
     CoreCoord core = {0, 0};
 
     // bfloat16: 2 bytes per element; a 16x32 tiny tile is half a full tile.
-    const uint32_t tile_byte_size = 2 * config.tile_height * TILE_WIDTH;
-    const tt::tt_metal::Tile cb_tile({config.tile_height, TILE_WIDTH});
-    const bool tiny_tile = (config.tile_height != 32);
+    const uint32_t tile_byte_size = 2 * config.tile_height * tt::constants::TILE_WIDTH;
+    const tt::tt_metal::Tile cb_tile({config.tile_height, tt::constants::TILE_WIDTH});
+    const bool tiny_tile = (config.tile_height != tt::constants::TILE_HEIGHT);
 
     uint32_t input_buffer_size = config.num_tiles * tile_byte_size;
     tt_metal::InterleavedBufferConfig dram_config = {

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
@@ -20,6 +20,8 @@ void kernel_main() {
     constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(4);
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(5);
     constexpr uint32_t do_eltwise = get_compile_time_arg_val(6);
+    // Operand tile geometry: 4 faces for a 32x32 tile, 2 faces for a 16x32 tiny tile.
+    constexpr uint32_t num_faces = get_compile_time_arg_val(7);
 
     // Init compute
     compute_kernel_hw_startup<SrcOrder::Reverse>(qk_im_cb, qk_im_cb, qk_im_cb);
@@ -48,8 +50,8 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < rows; i++) {
         tile_regs_acquire();
-        reduce_block_max_row_init<cols>(out_max_cb);
-        reduce_block_max_row<cols>(qk_im_cb, scale_cb, i * cols, reduce_dst_idx);
+        reduce_block_max_row_init<cols, /*respect_trigger=*/false, num_faces>(out_max_cb);
+        reduce_block_max_row<cols, /*respect_trigger=*/false, num_faces>(qk_im_cb, scale_cb, i * cols, reduce_dst_idx);
         reduce_block_max_row_uninit(qk_im_cb);
 
         if (do_eltwise) {

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
@@ -11,17 +11,20 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/reduce_custom.h"
 #include "api/compute/binary_max_min.h"
+#include "tensor_shape.h"
 
 void kernel_main() {
-    constexpr uint32_t qk_im_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t prev_max_cb = get_compile_time_arg_val(1);
-    constexpr uint32_t out_max_cb = get_compile_time_arg_val(2);
-    constexpr uint32_t scale_cb = get_compile_time_arg_val(3);
-    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(4);
-    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(5);
-    constexpr uint32_t do_eltwise = get_compile_time_arg_val(6);
+    constexpr std::uint32_t qk_im_cb = get_compile_time_arg_val(0);
+    constexpr std::uint32_t prev_max_cb = get_compile_time_arg_val(1);
+    constexpr std::uint32_t out_max_cb = get_compile_time_arg_val(2);
+    constexpr std::uint32_t scale_cb = get_compile_time_arg_val(3);
+    constexpr std::uint32_t Sq_chunk_t = get_compile_time_arg_val(4);
+    constexpr std::uint32_t Sk_chunk_t = get_compile_time_arg_val(5);
+    constexpr std::uint32_t do_eltwise = get_compile_time_arg_val(6);
     // Operand tile geometry: 4 faces for a 32x32 tile, 2 faces for a 16x32 tiny tile.
-    constexpr uint32_t num_faces = get_compile_time_arg_val(7);
+    constexpr std::uint32_t num_faces = get_compile_time_arg_val(7);
+    // 16x32 tiny tile (num_faces=2) is a single face-row (num_faces_r_dim=1); 32x32 (num_faces=4) is 2x2.
+    const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(num_faces);
 
     // Init compute
     compute_kernel_hw_startup<SrcOrder::Reverse>(qk_im_cb, qk_im_cb, qk_im_cb);
@@ -38,20 +41,21 @@ void kernel_main() {
     pack_reconfig_data_format(out_max_cb);
 
     // Custom block-based reduce_block_max_row implementation
-    constexpr uint32_t rows = Sq_chunk_t;
-    constexpr uint32_t cols = Sk_chunk_t;
-    constexpr uint32_t num_tiles = rows * cols;
+    constexpr std::uint32_t rows = Sq_chunk_t;
+    constexpr std::uint32_t cols = Sk_chunk_t;
+    constexpr std::uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);
     cb_wait_front(qk_im_cb, num_tiles);
     cb_reserve_back(out_max_cb, rows);
 
-    constexpr uint32_t reduce_dst_idx = 0;
-    constexpr uint32_t prev_max_dst_idx = 1;
+    constexpr std::uint32_t reduce_dst_idx = 0;
+    constexpr std::uint32_t prev_max_dst_idx = 1;
 
-    for (uint32_t i = 0; i < rows; i++) {
+    for (std::uint32_t i = 0; i < rows; i++) {
         tile_regs_acquire();
-        reduce_block_max_row_init<cols, /*respect_trigger=*/false, num_faces>(out_max_cb);
-        reduce_block_max_row<cols, /*respect_trigger=*/false, num_faces>(qk_im_cb, scale_cb, i * cols, reduce_dst_idx);
+        reduce_block_max_row_init<cols, /*respect_trigger=*/false>(tensor_shape, out_max_cb);
+        reduce_block_max_row<cols, /*respect_trigger=*/false>(
+            tensor_shape, qk_im_cb, scale_cb, i * cols, reduce_dst_idx);
         reduce_block_max_row_uninit(qk_im_cb);
 
         if (do_eltwise) {

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row_runtime/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row_runtime/compute.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/matmul.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/reduce_custom.h"
+#include "api/compute/binary_max_min.h"
+#include "tensor_shape.h"
+
+// Repro kernel: exercises the RUNTIME reduce_block_max_row path (reduce_block_max_row_init_runtime /
+// reduce_block_max_row_runtime / reduce_block_max_row_uninit_runtime) — the exact path the streaming
+// SDPA uses (via reduce_c_row_group), which the compile-time reduce_block_max_row kernel does NOT cover.
+// For a 16x32 tiny tile (num_faces=2) this is where the second k-face (F1) is dropped from the row-max.
+void kernel_main() {
+    constexpr std::uint32_t qk_im_cb = get_compile_time_arg_val(0);
+    constexpr std::uint32_t prev_max_cb = get_compile_time_arg_val(1);
+    constexpr std::uint32_t out_max_cb = get_compile_time_arg_val(2);
+    constexpr std::uint32_t scale_cb = get_compile_time_arg_val(3);
+    constexpr std::uint32_t Sq_chunk_t = get_compile_time_arg_val(4);
+    constexpr std::uint32_t Sk_chunk_t = get_compile_time_arg_val(5);
+    constexpr std::uint32_t do_eltwise = get_compile_time_arg_val(6);
+    // Operand tile geometry: 4 faces for a 32x32 tile, 2 faces for a 16x32 tiny tile.
+    constexpr std::uint32_t num_faces = get_compile_time_arg_val(7);
+
+    // Init compute
+    compute_kernel_hw_startup<SrcOrder::Reverse>(qk_im_cb, qk_im_cb, qk_im_cb);
+    matmul_init(qk_im_cb, qk_im_cb);
+
+    cb_push_back(qk_im_cb, Sq_chunk_t * Sk_chunk_t);
+    cb_push_back(scale_cb, 1);
+    if (do_eltwise) {
+        cb_push_back(prev_max_cb, Sq_chunk_t);
+    }
+
+    reconfig_data_format(qk_im_cb, scale_cb);
+    pack_reconfig_data_format(out_max_cb);
+
+    constexpr std::uint32_t rows = Sq_chunk_t;
+    constexpr std::uint32_t cols = Sk_chunk_t;
+    constexpr std::uint32_t num_tiles = rows * cols;
+    cb_wait_front(scale_cb, 1);
+    cb_wait_front(qk_im_cb, num_tiles);
+    cb_reserve_back(out_max_cb, rows);
+
+    constexpr std::uint32_t reduce_dst_idx = 0;
+    constexpr std::uint32_t prev_max_dst_idx = 1;
+
+    for (std::uint32_t i = 0; i < rows; i++) {
+        tile_regs_acquire();
+        // Runtime reduce path (matches SDPA reduce_c_row_group's inner call).
+        reduce_block_max_row_init_runtime(out_max_cb, cols, /*respect_trigger=*/false, num_faces);
+        reduce_block_max_row_runtime(
+            qk_im_cb, scale_cb, i * cols, reduce_dst_idx, /*respect_trigger=*/false, /*overlap_first_half=*/false, num_faces);
+        reduce_block_max_row_uninit_runtime(qk_im_cb);
+
+        if (do_eltwise) {
+            copy_tile_to_dst_init_short(prev_max_cb);
+            copy_tile(prev_max_cb, i, prev_max_dst_idx);
+            binary_max_tile_init();
+            binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx);
+        }
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(reduce_dst_idx, out_max_cb);
+        tile_regs_release();
+    }
+
+    cb_push_back(out_max_cb, rows);
+
+    // Ensure outputs are produced before exiting
+    cb_wait_front(out_max_cb, Sq_chunk_t);
+}

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -51,10 +51,15 @@ static std::vector<bfloat16> golden_reduce_c(
     const std::vector<bfloat16>& prev_max_first_col,
     uint32_t q_chunk_size,
     uint32_t k_chunk_size,
-    bool do_eltwise_max) {
+    bool do_eltwise_max,
+    uint32_t num_faces = 4) {
     const uint32_t rows = q_chunk_size * 32;
     const uint32_t cols = k_chunk_size * 32;
     const uint32_t stats_cols = 32;
+
+    // For a 16x32 tiny tile (num_faces=2) only the first face-row (rows 0-15 of each 32-row tile)
+    // is reduced by MATH; rows 16-31 of every tile hold no valid reduced output.
+    const uint32_t face_rows = (num_faces == 2) ? 16 : 32;
 
     bool prev_max_larger = false;
 
@@ -62,6 +67,10 @@ static std::vector<bfloat16> golden_reduce_c(
     std::vector<bfloat16> out(rows * stats_cols, static_cast<bfloat16>(0.0f));
 
     for (uint32_t r = 0; r < rows; ++r) {
+        // Skip rows in the second face-row of each tile when the operand is a 16x32 tiny tile.
+        if ((r % 32) >= face_rows) {
+            continue;
+        }
         auto row_begin = qk_im_rm.begin() + r * cols;
         auto row_end = row_begin + cols;
         float row_max = -std::numeric_limits<float>::infinity();
@@ -89,18 +98,25 @@ static std::vector<bfloat16> golden_reduce_c(
 }
 
 static float compare_first_col_mse(
-    const std::vector<bfloat16>& result_rm, const std::vector<bfloat16>& golden_first_col_rm) {
+    const std::vector<bfloat16>& result_rm, const std::vector<bfloat16>& golden_first_col_rm, uint32_t num_faces = 4) {
     // result_rm is rows x 32 row-major (from untilize); we compare only column 0 vs golden_first_col_rm (rows x 32,
-    // only col0 set)
+    // only col0 set). For a 16x32 tiny tile (num_faces=2) only the first face-row (rows 0-15 of each
+    // 32-row tile) carries valid output, so rows 16-31 of every tile are excluded from the comparison.
     const uint32_t rows = golden_first_col_rm.size() / 32;
+    const uint32_t face_rows = (num_faces == 2) ? 16 : 32;
     float mse = 0.0f;
+    uint32_t counted = 0;
     for (uint32_t r = 0; r < rows; ++r) {
+        if ((r % 32) >= face_rows) {
+            continue;
+        }
         float a = static_cast<float>(result_rm[(r * 32) + 0]);
         float b = static_cast<float>(golden_first_col_rm[(r * 32) + 0]);
         float d = a - b;
         mse += d * d;
+        ++counted;
     }
-    mse /= rows;
+    mse /= (counted > 0 ? counted : 1);
     return mse;
 }
 
@@ -111,18 +127,20 @@ static bool test_sdpa_reduce_c(
     bool fp32_dest_acc_en,
     bool do_eltwise_max,
     const std::string& kernel_path,
-    const std::string& kernel_name) {
+    const std::string& kernel_name,
+    uint32_t num_faces = 4) {
     bool pass = true;
 
     log_info(
         LogTest,
         "Running {} test with q_chunk_size: {}, k_chunk_size: {}, fp32_dest_acc_en: {}, "
-        "do_eltwise_max: {}",
+        "do_eltwise_max: {}, num_faces: {}",
         kernel_name,
         q_chunk_size,
         k_chunk_size,
         fp32_dest_acc_en,
-        do_eltwise_max);
+        do_eltwise_max,
+        num_faces);
 
     // Get device and command queue from mesh
     tt_metal::IDevice* device = mesh_device->get_devices().at(0);
@@ -218,7 +236,8 @@ static bool test_sdpa_reduce_c(
         cb_identity_scale_id,
         q_chunk_size,
         k_chunk_size,
-        static_cast<uint32_t>(do_eltwise_max ? 1 : 0)};
+        static_cast<uint32_t>(do_eltwise_max ? 1 : 0),
+        num_faces};
     std::map<std::string, std::string> compute_defines;
     compute_defines["EXP_APPROX_MODE"] = "0";
     compute_defines["REDUCE_GRANULARITY"] = "1";
@@ -271,10 +290,10 @@ static bool test_sdpa_reduce_c(
     auto out_max_rm = untilize_nfaces(out_max_bfp16, q_chunk_size * 32, 32);
 
     // Golden
-    auto golden_first_col_rm =
-        golden_reduce_c(qk_im_tensor.get_values(), prev_max_first_col, q_chunk_size, k_chunk_size, do_eltwise_max);
+    auto golden_first_col_rm = golden_reduce_c(
+        qk_im_tensor.get_values(), prev_max_first_col, q_chunk_size, k_chunk_size, do_eltwise_max, num_faces);
 
-    float mse = compare_first_col_mse(out_max_rm, golden_first_col_rm);
+    float mse = compare_first_col_mse(out_max_rm, golden_first_col_rm, num_faces);
     const float max_mse = 0.0f;  // expect exact max match in first column
     log_info(LogTest, "{} first-col mse: {} (do_eltwise: {})", kernel_name, mse, do_eltwise_max);
     if (mse > max_mse) {
@@ -341,6 +360,52 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, NIGHTLY_SdpaReduceC) {
                                 k_chunk_size,
                                 fp32_dest_acc_en,
                                 do_elt);
+                        }
+                        pass &= this_passed;
+                    }
+                }
+            }
+        }
+    }
+
+    // 16x32 tiny-tile (num_faces=2, one face-row) case for the block-based reduce.
+    // Threads num_faces=2 through reduce_block_max_row_init / reduce_block_max_row on both the
+    // UNPACK and MATH sides. Only the first face-row (rows 0-15 of each 32-row tile) is reduced;
+    // the golden/comparison exclude the second face-row accordingly.
+    {
+        const std::string tiny_kernel_path =
+            "tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp";
+        const std::string tiny_kernel_name = "reduce_block_max_row_tiny_16x32";
+        constexpr uint32_t tiny_num_faces = 2;
+        for (uint32_t q_chunk_size : q_chunk_sizes) {
+            for (uint32_t k_chunk_size : k_chunk_sizes) {
+                for (bool fp32_dest_acc_en : fp32_dest_acc_ens) {
+                    // 16x32 tiny-tile reduce_block_max_row is only supported in non-fp32 dest mode
+                    // (the LLK static_asserts fp32 + num_faces==2). fp32 16x32 is a future item.
+                    if (fp32_dest_acc_en) {
+                        continue;
+                    }
+                    for (bool do_elt : do_eltwise) {
+                        bool this_passed = test_sdpa_reduce_c(
+                            devices_[0],
+                            q_chunk_size,
+                            k_chunk_size,
+                            fp32_dest_acc_en,
+                            do_elt,
+                            tiny_kernel_path,
+                            tiny_kernel_name,
+                            tiny_num_faces);
+                        if (!this_passed) {
+                            log_error(
+                                LogTest,
+                                "Test Failed for kernel: {}, q_chunk_size: {}, k_chunk_size: {}"
+                                "fp32_dest_acc_en: {}, do_eltwise: {}, num_faces: {}",
+                                tiny_kernel_name,
+                                q_chunk_size,
+                                k_chunk_size,
+                                fp32_dest_acc_en,
+                                do_elt,
+                                tiny_num_faces);
                         }
                         pass &= this_passed;
                     }

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -31,8 +31,8 @@ static std::vector<bfloat16> make_prev_max_matrix(
     std::mt19937 rng(0);
     std::uniform_real_distribution<float> dist(min_val, max_val);
 
-    const uint32_t rows = q_chunk_size * 32;
-    const uint32_t cols = 32;
+    const uint32_t rows = q_chunk_size * tt::constants::TILE_HEIGHT;
+    const uint32_t cols = tt::constants::TILE_WIDTH;
     std::vector<bfloat16> mat(rows * cols);
     prev_max_first_col_out.resize(rows);
 
@@ -53,13 +53,13 @@ static std::vector<bfloat16> golden_reduce_c(
     uint32_t k_chunk_size,
     bool do_eltwise_max,
     uint32_t num_faces = 4) {
-    const uint32_t rows = q_chunk_size * 32;
-    const uint32_t cols = k_chunk_size * 32;
-    const uint32_t stats_cols = 32;
+    const uint32_t rows = q_chunk_size * tt::constants::TILE_HEIGHT;
+    const uint32_t cols = k_chunk_size * tt::constants::TILE_WIDTH;
+    const uint32_t stats_cols = tt::constants::TILE_WIDTH;
 
     // For a 16x32 tiny tile (num_faces=2) only the first face-row (rows 0-15 of each 32-row tile)
     // is reduced by MATH; rows 16-31 of every tile hold no valid reduced output.
-    const uint32_t face_rows = (num_faces == 2) ? 16 : 32;
+    const uint32_t face_rows = (num_faces == 2) ? tt::constants::FACE_HEIGHT : tt::constants::TILE_HEIGHT;
 
     bool prev_max_larger = false;
 
@@ -68,7 +68,7 @@ static std::vector<bfloat16> golden_reduce_c(
 
     for (uint32_t r = 0; r < rows; ++r) {
         // Skip rows in the second face-row of each tile when the operand is a 16x32 tiny tile.
-        if ((r % 32) >= face_rows) {
+        if ((r % tt::constants::TILE_HEIGHT) >= face_rows) {
             continue;
         }
         auto row_begin = qk_im_rm.begin() + r * cols;
@@ -90,7 +90,7 @@ static std::vector<bfloat16> golden_reduce_c(
     }
 
     // Expand to tiles (each row has a 32x32 tile). Fill only first column; others left as zero and not checked.
-    std::vector<bfloat16> tilized(rows * stats_cols * 32, static_cast<bfloat16>(0.0f));
+    std::vector<bfloat16> tilized(rows * stats_cols * tt::constants::TILE_WIDTH, static_cast<bfloat16>(0.0f));
     // However, for comparison we will only use untilized first column from device output; no need to mirror tile layout
     // here.
     log_info(LogTest, "prev_max_larger: {}", prev_max_larger);
@@ -102,16 +102,16 @@ static float compare_first_col_mse(
     // result_rm is rows x 32 row-major (from untilize); we compare only column 0 vs golden_first_col_rm (rows x 32,
     // only col0 set). For a 16x32 tiny tile (num_faces=2) only the first face-row (rows 0-15 of each
     // 32-row tile) carries valid output, so rows 16-31 of every tile are excluded from the comparison.
-    const uint32_t rows = golden_first_col_rm.size() / 32;
-    const uint32_t face_rows = (num_faces == 2) ? 16 : 32;
+    const uint32_t rows = golden_first_col_rm.size() / tt::constants::TILE_WIDTH;
+    const uint32_t face_rows = (num_faces == 2) ? tt::constants::FACE_HEIGHT : tt::constants::TILE_HEIGHT;
     float mse = 0.0f;
     uint32_t counted = 0;
     for (uint32_t r = 0; r < rows; ++r) {
-        if ((r % 32) >= face_rows) {
+        if ((r % tt::constants::TILE_HEIGHT) >= face_rows) {
             continue;
         }
-        float a = static_cast<float>(result_rm[(r * 32) + 0]);
-        float b = static_cast<float>(golden_first_col_rm[(r * 32) + 0]);
+        float a = static_cast<float>(result_rm[(r * tt::constants::TILE_WIDTH) + 0]);
+        float b = static_cast<float>(golden_first_col_rm[(r * tt::constants::TILE_WIDTH) + 0]);
         float d = a - b;
         mse += d * d;
         ++counted;

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -21,17 +21,64 @@ using namespace tt;
 using std::string;
 using namespace tt::tt_metal;
 
-static std::vector<bfloat16> make_identity_scale_tile() {
-    std::vector<bfloat16> tile(tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH, static_cast<bfloat16>(1.0f));
+static std::vector<bfloat16> make_identity_scale_tile(uint32_t tile_height = tt::constants::TILE_HEIGHT) {
+    std::vector<bfloat16> tile(tile_height * tt::constants::TILE_WIDTH, static_cast<bfloat16>(1.0f));
     return tile;
 }
 
+// Tilize a row-major (rows x cols) buffer into GENUINE 16x32 tiles: each tile is two 16x16 faces
+// F0 (cols 0-15) then F1 (cols 16-31), both spanning rows 0-15 of the tile; tiles in row-major order.
+// tilize_nfaces() only produces 32x32 tiles, so a 16x32 (num_faces=2) tile needs this explicit layout —
+// this is exactly the layout the SDPA matmul packs into cb_qkt_im, and is what exposes the tiny reduce bug.
+static std::vector<bfloat16> tilize_16x32(const std::vector<bfloat16>& rm, uint32_t rows, uint32_t cols) {
+    constexpr uint32_t TH = 16, TW = 32, FH = 16, FW = 16;
+    std::vector<bfloat16> out(rows * cols);
+    uint32_t idx = 0;
+    for (uint32_t ti = 0; ti < rows / TH; ++ti) {
+        for (uint32_t tj = 0; tj < cols / TW; ++tj) {
+            for (uint32_t face = 0; face < 2; ++face) {
+                const uint32_t c0 = tj * TW + face * FW;
+                for (uint32_t r = 0; r < FH; ++r) {
+                    for (uint32_t c = 0; c < FW; ++c) {
+                        out[idx++] = rm[(ti * TH + r) * cols + (c0 + c)];
+                    }
+                }
+            }
+        }
+    }
+    return out;
+}
+
+// Inverse of tilize_16x32.
+static std::vector<bfloat16> untilize_16x32(const std::vector<bfloat16>& til, uint32_t rows, uint32_t cols) {
+    constexpr uint32_t TH = 16, TW = 32, FH = 16, FW = 16;
+    std::vector<bfloat16> out(rows * cols);
+    uint32_t idx = 0;
+    for (uint32_t ti = 0; ti < rows / TH; ++ti) {
+        for (uint32_t tj = 0; tj < cols / TW; ++tj) {
+            for (uint32_t face = 0; face < 2; ++face) {
+                const uint32_t c0 = tj * TW + face * FW;
+                for (uint32_t r = 0; r < FH; ++r) {
+                    for (uint32_t c = 0; c < FW; ++c) {
+                        out[(ti * TH + r) * cols + (c0 + c)] = til[idx++];
+                    }
+                }
+            }
+        }
+    }
+    return out;
+}
+
 static std::vector<bfloat16> make_prev_max_matrix(
-    uint32_t q_chunk_size, float min_val, float max_val, std::vector<bfloat16>& prev_max_first_col_out) {
+    uint32_t q_chunk_size,
+    float min_val,
+    float max_val,
+    std::vector<bfloat16>& prev_max_first_col_out,
+    uint32_t tile_height = tt::constants::TILE_HEIGHT) {
     std::mt19937 rng(0);
     std::uniform_real_distribution<float> dist(min_val, max_val);
 
-    const uint32_t rows = q_chunk_size * tt::constants::TILE_HEIGHT;
+    const uint32_t rows = q_chunk_size * tile_height;
     const uint32_t cols = tt::constants::TILE_WIDTH;
     std::vector<bfloat16> mat(rows * cols);
     prev_max_first_col_out.resize(rows);
@@ -53,24 +100,19 @@ static std::vector<bfloat16> golden_reduce_c(
     uint32_t k_chunk_size,
     bool do_eltwise_max,
     uint32_t num_faces = 4) {
-    const uint32_t rows = q_chunk_size * tt::constants::TILE_HEIGHT;
+    // Genuine 16x32 tiny tile (num_faces=2) has tile height 16; full 32x32 (num_faces=4) has height 32.
+    // Every row is a real q-row now (no phantom second-face-row to skip).
+    const uint32_t tile_height = (num_faces == 2) ? tt::constants::FACE_HEIGHT : tt::constants::TILE_HEIGHT;
+    const uint32_t rows = q_chunk_size * tile_height;
     const uint32_t cols = k_chunk_size * tt::constants::TILE_WIDTH;
     const uint32_t stats_cols = tt::constants::TILE_WIDTH;
 
-    // For a 16x32 tiny tile (num_faces=2) only the first face-row (rows 0-15 of each 32-row tile)
-    // is reduced by MATH; rows 16-31 of every tile hold no valid reduced output.
-    const uint32_t face_rows = (num_faces == 2) ? tt::constants::FACE_HEIGHT : tt::constants::TILE_HEIGHT;
-
     bool prev_max_larger = false;
 
-    // Produce tiles: rows tiles, each 32x32. We'll set first column to the row max (replicated down the column).
+    // Produce tiles: rows tiles. We'll set first column to the row max (replicated down the column).
     std::vector<bfloat16> out(rows * stats_cols, static_cast<bfloat16>(0.0f));
 
     for (uint32_t r = 0; r < rows; ++r) {
-        // Skip rows in the second face-row of each tile when the operand is a 16x32 tiny tile.
-        if ((r % tt::constants::TILE_HEIGHT) >= face_rows) {
-            continue;
-        }
         auto row_begin = qk_im_rm.begin() + r * cols;
         auto row_end = row_begin + cols;
         float row_max = -std::numeric_limits<float>::infinity();
@@ -99,17 +141,13 @@ static std::vector<bfloat16> golden_reduce_c(
 
 static float compare_first_col_mse(
     const std::vector<bfloat16>& result_rm, const std::vector<bfloat16>& golden_first_col_rm, uint32_t num_faces = 4) {
-    // result_rm is rows x 32 row-major (from untilize); we compare only column 0 vs golden_first_col_rm (rows x 32,
-    // only col0 set). For a 16x32 tiny tile (num_faces=2) only the first face-row (rows 0-15 of each
-    // 32-row tile) carries valid output, so rows 16-31 of every tile are excluded from the comparison.
+    // result_rm is rows x 32 row-major (from untilize); compare only column 0 vs golden_first_col_rm.
+    // With genuine 16x32 tiny tiles every row carries valid output, so no rows are excluded.
+    (void)num_faces;
     const uint32_t rows = golden_first_col_rm.size() / tt::constants::TILE_WIDTH;
-    const uint32_t face_rows = (num_faces == 2) ? tt::constants::FACE_HEIGHT : tt::constants::TILE_HEIGHT;
     float mse = 0.0f;
     uint32_t counted = 0;
     for (uint32_t r = 0; r < rows; ++r) {
-        if ((r % tt::constants::TILE_HEIGHT) >= face_rows) {
-            continue;
-        }
         float a = static_cast<float>(result_rm[(r * tt::constants::TILE_WIDTH) + 0]);
         float b = static_cast<float>(golden_first_col_rm[(r * tt::constants::TILE_WIDTH) + 0]);
         float d = a - b;
@@ -151,7 +189,10 @@ static bool test_sdpa_reduce_c(
     CoreCoord core = {0, 0};
 
     auto cb_df = tt::DataFormat::Float16_b;
-    auto cb_tile_size = tt::tile_size(cb_df);
+    // Genuine 16x32 tile (num_faces=2) => tile height 16; full 32x32 (num_faces=4) => height 32.
+    const uint32_t tile_height = (num_faces == 2) ? tt::constants::FACE_HEIGHT : tt::constants::TILE_HEIGHT;
+    const bool tiny = (tile_height == tt::constants::FACE_HEIGHT);
+    auto cb_tile_size = tile_height * tt::constants::TILE_WIDTH * sizeof(bfloat16);
 
     uint32_t qk_im_num_tiles = q_chunk_size * k_chunk_size;
     uint32_t stats_num_tiles = q_chunk_size;
@@ -164,9 +205,9 @@ static bool test_sdpa_reduce_c(
         .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = tt::tt_metal::ShardSpecBuffer(
             CoreRangeSet(std::set<CoreRange>({CoreRange(core, core)})),
-            {q_chunk_size * tt::constants::TILE_HEIGHT, k_chunk_size * tt::constants::TILE_WIDTH},
+            {q_chunk_size * tile_height, k_chunk_size * tt::constants::TILE_WIDTH},
             tt::tt_metal::ShardOrientation::ROW_MAJOR,
-            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            {tile_height, tt::constants::TILE_WIDTH},
             {q_chunk_size, k_chunk_size})};
 
     auto stats_buffer_config = tt::tt_metal::ShardedBufferConfig{
@@ -177,9 +218,9 @@ static bool test_sdpa_reduce_c(
         .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = tt::tt_metal::ShardSpecBuffer(
             CoreRangeSet(std::set<CoreRange>({CoreRange(core, core)})),
-            {stats_num_tiles * tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            {stats_num_tiles * tile_height, tt::constants::TILE_WIDTH},
             tt::tt_metal::ShardOrientation::ROW_MAJOR,
-            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            {tile_height, tt::constants::TILE_WIDTH},
             {stats_num_tiles, 1})};
 
     auto one_tile_buffer_config = tt::tt_metal::ShardedBufferConfig{
@@ -190,9 +231,9 @@ static bool test_sdpa_reduce_c(
         .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = tt::tt_metal::ShardSpecBuffer(
             CoreRangeSet(std::set<CoreRange>({CoreRange(core, core)})),
-            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            {tile_height, tt::constants::TILE_WIDTH},
             tt::tt_metal::ShardOrientation::ROW_MAJOR,
-            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            {tile_height, tt::constants::TILE_WIDTH},
             {1, 1})};
 
     // Create sharded buffers for CB inputs/outputs
@@ -253,23 +294,26 @@ static bool test_sdpa_reduce_c(
             .compile_args = compute_kernel_args,
             .defines = compute_defines});
 
-    // Prepare inputs
-    SHAPE qk_im_shape = {1, 1, q_chunk_size * 32, k_chunk_size * 32};
+    // Prepare inputs. For a genuine 16x32 tiny tile the operand rows are q_chunk_size*16 and the tile
+    // layout is F0(16x16)|F1(16x16) (tilize_16x32); the full 32x32 path keeps tilize_nfaces.
+    SHAPE qk_im_shape = {1, 1, q_chunk_size * tile_height, k_chunk_size * 32};
     tt::deprecated::Tensor<bfloat16> qk_im_tensor = tt::deprecated::initialize_tensor<bfloat16>(
         qk_im_shape, tt::deprecated::Initialize::RANDOM, -50, 50, 0 /* seed */);
 
     vector<uint32_t> qk_im;
-    auto qk_im_tilized = tilize_nfaces(qk_im_tensor.get_values(), q_chunk_size * 32, k_chunk_size * 32);
+    auto qk_im_tilized = tiny ? tilize_16x32(qk_im_tensor.get_values(), q_chunk_size * tile_height, k_chunk_size * 32)
+                              : tilize_nfaces(qk_im_tensor.get_values(), q_chunk_size * 32, k_chunk_size * 32);
     qk_im = pack_bfloat16_vec_into_uint32_vec(qk_im_tilized);
     tt_metal::detail::WriteToBuffer(qk_im_buffer, qk_im);
 
     std::vector<bfloat16> prev_max_first_col;
-    auto prev_max_rm = make_prev_max_matrix(q_chunk_size, 25.0f, 65.0f, prev_max_first_col);
-    auto prev_max_tilized = tilize_nfaces(prev_max_rm, q_chunk_size * 32, 32);
+    auto prev_max_rm = make_prev_max_matrix(q_chunk_size, 25.0f, 65.0f, prev_max_first_col, tile_height);
+    auto prev_max_tilized = tiny ? tilize_16x32(prev_max_rm, q_chunk_size * tile_height, 32)
+                                 : tilize_nfaces(prev_max_rm, q_chunk_size * 32, 32);
     auto prev_max_uint_vec = pack_bfloat16_vec_into_uint32_vec(prev_max_tilized);
     tt_metal::detail::WriteToBuffer(prev_max_buffer, prev_max_uint_vec);
 
-    auto identity_scale_tile = make_identity_scale_tile();
+    auto identity_scale_tile = make_identity_scale_tile(tile_height);
     auto identity_scale_uint_vec = pack_bfloat16_vec_into_uint32_vec(identity_scale_tile);
     tt_metal::detail::WriteToBuffer(identity_scale_buffer, identity_scale_uint_vec);
 
@@ -287,7 +331,8 @@ static bool test_sdpa_reduce_c(
     std::vector<uint32_t> out_max_vec;
     tt_metal::detail::ReadFromBuffer(out_max_buffer, out_max_vec);
     auto out_max_bfp16 = unpack_uint32_vec_into_bfloat16_vec(out_max_vec);
-    auto out_max_rm = untilize_nfaces(out_max_bfp16, q_chunk_size * 32, 32);
+    auto out_max_rm = tiny ? untilize_16x32(out_max_bfp16, q_chunk_size * tile_height, 32)
+                           : untilize_nfaces(out_max_bfp16, q_chunk_size * 32, 32);
 
     // Golden
     auto golden_first_col_rm = golden_reduce_c(
@@ -409,6 +454,42 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, NIGHTLY_SdpaReduceC) {
                         }
                         pass &= this_passed;
                     }
+                }
+            }
+        }
+    }
+
+    // Coverage for the RUNTIME reduce_block_max_row path (used by streaming SDPA via reduce_c_row_group),
+    // which the compile-time kernel variants above do not exercise. num_faces=2 uses a GENUINE 16x32
+    // tile (tilize_16x32) so the tiny-tile unpack tile-descriptor / multi-tile stride is actually tested
+    // — this is what caught the reduce dropping the second k-face (F1) for real 16x32 tiles.
+    {
+        const std::string rt_kernel_path =
+            "tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row_runtime/compute.cpp";
+        for (uint32_t nf : {4u, 2u}) {
+            const std::string rt_kernel_name =
+                (nf == 2) ? "reduce_block_max_row_runtime_tiny_16x32" : "reduce_block_max_row_runtime_32x32";
+            for (uint32_t q_chunk_size : {1u, 2u}) {
+                for (uint32_t k_chunk_size : {1u, 2u, 4u}) {
+                    bool this_passed = test_sdpa_reduce_c(
+                        devices_[0],
+                        q_chunk_size,
+                        k_chunk_size,
+                        /*fp32_dest_acc_en=*/false,
+                        /*do_eltwise_max=*/false,
+                        rt_kernel_path,
+                        rt_kernel_name,
+                        nf);
+                    if (!this_passed) {
+                        log_error(
+                            LogTest,
+                            "REPRO Failed: kernel {}, q {}, k {}, num_faces {}",
+                            rt_kernel_name,
+                            q_chunk_size,
+                            k_chunk_size,
+                            nf);
+                    }
+                    pass &= this_passed;
                 }
             }
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_assert.h"
 #include "llk_math_common_api.h"
 #include "experimental/llk_math_eltwise_binary_custom.h"
@@ -46,11 +47,11 @@ inline void llk_math_eltwise_binary_sub_bcast_cols_custom(
         "dst range out of bounds");
 
     const std::uint32_t operand_id = get_operand_id(operandA);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
     // dst_index is the absolute base dest tile slot; the LLK helper writes ct_dim
     // consecutive tiles from there and restores the dest base on exit.
-    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim, num_faces, dst_index);
+    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim, tensor_shape, dst_index);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -39,14 +39,18 @@ inline void llk_math_eltwise_binary_sub_bcast_cols_init_custom(
  * @note Run @ref llk_math_eltwise_binary_sub_bcast_cols_init_custom first.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_eltwise_binary_sub_bcast_cols_custom(const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
+inline void llk_math_eltwise_binary_sub_bcast_cols_custom(
+    const std::uint32_t operandA, const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
     LLK_ASSERT(
         (dst_index + ct_dim <= get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
         "dst range out of bounds");
 
-    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
-    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim);
-    math::clear_dst_reg_addr();
+    const std::uint32_t operand_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    // dst_index is the absolute base dest tile slot; the LLK helper writes ct_dim
+    // consecutive tiles from there and restores the dest base on exit.
+    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim, num_faces, dst_index);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_matmul_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_matmul_custom_api.h
@@ -10,6 +10,28 @@
  * LLK MATMUL NO MOP
  *************************************************************************/
 
+// Operand tile geometry for the no-mop matmul, derived from each operand's ckernel::TensorShape
+// (consistent with the other experimental SDPA ops, e.g. reduce_block_max_row / sub_bcast_col_custom,
+// which obtain their geometry via get_operand_tensor_shape). A 16x32 tiny tile is num_faces_r_dim=1,
+// num_faces_c_dim=2 (total 16x32); a full tile is 32x32.
+struct MatmulNoMopGeom {
+    std::uint32_t in0_tile_r_dim;
+    std::uint32_t in0_tile_c_dim;
+    std::uint32_t in1_tile_r_dim;
+    std::uint32_t in1_tile_c_dim;
+    bool partial_face;
+};
+
+inline MatmulNoMopGeom matmul_no_mop_geom(const std::uint32_t operandA, const std::uint32_t operandB) {
+    const ckernel::TensorShape in0_shape = get_operand_tensor_shape(get_operand_id(operandA));
+    const ckernel::TensorShape in1_shape = get_operand_tensor_shape(get_operand_id(operandB));
+    const std::uint32_t in0_tile_r_dim = in0_shape.total_row_dim();
+    const std::uint32_t in0_tile_c_dim = in0_shape.total_col_dim();
+    const std::uint32_t in1_tile_r_dim = in1_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_shape.total_col_dim();
+    return {in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, (in0_shape.face_r_dim < FACE_R_DIM)};
+}
+
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_init_no_mop(
     const std::uint32_t operandA,
@@ -17,28 +39,36 @@ inline void llk_math_matmul_init_no_mop(
     const bool transpose = false,
     const std::uint32_t ct_dim = 1,
     const std::uint32_t rt_dim = 1) {
-    const std::uint32_t in0_id = get_operand_id(operandA);
-    const std::uint32_t in1_id = get_operand_id(operandB);
-
-    const std::uint32_t in0_tile_r_dim = get_operand_tile_r_dim(in0_id);
-    const std::uint32_t in0_tile_c_dim = get_operand_tile_c_dim(in0_id);
-    const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
-    const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
-
-    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM);
-
+    const MatmulNoMopGeom g = matmul_no_mop_geom(operandA, operandB);
     _llk_math_matmul_init_no_mop_<math_fidelity, THROTTLE_LEVEL>(
-        in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
+        g.in0_tile_r_dim, g.in0_tile_c_dim, g.in1_tile_r_dim, g.in1_tile_c_dim, g.partial_face, transpose, ct_dim, rt_dim);
 }
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_no_mop(
-    const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
-    _llk_math_matmul_no_mop_<math_fidelity, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const uint dst_index,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    // Re-derive operand tile geometry so the execute replays the geometry-correct length recorded at
+    // init/reinit (16x32 tiny tiles record a shorter face-row-confined replay than full 32x32 tiles).
+    const MatmulNoMopGeom g = matmul_no_mop_geom(operandA, operandB);
+    _llk_math_matmul_no_mop_<math_fidelity, THROTTLE_LEVEL>(
+        dst_index, ct_dim, rt_dim, g.in0_tile_r_dim, g.in0_tile_c_dim, g.in1_tile_r_dim, g.in1_tile_c_dim, g.partial_face);
 }
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
-inline void llk_math_matmul_reinit_no_mop(const bool transpose = false) {
-    matmul_configure_addrmod_reinit<math_fidelity, THROTTLE_LEVEL>(transpose);
+inline void llk_math_matmul_reinit_no_mop(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const bool transpose = false,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    // Re-derive operand tile geometry so reinit restores the shape-aware addrmods for 16x32 tiny
+    // tiles (SDPA reinits the QK^T matmul between q-subblocks). Mirrors llk_math_matmul_init_no_mop.
+    const MatmulNoMopGeom g = matmul_no_mop_geom(operandA, operandB);
+    matmul_configure_addrmod_reinit<math_fidelity, THROTTLE_LEVEL>(
+        transpose, g.in0_tile_r_dim, g.in0_tile_c_dim, g.in1_tile_r_dim, g.in1_tile_c_dim, g.partial_face);
     math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary.h"
 #include "experimental/llk_math_mul_reduce_scalar.h"
@@ -26,7 +27,7 @@ inline void llk_math_eltwise_mul_reduce_scalar_init(
 
 template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void llk_math_eltwise_mul_reduce_scalar(
-    uint dst_index, const std::uint32_t icb0, const bool clear_fp32_dst_acc = true) {
+    std::uint32_t dst_index, const std::uint32_t icb0, const bool clear_fp32_dst_acc = true) {
     const std::uint32_t operand_id = get_operand_id(icb0);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
@@ -45,10 +46,10 @@ inline void llk_math_mul_reduce_scalar_reduce_init() {
 }
 
 template <MathFidelity math_fidelity>
-inline void llk_math_mul_reduce_column(const uint dst_index, const std::uint32_t icb0) {
+inline void llk_math_mul_reduce_column(const std::uint32_t dst_index, const std::uint32_t icb0) {
     const std::uint32_t operand_id = get_operand_id(icb0);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_mul_reduce_column_<math_fidelity>(dst_index, false, num_faces);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
+    _llk_math_mul_reduce_column_<math_fidelity>(dst_index, tensor_shape);
 }
 
 template <MathFidelity math_fidelity>
@@ -59,6 +60,6 @@ inline void llk_math_mul_reduce_scalar() {
 inline void llk_math_mul_reduce_scalar_clear_dvalid() { _llk_math_mul_reduce_scalar_clear_dvalid_(); }
 
 template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_mul_reduce_scalar_move_dest_to_src(uint32_t idst = 0) {
+inline void llk_math_mul_reduce_scalar_move_dest_to_src(std::uint32_t idst = 0) {
     _llk_math_mul_reduce_scalar_move_dest_to_src_<binary_reuse_dest>(idst);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
@@ -26,14 +26,14 @@
  * Use the standard llk_math_reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
 inline void llk_math_reduce_block_max_row_init() {
-    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en>();
+    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
 }
 
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
 inline void llk_math_reduce_block_max_row_mop_config() {
-    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>();
+    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
 }
 
 /**
@@ -51,11 +51,11 @@ inline void llk_math_reduce_block_max_row_mop_config() {
  * Use the standard llk_math_reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
 inline void llk_math_reduce_block_max_row(const uint dst_index) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en>(dst_index);
+    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en, num_faces>(dst_index);
 }
 
 /**
@@ -68,8 +68,8 @@ inline void llk_math_reduce_block_max_row(const uint dst_index) {
  */
 inline void llk_math_reduce_block_max_row_reinit_minimal() { reduce_max_row_configure_addrmod_reinit_minimal(); }
 
-template <uint32_t block_ct_dim>
+template <uint32_t block_ct_dim, uint32_t num_faces = 4>
 inline void llk_math_reduce_block_max_row_reinit_with_mop() {
     reduce_max_row_configure_addrmod();
-    _llk_math_reduce_block_max_row_mop_reprogram_only_<block_ct_dim>();
+    _llk_math_reduce_block_max_row_mop_reprogram_only_<block_ct_dim, num_faces>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "experimental/llk_math_reduce_custom.h"
 
@@ -26,14 +27,14 @@
  * Use the standard llk_math_reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
-inline void llk_math_reduce_block_max_row_init() {
-    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void llk_math_reduce_block_max_row_init(const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en>(tensor_shape);
 }
 
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
-inline void llk_math_reduce_block_max_row_mop_config() {
-    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void llk_math_reduce_block_max_row_mop_config(const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>(tensor_shape);
 }
 
 /**
@@ -51,11 +52,11 @@ inline void llk_math_reduce_block_max_row_mop_config() {
  * Use the standard llk_math_reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
-inline void llk_math_reduce_block_max_row(const uint dst_index) {
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void llk_math_reduce_block_max_row(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en, num_faces>(dst_index);
+    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en>(dst_index, tensor_shape);
 }
 
 /**
@@ -68,8 +69,8 @@ inline void llk_math_reduce_block_max_row(const uint dst_index) {
  */
 inline void llk_math_reduce_block_max_row_reinit_minimal() { reduce_max_row_configure_addrmod_reinit_minimal(); }
 
-template <uint32_t block_ct_dim, uint32_t num_faces = 4>
-inline void llk_math_reduce_block_max_row_reinit_with_mop() {
+template <std::uint32_t block_ct_dim>
+inline void llk_math_reduce_block_max_row_reinit_with_mop(const ckernel::TensorShape& tensor_shape) {
     reduce_max_row_configure_addrmod();
-    _llk_math_reduce_block_max_row_mop_reprogram_only_<block_ct_dim, num_faces>();
+    _llk_math_reduce_block_max_row_mop_reprogram_only_<block_ct_dim>(tensor_shape);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "experimental/llk_math_reduce_custom.h"
 #include "experimental/llk_math_reduce_runtime_custom.h"
@@ -28,13 +29,15 @@
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
-    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+inline void llk_math_reduce_block_max_row_init_runtime(
+    std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+inline void llk_math_reduce_block_max_row_mop_config_runtime(
+    std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 /**
@@ -53,10 +56,11 @@ inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_d
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_runtime(const uint dst_index, uint32_t num_faces = 4) {
+inline void llk_math_reduce_block_max_row_runtime(
+    const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, num_faces);
+    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, tensor_shape);
 }
 
 /**
@@ -77,8 +81,9 @@ inline void llk_math_reduce_block_max_row_reinit_runtime() { _llk_math_reduce_bl
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
-    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+inline void llk_math_reduce_block_max_row_reinit_short_runtime(
+    std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
@@ -28,13 +28,13 @@
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_init_runtime(uint32_t block_ct_dim) {
-    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+inline void llk_math_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
+    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_dim) {
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 /**
@@ -53,10 +53,10 @@ inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_d
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_runtime(const uint dst_index) {
+inline void llk_math_reduce_block_max_row_runtime(const uint dst_index, uint32_t num_faces = 4) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index);
+    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, num_faces);
 }
 
 /**
@@ -77,8 +77,8 @@ inline void llk_math_reduce_block_max_row_reinit_runtime() { _llk_math_reduce_bl
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim) {
-    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
+    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -45,9 +46,9 @@ using namespace ckernel::unpacker;
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
-inline void llk_unpack_AB_reduce_block_max_row_init() {
-    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger, num_faces>();
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+inline void llk_unpack_AB_reduce_block_max_row_init(const ckernel::TensorShape& tensor_shape) {
+    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger>(tensor_shape);
 }
 
 /**
@@ -69,7 +70,7 @@ inline void llk_unpack_AB_reduce_block_max_row_init() {
  * This function should NOT be used as a substitute for native llk_unpack_AB LLK.
  * Use the standard llk_unpack_AB<BroadcastType::NONE> in a loop for general-purpose operations.
  */
-template <uint32_t block_ct_dim, bool respect_trigger = false>
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
 inline void llk_unpack_AB_reduce_block_max_row(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t row_start_index) {
     std::uint32_t operandA_id = get_operand_id(operandA);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -31,7 +31,7 @@ using namespace ckernel::unpacker;
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
@@ -40,12 +40,14 @@ using namespace ckernel::unpacker;
  * with hardware semaphore synchronization, allowing better pipelining and avoiding a more costly circular buffer
  * synchronization. The same value has to be passed to init, execute and uninit functions for this to take effect.
  *
+ * num_faces selects the operand tile geometry (4 for a 32x32 tile, 2 for a 16x32 tiny tile).
+ *
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
 inline void llk_unpack_AB_reduce_block_max_row_init() {
-    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger>();
+    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger, num_faces>();
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -47,8 +48,9 @@ using namespace ckernel::unpacker;
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_unpack_AB_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
-    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger, num_faces);
+inline void llk_unpack_AB_reduce_block_max_row_init_runtime(
+    std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape& tensor_shape) {
+    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger, tensor_shape);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -32,7 +32,7 @@ using namespace ckernel::unpacker;
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
@@ -41,12 +41,14 @@ using namespace ckernel::unpacker;
  * with hardware semaphore synchronization, allowing better pipelining and avoiding a more costly circular buffer
  * synchronization. The same value has to be passed to init, execute and uninit functions for this to take effect.
  *
+ * num_faces selects the operand tile geometry (4 for a 32x32 tile, 2 for a 16x32 tiny tile).
+ *
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_unpack_AB_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, bool respect_trigger = false) {
-    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger);
+inline void llk_unpack_AB_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
+    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger, num_faces);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -11,8 +11,10 @@
  * LLK UNPACK AB SUB BCAST COL CUSTOM - SDPA specialized blocked sub path
  *************************************************************************/
 
-inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t /*operandA*/) {
-    _llk_unpack_AB_sub_bcast_col_init_custom_();
+inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
+    _llk_unpack_AB_sub_bcast_col_init_custom_(num_faces);
 }
 
 inline void llk_unpack_AB_sub_bcast_col_custom(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_unpack_common_api.h"
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
 
@@ -13,8 +14,8 @@
 
 inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
-    const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
-    _llk_unpack_AB_sub_bcast_col_init_custom_(num_faces);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
+    _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
 }
 
 inline void llk_unpack_AB_sub_bcast_col_custom(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "experimental/llk_math_eltwise_binary_custom.h"
 #include "llk_assert.h"
 #include "llk_math_common_api.h"
@@ -29,9 +30,9 @@ inline void llk_math_eltwise_binary_sub_bcast_cols_custom(
         "dst_index out of range");
 
     const std::uint32_t operand_id = get_operand_id(operandA);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
     // dst_index is the absolute base dest tile slot; the LLK helper writes ct_dim
     // consecutive tiles from there and restores the dest base on exit.
-    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim, num_faces, dst_index);
+    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim, tensor_shape, dst_index);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -23,12 +23,15 @@ inline void llk_math_eltwise_binary_sub_bcast_cols_init_custom(
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sub_bcast_cols_custom(
-    const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
+    const std::uint32_t operandA, const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
     LLK_ASSERT(
         (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
         "dst_index out of range");
 
-    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
-    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim);
-    math::clear_dst_reg_addr();
+    const std::uint32_t operand_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    // dst_index is the absolute base dest tile slot; the LLK helper writes ct_dim
+    // consecutive tiles from there and restores the dest base on exit.
+    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim, num_faces, dst_index);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -26,8 +26,8 @@ template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sub_bcast_cols_custom(
     const std::uint32_t operandA, const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
     LLK_ASSERT(
-        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
-        "dst_index out of range");
+        (dst_index + ct_dim <= get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "dst_index + ct_dim out of range");
 
     const std::uint32_t operand_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_matmul_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_matmul_custom_api.h
@@ -34,8 +34,26 @@ inline void llk_math_matmul_init_no_mop(
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_no_mop(
-    const std::uint32_t dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
-    _llk_math_matmul_no_mop_<math_fidelity, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t dst_index,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    // Operand cb ids are threaded from the compute API so the execute matches the geometry-aware
+    // Blackhole path; on Wormhole the fixed 16-MVMUL replay is tile-size independent so the derived
+    // dims are passed through for signature parity.
+    const std::uint32_t in0_id = get_operand_id(operandA);
+    const std::uint32_t in1_id = get_operand_id(operandB);
+
+    const std::uint32_t in0_tile_r_dim = get_operand_tile_r_dim(in0_id);
+    const std::uint32_t in0_tile_c_dim = get_operand_tile_c_dim(in0_id);
+    const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
+    const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
+
+    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM);
+
+    _llk_math_matmul_no_mop_<math_fidelity, THROTTLE_LEVEL>(
+        dst_index, ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 }
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary.h"
 #include "experimental/llk_math_mul_reduce_scalar.h"
@@ -26,7 +27,7 @@ inline void llk_math_eltwise_mul_reduce_scalar_init(
 
 template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void llk_math_eltwise_mul_reduce_scalar(
-    uint dst_index, const std::uint32_t icb0, const bool clear_fp32_dst_acc = true) {
+    std::uint32_t dst_index, const std::uint32_t icb0, const bool clear_fp32_dst_acc = true) {
     const std::uint32_t operand_id = get_operand_id(icb0);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
@@ -45,10 +46,10 @@ inline void llk_math_mul_reduce_scalar_reduce_init() {
 }
 
 template <MathFidelity math_fidelity>
-inline void llk_math_mul_reduce_column(const uint dst_index, const std::uint32_t icb0) {
+inline void llk_math_mul_reduce_column(const std::uint32_t dst_index, const std::uint32_t icb0) {
     const std::uint32_t operand_id = get_operand_id(icb0);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_mul_reduce_column_<math_fidelity>(dst_index, false, num_faces);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
+    _llk_math_mul_reduce_column_<math_fidelity>(dst_index, tensor_shape);
 }
 
 template <MathFidelity math_fidelity>
@@ -59,6 +60,6 @@ inline void llk_math_mul_reduce_scalar() {
 inline void llk_math_mul_reduce_scalar_clear_dvalid() { _llk_math_mul_reduce_scalar_clear_dvalid_(); }
 
 template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_mul_reduce_scalar_move_dest_to_src(uint32_t idst = 0) {
+inline void llk_math_mul_reduce_scalar_move_dest_to_src(std::uint32_t idst = 0) {
     _llk_math_mul_reduce_scalar_move_dest_to_src_<binary_reuse_dest>(idst);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_math_common_api.h"
+#include "llk_math_eltwise_binary.h"
+#include "experimental/llk_math_mul_reduce_scalar.h"
+
+/*************************************************************************
+ * LLK MUL REDUCE SCALAR - Fused multiply and scalar reduction
+ *************************************************************************/
+
+template <MathFidelity math_fidelity>
+inline void llk_math_eltwise_mul_reduce_scalar_init(
+    const std::uint32_t operand_A, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
+
+    _llk_math_eltwise_binary_init_<
+        EltwiseBinaryType::ELWMUL,
+        BroadcastType::NONE,
+        math_fidelity,
+        EltwiseBinaryReuseDestType::NONE>(tensor_shape, acc_to_dest);
+}
+
+template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
+inline void llk_math_eltwise_mul_reduce_scalar(
+    uint dst_index, const std::uint32_t icb0, const bool clear_fp32_dst_acc = true) {
+    const std::uint32_t operand_id = get_operand_id(icb0);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
+
+    _llk_math_eltwise_binary_<
+        EltwiseBinaryType::ELWMUL,
+        BroadcastType::NONE,
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        math_fidelity,
+        EltwiseBinaryReuseDestType::NONE>(tensor_shape, dst_index, clear_fp32_dst_acc);
+}
+
+template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool enforce_fp32_accumulation = false>
+inline void llk_math_mul_reduce_scalar_reduce_init() {
+    _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, math_fidelity, enforce_fp32_accumulation>();
+}
+
+template <MathFidelity math_fidelity>
+inline void llk_math_mul_reduce_column(const uint dst_index, const std::uint32_t icb0) {
+    const std::uint32_t operand_id = get_operand_id(icb0);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    _llk_math_mul_reduce_column_<math_fidelity>(dst_index, false, num_faces);
+}
+
+template <MathFidelity math_fidelity>
+inline void llk_math_mul_reduce_scalar() {
+    _llk_math_mul_reduce_scalar_<math_fidelity>();
+}
+
+inline void llk_math_mul_reduce_scalar_clear_dvalid() { _llk_math_mul_reduce_scalar_clear_dvalid_(); }
+
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_mul_reduce_scalar_move_dest_to_src(uint32_t idst = 0) {
+    _llk_math_mul_reduce_scalar_move_dest_to_src_<binary_reuse_dest>(idst);
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_api.h
@@ -26,9 +26,9 @@
  * Use the standard llk_math_reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
 inline void llk_math_reduce_block_max_row_init() {
-    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en>();
+    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
 }
 
 /**
@@ -46,9 +46,9 @@ inline void llk_math_reduce_block_max_row_init() {
  * Use the standard llk_math_reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
 inline void llk_math_reduce_block_max_row(const uint dst_index) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en>(dst_index);
+    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en, num_faces>(dst_index);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "experimental/llk_math_reduce_custom.h"
 
@@ -26,9 +27,9 @@
  * Use the standard llk_math_reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
-inline void llk_math_reduce_block_max_row_init() {
-    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void llk_math_reduce_block_max_row_init(const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en>(tensor_shape);
 }
 
 /**
@@ -46,9 +47,9 @@ inline void llk_math_reduce_block_max_row_init() {
  * Use the standard llk_math_reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, uint32_t num_faces = 4>
-inline void llk_math_reduce_block_max_row(const uint dst_index) {
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void llk_math_reduce_block_max_row(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en, num_faces>(dst_index);
+    _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en>(dst_index, tensor_shape);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "experimental/llk_math_reduce_custom.h"
 #include "experimental/llk_math_reduce_runtime_custom.h"
@@ -28,13 +29,15 @@
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
-    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+inline void llk_math_reduce_block_max_row_init_runtime(
+    std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+inline void llk_math_reduce_block_max_row_mop_config_runtime(
+    std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 /**
@@ -53,10 +56,11 @@ inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_d
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_runtime(const uint dst_index, uint32_t num_faces = 4) {
+inline void llk_math_reduce_block_max_row_runtime(
+    const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, num_faces);
+    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, tensor_shape);
 }
 
 /**
@@ -77,6 +81,7 @@ inline void llk_math_reduce_block_max_row_reinit_runtime() { _llk_math_reduce_bl
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
-    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+inline void llk_math_reduce_block_max_row_reinit_short_runtime(
+    std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
@@ -28,13 +28,13 @@
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_init_runtime(uint32_t block_ct_dim) {
-    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+inline void llk_math_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
+    _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_dim) {
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 /**
@@ -53,10 +53,10 @@ inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_d
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_runtime(const uint dst_index) {
+inline void llk_math_reduce_block_max_row_runtime(const uint dst_index, uint32_t num_faces = 4) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
-    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index);
+    _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, num_faces);
 }
 
 /**
@@ -77,6 +77,6 @@ inline void llk_math_reduce_block_max_row_reinit_runtime() { _llk_math_reduce_bl
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim) {
-    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim, uint32_t num_faces = 4) {
+    _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -45,9 +46,9 @@ using namespace ckernel::unpacker;
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
-inline void llk_unpack_AB_reduce_block_max_row_init() {
-    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger, num_faces>();
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+inline void llk_unpack_AB_reduce_block_max_row_init(const ckernel::TensorShape& tensor_shape) {
+    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger>(tensor_shape);
 }
 
 /**
@@ -69,7 +70,7 @@ inline void llk_unpack_AB_reduce_block_max_row_init() {
  * This function should NOT be used as a substitute for native llk_unpack_AB LLK.
  * Use the standard llk_unpack_AB<BroadcastType::NONE> in a loop for general-purpose operations.
  */
-template <uint32_t block_ct_dim, bool respect_trigger = false>
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
 inline void llk_unpack_AB_reduce_block_max_row(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t row_start_index) {
     std::uint32_t operandA_id = get_operand_id(operandA);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -31,7 +31,7 @@ using namespace ckernel::unpacker;
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
@@ -40,12 +40,14 @@ using namespace ckernel::unpacker;
  * with hardware semaphore synchronization, allowing better pipelining and avoiding a more costly circular buffer
  * synchronization. The same value has to be passed to init, execute and uninit functions for this to take effect.
  *
+ * num_faces selects the operand tile geometry (4 for a 32x32 tile, 2 for a 16x32 tiny tile).
+ *
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
 inline void llk_unpack_AB_reduce_block_max_row_init() {
-    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger>();
+    _llk_unpack_AB_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en, respect_trigger, num_faces>();
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -47,8 +48,9 @@ using namespace ckernel::unpacker;
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_unpack_AB_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
-    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger, num_faces);
+inline void llk_unpack_AB_reduce_block_max_row_init_runtime(
+    std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape& tensor_shape) {
+    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger, tensor_shape);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -32,7 +32,7 @@ using namespace ckernel::unpacker;
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
@@ -41,12 +41,14 @@ using namespace ckernel::unpacker;
  * with hardware semaphore synchronization, allowing better pipelining and avoiding a more costly circular buffer
  * synchronization. The same value has to be passed to init, execute and uninit functions for this to take effect.
  *
+ * num_faces selects the operand tile geometry (4 for a 32x32 tile, 2 for a 16x32 tiny tile).
+ *
  * This function should NOT be used as a substitute for native llk_unpack_AB_reduce_init LLK.
  * Use the standard llk_unpack_AB_reduce_init<ReduceDim::REDUCE_ROW> for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_unpack_AB_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, bool respect_trigger = false) {
-    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger);
+inline void llk_unpack_AB_reduce_block_max_row_init_runtime(uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
+    _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim, respect_trigger, num_faces);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -11,8 +11,10 @@
  * LLK UNPACK AB SUB BCAST COL CUSTOM - SDPA specialized blocked sub path
  *************************************************************************/
 
-inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t /*operandA*/) {
-    _llk_unpack_AB_sub_bcast_col_init_custom_();
+inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
+    _llk_unpack_AB_sub_bcast_col_init_custom_(num_faces);
 }
 
 inline void llk_unpack_AB_sub_bcast_col_custom(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
 #include "llk_unpack_common_api.h"
 
@@ -13,8 +14,8 @@
 
 inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
-    const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
-    _llk_unpack_AB_sub_bcast_col_init_custom_(num_faces);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
+    _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
 }
 
 inline void llk_unpack_AB_sub_bcast_col_custom(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "experimental/llk_unpack_mul_reduce_scalar.h"
+
+/*************************************************************************
+ * LLK UNPACK MUL REDUCE SCALAR
+ *************************************************************************/
+
+inline void llk_unpack_mul_reduce_scalar_switch_to_reduce() { _llk_unpack_mul_reduce_scalar_switch_to_reduce_(); }

--- a/tt_metal/hw/inc/api/compute/experimental/matmul_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/matmul_custom.h
@@ -81,7 +81,9 @@ ALWI void matmul_block_no_mop(
     uint32_t rt_dim,
     uint32_t kt_dim) {
     UNPACK((llk_unpack_AB_matmul(in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, ct_dim, rt_dim, kt_dim)));
-    MATH((llk_math_matmul_no_mop<MATH_FIDELITY, MM_THROTTLE>(idst, ct_dim, rt_dim)));
+    // Pass the operand cb ids so the math execute can re-derive the tile geometry and replay the
+    // geometry-correct length (16x32 tiny tiles use a shorter replay than full 32x32 tiles).
+    MATH((llk_math_matmul_no_mop<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, idst, ct_dim, rt_dim)));
 }
 
 // clang-format off
@@ -101,11 +103,9 @@ ALWI void mm_no_mop_reinit_short(
     uint32_t rt_dim = 1,
     uint32_t kt_dim = 1) {
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim)));
-#if defined(ARCH_BLACKHOLE)
-    MATH((llk_math_matmul_reinit_no_mop<MATH_FIDELITY, MM_THROTTLE>(transpose)));
-#else
+    // Both arches now re-derive operand tile geometry in reinit so 16x32 tiny-tile addrmods are
+    // restored (previously the Blackhole branch dropped the cb ids and reset to full-32x32 addrmods).
     MATH((llk_math_matmul_reinit_no_mop<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim)));
-#endif
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/sdpa_sub_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/sdpa_sub_custom.h
@@ -26,7 +26,7 @@ ALWI void sub_bcast_cols_init_short_custom(uint32_t icb0, uint32_t icb1, uint32_
 
 ALWI void sub_tiles_bcast_cols_custom(
     uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t ct_dim) {
-    MATH((llk_math_eltwise_binary_sub_bcast_cols_custom<DST_ACCUM_MODE>(idst, ct_dim)));
+    MATH((llk_math_eltwise_binary_sub_bcast_cols_custom<DST_ACCUM_MODE>(icb0, idst, ct_dim)));
     UNPACK((llk_unpack_AB_sub_bcast_col_custom(icb0, icb1, itile0, itile1, ct_dim)));
 }
 

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -31,7 +31,7 @@ namespace ckernel {
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile size is 32x32 (num_faces=4) or 16x32 (num_faces=2, a single face-row)
  * - Can work on both 16-bit or 32-bit DEST register modes based on DST_ACCUM_MODE
  * - Does only MAX pool on ROW dimension
  *
@@ -53,13 +53,14 @@ namespace ckernel {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | block_ct_dim              | The number of tiles in the width dimension to process as a block                        | uint32_t  | 1 to 2^32-1                                   | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
+ * | Template   | num_faces                 | Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile)              | uint32_t  | {2, 4}                                         | False    |
  * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false>
+template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
 ALWI void reduce_block_max_row_init(uint32_t ocb) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
-    MATH((llk_math_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE>()));
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger, num_faces>()));
+    MATH((llk_math_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, num_faces>()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
@@ -73,7 +74,7 @@ ALWI void reduce_block_max_row_init(uint32_t ocb) {
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile size is 32x32 (num_faces=4) or 16x32 (num_faces=2, a single face-row)
  * - Can work on both 16-bit or 32-bit DEST register modes based on DST_ACCUM_MODE
  * - Does only MAX pool on ROW dimension
  *
@@ -95,16 +96,17 @@ ALWI void reduce_block_max_row_init(uint32_t ocb) {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | block_ct_dim              | The number of tiles in the width dimension to process as a block                        | uint32_t  | 1 to 2^32-1                                   | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
+ * | Template   | num_faces                 | Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile)              | uint32_t  | {2, 4}                                         | False    |
  * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A                         | uint32_t  | 0 to 31                                        | True     |
  * | Function   | icb_scaler                | CB holding scaling factors                                                              | uint32_t  | 0 to 31                                        | True     |
  * | Function   | row_start_index           | The starting tile index for the row being processed                                     | uint32_t  | Must be less than the size of the CB           | True     |
  * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t  | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false>
+template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
 ALWI void reduce_block_max_row(uint32_t icb, uint32_t icb_scaler, uint32_t row_start_index, uint32_t idst) {
     UNPACK((llk_unpack_AB_reduce_block_max_row<block_ct_dim, respect_trigger>(icb, icb_scaler, row_start_index)));
-    MATH((llk_math_reduce_block_max_row<block_ct_dim, DST_ACCUM_MODE>(idst)));
+    MATH((llk_math_reduce_block_max_row<block_ct_dim, DST_ACCUM_MODE, num_faces>(idst)));
 }
 
 #ifdef ARCH_BLACKHOLE
@@ -130,10 +132,10 @@ ALWI void reduce_block_max_row(uint32_t icb, uint32_t icb_scaler, uint32_t row_s
  * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false>
+template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
 ALWI void reduce_block_max_row_reinit_short(uint32_t ocb) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
-    MATH((llk_math_reduce_block_max_row_reinit_with_mop<block_ct_dim>()));
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger, num_faces>()));
+    MATH((llk_math_reduce_block_max_row_reinit_with_mop<block_ct_dim, num_faces>()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 #endif
@@ -143,9 +145,9 @@ ALWI void reduce_block_max_row_reinit_short(uint32_t ocb) {
  * Minimal reinit: only ADDR_MOD_1 + ADDR_MOD_2 + ADDR_MOD_6. Requires copy_tile_custom
  * (which uses ADDR_MOD_4) so ADDR_MOD_3 is preserved from the previous reduce.
  */
-template <uint32_t block_ct_dim, bool respect_trigger = false>
+template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
 ALWI void reduce_block_max_row_reinit_minimal(uint32_t ocb) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger, num_faces>()));
     MATH((llk_math_reduce_block_max_row_reinit_minimal()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
@@ -156,8 +158,8 @@ ALWI void reduce_block_max_row_reinit_minimal(uint32_t ocb) {
  * from the previous reduce.
  */
 ALWI void reduce_block_max_row_reinit_minimal_runtime(
-    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
+    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4) {
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, num_faces)));
     MATH((llk_math_reduce_block_max_row_reinit_minimal_runtime()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
@@ -166,9 +168,10 @@ ALWI void reduce_block_max_row_reinit_minimal_runtime(
  * Short reinit (runtime variant): Reprograms reduce MOP and restores addrmods.
  * Used when reduce follows custom SDPA sub path with runtime block_ct_dim.
  */
-ALWI void reduce_block_max_row_reinit_short_runtime(uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
-    MATH((llk_math_reduce_block_max_row_reinit_short_runtime<DST_ACCUM_MODE>(block_ct_dim)));
+ALWI void reduce_block_max_row_reinit_short_runtime(
+    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4) {
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, num_faces)));
+    MATH((llk_math_reduce_block_max_row_reinit_short_runtime<DST_ACCUM_MODE>(block_ct_dim, num_faces)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 #endif
@@ -220,9 +223,10 @@ ALWI void reduce_block_max_row_uninit(uint32_t icb) {
 }
 
 // Runtime variants - block_ct_dim and respect_trigger are runtime parameters.
-ALWI void reduce_block_max_row_init_runtime(uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
-    MATH((llk_math_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim)));
+ALWI void reduce_block_max_row_init_runtime(
+    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4) {
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, num_faces)));
+    MATH((llk_math_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, num_faces)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
@@ -232,10 +236,11 @@ ALWI void reduce_block_max_row_runtime(
     uint32_t row_start_index,
     uint32_t idst,
     bool respect_trigger = false,
-    bool overlap_first_half = false) {
+    bool overlap_first_half = false,
+    uint32_t num_faces = 4) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_runtime(
         icb, icb_scaler, row_start_index, respect_trigger, overlap_first_half)));
-    MATH((llk_math_reduce_block_max_row_runtime<DST_ACCUM_MODE>(idst)));
+    MATH((llk_math_reduce_block_max_row_runtime<DST_ACCUM_MODE>(idst, num_faces)));
 }
 
 ALWI void reduce_block_max_row_uninit_runtime(

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common.h"
+#include "tensor_shape.h"
 #ifdef TRISC_MATH
 #include "llk_math_reduce_api.h"
 #include "experimental/llk_math_reduce_custom_api.h"
@@ -53,15 +55,21 @@ namespace ckernel {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | block_ct_dim              | The number of tiles in the width dimension to process as a block                        | uint32_t  | 1 to 2^32-1                                   | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
- * | Template   | num_faces                 | Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile)              | uint32_t  | {2, 4}                                         | False    |
+ * | Function   | tensor_shape              | Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile)            | ckernel::TensorShape | N/A                                 | True     |
  * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
-ALWI void reduce_block_max_row_init(uint32_t ocb) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger, num_faces>()));
-    MATH((llk_math_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, num_faces>()));
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row_init(const ckernel::TensorShape& tensor_shape, std::uint32_t ocb) {
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>(tensor_shape)));
+    MATH((llk_math_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE>(tensor_shape)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
+}
+
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4>
+ALWI void reduce_block_max_row_init(std::uint32_t ocb) {
+    reduce_block_max_row_init<block_ct_dim, respect_trigger>(ckernel::tensor_shape_from_num_faces(num_faces), ocb);
 }
 
 // clang-format off
@@ -96,17 +104,30 @@ ALWI void reduce_block_max_row_init(uint32_t ocb) {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | block_ct_dim              | The number of tiles in the width dimension to process as a block                        | uint32_t  | 1 to 2^32-1                                   | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
- * | Template   | num_faces                 | Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile)              | uint32_t  | {2, 4}                                         | False    |
+ * | Function   | tensor_shape              | Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile)            | ckernel::TensorShape | N/A                                 | True     |
  * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A                         | uint32_t  | 0 to 31                                        | True     |
  * | Function   | icb_scaler                | CB holding scaling factors                                                              | uint32_t  | 0 to 31                                        | True     |
  * | Function   | row_start_index           | The starting tile index for the row being processed                                     | uint32_t  | Must be less than the size of the CB           | True     |
  * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t  | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
-ALWI void reduce_block_max_row(uint32_t icb, uint32_t icb_scaler, uint32_t row_start_index, uint32_t idst) {
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row(
+    const ckernel::TensorShape& tensor_shape,
+    std::uint32_t icb,
+    std::uint32_t icb_scaler,
+    std::uint32_t row_start_index,
+    std::uint32_t idst) {
     UNPACK((llk_unpack_AB_reduce_block_max_row<block_ct_dim, respect_trigger>(icb, icb_scaler, row_start_index)));
-    MATH((llk_math_reduce_block_max_row<block_ct_dim, DST_ACCUM_MODE, num_faces>(idst)));
+    MATH((llk_math_reduce_block_max_row<block_ct_dim, DST_ACCUM_MODE>(idst, tensor_shape)));
+}
+
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4>
+ALWI void reduce_block_max_row(
+    std::uint32_t icb, std::uint32_t icb_scaler, std::uint32_t row_start_index, std::uint32_t idst) {
+    reduce_block_max_row<block_ct_dim, respect_trigger>(
+        ckernel::tensor_shape_from_num_faces(num_faces), icb, icb_scaler, row_start_index, idst);
 }
 
 #ifdef ARCH_BLACKHOLE
@@ -129,14 +150,22 @@ ALWI void reduce_block_max_row(uint32_t icb, uint32_t icb_scaler, uint32_t row_s
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | block_ct_dim              | The number of tiles in the width dimension to process as a block                        | uint32_t  | 1 to 2^32-1                                   | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
+ * | Function   | tensor_shape              | Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile)            | ckernel::TensorShape | N/A                                 | True     |
  * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
-ALWI void reduce_block_max_row_reinit_short(uint32_t ocb) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger, num_faces>()));
-    MATH((llk_math_reduce_block_max_row_reinit_with_mop<block_ct_dim, num_faces>()));
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row_reinit_short(const ckernel::TensorShape& tensor_shape, std::uint32_t ocb) {
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>(tensor_shape)));
+    MATH((llk_math_reduce_block_max_row_reinit_with_mop<block_ct_dim>(tensor_shape)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
+}
+
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4>
+ALWI void reduce_block_max_row_reinit_short(std::uint32_t ocb) {
+    reduce_block_max_row_reinit_short<block_ct_dim, respect_trigger>(
+        ckernel::tensor_shape_from_num_faces(num_faces), ocb);
 }
 #endif
 
@@ -145,11 +174,18 @@ ALWI void reduce_block_max_row_reinit_short(uint32_t ocb) {
  * Minimal reinit: only ADDR_MOD_1 + ADDR_MOD_2 + ADDR_MOD_6. Requires copy_tile_custom
  * (which uses ADDR_MOD_4) so ADDR_MOD_3 is preserved from the previous reduce.
  */
-template <uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4>
-ALWI void reduce_block_max_row_reinit_minimal(uint32_t ocb) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger, num_faces>()));
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row_reinit_minimal(const ckernel::TensorShape& tensor_shape, std::uint32_t ocb) {
+    UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>(tensor_shape)));
     MATH((llk_math_reduce_block_max_row_reinit_minimal()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
+}
+
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4>
+ALWI void reduce_block_max_row_reinit_minimal(std::uint32_t ocb) {
+    reduce_block_max_row_reinit_minimal<block_ct_dim, respect_trigger>(
+        ckernel::tensor_shape_from_num_faces(num_faces), ocb);
 }
 
 /**
@@ -158,8 +194,12 @@ ALWI void reduce_block_max_row_reinit_minimal(uint32_t ocb) {
  * from the previous reduce.
  */
 ALWI void reduce_block_max_row_reinit_minimal_runtime(
-    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, num_faces)));
+    const ckernel::TensorShape& tensor_shape,
+    std::uint32_t ocb,
+    std::uint32_t block_ct_dim,
+    bool respect_trigger = false) {
+    UNPACK(
+        (llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, tensor_shape)));
     MATH((llk_math_reduce_block_max_row_reinit_minimal_runtime()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
@@ -169,9 +209,13 @@ ALWI void reduce_block_max_row_reinit_minimal_runtime(
  * Used when reduce follows custom SDPA sub path with runtime block_ct_dim.
  */
 ALWI void reduce_block_max_row_reinit_short_runtime(
-    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, num_faces)));
-    MATH((llk_math_reduce_block_max_row_reinit_short_runtime<DST_ACCUM_MODE>(block_ct_dim, num_faces)));
+    const ckernel::TensorShape& tensor_shape,
+    std::uint32_t ocb,
+    std::uint32_t block_ct_dim,
+    bool respect_trigger = false) {
+    UNPACK(
+        (llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, tensor_shape)));
+    MATH((llk_math_reduce_block_max_row_reinit_short_runtime<DST_ACCUM_MODE>(block_ct_dim, tensor_shape)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 #endif
@@ -209,7 +253,7 @@ ALWI void reduce_block_max_row_reinit_short_runtime(
  */
 // clang-format on
 template <bool respect_trigger = false>
-ALWI void reduce_block_max_row_uninit(uint32_t icb) {
+ALWI void reduce_block_max_row_uninit(std::uint32_t icb) {
 #ifdef ARCH_BLACKHOLE
     MATH((llk_math_reduce_uninit()));
 #else
@@ -224,27 +268,57 @@ ALWI void reduce_block_max_row_uninit(uint32_t icb) {
 
 // Runtime variants - block_ct_dim and respect_trigger are runtime parameters.
 ALWI void reduce_block_max_row_init_runtime(
-    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false, uint32_t num_faces = 4) {
-    UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, num_faces)));
-    MATH((llk_math_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, num_faces)));
+    const ckernel::TensorShape& tensor_shape,
+    std::uint32_t ocb,
+    std::uint32_t block_ct_dim,
+    bool respect_trigger = false) {
+    UNPACK(
+        (llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, tensor_shape)));
+    MATH((llk_math_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, tensor_shape)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+ALWI void reduce_block_max_row_init_runtime(
+    std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
+    reduce_block_max_row_init_runtime(
+        ckernel::tensor_shape_from_num_faces(num_faces), ocb, block_ct_dim, respect_trigger);
+}
+
 ALWI void reduce_block_max_row_runtime(
-    uint32_t icb,
-    uint32_t icb_scaler,
-    uint32_t row_start_index,
-    uint32_t idst,
+    const ckernel::TensorShape& tensor_shape,
+    std::uint32_t icb,
+    std::uint32_t icb_scaler,
+    std::uint32_t row_start_index,
+    std::uint32_t idst,
     bool respect_trigger = false,
-    bool overlap_first_half = false,
-    uint32_t num_faces = 4) {
+    bool overlap_first_half = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_runtime(
         icb, icb_scaler, row_start_index, respect_trigger, overlap_first_half)));
-    MATH((llk_math_reduce_block_max_row_runtime<DST_ACCUM_MODE>(idst, num_faces)));
+    MATH((llk_math_reduce_block_max_row_runtime<DST_ACCUM_MODE>(idst, tensor_shape)));
+}
+
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+ALWI void reduce_block_max_row_runtime(
+    std::uint32_t icb,
+    std::uint32_t icb_scaler,
+    std::uint32_t row_start_index,
+    std::uint32_t idst,
+    bool respect_trigger = false,
+    bool overlap_first_half = false,
+    std::uint32_t num_faces = 4) {
+    reduce_block_max_row_runtime(
+        ckernel::tensor_shape_from_num_faces(num_faces),
+        icb,
+        icb_scaler,
+        row_start_index,
+        idst,
+        respect_trigger,
+        overlap_first_half);
 }
 
 ALWI void reduce_block_max_row_uninit_runtime(
-    uint32_t icb, bool respect_trigger = false, bool overlap_first_half = false) {
+    std::uint32_t icb, bool respect_trigger = false, bool overlap_first_half = false) {
 #ifdef ARCH_BLACKHOLE
     MATH((llk_math_reduce_uninit()));
 #else

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -69,7 +69,7 @@ ALWI void reduce_block_max_row_init(const ckernel::TensorShape& tensor_shape, st
 // num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
 template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4>
 ALWI void reduce_block_max_row_init(std::uint32_t ocb) {
-    reduce_block_max_row_init<block_ct_dim, respect_trigger>(ckernel::tensor_shape_from_num_faces(num_faces), ocb);
+    reduce_block_max_row_init<block_ct_dim, respect_trigger>(ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces), ocb);
 }
 
 // clang-format off
@@ -127,7 +127,7 @@ template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_
 ALWI void reduce_block_max_row(
     std::uint32_t icb, std::uint32_t icb_scaler, std::uint32_t row_start_index, std::uint32_t idst) {
     reduce_block_max_row<block_ct_dim, respect_trigger>(
-        ckernel::tensor_shape_from_num_faces(num_faces), icb, icb_scaler, row_start_index, idst);
+        ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces), icb, icb_scaler, row_start_index, idst);
 }
 
 #ifdef ARCH_BLACKHOLE
@@ -165,7 +165,7 @@ ALWI void reduce_block_max_row_reinit_short(const ckernel::TensorShape& tensor_s
 template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4>
 ALWI void reduce_block_max_row_reinit_short(std::uint32_t ocb) {
     reduce_block_max_row_reinit_short<block_ct_dim, respect_trigger>(
-        ckernel::tensor_shape_from_num_faces(num_faces), ocb);
+        ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces), ocb);
 }
 #endif
 
@@ -185,7 +185,7 @@ ALWI void reduce_block_max_row_reinit_minimal(const ckernel::TensorShape& tensor
 template <std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4>
 ALWI void reduce_block_max_row_reinit_minimal(std::uint32_t ocb) {
     reduce_block_max_row_reinit_minimal<block_ct_dim, respect_trigger>(
-        ckernel::tensor_shape_from_num_faces(num_faces), ocb);
+        ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces), ocb);
 }
 
 /**
@@ -208,7 +208,7 @@ ALWI void reduce_block_max_row_reinit_minimal_runtime(
 ALWI void reduce_block_max_row_reinit_minimal_runtime(
     std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
     reduce_block_max_row_reinit_minimal_runtime(
-        ckernel::tensor_shape_from_num_faces(num_faces), ocb, block_ct_dim, respect_trigger);
+        ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces), ocb, block_ct_dim, respect_trigger);
 }
 
 /**
@@ -230,7 +230,7 @@ ALWI void reduce_block_max_row_reinit_short_runtime(
 ALWI void reduce_block_max_row_reinit_short_runtime(
     std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
     reduce_block_max_row_reinit_short_runtime(
-        ckernel::tensor_shape_from_num_faces(num_faces), ocb, block_ct_dim, respect_trigger);
+        ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces), ocb, block_ct_dim, respect_trigger);
 }
 #endif
 
@@ -296,7 +296,7 @@ ALWI void reduce_block_max_row_init_runtime(
 ALWI void reduce_block_max_row_init_runtime(
     std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
     reduce_block_max_row_init_runtime(
-        ckernel::tensor_shape_from_num_faces(num_faces), ocb, block_ct_dim, respect_trigger);
+        ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces), ocb, block_ct_dim, respect_trigger);
 }
 
 ALWI void reduce_block_max_row_runtime(
@@ -322,7 +322,7 @@ ALWI void reduce_block_max_row_runtime(
     bool overlap_first_half = false,
     std::uint32_t num_faces = 4) {
     reduce_block_max_row_runtime(
-        ckernel::tensor_shape_from_num_faces(num_faces),
+        ckernel::tensor_shape_from_num_faces(ckernel::MAX_FACE_R_DIM, num_faces),
         icb,
         icb_scaler,
         row_start_index,

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -204,6 +204,13 @@ ALWI void reduce_block_max_row_reinit_minimal_runtime(
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+ALWI void reduce_block_max_row_reinit_minimal_runtime(
+    std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
+    reduce_block_max_row_reinit_minimal_runtime(
+        ckernel::tensor_shape_from_num_faces(num_faces), ocb, block_ct_dim, respect_trigger);
+}
+
 /**
  * Short reinit (runtime variant): Reprograms reduce MOP and restores addrmods.
  * Used when reduce follows custom SDPA sub path with runtime block_ct_dim.
@@ -217,6 +224,13 @@ ALWI void reduce_block_max_row_reinit_short_runtime(
         (llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger, tensor_shape)));
     MATH((llk_math_reduce_block_max_row_reinit_short_runtime<DST_ACCUM_MODE>(block_ct_dim, tensor_shape)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
+}
+
+// num_faces convenience overload: constructs a TensorShape from a flat face count (2 or 4).
+ALWI void reduce_block_max_row_reinit_short_runtime(
+    std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4) {
+    reduce_block_max_row_reinit_short_runtime(
+        ckernel::tensor_shape_from_num_faces(num_faces), ocb, block_ct_dim, respect_trigger);
 }
 #endif
 

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -64,9 +64,9 @@ inline bool _llk_math_skip_bh_tilize_workaround_wrapper_([[maybe_unused]] const 
 }
 
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_reinit_wrapper_()
+inline void _llk_math_reduce_block_max_row_reinit_wrapper_(const ckernel::TensorShape& tensor_shape)
 {
-    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en>();
+    _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en>(tensor_shape);
 }
 
 #elif defined(ARCH_BLACKHOLE)
@@ -111,7 +111,7 @@ inline bool _llk_math_skip_bh_tilize_workaround_wrapper_(const std::uint32_t unp
 }
 
 template <[[maybe_unused]] std::uint32_t block_ct_dim, [[maybe_unused]] bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_reinit_wrapper_()
+inline void _llk_math_reduce_block_max_row_reinit_wrapper_([[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod_reinit_minimal();
 }

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max.py
@@ -30,7 +30,8 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}>();\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, {num_faces}>();\n"
 
     def calculate(
         self,
@@ -41,12 +42,13 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
         tile_x_in_block = f"(({block.tile_id_block}) % {block.block_tiles_x})"
         tile_y_in_block = f"(({block.tile_id_block}) / {block.block_tiles_x})"
         dest_expr = f"(({tile_y_in_block}) * {block.block_tiles_x})"
         return (
             f"if (({tile_x_in_block}) % {ct_dim} == 0 ) {{\n"
-            f"    _llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}>({dest_expr});\n"
+            f"    _llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}, {num_faces}>({dest_expr});\n"
             f"}}\n"
         )
 
@@ -93,9 +95,11 @@ class ReduceBlockMaxFpu(Fpu):
 
         generate_golden = get_golden_generator(ReduceBlockMaxRowGolden)
 
+        # Rows/cols per tile: 32x32 tiles use 32, 16x32 tiny tiles use 16 rows (one face-row).
+        tile_r = operation.tile_shape.total_row_dim()
+        tile_c = operation.tile_shape.total_col_dim()
+
         def process_block(block_x, block_y, block_tiles_x_eff, block_tiles_y_eff):
-            tile_r = operation.tile_shape.total_row_dim()
-            tile_c = operation.tile_shape.total_col_dim()
             src_start_row = block_y * tile_r
             src_end_row = (block_y + block_tiles_y_eff) * tile_r
             start_col = block_x * tile_c

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max.py
@@ -30,8 +30,9 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, {num_faces}>();\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}>({tensor_shape_instantiation});\n"
 
     def calculate(
         self,
@@ -42,13 +43,14 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
         tile_x_in_block = f"(({block.tile_id_block}) % {block.block_tiles_x})"
         tile_y_in_block = f"(({block.tile_id_block}) / {block.block_tiles_x})"
         dest_expr = f"(({tile_y_in_block}) * {block.block_tiles_x})"
         return (
             f"if (({tile_x_in_block}) % {ct_dim} == 0 ) {{\n"
-            f"    _llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}, {num_faces}>({dest_expr});\n"
+            f"    _llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}>({dest_expr}, {tensor_shape_instantiation});\n"
             f"}}\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max_runtime.py
@@ -31,7 +31,9 @@ class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, {tensor_shape_instantiation});\n"
 
     def calculate(
         self,
@@ -41,7 +43,9 @@ class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
         block: BlockData,
     ) -> str:
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_reduce_block_max_row_runtime_<{dest_acc}>({block.tile_id_block});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_reduce_block_max_row_runtime_<{dest_acc}>({block.tile_id_block}, {tensor_shape_instantiation});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -192,9 +192,9 @@ _eltwise_bcast_32x16 = (
     "32x16 tiles are not supported for eltwise with column/row broadcast",
 )
 
-_only_32x32_tile = (
-    lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32),
-    "Only (32, 32) tiles are supported for this operation",
+_only_32x32_or_16x32_tile = (
+    lambda s, a, b: _tile_dims(a.tile_shape) not in ((32, 32), (16, 32)),
+    "Only (32, 32) or (16, 32) tiles are supported for this operation",
 )
 
 _datacopy_only_32x32 = (
@@ -285,14 +285,18 @@ FPU_MAP = {
     ),
     "ReduceBlockMax": (
         lambda s: ReduceBlockMaxFpu(),
-        [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxUnpacker"), _only_32x32_tile],
+        [
+            _no_reuse_dest,
+            _forced_unpacker("ReduceBlockMaxUnpacker"),
+            _only_32x32_or_16x32_tile,
+        ],
     ),
     "ReduceBlockMaxRuntime": (
         lambda s: ReduceBlockMaxRuntimeFpu(),
         [
             _no_reuse_dest,
             _forced_unpacker("ReduceBlockMaxRuntimeUnpacker"),
-            _only_32x32_tile,
+            _only_32x32_or_16x32_tile,
         ],
     ),
     "SubBcastColCustom": (
@@ -300,7 +304,7 @@ FPU_MAP = {
         [
             _no_reuse_dest,
             _forced_unpacker("SubBcastColCustomUnpacker"),
-            _only_32x32_tile,
+            _only_32x32_or_16x32_tile,
         ],
     ),
 }

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -197,6 +197,13 @@ _only_32x32_or_16x32_tile = (
     "Only (32, 32) or (16, 32) tiles are supported for this operation",
 )
 
+# 32x32-only: for ops whose Blackhole fuser generators do not yet plumb tile shape / dst_index
+# (e.g. SubBcastColCustom, whose BH math generator calls the ct_dim-only overload -> 32x32 default).
+_only_32x32_tile = (
+    lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32),
+    "Only (32, 32) tiles are supported for this operation",
+)
+
 _datacopy_only_32x32 = (
     lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32)
     and (
@@ -304,7 +311,7 @@ FPU_MAP = {
         [
             _no_reuse_dest,
             _forced_unpacker("SubBcastColCustomUnpacker"),
-            _only_32x32_or_16x32_tile,
+            _only_32x32_tile,
         ],
     ),
 }

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
@@ -27,8 +27,9 @@ class ReduceBlockMaxUnpacker(Unpacker):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, /*respect_trigger=*/false, {num_faces}>();\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, /*respect_trigger=*/false>({tensor_shape_instantiation});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
@@ -27,7 +27,8 @@ class ReduceBlockMaxUnpacker(Unpacker):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}>();\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, /*respect_trigger=*/false, {num_faces}>();\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max_runtime.py
@@ -65,7 +65,9 @@ class ReduceBlockMaxRuntimeUnpacker(Unpacker):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_unpack_AB_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_unpack_AB_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, /*respect_trigger=*/false, {tensor_shape_instantiation});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -345,12 +345,24 @@ class OperandRegistry:
             tile_cnt = output.tile_count
             tile_elements = output.tile_shape.total_tile_size()
 
-            read_bytes_cnt = output_format.num_bytes_per_tile(tile_elements) * tile_cnt
+            # Tiles are stored densely in L1 (one num_bytes_per_tile(tile_elements)
+            # slot per tile). For full 32x32 tiles this equals the default stride
+            # unpack_res_tiles assumes, but for sub-32x32 tiles (e.g. 16x32) the dense
+            # stride is smaller. Passing it explicitly for sub-tiles keeps the 32x32
+            # code path byte-identical while making unpack_res_tiles stride correctly
+            # for tiny tiles (otherwise it strides at 32x32 and reads only the first
+            # half of the tiles).
+            tile_dense_bytes = output_format.num_bytes_per_tile(tile_elements)
+            is_full_tile = (
+                output.tile_shape.total_row_dim() == DEFAULT_TILE_R_DIM
+                and output.tile_shape.total_col_dim() == DEFAULT_TILE_C_DIM
+            )
+            tile_stride_bytes = None if is_full_tile else tile_dense_bytes
+            read_bytes_cnt = tile_dense_bytes * tile_cnt
             read_data = read_from_device(
                 location, output.l1_address, num_bytes=read_bytes_cnt
             )
 
-            tile_stride = output_format.num_bytes_per_tile(tile_elements)
             res_from_l1 = unpack_res_tiles(
                 read_data,
                 output_format,
@@ -358,7 +370,7 @@ class OperandRegistry:
                 sfpu=False,
                 num_faces=output.tile_shape.total_num_faces(),
                 face_r_dim=output.tile_shape.face_r_dim,
-                tile_stride_bytes=tile_stride,
+                tile_stride_bytes=tile_stride_bytes,
             )
 
             torch_format = format_dict[output_format]
@@ -368,11 +380,12 @@ class OperandRegistry:
                 tilized_tensor,
                 stimuli_format=output_format,
                 dimensions=output_dimensions,
+                num_faces=output.tile_shape.total_num_faces(),
                 tile_dimensions=(
                     output.tile_shape.total_row_dim(),
                     output.tile_shape.total_col_dim(),
                 ),
-                num_faces=output.tile_shape.total_num_faces(),
+                face_r_dim=output.tile_shape.face_r_dim,
             )
 
             output._raw_data = raw_tensor

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -71,6 +71,11 @@ class OperandDefinition(BaseModel):
         Annotated[Tuple[int, int], Field(min_length=2, max_length=2)]
     ] = None
     const_value: Optional[float] = None
+    # Optional per-operand tile geometry (rows, cols). Defaults to a full 32x32 tile
+    # (4 faces). Use (16, 32) for a 16x32 tiny tile (num_faces=2, one face-row).
+    tile_dims: Optional[
+        Annotated[Tuple[int, int], Field(min_length=2, max_length=2)]
+    ] = None
 
     @field_validator("dims")
     @classmethod

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -67,9 +67,6 @@ class OperandDefinition(BaseModel):
     name: str = Field(..., min_length=1)
     dims: Annotated[Tuple[int, int], Field(min_length=2, max_length=2)]
     format: DataFormat
-    tile_dims: Optional[
-        Annotated[Tuple[int, int], Field(min_length=2, max_length=2)]
-    ] = None
     const_value: Optional[float] = None
     # Optional per-operand tile geometry (rows, cols). Defaults to a full 32x32 tile
     # (4 faces). Use (16, 32) for a 16x32 tiny tile (num_faces=2, one face-row).

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_block_max_tiny.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_block_max_tiny.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# 16x32 tiny-tile (num_faces=2, one face-row) variant of fpu_reduce_block_max.
+# Exercises the num_faces=2 unpack + math (2-face MOP/replay) path for
+# reduce_block_max_row. Source B is all ones as the identity scale.
+
+dest_acc: false
+
+operands:
+  - name: "input_A"
+    dims: [256, 256]
+    tile_dims: [16, 32]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [256, 256]
+    tile_dims: [16, 32]
+    format: "Float16_b"
+    const_value: 1.0
+  - name: "reduce_block_max_tiny_out"
+    dims: [256, 256]
+    tile_dims: [16, 32]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "ReduceBlockMax"
+        unpacker: "ReduceBlockMaxUnpacker"
+        math_fidelity: "HiFi2"
+    pack:
+      - output: "reduce_block_max_tiny_out"
+        packer: "Packer"
+    block_size: [16, 128]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max.py
@@ -30,7 +30,8 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}>();\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, {num_faces}>();\n"
 
     def calculate(
         self,
@@ -41,7 +42,8 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}>({block.tile_id_block});\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}, {num_faces}>({block.tile_id_block});\n"
 
     def uninit(
         self,
@@ -87,9 +89,11 @@ class ReduceBlockMaxFpu(Fpu):
 
         generate_golden = get_golden_generator(ReduceBlockMaxRowGolden)
 
+        # Rows/cols per tile: 32x32 tiles use 32, 16x32 tiny tiles use 16 rows (one face-row).
+        tile_r = operation.tile_shape.total_row_dim()
+        tile_c = operation.tile_shape.total_col_dim()
+
         def process_block(block_x, block_y, block_tiles_x_eff, block_tiles_y_eff):
-            tile_r = operation.tile_shape.total_row_dim()
-            tile_c = operation.tile_shape.total_col_dim()
             src_start_row = block_y * tile_r
             src_end_row = (block_y + block_tiles_y_eff) * tile_r
             start_col = block_x * tile_c

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max.py
@@ -30,8 +30,9 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, {num_faces}>();\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}>({tensor_shape_instantiation});\n"
 
     def calculate(
         self,
@@ -42,8 +43,9 @@ class ReduceBlockMaxFpu(Fpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}, {num_faces}>({block.tile_id_block});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}>({block.tile_id_block}, {tensor_shape_instantiation});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max_runtime.py
@@ -31,8 +31,9 @@ class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_math_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, {num_faces});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, {tensor_shape_instantiation});\n"
 
     def calculate(
         self,
@@ -42,8 +43,9 @@ class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
         block: BlockData,
     ) -> str:
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_math_reduce_block_max_row_runtime_<{dest_acc}>({block.tile_id_block}, {num_faces});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_reduce_block_max_row_runtime_<{dest_acc}>({block.tile_id_block}, {tensor_shape_instantiation});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max_runtime.py
@@ -31,7 +31,8 @@ class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim});\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_math_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, {num_faces});\n"
 
     def calculate(
         self,
@@ -41,7 +42,8 @@ class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
         block: BlockData,
     ) -> str:
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_reduce_block_max_row_runtime_<{dest_acc}>({block.tile_id_block});\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_math_reduce_block_max_row_runtime_<{dest_acc}>({block.tile_id_block}, {num_faces});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/sub_bcast_col_custom.py
@@ -49,8 +49,9 @@ class SubBcastColCustomFpu(EltwiseFpu):
         block: BlockData,
     ) -> str:
         ct_dim = block.block_tiles_x
-        num_faces = operation.tile_shape.total_num_faces()
-        return f"_llk_math_sub_bcast_cols_reuse_custom_({ct_dim}, {num_faces}, {block.tile_id_block});\n"
+        tile_shape = operation.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_math_sub_bcast_cols_reuse_custom_({ct_dim}, {tensor_shape_instantiation}, {block.tile_id_block});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/sub_bcast_col_custom.py
@@ -49,7 +49,8 @@ class SubBcastColCustomFpu(EltwiseFpu):
         block: BlockData,
     ) -> str:
         ct_dim = block.block_tiles_x
-        return f"_llk_math_sub_bcast_cols_reuse_custom_({ct_dim});\n"
+        num_faces = operation.tile_shape.total_num_faces()
+        return f"_llk_math_sub_bcast_cols_reuse_custom_({ct_dim}, {num_faces}, {block.tile_id_block});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
@@ -191,9 +191,9 @@ _eltwise_bcast_32x16 = (
     "32x16 tiles are not supported for eltwise with column/row broadcast",
 )
 
-_only_32x32_tile = (
-    lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32),
-    "Only (32, 32) tiles are supported for this operation",
+_only_32x32_or_16x32_tile = (
+    lambda s, a, b: _tile_dims(a.tile_shape) not in ((32, 32), (16, 32)),
+    "Only (32, 32) or (16, 32) tiles are supported for this operation",
 )
 
 _datacopy_only_32x32 = (
@@ -284,14 +284,18 @@ FPU_MAP = {
     ),
     "ReduceBlockMax": (
         lambda s: ReduceBlockMaxFpu(),
-        [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxUnpacker"), _only_32x32_tile],
+        [
+            _no_reuse_dest,
+            _forced_unpacker("ReduceBlockMaxUnpacker"),
+            _only_32x32_or_16x32_tile,
+        ],
     ),
     "ReduceBlockMaxRuntime": (
         lambda s: ReduceBlockMaxRuntimeFpu(),
         [
             _no_reuse_dest,
             _forced_unpacker("ReduceBlockMaxRuntimeUnpacker"),
-            _only_32x32_tile,
+            _only_32x32_or_16x32_tile,
         ],
     ),
     "SubBcastColCustom": (
@@ -299,7 +303,7 @@ FPU_MAP = {
         [
             _no_reuse_dest,
             _forced_unpacker("SubBcastColCustomUnpacker"),
-            _only_32x32_tile,
+            _only_32x32_or_16x32_tile,
         ],
     ),
 }

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
@@ -27,8 +27,9 @@ class ReduceBlockMaxUnpacker(Unpacker):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, /*respect_trigger=*/false, {num_faces}>();\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, /*respect_trigger=*/false>({tensor_shape_instantiation});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
@@ -27,7 +27,8 @@ class ReduceBlockMaxUnpacker(Unpacker):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}>();\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_unpack_AB_reduce_block_max_row_init_<{ct_dim}, {dest_acc}, /*respect_trigger=*/false, {num_faces}>();\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
@@ -65,7 +65,8 @@ class ReduceBlockMaxRuntimeUnpacker(Unpacker):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_unpack_AB_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim});\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_unpack_AB_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, /*respect_trigger=*/false, {num_faces});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
@@ -65,8 +65,9 @@ class ReduceBlockMaxRuntimeUnpacker(Unpacker):
     ) -> str:
         ct_dim = block.block_tiles_x
         dest_acc = config.dest_acc.cpp_enum_value
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_unpack_AB_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, /*respect_trigger=*/false, {num_faces});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_unpack_AB_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim}, /*respect_trigger=*/false, {tensor_shape_instantiation});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/sub_bcast_col_custom.py
@@ -112,8 +112,9 @@ class SubBcastColCustomUnpacker(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
-        return f"_llk_unpack_AB_sub_bcast_col_init_custom_({num_faces});\n"
+        tile_shape = compute_unit.src_a.tile_shape
+        tensor_shape_instantiation = f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}}"
+        return f"_llk_unpack_AB_sub_bcast_col_init_custom_({tensor_shape_instantiation});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/sub_bcast_col_custom.py
@@ -112,7 +112,8 @@ class SubBcastColCustomUnpacker(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        return "_llk_unpack_AB_sub_bcast_col_init_custom_();\n"
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        return f"_llk_unpack_AB_sub_bcast_col_init_custom_({num_faces});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -289,18 +289,35 @@ def get_golden_generator(cls):
     return golden_registry[cls]
 
 
+def _dummy_zeros(**kwargs):
+    # Size the dummy tensor from the caller's tile-shape kwargs when they are
+    # all present (num_faces * face_r_dim * FACE_DIM per tile, times tile_cnt),
+    # so callers that strictly size-check the result (e.g. untilize_block on a
+    # 16x32 tiny tile) get a correctly-sized tensor. When any sizing kwarg is
+    # absent, fall back to the historical ELEMENTS_PER_TILE (1024) so existing
+    # callers are unaffected.
+    num_faces = kwargs.get("num_faces")
+    face_r_dim = kwargs.get("face_r_dim")
+    tile_cnt = kwargs.get("tile_cnt")
+    if num_faces is None or face_r_dim is None or tile_cnt is None:
+        size = ELEMENTS_PER_TILE
+    else:
+        size = tile_cnt * num_faces * face_r_dim * FACE_DIM
+    return torch.zeros(size, dtype=torch.bfloat16)
+
+
 class DummyGoldenGenerator:
     def __call__(*args, **kwargs):
-        return torch.zeros(1024, dtype=torch.bfloat16)
+        return _dummy_zeros(**kwargs)
 
     def transpose_faces_multi_tile(*args, **kwargs):
-        return torch.zeros(1024, dtype=torch.bfloat16)
+        return _dummy_zeros(**kwargs)
 
     def transpose_within_faces_multi_tile(*args, **kwargs):
-        return torch.zeros(1024, dtype=torch.bfloat16)
+        return _dummy_zeros(**kwargs)
 
     def accumulate_l1(*args, **kwargs):
-        return torch.zeros(1024, dtype=torch.bfloat16)
+        return _dummy_zeros(**kwargs)
 
 
 def dummy_golden_generator(cls):
@@ -3458,11 +3475,16 @@ class ReduceGolden:
 
 @register_golden
 class ReduceBlockMaxRowGolden:
+    # Row-wise block max reduce. Works for both 32x32 (num_faces=4) and 16x32 (num_faces=2,
+    # one face-row) tiles: the reduce is per-row across the full block width and the caller
+    # passes block dims sized by the actual tile row/col dims. Column width per tile is 32 in
+    # both cases (only the row count shrinks for tiny tiles), so the reduce span is ct_dim * 32.
     def __call__(self, operand, ct_dim, data_format, dimensions):
         operand = operand.reshape(dimensions)
         output = torch.zeros(dimensions)
+        reduce_width = min(ct_dim * 32, dimensions[1])
         for i in range(dimensions[0]):
-            output[i, 0] = torch.max(operand[i, : ct_dim * 32])
+            output[i, 0] = torch.max(operand[i, :reduce_width])
 
         return output
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
@@ -26,12 +26,15 @@ from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     BROADCAST_TYPE,
+    INPUT_DIMENSIONS,
     MATH_FIDELITY,
     MATH_OP,
+    NUM_FACES,
+    TEST_FACE_DIMS,
     TILE_COUNT,
     TemplateParameter,
-    generate_input_dim,
 )
+from helpers.tile_constants import get_tile_params
 from helpers.tilize_untilize import tilize_block, untilize_block
 from helpers.utils import passed_test
 
@@ -44,6 +47,11 @@ class CT_DIM(TemplateParameter):
 
     def convert_to_cpp(self) -> str:
         return f"constexpr std::uint32_t CT_DIM = {self.ct_dim};"
+
+
+# Row height of the srcA operand. 32 -> full 32x32 tiles (num_faces=4);
+# 16 -> 16x32 "tiny tiles" (one face-row, num_faces=2).
+_TILE_ROWS = [32, 16]
 
 
 @parametrize(
@@ -64,8 +72,8 @@ class CT_DIM(TemplateParameter):
         MathFidelity.HiFi4,
     ],
     broadcast_type=[BroadcastType.Column],
-    input_dimensions_A=[[32, w] for w in range(32, 257, 32)],
-    input_dimensions_B=[[32, 32]],
+    tile_rows=_TILE_ROWS,
+    input_width=list(range(32, 257, 32)),
 )
 def test_eltwise_bcast_col_custom(
     cpp_source,
@@ -74,8 +82,8 @@ def test_eltwise_bcast_col_custom(
     dest_acc,
     math_fidelity,
     broadcast_type,
-    input_dimensions_A,
-    input_dimensions_B,
+    tile_rows,
+    input_width,
 ):
     if mathop != MathOperation.Elwmul and math_fidelity != MathFidelity.LoFi:
         pytest.skip("Fidelity does not affect Elwadd and Elwsub operations")
@@ -87,12 +95,24 @@ def test_eltwise_bcast_col_custom(
     ):
         pytest.skip("MUL bcast-col reuse scaffold is Blackhole-only")
 
+    input_dimensions_A = [tile_rows, input_width]
+    input_dimensions_B = [tile_rows, 32]
+
+    # 32x32 tile => num_faces=4, 16x32 tiny tile => num_faces=2.
+    tile_dims = [tile_rows, 32]
+    face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dims)
+    num_faces = num_faces_r_dim * num_faces_c_dim
+
     ct_dim = input_dimensions_A[1] // 32
+    # Each column tile is tile_rows x 32; the operand is a single row of ct_dim tiles.
+    rt_dim = 1
     logger.info(
-        "Running ct_dim=%d  srcA=%s  srcB=%s",
+        "Running ct_dim=%d  srcA=%s  srcB=%s  num_faces=%d  face_r_dim=%d",
         ct_dim,
         input_dimensions_A,
         input_dimensions_B,
+        num_faces,
+        face_r_dim,
     )
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
@@ -100,13 +120,24 @@ def test_eltwise_bcast_col_custom(
         input_dimensions_A=input_dimensions_A,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions_B,
+        tile_dimensions=tile_dims,
     )
 
     src_A_tilized = tilize_block(
-        src_A, input_dimensions_A, formats.input_format
+        src_A,
+        input_dimensions_A,
+        formats.input_format,
+        num_faces=num_faces,
+        tile_dimensions=tile_dims,
+        face_r_dim=face_r_dim,
     ).flatten()
     src_B_tilized = tilize_block(
-        src_B, input_dimensions_B, formats.input_format
+        src_B,
+        input_dimensions_B,
+        formats.input_format,
+        num_faces=num_faces,
+        tile_dimensions=tile_dims,
+        face_r_dim=face_r_dim,
     ).flatten()
 
     broadcast_golden = get_golden_generator(BroadcastGolden)
@@ -114,13 +145,18 @@ def test_eltwise_bcast_col_custom(
         broadcast_type,
         src_B_tilized,
         formats.input_format,
-        num_faces=4,
+        num_faces=num_faces,
         tile_cnt=tile_cnt_B,
-        face_r_dim=16,
+        face_r_dim=face_r_dim,
     )
 
     src_B_golden = untilize_block(
-        src_B_broadcasted_tilized, formats.input_format, input_dimensions_B
+        src_B_broadcasted_tilized,
+        formats.input_format,
+        input_dimensions_B,
+        num_faces=num_faces,
+        tile_dimensions=tile_dims,
+        face_r_dim=face_r_dim,
     ).flatten()
 
     src_B_2d = src_B_golden.view(input_dimensions_B[0], input_dimensions_B[1])
@@ -137,12 +173,21 @@ def test_eltwise_bcast_col_custom(
         formats,
         templates=[
             MATH_FIDELITY(math_fidelity),
-            generate_input_dim(input_dimensions_A, input_dimensions_A),
+            INPUT_DIMENSIONS(
+                full_rt_dim=rt_dim,
+                full_ct_dim=ct_dim,
+                block_ct_dim=ct_dim,
+                block_rt_dim=rt_dim,
+            ),
             MATH_OP(mathop=mathop),
             BROADCAST_TYPE(broadcast_type),
             CT_DIM(ct_dim),
         ],
-        runtimes=[TILE_COUNT(tile_cnt_A)],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces, num_faces, num_faces),
+            TEST_FACE_DIMS(face_r_dim),
+        ],
         variant_stimuli=StimuliConfig(
             src_A_tilized,
             formats.input_format,
@@ -152,13 +197,22 @@ def test_eltwise_bcast_col_custom(
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_B,
             tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            face_r_dim=face_r_dim,
+            tile_dimensions=tile_dims,
+            use_dense_tile_dimensions=True,
         ),
         dest_acc=dest_acc,
     )
     res_from_L1 = configuration.run().result
 
     res_from_L1 = untilize_block(
-        res_from_L1, formats.output_format, input_dimensions_A
+        res_from_L1,
+        formats.output_format,
+        input_dimensions_A,
+        num_faces=num_faces,
+        tile_dimensions=tile_dims,
+        face_r_dim=face_r_dim,
     ).flatten()
 
     assert len(res_from_L1) == len(
@@ -169,8 +223,9 @@ def test_eltwise_bcast_col_custom(
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
     # Spot-check: log a few elements per tile to verify srcA <op> bcast(srcB)
+    tile_elems = tile_rows * 32
     for t in range(ct_dim):
-        tile_start = t * 32 * 32
+        tile_start = t * tile_elems
         a_sample = src_A[tile_start : tile_start + 4].tolist()
         b_sample = src_B_golden_expanded[tile_start : tile_start + 4].tolist()
         g_sample = golden_tensor[tile_start : tile_start + 4].tolist()

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -18,12 +18,14 @@ std::uint32_t math_sync_tile_dst_index = 0;
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
 #include "llk_unpack_common.h"
 #include "params.h"
+#include "tensor_shape.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+    const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(params.num_faces, params.TEST_FACE_R_DIM);
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src,
         formats.unpack_B_src,
@@ -33,7 +35,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.TEST_FACE_R_DIM,
         params.num_faces,
         params.num_faces);
-    _llk_unpack_AB_sub_bcast_col_init_custom_(params.num_faces);
+    _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
 
     _llk_unpack_AB_sub_bcast_col_custom_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), CT_DIM);
 }
@@ -45,12 +47,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "experimental/llk_math_eltwise_binary_custom.h"
 #include "llk_math_common.h"
 #include "params.h"
+#include "tensor_shape.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+    const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(params.num_faces, params.TEST_FACE_R_DIM);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_eltwise_binary_init_custom_<ELTWISE_BINARY_OP, BROADCAST_TYPE>(params.num_faces);
@@ -60,9 +64,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // call custom LLK. The templated MUL/SUB scaffold is Blackhole-only; Wormhole has only the
     // SUB-named wrapper, so MUL is exercised on BH alone (the test skips the MUL variant on non-BH).
 #ifdef ARCH_BLACKHOLE
-    _llk_math_bcast_cols_reuse_custom_<ELTWISE_BINARY_OP>(CT_DIM, params.num_faces);
+    _llk_math_bcast_cols_reuse_custom_<ELTWISE_BINARY_OP>(CT_DIM, tensor_shape);
 #else
-    _llk_math_sub_bcast_cols_reuse_custom_(CT_DIM, params.num_faces);
+    _llk_math_sub_bcast_cols_reuse_custom_(CT_DIM, tensor_shape);
 #endif
 
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -25,8 +25,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /*num_faces */, 4 /* num_faces */);
-    _llk_unpack_AB_sub_bcast_col_init_custom_();
+        formats.unpack_A_src,
+        formats.unpack_B_src,
+        formats.unpack_A_dst,
+        formats.unpack_B_dst,
+        params.TEST_FACE_R_DIM,
+        params.TEST_FACE_R_DIM,
+        params.num_faces,
+        params.num_faces);
+    _llk_unpack_AB_sub_bcast_col_init_custom_(params.num_faces);
 
     _llk_unpack_AB_sub_bcast_col_custom_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), CT_DIM);
 }
@@ -46,16 +53,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-    _llk_math_eltwise_binary_init_custom_<ELTWISE_BINARY_OP, BROADCAST_TYPE>(4);
+    _llk_math_eltwise_binary_init_custom_<ELTWISE_BINARY_OP, BROADCAST_TYPE>(params.num_faces);
 
     _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
 
     // call custom LLK. The templated MUL/SUB scaffold is Blackhole-only; Wormhole has only the
     // SUB-named wrapper, so MUL is exercised on BH alone (the test skips the MUL variant on non-BH).
 #ifdef ARCH_BLACKHOLE
-    _llk_math_bcast_cols_reuse_custom_<ELTWISE_BINARY_OP>(CT_DIM);
+    _llk_math_bcast_cols_reuse_custom_<ELTWISE_BINARY_OP>(CT_DIM, params.num_faces);
 #else
-    _llk_math_sub_bcast_cols_reuse_custom_(CT_DIM);
+    _llk_math_sub_bcast_cols_reuse_custom_(CT_DIM, params.num_faces);
 #endif
 
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
@@ -74,11 +81,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */);
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats.pack_src,
+        formats.pack_dst,
+        params.TEST_FACE_R_DIM * FACE_C_DIM * params.num_faces /* tile_size */,
+        params.TEST_FACE_R_DIM,
+        TILE_C_DIM,
+        params.num_faces);
 
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
 
-    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>(params.TEST_FACE_R_DIM);
 
     // wait for math to finish
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -25,7 +25,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(params.num_faces, params.TEST_FACE_R_DIM);
+    const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces);
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src,
         formats.unpack_B_src,
@@ -54,7 +54,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(params.num_faces, params.TEST_FACE_R_DIM);
+    const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_eltwise_binary_init_custom_<ELTWISE_BINARY_OP, BROADCAST_TYPE>(params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -62,7 +62,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {
-        _llk_unpack_AB_reduce_block_max_row_init_<1, false>();
+        _llk_unpack_AB_reduce_block_max_row_init_<1, false>(ckernel::DEFAULT_TENSOR_SHAPE);
         if ((batch * 1 + 0) % 1 == 0)
         {
             _llk_unpack_AB_reduce_block_max_row_(L1_ADDRESS(buffer_A1[batch * 1 + 0]), L1_ADDRESS(buffer_B1[batch * 1 + 0]));
@@ -124,7 +124,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr DstSync dest_sync0     = DstSync::SyncHalf;
     _llk_math_hw_configure_<false>(math_format0, math_format0);
     _llk_math_pack_sync_init_<dest_sync0, false>();
-    _llk_math_reduce_block_max_row_init_<1, false>();
+    _llk_math_reduce_block_max_row_init_<1, false>(ckernel::DEFAULT_TENSOR_SHAPE);
 
     // Operation 0: Matmul FPU - Using experimental custom no-mop API
     _llk_math_matmul_init_no_mop_<ckernel::MathFidelity::LoFi, 0>(TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, 0, 1, 1);
@@ -145,12 +145,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_pack_sync_init_<dest_sync1, false>();
 
     // Custom addr_mod reinit for reduce_block_max_row (full init done in Operation 0)
-    _llk_math_reduce_block_max_row_reinit_wrapper_<1 /* block_ct_dim */, false /* is_fp32_dest_acc_en */>();
+    _llk_math_reduce_block_max_row_reinit_wrapper_<1 /* block_ct_dim */, false /* is_fp32_dest_acc_en */>(ckernel::DEFAULT_TENSOR_SHAPE);
 
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {
         _llk_math_wait_for_dest_available_<dest_sync1>();
-        _llk_math_reduce_block_max_row_<1, false>(0);
+        _llk_math_reduce_block_max_row_<1, false>(0, ckernel::DEFAULT_TENSOR_SHAPE);
         _llk_math_dest_section_done_<dest_sync1, false>();
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -11,6 +11,7 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -93,7 +94,7 @@ inline void _bcast_cols_op_()
  *
  * @tparam eltwise_binary_type: FPU op, values = <ELWSUB/ELWMUL>
  * @param ct_dim: Number of srcA column tiles processed in the block.
- * @param num_faces: Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
+ * @param tensor_shape: Shape of the operand tile (2 faces for 16x32 tiny tiles, 4 faces for full 32x32 tiles).
  * @param dst_index: Absolute dest tile slot where this block-row's ct_dim tiles begin. Multi-tile-row
  *                   callers (e.g. the fuser LoopBlockRow driver) advance this per block-row so each row
  *                   lands on its own dest slots; single-tile-row callers leave it at 0.
@@ -101,14 +102,16 @@ inline void _bcast_cols_op_()
  */
 template <EltwiseBinaryType eltwise_binary_type>
 inline void _llk_math_bcast_cols_reuse_custom_(
-    const std::uint32_t ct_dim = 1, const std::uint32_t num_faces = 4, const std::uint32_t dst_index = 0)
+    const std::uint32_t ct_dim = 1, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
 {
     static_assert(
         eltwise_binary_type == EltwiseBinaryType::ELWMUL || eltwise_binary_type == EltwiseBinaryType::ELWSUB,
         "blocked bcast-col reuse scaffold supports ELWMUL and ELWSUB only");
 
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     // Two faces make up one face-row; a full tile has two of them, a tiny tile one.
-    const std::uint32_t num_face_rows = num_faces / 2;
+    const std::uint32_t num_face_rows = tensor_shape.num_faces_r_dim;
 
     addr_mod_t {
         .srca = {.incr = 8},
@@ -177,11 +180,11 @@ inline void _llk_math_bcast_cols_reuse_custom_(
  * and calls @ref _llk_math_bcast_cols_reuse_custom_ <ELWMUL> directly.
  *
  * @param ct_dim: Number of srcA column tiles processed in the block.
- * @param num_faces: Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
+ * @param tensor_shape: Shape of the operand tile (2 faces for 16x32 tiny tiles, 4 faces for full 32x32 tiles).
  * @param dst_index: Absolute dest tile slot where this block-row's ct_dim tiles begin.
  */
 inline void _llk_math_sub_bcast_cols_reuse_custom_(
-    const std::uint32_t ct_dim = 1, const std::uint32_t num_faces = 4, const std::uint32_t dst_index = 0)
+    const std::uint32_t ct_dim = 1, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
 {
-    _llk_math_bcast_cols_reuse_custom_<EltwiseBinaryType::ELWSUB>(ct_dim, num_faces, dst_index);
+    _llk_math_bcast_cols_reuse_custom_<EltwiseBinaryType::ELWSUB>(ct_dim, tensor_shape, dst_index);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -87,16 +87,28 @@ inline void _bcast_cols_op_()
  * batch and calls once per head into the SAME dest -> dest[col] = sum_h qk[col,h]*w[h], one pack per
  * column instead of per (column, head). cb_qk must be head-major.
  *
+ * Each 16x16 face pair (one face-row) is processed by four ops (two per face; each covers an aligned
+ * 8x16 block). A full 32x32 tile has two face-rows (F0/F1 and F2/F3); a 16x32 tiny tile has a single
+ * face-row (F0/F1).
+ *
  * @tparam eltwise_binary_type: FPU op, values = <ELWSUB/ELWMUL>
  * @param ct_dim: Number of srcA column tiles processed in the block.
+ * @param num_faces: Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
+ * @param dst_index: Absolute dest tile slot where this block-row's ct_dim tiles begin. Multi-tile-row
+ *                   callers (e.g. the fuser LoopBlockRow driver) advance this per block-row so each row
+ *                   lands on its own dest slots; single-tile-row callers leave it at 0.
  * @note Canonical description of the shared blocked bcast-col mechanism; other files reference this one.
  */
 template <EltwiseBinaryType eltwise_binary_type>
-inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
+inline void _llk_math_bcast_cols_reuse_custom_(
+    const std::uint32_t ct_dim = 1, const std::uint32_t num_faces = 4, const std::uint32_t dst_index = 0)
 {
     static_assert(
         eltwise_binary_type == EltwiseBinaryType::ELWMUL || eltwise_binary_type == EltwiseBinaryType::ELWSUB,
         "blocked bcast-col reuse scaffold supports ELWMUL and ELWSUB only");
+
+    // Two faces make up one face-row; a full tile has two of them, a tiny tile one.
+    const std::uint32_t num_face_rows = num_faces / 2;
 
     addr_mod_t {
         .srca = {.incr = 8},
@@ -126,21 +138,25 @@ inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
     // the pair's 2nd op rereads the same srcB face; ADDR_MOD_6 then jumps srcB +24 to the next pair.
     for (std::uint32_t i = 0; i < ct_dim; i++)
     {
-        // face F0 (srcB face 0)
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 0 -> 8
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_5>(); // 8 -> 0
+        // Position the dest write pointer at the start of this tile's 32x32 dest
+        // slot (stride 64 rows). The packer indexes tiles at the full 32x32 tile
+        // stride regardless of num_faces, so tiles must be written one-per-slot.
+        // The ADDR_MOD dest increments below only advance 32 rows for a 16x32 tiny
+        // tile (num_faces=2) and 64 rows for a full 32x32 tile (num_faces=4); the
+        // per-slot base + counter reset makes both land on the right slot.
+        math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + i);
+        math::clear_dst_reg_addr();
 
-        // face F1 (srcB face 0, reused)
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 0 -> 8
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_6>(); // 8 -> 32
+        for (std::uint32_t face_row = 0; face_row < num_face_rows; face_row++)
+        {
+            // Even face (F0 / F2): op then rewind srcB by one face (ADDR_MOD_5) so the odd face reads it.
+            _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // srcB: 0 -> 8
+            _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_5>(); // srcB: 8 -> 0
 
-        // face F2 (srcB face 2)
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 32 -> 40
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_5>(); // 40 -> 32
-
-        // face F3 (srcB face 2, reused)
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 32 -> 40
-        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_6>(); // 40 -> 64, no CLR_A
+            // Odd face (F1 / F3): op then advance srcB +24 (ADDR_MOD_6) to the next face-row / tile.
+            _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // srcB: 0 -> 8
+            _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_6>(); // srcB: 8 -> 32 (next face-row)
+        }
 
         // Rewind srcB to 0 for the next srcA tile (CLR_A clears srcA's dvalid); srcA keeps advancing.
         TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_AB);
@@ -148,6 +164,9 @@ inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
 
     // Clear srcB dvalid on the way out.
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_AB);
+
+    // Restore the dest base offset so the next op starts from tile slot 0.
+    math::clear_dst_reg_addr();
 }
 
 /**
@@ -158,8 +177,11 @@ inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
  * and calls @ref _llk_math_bcast_cols_reuse_custom_ <ELWMUL> directly.
  *
  * @param ct_dim: Number of srcA column tiles processed in the block.
+ * @param num_faces: Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
+ * @param dst_index: Absolute dest tile slot where this block-row's ct_dim tiles begin.
  */
-inline void _llk_math_sub_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
+inline void _llk_math_sub_bcast_cols_reuse_custom_(
+    const std::uint32_t ct_dim = 1, const std::uint32_t num_faces = 4, const std::uint32_t dst_index = 0)
 {
-    _llk_math_bcast_cols_reuse_custom_<EltwiseBinaryType::ELWSUB>(ct_dim);
+    _llk_math_bcast_cols_reuse_custom_<EltwiseBinaryType::ELWSUB>(ct_dim, num_faces, dst_index);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -12,6 +12,7 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "llk_math_matmul.h" // tile-shape-aware matmul_configure_addrmod reused for 16x32 tiny-tile support
 
 using namespace ckernel;
 
@@ -36,9 +37,29 @@ inline void matmul_validate_no_mop_contract(
 }
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
-inline void matmul_configure_addrmod_no_mop(const bool transpose)
+inline void matmul_configure_addrmod_no_mop(
+    const bool transpose,
+    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const bool partial_face            = false)
 {
     static_assert(THROTTLE_LEVEL >= 0 && THROTTLE_LEVEL <= 5, "THROTTLE_LEVEL must be in range [0, 5]");
+
+    // For 16x32 tiny tiles (or any non-full-tile geometry) delegate to the tile-shape-aware regular
+    // matmul address-modifier programming. That path programs the SrcB cr-reset / reduced increments
+    // so the fixed no-mop replay stays confined to the tile's actual face-rows (mirrors the WH no-mop
+    // path, which likewise delegates to matmul_configure_addrmod). The hardcoded full-32x32 addrmods
+    // below are retained unchanged for the common full-tile case.
+    const bool is_full_tile = (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) &&
+                              (in1_tile_c_dim == TILE_C_DIM) && !partial_face;
+    if (!is_full_tile)
+    {
+        matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        return;
+    }
+
     constexpr bool high_fidelity     = math_fidelity != MathFidelity::LoFi;
     constexpr int fidelity_increment = high_fidelity ? 1 : 0;
 
@@ -128,15 +149,48 @@ inline void matmul_configure_addrmod_no_mop(const bool transpose)
 }
 
 template <MathFidelity math_fidelity = MathFidelity::LoFi, int THROTTLE_LEVEL = 0>
-inline void matmul_configure_addrmod_reinit(const bool transpose = false)
+inline void matmul_configure_addrmod_reinit(
+    const bool transpose               = false,
+    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const bool partial_face            = false)
 {
-    // Reinit must restore the full matmul address-modifier contract used by replay.
-    // In particular, transpose affects ADDR_MOD_1/4 and fidelity/throttle use ADDR_MOD_5/6.
-    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(transpose);
+    // Reinit must restore the address-modifier contract used by replay. For tiny tiles this
+    // re-establishes the shape-aware addrmods (see matmul_configure_addrmod_no_mop); for full tiles
+    // it restores the hardcoded 32x32 addrmods. transpose affects ADDR_MOD_1/4, fidelity uses ADDR_MOD_5/6.
+    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(
+        transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+}
+
+// Number of MVMULs (including the trailing fidelity/clear op) in the no-mop replay image for the given
+// operand geometry. Mirrors the replay_buf_len formula in the regular matmul_configure_mop so the tiny
+// (16x32 / 32x16) face-row-confined sequences record and replay the correct length.
+inline std::uint32_t matmul_no_mop_replay_len(
+    const std::uint32_t in0_tile_r_dim,
+    const std::uint32_t in0_tile_c_dim,
+    const std::uint32_t in1_tile_r_dim,
+    const std::uint32_t in1_tile_c_dim,
+    const bool partial_face)
+{
+    const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
+    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
+    const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
+    return (is_in0_16x32 && is_in1_32x16) ? 4
+                                          : ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
 }
 
 template <MathFidelity math_fidelity>
-inline void matmul_configure_mop_custom(const std::uint32_t ct_dim, const std::uint32_t rt_dim)
+inline void matmul_configure_mop_custom(
+    const std::uint32_t ct_dim,
+    const std::uint32_t rt_dim,
+    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const bool partial_face            = false)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -145,52 +199,105 @@ inline void matmul_configure_mop_custom(const std::uint32_t ct_dim, const std::u
     // by changing address increment amount via addr_mods
     // Col major layout in dest only impacts destination address increment
     // if col major layout faces are ordered as f0,f2,f1,f3
+    //
+    // 16x32 / 32x16 tiny tiles record a shorter, face-row-confined MVMUL sequence (identical to the proven
+    // regular matmul_configure_mop) so the replay never marches SrcB into non-existent faces; full 32x32
+    // tiles keep the original 16-MVMUL 4-face walk. The no-mop path drives this via direct lltt::replay.
 
-    constexpr bool high_fidelity                       = math_fidelity != MathFidelity::LoFi;
+    constexpr bool high_fidelity = math_fidelity != MathFidelity::LoFi;
 
     const bool reuse_a = ct_dim >= rt_dim;
 
-    const std::uint32_t replay_buf_len = 16;
+    const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
+    const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
+    const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
+    const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
+
+    const std::uint32_t replay_buf_len = matmul_no_mop_replay_len(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 
     load_replay_buf(
         ckernel::math::replay_buf_offset,
         replay_buf_len,
         // Lambda function to load reply buffer
-        [high_fidelity, reuse_a]
+        [high_fidelity, reuse_a, partial_face, is_in1_32x16, is_in0_16x32, is_in0_32x16, is_in1_16x32]
         {
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
+            if (is_in1_32x16)
+            {
+                if (is_in0_16x32)
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A1 // srca=srca, srcb+=8,  dest=+8, bias=1
+                }
+                else
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A1 // srca=srca, srcb+=8,  dest=+8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B1A1 // srca=0,    srcb+=8,  dest=16 (addr_mod_4), bias=0
 
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B2A0 // srca+=16,  srcb+=8,  dest=16
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A1 // srca=srca, srcb+=8,  dest+=8
+                }
+            }
+            else if (is_in0_16x32 || is_in0_32x16)
+            {
+                if (partial_face)
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest=+16
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B0A1 // srca+=16,  srcb+=16, dest=0 (addr_mod_4), bias=0
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A2 // srca+=16,  srcb=0,   dest=+16
+                }
+                else
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B0A1 // srca+=16/=0, srcb=16, dest=0/+=8 (addr_mod_4) // srca=0 dest+=8 if in0_32x16
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8/24 // dest+=24 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
+                }
+            }
+            else
+            {
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8  // A1 -> A2 if transposed
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A1 // srca=0,    srcb=32,  dest+=8  // A1 -> A2 if transposed
 
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8 // A2 -> A1 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A3 // srca=32,   srcb=48,  dest+=8
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // srca=srca, srcb+=8,  dest+=8
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B2A0 // srca+=16/32, srcb=0, dest+=8 // srca+=32 if transposed
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A1 // srca=srca, srcb+=8,  dest+=8 // A1 -> A2 if transposed
+                if (!is_in1_16x32)
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B2A1 // srca=32/16,srcb=16,  dest=0 (addr_mod_4) // A1 -> A2 && srca=16 if transposed
 
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A2 // srca+=16,  srcb=0,   dest+=8 // A2 -> A1 if transposed
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A3 // srca=32,   srcb=48,  dest+=8
+
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A2 // srca=srca, srcb+=8,  dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A2 // srca+=16,  srcb=0,   dest+=8 // A2 -> A1 if transposed
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
+                }
+            }
 
             if constexpr (high_fidelity)
             {
-                // TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0); // reset srca/srcb/dest, increment phase (addr_mod_5)
             }
             else
             {
                 if (reuse_a)
                 {
-                    TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                    TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0); // reset + increment phase (addr_mod_5), clear src A
                 }
                 else
                 {
-                    TTI_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
+                    TTI_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0); // reset + increment phase (addr_mod_5), clear src B
                 }
             }
         });
@@ -329,15 +436,15 @@ inline void _llk_math_matmul_init_no_mop_(
     const std::uint32_t ct_dim         = 1,
     const std::uint32_t rt_dim         = 1)
 {
-    matmul_validate_no_mop_contract(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
-    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(transpose);
+    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(
+        transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     if constexpr (THROTTLE_LEVEL > 0)
     {
         matmul_configure_mop_throttled_no_mop<THROTTLE_LEVEL>();
     }
     else
     {
-        matmul_configure_mop_custom<math_fidelity>(ct_dim, rt_dim);
+        matmul_configure_mop_custom<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
@@ -348,7 +455,15 @@ inline void _llk_math_matmul_uninit_no_mop_()
 }
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
-inline void _llk_math_matmul_no_mop_(std::uint32_t dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1)
+inline void _llk_math_matmul_no_mop_(
+    std::uint32_t dst_index,
+    const std::uint32_t ct_dim         = 1,
+    const std::uint32_t rt_dim         = 1,
+    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const bool partial_face            = false)
 {
     const bool reuse_a                = ct_dim >= rt_dim;
     const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;
@@ -356,7 +471,8 @@ inline void _llk_math_matmul_no_mop_(std::uint32_t dst_index, const std::uint32_
     constexpr int num_fidelity_phases = get_math_num_fidelity_phases(math_fidelity);
     constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
 
-    // Compute replay buffer length based on tile dimensions (same logic as in matmul_configure_mop)
+    // Compute replay buffer length based on tile dimensions (same logic as in matmul_configure_mop_custom).
+    // For 16x32 tiny tiles this is the shorter face-row-confined length (must match what was recorded at init).
     std::uint32_t replay_buf_len;
     if constexpr (THROTTLE_LEVEL > 0)
     {
@@ -364,7 +480,7 @@ inline void _llk_math_matmul_no_mop_(std::uint32_t dst_index, const std::uint32_
     }
     else
     {
-        replay_buf_len = 16;
+        replay_buf_len = matmul_no_mop_replay_len(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     }
 
     for (std::uint32_t t = 0; t < t_dim; t++)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -13,6 +13,7 @@
 #include "llk_defs.h"
 #include "llk_math_common.h"
 #include "llk_operands.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -196,15 +197,16 @@ inline void _llk_math_mul_reduce_scalar_init_()
  *
  * @tparam MATH_FIDELITY_DESC Math fidelity descriptor (0 = default, higher = more precision)
  * @param dst_index Destination tile index to accumulate into (0-7)
- * @param narrow_tile If true, process only 2 row tiles instead of full tile
- * @param num_faces Number of faces (1, 2, or 4)
+ * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile)
  */
 template <MathFidelity math_fidelity>
-inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, bool narrow_tile = false, const std::uint32_t num_faces = 4)
+inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    const std::uint32_t num_row_tiles = narrow_tile ? 2 : ((num_faces > 1) ? num_faces / 2 : 1);
+    // A 32x16 narrow tile has fewer face-columns than face-rows; mirror generic llk_math_reduce.h.
+    const bool is_narrow_tile         = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
+    const std::uint32_t num_row_tiles = tensor_shape.num_faces_r_dim;
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
@@ -213,7 +215,7 @@ inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, bool nar
     {
         execute_high_fidelity_gapool<math_fidelity>();
 
-        if ((!narrow_tile) && (num_faces > 1))
+        if ((!is_narrow_tile) && (tensor_shape.total_num_faces() > 1))
         {
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -11,8 +11,10 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -129,15 +131,15 @@ inline void reduce_max_row_configure_addrmod_reinit_minimal()
  * This function should NOT be used as a substitute for native reduce LLK MOP configuration.
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
-inline void _llk_math_reduce_block_max_row_mop_config_()
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape& tensor_shape)
 {
     // Constraint on the outerloop and innerloop dim
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
-    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
-    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
 
-    if constexpr (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
         if constexpr (is_fp32_dest_acc_en)
@@ -267,21 +269,21 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
  * from the original _llk_math_reduce_block_max_row_mop_config_ call.
  * Use when the MOP was clobbered (e.g., by eltwise binary ops) but the replay buffer is intact.
  */
-template <std::uint32_t block_ct_dim, std::uint32_t num_faces = 4>
-inline void _llk_math_reduce_block_max_row_mop_reprogram_only_()
+template <std::uint32_t block_ct_dim>
+inline void _llk_math_reduce_block_max_row_mop_reprogram_only_(const ckernel::TensorShape& tensor_shape)
 {
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
-    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    if constexpr (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row: reduce F0&F1 only, no F2 jump, no second reduce.
-        constexpr std::uint32_t outer_loop      = block_ct_dim;
-        constexpr std::uint32_t inner_loop      = 1;
-        constexpr std::uint32_t start_op        = TT_OP_REPLAY(0, 2, 0, 0);
-        constexpr std::uint32_t inner_loop_op   = TT_OP_NOP;
-        constexpr std::uint32_t end_op_1        = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
-        constexpr std::uint32_t end_op_2        = TT_OP_NOP;
+        constexpr std::uint32_t outer_loop    = block_ct_dim;
+        constexpr std::uint32_t inner_loop    = 1;
+        constexpr std::uint32_t start_op      = TT_OP_REPLAY(0, 2, 0, 0);
+        constexpr std::uint32_t inner_loop_op = TT_OP_NOP;
+        constexpr std::uint32_t end_op_1      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        constexpr std::uint32_t end_op_2      = TT_OP_NOP;
 
         ckernel::ckernel_template mop_template(outer_loop, inner_loop, inner_loop_op);
         mop_template.set_start_op(start_op);
@@ -319,8 +321,8 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_()
  * Use the standard _llk_math_reduce_init_<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
-inline void _llk_math_reduce_block_max_row_init_()
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod();
 
@@ -328,7 +330,7 @@ inline void _llk_math_reduce_block_max_row_init_()
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
+    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>(tensor_shape);
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -351,11 +353,11 @@ inline void _llk_math_reduce_block_max_row_uninit_()
  * Use the standard _llk_math_reduce_<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
-inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
-    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
-    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
 
     // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
@@ -365,7 +367,7 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
     // replayed below.
     ckernel::ckernel_template::run();
 
-    if constexpr (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row: transpose only the one recorded face-row. The 2-face record has no
         // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -23,9 +23,13 @@ using namespace ckernel;
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block/tile operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile size is 32x32 (num_faces=4) or 16x32 (num_faces=2, a single face-row)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * @note ADDR_MOD_3 (the +20 DEST jump into F2) is only consumed by the two-face-row
+ *       (num_faces=4) code path. For num_faces=2 there is no F2/F3, so it is unused, but it
+ *       is still programmed here so that both code paths share one addrmod configuration.
  *
  * This function should NOT be used as a substitute for native reduce LLK configuration.
  * Use the standard reduce configuration functions for general-purpose reduction operations.
@@ -115,14 +119,96 @@ inline void reduce_max_row_configure_addrmod_reinit_minimal()
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
+ * For num_faces=4 the per-tile MOP reduces F0&F1 into DEST rows 0-15, jumps DEST to row 32 via a
+ * CR_D+8 SETRWC repeated inner_loop=4 times (4*8=32 = row 32 = F2), then reduces F2&F3, and the
+ * transpose (replayed by the execute function) covers both face-rows.
+ *
+ * For num_faces=2 there is only one face-row (F0&F1): the per-tile MOP reduces F0&F1 only, with no
+ * F2 jump and no second reduce, and the recorded transpose block covers the single face-row.
+ *
  * This function should NOT be used as a substitute for native reduce LLK MOP configuration.
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
 inline void _llk_math_reduce_block_max_row_mop_config_()
 {
     // Constraint on the outerloop and innerloop dim
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
+    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+
+    if constexpr (num_faces == 2)
+    {
+        // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // FP32 path records the same 15-instruction layout as num_faces=4 (2 GMPOOLs + hi/lo
+            // transpose + CLR_B). Only the execute-side replay differs (single face-row, done below).
+            lltt::record(0, 15);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            // Move high 16 bits from DEST row 0 to SrcB rows 16 - 31 and transpose
+            TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // Move high 16 bits back to Dest
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
+            // Move low 16 bits to SrcB rows 16 - 31 and transpose
+            TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // Move low 16 bits from SrcB rows 16 - 31 to DEST rows 0, 4, 8, 12.
+            // ADDR_MOD_2 increments CR_D and Dest counter val by 4. No F2 for a single face-row, so
+            // the last write uses ADDR_MOD_2 (no +20 jump); CLR_B resets the counters afterwards.
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            // Clear B valid bits at the end and all address counters
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+        else
+        {
+            // Non-FP32 single face-row: 2 GMPOOLs + one transpose block (6 instrs) + CLR_B = 9 instructions.
+            lltt::record(0, 9);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
+            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // Move the reduced row from SrcB to DEST in 4-row chunks (rows 0, 4, 8, 12).
+            // ADDR_MOD_2 increments CR_D and Dest counter val by 4. No F2 jump (no ADDR_MOD_3): the
+            // last write uses ADDR_MOD_2 and CLR_B resets the counters afterwards.
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            // Clear B valid bits at the end and all address counters
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+
+        static constexpr std::uint32_t outer_loop = block_ct_dim;
+        static constexpr std::uint32_t inner_loop = 1;
+
+        // Reduce F0 and F1 column-wise, doesn't change DEST counter
+        static constexpr std::uint32_t start_op = TT_OP_REPLAY(0, 2, 0, 0);
+        // No F2 jump for a single face-row
+        static constexpr std::uint32_t inner_loop_op = TT_OP_NOP;
+        // Clear A valid bit to get another operand tile (scaler face stays the same)
+        static constexpr std::uint32_t end_op_1 = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        static constexpr std::uint32_t end_op_2 = TT_OP_NOP;
+
+        ckernel::ckernel_template mop_template(outer_loop, inner_loop, inner_loop_op);
+        mop_template.set_start_op(start_op);
+        mop_template.set_end_ops(end_op_1, end_op_2);
+        mop_template.program();
+        return;
+    }
 
     // See _llk_math_reduce_max_row_ for a full algorithm explanation
     // Put the following 15 instructions in a REPLAY buffer
@@ -181,10 +267,28 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
  * from the original _llk_math_reduce_block_max_row_mop_config_ call.
  * Use when the MOP was clobbered (e.g., by eltwise binary ops) but the replay buffer is intact.
  */
-template <std::uint32_t block_ct_dim>
+template <std::uint32_t block_ct_dim, std::uint32_t num_faces = 4>
 inline void _llk_math_reduce_block_max_row_mop_reprogram_only_()
 {
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
+
+    if constexpr (num_faces == 2)
+    {
+        // Single face-row: reduce F0&F1 only, no F2 jump, no second reduce.
+        constexpr std::uint32_t outer_loop      = block_ct_dim;
+        constexpr std::uint32_t inner_loop      = 1;
+        constexpr std::uint32_t start_op        = TT_OP_REPLAY(0, 2, 0, 0);
+        constexpr std::uint32_t inner_loop_op   = TT_OP_NOP;
+        constexpr std::uint32_t end_op_1        = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        constexpr std::uint32_t end_op_2        = TT_OP_NOP;
+
+        ckernel::ckernel_template mop_template(outer_loop, inner_loop, inner_loop_op);
+        mop_template.set_start_op(start_op);
+        mop_template.set_end_ops(end_op_1, end_op_2);
+        mop_template.program();
+        return;
+    }
 
     constexpr std::uint32_t outer_loop = block_ct_dim;
     constexpr std::uint32_t inner_loop = 4;
@@ -215,7 +319,7 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_()
  * Use the standard _llk_math_reduce_init_<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
 inline void _llk_math_reduce_block_max_row_init_()
 {
     reduce_max_row_configure_addrmod();
@@ -224,7 +328,7 @@ inline void _llk_math_reduce_block_max_row_init_()
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>();
+    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -247,13 +351,48 @@ inline void _llk_math_reduce_block_max_row_uninit_()
  * Use the standard _llk_math_reduce_<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
 inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 {
+    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
+    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+
+    // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    // Run the MOP, performing a column reduce across all 4 faces
+    // Run the MOP. For num_faces=4 this reduces both face-rows (F0&F1 then F2&F3); for num_faces=2
+    // it reduces the single face-row (F0&F1). The MOP only emits the GMPOOLs; the transpose is
+    // replayed below.
     ckernel::ckernel_template::run();
+
+    if constexpr (num_faces == 2)
+    {
+        // Single face-row: transpose only the one recorded face-row. The 2-face record has no
+        // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // MOVB2D/D2B depends on the SrcA ALU format; Hi/Lo16 transpose does not work with the
+            // Tf32 that the pool wrote, so override SrcA to Tf32 (and disable the zero-flag source)
+            // for the replayed transpose, exactly as the num_faces=4 path does below.
+            TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
+
+            // Replay the 13 instructions (recorded slots 2-14): hi/lo transpose of the single reduced
+            // face-row + CLR_B.
+            lltt::replay(2, 13);
+
+            TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+        }
+        else
+        {
+            // Replay the 7 instructions (recorded slots 2-8) to transpose the single reduced
+            // face-row. 7th instruction (CLR_B) releases SrcB bank and clears all address counters.
+            lltt::replay(2, 7);
+        }
+        return;
+    }
 
     if constexpr (is_fp32_dest_acc_en)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -11,6 +11,7 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
 
@@ -142,18 +143,78 @@ inline void reduce_max_row_configure_addrmod_reinit_minimal_runtime()
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile size is 32x32 (num_faces=4) or 16x32 (num_faces=2, a single face-row)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * For num_faces=2 the per-tile MOP reduces only F0&F1 (no F2 jump, no second reduce) and the
+ * recorded transpose block covers the single face-row.
  *
  * This function should NOT be used as a substitute for native reduce LLK MOP configuration.
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
     // Constraint on the outerloop and innerloop dim
     // static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+
+    if (num_faces == 2)
+    {
+        // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // FP32 path records the same 15-instruction layout; only the execute-side replay differs.
+            lltt::record(0, 15);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
+            TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // No F2 for a single face-row: last write uses ADDR_MOD_2 (no +20 jump); CLR_B resets counters.
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+        else
+        {
+            // Non-FP32 single face-row: 2 GMPOOLs + one transpose block (6 instrs) + CLR_B = 9 instructions.
+            lltt::record(0, 9);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+
+        const std::uint32_t outer_loop_2f      = block_ct_dim;
+        const std::uint32_t inner_loop_2f      = 1;
+        static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
+        static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
+        static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        static constexpr std::uint32_t end_op_2_2f      = TT_OP_NOP;
+
+        ckernel::ckernel_template mop_template(outer_loop_2f, inner_loop_2f, inner_loop_op_2f);
+        mop_template.set_start_op(start_op_2f);
+        mop_template.set_end_ops(end_op_1_2f, end_op_2_2f);
+        mop_template.program();
+        return;
+    }
 
     // See _llk_math_reduce_max_row_ for a full algorithm explanation
     // Put the following 15 instructions in a REPLAY buffer
@@ -209,8 +270,25 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
  * Use when the MOP was clobbered (e.g., by eltwise binary ops) but the replay buffer is intact.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
+    if (num_faces == 2)
+    {
+        // Single face-row: reduce F0&F1 only, no F2 jump, no second reduce.
+        const std::uint32_t outer_loop_2f      = block_ct_dim;
+        const std::uint32_t inner_loop_2f      = 1;
+        static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
+        static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
+        static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        static constexpr std::uint32_t end_op_2_2f      = TT_OP_NOP;
+
+        ckernel::ckernel_template mop_template(outer_loop_2f, inner_loop_2f, inner_loop_op_2f);
+        mop_template.set_start_op(start_op_2f);
+        mop_template.set_end_ops(end_op_1_2f, end_op_2_2f);
+        mop_template.program();
+        return;
+    }
+
     const std::uint32_t outer_loop = block_ct_dim;
     const std::uint32_t inner_loop = 4;
 
@@ -241,7 +319,7 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
     reduce_max_row_configure_addrmod_runtime();
 
@@ -249,7 +327,7 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -273,12 +351,46 @@ inline void _llk_math_reduce_block_max_row_uninit_runtime_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index)
+inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, std::uint32_t num_faces = 4)
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        LLK_ASSERT(num_faces != 2, "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+    }
+    // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    // Run the MOP, performing a column reduce across all 4 faces
+    // Run the MOP. For num_faces=4 this reduces both face-rows (F0&F1 then F2&F3); for num_faces=2
+    // it reduces the single face-row (F0&F1). The MOP only emits the GMPOOLs; the transpose is
+    // replayed below.
     ckernel::ckernel_template::run();
+
+    if (num_faces == 2)
+    {
+        // Single face-row: transpose only the one recorded face-row. The 2-face record has no
+        // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // MOVB2D/D2B depends on the SrcA ALU format; Hi/Lo16 transpose does not work with the
+            // Tf32 that the pool wrote, so override SrcA to Tf32 (and disable the zero-flag source)
+            // for the replayed transpose, exactly as the num_faces=4 path does below.
+            TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
+
+            // Replay the 13 instructions (slots 2-14): hi/lo transpose of the single face-row + CLR_B.
+            lltt::replay(2, 13);
+
+            TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+        }
+        else
+        {
+            // Replay the 7 instructions (slots 2-8) to transpose the single reduced face-row + CLR_B.
+            lltt::replay(2, 7);
+        }
+        return;
+    }
 
     if constexpr (is_fp32_dest_acc_en)
     {
@@ -319,12 +431,12 @@ inline void _llk_math_reduce_block_max_row_reinit_runtime_()
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
     reduce_max_row_configure_addrmod();
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);
-    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -14,6 +14,7 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -154,12 +155,14 @@ inline void reduce_max_row_configure_addrmod_reinit_minimal_runtime()
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
     // Constraint on the outerloop and innerloop dim
     // static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
 
-    if (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
         if constexpr (is_fp32_dest_acc_en)
@@ -202,8 +205,8 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
         }
 
-        const std::uint32_t outer_loop_2f      = block_ct_dim;
-        const std::uint32_t inner_loop_2f      = 1;
+        const std::uint32_t outer_loop_2f               = block_ct_dim;
+        const std::uint32_t inner_loop_2f               = 1;
         static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
         static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
         static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
@@ -270,13 +273,13 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
  * Use when the MOP was clobbered (e.g., by eltwise binary ops) but the replay buffer is intact.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
-    if (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row: reduce F0&F1 only, no F2 jump, no second reduce.
-        const std::uint32_t outer_loop_2f      = block_ct_dim;
-        const std::uint32_t inner_loop_2f      = 1;
+        const std::uint32_t outer_loop_2f               = block_ct_dim;
+        const std::uint32_t inner_loop_2f               = 1;
         static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
         static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
         static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
@@ -319,7 +322,7 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod_runtime();
 
@@ -327,7 +330,7 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -351,12 +354,9 @@ inline void _llk_math_reduce_block_max_row_uninit_runtime_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        LLK_ASSERT(num_faces != 2, "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
-    }
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
     // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
@@ -365,7 +365,7 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
     // replayed below.
     ckernel::ckernel_template::run();
 
-    if (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row: transpose only the one recorded face-row. The 2-face record has no
         // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.
@@ -431,12 +431,12 @@ inline void _llk_math_reduce_block_max_row_reinit_runtime_()
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod();
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);
-    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -54,14 +54,16 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * @tparam num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
 inline void _llk_unpack_AB_reduce_block_max_row_init_()
 {
     if constexpr (is_fp32_dest_acc_en)
@@ -73,8 +75,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_()
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);       // Unpack a single face of a scaler
-    TTI_SETADCXX(p_setadc::UNP_A, 4 * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack a whole tile of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);                // Unpack a single face of a scaler
+    TTI_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0);  // Unpack num_faces faces of an operand
 
     // save the following state that is going to be modified:
     // tile x, y, and z dims for both unpackers

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -12,7 +12,9 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cunpack_common.h"
+#include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -58,14 +60,16 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
- * @tparam num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
+ * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
-inline void _llk_unpack_AB_reduce_block_max_row_init_()
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     if constexpr (is_fp32_dest_acc_en)
     {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
@@ -75,8 +79,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_()
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);                // Unpack a single face of a scaler
-    TTI_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0);  // Unpack num_faces faces of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);         // Unpack a single face of a scaler
+    TT_SETADCXX(p_setadc::UNP_A, tensor_shape.total_tensor_size() - 1, 0x0); // Unpack all faces of an operand
 
     // save the following state that is going to be modified:
     // tile x, y, and z dims for both unpackers
@@ -114,7 +118,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
     // Program srcA and srcB base addresses
-    volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
     wait_for_next_context(2);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -91,7 +91,14 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, LO_16(p_gpr_unpack::TMP0));
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, HI_16(p_gpr_unpack::TMP0));
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
-    TTI_SETDMAREG(0, 4 /* y_dim */, 0, LO_16(p_gpr_unpack::TMP0));
+    // y_dim = number of faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile). Hardcoding 4 makes the
+    // unpacker stride a full 32x32 tile between block tiles, over-reading the next tile (out-of-bounds
+    // / wrong tile) for a genuine 16x32 operand.
+    if (tensor_shape.num_faces_r_dim == 1) {
+        TTI_SETDMAREG(0, 2 /* y_dim: 2 faces (16x32 tiny tile) */, 0, LO_16(p_gpr_unpack::TMP0));
+    } else {
+        TTI_SETDMAREG(0, 4 /* y_dim: 4 faces (32x32 tile) */, 0, LO_16(p_gpr_unpack::TMP0));
+    }
     TTI_SETDMAREG(0, 1 /* z_dim */, 0, HI_16(p_gpr_unpack::TMP0));
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -12,7 +12,9 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cunpack_common.h"
+#include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -55,14 +57,16 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
- * @param num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
+ * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4)
+inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape& tensor_shape)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     if constexpr (is_fp32_dest_acc_en)
     {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
@@ -72,8 +76,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);              // Unpack a single face of a scaler
-    TT_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack num_faces faces of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);         // Unpack a single face of a scaler
+    TT_SETADCXX(p_setadc::UNP_A, tensor_shape.total_tensor_size() - 1, 0x0); // Unpack all faces of an operand
 
     // save the following state that is going to be modified:
     // tile x, y, and z dims for both unpackers
@@ -111,7 +115,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
     // Program srcA and srcB base addresses
-    volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
     wait_for_next_context(2);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -51,15 +51,17 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * @param num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4)
 {
     if constexpr (is_fp32_dest_acc_en)
     {
@@ -70,8 +72,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);       // Unpack a single face of a scaler
-    TTI_SETADCXX(p_setadc::UNP_A, 4 * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack a whole tile of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);              // Unpack a single face of a scaler
+    TT_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack num_faces faces of an operand
 
     // save the following state that is going to be modified:
     // tile x, y, and z dims for both unpackers

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -88,7 +88,14 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, LO_16(p_gpr_unpack::TMP0));
     TTI_SETDMAREG(0, 1 * FACE_C_DIM * FACE_R_DIM, 0, HI_16(p_gpr_unpack::TMP0));
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
-    TTI_SETDMAREG(0, 4 /* y_dim */, 0, LO_16(p_gpr_unpack::TMP0));
+    // y_dim = number of faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile). Hardcoding 4 makes the
+    // unpacker stride a full 32x32 tile between block tiles, over-reading the next tile (out-of-bounds
+    // / wrong tile) for a genuine 16x32 operand.
+    if (tensor_shape.num_faces_r_dim == 1) {
+        TTI_SETDMAREG(0, 2 /* y_dim: 2 faces (16x32 tiny tile) */, 0, LO_16(p_gpr_unpack::TMP0));
+    } else {
+        TTI_SETDMAREG(0, 4 /* y_dim: 4 faces (32x32 tile) */, 0, LO_16(p_gpr_unpack::TMP0));
+    }
     TTI_SETDMAREG(0, 1 /* z_dim */, 0, HI_16(p_gpr_unpack::TMP0));
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -11,20 +11,24 @@
 #include "ckernel_globals.h"
 #include "ckernel_ops.h"
 #include "cunpack_common.h"
+#include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
 // SDPA-specific custom init for the blocked sub+bcast(col) unpack flow.
-// @param num_faces Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
-inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const std::uint32_t num_faces = 4)
+// @param tensor_shape Shape of the operand tile (2 faces for 16x32 tiny tiles, 4 faces for full 32x32 tiles).
+inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0); // transpose within the face
 
-    // Force both unpackers to unpack the requested number of faces (num_faces * 16 * 16
-    // datums). Full 32x32 tile = 4 faces = 1024 datums, 16x32 tiny tile = 2 faces = 512 datums.
-    const std::uint32_t x_end = num_faces * FACE_R_DIM * FACE_C_DIM - 1;
+    // Force both unpackers to unpack all faces of the operand. Full 32x32 tile = 4 faces = 1024
+    // datums, 16x32 tiny tile = 2 faces = 512 datums.
+    const std::uint32_t x_end = tensor_shape.total_tensor_size() - 1;
     TT_SETADCXX(p_setadc::UNP0, x_end, 0x0);
     TT_SETADCXX(p_setadc::UNP1, x_end, 0x0);
 }
@@ -35,7 +39,7 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
     // Program srcA and srcB base addresses
-    volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
     wait_for_next_context(2);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -17,13 +17,16 @@ using namespace ckernel;
 using namespace ckernel::unpacker;
 
 // SDPA-specific custom init for the blocked sub+bcast(col) unpack flow.
-inline void _llk_unpack_AB_sub_bcast_col_init_custom_()
+// @param num_faces Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
+inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const std::uint32_t num_faces = 4)
 {
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0); // transpose within the face
 
-    // Force both unpackers to unpack entire tile
-    TTI_SETADCXX(p_setadc::UNP0, 1023, 0x0);
-    TTI_SETADCXX(p_setadc::UNP1, 1023, 0x0);
+    // Force both unpackers to unpack the requested number of faces (num_faces * 16 * 16
+    // datums). Full 32x32 tile = 4 faces = 1024 datums, 16x32 tiny tile = 2 faces = 512 datums.
+    const std::uint32_t x_end = num_faces * FACE_R_DIM * FACE_C_DIM - 1;
+    TT_SETADCXX(p_setadc::UNP0, x_end, 0x0);
+    TT_SETADCXX(p_setadc::UNP1, x_end, 0x0);
 }
 
 // SDPA-specific custom blocked unpack: one SrcB tile + ct_dim SrcA tiles.

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -74,8 +74,6 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
-    // Restore the default single-face unpack X span used by the generic unpack
-    // helpers. The custom blocked path forces both unpackers to a multi-face span
-    // (num_faces * 16 * 16 datums) in the init.
-    TTI_SETADCXX(p_setadc::UNP_AB, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    // No state to restore: the multi-face unpack X span set in the custom init is transient — every
+    // generic unpack op re-establishes its own X span (config_unpacker_x_end / SETADCXX) in its init.
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -74,4 +74,8 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
+    // Restore the default single-face unpack X span used by the generic unpack
+    // helpers. The custom blocked path forces both unpackers to a multi-face span
+    // (num_faces * 16 * 16 datums) in the init.
+    TTI_SETADCXX(p_setadc::UNP_AB, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -12,6 +12,7 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -78,16 +79,18 @@ inline void _llk_math_eltwise_binary_uninit_custom_()
 // Each 16x16 face pair (one face-row) is processed by four ELWSUBs (two per
 // face; each ELWSUB covers an aligned 8x16 block). A full 32x32 tile has two
 // face-rows (F0/F1 and F2/F3); a 16x32 tiny tile has a single face-row (F0/F1).
-// @param ct_dim    Number of SrcA tiles that reuse the single broadcast SrcB tile.
-// @param num_faces Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
-// @param dst_index Absolute dest tile slot where this block-row's ct_dim tiles begin. Multi-tile-row
-//                  callers (e.g. the fuser LoopBlockRow driver) advance this per block-row so each row
-//                  lands on its own dest slots; single-tile-row callers leave it at 0.
+// @param ct_dim       Number of SrcA tiles that reuse the single broadcast SrcB tile.
+// @param tensor_shape Shape of the operand tile (2 faces for 16x32 tiny tiles, 4 faces for full 32x32 tiles).
+// @param dst_index    Absolute dest tile slot where this block-row's ct_dim tiles begin. Multi-tile-row
+//                     callers (e.g. the fuser LoopBlockRow driver) advance this per block-row so each row
+//                     lands on its own dest slots; single-tile-row callers leave it at 0.
 inline void _llk_math_sub_bcast_cols_reuse_custom_(
-    const std::uint32_t ct_dim = 1, const std::uint32_t num_faces = 4, const std::uint32_t dst_index = 0)
+    const std::uint32_t ct_dim = 1, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     // Two faces make up one face-row; a full tile has two of them, a tiny tile one.
-    const std::uint32_t num_face_rows = num_faces / 2;
+    const std::uint32_t num_face_rows = tensor_shape.num_faces_r_dim;
 
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_AB);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -74,31 +74,46 @@ inline void _llk_math_eltwise_binary_uninit_custom_()
 // generic. The current in-tree caller is blocked sub+bcast(col), so the
 // instruction sequence is hard-wired to ELWSUB with SrcB column broadcast and
 // SrcB reuse across ct_dim.
-inline void _llk_math_sub_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
+//
+// Each 16x16 face pair (one face-row) is processed by four ELWSUBs (two per
+// face; each ELWSUB covers an aligned 8x16 block). A full 32x32 tile has two
+// face-rows (F0/F1 and F2/F3); a 16x32 tiny tile has a single face-row (F0/F1).
+// @param ct_dim    Number of SrcA tiles that reuse the single broadcast SrcB tile.
+// @param num_faces Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
+// @param dst_index Absolute dest tile slot where this block-row's ct_dim tiles begin. Multi-tile-row
+//                  callers (e.g. the fuser LoopBlockRow driver) advance this per block-row so each row
+//                  lands on its own dest slots; single-tile-row callers leave it at 0.
+inline void _llk_math_sub_bcast_cols_reuse_custom_(
+    const std::uint32_t ct_dim = 1, const std::uint32_t num_faces = 4, const std::uint32_t dst_index = 0)
 {
+    // Two faces make up one face-row; a full tile has two of them, a tiny tile one.
+    const std::uint32_t num_face_rows = num_faces / 2;
+
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_AB);
 
     for (std::uint32_t tile = 0; tile < ct_dim; tile++)
     {
-        // F0 - F0
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_0, 0);
-        // F0 - F1, restore SrcB to the start of the broadcast tile.
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_1, 0);
+        // Position the dest write pointer at the start of this tile's 32x32 dest
+        // slot (stride 64 rows). The packer indexes tiles at the full 32x32 tile
+        // stride regardless of num_faces, so tiles must be written one-per-slot.
+        // The ADDR_MOD dest increments below only advance 32 rows for a 16x32 tiny
+        // tile (num_faces=2) and 64 rows for a full 32x32 tile (num_faces=4); the
+        // per-slot base + counter reset makes both land on the right slot.
+        math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index + tile);
+        math::clear_dst_reg_addr();
 
-        // F1 - F0
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_0, 0);
-        // F1 - F2
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_2, 0);
+        for (std::uint32_t face_row = 0; face_row < num_face_rows; face_row++)
+        {
+            // Even face (F0 / F2) - F0
+            TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_0, 0);
+            // Even face - next, rewind SrcB by one face to the start of the broadcast tile.
+            TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_1, 0);
 
-        // F2 - F2
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_0, 0);
-        // F2 - F3, restore SrcB to the third face of the broadcast tile.
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_1, 0);
-
-        // F3 - F2
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_0, 0);
-        // F3 - next tile
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_2, 0);
+            // Odd face (F1 / F3) - F0
+            TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_0, 0);
+            // Odd face - advance SrcB to the next face-row (or next tile on the last face-row).
+            TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_2, 0);
+        }
 
         // Move to the next SrcA tile while keeping the broadcasted SrcB tile
         // available for reuse on the next outer iteration.
@@ -107,4 +122,7 @@ inline void _llk_math_sub_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 
 
     // Release the reused SrcB tile once the whole ct_dim block is consumed.
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_AB);
+
+    // Restore the dest base offset so the next op starts from tile slot 0.
+    math::clear_dst_reg_addr();
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -13,6 +13,7 @@
 #include "llk_defs.h"
 #include "llk_math_common.h"
 #include "llk_operands.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -196,15 +197,16 @@ inline void _llk_math_mul_reduce_scalar_init_()
  *
  * @tparam MATH_FIDELITY_DESC Math fidelity descriptor (0 = default, higher = more precision)
  * @param dst_index Destination tile index to accumulate into (0-7)
- * @param narrow_tile If true, process only 2 row tiles instead of full tile
- * @param num_faces Number of faces (1, 2, or 4)
+ * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile)
  */
 template <MathFidelity math_fidelity>
-inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, bool narrow_tile = false, const std::uint32_t num_faces = 4)
+inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    const std::uint32_t num_row_tiles = narrow_tile ? 2 : ((num_faces > 1) ? num_faces / 2 : 1);
+    // A 32x16 narrow tile has fewer face-columns than face-rows; mirror generic llk_math_reduce.h.
+    const bool is_narrow_tile         = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
+    const std::uint32_t num_row_tiles = tensor_shape.num_faces_r_dim;
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
@@ -213,7 +215,7 @@ inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, bool nar
     {
         execute_high_fidelity_gapool<math_fidelity>();
 
-        if ((!narrow_tile) && (num_faces > 1))
+        if ((!is_narrow_tile) && (tensor_shape.total_num_faces() > 1))
         {
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);
             TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -260,7 +260,9 @@ inline void _llk_math_mul_reduce_scalar_()
     TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
     TTI_GATESRCRST(0b1, 0b1);
 
-    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_0, 0);
+    // WH ZEROACC signature is (clear_mode, AddrMode, dst) — BH additionally has use_32_bit_mode /
+    // clear_zero_flags fields that WH does not expose.
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, ADDR_MOD_0, 0);
 
     execute_high_fidelity_gapool<math_fidelity>();
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_globals.h"
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "cmath_common.h"
+#include "llk_defs.h"
+#include "llk_math_common.h"
+#include "llk_operands.h"
+
+using namespace ckernel;
+
+/*************************************************************************
+ * LLK MUL REDUCE SCALAR - Low-level reduce operations for fused mul+reduce
+ *************************************************************************/
+
+// Helper macros for moving destination to source registers
+#define MOVD2A_4_ROWS(base_offset, row_offset) \
+    TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + (row_offset) * 4, ADDR_MOD_0, p_movd2a::MOV_4_ROWS, (base_offset) + (row_offset) * 4);
+
+#define MOVD2A_16_ROWS(base_offset) \
+    MOVD2A_4_ROWS(base_offset, 0)   \
+    MOVD2A_4_ROWS(base_offset, 1)   \
+    MOVD2A_4_ROWS(base_offset, 2)   \
+    MOVD2A_4_ROWS(base_offset, 3)   \
+    MOVD2A_4_ROWS(base_offset, 4)   \
+    MOVD2A_4_ROWS(base_offset, 5)   \
+    MOVD2A_4_ROWS(base_offset, 6)   \
+    MOVD2A_4_ROWS(base_offset, 7)   \
+    MOVD2A_4_ROWS(base_offset, 8)   \
+    MOVD2A_4_ROWS(base_offset, 9)   \
+    MOVD2A_4_ROWS(base_offset, 10)  \
+    MOVD2A_4_ROWS(base_offset, 11)  \
+    MOVD2A_4_ROWS(base_offset, 12)  \
+    MOVD2A_4_ROWS(base_offset, 13)  \
+    MOVD2A_4_ROWS(base_offset, 14)  \
+    MOVD2A_4_ROWS(base_offset, 15)
+
+/**
+ * @brief Execute GAPOOL operations with optional high fidelity phases
+ *
+ * Executes the appropriate number of GAPOOL instructions based on fidelity level.
+ * For high fidelity (math_fidelity > LoFi), executes Number of Fidelity Phases - 1
+ * iterations with ADDR_MOD_2, followed by one final GAPOOL with ADDR_MOD_0.
+ *
+ * @tparam math_fidelity: MathFidelity value LoFi, HiFi2, HiFi3, HiFi4
+ */
+template <MathFidelity math_fidelity>
+inline void execute_high_fidelity_gapool()
+{
+    if constexpr (math_fidelity >= MathFidelity::HiFi2)
+    {
+        TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_2, p_gpool::INDEX_DIS, 0);
+    }
+    if constexpr (math_fidelity >= MathFidelity::HiFi3)
+    {
+        TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_2, p_gpool::INDEX_DIS, 0);
+    }
+    if constexpr (math_fidelity >= MathFidelity::HiFi4)
+    {
+        TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_2, p_gpool::INDEX_DIS, 0);
+    }
+
+    TTI_GAPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0);
+}
+
+/**
+ * @brief Move destination tile to source registers for mul_reduce_scalar
+ *
+ * Moves data from destination registers to source A or B registers.
+ *
+ * @tparam binary_reuse_dest Direction: DEST_TO_SRCA or DEST_TO_SRCB
+ * @param idst Destination tile index (0-7)
+ */
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::uint32_t idst = 0)
+{
+    if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA)
+    {
+        if (idst == 0)
+        {
+            TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, get_dest_buffer_base());
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+        }
+
+        switch (idst)
+        {
+            case 0:
+                MOVD2A_16_ROWS(0);
+                break;
+            case 1:
+                MOVD2A_16_ROWS(64);
+                break;
+            case 2:
+                MOVD2A_16_ROWS(128);
+                break;
+            case 3:
+                MOVD2A_16_ROWS(192);
+                break;
+            case 4:
+                MOVD2A_16_ROWS(256);
+                break;
+            case 5:
+                MOVD2A_16_ROWS(320);
+                break;
+            case 6:
+                MOVD2A_16_ROWS(384);
+                break;
+            case 7:
+                MOVD2A_16_ROWS(448);
+                break;
+            default:
+                break;
+        }
+    }
+    else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
+    {
+        TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
+
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 16, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 16);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 20, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 20);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 24, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 24);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 28, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 28);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 32, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 32);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 36, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 36);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 40, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 40);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 44, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 44);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 48, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 48);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 52, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 52);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 56, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 56);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 60, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 60);
+    }
+}
+
+/**
+ * @brief Configure address modifiers for mul_reduce_scalar operations
+ *
+ * Sets up address modifiers for source A, source B, destination, and fidelity
+ * registers based on the specified math fidelity level.
+ *
+ * @tparam MathFidelity math_fidelity -> MathFidelity value LoFi, HiFi2, HiFi3, HiFi4
+ */
+template <MathFidelity math_fidelity>
+inline void mul_reduce_scalar_configure_addrmod()
+{
+    constexpr std::uint32_t FIDELITY_INCREMENT = 1;
+    constexpr bool HIGH_FIDELITY               = is_high_fidelity(math_fidelity);
+
+    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_0);
+    addr_mod_t {.srca = {.incr = 16}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.clr = 1}}.set(ADDR_MOD_1);
+
+    if constexpr (HIGH_FIDELITY)
+    {
+        addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = FIDELITY_INCREMENT}}.set(ADDR_MOD_2);
+    }
+}
+
+/**
+ * @brief Initialize reduce for mul_reduce_scalar operation
+ *
+ * Configures address modifiers and resets counters for the fused
+ * multiply-reduce-scalar operation.
+ *
+ * @tparam is_fp32_dest_acc_en If true, enables FP32 destination accumulation
+ * @tparam MATH_FIDELITY_DESC Math fidelity descriptor (0 = default, higher = more precision)
+ * @tparam enforce_fp32_accumulation If true, enforces FP32 accumulation (requires is_fp32_dest_acc_en)
+ */
+template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool enforce_fp32_accumulation = false>
+inline void _llk_math_mul_reduce_scalar_init_()
+{
+    mul_reduce_scalar_configure_addrmod<math_fidelity>();
+
+    if constexpr (enforce_fp32_accumulation)
+    {
+        static_assert(is_fp32_dest_acc_en, "FP32 Dest must be enabled for FP32 accumulation");
+    }
+    TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+/**
+ * @brief Perform column reduction for mul_reduce_scalar (accumulates across tiles)
+ *
+ * Performs column-wise reduction that accumulates results into the specified
+ * destination tile. Used in a loop to accumulate multiple input tiles.
+ *
+ * @tparam MATH_FIDELITY_DESC Math fidelity descriptor (0 = default, higher = more precision)
+ * @param dst_index Destination tile index to accumulate into (0-7)
+ * @param narrow_tile If true, process only 2 row tiles instead of full tile
+ * @param num_faces Number of faces (1, 2, or 4)
+ */
+template <MathFidelity math_fidelity>
+inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, bool narrow_tile = false, const std::uint32_t num_faces = 4)
+{
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+
+    const std::uint32_t num_row_tiles = narrow_tile ? 2 : ((num_faces > 1) ? num_faces / 2 : 1);
+
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    for (std::uint32_t row_tile = 0; row_tile < num_row_tiles; row_tile++)
+    {
+        execute_high_fidelity_gapool<math_fidelity>();
+
+        if ((!narrow_tile) && (num_faces > 1))
+        {
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);
+
+            execute_high_fidelity_gapool<math_fidelity>();
+        }
+
+        if (row_tile == 0)
+        {
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_A, 0, 0, 8, p_setrwc::SET_A);
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+        }
+        else
+        {
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_AD);
+        }
+    }
+}
+
+/**
+ * @brief Perform final scalar reduction for mul_reduce_scalar
+ *
+ * Collapses a column-reduced tile into a single scalar value stored in the
+ * first element of the output tile.
+ *
+ * @tparam MATH_FIDELITY_DESC Math fidelity descriptor (0 = default, higher = more precision)
+ */
+template <MathFidelity math_fidelity>
+inline void _llk_math_mul_reduce_scalar_()
+{
+    // Copy row 0 from dest to srcB (rows 16-31 as scratch) and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+    TTI_GATESRCRST(0b1, 0b1);
+    TTI_TRNSPSRCB;
+    TTI_GATESRCRST(0b1, 0b1);
+
+    // Copy all 16 rows from srcB to srcA
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
+    TTI_GATESRCRST(0b1, 0b1);
+
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_0, 0);
+
+    execute_high_fidelity_gapool<math_fidelity>();
+}
+
+/**
+ * @brief Clear data valid flags after mul_reduce_scalar operation
+ *
+ * Clears DVALID flags and resets all counters. Should be called after
+ * mul_reduce_scalar operations are complete.
+ */
+inline void _llk_math_mul_reduce_scalar_clear_dvalid_()
+{
+    TTI_CLEARDVALID(p_setrwc::CLR_AB, 0);
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD_F);
+}

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -11,8 +11,10 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -101,15 +103,15 @@ inline void reduce_max_row_configure_addrmod()
  * This function should NOT be used as a substitute for native reduce LLK MOP configuration.
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
-inline void _llk_math_reduce_block_max_row_mop_config_()
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape& tensor_shape)
 {
     // Constraint on the outerloop and innerloop dim
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
-    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
-    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
 
-    if constexpr (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
         if constexpr (is_fp32_dest_acc_en)
@@ -249,8 +251,8 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
  * Use the standard _llk_math_reduce_init_<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
-inline void _llk_math_reduce_block_max_row_init_()
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod();
 
@@ -258,7 +260,7 @@ inline void _llk_math_reduce_block_max_row_init_()
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
+    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>(tensor_shape);
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -281,11 +283,11 @@ inline void _llk_math_reduce_block_max_row_uninit_()
  * Use the standard _llk_math_reduce_<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
-inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
-    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
-    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
 
     // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
@@ -295,7 +297,7 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
     // replayed below.
     ckernel::ckernel_template::run();
 
-    if constexpr (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row: transpose only the one recorded face-row. The 2-face record has no
         // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -23,9 +23,13 @@ using namespace ckernel;
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block/tile operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile size is 32x32 (num_faces=4) or 16x32 (num_faces=2, a single face-row)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * @note ADDR_MOD_3 (the +20 DEST jump into F2) is only consumed by the two-face-row
+ *       (num_faces=4) code path. For num_faces=2 there is no F2/F3, so it is unused, but it
+ *       is still programmed here so that both code paths share one addrmod configuration.
  *
  * This function should NOT be used as a substitute for native reduce LLK configuration.
  * Use the standard reduce configuration functions for general-purpose reduction operations.
@@ -83,18 +87,101 @@ inline void reduce_max_row_configure_addrmod()
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile size is 32x32 (num_faces=4) or 16x32 (num_faces=2, a single face-row)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * For num_faces=4 the per-tile MOP reduces F0&F1 into DEST rows 0-15, jumps DEST to row 32 via a
+ * CR_D+8 SETRWC repeated inner_loop=4 times (4*8=32 = row 32 = F2), then reduces F2&F3, and the
+ * transpose (replayed by the execute function) covers both face-rows.
+ *
+ * For num_faces=2 there is only one face-row (F0&F1): the per-tile MOP reduces F0&F1 only, with no
+ * F2 jump and no second reduce, and the recorded transpose block covers the single face-row.
  *
  * This function should NOT be used as a substitute for native reduce LLK MOP configuration.
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
 inline void _llk_math_reduce_block_max_row_mop_config_()
 {
     // Constraint on the outerloop and innerloop dim
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
+    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+
+    if constexpr (num_faces == 2)
+    {
+        // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // FP32 path records the same 15-instruction layout as num_faces=4 (2 GMPOOLs + hi/lo
+            // transpose + CLR_B). Only the execute-side replay differs (single face-row, done below).
+            lltt::record(0, 15);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            // Move high 16 bits from DEST row 0 to SrcB rows 16 - 31 and transpose
+            TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // Move high 16 bits back to Dest
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+            // Move low 16 bits to SrcB rows 16 - 31 and transpose
+            TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // Move low 16 bits from SrcB rows 16 - 31 to DEST rows 0, 4, 8, 12.
+            // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so DEST location is '0', not '0, 4, 8, 12'.
+            // No F2 exists for a single face-row, so the last write uses ADDR_MOD_2 (no +20 jump); CLR_B
+            // resets the counters afterwards regardless.
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            // Clear B valid bits at the end and all address counters
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+        else
+        {
+            // Non-FP32 single face-row: 2 GMPOOLs + one transpose block (6 instrs) + CLR_B = 9 instructions.
+            lltt::record(0, 9);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
+            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // Move the reduced row from SrcB to DEST in 4-row chunks (rows 0, 4, 8, 12).
+            // ADDR_MOD_2 increments CR_D and Dest counter val by 4. No F2 jump (no ADDR_MOD_3): the
+            // last write uses ADDR_MOD_2 and CLR_B resets the counters afterwards.
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            // Clear B valid bits at the end and all address counters
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+
+        static constexpr std::uint32_t outer_loop = block_ct_dim;
+        static constexpr std::uint32_t inner_loop = 1;
+
+        // Reduce F0 and F1 column-wise, doesn't change DEST counter
+        static constexpr std::uint32_t start_op = TT_OP_REPLAY(0, 2, 0, 0);
+        // No F2 jump for a single face-row
+        static constexpr std::uint32_t inner_loop_op = TT_OP_NOP;
+        // Clear A valid bit to get another operand tile (scaler face stays the same)
+        static constexpr std::uint32_t end_op_1 = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        static constexpr std::uint32_t end_op_2 = TT_OP_NOP;
+
+        ckernel::ckernel_template mop_template(outer_loop, inner_loop, inner_loop_op);
+        mop_template.set_start_op(start_op);
+        mop_template.set_end_ops(end_op_1, end_op_2);
+        mop_template.program();
+        return;
+    }
 
     // See _llk_math_reduce_max_row_ for a full algorithm explanation
     // Put the following 15 instructions in a REPLAY buffer
@@ -162,7 +249,7 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
  * Use the standard _llk_math_reduce_init_<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
 inline void _llk_math_reduce_block_max_row_init_()
 {
     reduce_max_row_configure_addrmod();
@@ -171,7 +258,7 @@ inline void _llk_math_reduce_block_max_row_init_()
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>();
+    _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en, num_faces>();
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -194,13 +281,48 @@ inline void _llk_math_reduce_block_max_row_uninit_()
  * Use the standard _llk_math_reduce_<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, std::uint32_t num_faces = 4>
 inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 {
+    static_assert(num_faces == 4 || num_faces == 2, "reduce_block_max_row supports 32x32 (num_faces=4) or 16x32 (num_faces=2) tiles only");
+    static_assert(!(num_faces == 2 && is_fp32_dest_acc_en), "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+
+    // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    // Run the MOP, performing a column reduce across all 4 faces
+    // Run the MOP. For num_faces=4 this reduces both face-rows (F0&F1 then F2&F3); for num_faces=2
+    // it reduces the single face-row (F0&F1). The MOP only emits the GMPOOLs; the transpose is
+    // replayed below.
     ckernel::ckernel_template::run();
+
+    if constexpr (num_faces == 2)
+    {
+        // Single face-row: transpose only the one recorded face-row. The 2-face record has no
+        // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // MOVB2D/D2B depends on the SrcA ALU format; Hi/Lo16 transpose does not work with the
+            // Tf32 that the pool wrote, so override SrcA to Tf32 (and disable the zero-flag source)
+            // for the replayed transpose, exactly as the num_faces=4 path does below.
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
+
+            // Replay the 13 instructions (recorded slots 2-14) to transpose the single reduced
+            // face-row: hi/lo transpose + CLR_B.
+            lltt::replay(2, 13);
+
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+        }
+        else
+        {
+            // Replay the 7 instructions (recorded slots 2-8) to transpose the single reduced
+            // face-row. 7th instruction (CLR_B) releases SrcB bank and clears all address counters.
+            lltt::replay(2, 7);
+        }
+        return;
+    }
 
     if constexpr (is_fp32_dest_acc_en)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -14,6 +14,7 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 
@@ -66,9 +67,12 @@ inline void reduce_max_row_configure_addrmod_reinit_runtime()
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
-    if (num_faces == 2)
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
+
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
         if constexpr (is_fp32_dest_acc_en)
@@ -111,8 +115,8 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
         }
 
-        const std::uint32_t outer_loop_2f      = block_ct_dim;
-        const std::uint32_t inner_loop_2f      = 1;
+        const std::uint32_t outer_loop_2f               = block_ct_dim;
+        const std::uint32_t inner_loop_2f               = 1;
         static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
         static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
         static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
@@ -179,13 +183,13 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
  * Use when the MOP was clobbered (e.g., by eltwise binary ops) but the replay buffer is intact.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
-    if (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row: reduce F0&F1 only, no F2 jump, no second reduce.
-        const std::uint32_t outer_loop_2f      = block_ct_dim;
-        const std::uint32_t inner_loop_2f      = 1;
+        const std::uint32_t outer_loop_2f               = block_ct_dim;
+        const std::uint32_t inner_loop_2f               = 1;
         static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
         static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
         static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
@@ -228,7 +232,7 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod_reinit_runtime();
 
@@ -236,7 +240,7 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -260,12 +264,9 @@ inline void _llk_math_reduce_block_max_row_uninit_runtime_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        LLK_ASSERT(num_faces != 2, "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
-    }
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
     // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
@@ -274,7 +275,7 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
     // replayed below.
     ckernel::ckernel_template::run();
 
-    if (num_faces == 2)
+    if (tensor_shape.num_faces_r_dim == 1)
     {
         // Single face-row: transpose only the one recorded face-row. The 2-face record has no
         // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.
@@ -340,10 +341,10 @@ inline void _llk_math_reduce_block_max_row_reinit_runtime_()
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
+inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod();
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);
-    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
+    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim, tensor_shape);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -11,6 +11,7 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
 
@@ -54,16 +55,76 @@ inline void reduce_max_row_configure_addrmod_reinit_runtime()
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile size is 32x32 (num_faces=4) or 16x32 (num_faces=2, a single face-row)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * For num_faces=2 the per-tile MOP reduces only F0&F1 (no F2 jump, no second reduce) and the
+ * recorded transpose block covers the single face-row.
  *
  * This function should NOT be used as a substitute for native reduce LLK MOP configuration.
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
+    if (num_faces == 2)
+    {
+        // Single face-row (16x32 tiny tile): only F0&F1 exist. Reduce them, transpose once, no F2 jump.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // FP32 path records the same 15-instruction layout; only the execute-side replay differs.
+            lltt::record(0, 15);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
+            TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+            TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            // No F2 exists for a single face-row: last write uses ADDR_MOD_2 (no +20 jump); CLR_B resets counters.
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+        else
+        {
+            // Non-FP32 single face-row: 2 GMPOOLs + one transpose block (6 instrs) + CLR_B = 9 instructions.
+            lltt::record(0, 9);
+
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+            TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
+
+            TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+            TTI_TRNSPSRCB;
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        }
+
+        const std::uint32_t outer_loop_2f      = block_ct_dim;
+        const std::uint32_t inner_loop_2f      = 1;
+        static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
+        static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
+        static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        static constexpr std::uint32_t end_op_2_2f      = TT_OP_NOP;
+
+        ckernel::ckernel_template mop_template(outer_loop_2f, inner_loop_2f, inner_loop_op_2f);
+        mop_template.set_start_op(start_op_2f);
+        mop_template.set_end_ops(end_op_1_2f, end_op_2_2f);
+        mop_template.program();
+        return;
+    }
+
     // See _llk_math_reduce_max_row_ for a full algorithm explanation
     // Put the following 15 instructions in a REPLAY buffer
     lltt::record(0, 15);
@@ -118,8 +179,25 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
  * Use when the MOP was clobbered (e.g., by eltwise binary ops) but the replay buffer is intact.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
+    if (num_faces == 2)
+    {
+        // Single face-row: reduce F0&F1 only, no F2 jump, no second reduce.
+        const std::uint32_t outer_loop_2f      = block_ct_dim;
+        const std::uint32_t inner_loop_2f      = 1;
+        static constexpr std::uint32_t start_op_2f      = TT_OP_REPLAY(0, 2, 0, 0);
+        static constexpr std::uint32_t inner_loop_op_2f = TT_OP_NOP;
+        static constexpr std::uint32_t end_op_1_2f      = TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD);
+        static constexpr std::uint32_t end_op_2_2f      = TT_OP_NOP;
+
+        ckernel::ckernel_template mop_template(outer_loop_2f, inner_loop_2f, inner_loop_op_2f);
+        mop_template.set_start_op(start_op_2f);
+        mop_template.set_end_ops(end_op_1_2f, end_op_2_2f);
+        mop_template.program();
+        return;
+    }
+
     const std::uint32_t outer_loop = block_ct_dim;
     const std::uint32_t inner_loop = 4;
 
@@ -150,7 +228,7 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
  * _llk_math_reduce_() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
     reduce_max_row_configure_addrmod_reinit_runtime();
 
@@ -158,7 +236,7 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
 
     math::reset_counters(p_setrwc::SET_ABD_F);
 
-    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+    _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }
 
 template <bool is_fp32_dest_acc_en = false>
@@ -182,12 +260,46 @@ inline void _llk_math_reduce_block_max_row_uninit_runtime_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index)
+inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, std::uint32_t num_faces = 4)
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        LLK_ASSERT(num_faces != 2, "16x32 (num_faces=2) reduce_block_max_row is not yet supported in FP32 dest-accumulation mode");
+    }
+    // Packer indexes at the 32x32 slot stride regardless of the operand's face count.
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    // Run the MOP, performing a column reduce across all 4 faces
+    // Run the MOP. For num_faces=4 this reduces both face-rows (F0&F1 then F2&F3); for num_faces=2
+    // it reduces the single face-row (F0&F1). The MOP only emits the GMPOOLs; the transpose is
+    // replayed below.
     ckernel::ckernel_template::run();
+
+    if (num_faces == 2)
+    {
+        // Single face-row: transpose only the one recorded face-row. The 2-face record has no
+        // ADDR_MOD_3 F2 jump, so no spurious DEST advance occurs.
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            // MOVB2D/D2B depends on the SrcA ALU format; Hi/Lo16 transpose does not work with the
+            // Tf32 that the pool wrote, so override SrcA to Tf32 (and disable the zero-flag source)
+            // for the replayed transpose, exactly as the num_faces=4 path does below.
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
+
+            // Replay the 13 instructions (slots 2-14): hi/lo transpose of the single face-row + CLR_B.
+            lltt::replay(2, 13);
+
+            cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+        }
+        else
+        {
+            // Replay the 7 instructions (slots 2-8) to transpose the single reduced face-row + CLR_B.
+            lltt::replay(2, 7);
+        }
+        return;
+    }
 
     if constexpr (is_fp32_dest_acc_en)
     {
@@ -228,10 +340,10 @@ inline void _llk_math_reduce_block_max_row_reinit_runtime_()
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim)
+inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim, std::uint32_t num_faces = 4)
 {
     reduce_max_row_configure_addrmod();
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);
-    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
+    _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_<is_fp32_dest_acc_en>(block_ct_dim, num_faces);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -54,14 +54,16 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * @tparam num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
 inline void _llk_unpack_AB_reduce_block_max_row_init_()
 {
     if constexpr (is_fp32_dest_acc_en)
@@ -73,8 +75,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_()
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);       // Unpack a single face of a scaler
-    TTI_SETADCXX(p_setadc::UNP_A, 4 * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack a whole tile of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);                // Unpack a single face of a scaler
+    TTI_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0);  // Unpack num_faces faces of an operand
 
     // save the following state that is going to be modified:
     // tile y and z dims for both unpackers

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -12,7 +12,9 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cunpack_common.h"
+#include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -58,14 +60,16 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
- * @tparam num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
+ * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false, std::uint32_t num_faces = 4>
-inline void _llk_unpack_AB_reduce_block_max_row_init_()
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
+inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     if constexpr (is_fp32_dest_acc_en)
     {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
@@ -75,8 +79,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_()
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);                // Unpack a single face of a scaler
-    TTI_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0);  // Unpack num_faces faces of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);         // Unpack a single face of a scaler
+    TT_SETADCXX(p_setadc::UNP_A, tensor_shape.total_tensor_size() - 1, 0x0); // Unpack all faces of an operand
 
     // save the following state that is going to be modified:
     // tile y and z dims for both unpackers
@@ -109,7 +113,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
     // Program srcA and srcB base addresses
-    volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
     wait_for_next_context(2);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -51,15 +51,17 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
  * - Scaler values are 1.0 and are contained inside F0 of the scaler tile
  * - The scaler doesn't change for the duration of the whole block operation
  * - Operand and scaler data format is bfloat16_b
- * - Operand tile size is 32x32
+ * - Operand tile is num_faces faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile)
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
+ *
+ * @param num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4)
 {
     if constexpr (is_fp32_dest_acc_en)
     {
@@ -70,8 +72,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);       // Unpack a single face of a scaler
-    TTI_SETADCXX(p_setadc::UNP_A, 4 * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack a whole tile of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);              // Unpack a single face of a scaler
+    TT_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack num_faces faces of an operand
 
     // save the following state that is going to be modified:
     // tile y and z dims for both unpackers

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -12,7 +12,9 @@
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cunpack_common.h"
+#include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -55,14 +57,16 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
  * - Can work on both 16-bit or 32-bit DEST register modes based on is_fp32_dest_acc_en flag
  * - Does only MAX pool on ROW dimension
  *
- * @param num_faces Number of faces in the operand tile (4 for 32x32, 2 for a 16x32 tiny tile).
+ * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile).
  *
  * This function should NOT be used as a substitute for native reduce unpacking LLK initialization.
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false, std::uint32_t num_faces = 4)
+inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape& tensor_shape)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     if constexpr (is_fp32_dest_acc_en)
     {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
@@ -72,8 +76,8 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);
 
-    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);              // Unpack a single face of a scaler
-    TT_SETADCXX(p_setadc::UNP_A, num_faces * (FACE_R_DIM * FACE_C_DIM) - 1, 0x0); // Unpack num_faces faces of an operand
+    TTI_SETADCXX(p_setadc::UNP_B, FACE_R_DIM * FACE_C_DIM - 1, 0x0);         // Unpack a single face of a scaler
+    TT_SETADCXX(p_setadc::UNP_A, tensor_shape.total_tensor_size() - 1, 0x0); // Unpack all faces of an operand
 
     // save the following state that is going to be modified:
     // tile y and z dims for both unpackers
@@ -106,7 +110,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111); // reset counters
 
     // Program srcA and srcB base addresses
-    volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
 
     // Wait for free context
     wait_for_next_context(2);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -14,20 +14,22 @@
 #include "cunpack_common.h"
 #include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
 // Custom init for the blocked sub+bcast(col) unpack flow.
-// @param num_faces Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
-inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const std::uint32_t num_faces = 4)
+// @param tensor_shape Shape of the operand tile (2 faces for 16x32 tiny tiles, 4 faces for full 32x32 tiles).
+inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0); // transpose within the face
 
-    // Force both unpackers to unpack the requested number of faces (num_faces * 16 * 16
-    // datums) for the blocked path. Full 32x32 tile = 4 faces = 1024 datums, 16x32 tiny
-    // tile = 2 faces = 512 datums.
-    const std::uint32_t x_end = num_faces * FACE_R_DIM * FACE_C_DIM - 1;
+    // Force both unpackers to unpack all faces of the operand for the blocked path. Full 32x32
+    // tile = 4 faces = 1024 datums, 16x32 tiny tile = 2 faces = 512 datums.
+    const std::uint32_t x_end = tensor_shape.total_tensor_size() - 1;
     TT_SETADCXX(p_setadc::UNP0, x_end, 0x0);
     TT_SETADCXX(p_setadc::UNP1, x_end, 0x0);
 }
@@ -39,7 +41,7 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
 
     // Program SrcA and SrcB base addresses.
-    volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer();
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer();
     // Wait for a free unpack config context before programming the next block.
     wait_for_next_context(2);
     _llk_unpack_configure_addresses_(address_a, address_b, cfg);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -19,13 +19,17 @@ using namespace ckernel;
 using namespace ckernel::unpacker;
 
 // Custom init for the blocked sub+bcast(col) unpack flow.
-inline void _llk_unpack_AB_sub_bcast_col_init_custom_()
+// @param num_faces Number of faces per tile (2 for 16x32 tiny tiles, 4 for full 32x32 tiles).
+inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const std::uint32_t num_faces = 4)
 {
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0); // transpose within the face
 
-    // Force both unpackers to unpack the full 32x32 tile for the blocked path.
-    TTI_SETADCXX(p_setadc::UNP0, 1023, 0x0);
-    TTI_SETADCXX(p_setadc::UNP1, 1023, 0x0);
+    // Force both unpackers to unpack the requested number of faces (num_faces * 16 * 16
+    // datums) for the blocked path. Full 32x32 tile = 4 faces = 1024 datums, 16x32 tiny
+    // tile = 2 faces = 512 datums.
+    const std::uint32_t x_end = num_faces * FACE_R_DIM * FACE_C_DIM - 1;
+    TT_SETADCXX(p_setadc::UNP0, x_end, 0x0);
+    TT_SETADCXX(p_setadc::UNP1, x_end, 0x0);
 }
 
 // Custom blocked unpack: one SrcB tile + ct_dim SrcA tiles.
@@ -64,4 +68,8 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
+    // Restore the default single-face unpack X span used by the generic unpack
+    // helpers. The custom blocked path forces both unpackers to a multi-face span
+    // (num_faces * 16 * 16 datums) in the init.
+    TTI_SETADCXX(p_setadc::UNP_AB, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -70,8 +70,6 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
-    // Restore the default single-face unpack X span used by the generic unpack
-    // helpers. The custom blocked path forces both unpackers to a multi-face span
-    // (num_faces * 16 * 16 datums) in the init.
-    TTI_SETADCXX(p_setadc::UNP_AB, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    // No state to restore: the multi-face unpack X span set in the custom init is transient — every
+    // generic unpack op re-establishes its own X span (config_unpacker_x_end / SETADCXX) in its init.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_globals.h"
+#include "ckernel_include.h"
+#include "llk_defs.h"
+
+using namespace ckernel;
+
+/*************************************************************************
+ * LLK MUL REDUCE SCALAR UNPACK - Unpacker operations for fused mul+reduce
+ *************************************************************************/
+
+/**
+ * @brief Switch UNPACK state for mul_reduce_scalar reduce phase
+ *
+ * Prepares for the reduce phase where the math thread reuses destination
+ * registers as source operands. Resets UNPACK counters, signals context switch,
+ * and sets DVALID flags for srcA and srcB.
+ *
+ * Must be called after multiply phase and before reduce phase.
+ */
+inline void _llk_unpack_mul_reduce_scalar_switch_to_reduce_()
+{
+    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+    semaphore_post(semaphore::UNPACK_SYNC);
+    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    t6_semaphore_get(semaphore::UNPACK_SYNC);
+}

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
@@ -27,7 +27,9 @@ inline void _llk_unpack_mul_reduce_scalar_switch_to_reduce_()
 {
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
     semaphore_post(semaphore::UNPACK_SYNC);
-    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    // WH UNPACR_NOP takes (block_selection, NoOp); UNP_ZEROSRC_SET_DVALID both zeroes the source
+    // and sets DVALID in one op (BH encodes the same via separate Set_Dvalid + Unpack_Pop fields).
+    TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC_SET_DVALID);
+    TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC_SET_DVALID);
     t6_semaphore_get(semaphore::UNPACK_SYNC);
 }


### PR DESCRIPTION
## What

Adds **16x32 "tiny tile" (num_faces=2, one face-row)** support to the experimental SDPA/denoise LLK ops, on **Wormhole B0 and Blackhole**, for the Pi 0.5 denoise path (#48198).

- **`sub_bcast_col_custom`** (Elwsub + column broadcast): parameterized by `num_faces` and a `dst_index` base. Fixes a latent **DEST tile-slot stride bug** (tiles were written contiguously instead of at the 32x32 packer slot stride, corrupting tile ≥1 of tiny tiles and multi-tile-row blocks).
- **`reduce_block_max_row`** (unpack + math, static + runtime): new **2-face MOP / addr-mod / replay** path (reduce F0&F1 only, no F2 jump).
- Propagated `num_faces`/`dst_index` through the **metal LLK API** and **Compute API** (`reduce_custom.h`, `sdpa_sub_custom.h`).
- **Fuser**: `tile_dims` plumbing, a tiny-tile config, golden + readback-stride fixes, and relaxing the `(32,32)`-only validator to also allow `(16,32)` for these ops.

`num_faces=4` (32x32) paths are byte-identical to before.

## Validation

Run on **Wormhole silicon** (this is a WH-only host):
- `test_fused.py` — `fpu_sub_bcast_col_custom`, `fpu_reduce_block_max`, `fpu_reduce_block_max_tiny`, `fpu_reduce_block_max_runtime`: **all pass, PCC ~1.0**.
- `test_eltwise_bcast_col_custom.py` (standalone, adds 16x32 rows): **16 pass**.
- **Blackhole**: all changes mirrored and **compile-verified**; runtime validation via CI (see below).

## Scope / follow-up

- **fp32 (dest-accum) 16x32 `reduce_block_max_row` is intentionally not supported yet** — guarded by `static_assert` (compile-time path) and `LLK_ASSERT` (runtime path). It was never validated on any branch (original validation was Float16_b). The fp32 **32x32** reduce is unaffected. This is a documented follow-up.

## Notes

- Rebased/ported onto latest `main` (the reduce math + fuser schema/validator had been refactored on main since the original work).
- Draft pending Blackhole CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/issue-48198-16x32-tiny-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/issue-48198-16x32-tiny-tile)