### PR TITLE
ttnn/move: get_dynamic for sharded move — skip rebuild-on-cache-hit (#48928)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -12,6 +12,7 @@
 #include "move_sharded_program_factory.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/distributed/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -11,6 +11,7 @@
 #include "move_overlap_program_factory.hpp"
 #include "move_sharded_program_factory.hpp"
 #include "ttnn/operation.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::prim {
 
@@ -42,6 +43,15 @@ struct MoveDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
+
+    // #48928: the sharded factory re-runs create_descriptor on every cache hit only to recompute the
+    // reader's address-derived rt-args (chunk = dst_addr - src_addr). Recompute just those on a hit.
+    // Defined in move_sharded_program_factory.cpp to reuse its arg arithmetic.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "move_sharded_program_factory.hpp"
+#include "ttnn/operations/data_movement/move/device/move_device_operation.hpp"
 
 #include <cmath>
 #include <tt-metalium/work_split.hpp>
@@ -107,12 +108,50 @@ ProgramDescriptor MoveShardedProgramFactory::create_descriptor(
     const auto cores = corerange_to_cores(shard_grid, std::nullopt, true);
     for (const auto& core : cores) {
         reader_desc.emplace_runtime_args(
-            core, {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes});
+            core,
+            {total_size_bytes,
+             num_chunks,
+             move_chunk_size_bytes,  // smuggled-rta-ok: re-applied on cache hit via get_dynamic_runtime_args (#48928)
+             remainder_chunk_size_bytes});
     }
 
     desc.kernels.push_back(std::move(reader_desc));
 
     return desc;
+}
+
+// #48928: on a cache hit, recompute only the reader's address-derived scalar args (arg 0
+// total_size_bytes is shape-constant; args 1-3 ride on chunk = dst_addr - src_addr) instead of
+// re-running create_descriptor. Trips the descriptor fast path (which also re-patches the sharded
+// CB addresses). Returns empty for the non-sharded factories so they are unaffected.
+std::vector<tt::tt_metal::DynamicRuntimeArg> MoveDeviceOperation::get_dynamic_runtime_args(
+    const MoveOperationAttributes& operation_attributes,
+    const MoveTensorArgs& tensor_args,
+    Tensor& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_coordinate*/) {
+    if (operation_attributes.move_op_parallelization_strategy != MoveOpParallelizationStrategy::MULTI_CORE_SHARDED) {
+        return {};
+    }
+    Buffer* src_buffer = tensor_args.input_tensor.buffer();
+    Buffer* dst_buffer = tensor_return_value.buffer();
+    const uint32_t total_size_bytes = src_buffer->aligned_size_per_bank();
+    const uint32_t move_chunk_size_bytes = dst_buffer->address() - src_buffer->address();
+    if (move_chunk_size_bytes == 0) {
+        return {};  // src == dst address: let the slow path handle it (matches create_descriptor).
+    }
+    const uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
+    const uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
+
+    const auto cores = corerange_to_cores(tensor_args.input_tensor.shard_spec().value().grid, std::nullopt, true);
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size() * 3);
+    for (const auto& core : cores) {
+        dynamic_args.push_back({0, core, 1, num_chunks});
+        dynamic_args.push_back(
+            {0, core, 2, move_chunk_size_bytes});  // smuggled-rta-ok: this IS the get_dynamic re-application (#48928)
+        dynamic_args.push_back({0, core, 3, remainder_chunk_size_bytes});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
@@ -137,7 +137,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> MoveDeviceOperation::get_dynamic_ru
     const uint32_t total_size_bytes = src_buffer->aligned_size_per_bank();
     const uint32_t move_chunk_size_bytes = dst_buffer->address() - src_buffer->address();
     if (move_chunk_size_bytes == 0) {
-        return {};  // src == dst address: let the slow path handle it (matches create_descriptor).
+        return {};  // degenerate dst==src (unreachable for a real move); avoids div-by-zero below.
     }
     const uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
     const uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;


### PR DESCRIPTION
### What

Stops the sharded `Move` op from re-running `create_descriptor` on every program-cache hit (#48928).

The sharded move reader's runtime args are derived from the *live buffer addresses* —
`move_chunk_size_bytes = dst_addr - src_addr`, and `num_chunks`/`remainder` follow from it — so they
can't be plain `Buffer*` bindings (which only patch a raw address). The factory therefore emitted them
as scalars and let the slow path rebuild the whole descriptor on every hit. This adds
`MoveDeviceOperation::get_dynamic_runtime_args` (guarded to the `MULTI_CORE_SHARDED` strategy) that
recomputes just those scalars from the current addresses and re-applies them per core on a cache hit —
no descriptor rebuild. The sharded CB addresses are still patched via the existing `.buffer` bindings.

### Validation (wormhole_b0, all-fixes build)

`REBUILD_ON_HIT MoveDeviceOperation` count, before → after:

| model | before | after |
|---|---|---|
| mobilenetv2 | 64 | **0** |
| vgg_unet | 52 | **0** |
| vgg | 10 | **0** |

Both host e2e tests still PASS; mobilenetv2 is now fully free of rebuild-on-cache-hit.

### Dependency

Requires the adapter cache-hit gate change from **#49159** (`|| !dynamic_args.empty()`), which is what
lets a `get_dynamic_runtime_args`-only op take the fast path. Should merge after #49159.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-move-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-move-descriptor-rebuild)