### PR TITLE
[cleanup][metal 2.0] Rename fields in `ComputeHardwareConfig`

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1749,7 +1749,7 @@ TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithUnpackToDestFp32ModeSucceeds) {
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
-            config.fp32_dest_acc_en = true;
+            config.accumulator_width = experimental::AccumulatorWidth::Wide;
             config.unpack_to_dest_mode = {{DFBSpecName{"dfb_0"}, UnpackToDestMode::UnpackToDestFp32}};
         }
     }
@@ -1767,7 +1767,7 @@ TEST_F(ProgramSpecTestQuasar, FP32ConsumerWithFp32DestAccEnAndNoEntryFails) {
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
-            config.fp32_dest_acc_en = true;
+            config.accumulator_width = experimental::AccumulatorWidth::Wide;
         }
     }
     // Compute kernel intentionally has no unpack_to_dest_mode entry.
@@ -1802,7 +1802,7 @@ TEST_F(ProgramSpecTestQuasar, FP32ProducerOnlyBindingDoesNotRequireEntry) {
 
     auto producer_compute = MakeMinimalComputeKernel("producer_compute");
     auto& producer_config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(producer_compute.hw_config));
-    producer_config.fp32_dest_acc_en = true;
+    producer_config.accumulator_width = experimental::AccumulatorWidth::Wide;
 
     auto consumer_dm = MakeMinimalGen2DMKernel("consumer_dm");
 
@@ -1830,7 +1830,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32OnProducerBindingSucceeds) {
 
     auto producer_compute = MakeMinimalComputeKernel("producer_compute");
     auto& producer_config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(producer_compute.hw_config));
-    producer_config.fp32_dest_acc_en = true;
+    producer_config.accumulator_width = experimental::AccumulatorWidth::Wide;
     producer_config.unpack_to_dest_mode = {{DFBSpecName{"dfb_0"}, UnpackToDestMode::UnpackToDestFp32}};
 
     auto consumer_dm = MakeMinimalGen2DMKernel("consumer_dm");
@@ -1881,7 +1881,7 @@ TEST_F(ProgramSpecTestQuasar, FP32DFBWithDefaultUnpackToDestModeSucceeds) {
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
-            config.fp32_dest_acc_en = true;
+            config.accumulator_width = experimental::AccumulatorWidth::Wide;
             config.unpack_to_dest_mode = {{DFBSpecName{"dfb_0"}, UnpackToDestMode::Default}};
         }
     }
@@ -2393,7 +2393,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigMathFidelitySucceeds) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
             config.math_fidelity = MathFidelity::LoFi;
-            config.fp32_dest_acc_en = true;
+            config.accumulator_width = experimental::AccumulatorWidth::Wide;
             config.math_approx_mode = true;
         }
     }
@@ -2414,7 +2414,7 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
             auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
-            config.fp32_dest_acc_en = true;
+            config.accumulator_width = experimental::AccumulatorWidth::Wide;
             config.unpack_to_dest_mode = {{DFBSpecName{"dfb_0"}, UnpackToDestMode::UnpackToDestFp32}};
         }
     }
@@ -2448,7 +2448,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
     consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_1"}, "in1"));
 
     auto& compute_config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(consumer.hw_config));
-    compute_config.fp32_dest_acc_en = true;
+    compute_config.accumulator_width = experimental::AccumulatorWidth::Wide;
     compute_config.unpack_to_dest_mode = {{DFBSpecName{"dfb_1"}, UnpackToDestMode::UnpackToDestFp32}};
 
     spec.kernels = {producer, consumer};
