### PR TITLE
[Quasar] Fix VIRTUAL_TENSIX_START_X: 1 → 2 to match physical worker origin

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
@@ -7,8 +7,13 @@
 #ifndef _NOC_PARAMETERS_H_
 #define _NOC_PARAMETERS_H_
 
-// TODO: review these values
-#define VIRTUAL_TENSIX_START_X 1
+// Quasar functional workers occupy physical x[2..9], y[2..5] (no harvesting;
+// physical col x=1 is empty, x=0 is router). Coordinate virtualization is
+// identity here (tt-umd translated==physical, craq-sim applies no QSR remap),
+// so the virtual Tensix origin must equal the physical worker start. X was
+// copy-pasted from Blackhole (=1, where BH's physical Tensix start is 1) and
+// must be 2 for Quasar; Y already matches (physical y-start is 2).
+#define VIRTUAL_TENSIX_START_X 2
 #define VIRTUAL_TENSIX_START_Y 2
 #define COORDINATE_VIRTUALIZATION_ENABLED 1
 


### PR DESCRIPTION
## Summary
Fixes the Quasar watcher NoC-sanitize false positive tracked in craq-sim tenstorrent/craq-sim#185: a correctly-oriented full worker-grid multicast `(2,2)-(9,5)` trips `DebugSanitizeNocMixedVirtualandPhysical`.

## Root cause
`VIRTUAL_TENSIX_START_X` was `1`, copy-pasted from Blackhole (where the physical Tensix start **is** 1). On Quasar the functional workers are physical `x[2..9]`, `y[2..5]` (no harvesting; column x=1 is empty, x=0 is router), and coordinate virtualization is **identity** (tt-umd emits translated==physical). The firmware classifier `get_core_type` (`hw/inc/internal/debug/sanitize.h`) builds the virtual Tensix range as `[VIRTUAL_TENSIX_START_X .. VIRTUAL_TENSIX_START_X + worker_grid_size_x - 1]` = `[1..8]`. A correct full-grid mcast then has its end `x=9` fall **outside** that range (tagged physical) while the start `x=2` is tagged virtual → `is_virtual != is_virtual_end` → false `MixedVirtualandPhysical`. `VIRTUAL_TENSIX_START_Y` already matched the physical y-start (=2); only X was off by one.

## Fix
Set `VIRTUAL_TENSIX_START_X = 2`. The virtual range becomes `[2..9]` == the physical workers, so a correctly-oriented full-grid mcast classifies fully-virtual and passes. The `ARCH_QUASAR` start>end guard (`MulticastInvalidRange`) is orthogonal to this constant and still fires, so genuine bottom-right/orientation bugs are still caught. This also aligns the CCL/sharded `VirtualCoordWormholeWorkerToNocLookup` (`worker_x + VIRTUAL_TENSIX_START_X`, kernel build) to emit physical `[2..9]` instead of `[1..8]`.

## Validation
- **Classifier replica**: a faithful standalone reproduction of `get_core_type` + the multicast decision block, run over both orientations × both START_X values:
  | mcast | START_X=1 (before) | START_X=2 (fix) |
  |---|---|---|
  | correct `(2,2)-(9,5)` | `MixedVirtualandPhysical` (the reported bug) | `OK` |
  | bottom-right `(9,5)-(2,2)` | `MulticastInvalidRange` | `MulticastInvalidRange` |
- **On simulator (craq-sim) with watcher NoC-sanitize ON**: the resnet fc-linear 1D-mcast matmul exercises the identical `DM2 … noc0 … multicast` path from the issue; the live device runs reproduce the replica's `InvalidRange` predictions exactly, confirming fidelity.

No tt-umd or simulator change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/quasar-virtual-tensix-start-x)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/quasar-virtual-tensix-start-x)