### PR TITLE
Bug fix: preserve dtypes in repeat_interleave

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
@@ -28,6 +28,39 @@ def test_repeat_interleave(device, repeats, dim, dtype):
     assert_equal(torch_result, output)
 
 
+# Regression test for #41631: integer dtypes must not round-trip through bf16.
+@pytest.mark.parametrize("repeats", [2, 4, 32])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3, -1])
+@pytest.mark.parametrize(
+    "dtype, torch_dtype, lo, hi",
+    [
+        (ttnn.uint32, torch.int32, 256, 1_000_000),
+        (ttnn.int32, torch.int32, 256, 1_000_000),
+        (ttnn.uint16, torch.int16, 256, 30_000),
+        (ttnn.uint8, torch.uint8, 0, 256),
+    ],
+)
+def test_repeat_interleave_preserves_integer_values(device, repeats, dim, dtype, torch_dtype, lo, hi):
+    torch.manual_seed(0)
+    torch_input_tensor = torch.randint(lo, hi, (1, 1, 32, 32), dtype=torch_dtype)
+    torch_result = torch.repeat_interleave(torch_input_tensor, repeats, dim=dim)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
+    output = ttnn.to_torch(ttnn.repeat_interleave(input_tensor, repeats, dim=dim)).to(torch_dtype)
+    assert_equal(torch_result, output)
+
+
+# Regression test for #41631: fp32 must not round-trip through bf16.
+@pytest.mark.parametrize("repeats", [2, 4, 32])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3, -1])
+def test_repeat_interleave_preserves_fp32_precision(device, repeats, dim):
+    torch.manual_seed(0)
+    torch_input_tensor = torch.rand(1, 1, 32, 32, dtype=torch.float32) * 1000.0
+    torch_result = torch.repeat_interleave(torch_input_tensor, repeats, dim=dim)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.float32, device=device)
+    output = ttnn.to_torch(ttnn.repeat_interleave(input_tensor, repeats, dim=dim))
+    assert_equal(torch_result, output)
+
+
 @pytest.mark.skip(reason="ttnn.repeat_interleave only supports `repeats` as int")
 def test_repeat_interleave_with_repeat_tensor(device):
     torch_input_tensor = torch.rand(1, 2, 32, 32, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
@@ -14,12 +14,13 @@ from tests.ttnn.utils_for_testing import assert_equal
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint16])
 def test_repeat_interleave(device, repeats, dim, dtype):
+    torch.manual_seed(42)
     if dtype == ttnn.uint16:
-        torch_dtype = torch.int16
-        torch_input_tensor = torch.randint(0, 100, (1, 1, 32, 32), dtype=torch_dtype)
+        torch_dtype = torch.int32
+        torch_input_tensor = torch.randint(0, (2**16) - 1, (1, 1, 32, 32), dtype=torch_dtype)
     else:
         torch_dtype = torch.bfloat16
-        torch_input_tensor = torch.rand(1, 1, 32, 32, dtype=torch_dtype)
+        torch_input_tensor = torch.randn(1, 1, 32, 32, dtype=torch_dtype) * 1000.0
 
     torch_result = torch.repeat_interleave(torch_input_tensor, repeats, dim=dim)
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
@@ -63,6 +64,7 @@ def test_repeat_interleave_preserves_fp32_precision(device, repeats, dim):
 
 @pytest.mark.skip(reason="ttnn.repeat_interleave only supports `repeats` as int")
 def test_repeat_interleave_with_repeat_tensor(device):
+    torch.manual_seed(42)
     torch_input_tensor = torch.rand(1, 2, 32, 32, dtype=torch.bfloat16)
     torch_repeats = torch.tensor([1, 2])
     torch_result = torch.repeat_interleave(torch_input_tensor, torch_repeats, dim=1)

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
@@ -32,7 +32,10 @@ ttnn::Tensor repeat_interleave(
     }
 
     ttnn::Tensor rm_input = input_a;
