### PR TITLE
[skip ci] Add CODEOWNERS entries for disaggregation internal/ paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -182,6 +182,8 @@ tt_metal/tools/jit_compile_server/**/CMakeLists.txt @abhullar-tt @ruizhangTT @te
 tt_metal/tools/dispatch_telemetry_dump/**/CMakeLists.txt @anashTT @jbaumanTT @sidnadTT @tenstorrent/metalium-developers-infra
 tt_metal/api/tt-metalium/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental APIs
 tt_metal/impl/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental impl
+tt_metal/api/tt-metalium/internal/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation internal APIs (moved from experimental in #48638)
+tt_metal/impl/internal/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation internal impl (moved from experimental in #48638)
 tt_metal/api/tt-metalium/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
 tt_metal/impl/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
 tt_metal/impl/experimental/udm/**/CMakeLists.txt @yugaoTT @SeanNijjar @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass


### PR DESCRIPTION
### Summary

#48620 is pulling in the metal infra team (`@tenstorrent/metalium-developers-infra`) as a required reviewer on plain C++ changes, which isn't a fit for that team.

Root cause: #48638 moved disaggregation code from `experimental/` to `internal/` but didn't add matching `CODEOWNERS` entries for the new paths. `tt_metal/impl/internal/disaggregation/` has no explicit owner, so it falls through to the `tt_metal/` catch-all rule (`@tenstorrent/metalium-developers-infra`), which exists specifically to flag paths like this that are missing real ownership.

`git blame` on the pre-move files (`tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp`, `kv_chunk_address_table.cpp`, `kv_chunk_address_table_protobuf.cpp`) shows Sean Nijjar as the dominant author, matching the existing `experimental/disaggregation` CODEOWNERS entries. This PR adds the equivalent `internal/disaggregation` entries with the same owners.

### Changes

- `tt_metal/api/tt-metalium/internal/disaggregation/` → `@SeanNijjar @ubcheema`
- `tt_metal/impl/internal/disaggregation/` → `@SeanNijjar @ubcheema`

Closes the review-routing gap seen on #48620.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/codeowners-disaggregation-internal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/codeowners-disaggregation-internal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:blozano/codeowners-disaggregation-internal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/codeowners-disaggregation-internal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/codeowners-disaggregation-internal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/codeowners-disaggregation-internal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/codeowners-disaggregation-internal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/codeowners-disaggregation-internal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/codeowners-disaggregation-internal)