### PR TITLE
Fix ShardSpec stream out with mismatch of {}

### DIFF
--- a/model_tracer/generic_ops_tracer.py
+++ b/model_tracer/generic_ops_tracer.py
@@ -1207,7 +1207,7 @@ def parse_shard_spec_string(shard_spec_str):
     The C++ bug (missing closing brace) has been fixed, but this handles old traces.
 
     Example input:
-    'ShardSpec{grid=[{"start":{"x":0,"y":0},"end":{"x":7,"y":7}}], shape=[32, 32], orientation=ShardOrientation::ROW_MAJOR}'
+    'ShardSpec(grid=[{"start":{"x":0,"y":0},"end":{"x":7,"y":7}}], shape=[32, 32], orientation=ShardOrientation::ROW_MAJOR)'
 
     Returns:
     {
@@ -1218,7 +1218,7 @@ def parse_shard_spec_string(shard_spec_str):
     """
     import re
 
-    if not isinstance(shard_spec_str, str) or not shard_spec_str.startswith("ShardSpec{"):
+    if not isinstance(shard_spec_str, str) or not shard_spec_str.startswith("ShardSpec("):
         return shard_spec_str
 
     try:
@@ -1293,7 +1293,7 @@ def fix_memory_config_recursive(obj, fixed_count_ref):
             if obj["shard_spec"] == "None":
                 obj["shard_spec"] = None
                 fixed_count_ref[0] += 1
-            elif obj["shard_spec"].startswith("ShardSpec{"):
+            elif obj["shard_spec"].startswith("ShardSpec("):
                 parsed = parse_shard_spec_string(obj["shard_spec"])
                 if isinstance(parsed, dict):
                     obj["shard_spec"] = parsed

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -217,7 +217,7 @@ void validate_sub_device_manager_id(std::optional<SubDeviceManagerId> sub_device
 std::atomic<size_t> Buffer::next_unique_id = 0;
 
 std::ostream& operator<<(std::ostream& os, const ShardSpec& spec) {
-    os << "ShardSpec{";
+    os << "ShardSpec(";
     os << "grid=[";
 
     // Format grid as proper JSON array of ranges
@@ -226,7 +226,7 @@ std::ostream& operator<<(std::ostream& os, const ShardSpec& spec) {
         const auto& range = ranges[i];
         os << "{";
         os << R"("start":{"x":)" << range.start_coord.x << R"(,"y":)" << range.start_coord.y << R"(},)";
-        os << R"("end":{"x":)" << range.end_coord.x << R"(,"y":)" << range.end_coord.y << R"()";
+        os << R"("end":{"x":)" << range.end_coord.x << R"(,"y":)" << range.end_coord.y << R"(})";
         os << "}";
         if (i < ranges.size() - 1) {
             os << ", ";
@@ -243,7 +243,7 @@ std::ostream& operator<<(std::ostream& os, const ShardSpec& spec) {
         case ShardOrientation::COL_MAJOR: os << "ShardOrientation::COL_MAJOR"; break;
     }
 
-    os << "}";
+    os << ")";
     return os;
 }
 


### PR DESCRIPTION
This will fix ShardSpec stream out with mismatch of {} in coord.
And use `ShaedSpec()` instead of `ShardSpec{}` for function type.

### PR Category
Bug fix

### Summary
I get "SyntaxError: closing parenthesis ']' does not match opening parenthesis '{'" when parse with ast parse.
This PR is to fix this issue.

### Notes for reviewers

Matching parenthesis.
