### PR TITLE
ttnn/eltwise/unary: Buffer* rt-arg bindings to skip rebuild-on-cache-hit (#48928)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -9,10 +9,12 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::operations::unary {
 
@@ -52,6 +54,16 @@ struct UnaryDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+
+    // unary's compute_program_hash excludes the tensor volume, so one cached program is shared across
+    // shapes. The Buffer* rt-arg bindings trip the cache-hit fast path (patch addresses, skip rebuild),
+    // which would freeze the per-core work-split (tile counts, start ids) at the first-miss volume.
+    // Re-apply every per-core runtime arg for the current tensors on each hit.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -514,4 +514,25 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
     return desc;
 }
 
+std::vector<tt::tt_metal::DynamicRuntimeArg> UnaryDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Recompute the descriptor for the current tensors and re-apply every per-core runtime arg
+    // (kernels pushed in create_descriptor order: reader=0, writer=1, compute=2). Buffer slots hold
+    // the current address here too, matching the bindings, so re-applying them is a no-op; the point
+    // is the volume-dependent work-split args, which the fast path would otherwise leave frozen.
+    auto desc = ProgramFactory::create_descriptor(operation_attributes, tensor_args, output);
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    for (uint32_t kernel_idx = 0; kernel_idx < desc.kernels.size(); ++kernel_idx) {
+        for (const auto& [core, args] : desc.kernels[kernel_idx].runtime_args) {
+            for (uint32_t arg_idx = 0; arg_idx < args.size(); ++arg_idx) {
+                dynamic_args.push_back({kernel_idx, core, arg_idx, args[arg_idx]});
+            }
+        }
+    }
+    return dynamic_args;
+}
+
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -432,10 +432,8 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
             uint32_t o_tiles = out_shard_pages(core);
             uint32_t out_start_id = ((i / num_shards_per_width) * (out_shard_height * oWt)) +
                                     ((i % num_shards_per_width) * out_shard_width);
-            reader_desc.runtime_args.emplace_back(
-                core, KernelDescriptor::CoreRuntimeArgs{input.buffer()->address(), in_tiles, out_start_id});
-            writer_desc.runtime_args.emplace_back(
-                core, KernelDescriptor::CoreRuntimeArgs{output.buffer()->address(), o_tiles, out_start_id});
+            reader_desc.emplace_runtime_args(core, {input.buffer(), in_tiles, out_start_id});
+            writer_desc.emplace_runtime_args(core, {output.buffer(), o_tiles, out_start_id});
             compute_desc.runtime_args.emplace_back(
                 core, KernelDescriptor::CoreRuntimeArgs{o_tiles, packed_scalar1, packed_scalar2});
         }
@@ -476,39 +474,31 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
             }
 
             if (rm_interleaved) {
-                reader_desc.runtime_args.emplace_back(
+                reader_desc.emplace_runtime_args(
                     core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input.buffer()->address(),
-                        npc,
-                        start_tile_id,
-                        chunks_per_row,
-                        input_chunk_size,
-                        input_last_chunk_size,
-                        rows_per_tile,
-                        total_rows});
-                writer_desc.runtime_args.emplace_back(
+                    {input.buffer(),
+                     npc,
+                     start_tile_id,
+                     chunks_per_row,
+                     input_chunk_size,
+                     input_last_chunk_size,
+                     rows_per_tile,
+                     total_rows});
+                writer_desc.emplace_runtime_args(
                     core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        output.buffer()->address(),
-                        npc,
-                        start_tile_id,
-                        chunks_per_row,
-                        output_chunk_size,
-                        output_last_chunk_size,
-                        rows_per_tile,
-                        total_rows});
+                    {output.buffer(),
+                     npc,
+                     start_tile_id,
+                     chunks_per_row,
+                     output_chunk_size,
+                     output_last_chunk_size,
+                     rows_per_tile,
+                     total_rows});
                 compute_desc.runtime_args.emplace_back(
                     core, KernelDescriptor::CoreRuntimeArgs{npc * chunks_per_row, packed_scalar1, packed_scalar2});
             } else {
-                reader_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input.buffer()->address(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
-                writer_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        output.buffer()->address(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
+                reader_desc.emplace_runtime_args(core, {input.buffer(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
+                writer_desc.emplace_runtime_args(core, {output.buffer(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
                 compute_desc.runtime_args.emplace_back(
                     core, KernelDescriptor::CoreRuntimeArgs{npc, packed_scalar1, packed_scalar2});
             }


### PR DESCRIPTION
Removes the last smuggled buffer-address runtime args in the unary op — the three factory variants (sharded, rm-interleaved, tiled-interleaved) that survived the merged `[eltwise]` #49132 cleanup and still pushed raw `input/output.buffer()->address()` into `CoreRuntimeArgs`, forcing a `create_descriptor` rebuild on every program-cache hit.

Fix: emit input/output as `Buffer*` bindings via `emplace_runtime_args` (same pattern as the merged campaign), so the framework patches the addresses on a cache hit.

**Validation (wormhole_b0):** `UnaryDeviceOperation` rebuild-on-cache-hit **6 → 0** on vgg (test passes); unary PCC tests pass. Passes the `detect-smuggled-rta` guard.

Found via a 40-model proactive sweep — Unary was the most *widespread* rebuild-on-hit offender (21 of the models). Complements the merged `[eltwise]` #49132.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-unary-descriptor-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-unary-descriptor-rebuild)