### PR TITLE
Close T3K batch-1 decode gap (small models)

### DIFF
--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -19,6 +19,7 @@ Design principle: Thick engine, thin model executor.
 from __future__ import annotations
 
 import contextlib
+import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -952,6 +953,23 @@ class TracedLLMExecutor:
         self.trace_inputs_decode: dict[bool, tuple | None] = defaultdict(lambda: None)
         self.trace_output_decode: dict[bool, tuple | None] = defaultdict(lambda: None)
 
+        # On-device decode loop (opt-in, default OFF). When enabled, the captured decode trace
+        # advances position/rope on device (in-place ``ttnn.plus_one``) and feeds the sampled token
+        # back into the persistent token buffer (``ttnn.sampling(output_tensor=...)``), so steady-state
+        # steps replay with NO per-step host input staging. Mirrors TTTv1's on-device sampling trace
+        # (tt_transformers generator ``refresh_trace_inputs=False`` + model ``_increment_decode_positions_device``).
+        # Only valid for free-running greedy/top-k generation — NOT teacher forcing (which injects
+        # host tokens every step), so accuracy/teacher-forcing runs must leave this OFF.
+        self._ondevice_decode_loop = os.environ.get("TTT_ONDEVICE_DECODE_LOOP", "0") == "1"
+        # Diagnostic: read back device current_pos on the first few steps to prove plus_one persistence.
+        self._ondevice_decode_loop_debug = os.environ.get("TTT_ONDEVICE_DECODE_LOOP_DEBUG", "0") == "1"
+        # Per sampling-mode flag: the next decode step must re-seed the persistent buffers from host
+        # (correct first token + start position). Set after every prefill and at init; cleared once
+        # the device has been seeded, after which steady-state steps carry state on device.
+        self._decode_needs_reseed: dict[bool, bool] = defaultdict(lambda: True)
+        self._prev_decode_page_table: torch.Tensor | None = None
+        self._decode_dbg_count = 0
+
         self.mode = None
         self.already_warmed_up_prefill = False
 
@@ -1009,6 +1027,20 @@ class TracedLLMExecutor:
     def _get_decode_trace_key(self, sampling_params) -> bool:
         """Decode trace key = whether sampling is on device."""
         return sampling_params is not None
