### PR TITLE
feat: add asserts for unsupported features of compute API on Quasar

### DIFF
--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -6,6 +6,7 @@
 
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
+#include "llk_assert.h"
 #ifdef TRISC_MATH
 #include "llk_math_common_api.h"
 #include "llk_math_binary_api.h"
@@ -59,6 +60,13 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __bu
 #else
     UNPACK((llk_unpack_hw_configure(icb)));
 #if defined(TRISC_UNPACK) || defined(TRISC_MATH)
+    // 32bit formats require the A2D unpack-to-dest path (SrcB is only 19 bits wide), which is not
+    // implemented for Quasar yet; only the B2D path is supported here.
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
+    LLK_ASSERT(!enable_unpack_to_dest, "32-bit unary broadcast (unpack-to-dest) not supported on Quasar");
     UNPACK((llk_unpack_A_init<
             bcast_type,
             false /*acc_to_dest*/,
@@ -98,6 +106,13 @@ ALWI void unary_bcast(uint32_t icb, uint32_t in_tile_index, uint32_t dst_tile_in
 #else
 #if defined(TRISC_UNPACK) || defined(TRISC_MATH)
     // Broadcast mode and B2D vs A2D are fixed in unary_bcast_init; pass logical operand ids through to LLK.
+    // 32bit formats would require the A2D unpack-to-dest path (SrcB is only 19 bits wide), which is not
+    // implemented for Quasar yet; only the B2D path is supported here.
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
+    LLK_ASSERT(!enable_unpack_to_dest, "32-bit unary broadcast (unpack-to-dest) not supported on Quasar");
     UNPACK((llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, false>(icb, in_tile_index)));
     MATH((llk_math_eltwise_unary_datacopy<DataCopyType::B2D, false, bcast_type, false>(dst_tile_index, icb)));
 #endif
@@ -210,6 +225,9 @@ ALWI void mul_tiles_bcast_cols(uint32_t icb0, uint32_t icb1, uint32_t itile0, ui
  */
 ALWI void mul_tiles_bcast_rows(
     uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t bcast_row_idx = 0) {
+#ifdef ARCH_QUASAR
+    LLK_ASSERT(bcast_row_idx == 0, "non-default bcast_row_idx not supported on Quasar");
+#endif
     MATH((llk_math_eltwise_binary<
           EltwiseBinaryType::ELWMUL,
           BroadcastType::ROW,
@@ -224,6 +242,9 @@ ALWI void mul_tiles_bcast_rows(
  */
 ALWI void add_tiles_bcast_rows(
     uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t bcast_row_idx = 0) {
+#ifdef ARCH_QUASAR
+    LLK_ASSERT(bcast_row_idx == 0, "non-default bcast_row_idx not supported on Quasar");
+#endif
     MATH((llk_math_eltwise_binary<
           EltwiseBinaryType::ELWADD,
           BroadcastType::ROW,
@@ -238,6 +259,9 @@ ALWI void add_tiles_bcast_rows(
  */
 ALWI void sub_tiles_bcast_rows(
     uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t bcast_row_idx = 0) {
+#ifdef ARCH_QUASAR
+    LLK_ASSERT(bcast_row_idx == 0, "non-default bcast_row_idx not supported on Quasar");
+#endif
     MATH((llk_math_eltwise_binary<
           EltwiseBinaryType::ELWSUB,
           BroadcastType::ROW,
@@ -320,6 +344,12 @@ Internal helper function for all broadcast ops
 template <EltwiseBinaryType tBcastOp, BroadcastType tBcastDim>
 ALWI void any_tiles_bcast(
     uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t bcast_row_idx = 0) {
+#ifdef ARCH_QUASAR
+    // bcast_row_idx is only consumed by the ROW broadcast path; it is ignored by the Quasar LLK.
+    if constexpr (tBcastDim == BroadcastType::ROW) {
+        LLK_ASSERT(bcast_row_idx == 0, "non-default bcast_row_idx not supported on Quasar");
+    }
+#endif
     MATH((llk_math_eltwise_binary<tBcastOp, tBcastDim, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
         icb0, icb1, idst, true /* clear_fp32_dst_acc */)));
     UNPACK((llk_unpack_AB<tBcastDim>(icb0, icb1, itile0, itile1, bcast_row_idx)));

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -105,7 +105,7 @@ ALWI void matmul_init(
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
 #else
-    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
+    LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));
     MATH((llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id)));
 #endif
@@ -185,7 +185,7 @@ ALWI void matmul_block_init(
     MATH((throttled_mop_status = 0));
 #endif
 #else
-    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
+    LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));
     MATH((llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id, ct_dim, rt_dim)));
 #endif
@@ -240,6 +240,8 @@ ALWI void matmul_block(
     MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst, ct_dim, rt_dim)));
 #endif
 #else
+    LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");
+    LLK_ASSERT(idst == 0, "non-default idst not supported on Quasar");
     UNPACK((llk_unpack_AB_matmul(in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, ct_dim, rt_dim, kt_dim)));
     MATH((llk_math_matmul_block(ct_dim, rt_dim)));
 #endif
@@ -292,7 +294,7 @@ mm_init(
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
     PACK((llk_pack_init(out_cb_id)));
 #else
-    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
+    LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");
     UNPACK((llk_unpack_hw_configure(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));
 
@@ -415,7 +417,7 @@ mm_block_init(
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
     PACK((llk_pack_init<PackMode::Default, false /* zero_output */>(out_cb_id)));
 #else
-    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
+    LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");
     UNPACK((llk_unpack_hw_configure(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));
 

--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -43,7 +43,9 @@ ALWI void pack_untilize_dest_init_impl(uint32_t ocb, uint32_t call_line = __buil
         llk_pack_untilize_init<block_ct_dim, full_ct_dim, false /*diagonal*/, narrow_row, row_num_datums, dense>(ocb)));
     PACK((llk_init_packer_dest_offset_registers<PackMode::Untilize, false /*diagonal*/>()));
 #else
-    LLK_ASSERT(narrow_row == false, "narrow_row not supported on Quasar");
+    static_assert(narrow_row == false, "non-default narrow_row not supported on Quasar");
+    static_assert(row_num_datums == TILE_C_DIM, "non-default row_num_datums not supported on Quasar");
+    static_assert(dense == false, "non-default dense not supported on Quasar");
     PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
 #endif
 }
@@ -82,7 +84,9 @@ pack_untilize_dest_init_impl(
 #pragma GCC diagnostic pop
     PACK((llk_init_packer_dest_offset_registers<PackMode::Untilize, false /*diagonal*/>()));
 #else
-    LLK_ASSERT(narrow_row == false, "narrow_row not supported on Quasar");
+    static_assert(narrow_row == false, "non-default narrow_row not supported on Quasar");
+    static_assert(row_num_datums == TILE_C_DIM, "non-default row_num_datums not supported on Quasar");
+    static_assert(dense == false, "non-default dense not supported on Quasar");
     PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
 #endif
 }
@@ -417,6 +421,11 @@ ALWI void pack_untilize_dest(
     PACK((llk_pack_untilize<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset, dense>(
         block_rt_dim, ocb, block_c_index, tile_dst_rt_offset)));
 #else
+    static_assert(narrow_row == false, "non-default narrow_row not supported on Quasar");
+    static_assert(row_num_datums == TILE_C_DIM, "non-default row_num_datums not supported on Quasar");
+    static_assert(tile_dst_ct_offset == 0, "non-default tile_dst_ct_offset not supported on Quasar");
+    static_assert(dense == false, "non-default dense not supported on Quasar");
+    static_assert(diagonal == false, "non-default diagonal not supported on Quasar");
     PACK((llk_pack_untilize<block_ct_dim, full_ct_dim>(block_rt_dim, ocb, block_c_index, tile_dst_rt_offset)));
 #endif
 }
@@ -473,6 +482,11 @@ pack_untilize_dest(
         block_rt_dim, ocb, face_r_dim, num_faces, block_c_index, tile_dst_rt_offset)));
 #pragma GCC diagnostic pop
 #else
+    static_assert(narrow_row == false, "non-default narrow_row not supported on Quasar");
+    static_assert(row_num_datums == TILE_C_DIM, "non-default row_num_datums not supported on Quasar");
+    static_assert(tile_dst_ct_offset == 0, "non-default tile_dst_ct_offset not supported on Quasar");
+    static_assert(dense == false, "non-default dense not supported on Quasar");
+    static_assert(diagonal == false, "non-default diagonal not supported on Quasar");
     PACK((llk_pack_untilize<block_ct_dim, full_ct_dim>(block_rt_dim, ocb, block_c_index, tile_dst_rt_offset)));
 #endif
 }

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -25,6 +25,11 @@ namespace ckernel {
 template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t srcb_new_operand) {
     LLK_SAN_FUNCTION();
+#ifdef ARCH_QUASAR
+    // to_from_int8 is silently ignored on Quasar: the unpack LLK marks it [[maybe_unused]] and the
+    // math reconfig is a no-op.
+    static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
+#endif
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format<
             DST_ACCUM_MODE,
@@ -45,6 +50,11 @@ ALWI void reconfig_data_format(
     const uint32_t srcb_old_operand,
     const uint32_t srcb_new_operand) {
     LLK_SAN_FUNCTION();
+#ifdef ARCH_QUASAR
+    // to_from_int8 is silently ignored on Quasar: the unpack LLK marks it [[maybe_unused]] and the
+    // math reconfig is a no-op.
+    static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
+#endif
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format<
             DST_ACCUM_MODE,
@@ -60,6 +70,11 @@ ALWI void reconfig_data_format(
 template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
     LLK_SAN_FUNCTION();
+#ifdef ARCH_QUASAR
+    // to_from_int8 is silently ignored on Quasar: the unpack LLK marks it [[maybe_unused]] and the
+    // math reconfig is a no-op.
+    static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
+#endif
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srca<
             DST_ACCUM_MODE,
@@ -74,6 +89,11 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
 template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand) {
     LLK_SAN_FUNCTION();
+#ifdef ARCH_QUASAR
+    // to_from_int8 is silently ignored on Quasar: the unpack LLK marks it [[maybe_unused]] and the
+    // math reconfig is a no-op.
+    static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
+#endif
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srca<
             DST_ACCUM_MODE,
@@ -88,6 +108,11 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint3
 template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
     LLK_SAN_FUNCTION();
+#ifdef ARCH_QUASAR
+    // to_from_int8 is silently ignored on Quasar: the unpack LLK marks it [[maybe_unused]] and the
+    // math reconfig is a no-op.
+    static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
+#endif
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srcb<
             DST_ACCUM_MODE,
@@ -102,6 +127,11 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
 template <bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand) {
     LLK_SAN_FUNCTION();
+#ifdef ARCH_QUASAR
+    // to_from_int8 is silently ignored on Quasar: the unpack LLK marks it [[maybe_unused]] and the
+    // math reconfig is a no-op.
+    static_assert(!to_from_int8, "non-default to_from_int8 not supported on Quasar");
+#endif
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srcb<
             DST_ACCUM_MODE,

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
+#include "llk_assert.h"
 #include "tensor_shape.h"
 
 #ifdef TRISC_MATH
@@ -196,6 +197,7 @@ ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = 4) {
         (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<std::uint8_t>(num_faces) : MAX_NUM_FACES_C_DIM};
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
 #else
+    LLK_ASSERT(num_faces == 4, "non-default num_faces not supported on Quasar");
     MATH((llk_math_reduce(idst)));
 #endif
 }
@@ -217,6 +219,12 @@ ALWI void reduce_tile_math(std::uint32_t idst, const ckernel::TensorShape& tenso
 #ifndef ARCH_QUASAR
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
 #else
+    LLK_ASSERT(
+        tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim &&
+            tensor_shape.face_c_dim == DEFAULT_TENSOR_SHAPE.face_c_dim &&
+            tensor_shape.num_faces_r_dim == DEFAULT_TENSOR_SHAPE.num_faces_r_dim &&
+            tensor_shape.num_faces_c_dim == DEFAULT_TENSOR_SHAPE.num_faces_c_dim,
+        "non-default tensor_shape not supported on Quasar");
     MATH((llk_math_reduce(idst)));
 #endif
 }

--- a/tt_metal/hw/inc/api/compute/transpose.h
+++ b/tt_metal/hw/inc/api/compute/transpose.h
@@ -6,6 +6,7 @@
 
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
+#include "llk_assert.h"
 #include "sanitizer/api.h"
 #ifdef TRISC_MATH
 #include "llk_math_common_api.h"
@@ -70,9 +71,16 @@ ALWI void transpose_init(uint32_t icb, uint32_t call_line = __builtin_LINE()) {
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     }
 #else
-    const bool enable_unpack_to_dest =
-        (dst_format == (std::uint32_t)DataFormat::Float32) || (dst_format == (std::uint32_t)DataFormat::Int32);
-    ASSERT(!enable_unpack_to_dest);  // transpose dest not implemented for Quasar yet, TODO: tt-llk#1559
+    // Quasar has no unpack-to-dest transpose path (TODO: tt-llk#1559) and no int-FPU 8-bit integer
+    // reconstruct path; reject formats that would otherwise silently take the wrong path. UInt32 is
+    // treated as unpack-to-dest on WH/BH and Int8/UInt8 (low nibble 0xE) need the int-FPU path.
+    const bool is_8bit_int = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
+    LLK_ASSERT(
+        !enable_unpack_to_dest, "32-bit (unpack-to-dest) transpose not supported on Quasar");  // TODO: tt-llk#1559
+    LLK_ASSERT(!is_8bit_int, "8-bit integer transpose not supported on Quasar");
     UNPACK((llk_unpack_A_init<
             BroadcastType::NONE,
             false /*acc_to_dest*/,
@@ -122,9 +130,11 @@ ALWI void transpose_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
         MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(idst, icb)));
     }
 #else
-    const bool enable_unpack_to_dest =
-        (dst_format == (std::uint32_t)DataFormat::Float32) || (dst_format == (std::uint32_t)DataFormat::Int32);
-    ASSERT(!enable_unpack_to_dest);  // transpose dest not implemented for Quasar yet, TODO: tt-llk#1559
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
+    LLK_ASSERT(
+        !enable_unpack_to_dest, "32-bit (unpack-to-dest) transpose not supported on Quasar");  // TODO: tt-llk#1559
     UNPACK((llk_unpack_A<BroadcastType::NONE, false /*acc_to_dest*/>(icb, itile)));
     MATH((llk_math_eltwise_unary_datacopy(idst, icb)));
 #endif

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -19,6 +19,7 @@
 //
 
 #include "api/compute/transpose.h"
+#include "llk_assert.h"
 
 namespace ckernel {
 
@@ -73,9 +74,16 @@ transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LIN
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
 #else
-    const bool enable_unpack_to_dest =
-        (dst_format == (std::uint32_t)DataFormat::Float32) || (dst_format == (std::uint32_t)DataFormat::Int32);
-    ASSERT(!enable_unpack_to_dest);  // transpose dest not implemented for Quasar yet, TODO: tt-llk#1559
+    // Quasar has no unpack-to-dest transpose path (TODO: tt-llk#1559) and no int-FPU 8-bit integer
+    // reconstruct path; reject formats that would otherwise silently take the wrong path. UInt32 is
+    // treated as unpack-to-dest on WH/BH and Int8/UInt8 (low nibble 0xE) need the int-FPU path.
+    const bool is_8bit_int = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
+    LLK_ASSERT(
+        !enable_unpack_to_dest, "32-bit (unpack-to-dest) transpose not supported on Quasar");  // TODO: tt-llk#1559
+    LLK_ASSERT(!is_8bit_int, "8-bit integer transpose not supported on Quasar");
     UNPACK((llk_unpack_hw_configure(icb)));
     UNPACK((llk_unpack_A_init<
             BroadcastType::NONE,


### PR DESCRIPTION
### PR Category
Feature

### Summary
Guard features that are not supported on Quasar with static and runtime (LLK) asserts.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/quasar-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/quasar-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:filip/quasar-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/quasar-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/quasar-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/quasar-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/quasar-asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/quasar-asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/quasar-asserts)