### PR TITLE
Improve matmul performance

### DIFF
--- a/models/common/modules/moe/tt_moe_gate.py
+++ b/models/common/modules/moe/tt_moe_gate.py
@@ -406,14 +406,18 @@ class TTMoEGate:
 
     def _derive_program_config(self) -> dict:
         """Derive the 2D-mcast blocking for the gate matmul (``batch×hidden @ hidden×padded_experts``) from
-        its shape + the device grid. Reproduces the previously hand-tuned per-model configs exactly.
+        its shape + the device grid. Matches the previously hand-tuned per-model configs, except the
+        256-expert gate now uses ``per_core_N=1`` instead of ``2`` (see the ``per_core_N`` bullet).
 
           ``M_tiles = ceil(batch/32)`` (=1 for the batch-32 decode gate); ``K_tiles = hidden/32``;
           ``N_tiles = padded_experts/32`` (256 experts → 8, the 512-combine path → 16).
             • ``in0_block_w`` = largest divisor of ``K_tiles`` that is ≤ 32 (the widest K-block within the
               32-tile cap; a non-1024-multiple hidden gives e.g. 20 / 22 / 30 instead of 32).
-            • ``per_core_N`` = smallest divisor ≥ 2 of ``N_tiles`` that fits the grid
-              (``N_tiles / per_core_N ≤ grid.x``): 2 on an 8-wide grid, growing to 4 on a narrower one.
+            • ``per_core_N`` = smallest divisor ≥ 1 of ``N_tiles`` that fits the grid
+              (``N_tiles / per_core_N ≤ grid.x``) — i.e. spread N across as many cores as the grid holds.
+              256 experts (``N_tiles=8``) on an 8-wide grid → ``1`` (8 N-cores); the 512-combine path
+              (``N_tiles=16``) → ``2`` (16 tiles can't map to 16 cores, so 8). NOTE: ``per_core_N=1``
+              measured faster than ``2`` for the tiny (``M_tiles=1``) 256 gate.
             • ``out_block_{h,w}`` = ``per_core_{M,N}``; ``out_subblock_{h,w}`` = largest factors with
               ``h * w ≤ dst_subblock_cap`` — the DEST subblock budget = HALF of the DEST tile capacity
               (MATH/PACK double-buffer): 8 tiles for bf16 accumulation, but **4 for fp32 accumulation**

--- a/models/common/modules/moe/tt_moe_gate.py
+++ b/models/common/modules/moe/tt_moe_gate.py
@@ -432,7 +432,7 @@ class TTMoEGate:
         n_tiles = self._padded_experts // 32
         grid_x = self._grid.x
         in0_block_w = max(d for d in range(1, 33) if k_tiles % d == 0)
-        per_core_n = next((d for d in range(2, n_tiles + 1) if n_tiles % d == 0 and n_tiles // d <= grid_x), n_tiles)
+        per_core_n = next((d for d in range(1, n_tiles + 1) if n_tiles % d == 0 and n_tiles // d <= grid_x), n_tiles)
         # out_subblock_w capped at dst_subblock_cap too: out_subblock_h can be 1, so w alone can equal the
         # h*w budget — without the cap a wide per_core_n (e.g. 8) would pick w=8,h=1 = 8 tiles, busting fp32's 4.
         out_subblock_w = next((w for w in range(min(per_core_n, dst_subblock_cap), 0, -1) if per_core_n % w == 0), 1)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This is to improve the performance of matmul op in generalized MoEGate by updating the logic of generating matmul program_config. In experiments I found that '1' works better than '2'.

### CI Status

All the [tests](https://github.com/tenstorrent/tt-metal/blob/main/models/common/tests/modules/moe/test_tt_moe_gate.py) in `models/common/tests/modules/moe/test_tt_moe_gate.py` pass.

<img width="1898" height="512" alt="image" src="https://github.com/user-attachments/assets/f2262823-3c43-44a0-a378-7a7c5633b402" />

And here are perf results:

| Model | WH1(us) | WH2(us) | BH1(us) | BH2(us) |
|---|---|---|---|---|
| DeepSeek OCR | 10.33 | 11.77 | 5.14 | 6.62 |
| DeepSeek V3 | 40.67 | 44.17 | 19.81 | 22.85 |
| DeepSeek V4 Flash | 25.19 | 27.71 | 12.24 | 14.37 |
| DeepSeek V4 Pro | 50.23 | 50.93 | 28.61 | 28.84 |
| Gemma 4 26B | 18.64 | 20.37 | 9.48 | 11.31 |
| GLM5 | 35.4 | 38.63 | 17.28 | 19.91 |
| GLM 4.7 | 30.31 | 33.03 | 14.56 | 17.08 |
| GPT-OSS | 19.21 | 21.25 | 9.06 | 11.52 |
| Kimi K2.5 | 51.14 | 51.26 | 28.41 | 28.21 |
| Ling 1T | 45.92 | 49.7 | 22.34 | 25.28 |
| Mistral Large 3 | 40.62 | 44.14 | 19.8 | 22.86 |
| Qwen3.5 35B | 14.74 | 16.68 | 7 | 9.11 |
| Qwen3.5 397B | 31.42 | 31.37 | 16.69 | 16.65 |
| Qwen3 235B | 25.08 | 27.59 | 12.23 | 14.31 |
| Qwen3 Omni Talker | 9.55 | 10.83 | 4.61 | 6 |
| Qwen3 Omni Thinker | 14.75 | 16.66 | 7.01 | 9.1 |

Note that here '1' / '2' corresponds to the line [#491](https://github.com/tenstorrent/tt-metal/pull/49280/changes#diff-c456d3c905bfa8e356ca3aee35d2cf8f4aa529c18011dd803aade16613fc9400R439)'s change.