@@ -2798,7 +2798,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
             ComputeHardwareConfig{
                 ComputeGen2Config{
                     .math_fidelity = MathFidelity::LoFi,
-                    .fp32_dest_acc_en = true,
+                    .accumulator_width = experimental::AccumulatorWidth::Wide,
                 },
             },
     };

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -467,15 +467,19 @@ bool reader_datacopy_writer(
             : experimental::ComputeUnpackToDestModes{};
     if (is_quasar) {
         compute_hw_config = experimental::ComputeGen2Config{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width =
+                fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
             .unpack_to_dest_en = fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_modes,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width =
+                fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
             .unpack_to_dest_mode = unpack_modes,
         };
     }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -337,14 +337,18 @@ static void matmul_tile_block(
     if (mesh_device->arch() == ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .math_fidelity = cfg.math_fidelity,
-            .fp32_dest_acc_en = cfg.fp32_dest_acc_en,
-            .dst_full_sync_en = cfg.dst_full_sync_en,
+            .accumulator_width =
+                cfg.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = cfg.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                          : experimental::AccumulatorBuffering::Pipelined,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
             .math_fidelity = cfg.math_fidelity,
-            .fp32_dest_acc_en = cfg.fp32_dest_acc_en,
-            .dst_full_sync_en = cfg.dst_full_sync_en,
+            .accumulator_width =
+                cfg.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = cfg.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                          : experimental::AccumulatorBuffering::Pipelined,
         };
     }
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -167,14 +167,18 @@ void run_single_core_copy_block_matmul_partials(
                 : experimental::ComputeUnpackToDestModes{};
         if (mesh_device->arch() == tt::ARCH::QUASAR) {
             compute_hw_config = experimental::ComputeGen2Config{
-                .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-                .dst_full_sync_en = test_config.dst_full_sync_en,
+                .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                                  : experimental::AccumulatorWidth::Standard,
+                .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                      : experimental::AccumulatorBuffering::Pipelined,
                 .unpack_to_dest_mode = unpack_modes,
             };
         } else {
             compute_hw_config = experimental::ComputeGen1Config{
-                .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-                .dst_full_sync_en = test_config.dst_full_sync_en,
+                .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                                  : experimental::AccumulatorWidth::Standard,
+                .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                      : experimental::AccumulatorBuffering::Pipelined,
                 .unpack_to_dest_mode = unpack_modes,
             };
         }

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -135,7 +135,8 @@ static vector<uint32_t> run_mxfp4_typecast(
         .hw_config =
             experimental::ComputeHardwareConfig{
                 experimental::ComputeGen2Config{
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .accumulator_width = fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                          : experimental::AccumulatorWidth::Standard,
                 },
             },
     };

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -140,7 +140,8 @@ static vector<uint32_t> run_mxfp6_typecast(
         .hw_config =
             experimental::ComputeHardwareConfig{
                 experimental::ComputeGen2Config{
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .accumulator_width = fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                          : experimental::AccumulatorWidth::Standard,
                 },
             },
     };

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -139,7 +139,8 @@ static vector<uint32_t> run_mxfp8_typecast(
         .hw_config =
             experimental::ComputeHardwareConfig{
                 experimental::ComputeGen2Config{
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .accumulator_width = fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                          : experimental::AccumulatorWidth::Standard,
                 },
             },
     };

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -123,7 +123,8 @@ static vector<uint32_t> run_mxint_typecast(
         .hw_config =
             experimental::ComputeHardwareConfig{
                 experimental::ComputeGen2Config{
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .accumulator_width = fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                          : experimental::AccumulatorWidth::Standard,
                 },
             },
     };

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -492,7 +492,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
             experimental::ComputeHardwareConfig{
                 experimental::ComputeGen2Config{
                     .math_fidelity = MathFidelity::HiFi4,
-                    .fp32_dest_acc_en = true,
+                    .accumulator_width = experimental::AccumulatorWidth::Wide,
                     .unpack_to_dest_mode =
                         {{INP2_DFB, tt::tt_metal::UnpackToDestMode::Default},
                          {INP3_DFB, tt::tt_metal::UnpackToDestMode::Default}},
@@ -833,7 +833,7 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
             experimental::ComputeHardwareConfig{
                 experimental::ComputeGen2Config{
                     .math_fidelity = MathFidelity::HiFi4,
-                    .fp32_dest_acc_en = true,
+                    .accumulator_width = experimental::AccumulatorWidth::Wide,
                     .unpack_to_dest_mode =
                         {{INP2_DFB, tt::tt_metal::UnpackToDestMode::Default},
                          {INP3_DFB, tt::tt_metal::UnpackToDestMode::Default}},

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -428,15 +428,19 @@ void run_single_core_reduce_program(
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .math_fidelity = test_config.math_fidelity,
-            .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                              : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
             .enable_2x_src_format = test_config.enable_2x_src_format,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
             .math_fidelity = test_config.math_fidelity,
-            .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                              : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
         };
     }
     experimental::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -730,16 +730,22 @@ std::vector<uint32_t> run_sfpu_pipeline(
             : experimental::ComputeUnpackToDestModes{};
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
-            .fp32_dest_acc_en = test_config.en_32bit_dest || test_config.unpack_to_dest_fp32,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = (test_config.en_32bit_dest || test_config.unpack_to_dest_fp32)
+                                     ? experimental::AccumulatorWidth::Wide
+                                     : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
             .math_approx_mode = test_config.approx_mode,
             .unpack_to_dest_en = test_config.unpack_to_dest_fp32 || test_config.unpack_to_dest_en,
             .unpack_to_dest_mode = unpack_modes,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
-            .fp32_dest_acc_en = test_config.en_32bit_dest || test_config.unpack_to_dest_fp32,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = (test_config.en_32bit_dest || test_config.unpack_to_dest_fp32)
+                                     ? experimental::AccumulatorWidth::Wide
+                                     : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
             .math_approx_mode = test_config.approx_mode,
             .unpack_to_dest_mode = unpack_modes,
         };
@@ -1042,12 +1048,14 @@ bool run_sfpu_binary_two_input_buffer(
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
-            .fp32_dest_acc_en = is_int8_op,
+            .accumulator_width =
+                is_int8_op ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
             .math_approx_mode = test_config.approx_mode,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
-            .fp32_dest_acc_en = is_int8_op,
+            .accumulator_width =
+                is_int8_op ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
             .math_approx_mode = test_config.approx_mode,
         };
     }

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -258,15 +258,19 @@ void run_single_core_transpose(
             : experimental::ComputeUnpackToDestModes{};
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width =
+                fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
             .unpack_to_dest_en = fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_modes,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width =
+                fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
             .unpack_to_dest_mode = unpack_modes,
         };
     }

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -330,13 +330,17 @@ void run_single_core_tilize_program(
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
-            .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                              : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
-            .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                              : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
         };
     }
     experimental::KernelSpec compute_spec{
@@ -654,13 +658,17 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
-            .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                              : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
-            .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .accumulator_width = test_config.fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide
+                                                              : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = test_config.dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                                  : experimental::AccumulatorBuffering::Pipelined,
         };
     }
     experimental::KernelSpec compute_spec{
@@ -1008,13 +1016,17 @@ static void run_quasar_tilize_untilize_test(
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = dst_full_sync_en,
+            .accumulator_width =
+                fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                      : experimental::AccumulatorBuffering::Pipelined,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = dst_full_sync_en,
+            .accumulator_width =
+                fp32_dest_acc_en ? experimental::AccumulatorWidth::Wide : experimental::AccumulatorWidth::Standard,
+            .accumulator_buffering = dst_full_sync_en ? experimental::AccumulatorBuffering::MaxCapacity
+                                                      : experimental::AccumulatorBuffering::Pipelined,
         };
     }
     experimental::KernelSpec compute_spec{

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -50,27 +50,35 @@ namespace tt::tt_metal::experimental {
 // This choice matters only when ALL of the following hold for the DFB binding:
 //   1. The kernel is the consumer endpoint (unpacking data into the kernel)
 //   2. The DFB's data format is Float32.
-//   3. fp32_dest_acc_en is true (Dest must be 32-bit-wide to hold FP32).
+//   3. accumulator_width == Wide (Dest must be 32-bit-wide to hold FP32).
 //
 // You MUST provide an unpack_to_dest_mode entry for the DFB when all three conditions hold;
 // failing to do so will trigger an error. Outside the triple an entry is optional: Default is
 // always accepted, and UnpackToDestFp32 is tolerated where it is inert (non-consumer or
 // non-Float32 — the hardware ignores the mode there, and legacy ops set it unconditionally).
-// UnpackToDestFp32 always requires fp32_dest_acc_en=true, even where inert; otherwise it is
+// UnpackToDestFp32 always requires accumulator_width == Wide, even where inert; otherwise it is
 // rejected as incoherent (Dest is 16-bit and cannot hold full FP32).
 using ComputeUnpackToDestModes = Table<DFBSpecName, tt::tt_metal::UnpackToDestMode>;
+
+// Dest register element width.
+//   Standard — Dest holds 16-bit elements (default)
+//   Wide     — Dest holds 32-bit (FP32) elements
+enum class AccumulatorWidth { Standard, Wide };
+
+// Dest register sync mode.
+//   Pipelined   — Dest is split in half; math and pack overlap (double-buffered)
+//   MaxCapacity — Dest is one buffer; twice the capacity, no math/pack overlap
+enum class AccumulatorBuffering { Pipelined, MaxCapacity };
 
 struct ComputeGen1Config {
     // Number of multiply passes the FPU runs to use more mantissa bits
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 
-    // Configure Dest register to hold 32-bit elements (instead of the default 16-bit)
-    bool fp32_dest_acc_en = false;
+    // Dest register element width.
+    AccumulatorWidth accumulator_width = AccumulatorWidth::Standard;
 
-    // Dest register sync mode:
-    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered)
-    //   true  (Full) — Dest is one buffer; twice the capacity, no math/pack overlap
-    bool dst_full_sync_en = false;
+    // Dest register sync mode.
+    AccumulatorBuffering accumulator_buffering = AccumulatorBuffering::Pipelined;
 
     // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
     bool math_approx_mode = false;
@@ -88,13 +96,11 @@ struct ComputeGen2Config {
     // Number of multiply passes the FPU runs to use more mantissa bits
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 
-    // Configure Dest register to hold 32-bit elements (instead of the default 16-bit)
-    bool fp32_dest_acc_en = false;
+    // Dest register element width.
+    AccumulatorWidth accumulator_width = AccumulatorWidth::Standard;
 
-    // Dest register sync mode:
-    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered)
-    //   true  (Full) — Dest is one buffer; twice the capacity, no math/pack overlap
-    bool dst_full_sync_en = false;
+    // Dest register sync mode.
+    AccumulatorBuffering accumulator_buffering = AccumulatorBuffering::Pipelined;
 
     // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
     bool math_approx_mode = false;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -915,8 +915,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         const auto& unpack_to_dest_mode =
             std::visit([](const auto& config) { return config.unpack_to_dest_mode; }, compute_config);
 
-        const bool fp32_dest_acc_en =
-            std::visit([](const auto& config) { return config.fp32_dest_acc_en; }, compute_config);
+        const bool fp32_dest_acc_en = std::visit(
+            [](const auto& config) { return config.accumulator_width == AccumulatorWidth::Wide; }, compute_config);
 
         // Index the kernel's DFB bindings: which DFBs it binds.
         std::unordered_set<DFBSpecName> bound_dfbs;
@@ -2586,8 +2586,8 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
 
     return ComputeConfig{
         .math_fidelity = gen1.math_fidelity,
-        .fp32_dest_acc_en = gen1.fp32_dest_acc_en,
-        .dst_full_sync_en = gen1.dst_full_sync_en,
+        .fp32_dest_acc_en = gen1.accumulator_width == AccumulatorWidth::Wide,
+        .dst_full_sync_en = gen1.accumulator_buffering == AccumulatorBuffering::MaxCapacity,
         .unpack_to_dest_mode = unpack_modes,
         .bfp8_pack_precise = gen1.bfp8_pack_precise,
         .math_approx_mode = gen1.math_approx_mode,
@@ -2636,8 +2636,8 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
         .math_fidelity = gen2.math_fidelity,
-        .fp32_dest_acc_en = gen2.fp32_dest_acc_en,
-        .dst_full_sync_en = gen2.dst_full_sync_en,
+        .fp32_dest_acc_en = gen2.accumulator_width == AccumulatorWidth::Wide,
+        .dst_full_sync_en = gen2.accumulator_buffering == AccumulatorBuffering::MaxCapacity,
         .unpack_to_dest_mode = unpack_modes,
         .math_approx_mode = gen2.math_approx_mode,
         .enable_2x_src_format = gen2.enable_2x_src_format,

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -109,19 +109,23 @@ std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kerne
 tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
     tt::ARCH arch, const ComputeKernelConfig& config) {
     // The four knobs are common to both generations; select the alternative matching the target arch.
+    auto accumulator_width = config.fp32_dest_acc_en ? tt::tt_metal::experimental::AccumulatorWidth::Wide
+                                                     : tt::tt_metal::experimental::AccumulatorWidth::Standard;
+    auto accumulator_buffering = config.dst_full_sync_en ? tt::tt_metal::experimental::AccumulatorBuffering::MaxCapacity
+                                                         : tt::tt_metal::experimental::AccumulatorBuffering::Pipelined;
     if (arch == tt::ARCH::QUASAR) {
         return tt::tt_metal::experimental::ComputeGen2Config{
             .math_fidelity = config.math_fidelity,
-            .fp32_dest_acc_en = config.fp32_dest_acc_en,
-            .dst_full_sync_en = config.dst_full_sync_en,
+            .accumulator_width = accumulator_width,
+            .accumulator_buffering = accumulator_buffering,
             .math_approx_mode = config.math_approx_mode,
             // Omitted fields use defaults: enable_2x_src_format, unpack_to_dest_en, unpack_to_dest_mode
         };
     }
     return tt::tt_metal::experimental::ComputeGen1Config{
         .math_fidelity = config.math_fidelity,
-        .fp32_dest_acc_en = config.fp32_dest_acc_en,
-        .dst_full_sync_en = config.dst_full_sync_en,
+        .accumulator_width = accumulator_width,
+        .accumulator_buffering = accumulator_buffering,
         .math_approx_mode = config.math_approx_mode,
         // Omitted fields use defaults: bfp8_pack_precise, unpack_to_dest_mode
     };


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

This PR renames some of the confusing fields in `ComputeHardwareConfig` to better reflect their intention.

Rename performed in this PR:


#### `fp32_dest_acc_en`
Renamed to `accumulator_width`
Was originally a bool type, now an enum with { Wide, Standard }

#### `dst_full_sync_en`
Renamed to `accumulator_buffering`

Was originally a bool type, now an enum with { MaxCapacity, Pipelined }

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Use sites have been updated at their immediate usage, better integration could be explored after we agree on the names.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/compute-config-rename)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/compute-config-rename)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/compute-config-rename)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/compute-config-rename)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/compute-config-rename)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/compute-config-rename)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/compute-config-rename)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/compute-config-rename)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/compute-config-rename)