+
+    def _decode_loop_active(self, sampling_params) -> bool:
+        """Whether the on-device decode loop applies for this decode call.
+
+        Requires: the opt-in flag, on-device sampling, AND the top-k op path (``ttnn.sampling``),
+        whose output is uint32 ``[1,1,1,32]`` on Wormhole/Blackhole — an exact match for the
+        persistent token buffer, so it can be fed back in place via ``output_tensor=`` with no
+        realloc. The force-argmax path (``ttnn.argmax`` → uint32 ``[1,1,32]``, rank-3) does NOT
+        match the rank-4 token buffer, so the loop stays off there and falls back to host resupply.
+        """
+        if not self._ondevice_decode_loop or sampling_params is None or self.model.sampling is None:
+            return False
+        # kpt is None only for the force-argmax path; non-None => top-k op path.
+        return self._eager._get_decode_sampling_kpt(sampling_params) is not None
 
     def _prepare_prefill_trace_inputs_host(
         self, tokens, page_table, start_pos=0, chunk_page_table=None, last_token_idx=None
@@ -1221,6 +1253,10 @@ class TracedLLMExecutor:
 
         self.mode = Mode.PREFILL
         self._eager._assert_kv_cache_identity(kv_cache)
+        # A prefill breaks decode continuity: the next decode step must re-seed the persistent
+        # on-device buffers from host (correct first token + start position) before the device
+        # can carry state on its own. Mark all sampling modes stale.
+        self._decode_needs_reseed = defaultdict(lambda: True)
 
         batch_size, batch_seq_len = tokens.shape
         vocab_size = self.model.vocab_size
@@ -1450,11 +1486,27 @@ class TracedLLMExecutor:
         if not self.trace_ids_decode[sampling_on_device]:
             self._capture_decode_trace(tokens, start_pos, page_table, kv_cache, sampling_on_device, sampling_params)
 
-        host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
-        copy_host_to_device(
-            host_tensors=host_inputs,
-            device_tensors=self.trace_inputs_decode[sampling_on_device],
-        )
+        loop_active = self._decode_loop_active(sampling_params)
+        if loop_active and not self._decode_needs_reseed[sampling_on_device]:
+            # Steady-state on-device loop: the captured trace advanced current_pos/rot_mat_idxs
+            # (in-place plus_one) and wrote the sampled token back into the persistent token buffer
+            # on the previous replay, so tokens/positions need NO host staging. Refresh only the
+            # page table, and only when it actually changed (block boundaries crossed).
+            if self._prev_decode_page_table is None or not torch.equal(self._prev_decode_page_table, page_table):
+                host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
+                device_inputs = self.trace_inputs_decode[sampling_on_device]
+                ttnn.copy_host_to_device_tensor(host_inputs[3], device_inputs[3])  # page_table only
+                self._prev_decode_page_table = page_table.clone()
+        else:
+            # Reseed (first step after prefill, or loop disabled): full host refresh of all inputs.
+            host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
+            copy_host_to_device(
+                host_tensors=host_inputs,
+                device_tensors=self.trace_inputs_decode[sampling_on_device],
+            )
+            self._prev_decode_page_table = page_table.clone()
+            if loop_active:
+                self._decode_needs_reseed[sampling_on_device] = False
 
         ttnn.execute_trace(
             self.mesh_device,
@@ -1464,16 +1516,23 @@ class TracedLLMExecutor:
         )
         tt_output = self.trace_output_decode[sampling_on_device]
 
+        if loop_active and self._ondevice_decode_loop_debug and self._decode_dbg_count < 6:
+            # Prove plus_one persistence: read back the device position after this replay.
+            # Expect device current_pos to track host+1 (device already incremented for next step);
+            # if it stays pinned, plus_one is not persisting across replays.
+            self._decode_dbg_count += 1
+            dbg_pos = self.trace_inputs_decode[sampling_on_device][1]
+            pos_host = ttnn.to_torch(ttnn.get_device_tensors(dbg_pos)[0]).flatten()[:1].tolist()
+            logger.info(f"[ondevice-loop-debug] host start_pos[0]={int(start_pos[0])} device current_pos[0]={pos_host}")
+
         if read_from_device:
             if sampling_on_device:
                 tt_toks, tt_log_probs = tt_output
                 toks_host = tt_toks.cpu()
-                ttnn.synchronize_device(self.mesh_device)
                 return _process_output_decode_tokens(toks_host, B, cluster_shape), None
             else:
                 logits, _ = tt_output
                 logits_host = logits.cpu()
-                ttnn.synchronize_device(self.mesh_device)
                 return _process_output_decode(logits_host, B, vocab_size, num_devices, cluster_shape), None
 
         return tt_output
@@ -1516,6 +1575,10 @@ class TracedLLMExecutor:
         host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
         device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
 
+        # On-device decode loop: when active, the sampled token is fed back in place into the
+        # persistent token buffer (device_inputs[0]) and position/rope are advanced on device.
+        loop_active = self._decode_loop_active(sampling_params)
+
         # On-device sampling: materialise sampling buffers AND JIT-compile the sampling program
         # BEFORE trace capture. Both buffer materialisation (Sampling1D LazyBuffers + the
         # LogProbsCalculator's ttnn.as_tensor scratch) and a first-run program compile issue device
@@ -1535,10 +1598,26 @@ class TracedLLMExecutor:
                 wu_rot_mats = self.model.rope_setup.get_rot_mats(wu_rot_mat_idxs)
                 wu_embed = self.model.embed_decode(wu_tokens)
                 wu_logits = self.model.decode_forward(wu_embed, wu_current_pos, wu_rot_mats, page_table=wu_page_table)
-                wu_toks, _ = self._eager._sampling_decode_forward(wu_logits, sampling_params, tt_out_tok=None)
+                # Warm up with the SAME output_tensor the captured body uses, so the
+                # ttnn.sampling(output_tensor=...) program variant is compiled before capture
+                # (avoids a "compile during trace capture" fatal).
+                wu_feedback = wu_tokens if loop_active else None
+                wu_toks, _ = self._eager._sampling_decode_forward(wu_logits, sampling_params, tt_out_tok=wu_feedback)
             ttnn.synchronize_device(self.mesh_device)
-            cleanup_ttnn_value(wu_toks)
+            # Only free wu_toks if it is a fresh allocation; when loop_active it aliases the
+            # persistent token buffer (device_inputs[0]) and MUST NOT be deallocated.
+            if wu_feedback is None:
+                cleanup_ttnn_value(wu_toks)
             ttnn.synchronize_device(self.mesh_device)
+            if loop_active:
+                # Warm up BOTH ttnn.plus_one program variants (skip_negative_entries True/False are
+                # distinct compile-time programs) so they are in the program cache before capture —
+                # otherwise the in-trace plus_one triggers "Cannot load new binaries during trace
+                # capture". These increment wu_current_pos/wu_rot_mat_idxs once; harmless, since the
+                # first decode step re-seeds the persistent buffers from host.
+                ttnn.plus_one(wu_current_pos, skip_negative_entries=True)
+                ttnn.plus_one(wu_rot_mat_idxs)
+                ttnn.synchronize_device(self.mesh_device)
             logger.info("Compiled on-device sampling")
 
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
@@ -1556,15 +1635,27 @@ class TracedLLMExecutor:
             )
 
             if sampling_on_device and self.model.sampling is not None:
