### PR TITLE
models: non-trace host e2e perf guards for mobilenetv2 + vgg_unet (#48928)

### DIFF
--- a/models/demos/vision/classification/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2_host.py
+++ b/models/demos/vision/classification/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2_host.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Non-trace HOST end-to-end perf test. Runs the model for several iterations: iteration 0 is
+# compile + program-cache miss, later iterations are cache hits. A descriptor rebuild-on-cache-hit
+# regression (see #48928) balloons the steady-state cache-hit host time, so this guards against it.
+
+import time
+
+import pytest
+from loguru import logger
+
+import ttnn
+from models.demos.vision.classification.mobilenetv2.common import (
+    MOBILENETV2_BATCH_SIZE,
+    MOBILENETV2_L1_SMALL_SIZE,
+    load_torch_model,
+)
+from models.demos.vision.classification.mobilenetv2.reference.mobilenetv2 import Mobilenetv2
+from models.demos.vision.classification.mobilenetv2.tt import ttnn_mobilenetv2
+from models.demos.vision.classification.mobilenetv2.tt.model_preprocessing import (
+    create_mobilenetv2_input_tensors,
+    create_mobilenetv2_model_parameters,
+)
+from models.perf.perf_utils import prep_perf_report
+
+
+def get_expected_times():
+    # (compile+miss, steady-state cache-hit). Calibrated on wormhole_b0; cache-hit time carries the
+    # margin that a rebuild-on-cache-hit regression would blow through.
+    return (
+        45.0,
+        0.025,
+    )  # wh_b0: measured compile ~33s, cache-hit ~0.019s (Move x64 still rebuilds pre-Move-fix); tighten once Move is bound
+
+
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE}], indirect=True)
+@pytest.mark.parametrize("batch_size", [MOBILENETV2_BATCH_SIZE])
+def test_perf_e2e_mobilenetv2(device, batch_size, reset_seeds, model_location_generator):
+    torch_model = Mobilenetv2()
+    torch_model = load_torch_model(torch_model, model_location_generator)
+    torch_model.eval()
+
+    model_parameters = create_mobilenetv2_model_parameters(torch_model, device=device)
+    ttnn_model = ttnn_mobilenetv2.TtMobileNetV2(model_parameters, device, batchsize=batch_size)
+
+    iterations = 4
+    durations = []
+    for _ in range(iterations):
+        _, ttnn_input_tensor = create_mobilenetv2_input_tensors(batch=batch_size, input_height=224, input_width=224)
+        start = time.time()
+        output = ttnn_model(ttnn_input_tensor)
+        output = ttnn.from_device(output)
+        durations.append(time.time() - start)
+
+    inference_and_compile_time = durations[0]
+    inference_time = min(durations[1:])  # steady-state cache-hit
+
+    expected_compile_time, expected_inference_time = get_expected_times()
+    prep_perf_report(
+        model_name="MobileNetV2",
+        batch_size=batch_size,
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="non-trace host e2e",
+        inference_time_cpu=0.0,
+    )
+    logger.info(f"Compile time: {inference_and_compile_time - inference_time}")
+    logger.info(f"Cache-hit inference time (avg): {inference_time}")

--- a/models/demos/vision/segmentation/vgg_unet/wormhole/tests/perf/test_perf_e2e_vgg_unet_host.py
+++ b/models/demos/vision/segmentation/vgg_unet/wormhole/tests/perf/test_perf_e2e_vgg_unet_host.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Non-trace HOST end-to-end perf test. Iteration 0 is compile + program-cache miss; later iterations
+# are cache hits. A descriptor rebuild-on-cache-hit regression (#48928) balloons the steady-state
+# cache-hit host time, so this guards against it.
+
+import time
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.vision.segmentation.vgg_unet.common.reference.vgg_unet import UNetVGG19
+from models.demos.vision.segmentation.vgg_unet.common.ttnn.model_preprocessing import create_vgg_unet_model_parameters
+from models.demos.vision.segmentation.vgg_unet.common.ttnn.ttnn_vgg_unet import Tt_vgg_unet
+from models.perf.perf_utils import prep_perf_report
+
+
+def get_expected_times():
+    # (compile+miss, steady-state cache-hit). Calibrated on wormhole_b0.
+    return (
+        45.0,
+        0.012,
+    )  # wh_b0: measured compile ~33s, cache-hit ~0.009s (Move x52/Concat x12 still rebuild pre-fix); tighten once bound
+
+
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("batch_size", [1])
+def test_perf_e2e_vgg_unet(device, batch_size, reset_seeds):
+    torch_input = torch.randn((batch_size, 3, 256, 256))
+    torch_model = UNetVGG19()
+    torch_model.eval()
+
+    parameters = create_vgg_unet_model_parameters(torch_model, torch_input, device)
+    ttnn_model = Tt_vgg_unet(device, parameters, parameters.conv_args)
+
+    iterations = 4
+    durations = []
+    for _ in range(iterations):
+        ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16).to(device, ttnn.L1_MEMORY_CONFIG)
+        start = time.time()
+        output = ttnn_model(ttnn_input)
+        output = ttnn.from_device(output)
+        durations.append(time.time() - start)
+
+    inference_and_compile_time = durations[0]
+    inference_time = min(durations[1:])  # steady-state cache-hit
+
+    expected_compile_time, expected_inference_time = get_expected_times()
+    prep_perf_report(
+        model_name="VGG_UNet",
+        batch_size=batch_size,
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="non-trace host e2e",
+        inference_time_cpu=0.0,
+    )
+    logger.info(f"Compile time: {inference_and_compile_time - inference_time}")
+    logger.info(f"Cache-hit inference time (avg): {inference_time}")


### PR DESCRIPTION
### What

Adds non-trace **host** end-to-end perf tests for **MobileNetV2** and **VGG-UNet**. Both models
previously shipped only device/tracy profiler perf tests, which are blind to the host-side descriptor
**rebuild-on-cache-hit** regression class (#48928). These run the model non-trace for several iterations
(iteration 0 = compile + program-cache miss, later iterations = cache hits) and report the steady-state
cache-hit `inference_time` via `prep_perf_report`. A rebuild-on-cache-hit regression balloons the
cache-hit host time (~18x on resnet50), so the perf pipeline's comparison catches it.

Modeled on the existing resnet50 / vgg host perf tests.

### Why now

A proactive sweep of the non-trace host path found that these two models had no host perf coverage,
and that they rebuild descriptors on cache hits for ops not yet fixed:

| Model | cache-hit time (wh_b0) | rebuild-on-hit ops |
|---|---|---|
| MobileNetV2 | ~0.019s | Move x64 |
| VGG-UNet | ~0.009s | Move x52, Concat x12, Unary x3 |

(`MoveDeviceOperation` is the dominant offender across CNNs — a follow-up fix candidate, same playbook
as #48928: give the factory `Buffer*` rt-arg bindings or `get_dynamic_runtime_args`.)

### Notes

- Expected times are calibrated on wormhole_b0 against the *current* state where Move/Concat/Unary still
  rebuild; they should be tightened once those ops are bound.
- Local: both tests PASS.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/model-perf-e2e-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/model-perf-e2e-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/model-perf-e2e-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/model-perf-e2e-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/model-perf-e2e-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/model-perf-e2e-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/model-perf-e2e-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/model-perf-e2e-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/model-perf-e2e-guards)