-    bool typecast = input_a.dtype() != DataType::BFLOAT16;
+    // Block-float dtypes need bf16 unpacking for ROW_MAJOR; UINT8 is converted because the
+    // tilize/untilize kernels don't support it (uint8 values are exactly representable in bf16).
+    bool typecast = input_a.dtype() == DataType::BFLOAT8_B || input_a.dtype() == DataType::BFLOAT4_B ||
+                    input_a.dtype() == DataType::UINT8;
     if (typecast) {
         rm_input = ttnn::typecast(rm_input, DataType::BFLOAT16, mem_config);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
@@ -25,17 +25,23 @@ ttnn::Tensor repeat_interleave(
     const auto& input_a_shape = input_a.logical_shape();
     uint32_t input_rank = input_a_shape.rank();
     uint32_t normalized_dim = input_a_shape.get_normalized_index(dim);
+
+    // UINT8 must be typecast before any path (including the last-dim transpose path)
+    // because transpose and tilize/untilize kernels don't support 1-byte elements.
+    const DataType original_dtype = input_a.dtype();
+    const bool uint8_typecast = original_dtype == DataType::UINT8;
+    ttnn::Tensor working_input = uint8_typecast ? ttnn::typecast(input_a, DataType::BFLOAT16, mem_config) : input_a;
+
     if (normalized_dim == input_rank - 1) {
-        auto transposed_input = ttnn::transpose(input_a, -1, -2, mem_config);
+        auto transposed_input = ttnn::transpose(working_input, -1, -2, mem_config);
         auto repeated_input = ttnn::repeat_interleave(transposed_input, repeat, -2, mem_config);
-        return ttnn::transpose(repeated_input, -1, -2, mem_config);
+        auto result = ttnn::transpose(repeated_input, -1, -2, mem_config);
+        return uint8_typecast ? ttnn::typecast(result, original_dtype, mem_config) : result;
     }
 
-    ttnn::Tensor rm_input = input_a;
-    // Block-float dtypes need bf16 unpacking for ROW_MAJOR; UINT8 is converted because the
-    // tilize/untilize kernels don't support it (uint8 values are exactly representable in bf16).
-    bool typecast = input_a.dtype() == DataType::BFLOAT8_B || input_a.dtype() == DataType::BFLOAT4_B ||
-                    input_a.dtype() == DataType::UINT8;
+    ttnn::Tensor rm_input = working_input;
+    // Block-float dtypes need bf16 unpacking for ROW_MAJOR layout.
+    bool typecast = original_dtype == DataType::BFLOAT8_B || original_dtype == DataType::BFLOAT4_B;
     if (typecast) {
         rm_input = ttnn::typecast(rm_input, DataType::BFLOAT16, mem_config);
     }
@@ -68,7 +74,8 @@ ttnn::Tensor repeat_interleave(
     auto concatenated_tensor = ttnn::concat(combined_tensors, normalized_dim + 1);
     auto reshaped_tensor = ttnn::reshape(concatenated_tensor, ttnn::Shape(final_shape));
     auto original_layout = ttnn::to_layout(reshaped_tensor, input_a.layout());
-    return typecast ? ttnn::typecast(original_layout, input_a.dtype(), mem_config) : original_layout;
+    bool needs_castback = typecast || uint8_typecast;
+    return needs_castback ? ttnn::typecast(original_layout, original_dtype, mem_config) : original_layout;
 }
 
 }  // namespace ttnn


### PR DESCRIPTION
## Summary

Related to #41631, mirrors #44115

`ttnn.repeat_interleave` was force-casting all non-bf16 inputs to bf16 internally, corrupting integers > 256.

Replaced the typecast guard with a whitelist: only `BFLOAT8_B` / `BFLOAT4_B` (which need bf16 unpacking for ROW_MAJOR layout) and `UINT8` (tilize/untilize kernels don't support it) round-trip through bf16. All other dtypes — `BFLOAT16`, `FLOAT32`, `UINT16`, `UINT32`, `INT32` — stay in their native dtype.

### Changes
- **`repeat_interleave.cpp`**: Restrict internal BF16 typecast to block-float dtypes (`BFLOAT8_B`, `BFLOAT4_B`) and `UINT8` only, preserving all other dtypes end-to-end.
- **`test_repeat_interleave.py`**: Add regression tests ensuring integer dtypes (`uint32`, `int32`, `uint16`, `uint8`) preserve exact values and `float32` preserves full precision across various `repeats` and `dim` values.

## Test plan
- [x] Regression tests for integer-value preservation (`uint32`, `int32`, `uint16`, `uint8`)
- [x] Regression tests for fp32 precision preservation
- [ ] Sanity tests
- [ ] Nightly L2 test for DM ops
- [ ] Single Card mandatory model tests


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kalaivani/fix-repeat-interleave-preserve-dtypes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kalaivani/fix-repeat-interleave-preserve-dtypes)