-                # NOTE: increment_positions (ttnn.plus_one) is intentionally NOT called inside the
-                # captured body. plus_one issues per-device host-assisted writes that are illegal
-                # during trace capture ("Writes are not supported during trace capture"), and it is
-                # redundant here: decode_forward re-supplies current_pos/rot_mat_idxs from the host
-                # via copy_host_to_device at the start of every step, so any in-trace increment is
-                # overwritten before the next replay. Host owns position bookkeeping.
-                # tt_out_tok=None: sampling allocates its own [1,1,32] argmax output captured in the
-                # trace (reusing the [1,1,1,32] input-token buffer is a shape mismatch -> realloc).
-                tt_toks, tt_log_probs = self._eager._sampling_decode_forward(logits, sampling_params, tt_out_tok=None)
+                if loop_active:
+                    # On-device loop: feed the sampled token back into the persistent token buffer
+                    # (device_inputs[0]) in place. On the top-k path ttnn.sampling emits uint32
+                    # [1,1,1,32] on Wormhole/Blackhole — an exact match for the token buffer, so
+                    # output_tensor= writes in place with no realloc (safe during capture). Then
+                    # advance position + rope index on device (in-place plus_one), so the NEXT
+                    # execute_trace sees the new token at the new position with zero host staging.
+                    # These writes are AFTER every read of the buffers in this body, so there is no
+                    # intra-trace hazard. plus_one is a pure device op (in-place, traceable); the
+                    # earlier "host-assisted writes illegal during capture" note was mistaken.
+                    tt_toks, tt_log_probs = self._eager._sampling_decode_forward(
+                        logits, sampling_params, tt_out_tok=tt_tokens
+                    )
+                    ttnn.plus_one(tt_current_pos, skip_negative_entries=True)
+                    ttnn.plus_one(tt_rot_mat_idxs)
+                else:
+                    # tt_out_tok=None: sampling allocates its own output; decode_forward re-supplies
+                    # current_pos/rot_mat_idxs from host every step, so no in-trace increment.
+                    tt_toks, tt_log_probs = self._eager._sampling_decode_forward(
+                        logits, sampling_params, tt_out_tok=None
+                    )
                 output = (tt_toks, tt_log_probs)
             else:
                 logits = self.model.gather_and_untilize_logits(logits)
@@ -1929,8 +2020,6 @@ def run_perf_benchmark(
             read_from_device=True,
             sampling_params=sampling_params,
         )
-        if hasattr(executor, "mesh_device"):
-            ttnn.synchronize_device(executor.mesh_device)
         elapsed = time.perf_counter() - t0
 
         if i == 0:

