### PR TITLE
[Performance] New delivery architecture for the real-time profiler

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -413,6 +413,7 @@ tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py @tensto
 
 tests/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
 tests/ttnn/**/*realtime_profiler* @tenstorrent/metalium-developers-ttnn-core @mo-tenstorrent @yusufbashiTT @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
+tests/ttnn/tracy/ @tenstorrent/metalium-developers-ttnn-core @mo-tenstorrent @yusufbashiTT @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
 tests/ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra
 tests/ttnn/multidevice_perf_tests/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/nightly/t3000/ccl/test_all_reduce.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,7 +106,7 @@ tt_metal/api/tt-metalium/experimental/fabric @ubcheema @aliuTT @aagarwalTT @tt-a
 tt_metal/api/tt-metalium/experimental/tensor/ @akerteszTT @riverwuTT @tenstorrent/codeowner-bypass # tensor WIP
 tt_metal/common/ @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/common/**/CMakeLists.txt @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
-tt_metal/common/broadcast_ring.hpp @yusufbashiTT @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/codeowner-bypass
+tt_metal/common/broadcast_ring.hpp @yusufbashiTT @mo-tenstorrent @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/core_descriptors/ @abhullar-tt @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/detail/ @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/codeowner-bypass # this should go away
 tt_metal/detail/**/CMakeLists.txt @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass # this should go away

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,10 +106,12 @@ tt_metal/api/tt-metalium/experimental/fabric @ubcheema @aliuTT @aagarwalTT @tt-a
 tt_metal/api/tt-metalium/experimental/tensor/ @akerteszTT @riverwuTT @tenstorrent/codeowner-bypass # tensor WIP
 tt_metal/common/ @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/common/**/CMakeLists.txt @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+tt_metal/common/broadcast_ring.hpp @yusufbashiTT @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/core_descriptors/ @abhullar-tt @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/detail/ @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/codeowner-bypass # this should go away
 tt_metal/detail/**/CMakeLists.txt @abhullar-tt @tt-aho @tt-asaigal @cfjchu @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass # this should go away
 tt_metal/distributed/ @cfjchu @aliuTT @tt-asaigal @jbaumanTT @sidnadTT @tenstorrent/codeowner-bypass
+tt_metal/distributed/realtime_profiler_manager.* @mo-tenstorrent @yusufbashiTT @cfjchu @aliuTT @tt-asaigal @jbaumanTT @sidnadTT @tenstorrent/codeowner-bypass
 tt_metal/distributed/**/CMakeLists.txt @cfjchu @aliuTT @tt-asaigal @jbaumanTT @sidnadTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 tt_metal/fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @cfjchu @p1-0tr @tenstorrent/codeowner-bypass
 tt_metal/fabric/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @cfjchu @p1-0tr @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
@@ -121,6 +123,7 @@ tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicT
 tt_metal/hw/ckernels/**/llk_api/llk_sfpu @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @ndivnicTT @fvranicTT @nmauriceTT @tenstorrent/codeowner-bypass
 tt_metal/hw/firmware/src/tt-1xx/*erisc* @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/ @abhullar-tt @jbaumanTT @kstevensTT @nathan-TT @vvukomanovicTT @atatuzunerTT @ruizhangTT @arikTT @tenstorrent/codeowner-bypass
+tt_metal/hw/inc/hostdev/realtime_profiler_msgs.h @mo-tenstorrent @yusufbashiTT @abhullar-tt @jbaumanTT @kstevensTT @nathan-TT @vvukomanovicTT @atatuzunerTT @ruizhangTT @arikTT @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/api/debug/ @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/internal/ethernet/ @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/internal/tt-1xx/wormhole/eth_l1_address_map.h @aliuTT @ubcheema @tenstorrent/codeowner-bypass
@@ -137,7 +140,9 @@ tt_metal/impl/debug/ @abhullar-tt @ruizhangTT @sidnadTT @tenstorrent/metalium-de
 tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/impl/dispatch/ @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
 tt_metal/impl/dispatch/kernels/*telemetry* @anashTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
-tt_metal/impl/dispatch/kernels/*realtime_profiler* @mo-tenstorrent @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
+tt_metal/impl/dispatch/kernels/*realtime_profiler* @mo-tenstorrent @yusufbashiTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
+tt_metal/impl/dispatch/kernels/REALTIME_PROFILER.md @mo-tenstorrent @yusufbashiTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
+tt_metal/impl/dispatch/realtime_profiler_tracy_handler.* @mo-tenstorrent @yusufbashiTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
 tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate_compute.cpp @anashTT @mo-tenstorrent @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
 tt_metal/impl/event @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/codeowner-bypass
 tt_metal/impl/flatbuffer/ @cfjchu @kmabeeTT @nsmithtt @tenstorrent/codeowner-bypass
@@ -166,7 +171,7 @@ tt_metal/logging/**/CMakeLists.txt @abhullar-tt @jbaumanTT @tenstorrent/metalium
 tt_metal/llrt/ @abhullar-tt @jbaumanTT @ruizhangTT @arikTT @tt-asaigal @tt-aho @tenstorrent/codeowner-bypass
 tt_metal/llrt/**/CMakeLists.txt @abhullar-tt @jbaumanTT @ruizhangTT @arikTT @tt-asaigal @tt-aho @tenstorrent/metalium-developers-infra
 tt_metal/programming_examples/ @tt-asaigal @afuller-TT @ebanerjeeTT @ncvetkovicTT @lpremovicTT @rtawfik01 @nvelickovicTT @tenstorrent/metalium-api-owners @tenstorrent/codeowner-bypass
-tt_metal/programming_examples/profiler/ @mo-tenstorrent @akerteszTT @tenstorrent/codeowner-bypass
+tt_metal/programming_examples/profiler/ @mo-tenstorrent @akerteszTT @yusufbashiTT @tenstorrent/codeowner-bypass
 tt_metal/programming_examples/profiler/test_noc_event_profiler/ @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/programming_examples/**/CMakeLists.txt @tt-asaigal @afuller-TT @ebanerjeeTT @tenstorrent/metalium-api-owners @tenstorrent/metalium-developers-infra
 tt_metal/soc_descriptors @abhullar-tt @aliuTT @ubcheema @tenstorrent/codeowner-bypass
@@ -232,6 +237,8 @@ tests/tt_metal/distributed/ @tenstorrent/metalium-developers-metal-distributed @
 tests/tt_metal/distributed/**/CMakeLists.txt @cfjchu @tt-asaigal @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 tests/tt_metal/microbenchmarks/ethernet/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/ @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @tenstorrent/codeowner-bypass
+tests/tt_metal/tt_metal/dispatch/dispatch_program/*realtime_profiler* @mo-tenstorrent @yusufbashiTT @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @tenstorrent/codeowner-bypass
+tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp @yusufbashiTT @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/sources.cmake @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @riverwuTT @akerteszTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/**/CMakeLists.txt @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/api/metal2_host_api/ @tenstorrent/metalium-api-owners @tenstorrent/codeowner-bypass
@@ -405,6 +412,7 @@ tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py @tensto
 
 
 tests/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
+tests/ttnn/**/*realtime_profiler* @tenstorrent/metalium-developers-ttnn-core @mo-tenstorrent @yusufbashiTT @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
 tests/ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra
 tests/ttnn/multidevice_perf_tests/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/nightly/t3000/ccl/test_all_reduce.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
@@ -594,7 +602,7 @@ tools/tests/triage/ @tenstorrent/metalium-developers-triage @tenstorrent/codeown
 tools/tests/triage/**/CMakeLists.txt @tenstorrent/metalium-developers-triage @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 
 # docs
-docs/realtime_profiler_architecture.md @mo-tenstorrent @akerteszTT @tenstorrent/codeowner-bypass
+docs/realtime_profiler_architecture.md @mo-tenstorrent @akerteszTT @yusufbashiTT @tenstorrent/codeowner-bypass
 docs/Makefile @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 docs/source/tt-metalium/* @bbradelTT @pavlejosipovic @aczajkowskiTT @ntarafdar @tenstorrent/codeowner-bypass
 docs/source/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @aczajkowskiTT @tenstorrent/codeowner-bypass
@@ -623,4 +631,5 @@ tt-train/tests/**/CMakeLists.txt @mdragulaTT @vmelnykovTT @dyurshevichTT @zbacze
 
 # Tech reports
 tech_reports/LLMs/vLLM_integration.md @viktorpusTT @tchedaTT @tenstorrent/codeowner-bypass
+tech_reports/real_time_profiler/ @mo-tenstorrent @yusufbashiTT @tenstorrent/codeowner-bypass
 models/experimental/yunet @tvardhineniTT @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -238,7 +238,7 @@ tests/tt_metal/distributed/**/CMakeLists.txt @cfjchu @tt-asaigal @tenstorrent/me
 tests/tt_metal/microbenchmarks/ethernet/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/ @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/dispatch/dispatch_program/*realtime_profiler* @mo-tenstorrent @yusufbashiTT @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @tenstorrent/codeowner-bypass
-tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp @yusufbashiTT @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @tenstorrent/codeowner-bypass
+tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp @yusufbashiTT @mo-tenstorrent @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/sources.cmake @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @riverwuTT @akerteszTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/**/CMakeLists.txt @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/api/metal2_host_api/ @tenstorrent/metalium-api-owners @tenstorrent/codeowner-bypass

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -231,15 +231,15 @@ runtime:
     sim_wormhole_b0_galaxy: 10
     sim_blackhole_galaxy: 10
   unit:
-    wh_n150_civ2: 226
+    wh_n150_civ2: 232
     wh_n300_civ2: 99
     wh_llmbox: 20
     bh_p150b_civ2: 214
     bh_p300: 69
-    bh_p150b_civ2_viommu: 5
+    bh_p150b_civ2_viommu: 11
     bh_p100a_civ2_viommu: 74
     bh_loudbox: 20
-    wh_galaxy: 35
+    wh_galaxy: 39
   integration:
     wh_n150_civ2: 360
     bh_p150b_civ2: 360

--- a/tech_reports/real_time_profiler/getting-started.md
+++ b/tech_reports/real_time_profiler/getting-started.md
@@ -2,7 +2,7 @@
 
 The **real-time profiler** (RT profiler) streams per-program timing from the device over the existing fast-dispatch path (D2H socket). Each completed program yields a `ProgramRealtimeRecord`: `runtime_id`, raw `start_timestamp` / `end_timestamp`, device `frequency` (cycles per ns), `chip_id`, and `kernel_sources` (paths for that program).
 
-You can register **multiple** callbacks; they run concurrently. If you share a resource between callbacks or across multiple meshes, synchronize it (e.g. with a lock). Use `UnregisterProgramRealtimeProfilerCallback(handle)` when done (Python: `ttnn.device.UnregisterProgramRealtimeProfilerCallback`).
+You can register **multiple** callbacks; they are invoked concurrently. If a callback shares a resource with other callbacks or across multiple meshes, access it in a thread-safe way (e.g. with a lock). Use `UnregisterProgramRealtimeProfilerCallback(handle)` when done (Python: `ttnn.device.UnregisterProgramRealtimeProfilerCallback`).
 
 On some dispatch setups (e.g. ETH dispatch, remote chips without the needed resources) the profiler stays inactive — check `ttnn.device.IsProgramRealtimeProfilerActive()` before asserting on record counts.
 

--- a/tech_reports/real_time_profiler/getting-started.md
+++ b/tech_reports/real_time_profiler/getting-started.md
@@ -2,7 +2,7 @@
 
 The **real-time profiler** (RT profiler) streams per-program timing from the device over the existing fast-dispatch path (D2H socket). Each completed program yields a `ProgramRealtimeRecord`: `runtime_id`, raw `start_timestamp` / `end_timestamp`, device `frequency` (cycles per ns), `chip_id`, and `kernel_sources` (paths for that program).
 
-You can register **multiple** callbacks; they run on the profiler receiver thread in registration order. Use `UnregisterProgramRealtimeProfilerCallback(handle)` when done (Python: `ttnn.device.UnregisterProgramRealtimeProfilerCallback`).
+You can register **multiple** callbacks. Each runs on its own thread, so if multiple callbacks touch the same mutable data, synchronize it (e.g. with a lock). Use `UnregisterProgramRealtimeProfilerCallback(handle)` when done (Python: `ttnn.device.UnregisterProgramRealtimeProfilerCallback`).
 
 On some dispatch setups (e.g. ETH dispatch, remote chips without the needed resources) the profiler stays inactive — check `ttnn.device.IsProgramRealtimeProfilerActive()` before asserting on record counts.
 