--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -2010,32 +2010,104 @@ def run_perf_benchmark(
     compile_time = None
     decode_times = []
 
-    for i in range(num_decode_tokens):
-        t0 = time.perf_counter()
-        logits, _ = executor.decode_forward(
-            current_tokens,
-            current_pos,
-            page_table=page_table,
-            kv_cache=kv_cache,
-            read_from_device=True,
-            sampling_params=sampling_params,
-        )
-        elapsed = time.perf_counter() - t0
+    # Pipelined non-blocking readback (on-device decode loop, top-k path only).
+    # The captured trace feeds the sampled token back on device (ttnn.sampling
+    # output_tensor=) and advances position/rope on device (ttnn.plus_one), so step
+    # N+1's replay does NOT depend on step N's token reaching the host. We therefore
+    # issue each step's token readback non-blocking, launch the next step's trace,
+    # and resolve step N's token one iteration later — the host stays exactly one
+    # step behind the device, mirroring TTTv1's on-device sampling loop. This
+    # overlaps the readback + host bookkeeping with device compute, removing the
+    # per-step host round-trip that otherwise serializes with the tiny b1 device step
+    # (the residual after Stage-1/1b). The token stream is unchanged: the device
+    # produces the same tokens; we only read them back deferred, then drain the last
+    # one so generated_token_ids is byte-identical to the blocking loop. Escape
+    # hatch for A/B: TTT_DECODE_PIPELINE_READBACK=0 keeps the blocking readback.
+    # Every other path (host resupply, force-argmax, host sampling) is unaffected —
+    # only _decode_loop_active (opt-in TTT_ONDEVICE_DECODE_LOOP=1 + top-k) qualifies.
+    _engine = getattr(executor, "_engine", executor)
+    _pipeline_readback = (
+        isinstance(_engine, TracedLLMExecutor)
+        and _engine._decode_loop_active(sampling_params)
+        and os.environ.get("TTT_DECODE_PIPELINE_READBACK", "1") == "1"
+    )
 
-        if i == 0:
-            compile_time = elapsed
-        else:
-            decode_times.append(elapsed)
+    if _pipeline_readback:
+        cluster_shape = _engine.model_args.cluster_shape if getattr(_engine, "model_args", None) else [1, 1]
+        mesh_device = executor.mesh_device
 
-        if isinstance(logits, torch.Tensor) and logits.dim() >= 2:
-            next_tok = torch.argmax(logits[:, -1, :], dim=-1)
-        else:
-            next_tok = logits
-        next_tok = next_tok.view(-1)[:batch_size].detach().cpu()
-        for user_id, tok in enumerate(next_tok.tolist()):
-            generated_token_ids[user_id].append(int(tok))
-        current_tokens[:batch_size] = next_tok
-        current_pos[:batch_size] += 1
+        def _consume(host_tok):
+            toks = _process_output_decode_tokens(host_tok, batch_size, cluster_shape)
+            for user_id, tok in enumerate(toks.view(-1)[:batch_size].tolist()):
+                generated_token_ids[user_id].append(int(tok))
+
+        prev_event = None
+        prev_host_tok = None
+        for i in range(num_decode_tokens):
+            t0 = time.perf_counter()
+            # read_from_device=False: get the persistent device token buffer without
+            # a blocking readback. current_tokens is intentionally not refreshed — the
+            # device owns the token via in-trace feedback after the first (reseed)
+            # step; the steady-state path ignores it (and a page-table refresh copies
+            # only the page table, never the token buffer).
+            tt_output = executor.decode_forward(
+                current_tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                read_from_device=False,
+                sampling_params=sampling_params,
+            )
+            tt_toks = tt_output[0]
+            host_tok = tt_toks.cpu(blocking=False)  # issue read; do not wait
+            read_event = ttnn.record_event(mesh_device, 0)  # retires when this read lands
+            if prev_event is not None:
+                # Wait for the PREVIOUS step's read, which retired in the background
+                # while this step's trace ran — this is the loop's device-paced beat.
+                ttnn.event_synchronize(prev_event)
+            elapsed = time.perf_counter() - t0
+
+            if prev_host_tok is not None:
+                _consume(prev_host_tok)
+            prev_event, prev_host_tok = read_event, host_tok
+            current_pos[:batch_size] += 1
+
+            if i == 0:
+                compile_time = elapsed
+            else:
+                decode_times.append(elapsed)
+
+        # Drain the final in-flight token so the generated stream matches exactly.
+        if prev_host_tok is not None:
+            ttnn.event_synchronize(prev_event)
+            _consume(prev_host_tok)
+    else:
+        for i in range(num_decode_tokens):
+            t0 = time.perf_counter()
+            logits, _ = executor.decode_forward(
+                current_tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                read_from_device=True,
+                sampling_params=sampling_params,
+            )
+            elapsed = time.perf_counter() - t0
+
+            if i == 0:
+                compile_time = elapsed
+            else:
+                decode_times.append(elapsed)
+
+            if isinstance(logits, torch.Tensor) and logits.dim() >= 2:
+                next_tok = torch.argmax(logits[:, -1, :], dim=-1)
+            else:
+                next_tok = logits
+            next_tok = next_tok.view(-1)[:batch_size].detach().cpu()
+            for user_id, tok in enumerate(next_tok.tolist()):
+                generated_token_ids[user_id].append(int(tok))
+            current_tokens[:batch_size] = next_tok
+            current_pos[:batch_size] += 1
 
     return PerfBenchmarkResult(
         prefill_time_s=prefill_time,

--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -19,7 +19,6 @@ Design principle: Thick engine, thin model executor.
 from __future__ import annotations
 
 import contextlib
-import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -929,17 +928,34 @@ class TracedLLMExecutor:
         decode_output_spec: Captured output spec from compile_decode().
     """
 
-    def __init__(self, model, mesh_device: ttnn.MeshDevice, iter_named_modules=None) -> None:
+    def __init__(
+        self,
+        model,
+        mesh_device: ttnn.MeshDevice,
+        iter_named_modules=None,
+        ondevice_decode_loop: bool = False,
+    ) -> None:
         """Initialize traced executor engine.
 
         Args:
             model: Transformer model with prefill_forward(), decode_forward(), model_args, etc.
             mesh_device: TT mesh device for execution.
+            iter_named_modules: Optional callable yielding the model's named modules for config
+                validation (model-specific; defaults to the generic walk in the eager engine).
+            ondevice_decode_loop: Opt-in, default OFF. When True, the captured decode trace advances
+                position/rope on device (in-place ``ttnn.plus_one``) and feeds the sampled token back
+                into the persistent token buffer (``ttnn.sampling(output_tensor=...)``), so steady-state
+                steps replay with NO per-step host input staging — mirroring TTTv1's on-device sampling
+                trace (generator ``refresh_trace_inputs=False`` + ``_increment_decode_positions_device``).
+                Valid ONLY for free-running greedy/top-k generation, NOT teacher forcing (which injects
+                host tokens every step), so accuracy/teacher-forcing runs must leave this OFF. Also inert
+                on the force-argmax path (``_decode_loop_active`` gates it to the top-k op path).
         """
         self.model = model
         self.mesh_device = mesh_device
         self._eager = EagerLLMExecutor(model, mesh_device, iter_named_modules=iter_named_modules)
         self._cleaned_up = False
+        self.ondevice_decode_loop = ondevice_decode_loop
 
         # todo)) we cannot save many traces in memory! Gotta limit the number of traces! --> lru_cache?
         #        but the warmup_model_prefill() traces must be kept around forever!
@@ -953,14 +969,6 @@ class TracedLLMExecutor:
         self.trace_inputs_decode: dict[bool, tuple | None] = defaultdict(lambda: None)
         self.trace_output_decode: dict[bool, tuple | None] = defaultdict(lambda: None)
 
-        # On-device decode loop (opt-in, default OFF). When enabled, the captured decode trace
-        # advances position/rope on device (in-place ``ttnn.plus_one``) and feeds the sampled token
-        # back into the persistent token buffer (``ttnn.sampling(output_tensor=...)``), so steady-state
-        # steps replay with NO per-step host input staging. Mirrors TTTv1's on-device sampling trace
-        # (tt_transformers generator ``refresh_trace_inputs=False`` + model ``_increment_decode_positions_device``).
-        # Only valid for free-running greedy/top-k generation — NOT teacher forcing (which injects
-        # host tokens every step), so accuracy/teacher-forcing runs must leave this OFF.
-        self._ondevice_decode_loop = os.environ.get("TTT_ONDEVICE_DECODE_LOOP", "0") == "1"
         # Per sampling-mode flag: the next decode step must re-seed the persistent buffers from host
         # (correct first token + start position). Set after every prefill and at init; cleared once
         # the device has been seeded, after which steady-state steps carry state on device.
@@ -1034,7 +1042,7 @@ class TracedLLMExecutor:
         realloc. The force-argmax path (``ttnn.argmax`` → uint32 ``[1,1,32]``, rank-3) does NOT
         match the rank-4 token buffer, so the loop stays off there and falls back to host resupply.
         """
-        if not self._ondevice_decode_loop or sampling_params is None or self.model.sampling is None:
+        if not self.ondevice_decode_loop or sampling_params is None or self.model.sampling is None:
             return False
         # kpt is None only for the force-argmax path; non-None => top-k op path.
         return self._eager._get_decode_sampling_kpt(sampling_params) is not None
@@ -1920,6 +1928,7 @@ def run_perf_benchmark(
     prompt_lens: torch.Tensor | None = None,
     start_pos: list[int] | None = None,
     sampling_params=None,
+    pipeline_readback: bool = True,
 ) -> PerfBenchmarkResult:
     """Run timed prefill + decode loop for performance measurement.
 
@@ -1936,6 +1945,10 @@ def run_perf_benchmark(
         prompt_lens: Actual prompt length per user, shape [batch_size].
         start_pos: Starting position for prefix caching.
         sampling_params: Explicit sampling params (None = host argmax).
+        pipeline_readback: Overlap each step's token readback with the next step's
+            trace (host one step behind the device). Only engages when the executor's
+            on-device decode loop is active on the top-k path; ignored otherwise. Set
+            False to A/B against the blocking readback.
 
     Returns:
         PerfBenchmarkResult with raw timings + derived metrics.
@@ -2004,20 +2017,20 @@ def run_perf_benchmark(
     # N+1's replay does NOT depend on step N's token reaching the host. We therefore
     # issue each step's token readback non-blocking, launch the next step's trace,
     # and resolve step N's token one iteration later — the host stays exactly one
-    # step behind the device, mirroring TTTv1's on-device sampling loop. This
-    # overlaps the readback + host bookkeeping with device compute, removing the
-    # per-step host round-trip that otherwise serializes with the tiny b1 device step
-    # (the residual after Stage-1/1b). The token stream is unchanged: the device
-    # produces the same tokens; we only read them back deferred, then drain the last
-    # one so generated_token_ids is byte-identical to the blocking loop. Escape
-    # hatch for A/B: TTT_DECODE_PIPELINE_READBACK=0 keeps the blocking readback.
+    # step behind the device. This mirrors the deferred-readback idiom in
+    # models/demos/llama3_70b_galaxy/demo/demo_decode.py (``.cpu(blocking=False)`` +
+    # ``record_event`` ... ``event_synchronize``) and the vLLM async-read path; note
+    # the single-box text demo instead reads back blocking. Overlapping the readback +
+    # host bookkeeping with device compute removes the per-step host round-trip that
+    # otherwise serializes with the very short batch-1 device step. The token stream is
+    # unchanged: the device produces the same tokens; we only read them back deferred,
+    # then drain the last one so generated_token_ids is byte-identical to the blocking
+    # loop. Pass pipeline_readback=False to A/B back to the blocking readback.
     # Every other path (host resupply, force-argmax, host sampling) is unaffected —
-    # only _decode_loop_active (opt-in TTT_ONDEVICE_DECODE_LOOP=1 + top-k) qualifies.
+    # only _decode_loop_active (executor.ondevice_decode_loop + top-k) qualifies.
     _engine = getattr(executor, "_engine", executor)
     _pipeline_readback = (
-        isinstance(_engine, TracedLLMExecutor)
-        and _engine._decode_loop_active(sampling_params)
-        and os.environ.get("TTT_DECODE_PIPELINE_READBACK", "1") == "1"
+        isinstance(_engine, TracedLLMExecutor) and _engine._decode_loop_active(sampling_params) and pipeline_readback
     )
 
     if _pipeline_readback:

--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -973,7 +973,11 @@ class TracedLLMExecutor:
         # (correct first token + start position). Set after every prefill and at init; cleared once
         # the device has been seeded, after which steady-state steps carry state on device.
         self._decode_needs_reseed: dict[bool, bool] = defaultdict(lambda: True)
-        self._prev_decode_page_table: torch.Tensor | None = None
+        # Keyed per sampling-mode (True=on-device sampling, False=host), matching the per-key
+        # decode trace + device page_table buffer in trace_inputs_decode. A single shared tensor
+        # would let one mode's page-table update mask a needed copy on the other mode's trace
+        # (whose device buffer is separate), leaving it stale.
+        self._prev_decode_page_table: dict[bool, torch.Tensor | None] = defaultdict(lambda: None)
 
         self.mode = None
         self.already_warmed_up_prefill = False
@@ -1260,8 +1264,10 @@ class TracedLLMExecutor:
         self._eager._assert_kv_cache_identity(kv_cache)
         # A prefill breaks decode continuity: the next decode step must re-seed the persistent
         # on-device buffers from host (correct first token + start position) before the device
-        # can carry state on its own. Mark all sampling modes stale.
+        # can carry state on its own. Mark all sampling modes stale, and drop the cached page
+        # tables so the first post-prefill step always re-copies (device buffers are reused).
         self._decode_needs_reseed = defaultdict(lambda: True)
+        self._prev_decode_page_table = defaultdict(lambda: None)
 
         batch_size, batch_seq_len = tokens.shape
         vocab_size = self.model.vocab_size
@@ -1497,11 +1503,12 @@ class TracedLLMExecutor:
             # (in-place plus_one) and wrote the sampled token back into the persistent token buffer
             # on the previous replay, so tokens/positions need NO host staging. Refresh only the
             # page table, and only when it actually changed (block boundaries crossed).
-            if self._prev_decode_page_table is None or not torch.equal(self._prev_decode_page_table, page_table):
+            prev_page_table = self._prev_decode_page_table[sampling_on_device]
+            if prev_page_table is None or not torch.equal(prev_page_table, page_table):
                 host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
                 device_inputs = self.trace_inputs_decode[sampling_on_device]
                 ttnn.copy_host_to_device_tensor(host_inputs[3], device_inputs[3])  # page_table only
-                self._prev_decode_page_table = page_table.clone()
+                self._prev_decode_page_table[sampling_on_device] = page_table.clone()
         else:
             # Reseed (first step after prefill, or loop disabled): full host refresh of all inputs.
             host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
@@ -1509,7 +1516,7 @@ class TracedLLMExecutor:
                 host_tensors=host_inputs,
                 device_tensors=self.trace_inputs_decode[sampling_on_device],
             )
-            self._prev_decode_page_table = page_table.clone()
+            self._prev_decode_page_table[sampling_on_device] = page_table.clone()
             if loop_active:
                 self._decode_needs_reseed[sampling_on_device] = False
 

--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -961,14 +961,11 @@ class TracedLLMExecutor:
         # Only valid for free-running greedy/top-k generation — NOT teacher forcing (which injects
         # host tokens every step), so accuracy/teacher-forcing runs must leave this OFF.
         self._ondevice_decode_loop = os.environ.get("TTT_ONDEVICE_DECODE_LOOP", "0") == "1"
-        # Diagnostic: read back device current_pos on the first few steps to prove plus_one persistence.
-        self._ondevice_decode_loop_debug = os.environ.get("TTT_ONDEVICE_DECODE_LOOP_DEBUG", "0") == "1"
         # Per sampling-mode flag: the next decode step must re-seed the persistent buffers from host
         # (correct first token + start position). Set after every prefill and at init; cleared once
         # the device has been seeded, after which steady-state steps carry state on device.
         self._decode_needs_reseed: dict[bool, bool] = defaultdict(lambda: True)
         self._prev_decode_page_table: torch.Tensor | None = None
-        self._decode_dbg_count = 0
 
         self.mode = None
         self.already_warmed_up_prefill = False
@@ -1515,15 +1512,6 @@ class TracedLLMExecutor:
             blocking=False,
         )
         tt_output = self.trace_output_decode[sampling_on_device]
-
-        if loop_active and self._ondevice_decode_loop_debug and self._decode_dbg_count < 6:
-            # Prove plus_one persistence: read back the device position after this replay.
-            # Expect device current_pos to track host+1 (device already incremented for next step);
-            # if it stays pinned, plus_one is not persisting across replays.
-            self._decode_dbg_count += 1
-            dbg_pos = self.trace_inputs_decode[sampling_on_device][1]
-            pos_host = ttnn.to_torch(ttnn.get_device_tensors(dbg_pos)[0]).flatten()[:1].tolist()
-            logger.info(f"[ondevice-loop-debug] host start_pos[0]={int(start_pos[0])} device current_pos[0]={pos_host}")
 
         if read_from_device:
             if sampling_on_device:

--- a/models/common/models/llama32_1b/model.py
+++ b/models/common/models/llama32_1b/model.py
@@ -1131,10 +1131,21 @@ class EagerLlama32_1BExecutor:
 class TracedLlama32_1BExecutor:
     """Thin wrapper: passes Llama32_1B model to TracedLLMExecutor."""
 
-    def __init__(self, model: Llama32_1BTransformer1D, mesh_device: ttnn.MeshDevice, model_args=None):
+    def __init__(
+        self,
+        model: Llama32_1BTransformer1D,
+        mesh_device: ttnn.MeshDevice,
+        model_args=None,
+        ondevice_decode_loop: bool = False,
+    ):
         if model_args is not None:
             model.model_args = model_args
-        self._engine = TracedLLMExecutor(model, mesh_device, iter_named_modules=_iter_llama_executor_named_modules)
+        self._engine = TracedLLMExecutor(
+            model,
+            mesh_device,
+            iter_named_modules=_iter_llama_executor_named_modules,
+            ondevice_decode_loop=ondevice_decode_loop,
+        )
 
     @property
     def model(self):

--- a/models/common/tests/demos/llama32_1b/demo.py
+++ b/models/common/tests/demos/llama32_1b/demo.py
@@ -466,7 +466,26 @@ def _run_perf_benchmark(
     hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
     tokenizer = AutoTokenizer.from_pretrained(hf_model)
 
-    traced_executor = TracedLlama32_1BExecutor(model, mesh_device)
+    # On-device sampling toggle for N150/N300 evidence-gathering (see sampling handoff docs):
+    #   host            -> sampling_params=None (host-argmax, the default shipped path)
+    #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+    #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
+    #                      the [*,32] tuples; PERF.md-parity recipe, faster than force-argmax)
+    sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
+    _on_device_params = {
+        "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
+        "on_device_topk": SamplingParams(temperature=0.0, top_k=32, top_p=0.08),
+    }
+    sampling_params = (
+        _on_device_params[sampling_mode]
+        if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
+        else None
+    )
+    logger.info(f"[{case_name}] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
+
+    # Free-running perf run: enable the executor's on-device decode loop on the on-device sampling
+    # path (inert on host/force-argmax; gated to the top-k path by _decode_loop_active).
+    traced_executor = TracedLlama32_1BExecutor(model, mesh_device, ondevice_decode_loop=sampling_params is not None)
     try:
         ma = model.model_args
         assert ma is not None
@@ -485,23 +504,6 @@ def _run_perf_benchmark(
         # Natural-length tokenization (matches TTTv1): the executor buckets each user's real
         # length to get_padded_prefill_len. These sample prompts are ~90-125 tokens -> 128 bucket.
         input_tokens, prompt_lens = tokenize_prompts(prompts, tokenizer, max_prefill_len=max_prefill_len)
-
-        # On-device sampling toggle for N150/N300 evidence-gathering (see sampling handoff docs):
-        #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
-        #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
-        #                      the [*,32] tuples; PERF.md-parity recipe, faster than force-argmax)
-        sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
-        _on_device_params = {
-            "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
-            "on_device_topk": SamplingParams(temperature=0.0, top_k=32, top_p=0.08),
-        }
-        sampling_params = (
-            _on_device_params[sampling_mode]
-            if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
-            else None
-        )
-        logger.info(f"[{case_name}] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
 
         result = run_perf_benchmark(
             traced_executor,


### PR DESCRIPTION
# tttv2: close T3K batch-1 decode gap (on-device loop + sync removal + pipelined readback)

Closes #49282

## Scope

**Llama-3.2-1B on T3K, batch-1, `on_device_topk`.** With this PR the 1B gap vs same-box TTTv1
(128.1 vs 153.5 t/s/u, 83%) is fully closed to parity (153.9 vs 153.5, 100%). The remaining 3B and
Mistral-7B residuals seen at the start of this workstream have been root-caused as **device-side**
(host round-trip is fully removed on both; the delta did not close) and are filed as separate,
model-specific follow-up issues — they need per-token device trace-replay profiling, not further
host-side work in the executor.

**The fix is model-agnostic.** It lives entirely in the shared executor
(`models/common/models/executor.py`), so **every TTTv2 model on the `on_device_topk` traced-decode
path benefits from the same three measures** — this is not a 1B-only change. Llama-1B is simply where
the gap fully closes to parity; 3B and Mistral-7B get partial gains from the identical changes (see
the cross-model table under Results), with a device-side residual tracked as the follow-ups below.

## Problem

On a healthy T3K, TTTv2 batch-1 decode ran **~14-18% slower than TTTv1** for small/mid models in
`on_device_topk` mode. The gap closed to parity/better at batch-32 and was absent on N150/N300.

Root cause is **fixed per-step host overhead** in the TTTv2 traced-decode path — not device work,
CCL, or `lm_head` (an `lm_head` core-grid/split hypothesis was investigated and refuted; the shipped
32-core/2-split is TTTv2's tuned optimum). Both stacks issue an identical per-step device op inventory.
The difference was:

- **TTTv2** re-supplied `current_pos`, `rot_mat_idxs`, tokens, and page_table from the host every step
  (`prepare_decode_inputs_host` + `copy_host_to_device`), did a blocking readback **plus a redundant
  `synchronize_device`** each step, and left the device idle between the blocking `.cpu()` and the
  next `execute_trace` enqueue.
- **TTTv1** advances position/rope in-trace (`ttnn.plus_one`), feeds the sampled token back on device,
  and its per-iteration harness leaves no comparable host round-trip in the timed loop.

Instrumented, the removable host overhead accounts for essentially the whole 1B gap. Because it is
fixed per step, it caps batch-1 throughput regardless of device speed and amortizes at batch-32 —
matching the observed batch-size behavior.

## Changes

All changes are executor-only (`models/common/models/executor.py`), correctness-neutral, and produce
byte-identical generated tokens.

**Stage 1 — On-device decode loop** (opt-in via the traced executor's `ondevice_decode_loop=True`
constructor arg, **default OFF**; the 1B demo enables it automatically whenever the on-device
sampling path is selected, and `_decode_loop_active` restricts it to the top-k op path):
- advance position/rope on device with in-place `ttnn.plus_one`,
- feed the sampled token back into the persistent token buffer via `ttnn.sampling(output_tensor=...)`,
- skip all per-step host input staging on steady-state steps (page-table refreshed only if it changes).

This mirrors TTTv1's on-device sampling trace. Force-argmax models transparently fall back to the
host-resupply path, and the host-resupply path is unchanged when the flag is off, so accuracy /
teacher-forcing runs are unaffected. Requires pre-capture warmup of both `plus_one` variants and the
`sampling(output_tensor=...)` variant (otherwise trace capture would try to load binaries mid-capture).

**Stage 1b — Remove 3 redundant per-step `synchronize_device` calls** that followed a blocking
`.cpu()`. A blocking read already drains the command queue and retires the read; the trailing sync
re-ran `finish` on an idle queue plus a profiler-sync-check plus a cross-host `barrier()` — strictly
extra cost, never needed for correctness (unconditional, no flag).

**Stage 2 — Pipelined non-blocking readback** (gated on the on-device loop + top-k; `run_perf_benchmark`'s
`pipeline_readback` parameter, **default ON** — pass `pipeline_readback=False` to A/B against blocking). In `run_perf_benchmark`, issue each step's token readback
non-blocking + `record_event`, launch the next step's trace, and resolve step N's token one iteration
later — the host stays exactly one step behind the device. Same canonical tt-metal idiom used in
`llama3_70b_galaxy/demo/demo_decode.py` and TTTv1's vLLM async-read path. Correctness rests on the
single-CQ FIFO: read i completes before trace i+1 overwrites the aliased token buffer, and the device
never idles because trace i+1 is enqueued while trace i is still running. `decode_forward` and all
non-loop callers are byte-for-byte untouched.

## Results

T3K, batch-1, `on_device_topk`, loop ON, ≥3 reps (modal), **token-identical output**, no hang, no
OFF-path regression:

| model | before | Stage-1 | Stage-1b | Stage-2 | vs same-box TTTv1 |
|---|---|---|---|---|---|
| Llama-3.2-1B | 128.1 | 137.6 | 144.6 | **153.9 t/s/u** | 83% → **100% (parity)** (TTTv1 153.5) |

Per-step ms: 7.80 → 7.27 → 6.91 → **6.50** = TTTv1's 6.51. The removed per-step cost is a
near-constant ~1.3 ms across the three stages, so relative win is largest on the smallest/fastest
model (matching "gap closes at batch-32").

**Cross-model** — net effect of the same executor changes across other small/mid models (T3K, b1,
`on_device_topk`, loop ON), baseline → now vs same-box TTTv1:

| model | baseline | now | same-box TTTv1 | ratio |
|---|---|---|---|---|
| Llama-3.2-1B | 128.1 (83%) | **153.9 t/s/u** | 153.5 | **100% (parity)** |
| Llama-3.2-3B | 68.8 (86%) | **77.2 t/s/u** | 80.4 | **96%** |
| Mistral-7B | 44.5 (85%) | **47.0 t/s/u** | 52.6 | 89% (Stage-1b; device-side residual) |

Every model gains from the shared measures; the per-step host round-trip removed is a near-constant
−0.39…−0.41 ms/step across 1B/3B. 1B reaches parity; the 3B/Mistral remainder is device-side and
tracked separately.

**3B and Mistral-7B** were included in earlier stages of this workstream and got partial wins from
Stages 1/1b (see `AUTOFIX.md` for the full A/B tables), but the leftover delta after Stage-2 is
device-side (host round-trip is fully removed and the gap did not close). Those are tracked as
separate model-specific issues; see the follow-up docs referenced below.

## Gate

**Not a gate change.** The port gate stays anchored to the documented TTTv1 baseline (127.7 t/s/u);
TTTv2 now clears it with a wide margin.

## Validation

- Generated tokens are byte-for-byte identical between all three stages and the flag-off path on
  Llama-1B (the hard oracle; sha256[:16] `0cdd7ac85548bdb3`, 200 tokens).
- No hang on any of the runs.
- Loop-OFF path re-measured on Llama-1B: reproduces the documented 128.1 exactly (no regression from
  Stage-1b's unconditional sync removal, which also touches the OFF path, or from Stage-2 which is
  gated OFF by `_decode_loop_active`).

Repro:
```
MESH_DEVICE=T3K SAMPLING_MODE=on_device_topk \
  pytest models/common/tests/demos/llama32_1b/demo.py -k 'performance and batch-1'
```
The demo enables the on-device loop automatically on the on-device sampling path. To A/B Stage-2
back to blocking, pass `pipeline_readback=False` to `run_perf_benchmark`.

## Fairness note

The 153.9 (TTTv2 pipelined) vs 153.5 (TTTv1 blocking) comparison is apples-to-apples at the
**device/model layer** — same ttnn ops, same program configs, same tokens. At the **harness layer**
TTTv2's `run_perf_benchmark` is more pipelined than TTTv1's demo (which uses blocking `.cpu()`). A
same-shape harness A/B would be TTTv2 blocking (144.6) vs TTTv1 blocking (153.5), where TTTv2 is
~5% behind purely due to per-step Python bookkeeping in `run_perf_benchmark` that TTTv1's demo loop
does not have. The pipeline is a legitimate optimization (same idiom used in
`llama3_70b_galaxy/demo/demo_decode.py:524-535` and TTTv1's own vLLM async-read path); the model
graph is unchanged and any consumer of `decode_forward` gets the same tokens.

## Follow-ups (separate issues)

- **Llama-3.2-3B T3K b1 device-side decode residual** (#49345) — TTTv2 77.2 vs TTTv1 80.4 (96%). Host
  round-trip fully removed by this workstream; the leftover ~0.4 ms/step is device-side (per-token
  trace-replay).
- **Mistral-7B T3K b1 device-side decode residual** (#49346) — TTTv2 47.0 vs TTTv1 52.6 (89%). Same
  class as 3B — host-side work exhausted, residual is device-side.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apascual/tttv2-t3k-b1-decode-autofix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/tttv2-t3k-b1-decode-autofix)