@@ -14,27 +14,28 @@ On some dispatch setups (e.g. ETH dispatch, remote chips without the needed reso
 
 ```python
 import json
-import threading
 
 import ttnn
 
 out = open("rt_records.jsonl", "a")
-lock = threading.Lock()
+dropped_total = 0
 
-def on_record(record):
-    row = {
-        "runtime_id": record.runtime_id,
-        "chip_id": record.chip_id,
-        "start_timestamp": record.start_timestamp,
-        "end_timestamp": record.end_timestamp,
-        "frequency": record.frequency,
-        "kernel_sources": list(record.kernel_sources),
-    }
-    with lock:
+def on_record_batch(batch):
+    global dropped_total
+    dropped_total += batch.dropped
+    for record in batch.records:
+        row = {
+            "runtime_id": record.runtime_id,
+            "chip_id": record.chip_id,
+            "start_timestamp": record.start_timestamp,
+            "end_timestamp": record.end_timestamp,
+            "frequency": record.frequency,
+            "kernel_sources": list(record.kernel_sources),
+        }
         out.write(json.dumps(row) + "\n")
-        out.flush()
+    out.flush()
 
-handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(on_record)
+handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(on_record_batch)
 try:
     # open device, run workloads, synchronize...
     pass

--- a/tech_reports/real_time_profiler/getting-started.md
+++ b/tech_reports/real_time_profiler/getting-started.md
@@ -2,7 +2,7 @@
 
 The **real-time profiler** (RT profiler) streams per-program timing from the device over the existing fast-dispatch path (D2H socket). Each completed program yields a `ProgramRealtimeRecord`: `runtime_id`, raw `start_timestamp` / `end_timestamp`, device `frequency` (cycles per ns), `chip_id`, and `kernel_sources` (paths for that program).
 
-You can register **multiple** callbacks. Each runs on its own thread, so if multiple callbacks touch the same mutable data, synchronize it (e.g. with a lock). Use `UnregisterProgramRealtimeProfilerCallback(handle)` when done (Python: `ttnn.device.UnregisterProgramRealtimeProfilerCallback`).
+You can register **multiple** callbacks; they run concurrently. If you share a resource between callbacks or across multiple meshes, synchronize it (e.g. with a lock). Use `UnregisterProgramRealtimeProfilerCallback(handle)` when done (Python: `ttnn.device.UnregisterProgramRealtimeProfilerCallback`).
 
 On some dispatch setups (e.g. ETH dispatch, remote chips without the needed resources) the profiler stays inactive — check `ttnn.device.IsProgramRealtimeProfilerActive()` before asserting on record counts.
 

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -15,7 +15,7 @@
 - name: runtime_fast_dispatch_on_eth
   cmd: |
     [ "$ARCH_NAME" = "wormhole_b0" ] && export TT_METAL_GTEST_ETH_DISPATCH=1
-    ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='-*NIGHTLY_*'
+    ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='-*NIGHTLY_*:RealtimeProfiler*'
   skus:
     wh_n150_civ2:
       timeout: 10
@@ -35,6 +35,16 @@
       timeout: 5
     bh_p150b_civ2:
       timeout: 5
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
+- name: runtime_rt_profiler
+  cmd: ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='RealtimeProfiler*'
+  skus:
+    wh_n150_civ2:
+      timeout: 6
+    bh_p150b_civ2_viommu:
+      timeout: 6
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -366,9 +376,11 @@
       --gtest_filter='UnitMeshCQSingleCardBufferFixture.ShardedBufferLarge*ReadWrites'
     TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch \
       --gtest_filter='UnitMeshMultiCQMultiDevice*Fixture.*'
+    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch \
+      --gtest_filter='RealtimeProfilerStress.*'
   skus:
     wh_galaxy:
-      timeout: 15
+      timeout: 19
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -320,6 +320,7 @@ TEST(RealtimeProfilerSanity, LastProgramRecordDeliveredOnFinish) {
     }
 
     distributed::Finish(mesh_device->mesh_command_queue());
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
     UnregisterProgramRealtimeProfilerCallback(handle);
 
     constexpr uint32_t last_runtime_id = kNumPrograms;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -20,8 +20,8 @@
 
 #include <chrono>
 #include <cstdint>
-#include <mutex>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -47,6 +47,7 @@ namespace {
 using tt::tt_metal::experimental::IsProgramRealtimeProfilerActive;
 using tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle;
 using tt::tt_metal::experimental::ProgramRealtimeRecord;
+using tt::tt_metal::experimental::ProgramRealtimeRecordBatch;
 using tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback;
 using tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback;
 
@@ -137,18 +138,17 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
         GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
     }
 
-    std::mutex records_mu;
     std::vector<ProgramRealtimeRecord> records;
+    uint64_t dropped = 0;
 
     ProgramRealtimeProfilerCallbackHandle handle =
-        RegisterProgramRealtimeProfilerCallback([&records_mu, &records](const ProgramRealtimeRecord& record) {
-            std::lock_guard<std::mutex> lk(records_mu);
-            records.push_back(record);
+        RegisterProgramRealtimeProfilerCallback([&records, &dropped](const ProgramRealtimeRecordBatch& batch) {
+            dropped += batch.dropped;
+            records.insert(records.end(), batch.records.begin(), batch.records.end());
         });
 
     CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();
     CoreRange all_cores(CoreCoord{0, 0}, CoreCoord{compute_grid.x - 1, compute_grid.y - 1});
-
     for (uint32_t i = 0; i < kNumPrograms; ++i) {
         // Runtime IDs start at 1 so every program emits a record (runtime_id == 0
         // is reserved for infrastructure traffic and filtered host-side).
@@ -164,16 +164,11 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
 
     UnregisterProgramRealtimeProfilerCallback(handle);
 
-    std::vector<ProgramRealtimeRecord> collected;
-    {
-        std::lock_guard<std::mutex> lk(records_mu);
-        collected = std::move(records);
-    }
+    ASSERT_GE(records.size(), kNumPrograms)
+        << "Expected at least " << kNumPrograms << " RT profiler records (one per program), got " << records.size();
+    EXPECT_EQ(dropped, 0u);
 
-    ASSERT_GE(collected.size(), kNumPrograms)
-        << "Expected at least " << kNumPrograms << " RT profiler records (one per program), got " << collected.size();
-
-    for (const auto& rec : collected) {
+    for (const auto& rec : records) {
         EXPECT_GT(rec.end_timestamp, rec.start_timestamp)
             << "RT record end_timestamp must be strictly greater than start_timestamp (runtime_id=" << rec.runtime_id
             << ", chip=" << rec.chip_id << ")";
@@ -192,7 +187,7 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
     // Every program embeds "<prefix><runtime_id>" in its source, so we can verify each record carries the correct
     // source.
     std::set<uint32_t> programs_with_correct_sources;
-    for (const auto& rec : collected) {
+    for (const auto& rec : records) {
         if (rec.runtime_id < 1 || rec.runtime_id > kNumPrograms) {
             continue;
         }
@@ -209,8 +204,92 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
     }
     EXPECT_EQ(programs_with_correct_sources.size(), kNumPrograms)
         << "Not every program's source was correctly correlated by runtime ID";
+}
 
+TEST(RealtimeProfilerSanity, CloseDrainsRegisteredCallback) {
+    constexpr int kDeviceId = 0;
+
+    auto mesh_device = distributed::MeshDevice::create_unit_mesh(
+        kDeviceId, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreConfig{DispatchCoreType::WORKER});
+    ASSERT_NE(mesh_device, nullptr);
+
+    if (!IsProgramRealtimeProfilerActive()) {
+        mesh_device->close();
+        GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
+    }
+
+    std::vector<ProgramRealtimeRecord> records;
+    ProgramRealtimeProfilerCallbackHandle handle =
+        RegisterProgramRealtimeProfilerCallback([&records](const ProgramRealtimeRecordBatch& batch) {
+            records.insert(records.end(), batch.records.begin(), batch.records.end());
+        });
+
+    CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();
+    CoreRange all_cores(CoreCoord{0, 0}, CoreCoord{compute_grid.x - 1, compute_grid.y - 1});
+    for (uint32_t i = 0; i < kNumPrograms; ++i) {
+        enqueue_sanity_program(mesh_device, i + 1, all_cores);
+    }
+
+    mesh_device->quiesce_devices();
     EXPECT_TRUE(mesh_device->close());
+
+    UnregisterProgramRealtimeProfilerCallback(handle);
+
+    std::set<uint32_t> observed_runtime_ids;
+    for (const auto& rec : records) {
+        if (rec.runtime_id >= 1 && rec.runtime_id <= kNumPrograms) {
+            observed_runtime_ids.insert(rec.runtime_id);
+        }
+    }
+    EXPECT_EQ(observed_runtime_ids.size(), kNumPrograms)
+        << "Mesh close should drain records for callbacks still registered at shutdown";
+}
+
+TEST(RealtimeProfilerSanity, ThrowingCallbackIsIsolated) {
+    constexpr int kDeviceId = 0;
+
+    auto mesh_device = distributed::MeshDevice::create_unit_mesh(
+        kDeviceId, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreConfig{DispatchCoreType::WORKER});
+    ASSERT_NE(mesh_device, nullptr);
+
+    if (!IsProgramRealtimeProfilerActive()) {
+        mesh_device->close();
+        GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
+    }
+
+    uint64_t throwing_invocations = 0;
+    std::vector<ProgramRealtimeRecord> records;
+    ProgramRealtimeProfilerCallbackHandle throwing_handle =
+        RegisterProgramRealtimeProfilerCallback([&throwing_invocations](const ProgramRealtimeRecordBatch&) {
+            ++throwing_invocations;
+            throw std::runtime_error("intentional callback failure");
+        });
+    ProgramRealtimeProfilerCallbackHandle good_handle =
+        RegisterProgramRealtimeProfilerCallback([&records](const ProgramRealtimeRecordBatch& batch) {
+            records.insert(records.end(), batch.records.begin(), batch.records.end());
+        });
+
+    CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();
+    CoreRange all_cores(CoreCoord{0, 0}, CoreCoord{compute_grid.x - 1, compute_grid.y - 1});
+    for (uint32_t i = 0; i < kNumPrograms; ++i) {
+        enqueue_sanity_program(mesh_device, i + 1, all_cores);
+    }
+
+    mesh_device->quiesce_devices();
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    UnregisterProgramRealtimeProfilerCallback(throwing_handle);
+    UnregisterProgramRealtimeProfilerCallback(good_handle);
+
+    std::set<uint32_t> observed_runtime_ids;
+    for (const auto& rec : records) {
+        if (rec.runtime_id >= 1 && rec.runtime_id <= kNumPrograms) {
+            observed_runtime_ids.insert(rec.runtime_id);
+        }
+    }
+    EXPECT_GT(throwing_invocations, 0u) << "throwing callback should have been invoked";
+    EXPECT_EQ(observed_runtime_ids.size(), kNumPrograms)
+        << "sibling callback must receive every record despite the other callback throwing";
 }
 
 TEST(RealtimeProfilerSanity, LastProgramRecordDeliveredOnFinish) {
@@ -276,12 +355,10 @@ TEST(RealtimeProfilerSanity, TraceReplayResolvesKernelSources) {
         GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
     }
 
-    std::mutex records_mu;
     std::vector<ProgramRealtimeRecord> records;
     ProgramRealtimeProfilerCallbackHandle handle =
-        RegisterProgramRealtimeProfilerCallback([&records_mu, &records](const ProgramRealtimeRecord& record) {
-            std::lock_guard<std::mutex> lk(records_mu);
-            records.push_back(record);
+        RegisterProgramRealtimeProfilerCallback([&records](const ProgramRealtimeRecordBatch& batch) {
+            records.insert(records.end(), batch.records.begin(), batch.records.end());
         });
 
     CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();
@@ -323,15 +400,9 @@ TEST(RealtimeProfilerSanity, TraceReplayResolvesKernelSources) {
     UnregisterProgramRealtimeProfilerCallback(handle);
     mesh_device->release_mesh_trace(trace_id);
 
-    std::vector<ProgramRealtimeRecord> collected;
-    {
-        std::lock_guard<std::mutex> lk(records_mu);
-        collected = std::move(records);
-    }
-
     const std::string expected_marker = kSourceMarkerPrefix + std::to_string(kTraceRuntimeId);
     uint32_t trace_records = 0;
-    for (const auto& rec : collected) {
+    for (const auto& rec : records) {
         if (rec.runtime_id != kTraceRuntimeId) {
             continue;
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -307,9 +307,9 @@ TEST(RealtimeProfilerSanity, LastProgramRecordDeliveredOnFinish) {
     std::mutex records_mu;
     std::vector<ProgramRealtimeRecord> records;
     ProgramRealtimeProfilerCallbackHandle handle =
-        RegisterProgramRealtimeProfilerCallback([&records_mu, &records](const ProgramRealtimeRecord& record) {
+        RegisterProgramRealtimeProfilerCallback([&records_mu, &records](const ProgramRealtimeRecordBatch& batch) {
             std::lock_guard<std::mutex> lk(records_mu);
-            records.push_back(record);
+            records.insert(records.end(), batch.records.begin(), batch.records.end());
         });
 
     CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -20,6 +20,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <mutex>
 #include <set>
 #include <stdexcept>
 #include <string>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -2,37 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Stress test for the real-time (RT) profiler ring buffer (BRISC writer ↔
-// NCRISC pusher). The ring is sized at RT_PROFILER_RING_CAPACITY = 4096
-// entries (see realtime_profiler_ring_buffer.hpp). Under a normal workload
-// NCRISC pushes each entry to the host over PCIe in ~50–80 µs, while BRISC
-// can write an entry in ~0.3 µs once dispatch_s flips the mailbox state.
-// That ~150× imbalance is what makes the BRISC↔NCRISC handshake worth
-// stress-testing: if we slam BRISC with thousands of program launches faster
-// than NCRISC can drain, BRISC must spin in `rt_ring_full` without dropping
-// records or wedging dispatch_s. This test forces exactly that scenario by
-// capturing a trace of 4096 blank-kernel program launches and replaying it
-// in one go (no host-side throttling between launches).
+// Stress test for the real-time (RT) profiler. If NCRISC or the host receiver can't drain as fast as
+// BRISC produces, the device ring fills and BRISC drops records.
 //
-// What the test buys us:
-//   * Catches BRISC dropping records when the ring is full (off-by-one in
-//     rt_ring_full / write_index wraparound).
-//   * Catches NCRISC livelock under sustained back-pressure (host receiver
-//     thread keeps up with steady-state push rate).
-//   * Catches dispatch_s stalling because the RT-profiler mailbox handshake
-//     gets wedged (e.g. BRISC stuck in rt_ring_full would block dispatch_s
-//     from firing the next launch via the shared mailbox).
-//
-// The kernel is intentionally as small as possible (literal `void
-// kernel_main() {}`) so dispatch overhead dominates and BRISC is fed at the
-// peak rate dispatch_s can sustain in a trace replay. Mirrors the placement
-// pattern in test_realtime_profiler_sanity.cpp (BASIC tier, single MMIO
-// device, gracefully skips when RT profiler is disabled).
+// The drain path is expected to absorb peak dispatch without backing up. This test replays a 4096 blank-kernel trace
+// back-to-back to feed BRISC at the peak rate dispatch_s can sustain, then asserts every record arrived, the device
+// ring never filled, the host D2H FIFO never filled, and there was no timestamp corruption.
 
 #include <algorithm>
+#include <atomic>
+#include <array>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
-#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -52,12 +34,16 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/experimental/realtime_profiler.hpp>
 
+#include "tt_metal/common/env_lib.hpp"
+#include "tt_metal/distributed/realtime_profiler_manager.hpp"
+#include "tt_metal/distributed/mesh_device_impl.hpp"
+
 namespace tt::tt_metal {
 namespace {
 
 using tt::tt_metal::experimental::IsProgramRealtimeProfilerActive;
 using tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle;
-using tt::tt_metal::experimental::ProgramRealtimeRecord;
+using tt::tt_metal::experimental::ProgramRealtimeRecordBatch;
 using tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback;
 using tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback;
 
@@ -67,6 +53,10 @@ using tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback;
 // takes NCRISC to push 1–2 entries over PCIe, so by enqueue ~80 of 4096
 // the ring is at capacity and stays there for the rest of the trace.
 constexpr uint32_t kNumProgramsInTrace = 4096;
+
+constexpr uint32_t kDefaultStressReplaySeconds = 60;
+
+constexpr uint32_t kDefaultDropAccountingSeconds = 15;
 
 // Trace stores one EnqueueProgram dispatch packet per program. Blank-kernel
 // programs with no CBs / no runtime args are tiny (~hundreds of bytes), so
@@ -146,19 +136,26 @@ distributed::MeshWorkload build_blank_kernel_workload(const std::shared_ptr<dist
     return workload;
 }
 
-TEST(RealtimeProfilerStress, RingBufferOverflowFromTrace) {
-    constexpr int kDeviceId = 0;
-
-    auto mesh_device = distributed::MeshDevice::create_unit_mesh(
-        kDeviceId,
+std::shared_ptr<distributed::MeshDevice> open_full_mesh() {
+    return distributed::MeshDevice::create(
+        distributed::MeshDeviceConfig(std::nullopt),
         DEFAULT_L1_SMALL_SIZE,
         kTraceRegionSize,
-        /*num_command_queues=*/1,
+        1,
         DispatchCoreConfig{DispatchCoreType::WORKER});
+}
+
+std::shared_ptr<distributed::MeshDevice> open_unit_mesh() {
+    return distributed::MeshDevice::create_unit_mesh(
+        0, DEFAULT_L1_SMALL_SIZE, kTraceRegionSize, 1, DispatchCoreConfig{DispatchCoreType::WORKER});
+}
+
+TEST(RealtimeProfilerStress, NIGHTLY_PeakLoadPreservesRecords) {
+    auto mesh_device = open_full_mesh();
     ASSERT_NE(mesh_device, nullptr);
 
     // RT profiler activation is decided during the init-sync handshake at
-    // mesh open, so by the time create_unit_mesh returns this query is
+    // mesh open, so by the time the mesh is opened this query is
     // stable. When false, the dispatch config (ETH dispatch, non-MMIO
     // chip, kernels nullified, no valid RT core, worker_l1_size shrunk
     // below the ring size, ...) leaves RT profiler off; the test has
@@ -167,23 +164,52 @@ TEST(RealtimeProfilerStress, RingBufferOverflowFromTrace) {
         mesh_device->close();
         GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
     }
+    const auto* rt = mesh_device->impl().get_realtime_profiler();
+    ASSERT_NE(rt, nullptr);
+    const uint64_t num_active_devices = rt->num_active_devices();
 
-    std::mutex records_mu;
-    std::vector<ProgramRealtimeRecord> records;
-    records.reserve(kNumProgramsInTrace);
-
+    uint64_t stress_records = 0;
+    uint64_t startup_race_skips = 0;
+    uint64_t large_negative_skips = 0;
+    uint64_t bad_frequency = 0;
+    uint64_t implausible_duration = 0;
+    int64_t worst_negative_delta = 0;
+    uint64_t max_callback_batch = 0;
     ProgramRealtimeProfilerCallbackHandle handle =
-        RegisterProgramRealtimeProfilerCallback([&records_mu, &records](const ProgramRealtimeRecord& record) {
-            std::lock_guard<std::mutex> lk(records_mu);
-            records.push_back(record);
+        RegisterProgramRealtimeProfilerCallback([&](const ProgramRealtimeRecordBatch& batch) {
+            max_callback_batch = std::max<uint64_t>(max_callback_batch, batch.records.size());
+            for (const auto& rec : batch.records) {
+                if (rec.runtime_id != kStressRuntimeId) {
+                    continue;
+                }
+                ++stress_records;
+                if (rec.end_timestamp < rec.start_timestamp) {
+                    const uint64_t neg_delta = rec.start_timestamp - rec.end_timestamp;
+                    if (neg_delta <= kStartupRaceSlackCycles) {
+                        ++startup_race_skips;
+                    } else {
+                        ++large_negative_skips;
+                        worst_negative_delta = std::min(-static_cast<int64_t>(neg_delta), worst_negative_delta);
+                    }
+                }
+                if (!(rec.frequency > 0.0)) {
+                    ++bad_frequency;
+                } else if (rec.end_timestamp >= rec.start_timestamp) {
+                    const double duration_ns =
+                        static_cast<double>(rec.end_timestamp - rec.start_timestamp) / rec.frequency;
+                    if (duration_ns >= kMaxStressDurationNs) {
+                        ++implausible_duration;
+                    }
+                }
+            }
         });
 
     distributed::MeshWorkload workload = build_blank_kernel_workload(mesh_device);
-    auto& mesh_command_queue = mesh_device->mesh_command_queue(0);
+    auto& cq = mesh_device->mesh_command_queue(0);
 
     // Compile + warm up the workload outside the trace capture so the trace
     // contains only steady-state dispatch packets (no compile/upload hops).
-    distributed::EnqueueMeshWorkload(mesh_command_queue, workload, /*blocking=*/true);
+    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
     // Capture: 4096 back-to-back EnqueueMeshWorkload calls of the same
     // blank-kernel workload. Reusing one workload (vs. building 4096
@@ -191,107 +217,67 @@ TEST(RealtimeProfilerStress, RingBufferOverflowFromTrace) {
     // memory pressure; the dispatch commands captured in the trace are
     // independent per-enqueue, so dispatch_s still fires 4096 separate
     // kernel_start pulses on replay.
-    distributed::MeshTraceId trace_id = distributed::BeginTraceCapture(mesh_device.get(), mesh_command_queue.id());
+    distributed::MeshTraceId trace_id = distributed::BeginTraceCapture(mesh_device.get(), cq.id());
     for (uint32_t i = 0; i < kNumProgramsInTrace; ++i) {
-        distributed::EnqueueMeshWorkload(mesh_command_queue, workload, /*blocking=*/false);
+        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
     }
-    mesh_device->end_mesh_trace(mesh_command_queue.id(), trace_id);
+    mesh_device->end_mesh_trace(cq.id(), trace_id);
 
-    // Replay the entire 4096-launch trace as a single blocking dispatch.
-    // No host-side per-launch overhead between programs => peak BRISC feed
-    // rate, ring saturates within the first few dozen launches.
-    mesh_device->replay_mesh_trace(mesh_command_queue.id(), trace_id, /*blocking=*/true);
+    const std::chrono::seconds replay_window(
+        tt::parse_env<std::uint32_t>("TT_RT_PROFILER_SATURATION_SECONDS", kDefaultStressReplaySeconds));
+    uint64_t num_replays = 0;
+    const auto replay_deadline = std::chrono::steady_clock::now() + replay_window;
+    do {
+        mesh_device->replay_mesh_trace(cq.id(), trace_id, true);
+        ++num_replays;
+    } while (std::chrono::steady_clock::now() < replay_deadline);
 
     mesh_device->quiesce_devices();
     std::this_thread::sleep_for(kPostQuiesceDrain);
-
+    const uint32_t peak_fifo_pages = rt->peak_fifo_pages();
+    const uint32_t fifo_capacity_pages = rt->host_fifo_capacity_pages();
+    const uint32_t ring_full_waits = rt->ring_full_wait_count();
+    const uint64_t published_batches = rt->num_published_batches();
+    const double mean_publish_batch =
+        published_batches ? static_cast<double>(rt->num_published_records()) / published_batches : 0.0;
     UnregisterProgramRealtimeProfilerCallback(handle);
     mesh_device->release_mesh_trace(trace_id);
 
-    std::vector<ProgramRealtimeRecord> collected;
-    {
-        std::lock_guard<std::mutex> lk(records_mu);
-        collected = std::move(records);
-    }
-
-    // Filter to records produced by this test's workload. The +1 warmup
-    // launch we did before BeginTraceCapture also lands in this bucket, so
-    // we expect at least kNumProgramsInTrace + 1 matching records. Compare
-    // with >= because infrastructure traffic on a freshly-opened mesh can
-    // emit a handful of extra non-stress records before our callback was
-    // hooked up.
-    uint32_t stress_records = 0;
-    for (const auto& rec : collected) {
-        if (rec.runtime_id == kStressRuntimeId) {
-            ++stress_records;
-        }
-    }
-
-    ASSERT_GE(stress_records, kNumProgramsInTrace)
-        << "Expected at least " << kNumProgramsInTrace
-        << " RT profiler records for the stress workload (one per traced launch); got " << stress_records
-        << " stress records out of " << collected.size() << " total. A shortfall here means BRISC dropped entries "
-        << "under sustained back-pressure or NCRISC stopped pushing partway through the trace.";
-
-    // Every record must have well-formed timestamps + frequency. Under
-    // ring-full back-pressure BRISC writes the timestamp slot _before_
-    // bumping write_index, so a torn read on the host side or a stale slot
-    // re-used after wraparound would surface as a large negative delta or
-    // freq <= 0.
-    //
-    // We classify end_timestamp < start_timestamp records into two buckets:
-    //   * startup_race_skips: |delta| <= kStartupRaceSlackCycles.
-    //     These are the documented dispatch_d/dispatch_s startup race;
-    //     freely tolerated, just counted for visibility.
-    //   * large_negative_skips: |delta| > kStartupRaceSlackCycles.
-    //     These are torn 64-bit reads / stale-slot residue. The production
-    //     Tracy handler already silently drops them
-    //     (realtime_profiler_tracy_handler.cpp::HandleRecord), so we tolerate
-    //     them up to kMaxBadTimestampFraction of total stress records and
-    //     fail above that — catching a regression where the corruption rate
-    //     becomes systemic instead of a rare blip.
-    uint32_t startup_race_skips = 0;
-    uint32_t large_negative_skips = 0;
-    uint32_t bad_frequency = 0;
-    uint32_t implausible_duration = 0;
-    int64_t worst_negative_delta = 0;
-    for (const auto& rec : collected) {
-        if (rec.runtime_id != kStressRuntimeId) {
-            continue;
-        }
-        if (rec.end_timestamp < rec.start_timestamp) {
-            const uint64_t neg_delta_cycles = rec.start_timestamp - rec.end_timestamp;
-            if (neg_delta_cycles <= kStartupRaceSlackCycles) {
-                ++startup_race_skips;
-            } else {
-                ++large_negative_skips;
-                worst_negative_delta = std::min(-static_cast<int64_t>(neg_delta_cycles), worst_negative_delta);
-            }
-        }
-        if (!(rec.frequency > 0.0)) {
-            ++bad_frequency;
-        } else if (rec.end_timestamp >= rec.start_timestamp) {
-            const uint64_t duration_cycles = rec.end_timestamp - rec.start_timestamp;
-            const double duration_ns = static_cast<double>(duration_cycles) / rec.frequency;
-            if (duration_ns >= kMaxStressDurationNs) {
-                ++implausible_duration;
-            }
-        }
-    }
+    const uint64_t expected_stress_records =
+        static_cast<uint64_t>(kNumProgramsInTrace) * num_replays * num_active_devices;
 
     log_info(
         tt::LogTest,
-        "[RT profiler stress] {} stress records, {} startup-race skips, {} large-negative-delta skips "
-        "(worst delta = {} cycles), {} bad-frequency, {} implausible-duration",
+        "[RT profiler stress] {} stress records across {} active device(s) over {} replays, max_callback_batch={}, "
+        "mean_publish_batch={:.1f}, peak_fifo={}/{} pages, ring_full_waits={}, {} startup-race skips, {} "
+        "large-negative-delta skips (worst delta = {} cycles), {} bad-frequency, {} implausible-duration",
         stress_records,
+        num_active_devices,
+        num_replays,
+        max_callback_batch,
+        mean_publish_batch,
+        peak_fifo_pages,
+        fifo_capacity_pages,
+        ring_full_waits,
         startup_race_skips,
         large_negative_skips,
         worst_negative_delta,
         bad_frequency,
         implausible_duration);
 
-    const uint32_t max_allowed_large_negative =
-        static_cast<uint32_t>(static_cast<double>(stress_records) * kMaxBadTimestampFraction);
+    ASSERT_GE(stress_records, expected_stress_records)
+        << "expected one record per program run: " << kNumProgramsInTrace << " programs per replay x " << num_replays
+        << " replays x " << num_active_devices
+        << " active device(s). A shortfall means profiler records were dropped at some point in the pipeline.";
+
+    EXPECT_LT(peak_fifo_pages, fifo_capacity_pages)
+        << "host D2H FIFO reached capacity; the receiver drained it slower than the device filled it";
+
+    EXPECT_EQ(ring_full_waits, 0u)
+        << "device ring reached capacity; the receiver drained it slower than the device filled it";
+
+    const uint64_t max_allowed_large_negative =
+        static_cast<uint64_t>(static_cast<double>(stress_records) * kMaxBadTimestampFraction);
     EXPECT_LE(large_negative_skips, max_allowed_large_negative)
         << large_negative_skips << " stress record(s) had end_timestamp < start_timestamp by more than "
         << kStartupRaceSlackCycles << " cycles, exceeding the allowed budget of " << max_allowed_large_negative
@@ -304,6 +290,304 @@ TEST(RealtimeProfilerStress, RingBufferOverflowFromTrace) {
     EXPECT_EQ(implausible_duration, 0u) << implausible_duration
                                         << " stress record(s) reported duration >= " << kMaxStressDurationNs
                                         << " ns (clock corruption / mis-decoded timestamp)";
+
+    EXPECT_TRUE(mesh_device->close());
+}
+
+TEST(RealtimeProfilerStress, NIGHTLY_CallbackDeliveryLatency) {
+    using namespace std::chrono_literals;
+    constexpr uint32_t kPacedId = 0x6AC0;
+    constexpr std::array<std::chrono::microseconds, 5> kGaps = {5us, 50us, 200us, 1000us, 5000us};
+    constexpr uint32_t kOpsPerGap = 100;
+    constexpr double kMaxPacedOverheadP50Us = 400.0;
+    constexpr double kMaxPacedOverheadP99Us = 1'000.0;
+
+    constexpr uint32_t num_gaps = static_cast<uint32_t>(kGaps.size());
+    constexpr uint32_t total_paced = kOpsPerGap * num_gaps;
+
+    auto mesh_device = open_unit_mesh();
+    ASSERT_NE(mesh_device, nullptr);
+    if (!IsProgramRealtimeProfilerActive()) {
+        mesh_device->close();
+        GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
+    }
+
+    std::vector<std::chrono::steady_clock::time_point> paced_enqueued(total_paced);
+    std::vector<std::atomic<std::chrono::steady_clock::rep>> paced_delivered(total_paced);
+    std::atomic<uint64_t> paced_idx{0};
+    std::atomic<uint64_t> dropped_total{0};
+
+    ProgramRealtimeProfilerCallbackHandle handle =
+        RegisterProgramRealtimeProfilerCallback([&](const ProgramRealtimeRecordBatch& batch) {
+            dropped_total.fetch_add(batch.dropped, std::memory_order_relaxed);
+            const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+            for (const auto& rec : batch.records) {
+                if (rec.runtime_id == kPacedId) {
+                    const uint64_t idx = paced_idx.fetch_add(1, std::memory_order_relaxed);
+                    if (idx < total_paced) {
+                        paced_delivered[idx].store(now, std::memory_order_relaxed);
+                    }
+                }
+            }
+        });
+
+    distributed::MeshWorkload workload = build_blank_kernel_workload(mesh_device);
+    auto& cq = mesh_device->mesh_command_queue(0);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    for (auto& [_, prog] : workload.get_programs()) {
+        prog.set_runtime_id(static_cast<uint64_t>(kPacedId));
+    }
+    distributed::MeshTraceId paced_trace = distributed::BeginTraceCapture(mesh_device.get(), cq.id());
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    mesh_device->end_mesh_trace(cq.id(), paced_trace);
+
+    uint32_t k = 0;
+    for (uint32_t gap_idx = 0; gap_idx < num_gaps; ++gap_idx) {
+        mesh_device->quiesce_devices();
+        const auto gap = kGaps[gap_idx];
+        const auto bucket_start = std::chrono::steady_clock::now();
+        for (uint32_t i = 0; i < kOpsPerGap; ++i) {
+            while (std::chrono::steady_clock::now() < bucket_start + gap * i) {
+            }
+            mesh_device->replay_mesh_trace(cq.id(), paced_trace, false);
+            paced_enqueued[k] = std::chrono::steady_clock::now();
+            ++k;
+        }
+    }
+
+    mesh_device->quiesce_devices();
+    std::this_thread::sleep_for(kPostQuiesceDrain);
+    UnregisterProgramRealtimeProfilerCallback(handle);
+    mesh_device->release_mesh_trace(paced_trace);
+
+    auto percentile = [](std::vector<double>& v, double p) {
+        if (v.empty()) {
+            return 0.0;
+        }
+        std::sort(v.begin(), v.end());
+        return v[std::min(v.size() - 1, static_cast<size_t>(std::lround(p * static_cast<double>(v.size() - 1))))];
+    };
+
+    const uint64_t paced_matched = std::min<uint64_t>(paced_idx.load(), total_paced);
+    double worst_paced_overhead_p50_us = 0.0;
+    double worst_paced_overhead_p99_us = 0.0;
+    for (uint32_t gap_idx = 0; gap_idx < num_gaps; ++gap_idx) {
+        std::vector<double> overhead_us;
+        overhead_us.reserve(kOpsPerGap);
+        for (uint32_t i = 0; i < kOpsPerGap; ++i) {
+            const uint32_t idx = gap_idx * kOpsPerGap + i;
+            const auto d = paced_delivered[idx].load(std::memory_order_relaxed);
+            if (d == 0) {
+                continue;
+            }
+            const auto delivered_tp = std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(d));
+            const double lat = std::chrono::duration<double, std::micro>(delivered_tp - paced_enqueued[idx]).count();
+            overhead_us.push_back(std::max(0.0, lat - static_cast<double>(kGaps[gap_idx].count())));
+        }
+        const double ov_p50 = percentile(overhead_us, 0.50);
+        const double ov_p99 = percentile(overhead_us, 0.99);
+        worst_paced_overhead_p50_us = std::max(worst_paced_overhead_p50_us, ov_p50);
+        worst_paced_overhead_p99_us = std::max(worst_paced_overhead_p99_us, ov_p99);
+        log_info(
+            tt::LogTest,
+            "[RT profiler stress] gap={:5}us | overhead p50={:.1f} p99={:.1f} max={:.1f}us",
+            kGaps[gap_idx].count(),
+            ov_p50,
+            ov_p99,
+            percentile(overhead_us, 1.0));
+    }
+
+    EXPECT_EQ(dropped_total.load(), 0u)
+        << "callback dropped records; deliveries are paired to enqueues by position, so a drop misaligns every "
+        << "later pair and the latencies below are meaningless";
+    EXPECT_GE(paced_matched, total_paced - total_paced / 100)
+        << "too few of the " << total_paced << " paced ops reached the callback; the latency percentiles "
+        << "below are over a partial sample and unreliable";
+    EXPECT_LT(worst_paced_overhead_p50_us, kMaxPacedOverheadP50Us)
+        << "median delivery overhead too high; the consumer is not waking promptly (a fixed "
+        << "backoff/oversleep would show up here)";
+    EXPECT_LT(worst_paced_overhead_p99_us, kMaxPacedOverheadP99Us)
+        << "tail delivery overhead too high; occasional long stalls in the delivery path";
+    EXPECT_TRUE(mesh_device->close());
+}
+
+// Three consumers read the same record stream at different throttled rates. Verifies the per-reader
+// drop accounting: for every consumer, received + dropped covers every record produced, and a
+// throttled consumer drops no more than its sustain rate forces (no over-dropping).
+TEST(RealtimeProfilerStress, NIGHTLY_ConsumerDropAccountingUnderLoad) {
+    const std::chrono::seconds run_window(
+        tt::parse_env<std::uint32_t>("TT_RT_PROFILER_DROP_ACCOUNTING", kDefaultDropAccountingSeconds));
+
+    auto mesh_device = open_full_mesh();
+    ASSERT_NE(mesh_device, nullptr);
+    if (!IsProgramRealtimeProfilerActive()) {
+        mesh_device->close();
+        GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
+    }
+    const uint64_t num_devices = mesh_device->num_devices();
+    const auto* rt = mesh_device->impl().get_realtime_profiler();
+    ASSERT_NE(rt, nullptr);
+
+    distributed::MeshWorkload workload = build_blank_kernel_workload(mesh_device);
+    auto& cq = mesh_device->mesh_command_queue(0);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    distributed::MeshTraceId trace_id = distributed::BeginTraceCapture(mesh_device.get(), cq.id());
+    for (uint32_t i = 0; i < kNumProgramsInTrace; ++i) {
+        distributed::EnqueueMeshWorkload(cq, workload, false);
+    }
+    mesh_device->end_mesh_trace(cq.id(), trace_id);
+
+    constexpr auto kCalibrationWindow = std::chrono::seconds(2);
+    const uint64_t pubs_before = rt->num_published_records();
+    const auto cal_start = std::chrono::steady_clock::now();
+    const auto cal_deadline = cal_start + kCalibrationWindow;
+    while (std::chrono::steady_clock::now() < cal_deadline) {
+        mesh_device->replay_mesh_trace(cq.id(), trace_id, true);
+    }
+    const double cal_seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - cal_start).count();
+    const double production_rate = static_cast<double>(rt->num_published_records() - pubs_before) / cal_seconds;
+    ASSERT_GT(production_rate, 0.0) << "no records produced during calibration";
+    mesh_device->quiesce_devices();
+
+    // fraction of the production rate each consumer can sustain
+    constexpr double kBorderlineSustainFraction = 0.95;
+    constexpr double kSlowSustainFraction = 0.1;
+
+    const auto borderline_per_record =
+        std::chrono::nanoseconds(static_cast<int64_t>(1e9 / (production_rate * kBorderlineSustainFraction)));
+    const auto slow_per_record =
+        std::chrono::nanoseconds(static_cast<int64_t>(1e9 / (production_rate * kSlowSustainFraction)));
+    log_info(
+        tt::LogTest,
+        "[RT profiler stress] measured production {:.0f} rec/s across {} device(s); borderline={}ns/rec slow={}ns/rec",
+        production_rate,
+        num_devices,
+        borderline_per_record.count(),
+        slow_per_record.count());
+
+    struct Counters {
+        std::atomic<uint64_t> received{0};
+        std::atomic<uint64_t> dropped{0};
+    };
+    Counters keeps_up;
+    Counters borderline;
+    Counters slow;
+
+    auto make_consumer = [](Counters& c, std::chrono::nanoseconds per_record) {
+        return [&c, per_record, start = std::chrono::steady_clock::time_point{}, paced = uint64_t{0}](
+                   const ProgramRealtimeRecordBatch& batch) mutable {
+            c.received.fetch_add(batch.records.size(), std::memory_order_relaxed);
+            c.dropped.fetch_add(batch.dropped, std::memory_order_relaxed);
+            if (per_record == std::chrono::nanoseconds::zero()) {
+                return;
+            }
+            if (paced == 0) {
+                start = std::chrono::steady_clock::now();
+            }
+            paced += batch.records.size();
+            const auto deadline = start + per_record * paced;
+            while (std::chrono::steady_clock::now() < deadline) {
+            }
+        };
+    };
+
+    ProgramRealtimeProfilerCallbackHandle h_keeps_up =
+        RegisterProgramRealtimeProfilerCallback(make_consumer(keeps_up, std::chrono::nanoseconds::zero()));
+    ProgramRealtimeProfilerCallbackHandle h_borderline =
+        RegisterProgramRealtimeProfilerCallback(make_consumer(borderline, borderline_per_record));
+    ProgramRealtimeProfilerCallbackHandle h_slow =
+        RegisterProgramRealtimeProfilerCallback(make_consumer(slow, slow_per_record));
+
+    const auto run_deadline = std::chrono::steady_clock::now() + run_window;
+    while (std::chrono::steady_clock::now() < run_deadline) {
+        mesh_device->replay_mesh_trace(cq.id(), trace_id, true);
+    }
+
+    mesh_device->quiesce_devices();
+    std::this_thread::sleep_for(kPostQuiesceDrain);
+
+    const uint32_t peak_fifo_pages = rt->peak_fifo_pages();
+    const uint32_t fifo_capacity_pages = rt->host_fifo_capacity_pages();
+    const uint64_t published_batches = rt->num_published_batches();
+    const double mean_publish_batch =
+        published_batches ? static_cast<double>(rt->num_published_records()) / published_batches : 0.0;
+
+    const uint64_t keeps_up_received = keeps_up.received.load();
+    const uint64_t keeps_up_dropped = keeps_up.dropped.load();
+    ASSERT_GT(keeps_up_received, 0u) << "no records delivered; cannot assess accounting";
+    ASSERT_EQ(keeps_up_dropped, 0u)
+        << "unthrottled consumer dropped; it does no per-record work, so this likely means host contention "
+        << "starved its callback thread";
+
+    auto accounted = [](const Counters& c) { return c.received.load() + c.dropped.load(); };
+    auto wait_until_accounted = [&accounted](const Counters& c, uint64_t target) {
+        const auto give_up = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (accounted(c) < target && std::chrono::steady_clock::now() < give_up) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    };
+    wait_until_accounted(borderline, keeps_up_received);
+    wait_until_accounted(slow, keeps_up_received);
+
+    const uint64_t borderline_received = borderline.received.load();
+    const uint64_t borderline_dropped = borderline.dropped.load();
+    const uint64_t slow_received = slow.received.load();
+    const uint64_t slow_dropped = slow.dropped.load();
+    const uint64_t borderline_total = borderline_received + borderline_dropped;
+    const uint64_t slow_total = slow_received + slow_dropped;
+
+    log_info(
+        tt::LogTest,
+        "[RT profiler stress] devices={} total={} peak_fifo={}/{} pages mean_publish_batch={:.1f} | "
+        "borderline: recv={} drop={} sum={} | slow: recv={} drop={} sum={}",
+        num_devices,
+        keeps_up_received,
+        peak_fifo_pages,
+        fifo_capacity_pages,
+        mean_publish_batch,
+        borderline_received,
+        borderline_dropped,
+        borderline_total,
+        slow_received,
+        slow_dropped,
+        slow_total);
+
+    UnregisterProgramRealtimeProfilerCallback(h_keeps_up);
+    UnregisterProgramRealtimeProfilerCallback(h_borderline);
+    UnregisterProgramRealtimeProfilerCallback(h_slow);
+    mesh_device->release_mesh_trace(trace_id);
+
+    EXPECT_LT(peak_fifo_pages, fifo_capacity_pages)
+        << "host D2H FIFO reached capacity; the receiver drained it slower than the device filled it";
+
+    EXPECT_EQ(borderline_total, keeps_up_received) << "borderline consumer lost or double-counted records";
+    EXPECT_EQ(slow_total, keeps_up_received) << "slow consumer lost or double-counted records";
+    EXPECT_LE(borderline_dropped, slow_dropped)
+        << "the faster (borderline) consumer dropped more than the slower one; impossible unless the ring is "
+        << "misattributing drops between the two readers";
+
+    constexpr double kMaxDeliveryShortfall = 0.2;
+    constexpr double kMinOverdropTolerance = 0.03;
+    auto expect_no_overdrop =
+        [kMinOverdropTolerance](const char* name, uint64_t dropped, uint64_t total, double sustain_fraction) {
+            const double drop_frac = static_cast<double>(dropped) / static_cast<double>(total);
+            const double max_drop =
+                (1.0 - sustain_fraction) + std::max(kMinOverdropTolerance, sustain_fraction * kMaxDeliveryShortfall);
+            log_info(
+                tt::LogTest,
+                "[RT profiler stress] {} dropped {:.1f}% (over-drop limit {:.1f}%, {} of {})",
+                name,
+                100.0 * drop_frac,
+                100.0 * max_drop,
+                dropped,
+                total);
+            EXPECT_LE(drop_frac, max_drop)
+                << name << " dropped past the over-drop limit; the ring overwrote records it had capacity to take";
+        };
+    expect_no_overdrop("borderline", borderline_dropped, borderline_total, kBorderlineSustainFraction);
+    expect_no_overdrop("slow", slow_dropped, slow_total, kSlowSustainFraction);
 
     EXPECT_TRUE(mesh_device->close());
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -56,7 +56,7 @@ constexpr uint32_t kNumProgramsInTrace = 4096;
 
 constexpr uint32_t kDefaultStressReplaySeconds = 60;
 
-constexpr uint32_t kDefaultDropAccountingSeconds = 15;
+constexpr uint32_t kDefaultDropAccountingSeconds = 60;
 
 // Trace stores one EnqueueProgram dispatch packet per program. Blank-kernel
 // programs with no CBs / no runtime args are tiny (~hundreds of bytes), so
@@ -147,7 +147,7 @@ std::shared_ptr<distributed::MeshDevice> open_unit_mesh() {
         0, DEFAULT_L1_SMALL_SIZE, kTraceRegionSize, 1, DispatchCoreConfig{DispatchCoreType::WORKER});
 }
 
-TEST(RealtimeProfilerStress, NIGHTLY_PeakLoadPreservesRecords) {
+TEST(RealtimeProfilerStress, PeakLoadPreservesRecords) {
     auto mesh_device = open_full_mesh();
     ASSERT_NE(mesh_device, nullptr);
 
@@ -291,7 +291,7 @@ TEST(RealtimeProfilerStress, NIGHTLY_PeakLoadPreservesRecords) {
     EXPECT_TRUE(mesh_device->close());
 }
 
-TEST(RealtimeProfilerStress, NIGHTLY_CallbackDeliveryLatency) {
+TEST(RealtimeProfilerStress, CallbackDeliveryLatency) {
     using namespace std::chrono_literals;
     constexpr uint32_t kPacedId = 0x6AC0;
     constexpr std::array<std::chrono::microseconds, 5> kGaps = {5us, 50us, 200us, 1000us, 5000us};
@@ -412,7 +412,7 @@ TEST(RealtimeProfilerStress, NIGHTLY_CallbackDeliveryLatency) {
 // Three consumers read the same record stream at different throttled rates. Verifies the per-reader
 // drop accounting: for every consumer, received + dropped covers every record produced, and a
 // throttled consumer drops no more than its sustain rate forces (no over-dropping).
-TEST(RealtimeProfilerStress, NIGHTLY_ConsumerDropAccountingUnderLoad) {
+TEST(RealtimeProfilerStress, ConsumerDropAccountingUnderLoad) {
     const std::chrono::seconds run_window(
         tt::parse_env<std::uint32_t>("TT_RT_PROFILER_DROP_ACCOUNTING", kDefaultDropAccountingSeconds));
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -296,8 +296,8 @@ TEST(RealtimeProfilerStress, CallbackDeliveryLatency) {
     constexpr uint32_t kPacedId = 0x6AC0;
     constexpr std::array<std::chrono::microseconds, 5> kGaps = {5us, 50us, 200us, 1000us, 5000us};
     constexpr uint32_t kOpsPerGap = 100;
-    constexpr double kMaxPacedOverheadP50Us = 400.0;
-    constexpr double kMaxPacedOverheadP99Us = 1'000.0;
+    constexpr double kMaxPacedOverheadP50Us = 500.0;
+    constexpr double kMaxPacedOverheadP99Us = 20'000.0;
 
     constexpr uint32_t num_gaps = static_cast<uint32_t>(kGaps.size());
     constexpr uint32_t total_paced = kOpsPerGap * num_gaps;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -80,10 +80,7 @@ constexpr uint32_t kStressRuntimeId = 0xBEEFu;
 // in anonymous namespaces would collide at compile time.
 constexpr double kMaxStressDurationNs = 1'000'000'000.0;
 
-// Quiesce + drain window before unregistering the callback. Mirrors the
-// 500ms used in test_realtime_profiler_sanity.cpp; bumped to 2s here
-// because at 4096 entries × ~50–80 µs/push the worst-case drain is
-// ~250–330 ms (ring fully backed up at trace replay completion).
+// Quiesce + drain window before unregistering the callback.
 constexpr auto kPostQuiesceDrain = std::chrono::milliseconds(2000);
 
 // Allowed slack for the deterministic startup race where the compute kernel

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -75,9 +75,6 @@ constexpr uint32_t kStressRuntimeId = 0xBEEFu;
 // kernel_start/end pulse spread by at least a handful of cycles, but it
 // should never be in the millisecond range. Anything beyond 1s means a
 // timestamp got corrupted (e.g. wraparound, swapped halves) under load.
-// Named distinctly from kMaxDurationNs in test_realtime_profiler_sanity.cpp
-// because both files share a Unity build TU and identically-named constants
-// in anonymous namespaces would collide at compile time.
 constexpr double kMaxStressDurationNs = 1'000'000'000.0;
 
 // Quiesce + drain window before unregistering the callback.
@@ -140,11 +137,6 @@ std::shared_ptr<distributed::MeshDevice> open_full_mesh() {
         kTraceRegionSize,
         1,
         DispatchCoreConfig{DispatchCoreType::WORKER});
-}
-
-std::shared_ptr<distributed::MeshDevice> open_unit_mesh() {
-    return distributed::MeshDevice::create_unit_mesh(
-        0, DEFAULT_L1_SMALL_SIZE, kTraceRegionSize, 1, DispatchCoreConfig{DispatchCoreType::WORKER});
 }
 
 TEST(RealtimeProfilerStress, PeakLoadPreservesRecords) {
@@ -288,124 +280,6 @@ TEST(RealtimeProfilerStress, PeakLoadPreservesRecords) {
                                         << " stress record(s) reported duration >= " << kMaxStressDurationNs
                                         << " ns (clock corruption / mis-decoded timestamp)";
 
-    EXPECT_TRUE(mesh_device->close());
-}
-
-TEST(RealtimeProfilerStress, CallbackDeliveryLatency) {
-    using namespace std::chrono_literals;
-    constexpr uint32_t kPacedId = 0x6AC0;
-    constexpr std::array<std::chrono::microseconds, 5> kGaps = {5us, 50us, 200us, 1000us, 5000us};
-    constexpr uint32_t kOpsPerGap = 100;
-    constexpr double kMaxPacedOverheadP50Us = 20'000.0;
-    constexpr double kMaxPacedOverheadP99Us = 50'000.0;
-
-    constexpr uint32_t num_gaps = static_cast<uint32_t>(kGaps.size());
-    constexpr uint32_t total_paced = kOpsPerGap * num_gaps;
-
-    auto mesh_device = open_unit_mesh();
-    ASSERT_NE(mesh_device, nullptr);
-    if (!IsProgramRealtimeProfilerActive()) {
-        mesh_device->close();
-        GTEST_SKIP() << "Real-time profiler is not active on this dispatch config";
-    }
-
-    std::vector<std::chrono::steady_clock::time_point> paced_enqueued(total_paced);
-    std::vector<std::atomic<std::chrono::steady_clock::rep>> paced_delivered(total_paced);
-    std::atomic<uint64_t> paced_idx{0};
-    std::atomic<uint64_t> dropped_total{0};
-
-    ProgramRealtimeProfilerCallbackHandle handle =
-        RegisterProgramRealtimeProfilerCallback([&](const ProgramRealtimeRecordBatch& batch) {
-            dropped_total.fetch_add(batch.dropped, std::memory_order_relaxed);
-            const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
-            for (const auto& rec : batch.records) {
-                if (rec.runtime_id == kPacedId) {
-                    const uint64_t idx = paced_idx.fetch_add(1, std::memory_order_relaxed);
-                    if (idx < total_paced) {
-                        paced_delivered[idx].store(now, std::memory_order_relaxed);
-                    }
-                }
-            }
-        });
-
-    distributed::MeshWorkload workload = build_blank_kernel_workload(mesh_device);
-    auto& cq = mesh_device->mesh_command_queue(0);
-    distributed::EnqueueMeshWorkload(cq, workload, true);
-
-    for (auto& [_, prog] : workload.get_programs()) {
-        prog.set_runtime_id(static_cast<uint64_t>(kPacedId));
-    }
-    distributed::MeshTraceId paced_trace = distributed::BeginTraceCapture(mesh_device.get(), cq.id());
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    mesh_device->end_mesh_trace(cq.id(), paced_trace);
-
-    uint32_t k = 0;
-    for (uint32_t gap_idx = 0; gap_idx < num_gaps; ++gap_idx) {
-        mesh_device->quiesce_devices();
-        const auto gap = kGaps[gap_idx];
-        const auto bucket_start = std::chrono::steady_clock::now();
-        for (uint32_t i = 0; i < kOpsPerGap; ++i) {
-            while (std::chrono::steady_clock::now() < bucket_start + gap * i) {
-            }
-            mesh_device->replay_mesh_trace(cq.id(), paced_trace, false);
-            paced_enqueued[k] = std::chrono::steady_clock::now();
-            ++k;
-        }
-    }
-
-    mesh_device->quiesce_devices();
-    std::this_thread::sleep_for(kPostQuiesceDrain);
-    UnregisterProgramRealtimeProfilerCallback(handle);
-    mesh_device->release_mesh_trace(paced_trace);
-
-    auto percentile = [](std::vector<double>& v, double p) {
-        if (v.empty()) {
-            return 0.0;
-        }
-        std::sort(v.begin(), v.end());
-        return v[std::min(v.size() - 1, static_cast<size_t>(std::lround(p * static_cast<double>(v.size() - 1))))];
-    };
-
-    const uint64_t paced_matched = std::min<uint64_t>(paced_idx.load(), total_paced);
-    double worst_paced_overhead_p50_us = 0.0;
-    double worst_paced_overhead_p99_us = 0.0;
-    for (uint32_t gap_idx = 0; gap_idx < num_gaps; ++gap_idx) {
-        std::vector<double> overhead_us;
-        overhead_us.reserve(kOpsPerGap);
-        for (uint32_t i = 0; i < kOpsPerGap; ++i) {
-            const uint32_t idx = gap_idx * kOpsPerGap + i;
-            const auto d = paced_delivered[idx].load(std::memory_order_relaxed);
-            if (d == 0) {
-                continue;
-            }
-            const auto delivered_tp = std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(d));
-            const double lat = std::chrono::duration<double, std::micro>(delivered_tp - paced_enqueued[idx]).count();
-            overhead_us.push_back(std::max(0.0, lat - static_cast<double>(kGaps[gap_idx].count())));
-        }
-        const double ov_p50 = percentile(overhead_us, 0.50);
-        const double ov_p99 = percentile(overhead_us, 0.99);
-        worst_paced_overhead_p50_us = std::max(worst_paced_overhead_p50_us, ov_p50);
-        worst_paced_overhead_p99_us = std::max(worst_paced_overhead_p99_us, ov_p99);
-        log_info(
-            tt::LogTest,
-            "[RT profiler stress] gap={:5}us | overhead p50={:.1f} p99={:.1f} max={:.1f}us",
-            kGaps[gap_idx].count(),
-            ov_p50,
-            ov_p99,
-            percentile(overhead_us, 1.0));
-    }
-
-    EXPECT_EQ(dropped_total.load(), 0u)
-        << "callback dropped records; deliveries are paired to enqueues by position, so a drop misaligns every "
-        << "later pair and the latencies below are meaningless";
-    EXPECT_GE(paced_matched, total_paced - total_paced / 100)
-        << "too few of the " << total_paced << " paced ops reached the callback; the latency percentiles "
-        << "below are over a partial sample and unreliable";
-    EXPECT_LT(worst_paced_overhead_p50_us, kMaxPacedOverheadP50Us)
-        << "median delivery overhead too high; the consumer is not waking promptly (a fixed "
-        << "backoff/oversleep would show up here)";
-    EXPECT_LT(worst_paced_overhead_p99_us, kMaxPacedOverheadP99Us)
-        << "tail delivery overhead too high; occasional long stalls in the delivery path";
     EXPECT_TRUE(mesh_device->close());
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_stress.cpp
@@ -296,8 +296,8 @@ TEST(RealtimeProfilerStress, CallbackDeliveryLatency) {
     constexpr uint32_t kPacedId = 0x6AC0;
     constexpr std::array<std::chrono::microseconds, 5> kGaps = {5us, 50us, 200us, 1000us, 5000us};
     constexpr uint32_t kOpsPerGap = 100;
-    constexpr double kMaxPacedOverheadP50Us = 500.0;
-    constexpr double kMaxPacedOverheadP99Us = 20'000.0;
+    constexpr double kMaxPacedOverheadP50Us = 20'000.0;
+    constexpr double kMaxPacedOverheadP99Us = 50'000.0;
 
     constexpr uint32_t num_gaps = static_cast<uint32_t>(kGaps.size());
     constexpr uint32_t total_paced = kOpsPerGap * num_gaps;

--- a/tests/tt_metal/tt_metal/dispatch/sources.cmake
+++ b/tests/tt_metal/tt_metal/dispatch/sources.cmake
@@ -22,7 +22,6 @@ set(UNIT_TESTS_DISPATCH_BASIC_SOURCES
     dispatch_program/test_dataflow_cb.cpp
     dispatch_program/test_global_circular_buffers.cpp
     dispatch_program/test_realtime_profiler_sanity.cpp
-    dispatch_program/test_realtime_profiler_stress.cpp
     dispatch_trace/test_sub_device.cpp
     dispatch_util/test_ringbuffer_cache.cpp
 )
@@ -31,5 +30,6 @@ set(UNIT_TESTS_DISPATCH_SLOW_SOURCES
     dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
     dispatch_buffer/test_large_mesh_buffer.cpp
     dispatch_program/test_EnqueueProgram.cpp
+    dispatch_program/test_realtime_profiler_stress.cpp
     dispatch_trace/test_EnqueueTrace.cpp
 )

--- a/tests/tt_metal/tt_metal/misc/sources.cmake
+++ b/tests/tt_metal/tt_metal/misc/sources.cmake
@@ -5,4 +5,5 @@ set(UNIT_TESTS_MISC_SRC
     test_tilize_untilize.cpp
     test_executor.cpp
     test_stable_hash.cpp
+    test_broadcast_ring.cpp
 )

--- a/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
@@ -339,9 +339,14 @@ TEST(BroadcastRing, ConcurrentIntegrityUnderDropPressure) {
         ready.count_down();
         start.wait();
         while (true) {
+            const bool done = writer_done.load(std::memory_order_acquire);
+            const uint64_t dropped_before = reader.dropped();
             auto batch = reader.read_batch(std::span<ProgramRealtimeRecord>(out));
             if (batch.empty()) {
-                if (writer_done.load(std::memory_order_acquire)) {
+                if (reader.dropped() != dropped_before) {
+                    continue;
+                }
+                if (done) {
                     break;
                 }
                 std::this_thread::yield();
@@ -531,6 +536,7 @@ TEST(BroadcastRing, ConcurrentBlockingWaitDeliversEveryItem) {
         uint64_t got = 0;
         while (true) {
             const auto token = readers[idx].wait_token();
+            const bool stopping = stop.load(std::memory_order_acquire);
             auto batch = readers[idx].read_batch(std::span<ProgramRealtimeRecord>(out));
             if (!batch.empty()) {
                 results[idx].received.insert(results[idx].received.end(), batch.begin(), batch.end());
@@ -538,7 +544,7 @@ TEST(BroadcastRing, ConcurrentBlockingWaitDeliversEveryItem) {
                 consumed[idx].store(got, std::memory_order_release);
                 continue;
             }
-            if (stop.load(std::memory_order_acquire)) {
+            if (stopping) {
                 break;
             }
             readers[idx].wait(token);
@@ -598,39 +604,41 @@ TEST(BroadcastRing, ConcurrentBlockingWaitDeliversEveryItem) {
 TEST(BroadcastRing, ConcurrentReaderChurnUnderLiveWriter) {
     constexpr size_t kCapacity = 512;
     constexpr size_t kReadBatchSize = 64;
-    constexpr uint32_t kChurnIterations = 2000;
     constexpr size_t kMaxPublishBatchSize = 128;
-    constexpr uint64_t kMaxRecords = 1u << 28;
+    constexpr uint64_t kLongReaderTarget = 1u << 16;
 
     BroadcastRing<ProgramRealtimeRecord> ring(kCapacity);
     auto long_reader = ring.make_reader();
 
     std::latch ready{3};
     std::latch start{1};
-    std::atomic<bool> churn_done{false};
+    std::atomic<bool> long_done{false};
+    std::atomic<uint64_t> long_consumed{0};
 
     auto long_result = std::vector<ProgramRealtimeRecord>{};
+    long_result.reserve(kLongReaderTarget + kReadBatchSize);
     std::thread long_thread([&]() {
         std::array<ProgramRealtimeRecord, kReadBatchSize> out;
         ready.count_down();
         start.wait();
-        while (!churn_done.load(std::memory_order_acquire)) {
+        while (long_result.size() < kLongReaderTarget) {
             auto batch = long_reader.read_batch(std::span<ProgramRealtimeRecord>(out));
             long_result.insert(long_result.end(), batch.begin(), batch.end());
+            long_consumed.store(long_result.size(), std::memory_order_release);
         }
+        long_done.store(true, std::memory_order_release);
     });
 
     std::thread churn_thread([&]() {
         std::array<ProgramRealtimeRecord, kReadBatchSize> out;
         ready.count_down();
         start.wait();
-        for (uint32_t i = 0; i < kChurnIterations; ++i) {
+        while (!long_done.load(std::memory_order_acquire)) {
             auto reader = ring.make_reader();
             for (int reads = 0; reads < 3; ++reads) {
                 (void)reader.read_batch(std::span<ProgramRealtimeRecord>(out));
             }
         }
-        churn_done.store(true, std::memory_order_release);
     });
 
     std::thread writer_thread([&]() {
@@ -638,7 +646,11 @@ TEST(BroadcastRing, ConcurrentReaderChurnUnderLiveWriter) {
         start.wait();
         std::array<ProgramRealtimeRecord, kMaxPublishBatchSize> records;
         uint64_t next = 0;
-        while (!churn_done.load(std::memory_order_acquire) && next < kMaxRecords) {
+        while (!long_done.load(std::memory_order_acquire)) {
+            while (next + kMaxPublishBatchSize - long_consumed.load(std::memory_order_acquire) > kCapacity / 2 &&
+                   !long_done.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
             const uint64_t base = next;
             for (size_t k = 0; k < kMaxPublishBatchSize; ++k) {
                 records[k] = make_seq_record(static_cast<uint32_t>(base + k));
@@ -650,9 +662,9 @@ TEST(BroadcastRing, ConcurrentReaderChurnUnderLiveWriter) {
 
     ready.wait();
     start.count_down();
+    long_thread.join();
     churn_thread.join();
     writer_thread.join();
-    long_thread.join();
 
     uint32_t prev_seq = 0;
     bool has_prev = false;
@@ -665,7 +677,100 @@ TEST(BroadcastRing, ConcurrentReaderChurnUnderLiveWriter) {
         prev_seq = seq;
         has_prev = true;
     }
-    EXPECT_GT(long_result.size(), 0u);
+    EXPECT_EQ(long_reader.dropped(), 0u);
+    EXPECT_GE(long_result.size(), kLongReaderTarget);
+}
+
+TEST(BroadcastRing, ConcurrentLockedSlotIntegrity) {
+    struct NonTrivialRecord {
+        uint32_t seq = 0;
+        std::string payload;
+    };
+    static_assert(!BroadcastRing<NonTrivialRecord>::is_always_lock_free);
+
+    constexpr uint64_t kTotalRecords = 1u << 15;
+    constexpr size_t kCapacity = 256;
+    constexpr size_t kReadBatchSize = 32;
+    constexpr size_t kMaxPublishBatchSize = 48;
+
+    // Heap-allocated and uniquely derived from seq so a corrupted or wrong-generation slot is detectable.
+    auto make_payload = [](uint32_t seq) {
+        return "rec-" + std::to_string(seq) + std::string(32, static_cast<char>('a' + seq % 26));
+    };
+
+    BroadcastRing<NonTrivialRecord> ring(kCapacity);
+    auto reader = ring.make_reader();
+
+    std::vector<NonTrivialRecord> received;
+    received.reserve(kTotalRecords);
+    uint64_t dropped = 0;
+
+    std::latch ready{2};
+    std::latch start{1};
+    std::atomic<bool> writer_done{false};
+
+    std::thread reader_thread([&]() {
+        std::array<NonTrivialRecord, kReadBatchSize> out;
+        ready.count_down();
+        start.wait();
+        while (true) {
+            const bool done = writer_done.load(std::memory_order_acquire);
+            const uint64_t dropped_before = reader.dropped();
+            auto batch = reader.read_batch(std::span<NonTrivialRecord>(out));
+            if (batch.empty()) {
+                if (reader.dropped() != dropped_before) {
+                    continue;
+                }
+                if (done) {
+                    break;
+                }
+                std::this_thread::yield();
+                continue;
+            }
+            for (auto& r : batch) {
+                received.push_back(std::move(r));
+            }
+        }
+        dropped = reader.dropped();
+    });
+
+    std::thread writer_thread([&]() {
+        ready.count_down();
+        start.wait();
+        std::mt19937 rng(kBatchSeed);
+        std::uniform_int_distribution<size_t> pick_batch(1, kMaxPublishBatchSize);
+        std::vector<NonTrivialRecord> records(kMaxPublishBatchSize);
+        uint64_t next = 0;
+        while (next < kTotalRecords) {
+            const uint64_t base = next;
+            const size_t batch_size = std::min<uint64_t>(pick_batch(rng), kTotalRecords - base);
+            for (size_t k = 0; k < batch_size; ++k) {
+                records[k].seq = static_cast<uint32_t>(base + k);
+                records[k].payload = make_payload(static_cast<uint32_t>(base + k));
+            }
+            ring.writer().publish_batch_move(std::span<NonTrivialRecord>(records.data(), batch_size));
+            next += batch_size;
+        }
+        writer_done.store(true, std::memory_order_release);
+    });
+
+    ready.wait();
+    start.count_down();
+    writer_thread.join();
+    reader_thread.join();
+
+    EXPECT_EQ(received.size() + dropped, kTotalRecords);
+    uint32_t prev_seq = 0;
+    bool has_prev = false;
+    for (const auto& r : received) {
+        ASSERT_EQ(r.payload, make_payload(r.seq)) << "corrupted LockedSlot record at seq " << r.seq;
+        if (has_prev) {
+            ASSERT_GT(r.seq, prev_seq) << "out-of-order / duplicate LockedSlot delivery at seq " << r.seq;
+        }
+        prev_seq = r.seq;
+        has_prev = true;
+    }
+    EXPECT_GT(received.size(), 0u);
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
@@ -202,6 +202,73 @@ TEST(BroadcastRing, ReadersLagAndDropIndependently) {
     EXPECT_EQ(slow_batch.back(), 6u);
 }
 
+TEST(BroadcastRing, DrainingBacklogDropsOnlyCapacityOverflow) {
+    constexpr uint32_t kCapacity = 64;
+
+    {
+        BroadcastRing<uint32_t> ring(kCapacity);
+        auto small_reader = ring.make_reader();
+        auto full_reader = ring.make_reader();
+        uint32_t items[kCapacity];
+        for (uint32_t i = 0; i < kCapacity; ++i) {
+            items[i] = i;
+        }
+        ring.writer().publish_batch(items);
+
+        uint32_t small_out[8] = {};
+        std::vector<uint32_t> got;
+        while (true) {
+            auto batch = small_reader.read_batch(small_out);
+            if (batch.empty()) {
+                break;
+            }
+            got.insert(got.end(), batch.begin(), batch.end());
+        }
+        EXPECT_EQ(small_reader.dropped(), 0u);
+        ASSERT_EQ(got.size(), static_cast<size_t>(kCapacity));
+        for (uint32_t i = 0; i < kCapacity; ++i) {
+            EXPECT_EQ(got[i], i) << "small buffer, index " << i;
+        }
+
+        uint32_t full_out[kCapacity] = {};
+        auto batch = full_reader.read_batch(full_out);
+        EXPECT_EQ(full_reader.dropped(), 0u);
+        ASSERT_EQ(batch.size(), static_cast<size_t>(kCapacity));
+        for (uint32_t i = 0; i < kCapacity; ++i) {
+            EXPECT_EQ(batch[i], i) << "full buffer, index " << i;
+        }
+    }
+
+    {
+        constexpr uint32_t kTotal = kCapacity + kCapacity / 2;
+        constexpr uint32_t kBatch = kTotal / 2;
+        BroadcastRing<uint32_t> ring(kCapacity);
+        auto reader = ring.make_reader();
+        for (uint32_t base : {0u, kBatch}) {
+            uint32_t items[kBatch];
+            for (uint32_t i = 0; i < kBatch; ++i) {
+                items[i] = base + i;
+            }
+            ring.writer().publish_batch(items);
+        }
+
+        uint32_t out[8] = {};
+        std::vector<uint32_t> got;
+        while (true) {
+            auto batch = reader.read_batch(out);
+            if (batch.empty()) {
+                break;
+            }
+            got.insert(got.end(), batch.begin(), batch.end());
+        }
+        EXPECT_EQ(reader.dropped(), kTotal - kCapacity);
+        ASSERT_EQ(got.size(), static_cast<size_t>(kCapacity));
+        for (uint32_t i = 0; i < kCapacity; ++i) {
+            EXPECT_EQ(got[i], (kTotal - kCapacity) + i) << "at index " << i;
+        }
+    }
+}
+
 TEST(BroadcastRing, WaitWakesOnPublishThenWake) {
     BroadcastRing<uint32_t> ring(4);
     auto reader = ring.make_reader();
@@ -629,14 +696,29 @@ TEST(BroadcastRing, ConcurrentReaderChurnUnderLiveWriter) {
         long_done.store(true, std::memory_order_release);
     });
 
+    std::atomic<bool> churn_fields_ok{true};
+    std::atomic<bool> churn_ordered{true};
     std::thread churn_thread([&]() {
         std::array<ProgramRealtimeRecord, kReadBatchSize> out;
         ready.count_down();
         start.wait();
         while (!long_done.load(std::memory_order_acquire)) {
             auto reader = ring.make_reader();
+            uint32_t last_seq = 0;
+            bool has_last = false;
             for (int reads = 0; reads < 3; ++reads) {
-                (void)reader.read_batch(std::span<ProgramRealtimeRecord>(out));
+                auto batch = reader.read_batch(std::span<ProgramRealtimeRecord>(out));
+                for (const auto& r : batch) {
+                    if (!seq_record_ok(r)) {
+                        churn_fields_ok.store(false, std::memory_order_relaxed);
+                    }
+                    const uint32_t seq = r.runtime_id - 1;
+                    if (has_last && seq <= last_seq) {
+                        churn_ordered.store(false, std::memory_order_relaxed);
+                    }
+                    last_seq = seq;
+                    has_last = true;
+                }
             }
         }
     });
@@ -679,6 +761,8 @@ TEST(BroadcastRing, ConcurrentReaderChurnUnderLiveWriter) {
     }
     EXPECT_EQ(long_reader.dropped(), 0u);
     EXPECT_GE(long_result.size(), kLongReaderTarget);
+    EXPECT_TRUE(churn_fields_ok.load()) << "a churned reader saw a torn/stale record";
+    EXPECT_TRUE(churn_ordered.load()) << "a churned reader saw out-of-order / duplicate delivery";
 }
 
 TEST(BroadcastRing, ConcurrentLockedSlotIntegrity) {

--- a/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
@@ -1,0 +1,672 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <atomic>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <latch>
+#include <random>
+#include <span>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <tt-metalium/experimental/realtime_profiler.hpp>
+
+#include "tt_metal/common/broadcast_ring.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+using tt::tt_metal::experimental::ProgramRealtimeRecord;
+
+constexpr uint32_t kBatchSeed = 0x9E3779B9u;
+
+ProgramRealtimeRecord make_record(uint32_t runtime_id, std::span<const std::string_view> sources = {}) {
+    return ProgramRealtimeRecord{
+        .runtime_id = runtime_id,
+        .chip_id = 7,
+        .start_timestamp = 100 + runtime_id,
+        .end_timestamp = 200 + runtime_id,
+        .frequency = 1.5,
+        .kernel_sources = sources,
+    };
+}
+
+TEST(BroadcastRing, CapacityRoundsUpToPowerOfTwo) {
+    EXPECT_EQ(BroadcastRing<uint32_t>(0).capacity(), 1u);
+    EXPECT_EQ(BroadcastRing<uint32_t>(1).capacity(), 1u);
+    EXPECT_EQ(BroadcastRing<uint32_t>(3).capacity(), 4u);
+    EXPECT_EQ(BroadcastRing<uint32_t>(4).capacity(), 4u);
+    EXPECT_EQ(BroadcastRing<uint32_t>(1000).capacity(), 1024u);
+}
+
+TEST(BroadcastRing, ReaderStartsAtTailAndSeesSubsequentItems) {
+    BroadcastRing<uint32_t> ring(4);
+    ring.writer().publish(1);
+    auto reader = ring.make_reader();
+
+    uint32_t value = 0;
+    EXPECT_FALSE(reader.read(value));
+
+    ring.writer().publish(2);
+    ASSERT_TRUE(reader.read(value));
+    EXPECT_EQ(value, 2u);
+    EXPECT_FALSE(reader.read(value));
+}
+
+TEST(BroadcastRing, ReadBatchIsOrderedAndBoundedByOutput) {
+    BroadcastRing<uint32_t> ring(8);
+    auto reader = ring.make_reader();
+
+    uint32_t items[] = {1, 2, 3, 4, 5};
+    ring.writer().publish_batch(items);
+
+    uint32_t none[1] = {};
+    EXPECT_TRUE(reader.read_batch(std::span<uint32_t>(none, 0)).empty());
+
+    uint32_t out2[2] = {};
+    auto first = reader.read_batch(out2);
+    ASSERT_EQ(first.size(), 2u);
+    EXPECT_EQ(first[0], 1u);
+    EXPECT_EQ(first[1], 2u);
+
+    uint32_t out8[8] = {};
+    auto rest = reader.read_batch(out8);
+    ASSERT_EQ(rest.size(), 3u);
+    EXPECT_EQ(rest[0], 3u);
+    EXPECT_EQ(rest[1], 4u);
+    EXPECT_EQ(rest[2], 5u);
+
+    EXPECT_EQ(reader.dropped(), 0u);
+    EXPECT_TRUE(reader.read_batch(out8).empty());
+}
+
+TEST(BroadcastRing, RecordsBroadcastToAllReadersWithSpanFieldsIntact) {
+    static_assert(std::is_trivially_copyable_v<ProgramRealtimeRecord>);
+    EXPECT_TRUE(BroadcastRing<ProgramRealtimeRecord>::is_always_lock_free);
+
+    std::string_view sources[] = {"kernel_a.cpp", "kernel_b.cpp"};
+    BroadcastRing<ProgramRealtimeRecord> ring(8);
+    auto reader_a = ring.make_reader();
+    auto reader_b = ring.make_reader();
+
+    ProgramRealtimeRecord records[] = {make_record(1, sources), make_record(2, sources), make_record(3, sources)};
+    ring.writer().publish_batch(records);
+
+    ProgramRealtimeRecord out_a[3];
+    ProgramRealtimeRecord out_b[3];
+    auto batch_a = reader_a.read_batch(out_a);
+    auto batch_b = reader_b.read_batch(out_b);
+
+    ASSERT_EQ(batch_a.size(), 3u);
+    ASSERT_EQ(batch_b.size(), 3u);
+    for (size_t i = 0; i < batch_a.size(); ++i) {
+        for (const auto* record : {&batch_a[i], &batch_b[i]}) {
+            EXPECT_EQ(record->runtime_id, i + 1);
+            EXPECT_EQ(record->chip_id, 7u);
+            EXPECT_EQ(record->start_timestamp, 100 + record->runtime_id);
+            EXPECT_EQ(record->end_timestamp, 200 + record->runtime_id);
+            EXPECT_DOUBLE_EQ(record->frequency, 1.5);
+            ASSERT_EQ(record->kernel_sources.size(), 2u);
+            EXPECT_EQ(record->kernel_sources[0], "kernel_a.cpp");
+            EXPECT_EQ(record->kernel_sources[1], "kernel_b.cpp");
+        }
+    }
+    EXPECT_EQ(reader_a.dropped(), 0u);
+    EXPECT_EQ(reader_b.dropped(), 0u);
+}
+
+TEST(BroadcastRing, NonTrivialTypeUsesLockedSlotWithMoveAndDrop) {
+    struct NonTrivialRecord {
+        uint32_t runtime_id = 0;
+        std::string name;
+    };
+    static_assert(!std::is_trivially_copyable_v<NonTrivialRecord>);
+    static_assert(!BroadcastRing<NonTrivialRecord>::is_always_lock_free);
+
+    BroadcastRing<NonTrivialRecord> ring(4);
+    auto reader = ring.make_reader();
+
+    std::vector<NonTrivialRecord> records;
+    records.reserve(7);
+    for (uint32_t i = 0; i < 7; ++i) {
+        records.push_back({.runtime_id = i, .name = std::string(256, static_cast<char>('a' + i))});
+    }
+    ring.writer().publish_batch_move(std::span<NonTrivialRecord>(records));
+
+    NonTrivialRecord out[4];
+    auto batch = reader.read_batch(out);
+
+    ASSERT_EQ(batch.size(), 4u);
+    EXPECT_EQ(reader.dropped(), 3u);
+    for (uint32_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(batch[i].runtime_id, i + 3);
+        EXPECT_EQ(batch[i].name, std::string(256, static_cast<char>('a' + i + 3)));
+    }
+}
+
+TEST(BroadcastRing, OversizedSinglePublishRetainsLastCapacity) {
+    BroadcastRing<uint32_t> ring(4);
+    auto reader = ring.make_reader();
+
+    uint32_t items[] = {0, 1, 2, 3, 4, 5};
+    ring.writer().publish_batch(items);
+
+    uint32_t out[4] = {};
+    auto batch = reader.read_batch(out);
+
+    ASSERT_EQ(batch.size(), 4u);
+    EXPECT_EQ(reader.dropped(), 2u);
+    EXPECT_EQ(batch[0], 2u);
+    EXPECT_EQ(batch[1], 3u);
+    EXPECT_EQ(batch[2], 4u);
+    EXPECT_EQ(batch[3], 5u);
+}
+
+TEST(BroadcastRing, ReadersLagAndDropIndependently) {
+    BroadcastRing<uint32_t> ring(4);
+    auto fast_reader = ring.make_reader();
+    auto slow_reader = ring.make_reader();
+
+    uint32_t first_batch[] = {1, 2};
+    ring.writer().publish_batch(first_batch);
+
+    uint32_t out[4] = {};
+    ASSERT_EQ(fast_reader.read_batch(out).size(), 2u);
+    EXPECT_EQ(out[0], 1u);
+    EXPECT_EQ(out[1], 2u);
+    EXPECT_EQ(fast_reader.dropped(), 0u);
+
+    uint32_t second_batch[] = {3, 4, 5, 6};
+    ring.writer().publish_batch(second_batch);
+
+    auto fast_batch = fast_reader.read_batch(out);
+    ASSERT_EQ(fast_batch.size(), 4u);
+    EXPECT_EQ(fast_reader.dropped(), 0u);
+    EXPECT_EQ(fast_batch.front(), 3u);
+    EXPECT_EQ(fast_batch.back(), 6u);
+
+    auto slow_batch = slow_reader.read_batch(out);
+    ASSERT_EQ(slow_batch.size(), 4u);
+    EXPECT_EQ(slow_reader.dropped(), 2u);
+    EXPECT_EQ(slow_batch.front(), 3u);
+    EXPECT_EQ(slow_batch.back(), 6u);
+}
+
+TEST(BroadcastRing, WaitWakesOnPublishThenWake) {
+    BroadcastRing<uint32_t> ring(4);
+    auto reader = ring.make_reader();
+    std::latch waiting{1};
+    std::atomic<bool> received{false};
+
+    std::thread reader_thread([&]() {
+        uint32_t out = 0;
+        EXPECT_FALSE(reader.read(out));
+        const auto token = reader.wait_token();
+        waiting.count_down();
+        reader.wait(token);
+        received.store(reader.read(out) && out == 42, std::memory_order_release);
+    });
+
+    waiting.wait();
+    ring.writer().publish(42);
+    ring.writer().wake_readers();
+
+    reader_thread.join();
+    EXPECT_TRUE(received.load(std::memory_order_acquire));
+}
+
+TEST(BroadcastRing, WaitWakesOnWakeWithoutData) {
+    BroadcastRing<uint32_t> ring(4);
+    auto reader = ring.make_reader();
+    std::latch waiting{1};
+    std::atomic<bool> woke{false};
+
+    std::thread reader_thread([&]() {
+        uint32_t out = 0;
+        EXPECT_FALSE(reader.read(out));
+        const auto token = reader.wait_token();
+        waiting.count_down();
+        reader.wait(token);
+        EXPECT_FALSE(reader.read(out));
+        woke.store(true, std::memory_order_release);
+    });
+
+    waiting.wait();
+    ring.writer().wake_readers();
+
+    reader_thread.join();
+    EXPECT_TRUE(woke.load(std::memory_order_acquire));
+}
+
+TEST(BroadcastRing, WakeBetweenTokenAndWaitIsNotLost) {
+    BroadcastRing<uint32_t> ring(4);
+    auto reader = ring.make_reader();
+
+    const auto token = reader.wait_token();
+    ring.writer().wake_readers();
+    reader.wait(token);
+
+    uint32_t out = 0;
+    EXPECT_FALSE(reader.read(out));
+}
+
+TEST(BroadcastRing, ReaderIsMovable) {
+    BroadcastRing<uint32_t> ring(8);
+    auto reader = ring.make_reader();
+    ring.writer().publish(10);
+    ring.writer().publish(20);
+
+    uint32_t value = 0;
+    auto moved = std::move(reader);
+    ASSERT_TRUE(moved.read(value));
+    EXPECT_EQ(value, 10u);
+
+    auto target = ring.make_reader();
+    target = std::move(moved);
+    ASSERT_TRUE(target.read(value));
+    EXPECT_EQ(value, 20u);
+    EXPECT_FALSE(target.read(value));
+}
+
+ProgramRealtimeRecord make_seq_record(uint32_t seq) {
+    return ProgramRealtimeRecord{
+        .runtime_id = seq + 1,
+        .chip_id = (seq % 31) + 1,
+        .start_timestamp = static_cast<uint64_t>(seq) * 7 + 3,
+        .end_timestamp = static_cast<uint64_t>(seq) * 7 + 9,
+        .frequency = 1.0 + static_cast<double>(seq) * 0.001,
+        .kernel_sources = {},
+    };
+}
+
+void verify_seq_records(const std::vector<ProgramRealtimeRecord>& received, uint64_t dropped, uint64_t total) {
+    EXPECT_EQ(received.size() + dropped, total);
+    uint32_t prev_seq = 0;
+    bool has_prev = false;
+    for (const auto& r : received) {
+        const uint32_t seq = r.runtime_id - 1;
+        ASSERT_EQ(r.chip_id, (seq % 31) + 1) << "torn/stale record: chip_id mismatch at seq " << seq;
+        ASSERT_EQ(r.start_timestamp, static_cast<uint64_t>(seq) * 7 + 3)
+            << "torn/stale record: start_timestamp mismatch at seq " << seq;
+        ASSERT_EQ(r.end_timestamp, static_cast<uint64_t>(seq) * 7 + 9)
+            << "torn/stale record: end_timestamp mismatch at seq " << seq;
+        ASSERT_DOUBLE_EQ(r.frequency, 1.0 + static_cast<double>(seq) * 0.001)
+            << "torn/stale record: frequency mismatch at seq " << seq;
+        if (has_prev) {
+            ASSERT_GT(seq, prev_seq) << "non-monotonic or duplicate delivery at seq " << seq;
+        }
+        prev_seq = seq;
+        has_prev = true;
+    }
+}
+
+TEST(BroadcastRing, ConcurrentIntegrityUnderDropPressure) {
+    constexpr uint64_t kTotalRecords = 1u << 20;
+    constexpr size_t kCapacity = 512;
+    constexpr size_t kReadBatchSize = 64;
+    constexpr size_t kMaxPublishBatchSize = 200;
+
+    BroadcastRing<ProgramRealtimeRecord> ring(kCapacity);
+    auto fast_reader = ring.make_reader();
+    auto slow_reader = ring.make_reader();
+
+    struct ReaderResult {
+        std::vector<ProgramRealtimeRecord> received;
+        uint64_t dropped = 0;
+    };
+    ReaderResult fast_result;
+    ReaderResult slow_result;
+    fast_result.received.reserve(kTotalRecords / 4);
+    slow_result.received.reserve(kTotalRecords / 4);
+
+    std::latch ready{3};
+    std::latch start{1};
+    std::atomic<bool> writer_done{false};
+
+    auto run_reader = [&](BroadcastRing<ProgramRealtimeRecord>::Reader& reader, ReaderResult& result, bool throttle) {
+        std::array<ProgramRealtimeRecord, kReadBatchSize> out;
+        uint32_t reads = 0;
+        ready.count_down();
+        start.wait();
+        while (true) {
+            auto batch = reader.read_batch(std::span<ProgramRealtimeRecord>(out));
+            if (batch.empty()) {
+                if (writer_done.load(std::memory_order_acquire)) {
+                    break;
+                }
+                std::this_thread::yield();
+                continue;
+            }
+            result.received.insert(result.received.end(), batch.begin(), batch.end());
+            if (throttle && (++reads % 4 == 0)) {
+                std::this_thread::sleep_for(std::chrono::microseconds(40));
+            }
+        }
+        result.dropped = reader.dropped();
+    };
+
+    std::thread fast_thread(run_reader, std::ref(fast_reader), std::ref(fast_result), false);
+    std::thread slow_thread(run_reader, std::ref(slow_reader), std::ref(slow_result), true);
+    std::thread writer_thread([&]() {
+        ready.count_down();
+        start.wait();
+        std::array<ProgramRealtimeRecord, kMaxPublishBatchSize> records;
+        std::mt19937 rng(kBatchSeed);
+        std::uniform_int_distribution<size_t> pick_batch(1, kMaxPublishBatchSize);
+        uint64_t next = 0;
+        while (next < kTotalRecords) {
+            const uint64_t base = next;
+            const size_t batch_size = std::min<uint64_t>(pick_batch(rng), kTotalRecords - base);
+            for (size_t k = 0; k < batch_size; ++k) {
+                records[k] = make_seq_record(static_cast<uint32_t>(base + k));
+            }
+            ring.writer().publish_batch(std::span<const ProgramRealtimeRecord>(records.data(), batch_size));
+            next += batch_size;
+            if ((next & 0x3fffu) == 0) {
+                std::this_thread::yield();
+            }
+        }
+        writer_done.store(true, std::memory_order_release);
+    });
+
+    ready.wait();
+    start.count_down();
+    writer_thread.join();
+    fast_thread.join();
+    slow_thread.join();
+
+    verify_seq_records(fast_result.received, fast_result.dropped, kTotalRecords);
+    verify_seq_records(slow_result.received, slow_result.dropped, kTotalRecords);
+    EXPECT_GT(fast_result.received.size(), 0u);
+    EXPECT_GT(slow_result.received.size(), 0u);
+}
+
+bool seq_record_ok(const ProgramRealtimeRecord& r) {
+    const uint32_t seq = r.runtime_id - 1;
+    return r.chip_id == (seq % 31) + 1 && r.start_timestamp == static_cast<uint64_t>(seq) * 7 + 3 &&
+           r.end_timestamp == static_cast<uint64_t>(seq) * 7 + 9 &&
+           r.frequency == 1.0 + static_cast<double>(seq) * 0.001;
+}
+
+TEST(BroadcastRing, ConcurrentManyReadersMixedRates) {
+    constexpr uint64_t kTotalRecords = 1u << 20;
+    constexpr size_t kCapacity = 1024;
+    constexpr size_t kReadBatchSize = 128;
+    constexpr uint32_t kNumReaders = 8;
+    constexpr size_t kMaxPublishBatchSize = 300;
+
+    BroadcastRing<ProgramRealtimeRecord> ring(kCapacity);
+
+    struct ReaderCheck {
+        uint64_t received = 0;
+        uint64_t dropped = 0;
+        uint32_t last_seq = 0;
+        bool has_last = false;
+        bool fields_ok = true;
+        bool ordered = true;
+    };
+    std::vector<BroadcastRing<ProgramRealtimeRecord>::Reader> readers;
+    std::vector<ReaderCheck> checks(kNumReaders);
+    readers.reserve(kNumReaders);
+    for (uint32_t i = 0; i < kNumReaders; ++i) {
+        readers.push_back(ring.make_reader());
+    }
+
+    std::latch ready{kNumReaders + 1};
+    std::latch start{1};
+    std::atomic<bool> writer_done{false};
+
+    auto run_reader = [&](uint32_t idx) {
+        std::array<ProgramRealtimeRecord, kReadBatchSize> out;
+        ReaderCheck& c = checks[idx];
+        ready.count_down();
+        start.wait();
+        while (true) {
+            const bool done = writer_done.load(std::memory_order_acquire);
+            const uint64_t dropped_before = readers[idx].dropped();
+            auto batch = readers[idx].read_batch(std::span<ProgramRealtimeRecord>(out));
+            if (batch.empty()) {
+                if (readers[idx].dropped() != dropped_before) {
+                    continue;
+                }
+                if (done) {
+                    break;
+                }
+                std::this_thread::yield();
+                continue;
+            }
+            for (const auto& r : batch) {
+                const uint32_t seq = r.runtime_id - 1;
+                c.fields_ok &= seq_record_ok(r);
+                c.ordered &= !c.has_last || seq > c.last_seq;
+                c.last_seq = seq;
+                c.has_last = true;
+                ++c.received;
+            }
+            if (idx != 0 && (c.received % (64u * idx)) == 0) {
+                std::this_thread::sleep_for(std::chrono::microseconds(idx * 10));
+            }
+        }
+        c.dropped = readers[idx].dropped();
+    };
+
+    std::vector<std::thread> reader_threads;
+    reader_threads.reserve(kNumReaders);
+    for (uint32_t i = 0; i < kNumReaders; ++i) {
+        reader_threads.emplace_back(run_reader, i);
+    }
+    std::thread writer_thread([&]() {
+        ready.count_down();
+        start.wait();
+        std::array<ProgramRealtimeRecord, kMaxPublishBatchSize> records;
+        std::mt19937 rng(kBatchSeed);
+        std::uniform_int_distribution<size_t> pick_batch(1, kMaxPublishBatchSize);
+        uint64_t next = 0;
+        while (next < kTotalRecords) {
+            const uint64_t base = next;
+            const size_t batch_size = std::min<uint64_t>(pick_batch(rng), kTotalRecords - base);
+            for (size_t k = 0; k < batch_size; ++k) {
+                records[k] = make_seq_record(static_cast<uint32_t>(base + k));
+            }
+            ring.writer().publish_batch(std::span<const ProgramRealtimeRecord>(records.data(), batch_size));
+            next += batch_size;
+        }
+        writer_done.store(true, std::memory_order_release);
+    });
+
+    ready.wait();
+    start.count_down();
+    writer_thread.join();
+    for (auto& t : reader_threads) {
+        t.join();
+    }
+
+    for (uint32_t i = 0; i < kNumReaders; ++i) {
+        EXPECT_TRUE(checks[i].fields_ok) << "reader " << i << " saw a torn/stale record";
+        EXPECT_TRUE(checks[i].ordered) << "reader " << i << " saw out-of-order / duplicate delivery";
+        EXPECT_EQ(checks[i].received + checks[i].dropped, kTotalRecords) << "reader " << i << " lost records";
+    }
+}
+
+TEST(BroadcastRing, ConcurrentBlockingWaitDeliversEveryItem) {
+    constexpr uint64_t kTotalRecords = 1u << 18;
+    constexpr size_t kCapacity = 4096;
+    constexpr size_t kReadBatchSize = 256;
+    constexpr uint32_t kNumReaders = 4;
+    constexpr size_t kMaxPublishBatchSize = 64;
+
+    BroadcastRing<ProgramRealtimeRecord> ring(kCapacity);
+
+    struct ReaderResult {
+        std::vector<ProgramRealtimeRecord> received;
+        uint64_t dropped = 0;
+    };
+    std::vector<BroadcastRing<ProgramRealtimeRecord>::Reader> readers;
+    std::vector<ReaderResult> results(kNumReaders);
+    std::vector<std::atomic<uint64_t>> consumed(kNumReaders);
+    readers.reserve(kNumReaders);
+    for (uint32_t i = 0; i < kNumReaders; ++i) {
+        readers.push_back(ring.make_reader());
+        results[i].received.reserve(kTotalRecords);
+    }
+
+    std::latch ready{kNumReaders + 1};
+    std::latch start{1};
+    std::atomic<bool> stop{false};
+
+    auto run_reader = [&](uint32_t idx) {
+        std::array<ProgramRealtimeRecord, kReadBatchSize> out;
+        ready.count_down();
+        start.wait();
+        uint64_t got = 0;
+        while (true) {
+            const auto token = readers[idx].wait_token();
+            auto batch = readers[idx].read_batch(std::span<ProgramRealtimeRecord>(out));
+            if (!batch.empty()) {
+                results[idx].received.insert(results[idx].received.end(), batch.begin(), batch.end());
+                got += batch.size();
+                consumed[idx].store(got, std::memory_order_release);
+                continue;
+            }
+            if (stop.load(std::memory_order_acquire)) {
+                break;
+            }
+            readers[idx].wait(token);
+        }
+        results[idx].dropped = readers[idx].dropped();
+    };
+
+    std::vector<std::thread> reader_threads;
+    reader_threads.reserve(kNumReaders);
+    for (uint32_t i = 0; i < kNumReaders; ++i) {
+        reader_threads.emplace_back(run_reader, i);
+    }
+    std::thread writer_thread([&]() {
+        ready.count_down();
+        start.wait();
+        std::array<ProgramRealtimeRecord, kMaxPublishBatchSize> records;
+        std::mt19937 rng(kBatchSeed);
+        std::uniform_int_distribution<size_t> pick_batch(1, kMaxPublishBatchSize);
+        uint64_t next = 0;
+        while (next < kTotalRecords) {
+            const uint64_t base = next;
+            const size_t batch_size = std::min<uint64_t>(pick_batch(rng), kTotalRecords - base);
+            while (true) {
+                uint64_t slowest = next;
+                for (auto& c : consumed) {
+                    slowest = std::min(slowest, c.load(std::memory_order_acquire));
+                }
+                if (next + batch_size - slowest <= kCapacity / 2) {
+                    break;
+                }
+                std::this_thread::yield();
+            }
+            for (size_t k = 0; k < batch_size; ++k) {
+                records[k] = make_seq_record(static_cast<uint32_t>(base + k));
+            }
+            ring.writer().publish_batch(std::span<const ProgramRealtimeRecord>(records.data(), batch_size));
+            ring.writer().wake_readers();
+            next += batch_size;
+        }
+    });
+
+    ready.wait();
+    start.count_down();
+    writer_thread.join();
+    stop.store(true, std::memory_order_release);
+    ring.writer().wake_readers();
+    for (auto& t : reader_threads) {
+        t.join();
+    }
+
+    for (uint32_t i = 0; i < kNumReaders; ++i) {
+        EXPECT_EQ(results[i].dropped, 0u) << "reader " << i << " dropped under a bounded wait/wake load";
+        verify_seq_records(results[i].received, results[i].dropped, kTotalRecords);
+    }
+}
+
+TEST(BroadcastRing, ConcurrentReaderChurnUnderLiveWriter) {
+    constexpr size_t kCapacity = 512;
+    constexpr size_t kReadBatchSize = 64;
+    constexpr uint32_t kChurnIterations = 2000;
+    constexpr size_t kMaxPublishBatchSize = 128;
+    constexpr uint64_t kMaxRecords = 1u << 28;
+
+    BroadcastRing<ProgramRealtimeRecord> ring(kCapacity);
+    auto long_reader = ring.make_reader();
+
+    std::latch ready{3};
+    std::latch start{1};
+    std::atomic<bool> churn_done{false};
+
+    auto long_result = std::vector<ProgramRealtimeRecord>{};
+    std::thread long_thread([&]() {
+        std::array<ProgramRealtimeRecord, kReadBatchSize> out;
+        ready.count_down();
+        start.wait();
+        while (!churn_done.load(std::memory_order_acquire)) {
+            auto batch = long_reader.read_batch(std::span<ProgramRealtimeRecord>(out));
+            long_result.insert(long_result.end(), batch.begin(), batch.end());
+        }
+    });
+
+    std::thread churn_thread([&]() {
+        std::array<ProgramRealtimeRecord, kReadBatchSize> out;
+        ready.count_down();
+        start.wait();
+        for (uint32_t i = 0; i < kChurnIterations; ++i) {
+            auto reader = ring.make_reader();
+            for (int reads = 0; reads < 3; ++reads) {
+                (void)reader.read_batch(std::span<ProgramRealtimeRecord>(out));
+            }
+        }
+        churn_done.store(true, std::memory_order_release);
+    });
+
+    std::thread writer_thread([&]() {
+        ready.count_down();
+        start.wait();
+        std::array<ProgramRealtimeRecord, kMaxPublishBatchSize> records;
+        uint64_t next = 0;
+        while (!churn_done.load(std::memory_order_acquire) && next < kMaxRecords) {
+            const uint64_t base = next;
+            for (size_t k = 0; k < kMaxPublishBatchSize; ++k) {
+                records[k] = make_seq_record(static_cast<uint32_t>(base + k));
+            }
+            ring.writer().publish_batch(std::span<const ProgramRealtimeRecord>(records.data(), kMaxPublishBatchSize));
+            next += kMaxPublishBatchSize;
+        }
+    });
+
+    ready.wait();
+    start.count_down();
+    churn_thread.join();
+    writer_thread.join();
+    long_thread.join();
+
+    uint32_t prev_seq = 0;
+    bool has_prev = false;
+    for (const auto& r : long_result) {
+        const uint32_t seq = r.runtime_id - 1;
+        ASSERT_TRUE(seq_record_ok(r)) << "long reader saw a torn/stale record at seq " << seq;
+        if (has_prev) {
+            ASSERT_GT(seq, prev_seq) << "long reader saw out-of-order / duplicate delivery at seq " << seq;
+        }
+        prev_seq = seq;
+        has_prev = true;
+    }
+    EXPECT_GT(long_result.size(), 0u);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/ttnn/profiling/realtime_profiler_utils.py
+++ b/tests/ttnn/profiling/realtime_profiler_utils.py
@@ -27,26 +27,27 @@ def profile_realtime_program(
 
     profile_records = []
 
-    def collect(record):
-        if profile_records and not collect_all:
-            return
+    def collect_records(batch):
+        for record in batch.records:
+            if profile_records and not collect_all:
+                return
 
-        start_timestamp = int(record.start_timestamp)
-        end_timestamp = int(record.end_timestamp)
-        frequency = float(record.frequency)
-        if frequency <= 0 or end_timestamp <= start_timestamp:
-            return
+            start_timestamp = int(record.start_timestamp)
+            end_timestamp = int(record.end_timestamp)
+            frequency = float(record.frequency)
+            if frequency <= 0 or end_timestamp <= start_timestamp:
+                continue
 
-        profile_records.append(
-            {
-                "runtime_id": int(record.runtime_id),
-                "chip_id": int(record.chip_id),
-                "duration_ns": (end_timestamp - start_timestamp) / frequency,
-                "kernel_sources": tuple(str(source) for source in record.kernel_sources),
-            }
-        )
+            profile_records.append(
+                {
+                    "runtime_id": int(record.runtime_id),
+                    "chip_id": int(record.chip_id),
+                    "duration_ns": (end_timestamp - start_timestamp) / frequency,
+                    "kernel_sources": tuple(str(source) for source in record.kernel_sources),
+                }
+            )
 
-    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect)
+    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect_records)
 
     try:
         result = run_fn()

--- a/tests/ttnn/tracy/cross_reference_workload.py
+++ b/tests/ttnn/tracy/cross_reference_workload.py
@@ -36,7 +36,6 @@ import ast
 import json
 import os
 import sys
-import threading
 
 import ttnn
 
@@ -75,7 +74,11 @@ def main():
     if os.environ.get("REQUIRE_GALAXY") == "1":
         try:
             cluster_type = ttnn.cluster.get_cluster_type()
-            is_galaxy = cluster_type in (ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG)
+            is_galaxy = cluster_type in (
+                ttnn.cluster.ClusterType.GALAXY,
+                ttnn.cluster.ClusterType.TG,
+                ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,
+            )
         except Exception:
             is_galaxy = False
         if not is_galaxy:
@@ -107,10 +110,9 @@ def main():
         sys.exit(5)
 
     rt_records = []
-    lock = threading.Lock()
 
-    def collect(record):
-        with lock:
+    def collect_records(batch):
+        for record in batch.records:
             rt_records.append(
                 {
                     "runtime_id": record.runtime_id,
@@ -121,7 +123,7 @@ def main():
                 }
             )
 
-    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect)
+    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect_records)
 
     try:
         _run_resnet50(device)
@@ -158,8 +160,7 @@ def main():
 
         ttnn.close_mesh_device(device)
 
-        with lock:
-            rt_snapshot = list(rt_records)
+        rt_snapshot = list(rt_records)
 
         with open(rt_path, "w") as f:
             json.dump(rt_snapshot, f)

--- a/tests/ttnn/tracy/debug_compare_rt_device.py
+++ b/tests/ttnn/tracy/debug_compare_rt_device.py
@@ -2,14 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os, threading, torch, ttnn
+import os, torch, ttnn
 
 
 def main():
-    records, lock = [], threading.Lock()
+    records = []
 
-    def collect(r):
-        with lock:
+    def collect_records(batch):
+        for r in batch.records:
             records.append(
                 {
                     "runtime_id": r.runtime_id,
@@ -25,7 +25,7 @@ def main():
         l1_small_size=24576,
         dispatch_core_config=ttnn.DispatchCoreConfig(ttnn.DispatchCoreType.WORKER),
     )
-    h = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect)
+    h = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect_records)
     try:
         torch.manual_seed(0)
         a = ttnn.to_layout(
@@ -54,8 +54,7 @@ def main():
         ttnn.close_mesh_device(dev)
         ttnn.device.UnregisterProgramRealtimeProfilerCallback(h)
 
-    with lock:
-        snap = list(records)
+    snap = list(records)
 
     csv_path = os.path.join("generated", "profiler", ".logs", "profile_log_device.csv")
     metal_home = os.environ.get("TT_METAL_HOME", "")

--- a/tests/ttnn/tracy/debug_trace_durations.py
+++ b/tests/ttnn/tracy/debug_trace_durations.py
@@ -2,14 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import threading, torch, ttnn
+import torch, ttnn
 
 
 def main():
-    records, lock = [], threading.Lock()
+    records = []
 
-    def collect(r):
-        with lock:
+    def collect_records(batch):
+        for r in batch.records:
             records.append(
                 {
                     "runtime_id": r.runtime_id,
@@ -25,7 +25,7 @@ def main():
         l1_small_size=24576,
         dispatch_core_config=ttnn.DispatchCoreConfig(ttnn.DispatchCoreType.WORKER),
     )
-    h = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect)
+    h = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect_records)
     try:
         torch.manual_seed(0)
         a = ttnn.to_layout(
@@ -54,8 +54,7 @@ def main():
         ttnn.close_mesh_device(dev)
         ttnn.device.UnregisterProgramRealtimeProfilerCallback(h)
 
-    with lock:
-        snap = list(records)
+    snap = list(records)
     print(f"Total records from callback: {len(snap)}")
     short_list = []
     for i, r in enumerate(snap):

--- a/tests/ttnn/tracy/host_device_correlation_workload.py
+++ b/tests/ttnn/tracy/host_device_correlation_workload.py
@@ -32,16 +32,19 @@ def main():
     records = []
     lock = threading.Lock()
 
-    def collect_record(record):
-        entry = {
-            "runtime_id": record.runtime_id,
-            "chip_id": record.chip_id,
-            "start_timestamp": record.start_timestamp,
-            "end_timestamp": record.end_timestamp,
-            "frequency_ghz": record.frequency,
-        }
+    def collect_records(batch):
+        entries = [
+            {
+                "runtime_id": record.runtime_id,
+                "chip_id": record.chip_id,
+                "start_timestamp": record.start_timestamp,
+                "end_timestamp": record.end_timestamp,
+                "frequency_ghz": record.frequency,
+            }
+            for record in batch.records
+        ]
         with lock:
-            records.append(entry)
+            records.extend(entries)
 
     # Read imagenet labels (same source as models/conftest.py)
     labels_path = "models/sample_data/imagenet_class_labels.txt"
@@ -70,7 +73,7 @@ def main():
         sys.exit(5)
 
     # Register callback to capture device-side program records
-    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect_record)
+    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect_records)
 
     try:
         from models.demos.vision.classification.resnet50.ttnn_resnet.demo.demo import run_resnet_inference

--- a/tests/ttnn/tracy/matmul_workload.py
+++ b/tests/ttnn/tracy/matmul_workload.py
@@ -22,7 +22,6 @@ Exit codes:
 import json
 import os
 import sys
-import threading
 
 import torch
 
@@ -75,10 +74,9 @@ def main():
     )
 
     records = []
-    lock = threading.Lock()
 
-    def collect(record):
-        with lock:
+    def collect_records(batch):
+        for record in batch.records:
             records.append(
                 {
                     "runtime_id": record.runtime_id,
@@ -90,7 +88,7 @@ def main():
                 }
             )
 
-    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect)
+    handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(collect_records)
 
     try:
         if mode == "simple":
@@ -117,8 +115,7 @@ def main():
         ttnn.close_mesh_device(device)
         ttnn.device.UnregisterProgramRealtimeProfilerCallback(handle)
 
-    with lock:
-        snapshot = list(records)
+    snapshot = list(records)
     with open(rt_path, "w") as f:
         json.dump(snapshot, f)
     print(f"Saved {len(snapshot)} RT records -> {rt_path}")

--- a/tests/ttnn/tracy/test_realtime_profiler.py
+++ b/tests/ttnn/tracy/test_realtime_profiler.py
@@ -290,8 +290,8 @@ def test_no_short_zones(tmp_path):
     with_sources = sum(1 for r in snapshot if r["runtime_id"] != 0 and r["kernel_sources"])
     assert with_sources == valid, (
         f"{with_sources}/{valid} valid records resolved kernel_sources. Trace-replayed records resolve "
-        f"sources only if their runtime_id is tied to program_id during trace capture; ensure TieRuntimeIdToProgramId "
-        f"and RecordKernelSourceMap are called in create_trace_node (dispatch.cpp)."
+        f"sources only if their runtime_id is tied to program metadata during trace capture; ensure RecordProgramMetadata "
+        f"is called in create_trace_node (dispatch.cpp)."
     )
 
 

--- a/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
+++ b/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
@@ -11,7 +11,6 @@
 
 namespace tt::tt_metal::experimental {
 
-// Record passed to registered callbacks when real-time profiler data arrives from a device.
 struct ProgramRealtimeRecord {
     uint32_t runtime_id;                               // Runtime ID. Currently truncated to 16 bits;
                                                        // widening tracked in #46103.
@@ -23,8 +22,16 @@ struct ProgramRealtimeRecord {
                                                        // MetalContext teardown or reinitialization.
 };
 
-// Callback type for real-time profiler data.
-using ProgramRealtimeProfilerCallback = std::function<void(const ProgramRealtimeRecord& record)>;
+struct ProgramRealtimeRecordBatch {
+    std::span<const ProgramRealtimeRecord> records;  // Non-empty, oldest first; valid
+                                                     // until the callback returns.
+    uint64_t dropped;                                // Records lost since this callback last ran; nonzero if the
+                                                     // callback could not keep up with incoming profiler data.
+};
+
+// Callback type for real-time profiler data. Invoked with a batch so a callback can
+// amortize fixed costs (a lock, a file flush, a network/DB round-trip, etc.) across many records.
+using ProgramRealtimeProfilerCallback = std::function<void(const ProgramRealtimeRecordBatch& batch)>;
 
 // Opaque handle returned by RegisterProgramRealtimeProfilerCallback, used to unregister.
 using ProgramRealtimeProfilerCallbackHandle = uint64_t;
@@ -32,8 +39,9 @@ using ProgramRealtimeProfilerCallbackHandle = uint64_t;
 // clang-format off
 /**
  * Register a callback to be invoked when real-time profiler data arrives from a device.
- * Multiple callbacks can be registered; they are called in order of registration from the
- * real-time profiler receiver thread.
+ * Multiple callbacks can be registered; each callback is called from its own thread.
+ * Callbacks that are too slow to keep up with incoming profiler data may miss records; this
+ * is tracked by ProgramRealtimeRecordBatch::dropped.
  *
  * Return value: ProgramRealtimeProfilerCallbackHandle - handle that can be passed to
  *               UnregisterProgramRealtimeProfilerCallback to remove the callback.

--- a/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
+++ b/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
@@ -42,7 +42,7 @@ using ProgramRealtimeProfilerCallbackHandle = uint64_t;
  * Multiple callbacks can be registered; they are invoked concurrently. If a callback shares a resource
  * with other callbacks or across multiple MeshDevices, access it in a thread-safe way (e.g. with a lock).
  * Callbacks that are too slow to keep up with incoming profiler data may miss records; this
- * is tracked by ProgramRealtimeRecordBatch::dropped.
+ * is reported by ProgramRealtimeRecordBatch::dropped.
  *
  * Return value: ProgramRealtimeProfilerCallbackHandle - handle that can be passed to
  *               UnregisterProgramRealtimeProfilerCallback to remove the callback.

--- a/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
+++ b/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
@@ -39,7 +39,8 @@ using ProgramRealtimeProfilerCallbackHandle = uint64_t;
 // clang-format off
 /**
  * Register a callback to be invoked when real-time profiler data arrives from a device.
- * Multiple callbacks can be registered; each callback is called from its own thread.
+ * Multiple callbacks can be registered; they are invoked concurrently. If a callback shares a resource
+ * with other callbacks or across multiple MeshDevices, access it in a thread-safe way (e.g. with a lock).
  * Callbacks that are too slow to keep up with incoming profiler data may miss records; this
  * is tracked by ProgramRealtimeRecordBatch::dropped.
  *

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -63,6 +63,15 @@ struct HDSocketConnectorState;
 class D2HSocket {
 public:
     /**
+     * @brief Process scope of the socket's host FIFO: sharable across processes, or private to this one.
+     *
+     * CrossProcess backs the FIFO with a named POSIX shared-memory object (/dev/shm) that this socket can export
+     * via export_descriptor() for another process to connect() and read zero-copy. InProcess backs it with a
+     * process-private anonymous mmap that cannot be exported.
+     */
+    enum class ProcessScope { CrossProcess, InProcess };
+
+    /**
      * @brief Constructs a D2HSocket for streaming data from a device core to host.
      *
      * Allocates pinned host memory for the data FIFO and bytes_sent signaling.
@@ -72,10 +81,16 @@ public:
      * @param mesh_device The mesh device containing the sender core.
      * @param sender_core The source core coordinate (device + core) that sends data.
      * @param fifo_size Size of the circular FIFO buffer in bytes. Must be PCIe-aligned.
+     * @param scope CrossProcess (FIFO sharable across processes) or InProcess (process-private); defaults to
+     * CrossProcess.
      *
      * @throws TT_FATAL if pinned memory allocation fails or addresses are invalid.
      */
-    D2HSocket(const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoreCoord& sender_core, uint32_t fifo_size);
+    D2HSocket(
+        const std::shared_ptr<MeshDevice>& mesh_device,
+        const MeshCoreCoord& sender_core,
+        uint32_t fifo_size,
+        ProcessScope scope = ProcessScope::CrossProcess);
 
     /**
      * @brief Identifies an L1 region on the sender core that the caller has already
@@ -113,7 +128,8 @@ public:
         const std::shared_ptr<MeshDevice>& mesh_device,
         const MeshCoreCoord& sender_core,
         uint32_t fifo_size,
-        ExternalConfigBuffer external_config);
+        ExternalConfigBuffer external_config,
+        ProcessScope scope = ProcessScope::CrossProcess);
 
     /**
      * @brief Connects to an existing D2HSocket from another process.
@@ -350,6 +366,7 @@ private:
     uint32_t* bytes_sent_ptr_ = nullptr;
     std::function<void(void*, uint32_t, uint64_t)> pcie_writer_ = nullptr;
     std::unique_ptr<NamedShm> shm_;
+    ProcessScope process_scope_ = ProcessScope::CrossProcess;
     std::unique_ptr<PCIeCoreWriter> pcie_writer_instance_;
     MeshDevice* mesh_device_ = nullptr;
     bool is_owner_ = true;

--- a/tt_metal/common/broadcast_ring.hpp
+++ b/tt_metal/common/broadcast_ring.hpp
@@ -173,7 +173,7 @@ public:
             // overwritten before we finish copying them, so we drop them now and spend the copies on records
             // we can actually keep
             const auto max_lag = [this](uint64_t want, uint64_t cap) {
-                const uint64_t margin = std::min<uint64_t>(std::max<uint64_t>(skip_margin_, want), cap >> 1);
+                const uint64_t margin = std::min<uint64_t>(skip_margin_, cap >> 1);
                 return std::max<uint64_t>(want, cap - margin);
             };
             // running max of how far the writer advances while we copy a batch, plus 25% headroom; decays

--- a/tt_metal/common/broadcast_ring.hpp
+++ b/tt_metal/common/broadcast_ring.hpp
@@ -1,0 +1,402 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <bit>
+#include <cstring>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <type_traits>
+#include <utility>
+
+#include <tt_stl/assert.hpp>
+#include <tt_stl/tt_pause.hpp>
+
+namespace tt::tt_metal {
+
+/**
+ * @brief Single-producer, multi-consumer broadcast ring buffer.
+ *
+ * One writer publishes a stream of items; each reader observes that stream independently and in
+ * order, starting from the point at which the reader is created. The writer never blocks on a reader: a
+ * reader that cannot keep up loses its oldest unread items (tracked by Reader::dropped()).
+ *
+ * If the compile-time constant `is_always_lock_free` is true, then the ring is guaranteed to be lock-free.
+ *
+ * Obtain the writer from writer() (driven by a single thread) and each reader from make_reader().
+ * Readers are single-threaded, and all readers must be destroyed before the ring.
+ *
+ * @tparam T Element type.
+ */
+template <typename T>
+class BroadcastRing {
+    static constexpr bool kTriviallyCopyable = std::is_trivially_copyable_v<T>;
+#if defined(__cpp_lib_atomic_lock_free_type_aliases)
+    using WakeTokenAtomic = std::atomic_unsigned_lock_free;
+#else
+    using WakeTokenAtomic = std::atomic<uint32_t>;
+#endif
+    static constexpr size_t kFalseSharingSize = 128;
+    struct SlotsView;
+    struct SharedState;
+
+public:
+    /**
+     * @brief True when the ring is guaranteed to be lock-free: requires T to be trivially copyable (otherwise
+     * each slot is guarded by a mutex) and the platform's 64-bit and wake-token atomics to be lock-free.
+     */
+    static constexpr bool is_always_lock_free =
+        kTriviallyCopyable && std::atomic<uint64_t>::is_always_lock_free && WakeTokenAtomic::is_always_lock_free;
+
+    /**
+     * @brief Constructs a broadcast ring with at least @p capacity slots.
+     * @param capacity Requested slot count; gets rounded up to the next power of two.
+     */
+    explicit BroadcastRing(size_t capacity) :
+        capacity_(capacity ? std::bit_ceil(capacity) : 1),
+        slots_(std::make_unique<Slot[]>(capacity_)),
+        writer_(&shared_state_, view()) {}
+
+    ~BroadcastRing() {
+        TT_FATAL(
+            active_readers_.load(std::memory_order_relaxed) == 0,
+            "BroadcastRing readers must be destroyed before the ring");
+    }
+
+    [[nodiscard]] size_t capacity() const noexcept { return capacity_; }
+
+    class alignas(kFalseSharingSize) Writer {
+    public:
+        /** @brief Publishes a single item (does not wake readers; see wake_readers()). */
+        void publish(const T& item) noexcept { publish_batch({&item, 1}); }
+
+        /**
+         * @brief Publishes a batch of items (does not wake readers; see wake_readers()).
+         *
+         * If @p items is larger than capacity(), only its last capacity() items are retained.
+         */
+        void publish_batch(std::span<const T> items) noexcept {
+            static_assert(kStoreNoexcept, "T must be nothrow-copyable; use publish_batch_move otherwise");
+            publish_impl(items);
+        }
+
+        /**
+         * @brief Publishes a batch of items with std::move (does not wake readers; see wake_readers()).
+         *
+         * If @p items is larger than capacity(), only its last capacity() items are retained.
+         */
+        void publish_batch_move(std::span<T> items) noexcept
+            requires std::is_move_constructible_v<T>
+        {
+            static_assert(kMoveStoreNoexcept, "T must be nothrow-movable");
+            publish_impl(items);
+        }
+
+        /**
+         * @brief Wakes readers blocked in Reader::wait().
+         *
+         * publish()/publish_batch() do not wake on their own; this must be called explicitly.
+         */
+        void wake_readers() noexcept {
+            shared_state_->wake_token.fetch_add(1, std::memory_order_release);
+            shared_state_->wake_token.notify_all();
+        }
+
+        Writer(const Writer&) = delete;
+        Writer& operator=(const Writer&) = delete;
+        Writer(Writer&&) = delete;
+        Writer& operator=(Writer&&) = delete;
+
+    private:
+        friend class BroadcastRing;
+        Writer(SharedState* shared_state, SlotsView view) noexcept :
+            shared_state_(shared_state), view_(view), head_cache_(shared_state->head.load(std::memory_order_relaxed)) {}
+
+        template <typename U>
+        void publish_impl(std::span<U> items) {
+            const size_t n = items.size();
+            const uint64_t head = head_cache_;
+            const SlotsView view = view_;
+            SharedState* const shared_state = shared_state_;
+            const size_t skip = n > view.capacity ? n - view.capacity : 0;
+
+            shared_state->claim.store(head + n, std::memory_order_relaxed);
+            std::atomic_thread_fence(std::memory_order_release);
+            for (size_t k = skip; k < n; k++) {
+                if constexpr (std::is_const_v<U>) {
+                    view.slot_at(head + k).store(items[k]);
+                } else {
+                    view.slot_at(head + k).store(std::move(items[k]));
+                }
+            }
+            shared_state->head.store(head + n, std::memory_order_release);
+            head_cache_ = head + n;
+        }
+
+        SharedState* shared_state_;
+        SlotsView view_;
+        uint64_t head_cache_;
+    };
+
+    [[nodiscard]] Writer& writer() noexcept { return writer_; }
+
+    class alignas(kFalseSharingSize) Reader {
+    public:
+        /**
+         * @brief Reads the next available items, oldest first; non-blocking.
+         *
+         * Consume only the returned span. It is a view into @p out, but may be shorter and offset
+         * within it; the rest of @p out holds unspecified data.
+         *
+         * A reader that has fallen too far behind drops its oldest unread items during this call;
+         * this is tracked by dropped().
+         *
+         * @param out Scratch buffer the items are read into; its size bounds how many are read.
+         * @return The items read, oldest first (a sub-span of @p out); empty in two cases: the reader is
+         *         caught up, or it fell behind and the writer overwrote the items this call would have
+         *         returned.
+         */
+        [[nodiscard]] std::span<T> read_batch(std::span<T> out) noexcept(kLoadNoexcept) {
+            if (out.empty()) {
+                return out;
+            }
+            // the furthest the cursor may fall behind claim; beyond it the oldest records would (likely) be
+            // overwritten before we finish copying them, so we drop them now and spend the copies on records
+            // we can actually keep
+            const auto max_lag = [this](uint64_t want, uint64_t cap) {
+                const uint64_t margin = std::min<uint64_t>(std::max<uint64_t>(skip_margin_, want), cap >> 1);
+                return std::max<uint64_t>(want, cap - margin);
+            };
+            // running max of how far the writer advances while we copy a batch, plus 25% headroom; decays
+            // slowly so it tracks recent advances rather than pinning to the highest ever seen
+            const auto update_skip_margin = [this](uint64_t advance) {
+                const uint64_t decayed = skip_margin_ - (skip_margin_ >> 6);
+                const uint64_t target = advance + (advance >> 2);
+                skip_margin_ = target > decayed ? target : decayed;
+            };
+
+            const SharedState* const shared_state = shared_state_;
+            const uint64_t head = shared_state->head.load(std::memory_order_acquire);
+            if (cursor_ >= head) {
+                return out.first(0);
+            }
+
+            const uint64_t claim_before = shared_state->claim.load(std::memory_order_relaxed);
+            const SlotsView view = view_;
+            const uint64_t want = std::min<uint64_t>(out.size(), view.capacity);
+            const uint64_t lag_limit = max_lag(want, view.capacity);
+            if (claim_before - cursor_ > lag_limit) {
+                dropped_ += (claim_before - cursor_) - lag_limit;
+                cursor_ = claim_before - lag_limit;
+            }
+
+            const uint64_t start = cursor_;
+            const size_t n = start < head ? std::min<uint64_t>(out.size(), head - start) : 0;
+            for (size_t k = 0; k < n; k++) {
+                view.slot_at(start + k).load(out[k]);
+            }
+            std::atomic_thread_fence(std::memory_order_acquire);
+
+            const uint64_t claim = shared_state->claim.load(std::memory_order_relaxed);
+            update_skip_margin(claim - claim_before);
+            if (claim - start > view.capacity) {
+                const uint64_t oldest = claim - view.capacity;
+                const uint64_t lost = oldest - start;
+                dropped_ += lost;
+                if (lost >= n) {
+                    cursor_ = oldest;
+                    return out.first(0);
+                }
+                cursor_ = start + n;
+                return out.subspan(lost, n - lost);
+            }
+
+            cursor_ = start + n;
+            return out.first(n);
+        }
+
+        /** @brief Reads one item into @p out; returns false when none is available (caught up or dropped). */
+        [[nodiscard]] bool read(T& out) noexcept(kLoadNoexcept) { return !read_batch({&out, 1}).empty(); }
+
+        using WakeToken = typename WakeTokenAtomic::value_type;
+
+        /** @brief Snapshots the wake state to pass to wait(); take it before testing any wait condition. */
+        [[nodiscard]] WakeToken wait_token() const noexcept {
+            return shared_state_->wake_token.load(std::memory_order_acquire);
+        }
+
+        /**
+         * @brief If no items are available to this reader, blocks until the next wake_readers() after @p since was
+         * read.
+         *
+         * Required instead of the parameterless wait() when the reader also waits on its own condition signalled
+         * through wake_readers() (e.g. a stop flag): take @p since before testing that condition, so a
+         * wake_readers() between the test and the wait is not lost.
+         */
+        void wait(WakeToken since) const noexcept {
+            if (cursor_ < shared_state_->head.load(std::memory_order_acquire)) {
+                return;
+            }
+            for (uint32_t spin = 0; spin < kWaitSpinIterations; ++spin) {
+                if (shared_state_->wake_token.load(std::memory_order_acquire) != since) {
+                    return;
+                }
+                ttsl::pause();
+            }
+            shared_state_->wake_token.wait(since, std::memory_order_acquire);
+        }
+
+        /** @brief If no items are available to this reader, blocks until wake_readers() is called. */
+        void wait() const noexcept { wait(wait_token()); }
+
+        /** @brief Number of items this reader skipped after lagging too far behind; updated only during read_batch().
+         */
+        [[nodiscard]] uint64_t dropped() const noexcept { return dropped_; }
+
+        Reader(const Reader&) = delete;
+        Reader& operator=(const Reader&) = delete;
+        Reader(Reader&& other) noexcept :
+            shared_state_(std::exchange(other.shared_state_, nullptr)),
+            view_(other.view_),
+            cursor_(other.cursor_),
+            dropped_(other.dropped_),
+            skip_margin_(other.skip_margin_),
+            active_readers_(std::exchange(other.active_readers_, nullptr)) {}
+        Reader& operator=(Reader&& other) noexcept {
+            if (this != &other) {
+                release();
+                shared_state_ = std::exchange(other.shared_state_, nullptr);
+                view_ = other.view_;
+                cursor_ = other.cursor_;
+                dropped_ = other.dropped_;
+                skip_margin_ = other.skip_margin_;
+                active_readers_ = std::exchange(other.active_readers_, nullptr);
+            }
+            return *this;
+        }
+        ~Reader() { release(); }
+
+    private:
+        friend class BroadcastRing;
+        Reader(
+            const SharedState* shared_state,
+            SlotsView view,
+            uint64_t start,
+            std::atomic<uint32_t>* active_readers) noexcept :
+            shared_state_(shared_state), view_(view), cursor_(start), active_readers_(active_readers) {
+            active_readers_->fetch_add(1, std::memory_order_relaxed);
+        }
+
+        void release() noexcept {
+            if (active_readers_ != nullptr) {
+                active_readers_->fetch_sub(1, std::memory_order_relaxed);
+                active_readers_ = nullptr;
+            }
+        }
+
+        const SharedState* shared_state_;
+        SlotsView view_;
+        uint64_t cursor_;
+        uint64_t dropped_ = 0;
+        uint64_t skip_margin_ = 0;
+        std::atomic<uint32_t>* active_readers_;
+    };
+
+    /** @brief Creates a reader at the current end of the stream; it sees only items published after this call. */
+    [[nodiscard]] Reader make_reader() const noexcept {
+        return Reader(&shared_state_, view(), shared_state_.head.load(std::memory_order_acquire), &active_readers_);
+    }
+
+private:
+    // avoids futex sleeps during short publish gaps
+    static constexpr uint32_t kWaitSpinIterations = 2048;
+
+    static constexpr bool kStoreNoexcept =
+        kTriviallyCopyable || (std::is_nothrow_copy_constructible_v<T> && std::is_nothrow_copy_assignable_v<T>);
+    static constexpr bool kMoveStoreNoexcept =
+        kTriviallyCopyable || (std::is_nothrow_move_constructible_v<T> && std::is_nothrow_move_assignable_v<T>);
+    static constexpr bool kLoadNoexcept = kTriviallyCopyable || std::is_nothrow_copy_assignable_v<T>;
+
+    struct AtomicSlot {
+        static constexpr size_t kWordCount = (sizeof(T) + sizeof(uint64_t) - 1) / sizeof(uint64_t);
+
+        std::array<std::atomic<uint64_t>, kWordCount> words;
+
+        void store(const T& v) noexcept {
+            const std::byte* src = reinterpret_cast<const std::byte*>(&v);
+#pragma GCC unroll 8
+            for (size_t k = 0; k < kWordCount; k++) {
+                uint64_t w = 0;
+                std::memcpy(&w, src + k * sizeof(uint64_t), word_bytes(k));
+                words[k].store(w, std::memory_order_relaxed);
+            }
+        }
+        void store(T&& v) noexcept { store(static_cast<const T&>(v)); }
+
+        void load(T& out) const noexcept {
+            std::byte* dst = reinterpret_cast<std::byte*>(&out);
+#pragma GCC unroll 8
+            for (size_t k = 0; k < kWordCount; k++) {
+                const uint64_t w = words[k].load(std::memory_order_relaxed);
+                std::memcpy(dst + k * sizeof(uint64_t), &w, word_bytes(k));
+            }
+        }
+
+        static constexpr size_t word_bytes(size_t k) noexcept {
+            return std::min(sizeof(uint64_t), sizeof(T) - k * sizeof(uint64_t));
+        }
+    };
+
+    struct LockedSlot {
+        mutable std::mutex mutex;
+        std::optional<T> value;
+
+        void store(const T& v) noexcept {
+            std::lock_guard lock(mutex);
+            value = v;
+        }
+        void store(T&& v) noexcept {
+            std::lock_guard lock(mutex);
+            value = std::move(v);
+        }
+        void load(T& out) const noexcept(kLoadNoexcept) {
+            std::lock_guard lock(mutex);
+            out = *value;
+        }
+    };
+
+    using Slot = std::conditional_t<kTriviallyCopyable, AtomicSlot, LockedSlot>;
+
+    struct SlotsView {
+        Slot* slots;
+        size_t capacity;
+        Slot& slot_at(uint64_t position) const noexcept { return slots[position & (capacity - 1)]; }
+    };
+
+    // head/claim are accessed together so they share a cache line; wake_token is on its own line so a
+    // reader spin-waiting on it in wait() can't steal the head/claim line from the writer
+    struct SharedState {
+        alignas(kFalseSharingSize) std::atomic<uint64_t> head{0};  // count of fully written items a reader may consume
+        std::atomic<uint64_t> claim{0};  // count the writer has started writing; always >= `head`
+        alignas(kFalseSharingSize) WakeTokenAtomic wake_token{0};
+    };
+
+    SlotsView view() const noexcept { return {slots_.get(), capacity_}; }
+
+    const size_t capacity_;
+    const std::unique_ptr<Slot[]> slots_;
+    SharedState shared_state_;
+    mutable std::atomic<uint32_t> active_readers_{0};
+    Writer writer_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/common/broadcast_ring.hpp
+++ b/tt_metal/common/broadcast_ring.hpp
@@ -31,6 +31,7 @@ namespace tt::tt_metal {
  * reader that cannot keep up loses its oldest unread items (tracked by Reader::dropped()).
  *
  * If the compile-time constant `is_always_lock_free` is true, then the ring is guaranteed to be lock-free.
+ * In particular, all publish and read operations are wait-free in this case.
  *
  * Obtain the writer from writer() (driven by a single thread) and each reader from make_reader().
  * Readers are single-threaded, and all readers must be destroyed before the ring.
@@ -129,6 +130,8 @@ public:
             SharedState* const shared_state = shared_state_;
             const size_t skip = n > view.capacity ? n - view.capacity : 0;
 
+            // bump claim before the slot stores, so a reader we lap mid-copy sees the
+            // raised claim in its recheck and drops the potentially overwritten items
             shared_state->claim.store(head + n, std::memory_order_relaxed);
             std::atomic_thread_fence(std::memory_order_release);
             for (size_t k = skip; k < n; k++) {
@@ -169,21 +172,6 @@ public:
             if (out.empty()) {
                 return out;
             }
-            // the furthest the cursor may fall behind claim; beyond it the oldest records would (likely) be
-            // overwritten before we finish copying them, so we drop them now and spend the copies on records
-            // we can actually keep
-            const auto max_lag = [this](uint64_t want, uint64_t cap) {
-                const uint64_t margin = std::min<uint64_t>(skip_margin_, cap >> 1);
-                return std::max<uint64_t>(want, cap - margin);
-            };
-            // running max of how far the writer advances while we copy a batch, plus 25% headroom; decays
-            // slowly so it tracks recent advances rather than pinning to the highest ever seen
-            const auto update_skip_margin = [this](uint64_t advance) {
-                const uint64_t decayed = skip_margin_ - (skip_margin_ >> 6);
-                const uint64_t target = advance + (advance >> 2);
-                skip_margin_ = target > decayed ? target : decayed;
-            };
-
             const SharedState* const shared_state = shared_state_;
             const uint64_t head = shared_state->head.load(std::memory_order_acquire);
             if (cursor_ >= head) {
@@ -192,11 +180,12 @@ public:
 
             const uint64_t claim_before = shared_state->claim.load(std::memory_order_relaxed);
             const SlotsView view = view_;
-            const uint64_t want = std::min<uint64_t>(out.size(), view.capacity);
-            const uint64_t lag_limit = max_lag(want, view.capacity);
-            if (claim_before - cursor_ > lag_limit) {
-                dropped_ += (claim_before - cursor_) - lag_limit;
-                cursor_ = claim_before - lag_limit;
+
+            const uint64_t max_lag = view.capacity - std::min<uint64_t>(writer_advance_estimate_, view.capacity >> 1);
+            if (uint64_t lag = claim_before - cursor_; lag > max_lag) {
+                const uint64_t drop = lag - max_lag;
+                dropped_ += drop;
+                cursor_ += drop;
             }
 
             const uint64_t start = cursor_;
@@ -204,10 +193,12 @@ public:
             for (size_t k = 0; k < n; k++) {
                 view.slot_at(start + k).load(out[k]);
             }
+            // we order the slot loads before we reload claim, so slots the writer lapped mid-copy show up as
+            // claim - start > capacity below and are dropped
             std::atomic_thread_fence(std::memory_order_acquire);
 
             const uint64_t claim = shared_state->claim.load(std::memory_order_relaxed);
-            update_skip_margin(claim - claim_before);
+            observe_advance(claim - claim_before);
             if (claim - start > view.capacity) {
                 const uint64_t oldest = claim - view.capacity;
                 const uint64_t lost = oldest - start;
@@ -269,7 +260,7 @@ public:
             view_(other.view_),
             cursor_(other.cursor_),
             dropped_(other.dropped_),
-            skip_margin_(other.skip_margin_),
+            writer_advance_estimate_(other.writer_advance_estimate_),
             active_readers_(std::exchange(other.active_readers_, nullptr)) {}
         Reader& operator=(Reader&& other) noexcept {
             if (this != &other) {
@@ -278,7 +269,7 @@ public:
                 view_ = other.view_;
                 cursor_ = other.cursor_;
                 dropped_ = other.dropped_;
-                skip_margin_ = other.skip_margin_;
+                writer_advance_estimate_ = other.writer_advance_estimate_;
                 active_readers_ = std::exchange(other.active_readers_, nullptr);
             }
             return *this;
@@ -303,11 +294,22 @@ public:
             }
         }
 
+        // proactive dropping to avoid copying records that are likely to be discarded by the claim re-check
+        static constexpr unsigned kAdvanceDecayShift = 4;     // estimate decays by ~1/16 per read
+        static constexpr unsigned kAdvanceHeadroomShift = 2;  // 25% headroom on the tracked advance
+        void observe_advance(uint64_t advance) noexcept {
+            const uint64_t decayed = writer_advance_estimate_ - (writer_advance_estimate_ >> kAdvanceDecayShift);
+            const uint64_t target = advance + (advance >> kAdvanceHeadroomShift);
+            writer_advance_estimate_ = std::max(target, decayed);
+        }
+
         const SharedState* shared_state_;
         SlotsView view_;
         uint64_t cursor_;
         uint64_t dropped_ = 0;
-        uint64_t skip_margin_ = 0;
+        // decaying max of how far the writer advances while we copy a batch, plus headroom;
+        // decays so it tracks recent advances rather than pinning to the highest ever seen
+        uint64_t writer_advance_estimate_ = 0;
         std::atomic<uint32_t>* active_readers_;
     };
 

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -264,12 +264,10 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
     MeshCoordinateRangeSet sender_device_range_set;
     sender_device_range_set.merge(MeshCoordinateRange(sender_core_.device_coord));
 
-    const auto& cluster = MetalContext::instance().get_cluster();
-    const auto& hal = MetalContext::instance().hal();
     const uint32_t pcie_alignment = pcie_alignment_;
     TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIe-aligned.");
 
-    bool can_use_pinned_memory = cluster.is_iommu_enabled() || hal.get_supports_64_bit_pcie_addressing();
+    bool can_use_pinned_memory = !d2h_uses_hugepage_fallback(MetalContext::instance());
 
     PinnedBufferInfo data_info;
     PinnedBufferInfo bytes_sent_info;

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -75,13 +75,26 @@ D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer(
     connector_state_offset_ = align(total_buffer_size_bytes, alignof(HDSocketConnectorState));
     size_t alloc_size = align(connector_state_offset_ + sizeof(HDSocketConnectorState), page_size);
 
-    shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, alloc_size));
-    void* aligned_ptr = shm_->ptr();
+    void* aligned_ptr = nullptr;
+    if (process_scope_ == ProcessScope::InProcess) {
+        void* p = mmap(nullptr, alloc_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        TT_FATAL(
+            p != MAP_FAILED,
+            "Anonymous mmap failed for D2H socket buffer ({} B): {}",
+            alloc_size,
+            std::strerror(errno));
+        aligned_ptr = p;
+        host_buffer_ = std::shared_ptr<uint32_t[]>(
+            static_cast<uint32_t*>(p), [alloc_size](uint32_t* ptr) { munmap(ptr, alloc_size); });
+    } else {
+        shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, alloc_size));
+        aligned_ptr = shm_->ptr();
+        // NamedShm::create zero-initializes the region; no explicit memset needed.
+        host_buffer_ = std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(aligned_ptr), [](uint32_t*) {});
+    }
     TT_FATAL(
         reinterpret_cast<uintptr_t>(aligned_ptr) % pcie_alignment == 0,
         "System Memory Allocation Error: D2H socket buffer must be aligned to the PCIe alignment.");
-    // NamedShm::create zero-initializes the region; no explicit memset needed.
-    host_buffer_ = std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(aligned_ptr), [](uint32_t*) {});
     bytes_sent_ptr_ = host_buffer_.get() + (fifo_size_ / sizeof(uint32_t));
 
     tt::tt_metal::HostBuffer host_buffer_view(
@@ -283,13 +296,15 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
         // Map the persistent connector-state struct living past the pinned region.
         // NamedShm::create zero-initialized the page; we stamp the version and set
         // clean_shutdown=1 so the first connect() sees "no prior crash" (the owner
-        // side has nothing to recover from). Hugepage fallback does not create an
-        // SHM region and cannot be exported, so connector_state_ stays null in
-        // that path.
-        connector_state_ =
-            reinterpret_cast<HDSocketConnectorState*>(static_cast<uint8_t*>(shm_->ptr()) + connector_state_offset_);
-        connector_state_->version = kHDSocketConnectorStateVersion;
-        connector_state_->clean_shutdown = 1;
+        // side has nothing to recover from). Paths without a named SHM region
+        // (anonymous backing, hugepage fallback) cannot be exported, so
+        // connector_state_ stays null there.
+        if (shm_) {
+            connector_state_ =
+                reinterpret_cast<HDSocketConnectorState*>(static_cast<uint8_t*>(shm_->ptr()) + connector_state_offset_);
+            connector_state_->version = kHDSocketConnectorStateVersion;
+            connector_state_->clean_shutdown = 1;
+        }
     } else {
         data_info = init_host_buffer_hugepage(mesh_device);
 
@@ -312,10 +327,14 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
 }
 
 D2HSocket::D2HSocket(
-    const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoreCoord& sender_core, uint32_t fifo_size) :
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    const MeshCoreCoord& sender_core,
+    uint32_t fifo_size,
+    ProcessScope scope) :
     sender_core_(sender_core),
     fifo_size_(fifo_size),
     pcie_alignment_(MetalContext::instance().hal().get_alignment(HalMemType::HOST)),
+    process_scope_(scope),
     mesh_device_(mesh_device.get()) {
     init_config_buffer(mesh_device);
     init_common(mesh_device);
@@ -325,10 +344,12 @@ D2HSocket::D2HSocket(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const MeshCoreCoord& sender_core,
     uint32_t fifo_size,
-    ExternalConfigBuffer external_config) :
+    ExternalConfigBuffer external_config,
+    ProcessScope scope) :
     sender_core_(sender_core),
     fifo_size_(fifo_size),
     pcie_alignment_(MetalContext::instance().hal().get_alignment(HalMemType::HOST)),
+    process_scope_(scope),
     mesh_device_(mesh_device.get()) {
     TT_FATAL(external_config.address != 0, "External config buffer address must be non-zero.");
     const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1510,9 +1510,7 @@ void MeshDeviceImpl::trigger_realtime_profiler_sync_check() {
     }
 }
 
-D2HSocket* MeshDeviceImpl::get_realtime_profiler_socket() const {
-    return realtime_profiler_ ? realtime_profiler_->get_socket() : nullptr;
-}
+RealtimeProfilerManager* MeshDeviceImpl::get_realtime_profiler() const { return realtime_profiler_.get(); }
 
 ::tt::tt_metal::DriscL1Arena& MeshDeviceImpl::drisc_l1_arena() {
     TT_FATAL(

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -66,7 +66,6 @@ class DriscL1Arena;
 
 namespace distributed {
 
-class D2HSocket;
 class MeshCommandQueue;
 class MeshDeviceView;
 struct MeshTraceBuffer;
@@ -306,7 +305,7 @@ public:
         bool minimal = false);
     void init_realtime_profiler_socket(const std::shared_ptr<MeshDevice>& mesh_device);
     void trigger_realtime_profiler_sync_check();
-    D2HSocket* get_realtime_profiler_socket() const;
+    RealtimeProfilerManager* get_realtime_profiler() const;
 
     // DRISC L1 arena. Consumed by the DRAM-sender GlobalCircularBuffer ctor for
     // pages_sent allocations. Constructed eagerly in initialize_impl() when the

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -7,19 +7,23 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <string>
 #include <thread>
-#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
 
 #include <enchantum/enchantum.hpp>
 #include <fmt/core.h>
@@ -47,10 +51,11 @@
 #include "dispatch/command_queue_common.hpp"
 #include "dispatch/dispatch_core_manager.hpp"
 #include "dispatch/dispatch_mem_map.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include "llrt/hal.hpp"
-#include "tools/profiler/tt_metal_tracy.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
+#include "tt_metal/impl/dispatch/data_collector.hpp"
 #include "tt_metal/impl/dispatch/kernels/realtime_profiler_ring_buffer.hpp"
 #include "tt_metal/impl/dispatch/realtime_profiler_tracy_handler.hpp"
 #include "tt_metal/impl/profiler/profiler.hpp"                // tt::tt_metal::SyncInfo, DeviceProfiler
@@ -64,6 +69,10 @@ namespace {
 // between finish-path sync checks, per physical chip. Matches the finish-path throttle.
 constexpr auto kRtProfilerMinSyncInterval = std::chrono::seconds(60);
 
+constexpr auto kFinishSyncRequestDelay = std::chrono::milliseconds(5);
+constexpr auto kFinishSyncResponseTimeout = std::chrono::milliseconds(5000);
+constexpr auto kSyncResponsePollBackoff = std::chrono::microseconds(100);
+
 // Last full init sync per chip, process-wide, to avoid repeating ~0.5s run_sync on every mesh open.
 std::mutex g_rt_profiler_init_sync_mu;
 std::unordered_map<uint32_t, std::chrono::steady_clock::time_point> g_rt_profiler_last_init_sync_by_chip;
@@ -74,10 +83,13 @@ constexpr uint32_t REALTIME_PROFILER_SYNC_MARKER_ID = 0xFFFFFFFF;
 // Real-time profiler runtime constants. On-device L1 layout sizes are reused from
 // realtime_profiler_ring_buffer.hpp so host and device share a single source of truth.
 struct RealtimeProfilerRuntimeSizes {
-    static constexpr uint32_t fifo_size = 4096;                    // 4KB pinned-host FIFO for D2H socket
+    static constexpr uint32_t fifo_pages = 32768;                  // host D2H FIFO depth, in pages
     static constexpr uint32_t page_size = RT_PROFILER_ENTRY_SIZE;  // host page size == ring entry size
+    static constexpr uint32_t fifo_size = fifo_pages * page_size;  // pinned-host FIFO, in bytes (2 MiB)
     static constexpr uint32_t core_l1_size = sizeof(RealtimeProfilerCoreL1);
 };
+
+constexpr uint32_t kMaxSocketPagesPerRead = 1024;
 
 // Compute the RT-profiler L1 carve-out addresses from a base anchored past UNRESERVED (outside the user-space
 // allocator).
@@ -284,27 +296,175 @@ void parallel_for_each_device_index(const std::vector<size_t>& indices, Fn&& fn)
 
 RealtimeProfilerManager::DeviceState::DeviceState() = default;
 RealtimeProfilerManager::DeviceState::~DeviceState() = default;
-RealtimeProfilerManager::DeviceState::DeviceState(DeviceState&& o) noexcept :
-    device(o.device),
-    chip_id(o.chip_id),
-    mesh_coord(std::move(o.mesh_coord)),
-    realtime_profiler_core(o.realtime_profiler_core),
-    socket(std::move(o.socket)),
-    realtime_profiler_program(std::move(o.realtime_profiler_program)),
-    core_l1(o.core_l1),
-    first_timestamp(o.first_timestamp),
-    sync_host_start(o.sync_host_start),
-    sync_frequency(o.sync_frequency),
-    realtime_profiler_base_addr(o.realtime_profiler_base_addr),
-    sync_request_addr(o.sync_request_addr),
-    sync_host_ts_addr(o.sync_host_ts_addr),
-    sync_response_received(o.sync_response_received.load(std::memory_order_relaxed)),
-    sync_host_time_before(o.sync_host_time_before),
-    last_finish_sync_at(o.last_finish_sync_at),
-    pending_first_unthrottled_finish_sync(o.pending_first_unthrottled_finish_sync) {}
+RealtimeProfilerManager::DeviceState::DeviceState(DeviceState&&) noexcept = default;
+
+void RealtimeProfilerManager::publish_pages(
+    const DeviceState& dev_state,
+    const uint32_t* page_buf,
+    uint32_t num_pages,
+    std::vector<tt::ProgramRealtimeRecord>& records) {
+    constexpr uint32_t kPageWords = RealtimeProfilerRuntimeSizes::page_size / sizeof(uint32_t);
+    auto is_record = [](const uint32_t* page) { return page[2] != 0 && page[3] != REALTIME_PROFILER_SYNC_MARKER_ID; };
+    records.clear();
+    const uint32_t chip_id = dev_state.chip_id;
+    const double sync_frequency = dev_state.sync_frequency;
+    const DataCollector* const data_collector = data_collector_;
+    for (uint32_t page = 0; page < num_pages; ++page) {
+        const uint32_t* rp = page_buf + page * kPageWords;
+        if (!is_record(rp)) {
+            continue;
+        }
+        records.emplace_back(
+            rp[2],
+            chip_id,
+            (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
+            (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
+            sync_frequency,
+            data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])));
+    }
+    if (records.empty()) {
+        return;
+    }
+    num_published_records_.fetch_add(records.size(), std::memory_order_relaxed);
+    num_published_batches_.fetch_add(1, std::memory_order_relaxed);
+    ring_->writer().publish_batch(std::span<const tt::ProgramRealtimeRecord>(records));
+}
+
+bool RealtimeProfilerManager::has_active_finish_sync() const {
+    for (const auto& dev_state : devices_) {
+        if (dev_state.finish_sync_phase != DeviceState::FinishSyncPhase::Idle) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void RealtimeProfilerManager::write_sync_request(RealtimeProfilerManager::DeviceState& dev_state, SyncRequest value) {
+    std::vector<uint32_t> data = {value};
+    tt::tt_metal::detail::WriteToDeviceL1(
+        dev_state.device, dev_state.realtime_profiler_core, dev_state.sync_request_addr, data, CoreType::WORKER);
+}
+
+void RealtimeProfilerManager::start_finish_syncs(std::chrono::steady_clock::time_point now) {
+    if (!finish_sync_requested_.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    bool started = false;
+    for (auto& dev_state : devices_) {
+        if (dev_state.finish_sync_phase != DeviceState::FinishSyncPhase::Idle) {
+            continue;
+        }
+        const bool interval_elapsed = !dev_state.last_finish_sync_at.has_value() ||
+                                      now - *dev_state.last_finish_sync_at >= kRtProfilerMinSyncInterval;
+        if (!interval_elapsed && !dev_state.pending_first_unthrottled_finish_sync) {
+            continue;
+        }
+        try {
+            write_sync_request(dev_state, SyncRequest::Set);
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogMetal,
+                "[Real-time profiler] Failed to start sync for device {}: {}",
+                dev_state.chip_id,
+                e.what());
+            continue;
+        }
+        dev_state.finish_sync_request_at = now;
+        dev_state.finish_sync_phase = DeviceState::FinishSyncPhase::AwaitingDelay;
+        started = true;
+    }
+    finish_sync_busy_.store(started || has_active_finish_sync(), std::memory_order_release);
+    finish_sync_requested_.store(false, std::memory_order_release);
+    notify_finish_sync_waiters();
+}
+
+void RealtimeProfilerManager::advance_finish_sync(DeviceState& dev_state, std::chrono::steady_clock::time_point now) {
+    switch (dev_state.finish_sync_phase) {
+        case DeviceState::FinishSyncPhase::Idle: return;
+        case DeviceState::FinishSyncPhase::AwaitingDelay: {
+            if (now - dev_state.finish_sync_request_at < kFinishSyncRequestDelay) {
+                return;
+            }
+            dev_state.sync_host_time_before = rt_profiler_host_ticks();
+            std::vector<uint32_t> host_time_data = {
+                static_cast<uint32_t>(dev_state.sync_host_time_before & 0xFFFFFFFF)};
+            TracyMessageL("FINISH_SYNC");
+            tt::tt_metal::detail::WriteToDeviceL1(
+                dev_state.device,
+                dev_state.realtime_profiler_core,
+                dev_state.sync_host_ts_addr,
+                host_time_data,
+                CoreType::WORKER);
+            dev_state.finish_sync_deadline = now + kFinishSyncResponseTimeout;
+            dev_state.finish_sync_phase = DeviceState::FinishSyncPhase::AwaitingResponse;
+            return;
+        }
+        case DeviceState::FinishSyncPhase::AwaitingResponse:
+            if (now > dev_state.finish_sync_deadline) {
+                log_warning(tt::LogMetal, "[Real-time profiler] Sync check timed out for device {}", dev_state.chip_id);
+                write_sync_request(dev_state, SyncRequest::Clear);
+                dev_state.finish_sync_phase = DeviceState::FinishSyncPhase::Idle;
+                finish_sync_busy_.store(has_active_finish_sync(), std::memory_order_release);
+                notify_finish_sync_waiters();
+            }
+            return;
+    }
+}
+
+void RealtimeProfilerManager::service_finish_sync(std::chrono::steady_clock::time_point now, bool allow_start) {
+    if (allow_start) {
+        start_finish_syncs(now);
+    }
+    if (!finish_sync_busy_.load(std::memory_order_acquire)) {
+        return;
+    }
+    for (auto& dev_state : devices_) {
+        try {
+            advance_finish_sync(dev_state, now);
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogMetal,
+                "[Real-time profiler] Exception advancing sync for device {}: {}",
+                dev_state.chip_id,
+                e.what());
+        }
+    }
+}
 
 RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevice>& mesh_device) :
     context_id_(mesh_device->impl().get_context_id()) {
+    initialize_devices(mesh_device);
+
+    if (devices_.empty()) {
+        log_debug(
+            tt::LogMetal, "[Real-time profiler] No local devices found in mesh, skipping real-time profiler setup");
+        return;
+    }
+
+    const size_t max_consumer_batch_records =
+        std::min(kMaxConsumerBatchCap, kMaxConsumerBatchPerDevice * devices_.size());
+    ring_.emplace(std::min(kMaxRingCapacity, max_consumer_batch_records * kRingHeadroomBatches));
+
+    for (const auto& dev_state : devices_) {
+        tt::NotifyProgramRealtimeProfilerActivated(dev_state.chip_id);
+    }
+
+    run_init_sync();
+
+    for (auto& dev_state : devices_) {
+        dev_state.pending_first_unthrottled_finish_sync = true;
+    }
+
+    DataCollector* data_collector = MetalContext::instance(context_id_).data_collector().get();
+    data_collector->AttachRealtimeProfilerCallbackListener(this);
+    data_collector_ = data_collector;
+
+    // Background receiver thread that polls all device sockets round-robin
+    receiver_thread_ = std::thread(&RealtimeProfilerManager::run_receiver, this);
+}
+
+void RealtimeProfilerManager::initialize_devices(const std::shared_ptr<MeshDevice>& mesh_device) {
     // HAL offsets are the same for all devices (same arch).
     const auto& hal = MetalContext::instance(context_id_).hal();
     const auto& factory = hal.get_realtime_profiler_msgs_factory(HalProgrammableCoreType::TENSIX);
@@ -403,7 +563,6 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             continue;
         }
 
-        dev_state.realtime_profiler_base_addr = realtime_profiler_base_addr;
         dev_state.sync_request_addr = realtime_profiler_base_addr + sync_request_offset;
         dev_state.sync_host_ts_addr = realtime_profiler_base_addr + sync_host_timestamp_offset;
 
@@ -427,13 +586,12 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 factory.offset_of<realtime_profiler_msgs::realtime_profiler_msg_t>(
                     realtime_profiler_msgs::realtime_profiler_msg_t::Field::realtime_profiler_state);
             uint32_t realtime_profiler_core_state_addr = realtime_profiler_base_addr + realtime_profiler_state_offset;
-            uint32_t profiler_msg_carve_base = realtime_profiler_base_addr;
 
             std::vector<uint32_t> noc_xy_data = {realtime_profiler_noc_xy};
             tt::tt_metal::detail::WriteToDeviceL1(
                 device,
                 dispatch_s_core,
-                profiler_msg_carve_base + realtime_profiler_core_noc_xy_offset,
+                realtime_profiler_base_addr + realtime_profiler_core_noc_xy_offset,
                 noc_xy_data,
                 CoreType::WORKER);
 
@@ -441,7 +599,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             tt::tt_metal::detail::WriteToDeviceL1(
                 device,
                 dispatch_s_core,
-                profiler_msg_carve_base + remote_state_addr_field_offset,
+                realtime_profiler_base_addr + remote_state_addr_field_offset,
                 remote_state_addr_data,
                 CoreType::WORKER);
 
@@ -574,18 +732,13 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
         MetalContext::instance(context_id_).device_manager()->mark_rt_profiler_device_init_complete(device_id);
         devices_.push_back(std::move(dev_state));
     }
+}
 
-    if (devices_.empty()) {
-        log_debug(
-            tt::LogMetal, "[Real-time profiler] No local devices found in mesh, skipping real-time profiler setup");
-        return;
-    }
-
-    // Announce activation; paired with NotifyProgramRealtimeProfilerDeactivated on shutdown.
-    for (const auto& dev_state : devices_) {
-        tt::NotifyProgramRealtimeProfilerActivated(dev_state.chip_id);
-    }
-
+void RealtimeProfilerManager::run_init_sync() {
+    constexpr uint32_t kInitSyncMaxRetries = 3;
+    constexpr auto kInitSyncRetryDelay = std::chrono::milliseconds(500);
+    constexpr auto kConstructorSyncCheckDelay = std::chrono::milliseconds(10);
+    constexpr auto kConstructorSyncCheckTimeout = std::chrono::milliseconds(3000);
     auto& cluster = MetalContext::instance(context_id_).get_cluster();
     const auto init_throttle_now = std::chrono::steady_clock::now();
     std::vector<bool> skip_init_sync_check(devices_.size(), false);
@@ -627,17 +780,15 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
 
     parallel_for_each_device_index(init_run_sync_indices, [&](size_t di) {
         auto& dev_state = devices_[di];
-        constexpr uint32_t kMaxSyncRetries = 3;
-        constexpr uint32_t kRetryDelayMs = 500;
-        for (uint32_t attempt = 0; attempt <= kMaxSyncRetries; attempt++) {
+        for (uint32_t attempt = 0; attempt <= kInitSyncMaxRetries; attempt++) {
             if (attempt > 0) {
                 log_debug(
                     tt::LogMetal,
                     "[Real-time profiler] Device {} sync retry {}/{}",
                     dev_state.chip_id,
                     attempt,
-                    kMaxSyncRetries);
-                std::this_thread::sleep_for(std::chrono::milliseconds(kRetryDelayMs));
+                    kInitSyncMaxRetries);
+                std::this_thread::sleep_for(kInitSyncRetryDelay);
             }
             run_sync(dev_state, 100);
             if (dev_state.first_timestamp != 0) {
@@ -675,15 +826,9 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
     }
     parallel_for_each_device_index(init_sync_check_indices, [&](size_t di) {
         auto& dev_state = devices_[di];
-        std::vector<uint32_t> sync_req = {1};
-        tt::tt_metal::detail::WriteToDeviceL1(
-            dev_state.device,
-            dev_state.realtime_profiler_core,
-            dev_state.sync_request_addr,
-            sync_req,
-            CoreType::WORKER);
+        write_sync_request(dev_state, SyncRequest::Set);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(kConstructorSyncCheckDelay);
 
         // Capture host TSC, emit Tracy message, then PCIe write; CalibrateDevice must precede PushSyncCheckMarker or
         // skew exceeds the ±10µs test bound.
@@ -698,24 +843,17 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             host_time_data,
             CoreType::WORKER);
 
-        constexpr uint32_t kSyncCheckTimeoutMs = 3000;
-        auto sc_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kSyncCheckTimeoutMs);
+        auto sc_deadline = std::chrono::steady_clock::now() + kConstructorSyncCheckTimeout;
         bool sc_got_response = false;
         while (std::chrono::steady_clock::now() < sc_deadline) {
             if (dev_state.socket->pages_available() > 0) {
                 sc_got_response = true;
                 break;
             }
-            std::this_thread::sleep_for(std::chrono::microseconds(100));
+            std::this_thread::sleep_for(kSyncResponsePollBackoff);
         }
 
-        sync_req[0] = 0;
-        tt::tt_metal::detail::WriteToDeviceL1(
-            dev_state.device,
-            dev_state.realtime_profiler_core,
-            dev_state.sync_request_addr,
-            sync_req,
-            CoreType::WORKER);
+        write_sync_request(dev_state, SyncRequest::Clear);
 
         if (sc_got_response) {
             std::vector<uint32_t> sync_page(RealtimeProfilerRuntimeSizes::page_size / sizeof(uint32_t));
@@ -744,157 +882,239 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 tt::LogMetal,
                 "[Real-time profiler] Device {} sync check timed out after {}ms, skipping",
                 dev_state.chip_id,
-                kSyncCheckTimeoutMs);
+                kConstructorSyncCheckTimeout.count());
         }
     });
+}
 
-    for (auto& dev_state : devices_) {
-        dev_state.pending_first_unthrottled_finish_sync = true;
+uint32_t RealtimeProfilerManager::drain_device_pages(
+    DeviceState& dev_state,
+    bool scan_sync_marker,
+    std::vector<uint32_t>& page_buf,
+    std::vector<tt::ProgramRealtimeRecord>& record_buf) {
+    constexpr uint32_t kPageWords = RealtimeProfilerRuntimeSizes::page_size / sizeof(uint32_t);
+    uint32_t available = dev_state.socket->pages_available();
+    if (available > peak_fifo_pages_.load(std::memory_order_relaxed)) {
+        peak_fifo_pages_.store(available, std::memory_order_relaxed);
     }
+    if (available >= RealtimeProfilerRuntimeSizes::fifo_pages && !dev_state.fifo_reached_capacity) {
+        dev_state.fifo_reached_capacity = true;
+        log_warning(
+            tt::LogMetal,
+            "[Real-time profiler] Device {} D2H FIFO reached capacity ({} pages); profiler data may be dropped",
+            dev_state.chip_id,
+            available);
+    }
+    if (available == 0) {
+        return 0;
+    }
+    const uint32_t num_pages_to_read = std::min(available, kMaxSocketPagesPerRead);
+    dev_state.socket->read(page_buf.data(), num_pages_to_read);
 
-    // Background receiver thread that polls all device sockets round-robin.
-    stop_.store(false);
-    receiver_thread_ = std::thread([this]() {
-        tracy::SetThreadName("RealtimeProfiler");
-        uint64_t pages_received = 0;
-
-        log_debug(tt::LogMetal, "[Real-time profiler] Receiver thread started for {} devices", devices_.size());
-
-        // Process one page from a device socket. Returns true if a page was consumed.
-        std::vector<uint32_t> page_buf(RealtimeProfilerRuntimeSizes::page_size / sizeof(uint32_t));
-        auto process_one_page = [&](DeviceState& dev_state) -> bool {
-            uint32_t available = dev_state.socket->pages_available();
-            if (available == 0) {
-                return false;
-            }
-
-            TTZoneScopedDN(RT_PROFILER, "ProcessPage");
-            dev_state.socket->read(page_buf.data(), 1);
-            uint32_t* read_ptr = page_buf.data();
-
-            uint32_t marker = read_ptr[3];
-            if (!dev_state.sync_response_received.load() && marker == REALTIME_PROFILER_SYNC_MARKER_ID) {
-                uint64_t device_time = (static_cast<uint64_t>(read_ptr[0]) << 32) | read_ptr[1];
-                tracy_handler_->CalibrateDevice(
-                    dev_state.chip_id, dev_state.sync_host_time_before, device_time, dev_state.sync_frequency);
-                tracy_handler_->PushSyncCheckMarker(dev_state.chip_id, device_time, dev_state.sync_frequency);
-                publish_device_profiler_sync_anchor(
-                    dev_state.chip_id,
-                    static_cast<double>(dev_state.sync_host_time_before),
-                    static_cast<double>(device_time),
-                    dev_state.sync_frequency,
-                    dev_state.realtime_profiler_core.str());
-                pages_received++;
-                dev_state.sync_response_received.store(true);
-                return true;
-            }
-
-            // kernel_start (words 0-3), kernel_end (words 4-7); each
-            // realtime_profiler_timestamp_t: time_hi, time_lo, id, header.
-            uint64_t start_time = (static_cast<uint64_t>(read_ptr[0]) << 32) | read_ptr[1];
-            uint32_t start_id = read_ptr[2];
-            uint64_t end_time = (static_cast<uint64_t>(read_ptr[4]) << 32) | read_ptr[5];
-
-            // Skip records with id==0 (non-GO dispatch commands like SET_NUM_WORKER_SEMS):
-            // they have no valid program and may carry stale end timestamps.
-            if (start_id != 0) {
-                TTZoneScopedDN(RT_PROFILER, "InvokeCallbacks");
-                tt::ProgramRealtimeRecord record{
-                    .runtime_id = start_id,
-                    .chip_id = dev_state.chip_id,
-                    .start_timestamp = start_time,
-                    .end_timestamp = end_time,
-                    .frequency = dev_state.sync_frequency,
-                    .kernel_sources = tt::GetKernelSourcesForRuntimeId(static_cast<uint16_t>(start_id)),
-                };
-                tt::InvokeProgramRealtimeProfilerCallbacks(record);
-            }
-
-            pages_received++;
-            return true;
-        };
-
-        while (!stop_.load()) {
-            if (pause_requested_.load(std::memory_order_acquire)) {
-                paused_.store(true, std::memory_order_release);
-                while (pause_requested_.load(std::memory_order_acquire) && !stop_.load()) {
-                    std::this_thread::sleep_for(std::chrono::microseconds(100));
-                }
-                paused_.store(false, std::memory_order_release);
+    if (scan_sync_marker && dev_state.finish_sync_phase == DeviceState::FinishSyncPhase::AwaitingResponse) {
+        for (uint32_t page = 0; page < num_pages_to_read; ++page) {
+            const uint32_t* read_ptr = page_buf.data() + page * kPageWords;
+            if (read_ptr[3] != REALTIME_PROFILER_SYNC_MARKER_ID) {
                 continue;
             }
-
-            TTZoneScopedDN(RT_PROFILER, "PollLoop");
-            bool any_data = false;
-
-            for (auto& dev_state : devices_) {
-                try {
-                    if (process_one_page(dev_state)) {
-                        any_data = true;
-                    }
-                } catch (const std::exception& e) {
-                    log_warning(
-                        tt::LogMetal,
-                        "[Real-time profiler] Exception in receiver for device {}: {}",
-                        dev_state.chip_id,
-                        e.what());
-                }
-            }
-
-            if (!any_data) {
-                TTZoneScopedDN(RT_PROFILER, "Idle");
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
-            }
+            const uint64_t device_time = (static_cast<uint64_t>(read_ptr[0]) << 32) | read_ptr[1];
+            tracy_handler_->CalibrateDevice(
+                dev_state.chip_id, dev_state.sync_host_time_before, device_time, dev_state.sync_frequency);
+            tracy_handler_->PushSyncCheckMarker(dev_state.chip_id, device_time, dev_state.sync_frequency);
+            publish_device_profiler_sync_anchor(
+                dev_state.chip_id,
+                static_cast<double>(dev_state.sync_host_time_before),
+                static_cast<double>(device_time),
+                dev_state.sync_frequency,
+                dev_state.realtime_profiler_core.str());
+            dev_state.last_finish_sync_at = std::chrono::steady_clock::now();
+            dev_state.pending_first_unthrottled_finish_sync = false;
+            write_sync_request(dev_state, SyncRequest::Clear);
+            dev_state.finish_sync_phase = DeviceState::FinishSyncPhase::Idle;
+            finish_sync_busy_.store(has_active_finish_sync(), std::memory_order_release);
+            notify_finish_sync_waiters();
+            break;
         }
+    }
+    publish_pages(dev_state, page_buf.data(), num_pages_to_read, record_buf);
+    return num_pages_to_read;
+}
 
-        // Drain in-flight PCIe pages until all sockets stay empty for several rounds.
-        {
-            TTZoneScopedDN(RT_PROFILER, "DrainShutdown");
-            constexpr uint32_t kDrainQuietRounds = 10;
-            uint64_t drain_pages = 0;
-            uint32_t quiet_rounds = 0;
-            while (quiet_rounds < kDrainQuietRounds) {
-                bool any_data = false;
-                for (auto& dev_state : devices_) {
-                    try {
-                        if (process_one_page(dev_state)) {
-                            any_data = true;
-                            drain_pages++;
-                        }
-                    } catch (const std::exception& e) {
-                        log_warning(
-                            tt::LogMetal,
-                            "[Real-time profiler] Exception draining device {}: {}",
-                            dev_state.chip_id,
-                            e.what());
-                    }
-                }
-                if (any_data) {
-                    quiet_rounds = 0;
-                } else {
-                    quiet_rounds++;
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-                }
-            }
-
-            log_debug(
-                tt::LogMetal,
-                "[Real-time profiler] Receiver thread stopped after {} pages ({} drained during shutdown)",
-                pages_received,
-                drain_pages);
+uint64_t RealtimeProfilerManager::run_receiver_loop() {
+    constexpr uint32_t kPageWords = RealtimeProfilerRuntimeSizes::page_size / sizeof(uint32_t);
+    std::vector<uint32_t> page_buf(kMaxSocketPagesPerRead * kPageWords);
+    std::vector<tt::ProgramRealtimeRecord> record_buf;
+    record_buf.reserve(kMaxSocketPagesPerRead);
+    constexpr std::chrono::microseconds kReceiverMaxBackoff{100};
+    std::chrono::microseconds backoff{1};
+    uint64_t num_pages_received = 0;
+    while (!stop_.load(std::memory_order_acquire)) {
+        const bool scan_sync_marker = finish_sync_busy_.load(std::memory_order_acquire);
+        const uint32_t num_pages = drain_all_devices(scan_sync_marker, page_buf, record_buf);
+        num_pages_received += num_pages;
+        const bool sync_requested = finish_sync_requested_.load(std::memory_order_acquire);
+        if (scan_sync_marker || sync_requested) {
+            service_finish_sync(std::chrono::steady_clock::now(), sync_requested);
         }
-    });
+        if (num_pages > 0) {
+            backoff = std::chrono::microseconds{1};
+            continue;
+        }
+        std::this_thread::sleep_for(backoff);
+        backoff += std::max(backoff / 4, std::chrono::microseconds{1});
+        backoff = std::min(backoff, kReceiverMaxBackoff);
+    }
+    return num_pages_received;
+}
+
+uint32_t RealtimeProfilerManager::drain_all_devices(
+    bool scan_sync_marker, std::vector<uint32_t>& page_buf, std::vector<tt::ProgramRealtimeRecord>& record_buf) {
+    uint32_t num_pages = 0;
+    for (auto& dev_state : devices_) {
+        try {
+            num_pages += drain_device_pages(dev_state, scan_sync_marker, page_buf, record_buf);
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogMetal, "[Real-time profiler] Exception draining device {}: {}", dev_state.chip_id, e.what());
+        }
+    }
+    if (num_pages > 0) {
+        ring_->writer().wake_readers();
+    }
+    return num_pages;
+}
+
+uint64_t RealtimeProfilerManager::drain_receiver_on_shutdown() {
+    constexpr uint32_t kPageWords = RealtimeProfilerRuntimeSizes::page_size / sizeof(uint32_t);
+    std::vector<uint32_t> page_buf(kMaxSocketPagesPerRead * kPageWords);
+    std::vector<tt::ProgramRealtimeRecord> record_buf;
+    record_buf.reserve(kMaxSocketPagesPerRead);
+    constexpr uint32_t kShutdownDrainQuietRounds = 10;
+    constexpr auto kShutdownDrainQuietBackoff = std::chrono::milliseconds(1);
+    uint64_t num_pages_drained = 0;
+    uint32_t quiet_rounds = 0;
+    while (quiet_rounds < kShutdownDrainQuietRounds) {
+        const bool scan_sync_marker = finish_sync_busy_.load(std::memory_order_acquire);
+        const uint32_t num_pages = drain_all_devices(scan_sync_marker, page_buf, record_buf);
+        if (num_pages != 0) {
+            num_pages_drained += num_pages;
+            quiet_rounds = 0;
+        } else {
+            quiet_rounds++;
+            std::this_thread::sleep_for(kShutdownDrainQuietBackoff);
+        }
+    }
+    return num_pages_drained;
+}
+
+void RealtimeProfilerManager::run_receiver() {
+    tracy::SetThreadName("RealtimeProfiler");
+#if defined(__linux__)
+    ::prctl(PR_SET_TIMERSLACK, 1UL, 0, 0, 0);
+#endif
+    log_debug(tt::LogMetal, "[Real-time profiler] Receiver thread started for {} devices", devices_.size());
+
+    const uint64_t num_pages_received = run_receiver_loop();
+    const uint64_t num_pages_drained = drain_receiver_on_shutdown();
+
+    log_debug(
+        tt::LogMetal,
+        "[Real-time profiler] Receiver thread stopped after {} pages ({} drained during shutdown)",
+        num_pages_received + num_pages_drained,
+        num_pages_drained);
+}
+
+void RealtimeProfilerManager::run_consumer(Consumer& consumer) {
+    tracy::SetThreadName(fmt::format("RtProfilerConsumer{}", consumer.handle).c_str());
+    std::vector<tt::ProgramRealtimeRecord> records(
+        std::min(kMaxConsumerBatchCap, kMaxConsumerBatchPerDevice * devices_.size()));
+    uint64_t reported_dropped = 0;
+
+    auto deliver_batch = [&](std::span<const tt::ProgramRealtimeRecord> batch, uint64_t dropped_total) {
+        const tt::ProgramRealtimeRecordBatch arg{batch, dropped_total - reported_dropped};
+        reported_dropped = dropped_total;
+        try {
+            consumer.callback(arg);
+        } catch (const std::exception& e) {
+            log_warning(tt::LogMetal, "[Real-time profiler] Callback threw an exception: {}", e.what());
+        } catch (...) {
+            log_warning(tt::LogMetal, "[Real-time profiler] Callback threw an unknown exception");
+        }
+    };
+
+    while (true) {
+        // stop_consumer sets the stop mode then wakes, so waiting on a token sampled only inside wait() could miss that
+        // wake and hang
+        const auto token = consumer.reader.wait_token();
+        const auto batch = consumer.reader.read_batch(records);
+        const uint64_t dropped_total = consumer.reader.dropped();
+        const ConsumerStopMode stop_mode = consumer.stop_mode.load(std::memory_order_acquire);
+        if (stop_mode == ConsumerStopMode::StopWithoutDrain) {
+            break;
+        }
+        if (!batch.empty()) {
+            deliver_batch(batch, dropped_total);
+        } else if (stop_mode == ConsumerStopMode::DrainThenStop) {
+            break;
+        } else {
+            consumer.reader.wait(token);
+        }
+    }
+    consumer.dropped = consumer.reader.dropped();
+}
+
+void RealtimeProfilerManager::stop_consumer(Consumer& consumer, ConsumerStopMode stop_mode) {
+    consumer.stop_mode.store(stop_mode, std::memory_order_release);
+    ring_->writer().wake_readers();
+    if (consumer.thread.joinable()) {
+        consumer.thread.join();
+    }
+}
+
+void RealtimeProfilerManager::on_callback_registered(
+    tt::ProgramRealtimeProfilerCallbackHandle handle, const tt::ProgramRealtimeProfilerCallback& callback) {
+    auto consumer = std::make_unique<Consumer>(ring_->make_reader(), callback, handle);
+    Consumer* raw = consumer.get();
+    std::lock_guard<std::mutex> lock(consumers_mutex_);
+    consumers_.emplace(handle, std::move(consumer));
+    raw->thread = std::thread([this, raw]() { run_consumer(*raw); });
+}
+
+void RealtimeProfilerManager::on_callback_unregistered(tt::ProgramRealtimeProfilerCallbackHandle handle) {
+    std::unique_ptr<Consumer> consumer;
+    {
+        std::lock_guard<std::mutex> lock(consumers_mutex_);
+        auto it = consumers_.find(handle);
+        if (it == consumers_.end()) {
+            return;
+        }
+        const auto caller = std::this_thread::get_id();
+        const bool from_callback_thread =
+            std::ranges::any_of(consumers_, [caller](const auto& kv) { return kv.second->thread.get_id() == caller; });
+        TT_FATAL(!from_callback_thread, "A real-time profiler callback must not unregister callbacks");
+        consumer = std::move(it->second);
+        consumers_.erase(it);
+    }
+    stop_consumer(*consumer, ConsumerStopMode::StopWithoutDrain);
+    const uint64_t dropped = consumer->dropped;
+    if (dropped > 0) {
+        log_warning(tt::LogMetal, "[Real-time profiler] Callback {} dropped {} record(s)", handle, dropped);
+    }
 }
 
 RealtimeProfilerManager::~RealtimeProfilerManager() { shutdown(); }
 
 void RealtimeProfilerManager::shutdown() {
+    constexpr auto kShutdownKernelExitGrace = std::chrono::milliseconds(100);
+    MetalContext::instance(context_id_).data_collector()->DetachRealtimeProfilerCallbackListener(this);
+
     // Re-write ring_buffer->terminate as a safety net, then let the push kernel deliver the last PCIe page.
     for (auto& dev_state : devices_) {
         if (dev_state.core_l1.ring_buffer != 0 && dev_state.device) {
             const uint32_t terminate_addr = dev_state.core_l1.ring_buffer + offsetof(RtProfilerRingBuffer, terminate);
             std::vector<uint32_t> terminate_flag = {1};
             try {
+                write_sync_request(dev_state, SyncRequest::Clear);
                 tt::tt_metal::detail::WriteToDeviceL1(
                     dev_state.device,
                     dev_state.realtime_profiler_core,
@@ -911,12 +1131,53 @@ void RealtimeProfilerManager::shutdown() {
         }
     }
     if (!devices_.empty()) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kShutdownKernelExitGrace);
     }
 
     if (receiver_thread_.joinable()) {
-        stop_.store(true);
+        stop_.store(true, std::memory_order_release);
+        notify_finish_sync_waiters();
         receiver_thread_.join();
+    }
+
+    for (const auto& dev_state : devices_) {
+        if (dev_state.core_l1.ring_buffer == 0 || !dev_state.device) {
+            continue;
+        }
+        const uint32_t full_wait_addr =
+            dev_state.core_l1.ring_buffer + offsetof(RtProfilerRingBuffer, ring_full_wait_count);
+        std::vector<uint32_t> full_wait(1, 0);
+        try {
+            tt::tt_metal::detail::ReadFromDeviceL1(
+                dev_state.device,
+                dev_state.realtime_profiler_core,
+                full_wait_addr,
+                sizeof(uint32_t),
+                full_wait,
+                CoreType::WORKER);
+            if (full_wait[0] != 0) {
+                log_warning(
+                    tt::LogMetal,
+                    "[Real-time profiler] Device {} L1 ring hit capacity {} time(s); profiler records may have been "
+                    "dropped",
+                    dev_state.chip_id,
+                    full_wait[0]);
+            }
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogMetal,
+                "[Real-time profiler] Failed to read ring_full_wait_count for device {}: {}",
+                dev_state.chip_id,
+                e.what());
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(consumers_mutex_);
+        for (auto& [handle, consumer] : consumers_) {
+            stop_consumer(*consumer, ConsumerStopMode::DrainThenStop);
+        }
+        consumers_.clear();
     }
 
     tracy_handler_.reset();
@@ -929,6 +1190,10 @@ void RealtimeProfilerManager::shutdown() {
 }
 
 void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samples) {
+    constexpr auto kRunSyncSettleDelay = std::chrono::milliseconds(50);
+    constexpr auto kRunSyncSampleInterval = std::chrono::milliseconds(5);
+    constexpr auto kRunSyncReadTimeout = std::chrono::milliseconds(2000);
+    constexpr uint32_t kRunSyncMaxConsecutiveTimeouts = 3;
     auto& cluster = MetalContext::instance(context_id_).get_cluster();
     int64_t host_start_time = rt_profiler_host_ticks();
 
@@ -950,22 +1215,14 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
             stale_pages);
     }
 
-    std::vector<uint32_t> sync_req_data = {1};
-    tt::tt_metal::detail::WriteToDeviceL1(
-        dev_state.device,
-        dev_state.realtime_profiler_core,
-        dev_state.sync_request_addr,
-        sync_req_data,
-        CoreType::WORKER);
+    write_sync_request(dev_state, SyncRequest::Set);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(kRunSyncSettleDelay);
 
-    constexpr uint32_t kSyncReadTimeoutMs = 2000;
     uint32_t consecutive_timeouts = 0;
-    constexpr uint32_t kMaxConsecutiveTimeouts = 3;
 
     for (uint32_t i = 0; i < num_samples + 1; i++) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        std::this_thread::sleep_for(kRunSyncSampleInterval);
 
         // Send truncated 32-bit value as echo identifier for pairing.
         int64_t host_before = rt_profiler_host_ticks() - host_start_time;
@@ -978,14 +1235,14 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
             host_time_data,
             CoreType::WORKER);
 
-        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kSyncReadTimeoutMs);
+        auto deadline = std::chrono::steady_clock::now() + kRunSyncReadTimeout;
         bool got_response = false;
         while (std::chrono::steady_clock::now() < deadline) {
             if (dev_state.socket->pages_available() > 0) {
                 got_response = true;
                 break;
             }
-            std::this_thread::sleep_for(std::chrono::microseconds(100));
+            std::this_thread::sleep_for(kSyncResponsePollBackoff);
         }
 
         if (!got_response) {
@@ -997,10 +1254,10 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
                 dev_state.chip_id,
                 i,
                 num_samples,
-                kSyncReadTimeoutMs,
+                kRunSyncReadTimeout.count(),
                 consecutive_timeouts,
-                kMaxConsecutiveTimeouts);
-            if (consecutive_timeouts >= kMaxConsecutiveTimeouts) {
+                kRunSyncMaxConsecutiveTimeouts);
+            if (consecutive_timeouts >= kRunSyncMaxConsecutiveTimeouts) {
                 log_warning(
                     tt::LogMetal,
                     "[Real-time profiler] Device {} sync aborted: {} consecutive timeouts. "
@@ -1027,17 +1284,11 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
         // Use host_before (not midpoint) because H2D and D2H latencies are asymmetric;
         // host_before brackets the device-side capture within ~2µs.
         if (marker == REALTIME_PROFILER_SYNC_MARKER_ID && echoed_host_time == host_time_id) {
-            samples.push_back({host_before, device_time});
+            samples.emplace_back(host_before, device_time);
         }
     }
 
-    sync_req_data[0] = 0;
-    tt::tt_metal::detail::WriteToDeviceL1(
-        dev_state.device,
-        dev_state.realtime_profiler_core,
-        dev_state.sync_request_addr,
-        sync_req_data,
-        CoreType::WORKER);
+    write_sync_request(dev_state, SyncRequest::Clear);
 
     // Mean-centered linear regression for slope (device cycles per TSC tick); centering avoids catastrophic
     // cancellation at absolute-timestamp magnitudes.
@@ -1112,9 +1363,11 @@ void RealtimeProfilerManager::publish_device_profiler_sync_anchor(
     if (!psm || !psm->device_profiler_map.contains(chip_id)) {
         return;
     }
-    std::scoped_lock map_lock(psm->device_profiler_map_mutex);
-    psm->device_profiler_map.at(chip_id).realtime_sync_line =
-        tt::tt_metal::DeviceProfiler::RealtimeSyncLine{host_anchor, device_anchor, frequency};
+    {
+        std::lock_guard<std::recursive_mutex> map_lock(psm->device_profiler_map_mutex);
+        psm->device_profiler_map.at(chip_id).realtime_sync_line =
+            tt::tt_metal::DeviceProfiler::RealtimeSyncLine{host_anchor, device_anchor, frequency};
+    }
     log_debug(
         tt::LogMetal,
         "[Real-time profiler] Device-profiler clock anchor for device {} core {}: "
@@ -1126,166 +1379,38 @@ void RealtimeProfilerManager::publish_device_profiler_sync_anchor(
         frequency);
 }
 
+void RealtimeProfilerManager::notify_finish_sync_waiters() {
+    std::lock_guard<std::mutex> lock(finish_sync_wait_mu_);
+    finish_sync_cv_.notify_all();
+}
+
 void RealtimeProfilerManager::trigger_sync_check() {
+    constexpr auto kFinishSyncWaitSlack = std::chrono::seconds(1);
     if (devices_.empty() || !tracy_handler_) {
         return;
     }
 
-    constexpr uint32_t kPageSize = 64;
-    constexpr uint32_t kPageWords = kPageSize / sizeof(uint32_t);
-    constexpr uint32_t kSyncTimeoutMs = 5000;
-    constexpr uint32_t kPauseTimeoutMs = 2000;
-
-    const auto throttle_now = std::chrono::steady_clock::now();
-    std::vector<size_t> device_indices_to_sync;
-    device_indices_to_sync.reserve(devices_.size());
-    for (size_t i = 0; i < devices_.size(); i++) {
-        const auto& dev_state = devices_[i];
-        const bool interval_elapsed = !dev_state.last_finish_sync_at.has_value() ||
-                                      throttle_now - *dev_state.last_finish_sync_at >= kRtProfilerMinSyncInterval;
-        if (interval_elapsed || dev_state.pending_first_unthrottled_finish_sync) {
-            device_indices_to_sync.push_back(i);
-        }
-    }
-    if (device_indices_to_sync.empty()) {
+    const auto now = std::chrono::steady_clock::now();
+    const std::chrono::steady_clock::time_point last{
+        std::chrono::steady_clock::duration{last_sync_request_at_.load(std::memory_order_relaxed)}};
+    if (now - last < kRtProfilerMinSyncInterval) {
         return;
     }
+    last_sync_request_at_.store(now.time_since_epoch().count(), std::memory_order_relaxed);
 
-    // 1. Pause the receiver for exclusive socket access (breaks a GIL deadlock vs Python callbacks); skip if pause
-    // times out.
-    pause_requested_.store(true, std::memory_order_release);
+    finish_sync_requested_.store(true, std::memory_order_release);
+    const auto deadline = now + kFinishSyncRequestDelay + kFinishSyncResponseTimeout + kFinishSyncWaitSlack;
     {
-        auto pause_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kPauseTimeoutMs);
-        while (!paused_.load(std::memory_order_acquire)) {
-            if (std::chrono::steady_clock::now() > pause_deadline) {
-                log_warning(
-                    tt::LogMetal, "[Real-time profiler] Could not pause receiver thread for sync check - skipping");
-                pause_requested_.store(false, std::memory_order_release);
-                return;
-            }
-            std::this_thread::sleep_for(std::chrono::microseconds(100));
-        }
+        std::unique_lock<std::mutex> lock(finish_sync_wait_mu_);
+        finish_sync_cv_.wait_until(lock, deadline, [this] {
+            return stop_.load(std::memory_order_acquire) || (!finish_sync_requested_.load(std::memory_order_acquire) &&
+                                                             !finish_sync_busy_.load(std::memory_order_acquire));
+        });
     }
-
-    // Only these devices enter sync mode and emit FINISH_SYNC; others keep receiving once the thread resumes.
-    parallel_for_each_device_index(device_indices_to_sync, [&](size_t dev_index) {
-        auto& dev_state = devices_[dev_index];
-        std::vector<uint32_t> page_buf(kPageWords);
-
-        // 2. Drain pending data pages so the socket has room for the sync response. Each
-        //    page is processed the same way the receiver thread would.
-        while (dev_state.socket->pages_available() > 0) {
-            dev_state.socket->read(page_buf.data(), 1);
-            uint32_t* rp = page_buf.data();
-            uint64_t start_time = (static_cast<uint64_t>(rp[0]) << 32) | rp[1];
-            uint32_t start_id = rp[2];
-            uint64_t end_time = (static_cast<uint64_t>(rp[4]) << 32) | rp[5];
-            if (start_id != 0) {
-                tt::ProgramRealtimeRecord record{
-                    .runtime_id = start_id,
-                    .chip_id = dev_state.chip_id,
-                    .start_timestamp = start_time,
-                    .end_timestamp = end_time,
-                    .frequency = dev_state.sync_frequency,
-                    .kernel_sources = tt::GetKernelSourcesForRuntimeId(static_cast<uint16_t>(start_id)),
-                };
-                std::lock_guard<std::mutex> cb_lock(parallel_finish_sync_callback_mu_);
-                tt::InvokeProgramRealtimeProfilerCallbacks(record);
-            }
-        }
-
-        // 3. Enter sync mode on the device kernel.
-        std::vector<uint32_t> sync_req = {1};
-        tt::tt_metal::detail::WriteToDeviceL1(
-            dev_state.device,
-            dev_state.realtime_profiler_core,
-            dev_state.sync_request_addr,
-            sync_req,
-            CoreType::WORKER);
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
-
-        // 4. Send host timestamp to trigger device response. Tracy marker goes immediately
-        //    before the PCIe write so FINISH_SYNC and SYNC_CHECK share a timing convention.
-        dev_state.sync_host_time_before = rt_profiler_host_ticks();
-        uint32_t host_time_id = static_cast<uint32_t>(dev_state.sync_host_time_before & 0xFFFFFFFF);
-        std::vector<uint32_t> host_time_data = {host_time_id};
-        TracyMessageL("FINISH_SYNC");
-        tt::tt_metal::detail::WriteToDeviceL1(
-            dev_state.device,
-            dev_state.realtime_profiler_core,
-            dev_state.sync_host_ts_addr,
-            host_time_data,
-            CoreType::WORKER);
-
-        // 5. Read until the sync response arrives or we time out; data pages that arrive
-        //    in the meantime are processed inline.
-        bool got_sync = false;
-        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kSyncTimeoutMs);
-        while (!got_sync) {
-            if (std::chrono::steady_clock::now() > deadline) {
-                log_warning(tt::LogMetal, "[Real-time profiler] Sync check timed out for device {}", dev_state.chip_id);
-                break;
-            }
-
-            if (dev_state.socket->pages_available() == 0) {
-                std::this_thread::sleep_for(std::chrono::microseconds(100));
-                continue;
-            }
-
-            dev_state.socket->read(page_buf.data(), 1);
-            uint32_t* rp = page_buf.data();
-            uint32_t marker = rp[3];
-
-            if (marker == REALTIME_PROFILER_SYNC_MARKER_ID) {
-                uint64_t device_time = (static_cast<uint64_t>(rp[0]) << 32) | rp[1];
-                tracy_handler_->CalibrateDevice(
-                    dev_state.chip_id, dev_state.sync_host_time_before, device_time, dev_state.sync_frequency);
-                tracy_handler_->PushSyncCheckMarker(dev_state.chip_id, device_time, dev_state.sync_frequency);
-                publish_device_profiler_sync_anchor(
-                    dev_state.chip_id,
-                    static_cast<double>(dev_state.sync_host_time_before),
-                    static_cast<double>(device_time),
-                    dev_state.sync_frequency,
-                    dev_state.realtime_profiler_core.str());
-                dev_state.last_finish_sync_at = std::chrono::steady_clock::now();
-                dev_state.pending_first_unthrottled_finish_sync = false;
-                got_sync = true;
-            } else {
-                uint64_t start_time = (static_cast<uint64_t>(rp[0]) << 32) | rp[1];
-                uint32_t start_id = rp[2];
-                uint64_t end_time = (static_cast<uint64_t>(rp[4]) << 32) | rp[5];
-                if (start_id != 0) {
-                    tt::ProgramRealtimeRecord record{
-                        .runtime_id = start_id,
-                        .chip_id = dev_state.chip_id,
-                        .start_timestamp = start_time,
-                        .end_timestamp = end_time,
-                        .frequency = dev_state.sync_frequency,
-                        .kernel_sources = tt::GetKernelSourcesForRuntimeId(static_cast<uint16_t>(start_id)),
-                    };
-                    std::lock_guard<std::mutex> cb_lock(parallel_finish_sync_callback_mu_);
-                    tt::InvokeProgramRealtimeProfilerCallbacks(record);
-                }
-            }
-        }
-
-        // 6. Exit sync mode.
-        sync_req[0] = 0;
-        tt::tt_metal::detail::WriteToDeviceL1(
-            dev_state.device,
-            dev_state.realtime_profiler_core,
-            dev_state.sync_request_addr,
-            sync_req,
-            CoreType::WORKER);
-    });
-
-    // 7. Resume receiver thread.
-    pause_requested_.store(false, std::memory_order_release);
-}
-
-D2HSocket* RealtimeProfilerManager::get_socket() const {
-    return devices_.empty() ? nullptr : devices_.front().socket.get();
+    if (!stop_.load(std::memory_order_acquire) &&
+        (finish_sync_requested_.load(std::memory_order_acquire) || finish_sync_busy_.load(std::memory_order_acquire))) {
+        log_warning(tt::LogMetal, "[Real-time profiler] Timed out waiting for finish-path sync to complete");
+    }
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -60,6 +60,7 @@
 #include "tt_metal/impl/dispatch/realtime_profiler_tracy_handler.hpp"
 #include "tt_metal/impl/profiler/profiler.hpp"                // tt::tt_metal::SyncInfo, DeviceProfiler
 #include "tt_metal/impl/profiler/profiler_state_manager.hpp"  // ProfilerStateManager
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -330,25 +331,32 @@ void RealtimeProfilerManager::publish_pages(
     const uint32_t chip_id = dev_state.chip_id;
     const double sync_frequency = dev_state.sync_frequency;
     const DataCollector* const data_collector = data_collector_;
-    for (uint32_t page = 0; page < num_pages; ++page) {
-        const uint32_t* rp = page_buf + page * kPageWords;
-        if (!is_record(rp)) {
-            continue;
+    {
+        TTZoneScopedDN(RT_PROFILER, "BuildRecords");
+        for (uint32_t page = 0; page < num_pages; ++page) {
+            const uint32_t* rp = page_buf + page * kPageWords;
+            if (!is_record(rp)) {
+                continue;
+            }
+            records.emplace_back(
+                rp[2],
+                chip_id,
+                (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
+                (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
+                sync_frequency,
+                data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])));
         }
-        records.emplace_back(
-            rp[2],
-            chip_id,
-            (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
-            (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
-            sync_frequency,
-            data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])));
     }
     if (records.empty()) {
         return;
     }
     num_published_records_.fetch_add(records.size(), std::memory_order_relaxed);
     num_published_batches_.fetch_add(1, std::memory_order_relaxed);
-    ring_->writer().publish_batch(std::span<const tt::ProgramRealtimeRecord>(records));
+    {
+        TTZoneScopedDN(RT_PROFILER, "PublishBatch");
+        TTZoneValueD(RT_PROFILER, records.size());
+        ring_->writer().publish_batch(std::span<const tt::ProgramRealtimeRecord>(records));
+    }
 }
 
 bool RealtimeProfilerManager::has_active_finish_sync() const {
@@ -930,7 +938,12 @@ uint32_t RealtimeProfilerManager::drain_device_pages(
         return 0;
     }
     const uint32_t num_pages_to_read = std::min(available, kMaxSocketPagesPerRead);
-    dev_state.socket->read(page_buf.data(), num_pages_to_read);
+    TTZoneScopedDN(RT_PROFILER, "DrainDevice");
+    TTZoneValueD(RT_PROFILER, num_pages_to_read);
+    {
+        TTZoneScopedDN(RT_PROFILER, "SocketRead");
+        dev_state.socket->read(page_buf.data(), num_pages_to_read);
+    }
 
     if (scan_sync_marker && dev_state.finish_sync_phase == DeviceState::FinishSyncPhase::AwaitingResponse) {
         for (uint32_t page = 0; page < num_pages_to_read; ++page) {
@@ -1052,6 +1065,8 @@ void RealtimeProfilerManager::run_consumer(Consumer& consumer) {
     uint64_t reported_dropped = 0;
 
     auto deliver_batch = [&](std::span<const tt::ProgramRealtimeRecord> batch, uint64_t dropped_total) {
+        TTZoneScopedDNC(RT_PROFILER, "Callback", 0xF032E6);
+        TTZoneValueD(RT_PROFILER, batch.size());
         const tt::ProgramRealtimeRecordBatch arg{batch, dropped_total - reported_dropped};
         reported_dropped = dropped_total;
         try {
@@ -1067,7 +1082,11 @@ void RealtimeProfilerManager::run_consumer(Consumer& consumer) {
         // stop_consumer sets the stop mode then wakes, so waiting on a token sampled only inside wait() could miss that
         // wake and hang
         const auto token = consumer.reader.wait_token();
-        const auto batch = consumer.reader.read_batch(records);
+        std::span<tt::ProgramRealtimeRecord> batch;
+        {
+            TTZoneScopedDN(RT_PROFILER, "ReadBatch");
+            batch = consumer.reader.read_batch(records);
+        }
         const uint64_t dropped_total = consumer.reader.dropped();
         const ConsumerStopMode stop_mode = consumer.stop_mode.load(std::memory_order_acquire);
         if (stop_mode == ConsumerStopMode::StopWithoutDrain) {
@@ -1078,6 +1097,7 @@ void RealtimeProfilerManager::run_consumer(Consumer& consumer) {
         } else if (stop_mode == ConsumerStopMode::DrainThenStop) {
             break;
         } else {
+            TTZoneScopedDN(RT_PROFILER, "Wait");
             consumer.reader.wait(token);
         }
     }

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -89,6 +89,10 @@ struct RealtimeProfilerRuntimeSizes {
     static constexpr uint32_t core_l1_size = sizeof(RealtimeProfilerCoreL1);
 };
 
+static_assert(
+    RealtimeProfilerRuntimeSizes::fifo_pages >= RT_PROFILER_RING_CAPACITY,
+    "Host D2H FIFO must be at least as deep as the device ring (RT_PROFILER_RING_CAPACITY)");
+
 constexpr uint32_t kMaxSocketPagesPerRead = 1024;
 
 // Compute the RT-profiler L1 carve-out addresses from a base anchored past UNRESERVED (outside the user-space

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -1093,6 +1093,10 @@ void RealtimeProfilerManager::on_callback_registered(
     auto consumer = std::make_unique<Consumer>(ring_->make_reader(), callback, handle);
     Consumer* raw = consumer.get();
     std::lock_guard<std::mutex> lock(consumers_mutex_);
+    const auto caller = std::this_thread::get_id();
+    const bool from_callback_thread =
+        std::ranges::any_of(consumers_, [caller](const auto& kv) { return kv.second->thread.get_id() == caller; });
+    TT_FATAL(!from_callback_thread, "A real-time profiler callback must not register callbacks");
     consumers_.emplace(handle, std::move(consumer));
     raw->thread = std::thread([this, raw]() { run_consumer(*raw); });
 }

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -298,6 +298,23 @@ RealtimeProfilerManager::DeviceState::DeviceState() = default;
 RealtimeProfilerManager::DeviceState::~DeviceState() = default;
 RealtimeProfilerManager::DeviceState::DeviceState(DeviceState&&) noexcept = default;
 
+uint32_t RealtimeProfilerManager::host_fifo_capacity_pages() const { return RealtimeProfilerRuntimeSizes::fifo_pages; }
+
+uint32_t RealtimeProfilerManager::ring_full_wait_count() const {
+    uint32_t peak = 0;
+    for (const auto& dev_state : devices_) {
+        if (dev_state.core_l1.ring_buffer == 0 || !dev_state.device) {
+            continue;
+        }
+        const uint32_t addr = dev_state.core_l1.ring_buffer + offsetof(RtProfilerRingBuffer, ring_full_wait_count);
+        std::vector<uint32_t> value(1, 0);
+        tt::tt_metal::detail::ReadFromDeviceL1(
+            dev_state.device, dev_state.realtime_profiler_core, addr, sizeof(uint32_t), value, CoreType::WORKER);
+        peak = std::max(peak, value[0]);
+    }
+    return peak;
+}
+
 void RealtimeProfilerManager::publish_pages(
     const DeviceState& dev_state,
     const uint32_t* page_buf,

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -270,11 +270,22 @@ void parallel_for_each_device_index(const std::vector<size_t>& indices, Fn&& fn)
     // Single std::forward: cppcoreguidelines-missing-std-forward; callable is then invoked
     // many times (not forwarding the parameter each time — bugprone-use-after-move).
     std::decay_t<Fn> callable = std::forward<Fn>(fn);
+    auto invoke = [&callable](size_t di) {
+        try {
+            callable(di);
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogMetal, "[Real-time profiler] Per-device init sync failed, skipping device: {}", e.what());
+        } catch (...) {
+            log_warning(
+                tt::LogMetal, "[Real-time profiler] Per-device init sync failed, skipping device (unknown error)");
+        }
+    };
     const unsigned hc = std::thread::hardware_concurrency();
     const size_t worker_count = std::min(indices.size(), static_cast<size_t>(std::max(1u, hc)));
     if (worker_count <= 1) {
         for (size_t di : indices) {
-            callable(di);
+            invoke(di);
         }
         return;
     }
@@ -288,7 +299,7 @@ void parallel_for_each_device_index(const std::vector<size_t>& indices, Fn&& fn)
                 if (k >= indices.size()) {
                     break;
                 }
-                callable(indices[k]);
+                invoke(indices[k]);
             }
         });
     }
@@ -933,10 +944,7 @@ uint32_t RealtimeProfilerManager::drain_device_pages(
         return 0;
     }
     const uint32_t num_pages_to_read = std::min(available, kMaxSocketPagesPerRead);
-    {
-        TTZoneScopedDN(RT_PROFILER, "SocketRead");
-        dev_state.socket->read(page_buf.data(), num_pages_to_read);
-    }
+    dev_state.socket->read(page_buf.data(), num_pages_to_read);
 
     if (scan_sync_marker && dev_state.finish_sync_phase == DeviceState::FinishSyncPhase::AwaitingResponse) {
         for (uint32_t page = 0; page < num_pages_to_read; ++page) {
@@ -983,7 +991,7 @@ uint64_t RealtimeProfilerManager::run_receiver_loop() {
         num_pages_received += num_pages;
         const auto now = std::chrono::steady_clock::now();
         if (now - last_fifo_plot >= kFifoPlotInterval) {
-            TTPlotD(
+            TTTracyPlotD(
                 RT_PROFILER,
                 "RT profiler D2H FIFO high-water mark (pages)",
                 static_cast<int64_t>(windowed_peak_fifo_pages_));
@@ -1071,7 +1079,12 @@ void RealtimeProfilerManager::run_consumer(Consumer& consumer) {
     auto deliver_batch = [&](std::span<const tt::ProgramRealtimeRecord> batch, uint64_t dropped_total) {
         TTZoneScopedDNC(RT_PROFILER, "Callback", 0xF032E6);
         TTZoneValueD(RT_PROFILER, batch.size());
-        const tt::ProgramRealtimeRecordBatch arg{batch, dropped_total - reported_dropped};
+        const uint64_t dropped_delta = dropped_total - reported_dropped;
+        if (TTZoneIsActiveD(RT_PROFILER) && dropped_delta > 0) {
+            const auto dropped_txt = fmt::format("dropped {}", dropped_delta);
+            TTZoneTextD(RT_PROFILER, dropped_txt.c_str(), dropped_txt.size());
+        }
+        const tt::ProgramRealtimeRecordBatch arg{batch, dropped_delta};
         reported_dropped = dropped_total;
         try {
             consumer.callback(arg);

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -331,32 +331,25 @@ void RealtimeProfilerManager::publish_pages(
     const uint32_t chip_id = dev_state.chip_id;
     const double sync_frequency = dev_state.sync_frequency;
     const DataCollector* const data_collector = data_collector_;
-    {
-        TTZoneScopedDN(RT_PROFILER, "BuildRecords");
-        for (uint32_t page = 0; page < num_pages; ++page) {
-            const uint32_t* rp = page_buf + page * kPageWords;
-            if (!is_record(rp)) {
-                continue;
-            }
-            records.emplace_back(
-                rp[2],
-                chip_id,
-                (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
-                (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
-                sync_frequency,
-                data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])));
+    for (uint32_t page = 0; page < num_pages; ++page) {
+        const uint32_t* rp = page_buf + page * kPageWords;
+        if (!is_record(rp)) {
+            continue;
         }
+        records.emplace_back(
+            rp[2],
+            chip_id,
+            (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
+            (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
+            sync_frequency,
+            data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])));
     }
     if (records.empty()) {
         return;
     }
     num_published_records_.fetch_add(records.size(), std::memory_order_relaxed);
     num_published_batches_.fetch_add(1, std::memory_order_relaxed);
-    {
-        TTZoneScopedDN(RT_PROFILER, "PublishBatch");
-        TTZoneValueD(RT_PROFILER, records.size());
-        ring_->writer().publish_batch(std::span<const tt::ProgramRealtimeRecord>(records));
-    }
+    ring_->writer().publish_batch(std::span<const tt::ProgramRealtimeRecord>(records));
 }
 
 bool RealtimeProfilerManager::has_active_finish_sync() const {
@@ -926,6 +919,7 @@ uint32_t RealtimeProfilerManager::drain_device_pages(
     if (available > peak_fifo_pages_.load(std::memory_order_relaxed)) {
         peak_fifo_pages_.store(available, std::memory_order_relaxed);
     }
+    windowed_peak_fifo_pages_ = std::max(windowed_peak_fifo_pages_, available);
     if (available >= RealtimeProfilerRuntimeSizes::fifo_pages && !dev_state.fifo_reached_capacity) {
         dev_state.fifo_reached_capacity = true;
         log_warning(
@@ -938,8 +932,6 @@ uint32_t RealtimeProfilerManager::drain_device_pages(
         return 0;
     }
     const uint32_t num_pages_to_read = std::min(available, kMaxSocketPagesPerRead);
-    TTZoneScopedDN(RT_PROFILER, "DrainDevice");
-    TTZoneValueD(RT_PROFILER, num_pages_to_read);
     {
         TTZoneScopedDN(RT_PROFILER, "SocketRead");
         dev_state.socket->read(page_buf.data(), num_pages_to_read);
@@ -980,15 +972,26 @@ uint64_t RealtimeProfilerManager::run_receiver_loop() {
     std::vector<tt::ProgramRealtimeRecord> record_buf;
     record_buf.reserve(kMaxSocketPagesPerRead);
     constexpr std::chrono::microseconds kReceiverMaxBackoff{100};
+    constexpr auto kFifoPlotInterval = std::chrono::milliseconds(10);
     std::chrono::microseconds backoff{1};
     uint64_t num_pages_received = 0;
+    auto last_fifo_plot = std::chrono::steady_clock::now();
     while (!stop_.load(std::memory_order_acquire)) {
         const bool scan_sync_marker = finish_sync_busy_.load(std::memory_order_acquire);
         const uint32_t num_pages = drain_all_devices(scan_sync_marker, page_buf, record_buf);
         num_pages_received += num_pages;
+        const auto now = std::chrono::steady_clock::now();
+        if (now - last_fifo_plot >= kFifoPlotInterval) {
+            TTPlotD(
+                RT_PROFILER,
+                "RT profiler D2H FIFO high-water mark (pages)",
+                static_cast<int64_t>(windowed_peak_fifo_pages_));
+            windowed_peak_fifo_pages_ = 0;
+            last_fifo_plot = now;
+        }
         const bool sync_requested = finish_sync_requested_.load(std::memory_order_acquire);
         if (scan_sync_marker || sync_requested) {
-            service_finish_sync(std::chrono::steady_clock::now(), sync_requested);
+            service_finish_sync(now, sync_requested);
         }
         if (num_pages > 0) {
             backoff = std::chrono::microseconds{1};
@@ -1082,11 +1085,7 @@ void RealtimeProfilerManager::run_consumer(Consumer& consumer) {
         // stop_consumer sets the stop mode then wakes, so waiting on a token sampled only inside wait() could miss that
         // wake and hang
         const auto token = consumer.reader.wait_token();
-        std::span<tt::ProgramRealtimeRecord> batch;
-        {
-            TTZoneScopedDN(RT_PROFILER, "ReadBatch");
-            batch = consumer.reader.read_batch(records);
-        }
+        std::span<tt::ProgramRealtimeRecord> batch = consumer.reader.read_batch(records);
         const uint64_t dropped_total = consumer.reader.dropped();
         const ConsumerStopMode stop_mode = consumer.stop_mode.load(std::memory_order_acquire);
         if (stop_mode == ConsumerStopMode::StopWithoutDrain) {

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -570,7 +570,8 @@ void RealtimeProfilerManager::initialize_devices(const std::shared_ptr<MeshDevic
                 mesh_device,
                 sender_core,
                 RealtimeProfilerRuntimeSizes::fifo_size,
-                D2HSocket::ExternalConfigBuffer{.address = dev_state.core_l1.socket_config});
+                D2HSocket::ExternalConfigBuffer{.address = dev_state.core_l1.socket_config},
+                D2HSocket::ProcessScope::InProcess);
             dev_state.socket->set_page_size(RealtimeProfilerRuntimeSizes::page_size);
         } catch (const std::exception& e) {
             log_warning(

--- a/tt_metal/distributed/realtime_profiler_manager.hpp
+++ b/tt_metal/distributed/realtime_profiler_manager.hpp
@@ -6,22 +6,29 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 
 #include "context/context_types.hpp"
+#include "tt_metal/common/broadcast_ring.hpp"
+#include "tt_metal/impl/dispatch/data_collection.hpp"
 
 namespace tt::tt_metal {
 
 class IDevice;
 class Program;
+class DataCollector;
 class RealtimeProfilerTracyHandler;
 
 namespace distributed {
@@ -39,10 +46,10 @@ struct RealtimeProfilerCoreL1Addrs {
 
 // Owns the RT-profiler subsystem for one MeshDevice: per-device state, the receiver thread, the Tracy handler, and the
 // host-device sync handshake (sharded across a small worker pool, with a 60s per-chip throttle).
-class RealtimeProfilerManager {
+class RealtimeProfilerManager : private tt::RealtimeProfilerCallbackListener {
 public:
     explicit RealtimeProfilerManager(const std::shared_ptr<MeshDevice>& mesh_device);
-    ~RealtimeProfilerManager();
+    ~RealtimeProfilerManager() override;
 
     RealtimeProfilerManager(const RealtimeProfilerManager&) = delete;
     RealtimeProfilerManager& operator=(const RealtimeProfilerManager&) = delete;
@@ -53,12 +60,14 @@ public:
     // and notifies deactivation. Safe to call multiple times.
     void shutdown();
 
-    // Runs the sync handshake only on devices due for one (last sync >60s ago, or first finish-path sync after init);
-    // pauses the receiver while doing so.
+    // Requests the receiver to run a finish-path sync and blocks until it completes or times out; throttled to one
+    // request per 60s and a no-op when no devices are active.
     void trigger_sync_check();
 
-    // First active device's D2H socket, or nullptr if no device is active.
-    D2HSocket* get_socket() const;
+    // Receiver diagnostics.
+    uint32_t peak_fifo_pages() const { return peak_fifo_pages_.load(std::memory_order_relaxed); }
+    uint64_t num_published_records() const { return num_published_records_.load(std::memory_order_relaxed); }
+    uint64_t num_published_batches() const { return num_published_batches_.load(std::memory_order_relaxed); }
 
 private:
     struct DeviceState {
@@ -71,13 +80,12 @@ private:
         // manager's lifetime.
         std::unique_ptr<Program> realtime_profiler_program;
         RealtimeProfilerCoreL1Addrs core_l1;
+        bool fifo_reached_capacity = false;
         uint64_t first_timestamp = 0;
         int64_t sync_host_start = 0;
         double sync_frequency = 0.0;
-        uint32_t realtime_profiler_base_addr = 0;
         uint32_t sync_request_addr = 0;
         uint32_t sync_host_ts_addr = 0;
-        std::atomic<bool> sync_response_received{true};
         int64_t sync_host_time_before = 0;
         // Updated after a successful finish-path or init SYNC_CHECK handshake; used to
         // throttle redundant finish syncs (minimum 60s between attempts per device).
@@ -85,6 +93,10 @@ private:
         // First finish-path sync bypasses the throttle so short runs still get a FINISH_SYNC pair; cleared after that
         // handshake.
         bool pending_first_unthrottled_finish_sync = false;
+        enum class FinishSyncPhase : uint8_t { Idle, AwaitingDelay, AwaitingResponse };
+        FinishSyncPhase finish_sync_phase = FinishSyncPhase::Idle;
+        std::chrono::steady_clock::time_point finish_sync_request_at;
+        std::chrono::steady_clock::time_point finish_sync_deadline;
 
         DeviceState();
         ~DeviceState();
@@ -94,7 +106,63 @@ private:
         DeviceState& operator=(const DeviceState&) = delete;
     };
 
+    // Set up the D2H socket and launch the BRISC/NCRISC kernels on each eligible local device. Devices failing the
+    // eligibility gate or socket creation are skipped.
+    void initialize_devices(const std::shared_ptr<MeshDevice>& mesh_device);
     void run_sync(DeviceState& dev_state, uint32_t num_samples);
+    void run_init_sync();
+
+    using RecordRing = BroadcastRing<tt::ProgramRealtimeRecord>;
+
+    enum class ConsumerStopMode : uint8_t { Running, StopWithoutDrain, DrainThenStop };
+
+    struct Consumer {
+        Consumer(
+            RecordRing::Reader reader,
+            tt::ProgramRealtimeProfilerCallback callback,
+            tt::ProgramRealtimeProfilerCallbackHandle handle) :
+            reader(std::move(reader)), callback(std::move(callback)), handle(handle) {}
+        RecordRing::Reader reader;
+        tt::ProgramRealtimeProfilerCallback callback;
+        tt::ProgramRealtimeProfilerCallbackHandle handle;
+        std::atomic<ConsumerStopMode> stop_mode{ConsumerStopMode::Running};
+        uint64_t dropped = 0;
+        std::thread thread;
+    };
+
+    void run_consumer(Consumer& consumer);
+    void stop_consumer(Consumer& consumer, ConsumerStopMode stop_mode);
+    void on_callback_registered(
+        tt::ProgramRealtimeProfilerCallbackHandle handle, const tt::ProgramRealtimeProfilerCallback& callback) override;
+    void on_callback_unregistered(tt::ProgramRealtimeProfilerCallbackHandle handle) override;
+
+    // Receiver thread entry point: drain every device socket, advance the finish-sync handshake, and
+    // publish decoded records to the ring for consumer threads to read.
+    void run_receiver();
+    uint64_t run_receiver_loop();
+    uint64_t drain_receiver_on_shutdown();
+    // One drain pass over every device; wakes readers if any pages were read. Returns the number of pages read.
+    uint32_t drain_all_devices(
+        bool scan_sync_marker, std::vector<uint32_t>& page_buf, std::vector<tt::ProgramRealtimeRecord>& record_buf);
+    // Returns the number of pages read from one device.
+    uint32_t drain_device_pages(
+        DeviceState& dev_state,
+        bool scan_sync_marker,
+        std::vector<uint32_t>& page_buf,
+        std::vector<tt::ProgramRealtimeRecord>& record_buf);
+    // Decode program records from drained pages and publish them to the broadcast ring.
+    void publish_pages(
+        const DeviceState& dev_state,
+        const uint32_t* page_buf,
+        uint32_t num_pages,
+        std::vector<tt::ProgramRealtimeRecord>& records);
+    enum SyncRequest : uint32_t { Clear = 0, Set = 1 };
+    static void write_sync_request(DeviceState& dev_state, SyncRequest value);
+    [[nodiscard]] bool has_active_finish_sync() const;
+    void start_finish_syncs(std::chrono::steady_clock::time_point now);
+    void advance_finish_sync(DeviceState& dev_state, std::chrono::steady_clock::time_point now);
+    void service_finish_sync(std::chrono::steady_clock::time_point now, bool allow_start);
+    void notify_finish_sync_waiters();
 
     // Mirror the rt-profiler Tracy calibration onto the device profiler's sync anchor so worker zones host-align to the
     // same line as rt records.
@@ -104,14 +172,32 @@ private:
     // Owning MeshDevice's ContextId; all MetalContext access must go through instance(context_id_) so a non-default
     // context doesn't leak to silicon DEFAULT_CONTEXT_ID. See #38445 / #39849.
     ContextId context_id_;
+    const DataCollector* data_collector_ = nullptr;
     std::vector<DeviceState> devices_;
     std::thread receiver_thread_;
     std::atomic<bool> stop_{false};
-    std::atomic<bool> pause_requested_{false};
-    std::atomic<bool> paused_{false};
+    std::atomic<bool> finish_sync_requested_{false};
+    std::atomic<bool> finish_sync_busy_{false};
+    std::atomic<std::chrono::steady_clock::rep> last_sync_request_at_{0};
+
+    std::mutex finish_sync_wait_mu_;
+    std::condition_variable finish_sync_cv_;
     std::unique_ptr<RealtimeProfilerTracyHandler> tracy_handler_;
-    // Finish-path sync may drain profiler pages from parallel workers; serialize callbacks.
-    std::mutex parallel_finish_sync_callback_mu_;
+
+    // Receiver diagnostics
+    std::atomic<uint32_t> peak_fifo_pages_{0};        // peak D2H FIFO usage
+    std::atomic<uint64_t> num_published_records_{0};  // count of records published to the ring
+    std::atomic<uint64_t> num_published_batches_{0};  // count of batches published to the ring
+
+    static constexpr size_t kMaxConsumerBatchPerDevice = 1u << 15;  // max batch size per device
+    static constexpr size_t kMaxConsumerBatchCap = 1u
+                                                   << 20;  // hard cap on total batch size (corresponds to 32 devices)
+    static constexpr size_t kRingHeadroomBatches = 4;
+    static constexpr size_t kMaxRingCapacity = 1u << 22;
+
+    std::optional<RecordRing> ring_;
+    std::mutex consumers_mutex_;
+    std::unordered_map<tt::ProgramRealtimeProfilerCallbackHandle, std::unique_ptr<Consumer>> consumers_;
 };
 
 }  // namespace distributed

--- a/tt_metal/distributed/realtime_profiler_manager.hpp
+++ b/tt_metal/distributed/realtime_profiler_manager.hpp
@@ -64,10 +64,13 @@ public:
     // request per 60s and a no-op when no devices are active.
     void trigger_sync_check();
 
-    // Receiver diagnostics.
+    // RT-profiler diagnostics
     uint32_t peak_fifo_pages() const { return peak_fifo_pages_.load(std::memory_order_relaxed); }
+    uint32_t host_fifo_capacity_pages() const;
     uint64_t num_published_records() const { return num_published_records_.load(std::memory_order_relaxed); }
     uint64_t num_published_batches() const { return num_published_batches_.load(std::memory_order_relaxed); }
+    uint32_t ring_full_wait_count() const;  // reads device L1
+    size_t num_active_devices() const { return devices_.size(); }
 
 private:
     struct DeviceState {

--- a/tt_metal/distributed/realtime_profiler_manager.hpp
+++ b/tt_metal/distributed/realtime_profiler_manager.hpp
@@ -188,7 +188,8 @@ private:
     std::unique_ptr<RealtimeProfilerTracyHandler> tracy_handler_;
 
     // Receiver diagnostics
-    std::atomic<uint32_t> peak_fifo_pages_{0};        // peak D2H FIFO usage
+    std::atomic<uint32_t> peak_fifo_pages_{0};        // all-time peak D2H FIFO usage
+    uint32_t windowed_peak_fifo_pages_ = 0;           // for plotting in Tracy; gets reset each plot sample
     std::atomic<uint64_t> num_published_records_{0};  // count of records published to the ring
     std::atomic<uint64_t> num_published_batches_{0};  // count of batches published to the ring
 

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -48,10 +48,6 @@ void RecordProgramRun(uint64_t program_id) {
     tt::tt_metal::MetalContext::instance().data_collector()->RecordProgramRun(program_id);
 }
 
-void RecordKernelSourceMap(ProgramImpl& program) {
-    tt::tt_metal::MetalContext::instance().data_collector()->RecordKernelSourceMap(program);
-}
-
 void RecordProgramSubDevice(
     tt::ChipId device_id,
     uint64_t sub_device_manager_id,
@@ -66,8 +62,8 @@ std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, ui
     return tt::tt_metal::MetalContext::instance().data_collector()->GetProgramSubDevice(device_id, runtime_id);
 }
 
-void TieRuntimeIdToProgramId(ProgramImpl& program) {
-    tt::tt_metal::MetalContext::instance().data_collector()->TieRuntimeIdToProgramId(program);
+void RecordProgramMetadata(ProgramImpl& program) {
+    tt::tt_metal::MetalContext::instance().data_collector()->RecordProgramMetadata(program);
 }
 
 std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id) {
@@ -82,10 +78,6 @@ ProgramRealtimeProfilerCallbackHandle RegisterProgramRealtimeProfilerCallback(
 
 void UnregisterProgramRealtimeProfilerCallback(ProgramRealtimeProfilerCallbackHandle handle) {
     tt::tt_metal::MetalContext::instance().data_collector()->UnregisterProgramRealtimeProfilerCallback(handle);
-}
-
-void InvokeProgramRealtimeProfilerCallbacks(const ProgramRealtimeRecord& record) {
-    tt::tt_metal::MetalContext::instance().data_collector()->InvokeProgramRealtimeProfilerCallbacks(record);
 }
 
 bool IsProgramRealtimeProfilerActive() {

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -84,7 +84,7 @@ std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, ui
 std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id);
 
 // Register a callback to be invoked when real-time profiler data arrives.
-// Multiple callbacks can be registered each callback is called from its own thread.
+// Multiple callbacks can be registered; each callback is called from its own thread.
 // Returns a handle that can be used to unregister the callback.
 ProgramRealtimeProfilerCallbackHandle RegisterProgramRealtimeProfilerCallback(ProgramRealtimeProfilerCallback callback);
 

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -7,7 +7,6 @@
 #include <device.hpp>
 #include <host_api.hpp>
 #include <stdint.h>
-#include <functional>
 #include <optional>
 #include <span>
 #include <string_view>
@@ -30,6 +29,7 @@ enum data_collector_t {
 
 // Aliases to the public experimental types for internal use.
 using ProgramRealtimeRecord = tt::tt_metal::experimental::ProgramRealtimeRecord;
+using ProgramRealtimeRecordBatch = tt::tt_metal::experimental::ProgramRealtimeRecordBatch;
 using ProgramRealtimeProfilerCallback = tt::tt_metal::experimental::ProgramRealtimeProfilerCallback;
 using ProgramRealtimeProfilerCallbackHandle = tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle;
 
@@ -58,8 +58,8 @@ void RecordKernelGroup(
 // Update stats with an enqueue of given program.
 void RecordProgramRun(uint64_t program_id);
 
-// Record this program's kernel source paths.
-void RecordKernelSourceMap(tt_metal::detail::ProgramImpl& program);
+// Record metadata used by profiler lookups for this program dispatch.
+void RecordProgramMetadata(tt_metal::detail::ProgramImpl& program);
 
 struct ProgramSubDeviceInfo {
     uint8_t sub_device_id = 0;
@@ -79,24 +79,25 @@ void RecordProgramSubDevice(
 // Look up the sub-device a program was dispatched on, keyed by physical device and runtime_id.
 std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, uint64_t runtime_id);
 
-// Tie the program's current runtime ID to its program ID.
-void TieRuntimeIdToProgramId(tt_metal::detail::ProgramImpl& program);
-
 // Look up kernel source paths by runtime_id; empty span if the runtime_id is unknown.
 // The returned span is valid until MetalContext teardown or reinitialization.
 std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id);
 
 // Register a callback to be invoked when real-time profiler data arrives.
-// Multiple callbacks can be registered; they are called in order of registration.
+// Multiple callbacks can be registered each callback is called from its own thread.
 // Returns a handle that can be used to unregister the callback.
 ProgramRealtimeProfilerCallbackHandle RegisterProgramRealtimeProfilerCallback(ProgramRealtimeProfilerCallback callback);
 
 // Unregister a previously registered callback by its handle.
 void UnregisterProgramRealtimeProfilerCallback(ProgramRealtimeProfilerCallbackHandle handle);
 
-// Invoke all registered real-time profiler callbacks with the given record.
-// Called internally by the real-time profiler receiver thread.
-void InvokeProgramRealtimeProfilerCallbacks(const ProgramRealtimeRecord& record);
+class RealtimeProfilerCallbackListener {
+public:
+    virtual ~RealtimeProfilerCallbackListener() = default;
+    virtual void on_callback_registered(
+        ProgramRealtimeProfilerCallbackHandle handle, const ProgramRealtimeProfilerCallback& callback) = 0;
+    virtual void on_callback_unregistered(ProgramRealtimeProfilerCallbackHandle handle) = 0;
+};
 
 // Returns true if the real-time profiler is currently active on at least one chip,
 // i.e. at least one MeshDevice finished the init+sync handshake and has a receiver

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -131,44 +131,25 @@ void DataCollector::RecordKernelGroup(
 
 void DataCollector::RecordProgramRun(uint64_t program_id) { program_id_to_call_count[program_id]++; }
 
-void DataCollector::TieRuntimeIdToProgramId(ProgramImpl& program) {
+void DataCollector::RecordProgramMetadata(ProgramImpl& program) {
     // The real-time profiler currently narrows the runtime ID to 16 bits, so we do the same here.
     uint16_t runtime_id = static_cast<uint16_t>(program.get_runtime_id());
     uint64_t program_id = program.get_id();
     std::lock_guard<std::mutex> lock(kernel_source_mutex_);
-    runtime_id_to_program_id_[runtime_id] = program_id;
-}
-
-void DataCollector::RecordKernelSourceMap(ProgramImpl& program) {
-    uint64_t program_id = program.get_id();
-    std::lock_guard<std::mutex> lock(kernel_source_mutex_);
-    if (program_id_to_kernel_sources_.contains(program_id)) {
-        return;
-    }
-    const auto& hal = MetalContext::instance().hal();
-    std::vector<std::string_view> kernel_sources;
-    for (uint32_t i = 0; i < hal.get_programmable_core_type_count(); i++) {
-        for (const auto& [handle, kernel] : program.get_kernels(i)) {
-            // insert(const string&) allocates only on a miss; on a hit it just returns the
-            // existing node, so this allocation is only done once per unique source.
-            const std::string& stored_path = *unique_kernel_sources_.insert(kernel->kernel_source().source_).first;
-            kernel_sources.emplace_back(stored_path);
+    auto [it, inserted] = program_id_to_kernel_sources_.try_emplace(program_id);
+    if (inserted) {
+        auto& kernel_sources = it->second;
+        const auto& hal = MetalContext::instance().hal();
+        for (uint32_t i = 0; i < hal.get_programmable_core_type_count(); i++) {
+            for (const auto& [handle, kernel] : program.get_kernels(i)) {
+                // insert(const string&) allocates only on a miss; on a hit it just returns the
+                // existing node, so this allocation is only done once per unique source.
+                const std::string& stored_path = *unique_kernel_sources_.insert(kernel->kernel_source().source_).first;
+                kernel_sources.emplace_back(stored_path);
+            }
         }
     }
-    program_id_to_kernel_sources_.emplace(program_id, std::move(kernel_sources));
-}
-
-std::span<const std::string_view> DataCollector::GetKernelSourcesForRuntimeId(uint16_t runtime_id) const {
-    std::lock_guard<std::mutex> lock(kernel_source_mutex_);
-    auto rid_it = runtime_id_to_program_id_.find(runtime_id);
-    if (rid_it == runtime_id_to_program_id_.end()) {
-        return {};
-    }
-    auto it = program_id_to_kernel_sources_.find(rid_it->second);
-    if (it == program_id_to_kernel_sources_.end()) {
-        return {};
-    }
-    return it->second;
+    runtime_id_to_kernel_sources_[runtime_id].store(&it->second, std::memory_order_release);
 }
 
 void DataCollector::RecordProgramSubDevice(
@@ -196,13 +177,16 @@ tt::ProgramRealtimeProfilerCallbackHandle DataCollector::RegisterProgramRealtime
     tt::ProgramRealtimeProfilerCallback callback) {
     std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
     auto handle = next_callback_handle_++;
-    program_realtime_profiler_callbacks_.push_back(
-        {handle, std::move(callback), std::make_shared<RealtimeCallbackState>()});
+    program_realtime_profiler_callbacks_.push_back({handle, std::move(callback)});
+    const auto& stored_callback = program_realtime_profiler_callbacks_.back().callback;
+    for (auto* listener : realtime_callback_listeners_) {
+        listener->on_callback_registered(handle, stored_callback);
+    }
     return handle;
 }
 
 void DataCollector::UnregisterProgramRealtimeProfilerCallback(tt::ProgramRealtimeProfilerCallbackHandle handle) {
-    std::unique_lock<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
+    std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
     auto it = std::find_if(
         program_realtime_profiler_callbacks_.begin(),
         program_realtime_profiler_callbacks_.end(),
@@ -210,58 +194,23 @@ void DataCollector::UnregisterProgramRealtimeProfilerCallback(tt::ProgramRealtim
     if (it == program_realtime_profiler_callbacks_.end()) {
         return;
     }
-
-    auto state = it->state;
-    state->unregistering = true;
     program_realtime_profiler_callbacks_.erase(it);
-
-    // Wait until all in-flight callback invocations that already captured this
-    // registration have completed.
-    state->drained_cv.wait(lock, [&state]() { return state->in_flight_invocations == 0; });
+    for (auto* listener : realtime_callback_listeners_) {
+        listener->on_callback_unregistered(handle);
+    }
 }
 
-void DataCollector::InvokeProgramRealtimeProfilerCallbacks(const tt::ProgramRealtimeRecord& record) {
-    using ActiveCallback = std::pair<tt::ProgramRealtimeProfilerCallback, std::shared_ptr<RealtimeCallbackState>>;
-    std::vector<ActiveCallback> active_callbacks;
-    {
-        std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
-        active_callbacks.reserve(program_realtime_profiler_callbacks_.size());
-        for (auto& registration : program_realtime_profiler_callbacks_) {
-            if (registration.state->unregistering) {
-                continue;
-            }
-            registration.state->in_flight_invocations++;
-            active_callbacks.emplace_back(registration.callback, registration.state);
-        }
+void DataCollector::AttachRealtimeProfilerCallbackListener(tt::RealtimeProfilerCallbackListener* listener) {
+    std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
+    realtime_callback_listeners_.push_back(listener);
+    for (const auto& registration : program_realtime_profiler_callbacks_) {
+        listener->on_callback_registered(registration.handle, registration.callback);
     }
+}
 
-    std::exception_ptr callback_exception;
-    for (const auto& [callback, state] : active_callbacks) {
-        (void)state;
-        try {
-            callback(record);
-        } catch (...) {
-            if (!callback_exception) {
-                callback_exception = std::current_exception();
-            }
-        }
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
-        for (const auto& [callback, state] : active_callbacks) {
-            (void)callback;
-            TT_ASSERT(state->in_flight_invocations > 0, "In-flight callback accounting underflow");
-            state->in_flight_invocations--;
-            if (state->unregistering && state->in_flight_invocations == 0) {
-                state->drained_cv.notify_all();
-            }
-        }
-    }
-
-    if (callback_exception) {
-        std::rethrow_exception(callback_exception);
-    }
+void DataCollector::DetachRealtimeProfilerCallbackListener(tt::RealtimeProfilerCallbackListener* listener) {
+    std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
+    std::erase(realtime_callback_listeners_, listener);
 }
 
 void DataCollector::NotifyRealtimeProfilerActivated(uint32_t chip_id) {

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -214,17 +214,17 @@ void DataCollector::DetachRealtimeProfilerCallbackListener(tt::RealtimeProfilerC
 }
 
 void DataCollector::NotifyRealtimeProfilerActivated(uint32_t chip_id) {
-    std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
+    std::lock_guard<std::mutex> lock(realtime_profiler_active_chips_mutex_);
     realtime_profiler_active_chips_.insert(chip_id);
 }
 
 void DataCollector::NotifyRealtimeProfilerDeactivated(uint32_t chip_id) {
-    std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
+    std::lock_guard<std::mutex> lock(realtime_profiler_active_chips_mutex_);
     realtime_profiler_active_chips_.erase(chip_id);
 }
 
 bool DataCollector::IsRealtimeProfilerActive() const {
-    std::lock_guard<std::mutex> lock(program_realtime_profiler_callbacks_mutex_);
+    std::lock_guard<std::mutex> lock(realtime_profiler_active_chips_mutex_);
     return !realtime_profiler_active_chips_.empty();
 }
 

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -119,7 +119,7 @@ private:
     std::vector<tt::RealtimeProfilerCallbackListener*> realtime_callback_listeners_;
     tt::ProgramRealtimeProfilerCallbackHandle next_callback_handle_{0};
 
-    // Chip ids whose RT profiler is currently live; shares the callback-list mutex.
+    mutable std::mutex realtime_profiler_active_chips_mutex_;
     std::unordered_set<uint32_t> realtime_profiler_active_chips_;
 };
 

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -4,11 +4,10 @@
 
 #pragma once
 
+#include <array>
+#include <atomic>
 #include <cstdint>
-#include <condition_variable>
-#include <functional>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <span>
 #include <string>
@@ -56,7 +55,7 @@ public:
         tt_metal::HalProgrammableCoreType core_type,
         const tt_metal::KernelGroup& kernel_group);
     void RecordProgramRun(uint64_t program_id);
-    void RecordKernelSourceMap(tt_metal::detail::ProgramImpl& program);
+    void RecordProgramMetadata(tt_metal::detail::ProgramImpl& program);
     void RecordProgramSubDevice(
         tt::ChipId device_id,
         uint64_t sub_device_manager_id,
@@ -64,18 +63,20 @@ public:
         SubDeviceId sub_device_id,
         uint32_t num_available_worker_cores = 0);
     std::optional<tt::ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, uint64_t runtime_id) const;
-    void TieRuntimeIdToProgramId(tt_metal::detail::ProgramImpl& program);
     // Look up kernel source paths by runtime_id; empty span if the runtime_id is unknown.
     // The returned span is valid until MetalContext teardown or reinitialization.
-    std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id) const;
+    std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id) const noexcept {
+        const auto* sources = runtime_id_to_kernel_sources_[runtime_id].load(std::memory_order_acquire);
+        return sources != nullptr ? std::span<const std::string_view>(*sources) : std::span<const std::string_view>{};
+    }
     // Register a callback to be invoked when real-time profiler data arrives.
     // Returns a handle that can be used to unregister the callback.
     tt::ProgramRealtimeProfilerCallbackHandle RegisterProgramRealtimeProfilerCallback(
         tt::ProgramRealtimeProfilerCallback callback);
     // Unregister a previously registered callback by its handle.
     void UnregisterProgramRealtimeProfilerCallback(tt::ProgramRealtimeProfilerCallbackHandle handle);
-    // Invoke all registered callbacks with the given record.
-    void InvokeProgramRealtimeProfilerCallbacks(const tt::ProgramRealtimeRecord& record);
+    void AttachRealtimeProfilerCallbackListener(tt::RealtimeProfilerCallbackListener* listener);
+    void DetachRealtimeProfilerCallbackListener(tt::RealtimeProfilerCallbackListener* listener);
 
     // Real-time profiler liveness tracking. MeshDevice notifies activation after a
     // successful init+sync handshake and deactivation at close; IsRealtimeProfilerActive()
@@ -87,16 +88,11 @@ public:
     void DumpData();
 
 private:
-    struct RealtimeCallbackState {
-        size_t in_flight_invocations = 0;
-        bool unregistering = false;
-        std::condition_variable drained_cv;
-    };
+    static constexpr size_t kRuntimeIdSlots = 1u << 16;
 
     struct RealtimeCallbackRegistration {
         tt::ProgramRealtimeProfilerCallbackHandle handle;
         tt::ProgramRealtimeProfilerCallback callback;
-        std::shared_ptr<RealtimeCallbackState> state;
     };
 
     struct KernelData {
@@ -115,12 +111,12 @@ private:
     mutable std::mutex kernel_source_mutex_;
     std::unordered_set<std::string> unique_kernel_sources_;
     std::unordered_map<uint64_t, std::vector<std::string_view>> program_id_to_kernel_sources_;
-    std::unordered_map<uint16_t, uint64_t> runtime_id_to_program_id_;
+    std::array<std::atomic<const std::vector<std::string_view>*>, kRuntimeIdSlots> runtime_id_to_kernel_sources_{};
     std::map<std::pair<tt::ChipId, uint64_t>, tt::ProgramSubDeviceInfo> runtime_id_to_sub_device;
     mutable std::mutex runtime_id_to_sub_device_mutex_;
-    // Registered real-time profiler callbacks (invoked from the receiver thread).
     mutable std::mutex program_realtime_profiler_callbacks_mutex_;
     std::vector<RealtimeCallbackRegistration> program_realtime_profiler_callbacks_;
+    std::vector<tt::RealtimeProfilerCallbackListener*> realtime_callback_listeners_;
     tt::ProgramRealtimeProfilerCallbackHandle next_callback_handle_{0};
 
     // Chip ids whose RT profiler is currently live; shares the callback-list mutex.

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -124,6 +124,8 @@ public:
     static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                      // 256 MB;
     static constexpr uint32_t DEVICES_PER_UMD_CHANNEL = MAX_HUGEPAGE_SIZE / MAX_DEV_CHANNEL_SIZE;  // 256 MB;
 
+    static constexpr uint32_t HUGEPAGE_D2H_FALLBACK_RESERVE_BYTES = 2 * 1024 * 1024;  // 2 MiB
+
     // Number of entries in the fabric header ring buffer
     static constexpr uint32_t FABRIC_HEADER_RB_ENTRIES = 1;
 

--- a/tt_metal/impl/dispatch/kernels/REALTIME_PROFILER.md
+++ b/tt_metal/impl/dispatch/kernels/REALTIME_PROFILER.md
@@ -11,187 +11,101 @@ during execution, enabling 1:1 correlation between host-side Tracy zones
 | Component | File | Core | NOC |
 |-----------|------|------|-----|
 | **dispatch_s** (signal source) | `cq_dispatch_subordinate.cpp` | NCRISC | NOC 1 |
-| **profiler kernel** (data mover) | `cq_realtime_profiler.cpp` | BRISC | NOC 0 |
-| **host receiver thread** | `mesh_device.cpp` | CPU thread | PCIe |
+| **BRISC reader** (fast path) | `cq_realtime_profiler.cpp` | reserved profiler tensix BRISC | NOC 0 |
+| **NCRISC pusher** (slow path) | `cq_realtime_profiler_push.cpp` | reserved profiler tensix NCRISC | NOC 1 |
+| **host manager** | `realtime_profiler_manager.cpp` | CPU threads | PCIe |
+
+The data mover is split across two RISCs on a reserved dedicated tensix core — an otherwise-unused core taken from the back of the dispatch core pool.
+The BRISC reader pulls timestamps off dispatch_s and drops them into an L1 ring
+buffer; the NCRISC pusher drains that ring to the host over PCIe. Splitting the
+work this way decouples the fast NOC read from the PCIe push, so that transient bursts
+can be absorbed without dropping records.
 
 ### Data Flow
 
 ```
-dispatch_s                    profiler kernel                  host
-(NCRISC, NOC 1)               (BRISC, NOC 0)                  (receiver thread)
-    |                              |                              |
-    |-- inline_dw_write(PUSH) ---->|                              |
-    |   (NOC 1, ~92 cycles)        |                              |
-    |                              |-- noc_async_read ----------->| dispatch_s L1
-    |                              |   (read timestamps, NOC 0)   |
-    |                              |                              |
-    |                              |-- noc_wwrite (PCIe) -------->| hugepage
-    |                              |   (push 64B page, ~50-80 us) |
-    |                              |                              |
-    |                              |                              |-- read page
-    |                              |                              |   buffer record
+dispatch_s            BRISC reader          NCRISC pusher          host
+(NCRISC, NOC 1)       (profiler tensix,     (profiler tensix,      (receiver thread)
+                       NOC 0)                NOC 1)
+    |                      |                      |                      |
+    |-- inline_dw_write -->|                      |                      |
+    |   PUSH_A / PUSH_B    |                      |                      |
+    |   (NOC 1, ~92 cyc)   |                      |                      |
+    |                      |-- noc_async_read     |                      |
+    |                      |   (read timestamps,  |                      |
+    |                      |    NOC 0)            |                      |
+    |                      |-- write_index++ ---->| L1 ring buffer       |
+    |                      |                      |                      |
+    |                      |                      |-- drain all pending  |
+    |                      |                      |   push_entries_to_host
+    |                      |                      |   (coalesced PCIe    |
+    |                      |                      |    writes, ~420 ns) ->| hugepage
+    |                      |                      |                      |-- read pages
+    |                      |                      |                      |   -> callbacks
 ```
 
 ## Double-Buffer Protocol
 
-dispatch_s maintains two timestamp buffers in L1 (`kernel_start_a/b`,
-`kernel_end_a/b`). On each `CQ_DISPATCH_CMD_WAIT` completion it:
+dispatch_s maintains two timestamp buffers in its own L1 (A/B). On each
+`CQ_DISPATCH_CMD_WAIT` completion it:
 
 1. Writes the program's start/end timestamps into the next buffer (alternating A/B)
-2. Sends a `PUSH_A` or `PUSH_B` state via NOC inline write to the profiler kernel
+2. Sends a `PUSH_A` or `PUSH_B` state to the reserved profiler tensix via a NOC
+   inline dword write
 
-The profiler kernel polls its mailbox, reads the indicated buffer from
-dispatch_s's L1 via `noc_async_read`, and pushes a 64-byte page to the host
-over PCIe via the D2H socket.
+This alternation only hands one in-flight record to the reader at a time;
+dispatch_s never blocks on the profiler.
 
-## Measured Timing (ResNet50 on Wormhole, 317 programs)
+The **BRISC reader** polls its state mailbox. On `PUSH_A`/`PUSH_B` it issues a
+`noc_async_read` of the 32-byte timestamp pair from the indicated dispatch_s
+buffer into the next ring slot, then advances `write_index` (records for
+unprofiled programs are read but not committed). If the ring is full it spins
+(heartbeat `ring_full_wait_count`); in practice this does not happen, because the
+host drains records faster than they are produced. The reader also services host
+clock-sync requests, enqueueing sync-marker records into the same ring.
 
-### Signal Cost (dispatch_s side)
+The **NCRISC pusher** owns the slow PCIe path. Each iteration it snapshots
+`write_index`/`read_index`, and if the ring is non-empty it pushes *all*
+available entries in one `push_entries_to_host` call, then advances `read_index`
+by the number drained.
+
+`push_entries_to_host` reserves the pages in the D2H socket, then issues
+coalesced NOC writes over PCIe — up to `NOC_MAX_BURST_SIZE` per write, chunked at
+ring-wrap, host-FIFO-wrap, and burst-size boundaries — followed by a single
+`socket_push_pages` + `socket_notify_receiver` + `noc_async_write_barrier`.
+
+## Measured Timing
+
+### Signal cost (dispatch_s side)
 
 | Metric | Value |
 |--------|-------|
 | `signal_realtime_profiler_and_switch` duration | **~92 cycles (~0.09 us)** |
 | Signal = NOC 1 inline dword write | Negligible overhead on dispatch |
 
-### Push Cost (profiler kernel side)
-
-The profiler's full push cycle (read from dispatch_s + PCIe write + barrier)
-dominates the latency:
-
-| Percentile | Cycle time (cycles) | Cycle time (us) |
-|------------|--------------------:|----------------:|
-| Fastest    |             23,469  |          23.5   |
-| P10        |             48,212  |          48.2   |
-| P25        |             59,359  |          59.4   |
-| **P50**    |         **79,985**  |      **80.0**   |
-| P75        |            164,416  |         164.4   |
-| P90        |            192,757  |         192.8   |
-
-The bottleneck is steps 4-8 of the push path:
-
-```
- 1. noc_async_read(dispatch_s buffer)      ~100-200 cycles (fast)
- 2. noc_async_read_barrier()               ~100 cycles
- 3. noc_write_init_state()                 trivial
- 4. socket_reserve_pages(1)             ** can block if D2H socket full **
- 5. noc_wwrite_with_state() (PCIe)      ** 64B write over PCIe **
- 6. socket_push_pages(1)                   trivial
- 7. pcie_socket_notify_receiver()          trivial
- 8. noc_async_write_barrier()           ** wait for PCIe completion **
-```
-
-### Signal Rate vs. Push Rate
-
-Programs in ResNet50 complete every **48-290 us** (at the fastest). The profiler
-push takes **50-80 us** at P50. When signals arrive faster than the profiler can
-push, the second signal overwrites the first in the mailbox, causing data loss.
-
-## The Double-Buffer Race Condition
-
-### Mechanism
-
-When dispatch_s fires signals faster than the profiler can drain them:
-
-```
-Time 0 us:   dispatch_s sends PUSH_B (program 174)
-Time 54 us:  dispatch_s sends PUSH_A (program 175) -- profiler still pushing 173
-Time 108 us: dispatch_s sends PUSH_B (program 176) -- overwrites 174's data in buffer B
-Time 160 us: profiler finishes push for 173, reads mailbox: sees PUSH_B (176)
-             program 174 and 175 are LOST
-```
-
-### Measured Impact
-
-From a ResNet50 run (317 programs, no ack mechanism):
+### Push cost (NCRISC pusher side)
 
 | Metric | Value |
-|--------|------:|
-| Total signals sent by dispatch_s | 317 |
-| Records received by host | 250-276 |
-| **Missing records** | **41-55 (13-17%)** |
+|--------|-------|
+| `push_entries_to_host` per drain | **~420 ns** |
 
-Missing IDs cluster in bursts (e.g., programs 174-215) because once the
-profiler falls behind, every subsequent signal overwrites the previous before
-it can be read, creating a cascading loss pattern.
+### Throughput
 
-### Gap Analysis at the Loss Region
+The profiler fully keeps up with dispatch. The signal-to-record path is a fast
+NOC read into a deep L1 ring, decoupled from the PCIe push; the pusher
+then drains the entire pending backlog per iteration and coalesces it into a few
+large bursts (~420 ns per push). Because the ring absorbs bursts and the push is cheap,
+signals never outrun the drain and no records are lost.
 
-```
-Signal # | Gap from prev (us) | Captured?
----------|-------------------:|-----------
-  173    |            161.8   | Yes
-  174    |             54.2   | MISSING  <-- profiler still pushing 173
-  175    |            286.7   | MISSING  <-- buffer A overwritten
-  176    |            204.7   | MISSING  <-- buffer B overwritten
-  ...    |              ...   | MISSING  (cascade continues)
-  188    |             50.6   | Yes      <-- profiler catches up
-```
+This is verified under load by `test_realtime_profiler_stress.cpp`, which replays
+a 4096-program blank-kernel trace back-to-back — the peak signal rate dispatch can
+sustain, since blank kernels minimize per-program dispatch overhead — and asserts
+every record arrives with the device ring and host D2H FIFO never filling.
 
-## Fix: Acknowledge-Before-Signal Protocol
+## Implementation Notes
 
-### Design
-
-Add a `profiler_ack` field to the mailbox. The profiler writes `1` after
-completing a push; dispatch_s waits for `ack==1` before sending the next signal.
-
-**dispatch_s (wait -> reset -> send):**
-```
-while (profiler_ack == 0) { }   // wait for previous push to complete
-profiler_ack = 0                // reset
-inline_dw_write(PUSH_A/B)      // send next signal
-```
-
-**profiler kernel (ack after full push):**
-```
-noc_async_read(data)            // read timestamps
-noc_async_read_barrier()
-... PCIe push ...               // slow path (~50-80 us)
-noc_async_write_barrier()
-mailbox->state = IDLE           // mark self idle BEFORE ack
-send_profiler_ack()             // NOC inline write to dispatch_s (cmd buf 3)
-```
-
-### Expected Overhead
-
-With the ack mechanism, dispatch_s waits ~50-80 us per program (the profiler's
-push cycle time). For 317 programs:
-
-| Metric | Value |
-|--------|------:|
-| Per-program overhead | 50-80 us |
-| Total overhead (317 programs) | 16-25 ms |
-| ResNet50 inference time | ~22 ms |
-| **Relative slowdown** | **~1.7-2.1x** |
-
-This is acceptable for a profiling mode (profiling always adds overhead).
-
-### Implementation Notes
-
-- `profiler_ack` is initialized to `1` by the host so the first signal passes
-  without waiting.
-- The ack uses `noc_inline_dw_write` on **cmd buf 3** (`write_at_cmd_buf`).
-  Using cmd buf 0 (`write_cmd_buf`) corrupts in-flight PCIe data writes.
-- The profiler writes `IDLE` to its own mailbox **before** sending the ack.
-  This prevents dispatch_s's subsequent PUSH (sent after seeing the ack) from
-  being overwritten by a late IDLE write.
-- The host receiver thread must use **C++ record buffering** (not Python
-  callbacks) to avoid a GIL deadlock: TTNN ops hold the GIL during
-  `EnqueueProgram`, so a Python callback from the receiver thread would block
-  on GIL acquisition while dispatch_s is stalled waiting for the ack.
-
-### NOC Coordinate Considerations (Wormhole)
-
-- dispatch_s runs on NCRISC (NOC 1); profiler kernel runs on BRISC (NOC 0).
-- On Wormhole, NOC 0 and NOC 1 have **transposed** coordinate systems.
-- The host must encode `realtime_profiler_core_noc_xy` in **NOC 1 space**
-  (for dispatch_s to address the profiler), and `DISPATCH_CORE_NOC_X/Y` in
-  **NOC 0 space** (virtual coordinates, for the profiler to address dispatch_s).
-
-## Future Optimization: L1 FIFO Buffering
-
-To reduce the ack-induced overhead, the profiler kernel could maintain a local
-L1 FIFO (e.g., 8-16 entries). On receiving a PUSH, it would quickly read the
-timestamps into the FIFO (~200 cycles) and ack immediately, then push FIFO
-entries to the host asynchronously. This would reduce the ack latency from
-~50-80 us (full PCIe push) to ~0.2 us (just the read), eliminating the
-dispatch_s stall almost entirely.
+- The host side runs a receiver thread that drains device→host pages and
+  publishes decoded records onto a `BroadcastRing`; separate per-callback
+  consumer threads read from the ring and invoke the registered callbacks. A slow
+  callback only drops records for that consumer (tracked in `Consumer::dropped`);
+  it never stalls page draining or dispatch.

--- a/tt_metal/impl/dispatch/kernels/cq_realtime_profiler.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_realtime_profiler.cpp
@@ -5,8 +5,8 @@
 // Real-time profiler BRISC kernel (fast path)
 // Reads timestamp data from dispatch_s A/B buffers and writes it into an L1
 // ring buffer. The companion NCRISC kernel drains the ring buffer to the host
-// via PCIe. This split decouples the fast NOC read (~0.3 µs) from the slow
-// PCIe push (~50-80 µs), allowing dispatch_s to proceed without waiting.
+// via PCIe. This split decouples the NOC read from the PCIe push, allowing
+// dispatch_s to proceed without waiting.
 
 #include <cstdint>
 #include "risc_common.h"

--- a/tt_metal/impl/dispatch/kernels/cq_realtime_profiler.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_realtime_profiler.cpp
@@ -53,7 +53,10 @@ __attribute__((noinline)) void realtime_profiler_read_and_enqueue(bool buffer_a)
     noc_async_read(dispatch_noc_addr, slot_addr, realtime_profiler_timestamp_size);
     noc_async_read_barrier();
 
-    ring_buffer->write_index++;
+    const uint32_t id = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(slot_addr)[2];
+    if (id != REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
+        ring_buffer->write_index++;
+    }
 }
 
 // Handle sync requests from host: capture device timestamp and enqueue

--- a/tt_metal/impl/dispatch/kernels/cq_realtime_profiler_push.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_realtime_profiler_push.cpp
@@ -8,7 +8,9 @@
 // dedicated NOC). On architectures where NOC0 != NOC1 coordinates (WH), the
 // host passes PCIE_NOC_X/Y so the kernel can compute the correct NOC1 encoding.
 
+#include <algorithm>
 #include <cstdint>
+#include "internal/risc_attribs.h"
 #include "risc_common.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
@@ -44,33 +46,50 @@ constexpr uint64_t pcie_noc_xy_full =
 constexpr uint32_t pcie_xy_enc_noc1 = static_cast<uint32_t>(pcie_noc_xy_full >> 32);
 #endif
 
-// Push one ring buffer entry to the host via PCIe D2H socket
-__attribute__((noinline)) void push_entry_to_host(
-    SocketSenderInterface& sock,
-    uint32_t slot_addr,
+// Push `num_pages` ring entries to the host via PCIe D2H socket
+__attribute__((noinline)) void push_entries_to_host(
+    SocketSenderInterface& socket,
+    uint32_t src_index,
+    uint32_t num_pages,
     uint32_t pcie_xy_enc,
     uint32_t data_addr_hi,
     uint32_t& host_write_ptr,
     uint32_t host_fifo_start,
     uint32_t fifo_page_aligned_size) {
-    noc_write_init_state<write_cmd_buf>(noc_index, NOC_UNICAST_WRITE_VC);
     RT_PROF_NCRISC_DBG_INC(ring_buffer, socket_reserve_pages_enter_count);
-    socket_reserve_pages(sock, 1);
+    socket_reserve_pages(socket, num_pages);
     RT_PROF_NCRISC_DBG_INC(ring_buffer, socket_reserve_pages_exit_count);
 
-    uint64_t pcie_dest_addr = (static_cast<uint64_t>(data_addr_hi) << 32) | static_cast<uint64_t>(host_write_ptr);
+    noc_write_init_state<write_cmd_buf>(noc_index, NOC_UNICAST_WRITE_VC);
+    constexpr uint32_t kMaxPagesPerWrite = NOC_MAX_BURST_SIZE / realtime_profiler_page_size;
+    uint32_t remaining = num_pages;
+    while (remaining > 0) {
+        const uint32_t ring_slot = src_index & (RT_PROFILER_RING_CAPACITY - 1);
+        const uint32_t pages_to_ring_wrap = RT_PROFILER_RING_CAPACITY - ring_slot;
+        const uint32_t pages_to_fifo_wrap =
+            (host_fifo_start + fifo_page_aligned_size - host_write_ptr) / realtime_profiler_page_size;
+        const uint32_t run = std::min({remaining, pages_to_ring_wrap, pages_to_fifo_wrap, kMaxPagesPerWrite});
 
-    noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
-        noc_index, slot_addr, pcie_xy_enc, pcie_dest_addr, realtime_profiler_page_size, 1);
+        const uint64_t pcie_dest_addr =
+            (static_cast<uint64_t>(data_addr_hi) << 32) | static_cast<uint64_t>(host_write_ptr);
+        noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+            noc_index,
+            rt_ring_data_addr(ring_buffer, src_index),
+            pcie_xy_enc,
+            pcie_dest_addr,
+            run * realtime_profiler_page_size,
+            1);
 
-    host_write_ptr += realtime_profiler_page_size;
-    if (host_write_ptr >= host_fifo_start + fifo_page_aligned_size) {
-        host_write_ptr = host_fifo_start;
+        src_index += run;
+        host_write_ptr += run * realtime_profiler_page_size;
+        if (host_write_ptr >= host_fifo_start + fifo_page_aligned_size) {
+            host_write_ptr = host_fifo_start;
+        }
+        remaining -= run;
     }
 
-    socket_push_pages(sock, 1);
-    socket_notify_receiver(sock);
-
+    socket_push_pages(socket, num_pages);
+    socket_notify_receiver(socket);
     noc_async_write_barrier();
     RT_PROF_NCRISC_DBG_INC(ring_buffer, push_write_barrier_exit_count);
 }
@@ -128,7 +147,9 @@ void kernel_main() {
         loop_count++;
         RT_PROF_NCRISC_DBG_SET(ring_buffer, loop_iteration, loop_count);
 
-        if (rt_ring_empty(ring_buffer)) {
+        const uint32_t read_index = ring_buffer->read_index;
+        const uint32_t write_index = ring_buffer->write_index;
+        if (write_index == read_index) {
             if (ring_buffer->terminate) {
                 return;
             }
@@ -136,17 +157,18 @@ void kernel_main() {
         }
 
         RT_PROF_NCRISC_DBG_SET(ring_buffer, stage, RT_PROFILER_NCRISC_STAGE_PUSHING);
-        uint32_t slot_addr = rt_ring_data_addr(ring_buffer, ring_buffer->read_index);
-        push_entry_to_host(
+        const uint32_t available = write_index - read_index;
+        push_entries_to_host(
             profiler_socket,
-            slot_addr,
+            read_index,
+            available,
             pcie_xy_enc,
             data_addr_hi,
             host_write_ptr,
             host_fifo_start,
             fifo_page_aligned_size);
-        ring_buffer->read_index++;
-        push_count++;
+        ring_buffer->read_index = read_index + available;
+        push_count += available;
         RT_PROF_NCRISC_DBG_SET(ring_buffer, push_count, push_count);
         RT_PROF_NCRISC_DBG_SET(ring_buffer, stage, RT_PROFILER_NCRISC_STAGE_MAIN_LOOP);
     }

--- a/tt_metal/impl/dispatch/kernels/cq_realtime_profiler_push.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_realtime_profiler_push.cpp
@@ -23,6 +23,7 @@
 // Real-time profiler page size - must match host-side
 // RealtimeProfilerRuntimeSizes::page_size (which is also RT_PROFILER_ENTRY_SIZE).
 constexpr uint32_t realtime_profiler_page_size = RT_PROFILER_ENTRY_SIZE;  // 64 bytes
+static_assert(realtime_profiler_page_size <= NOC_MAX_BURST_SIZE);
 
 // Compile-time defines set by host:
 // RING_BUFFER_ADDR  - L1 address of the shared ring buffer

--- a/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
+++ b/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
@@ -71,17 +71,25 @@ std::string FormatTopCounts(const std::unordered_map<Key, uint64_t>& counts) {
 }  // namespace
 
 RealtimeProfilerTracyHandler::RealtimeProfilerTracyHandler() {
-    callback_handle_ = tt::RegisterProgramRealtimeProfilerCallback(
-        [this](const tt::ProgramRealtimeRecord& record) { HandleRecord(record); });
+#if defined(TRACY_ENABLE)
+    callback_handle_ = tt::RegisterProgramRealtimeProfilerCallback([this](const tt::ProgramRealtimeRecordBatch& batch) {
+        if (!tracy::GetProfiler().IsConnected()) {
+            return;
+        }
+        for (const auto& record : batch.records) {
+            HandleRecord(record);
+        }
+    });
+#endif
 }
 
 RealtimeProfilerTracyHandler::~RealtimeProfilerTracyHandler() {
+#if defined(TRACY_ENABLE)
     tt::UnregisterProgramRealtimeProfilerCallback(callback_handle_);
 
     std::lock_guard<std::mutex> lock(mutex_);
     MaybeEmitSkippedZoneSummaryLocked();
 
-#if defined(TRACY_ENABLE)
     for (auto& entry : tracy_contexts_) {
         TracyTTDestroy(entry.second);
     }
@@ -202,9 +210,6 @@ void RealtimeProfilerTracyHandler::HandleRecord(const tt::ProgramRealtimeRecord&
     }
 
 #if defined(TRACY_ENABLE)
-    if (!tracy::GetProfiler().IsConnected()) {
-        return;
-    }
     TracyTTCtx ctx = GetContext(record.chip_id);
     if (!ctx) {
         return;

--- a/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
+++ b/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.cpp
@@ -229,6 +229,7 @@ void RealtimeProfilerTracyHandler::HandleRecord(const tt::ProgramRealtimeRecord&
     auto start = make_marker(record, record.start_timestamp, tracy::TTDeviceMarkerType::ZONE_START, file_str);
     auto end = make_marker(record, record.end_timestamp, tracy::TTDeviceMarkerType::ZONE_END, file_str);
 
+    std::lock_guard<std::mutex> lock(mutex_);
     TracyTTPushStartMarker(ctx, start);
     TracyTTPushEndMarker(ctx, end);
 #endif
@@ -269,6 +270,7 @@ void RealtimeProfilerTracyHandler::PushSyncCheckMarker(
     end_marker.timestamp = end_timestamp;
     end_marker.marker_type = tracy::TTDeviceMarkerType::ZONE_END;
 
+    std::lock_guard<std::mutex> lock(mutex_);
     TracyTTPushStartMarker(ctx, start_marker);
     TracyTTPushEndMarker(ctx, end_marker);
 #endif
@@ -287,6 +289,7 @@ void RealtimeProfilerTracyHandler::CalibrateDevice(
     if (!ctx) {
         return;
     }
+    std::lock_guard<std::mutex> lock(mutex_);
     TracyTTContextCalibrate(ctx, host_time, static_cast<double>(device_timestamp), frequency);
 #endif
 }

--- a/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.hpp
+++ b/tt_metal/impl/dispatch/realtime_profiler_tracy_handler.hpp
@@ -59,7 +59,9 @@ private:
     std::mutex mutex_;
     std::unordered_map<uint32_t, TracyTTCtx> tracy_contexts_;
     SkippedEndBeforeStartStats skipped_end_before_start_stats_;
+#if defined(TRACY_ENABLE)
     tt::ProgramRealtimeProfilerCallbackHandle callback_handle_;
+#endif
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -115,6 +115,10 @@ void loop_and_wait_with_timeout(
 }
 }  // namespace
 
+bool d2h_uses_hugepage_fallback(const MetalContext& ctx) {
+    return !ctx.hal().get_supports_64_bit_pcie_addressing() && !ctx.get_cluster().is_iommu_enabled();
+}
+
 SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, uint8_t num_hw_cqs) :
     context_id(context_id),
     device_id(device_id),
@@ -210,10 +214,8 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
     static constexpr uint32_t AUX_PAGES_PER_CQ = 2;
-    const bool d2h_uses_hugepage_fallback =
-        !ctx.hal().get_supports_64_bit_pcie_addressing() && !ctx.get_cluster().is_iommu_enabled();
     uint32_t per_cq_reduction = AUX_PAGES_PER_CQ * DispatchSettings::TRANSFER_PAGE_SIZE;
-    if (d2h_uses_hugepage_fallback) {
+    if (d2h_uses_hugepage_fallback(ctx)) {
         per_cq_reduction += tt::align(
             (DispatchSettings::HUGEPAGE_D2H_FALLBACK_RESERVE_BYTES + num_hw_cqs - 1) / num_hw_cqs,
             DispatchSettings::TRANSFER_PAGE_SIZE);

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -209,9 +209,20 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     this->channel_offset = DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel) +
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
-    // Two TRANSFER_PAGE_SIZE pages per HW CQ reserved for free_region_* (see DRAM-backed path above).
     static constexpr uint32_t AUX_PAGES_PER_CQ = 2;
+    const bool d2h_uses_hugepage_fallback =
+        !ctx.hal().get_supports_64_bit_pcie_addressing() && !ctx.get_cluster().is_iommu_enabled();
     uint32_t per_cq_reduction = AUX_PAGES_PER_CQ * DispatchSettings::TRANSFER_PAGE_SIZE;
+    if (d2h_uses_hugepage_fallback) {
+        per_cq_reduction += tt::align(
+            (DispatchSettings::HUGEPAGE_D2H_FALLBACK_RESERVE_BYTES + num_hw_cqs - 1) / num_hw_cqs,
+            DispatchSettings::TRANSFER_PAGE_SIZE);
+    }
+    TT_FATAL(
+        this->cq_size > per_cq_reduction,
+        "Command queue size {} B is too small for the {} B aux reservation",
+        this->cq_size,
+        per_cq_reduction);
     this->cq_size -= per_cq_reduction;
 
     uint32_t total_cq_space = static_cast<uint32_t>(num_hw_cqs) * this->cq_size;

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -20,6 +20,10 @@ using ChipId = int;
 namespace tt::tt_metal {
 
 class Buffer;
+class MetalContext;
+
+// True when the host can't pin D2H memory (no 64-bit PCIe addressing and no IOMMU).
+bool d2h_uses_hugepage_fallback(const MetalContext& ctx);
 
 class SystemMemoryManager {
 public:

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2537,8 +2537,7 @@ void update_program_dispatch_commands(
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         program_host_id_offset, &runtime_id, sizeof(runtime_id));
 
-    tt::TieRuntimeIdToProgramId(program);
-    tt::RecordKernelSourceMap(program);
+    RecordProgramMetadata(program);
 
     if (hal.get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
@@ -3081,8 +3080,7 @@ TraceNode create_trace_node(
         }
     }
 
-    tt::TieRuntimeIdToProgramId(program);
-    tt::RecordKernelSourceMap(program);
+    RecordProgramMetadata(program);
 
     return TraceNode{
         program.shared_from_this(),

--- a/tt_metal/programming_examples/profiler/test_realtime_profiler_csv/test_realtime_profiler_csv.cpp
+++ b/tt_metal/programming_examples/profiler/test_realtime_profiler_csv/test_realtime_profiler_csv.cpp
@@ -13,13 +13,17 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/realtime_profiler.hpp>
 
+#include <fmt/compile.h>
+#include <fmt/format.h>
+
 #include <cerrno>
 #include <chrono>
 #include <cstring>
 #include <fstream>
-#include <mutex>
+#include <iterator>
 #include <string>
 #include <thread>
+#include <vector>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -27,58 +31,55 @@ using namespace tt::tt_metal;
 constexpr uint32_t NUM_PROGRAMS = 100;
 const char* const DEFAULT_CSV_PATH = "realtime_profiler_records.csv";
 
-static std::mutex g_csv_mutex;
 static std::ofstream g_csv_file;
-static bool g_csv_header_written = false;
+static uint64_t g_dropped_records = 0;
 
-static void WriteRealtimeRecordToCsv(const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
-    uint64_t duration_cycles =
-        (record.end_timestamp >= record.start_timestamp) ? (record.end_timestamp - record.start_timestamp) : 0;
-    double duration_ns = (record.frequency > 0.0) ? (static_cast<double>(duration_cycles) / record.frequency) : 0.0;
+static void WriteRealtimeRecordsToCsv(const tt::tt_metal::experimental::ProgramRealtimeRecordBatch& batch) {
+    static thread_local fmt::memory_buffer csv_buffer;
+    csv_buffer.clear();
+    auto out = std::back_inserter(csv_buffer);
 
-    fmt::print(
-        "realtime record: id={} chip_id={} start={} end={} duration_cycles={} duration_ns={:.2f}\n",
-        record.runtime_id,
-        record.chip_id,
-        record.start_timestamp,
-        record.end_timestamp,
-        duration_cycles,
-        duration_ns);
+    for (const auto& record : batch.records) {
+        uint64_t duration_cycles =
+            (record.end_timestamp >= record.start_timestamp) ? (record.end_timestamp - record.start_timestamp) : 0;
+        double duration_ns = (record.frequency > 0.0) ? (static_cast<double>(duration_cycles) / record.frequency) : 0.0;
 
-    std::string kernel_sources_str;
-    for (size_t i = 0; i < record.kernel_sources.size(); i++) {
-        if (i > 0) {
-            kernel_sources_str += ";";
+        fmt::format_to(
+            out,
+            FMT_COMPILE("{},{},{},{},{},{:.6g},{:.6g},\""),
+            record.runtime_id,
+            record.chip_id,
+            record.start_timestamp,
+            record.end_timestamp,
+            duration_cycles,
+            duration_ns,
+            record.frequency);
+
+        for (size_t i = 0; i < record.kernel_sources.size(); i++) {
+            const std::string_view source = record.kernel_sources[i];
+            if (i > 0) {
+                csv_buffer.push_back(';');
+            }
+            if (source.find('"') == std::string_view::npos) {
+                csv_buffer.append(source);
+            } else {
+                for (char c : source) {
+                    if (c == '"') {
+                        csv_buffer.push_back('"');
+                    }
+                    csv_buffer.push_back(c);
+                }
+            }
         }
-        kernel_sources_str += record.kernel_sources[i];
-    }
-    // Escape quotes in kernel_sources for CSV
-    std::string escaped;
-    escaped.reserve(kernel_sources_str.size() + 2);
-    escaped += '"';
-    for (char c : kernel_sources_str) {
-        if (c == '"') {
-            escaped += "\"\"";
-        } else {
-            escaped += c;
-        }
-    }
-    escaped += '"';
-
-    std::lock_guard<std::mutex> lock(g_csv_mutex);
-    if (!g_csv_file.is_open()) {
-        return;
+        csv_buffer.push_back('"');
+        csv_buffer.push_back('\n');
     }
 
-    if (!g_csv_header_written) {
-        g_csv_file << "runtime_id,chip_id,start_timestamp,end_timestamp,duration_cycles,duration_ns,frequency_ghz,"
-                   << "kernel_sources\n";
-        g_csv_header_written = true;
+    g_dropped_records += batch.dropped;
+
+    if (csv_buffer.size() != 0) {
+        g_csv_file.write(csv_buffer.data(), static_cast<std::streamsize>(csv_buffer.size()));
     }
-    g_csv_file << record.runtime_id << "," << record.chip_id << "," << record.start_timestamp << ","
-               << record.end_timestamp << "," << duration_cycles << "," << duration_ns << "," << record.frequency << ","
-               << escaped << "\n";
-    g_csv_file.flush();
 }
 
 static void RunPrograms(const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t num_programs) {
@@ -131,12 +132,11 @@ int main(int argc, char** argv) {
             fmt::print(stderr, "Failed to open CSV file: {}\n", csv_path);
             return 1;
         }
+        g_csv_file << "runtime_id,chip_id,start_timestamp,end_timestamp,duration_cycles,duration_ns,frequency_ghz,"
+                   << "kernel_sources\n";
 
         tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle callback_handle =
-            tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(
-                [](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
-                    WriteRealtimeRecordToCsv(record);
-                });
+            tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(WriteRealtimeRecordsToCsv);
 
         RunPrograms(mesh_device, num_programs);
         mesh_device->quiesce_devices();
@@ -145,11 +145,14 @@ int main(int argc, char** argv) {
 
         tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback(callback_handle);
 
-        {
-            std::lock_guard<std::mutex> lock(g_csv_mutex);
-            g_csv_file.close();
-        }
+        g_csv_file.close();
 
+        if (g_dropped_records != 0) {
+            fmt::print(
+                stderr,
+                "Warning: dropped {} record(s); callback could not keep up with incoming records\n",
+                g_dropped_records);
+        }
         fmt::print("Wrote real-time profiler records to {} ({} programs)\n", csv_path, num_programs);
         pass &= mesh_device->close();
 

--- a/tt_metal/tools/profiler/tracy_debug_zones.hpp
+++ b/tt_metal/tools/profiler/tracy_debug_zones.hpp
@@ -9,8 +9,8 @@
 #include <tracy/Tracy.hpp>
 #include <type_traits>
 
-// Opt-in Tracy macros (zones, messages, plots) for debug-verbosity profiling. A TTZone*D / TTMessage*D /
-// TTPlotD macro's first argument is a category token (DISPATCH, RT_PROFILER, ...); it is compiled in only when
+// Opt-in Tracy macros (zones, messages, plots) for debug-verbosity profiling. A TTZone*D / TTTracyMessage*D /
+// TTTracyPlotD macro's first argument is a category token (DISPATCH, RT_PROFILER, ...); it is compiled in only when
 // that category is selected at build time via --build-perf-debug ('all' selects every category), and compiles
 // to nothing otherwise. Categories are defined once in tt_metal/tools/profiler/tracy_debug_categories.txt; from
 // it the build generates, per category, TT_TRACY_CATEGORY_<TOKEN> (1 if selected, 0 if not) and
@@ -111,27 +111,28 @@ constexpr bool zone_name_valid(const char* name) { return name != nullptr; }
 #define TTZoneValueD(category, value) TT_TRACY_EMIT(category, (void(sizeof(value))), ZoneValue(value))
 #define TTZoneIsActiveD(category) TT_TRACY_EMIT(category, false, ZoneIsActive)
 
-#define TTMessageD(category, txt, size) \
+#define TTTracyMessageD(category, txt, size) \
     TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size))), TracyMessage(txt, size))
-#define TTMessageDL(category, txt) TT_TRACY_EMIT(category, (void(sizeof(txt))), TracyMessageL(txt))
-#define TTMessageDC(category, txt, size, color) \
+#define TTTracyMessageDL(category, txt) TT_TRACY_EMIT(category, (void(sizeof(txt))), TracyMessageL(txt))
+#define TTTracyMessageDC(category, txt, size, color) \
     TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size) + sizeof(color))), TracyMessageC(txt, size, color))
-#define TTMessageDLC(category, txt, color) \
+#define TTTracyMessageDLC(category, txt, color) \
     TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(color))), TracyMessageLC(txt, color))
-#define TTMessageDS(category, txt, size, depth) \
+#define TTTracyMessageDS(category, txt, size, depth) \
     TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size) + sizeof(depth))), TracyMessageS(txt, size, depth))
-#define TTMessageDLS(category, txt, depth) \
+#define TTTracyMessageDLS(category, txt, depth) \
     TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(depth))), TracyMessageLS(txt, depth))
-#define TTMessageDCS(category, txt, size, color, depth)                     \
+#define TTTracyMessageDCS(category, txt, size, color, depth)                \
     TT_TRACY_EMIT(                                                          \
         category,                                                           \
         (void(sizeof(txt) + sizeof(size) + sizeof(color) + sizeof(depth))), \
         TracyMessageCS(txt, size, color, depth))
-#define TTMessageDLCS(category, txt, color, depth) \
+#define TTTracyMessageDLCS(category, txt, color, depth) \
     TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(color) + sizeof(depth))), TracyMessageLCS(txt, color, depth))
 
-#define TTPlotD(category, name, val) TT_TRACY_EMIT(category, (void(sizeof(name) + sizeof(val))), TracyPlot(name, val))
-#define TTPlotConfigD(category, name, type, step, fill, color)                                                 \
+#define TTTracyPlotD(category, name, val) \
+    TT_TRACY_EMIT(category, (void(sizeof(name) + sizeof(val))), TracyPlot(name, val))
+#define TTTracyPlotConfigD(category, name, type, step, fill, color)                                            \
     TT_TRACY_EMIT(                                                                                             \
         category,                                                                                              \
         (void(sizeof(name) + TT_TRACY_SIZEOF_IF_ENABLED(type) + sizeof(step) + sizeof(fill) + sizeof(color))), \

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -178,7 +178,8 @@ void py_device_module_types(nb::module_& m_device) {
             [](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
                 return std::vector<std::string>(record.kernel_sources.begin(), record.kernel_sources.end());
             },
-            "Kernel source paths associated with this runtime ID");
+            "Kernel source paths associated with this runtime ID. Resolve during the callback; invalid after device "
+            "or context teardown.");
 
     nb::class_<PythonProgramRealtimeRecordBatch>(
         m_device, "ProgramRealtimeRecordBatch", "Batch of real-time profiler records delivered to a callback.")

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -59,6 +59,11 @@ namespace {
 // RegisterProgramRealtimeProfilerCallback. Access only from the Python thread (always under GIL), so no mutex needed.
 std::unordered_map<uint64_t, PyObject*> python_realtime_callback_refs;
 
+struct PythonProgramRealtimeRecordBatch {
+    std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord> records;
+    uint64_t dropped = 0;
+};
+
 void ttnn_device(nb::module_& mod) {
     mod.def(
         "open_device",
@@ -174,6 +179,15 @@ void py_device_module_types(nb::module_& m_device) {
                 return std::vector<std::string>(record.kernel_sources.begin(), record.kernel_sources.end());
             },
             "Kernel source paths associated with this runtime ID");
+
+    nb::class_<PythonProgramRealtimeRecordBatch>(
+        m_device, "ProgramRealtimeRecordBatch", "Batch of real-time profiler records delivered to a callback.")
+        .def_ro("records", &PythonProgramRealtimeRecordBatch::records, "ProgramRealtimeRecord entries in this batch")
+        .def_ro(
+            "dropped",
+            &PythonProgramRealtimeRecordBatch::dropped,
+            "Records lost since this callback last ran; nonzero if the callback could not keep up with incoming "
+            "profiler data");
 
     nb::class_<tt::tt_metal::detail::MemoryView>(
         m_device, "MemoryView", "Class representing view of the memory (dram, l1, l1_small, trace) of a device.")
@@ -706,9 +720,14 @@ void device_module(nb::module_& m_device) {
             Py_INCREF(raw_cb);
 
             auto handle = tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(
-                [raw_cb](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
+                [raw_cb](const tt::tt_metal::experimental::ProgramRealtimeRecordBatch& batch) {
+                    PythonProgramRealtimeRecordBatch py_batch{
+                        .records = std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>(
+                            batch.records.begin(), batch.records.end()),
+                        .dropped = batch.dropped,
+                    };
                     nb::gil_scoped_acquire gil;
-                    (nb::handle(raw_cb))(nb::cast(record, nb::rv_policy::copy));
+                    (nb::handle(raw_cb))(nb::cast(std::move(py_batch), nb::rv_policy::move));
                 });
 
             python_realtime_callback_refs[handle] = raw_cb;
@@ -717,20 +736,21 @@ void device_module(nb::module_& m_device) {
         nb::arg("callback"),
         R"doc(
             Register a callback to be invoked when real-time profiler data arrives from a device.
-            The callback receives a ProgramRealtimeRecord and is called from the real-time profiler
-            receiver thread.
+            The callback receives a ProgramRealtimeRecordBatch and is called from its own thread.
+            Callbacks that are too slow to keep up with incoming profiler data may miss records.
 
             Multiple callbacks can be registered.
 
             Args:
-                callback: A callable that accepts a single ProgramRealtimeRecord argument.
+                callback: A callable that accepts a single ProgramRealtimeRecordBatch argument.
 
             Returns:
                 int: A handle that can be passed to UnregisterProgramRealtimeProfilerCallback.
 
             Example:
-                >>> def my_callback(record):
-                ...     print(f"runtime_id={record.runtime_id} on chip {record.chip_id}")
+                >>> def my_callback(batch):
+                ...     for record in batch.records:
+                ...         print(f"runtime_id={record.runtime_id} on chip {record.chip_id}")
                 >>> handle = ttnn.device.RegisterProgramRealtimeProfilerCallback(my_callback)
         )doc");
 

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -178,12 +178,14 @@ void py_device_module_types(nb::module_& m_device) {
             [](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
                 return std::vector<std::string>(record.kernel_sources.begin(), record.kernel_sources.end());
             },
-            "Kernel source paths associated with this runtime ID. Resolve during the callback; invalid after device "
-            "or context teardown.");
+            "Kernel source paths associated with this runtime ID; valid until the callback returns");
 
     nb::class_<PythonProgramRealtimeRecordBatch>(
         m_device, "ProgramRealtimeRecordBatch", "Batch of real-time profiler records delivered to a callback.")
-        .def_ro("records", &PythonProgramRealtimeRecordBatch::records, "ProgramRealtimeRecord entries in this batch")
+        .def_ro(
+            "records",
+            &PythonProgramRealtimeRecordBatch::records,
+            "ProgramRealtimeRecord entries in this batch; non-empty, oldest first")
         .def_ro(
             "dropped",
             &PythonProgramRealtimeRecordBatch::dropped,
@@ -738,7 +740,8 @@ void device_module(nb::module_& m_device) {
         R"doc(
             Register a callback to be invoked when real-time profiler data arrives from a device.
             The callback receives a ProgramRealtimeRecordBatch and is called from its own thread.
-            Callbacks that are too slow to keep up with incoming profiler data may miss records.
+            Callbacks that are too slow to keep up with incoming profiler data may miss records;
+            this is reported by ProgramRealtimeRecordBatch.dropped.
 
             Multiple callbacks can be registered.
 

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -722,16 +722,20 @@ void device_module(nb::module_& m_device) {
             PyObject* raw_cb = callback.ptr();
             Py_INCREF(raw_cb);
 
-            auto handle = tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(
-                [raw_cb](const tt::tt_metal::experimental::ProgramRealtimeRecordBatch& batch) {
-                    PythonProgramRealtimeRecordBatch py_batch{
-                        .records = std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>(
-                            batch.records.begin(), batch.records.end()),
-                        .dropped = batch.dropped,
-                    };
-                    nb::gil_scoped_acquire gil;
-                    (nb::handle(raw_cb))(nb::cast(std::move(py_batch), nb::rv_policy::move));
-                });
+            uint64_t handle = 0;
+            {
+                nb::gil_scoped_release release;
+                handle = tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(
+                    [raw_cb](const tt::tt_metal::experimental::ProgramRealtimeRecordBatch& batch) {
+                        PythonProgramRealtimeRecordBatch py_batch{
+                            .records = std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>(
+                                batch.records.begin(), batch.records.end()),
+                            .dropped = batch.dropped,
+                        };
+                        nb::gil_scoped_acquire gil;
+                        (nb::handle(raw_cb))(nb::cast(std::move(py_batch), nb::rv_policy::move));
+                    });
+            }
 
             python_realtime_callback_refs[handle] = raw_cb;
             return handle;

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -228,12 +228,14 @@ SubDeviceManagerId = ttnn._ttnn.device.SubDeviceManagerId
 
 # Real-time profiler callbacks (experimental)
 ProgramRealtimeRecord = ttnn._ttnn.device.ProgramRealtimeRecord
+ProgramRealtimeRecordBatch = ttnn._ttnn.device.ProgramRealtimeRecordBatch
 RegisterProgramRealtimeProfilerCallback = ttnn._ttnn.device.RegisterProgramRealtimeProfilerCallback
 UnregisterProgramRealtimeProfilerCallback = ttnn._ttnn.device.UnregisterProgramRealtimeProfilerCallback
 IsProgramRealtimeProfilerActive = ttnn._ttnn.device.IsProgramRealtimeProfilerActive
 
 __all__ = [
     "ProgramRealtimeRecord",
+    "ProgramRealtimeRecordBatch",
     "RegisterProgramRealtimeProfilerCallback",
     "UnregisterProgramRealtimeProfilerCallback",
     "IsProgramRealtimeProfilerActive",


### PR DESCRIPTION
### PR Category
Performance

### Summary
This PR introduces a new real-time profiler delivery architecture that significantly improves throughput, scalability, and reliability under load. These improvements are a prerequisite for any-source real-time profiling, which will support the capabilities of the DRAM-based profiler in real time and require much higher throughput than the current per-program stream.

Previously, callbacks ran serially on the receiver thread (i.e., the thread responsible for draining records from devices). A single slow callback could delay every other callback and stall D2H FIFO draining; eventually devices' L1 rings would overflow and silently drop profiler records. On many-device runs, the receiver itself could not keep up with the incoming record rate; e.g., running Llama-3.3-70B on a Wormhole Galaxy, about 20% of records were silently dropped even when the callback did no work.

Callback execution is now decoupled from record ingestion. The receiver processes records faster than devices produce them, while each callback consumes the record stream independently, concurrently, and at its own pace. A callback that falls behind loses only its own oldest records; it cannot slow any other callback. Because the drain loop never executes user code, the profiler's critical path is no longer gated by user callback latency.

### Architecture
- **Broadcast ring.** `BroadcastRing<T>` is a wait-free, single-producer, multi-consumer concurrent data structure used to pass records to callbacks. The receiver publishes one stream, and every callback reads it independently. The producer never waits for consumers, and no consumer can block another.
- **Adaptive batching.** Callbacks now receive a `ProgramRealtimeRecordBatch`, amortizing per-invocation overhead across many records. Each batch contains all records that arrived while the previous batch was processed, so batch size is self-tuning: it converges to the equilibrium where processing one batch takes exactly as long as accumulating the next.
- **Attributable loss.** `batch.dropped` makes per-callback record loss visible and attributable.
- **In-loop clock sync.** Clock synchronization is now a per-device state machine inside the receiver loop, eliminating the receiver pause and the worker-pool handoff.
- **Coalesced device writes.** The device push kernel packs multiple L1 ring entries into each NoC write instead of issuing one write per entry.
- **No silent loss.** Record loss is never silent at any stage of the pipeline. Device-side drops are not expected under the new architecture, but a warning is now emitted if they ever occur.

### Notes for reviewers
`BroadcastRing`'s mutex-per-slot path exists for C++20 conformance. `ProgramRealtimeRecord` contains a `std::span`, which was not formally guaranteed to be trivially copyable until C++23. It is trivially copyable in all existing implementations, so in practice the profiler always takes the wait-free path.

Closes #44007.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-perf-tests.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-perf-tests.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yusuf/optimize-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yusuf/optimize-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yusuf/optimize-rt-profiler)
