### PR TITLE
[Cleanup] Migrate data-movement + example ops to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/reader_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/reader_all_to_all_combine.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
@@ -23,16 +27,22 @@ inline uint32_t get_data_page_idx(const uint32_t e, const uint32_t token) {
 
 template <uint32_t DeviceIdx, uint32_t NumMappingPages, uint32_t MappingPageSizeBytes, typename AddrGen>
 void get_device_expert_indices(
+    const Noc& noc,
     const AddrGen& mapping_addrgen,
     const uint32_t mapping_l1_buffer_addr,
     const uint32_t mapping_page_size,
     volatile tt_l1_ptr uint16_t* output_ptr) {
     auto mapping_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(mapping_l1_buffer_addr);
+    CoreLocalMem<uint32_t> mapping_dst(mapping_l1_buffer_addr);
 
     for (uint32_t expert_idx = 0; expert_idx < NumMappingPages; ++expert_idx) {
-        const uint64_t map_page_noc_addr = mapping_addrgen.get_noc_addr(expert_idx);
-        noc_async_read(map_page_noc_addr, mapping_l1_buffer_addr,MappingPageSizeBytes);
-        noc_async_read_barrier();
+        noc.async_read(
+            mapping_addrgen,
+            mapping_dst,
+            MappingPageSizeBytes,
+            {.page_id = expert_idx, .offset_bytes = 0},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
 
         if (mapping_ptr[DeviceIdx] == 1u) {
             *(output_ptr++) = expert_idx;
@@ -72,24 +82,34 @@ void kernel_main() {
     const auto mapping_addrgen = TensorAccessor(mapping_args, mapping_tensor_addr);
     const auto data_addrgen = TensorAccessor(data_args, data_tensor_addr);
 
+    Noc noc;
+    CircularBuffer mapping_cb(mapping_cb_id);
+    CircularBuffer local_experts_cb(local_experts_cb_id);
+    CircularBuffer metadata_cb(metadata_cb_id);
+    CircularBuffer data_cb(data_cb_id);
+
     // this gets sent to writer
-    cb_reserve_back(local_experts_cb_id,1);
-    auto local_experts_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(local_experts_cb_id));
+    local_experts_cb.reserve_back(1);
+    auto local_experts_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(local_experts_cb.get_write_ptr());
 
     // temp buffer just used here
-    cb_reserve_back(mapping_cb_id,1);
-    uint32_t mapping_buffer_addr = get_write_ptr(mapping_cb_id);
-    cb_push_back(mapping_cb_id, 1);
+    mapping_cb.reserve_back(1);
+    uint32_t mapping_buffer_addr = mapping_cb.get_write_ptr();
+    mapping_cb.push_back(1);
 
     detail::get_device_expert_indices<linearized_mesh_coord, num_mapping_pages, mapping_page_size_bytes>(
-        mapping_addrgen, mapping_buffer_addr, mapping_page_size_bytes, local_experts_ptr);
-    cb_push_back(local_experts_cb_id,1);
+        noc, mapping_addrgen, mapping_buffer_addr, mapping_page_size_bytes, local_experts_ptr);
+    local_experts_cb.push_back(1);
     for (uint32_t token = token_start_idx; token < token_end_idx; ++token) {
-        cb_reserve_back(metadata_cb_id,1);
-        const uint32_t metadata_l1_addr = get_write_ptr(metadata_cb_id);
-        const uint64_t metadata_noc_addr = metadata_addrgen.get_noc_addr(token);
-        noc_async_read(metadata_noc_addr, metadata_l1_addr, metadata_page_size_bytes);
-        noc_async_read_barrier();
+        metadata_cb.reserve_back(1);
+        const uint32_t metadata_l1_addr = metadata_cb.get_write_ptr();
+        noc.async_read(
+            metadata_addrgen,
+            metadata_cb,
+            metadata_page_size_bytes,
+            {.page_id = token, .offset_bytes = 0},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
 
         auto metadata_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(metadata_l1_addr);
 
@@ -98,20 +118,23 @@ void kernel_main() {
             if (find_if<uint16_t, selected_experts_k, false>(metadata_ptr, expert_idx)) {
                 const uint32_t data_page_idx =
                     detail::get_data_page_idx<batch_size, seq_size, locally_reduced>(e, token);
-                cb_reserve_back(data_cb_id, 1);
+                data_cb.reserve_back(1);
 
-                const uint32_t data_l1_addr=get_write_ptr(data_cb_id);
-                const uint64_t data_noc_addr = data_addrgen.get_noc_addr(data_page_idx);
-                noc_async_read(data_noc_addr,data_l1_addr,data_size_bytes);
-                noc_async_read_barrier();
+                noc.async_read(
+                    data_addrgen,
+                    data_cb,
+                    data_size_bytes,
+                    {.page_id = data_page_idx, .offset_bytes = 0},
+                    {.offset_bytes = 0});
+                noc.async_read_barrier();
 
-                cb_push_back(data_cb_id, 1);
+                data_cb.push_back(1);
 
                 if constexpr (locally_reduced){
                     break;
                 }
             }
         }
-        cb_push_back(metadata_cb_id, 1);
+        metadata_cb.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
@@ -7,7 +7,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 using namespace tt::data_movement::common;
 
@@ -53,12 +55,12 @@ void kernel_main() {
             for (uint32_t l = lower_dim_start; l < lower_dim_end; l++) {
                 const uint32_t read_offset = h_offset + r_offset + l;
                 noc_async_read_sharded(noc, cb_slot, s, read_offset, 0, original_page_size_bytes);
-                noc_async_read_barrier();
+                noc.async_read_barrier();
                 for (uint32_t n = 0; n < repetitions; n++) {
                     const uint32_t write_offset = h_offset_rep + n * LOWER_DIMS_TIMES_REP_DIM + r_offset + l;
                     noc_async_write_sharded(noc, cb_slot, d, write_offset, 0, original_page_size_bytes);
                 }
-                noc_async_write_barrier();
+                noc.async_write_barrier();
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_tile.cpp
@@ -2,12 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// TILE higher-dim repeat; bare get_noc_addr (tile pages are atomic on one core).
+// TILE higher-dim repeat; direct per-page transfer (tile pages are atomic on one core).
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 using namespace tt::data_movement::common;
 
@@ -38,10 +41,12 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr);
     const auto d = TensorAccessor(dst_args, dst_addr);
 
+    Noc noc;
     CircularBuffer cb(cb_id_in0);
     cb.reserve_back(1);
     const uint32_t cb_slot = cb.get_write_ptr();
     cb.push_back(1);
+    const CoreLocalMem<uint32_t> cb_mem(cb_slot);
 
     for (uint32_t h = higher_dim_start; h < higher_dim_end; h++) {
         const uint32_t h_offset = h * LOWER_DIMS_TIMES_REP_DIM;
@@ -50,15 +55,23 @@ void kernel_main() {
             const uint32_t r_offset = r * LOWER_DIMS;
             for (uint32_t l = lower_dim_start; l < lower_dim_end; l++) {
                 const uint32_t read_offset = h_offset + r_offset + l;
-                const uint64_t src_noc_addr = s.get_noc_addr(read_offset, 0);
-                noc_async_read(src_noc_addr, cb_slot, original_page_size_bytes);
-                noc_async_read_barrier();
+                noc.async_read(
+                    s,
+                    cb_mem,
+                    original_page_size_bytes,
+                    {.page_id = read_offset, .offset_bytes = 0},
+                    {.offset_bytes = 0});
+                noc.async_read_barrier();
                 for (uint32_t n = 0; n < repetitions; n++) {
                     const uint32_t write_offset = h_offset_rep + n * LOWER_DIMS_TIMES_REP_DIM + r_offset + l;
-                    const uint64_t dst_noc_addr = d.get_noc_addr(write_offset, 0);
-                    noc_async_write(cb_slot, dst_noc_addr, original_page_size_bytes);
+                    noc.async_write(
+                        cb_mem,
+                        d,
+                        original_page_size_bytes,
+                        {.offset_bytes = 0},
+                        {.page_id = write_offset, .offset_bytes = 0});
                 }
-                noc_async_write_barrier();
+                noc.async_write_barrier();
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
@@ -7,7 +7,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 using namespace tt::data_movement::common;
 
@@ -41,10 +43,10 @@ void kernel_main() {
 
     for (uint32_t i = page_start; i < page_end; i++) {
         noc_async_read_sharded(noc, cb_slot, s, i, 0, original_page_size_bytes);
-        noc_async_read_barrier();
+        noc.async_read_barrier();
         for (uint32_t k = 0; k < num_repeats; k++) {
             noc_async_write_sharded(noc, cb_slot, d, i, k * original_page_size_bytes, original_page_size_bytes);
         }
-        noc_async_write_barrier();
+        noc.async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp
@@ -6,6 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp"
@@ -36,14 +37,16 @@ void kernel_main() {
     const auto map_addr_gen = TensorAccessor(map_args, map_addr);
 
     Noc noc;
+    CircularBuffer cb_mapping(mapping_cb_id);
+    CircularBuffer cb_input(input_cb_id);
     bool first = true;
     for (uint32_t out_page_idx = start_output_page_idx; out_page_idx < end_output_page_idx; ++out_page_idx) {
-        cb_reserve_back(mapping_cb_id, One_Tile_Reserve);
+        cb_mapping.reserve_back(One_Tile_Reserve);
         const uint64_t map_noc_addr = map_addr_gen.get_noc_addr(out_page_idx);
-        const uint32_t map_addr = get_write_ptr(mapping_cb_id);
+        const uint32_t map_addr = cb_mapping.get_write_ptr();
         enhanced_noc_async_read<Max_Map_Size_Bytes, true>(noc, map_noc_addr, map_addr, Max_Map_Size_Bytes);
-        noc_async_read_barrier();
-        cb_push_back(mapping_cb_id, 1);
+        noc.async_read_barrier();
+        cb_mapping.push_back(1);
 
         auto map_ptr = reinterpret_cast<volatile tt_l1_ptr SegmentMapData*>(map_addr);
         uint32_t previous_input_page_idx = std::numeric_limits<uint32_t>::max();
@@ -62,13 +65,13 @@ void kernel_main() {
                 }
             }
 
-            cb_reserve_back(input_cb_id, One_Tile_Reserve);
-            const uint32_t input_write_addr = get_write_ptr(input_cb_id);
+            cb_input.reserve_back(One_Tile_Reserve);
+            const uint32_t input_write_addr = cb_input.get_write_ptr();
             const uint64_t input_page_noc_addr = input_addr_gen.get_noc_addr(input_page_idx);
             enhanced_noc_async_read<Tile_Size_Bytes, true>(noc, input_page_noc_addr, input_write_addr, Tile_Size_Bytes);
             previous_input_page_idx = input_page_idx;
-            noc_async_read_barrier();
-            cb_push_back(input_cb_id, 1);
+            noc.async_read_barrier();
+            cb_input.push_back(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -4,6 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp"
@@ -29,13 +30,16 @@ void kernel_main() {
     const auto output_addrgen = TensorAccessor(output_args, output_base_addr);
 
     Noc noc;
+    CircularBuffer cb_mapping(cb_id_mapping);
+    CircularBuffer cb_input(cb_id_input);
+    CircularBuffer cb_working(cb_id_working);
     // loop over output (reshaped) pages this core is responsible for
     bool first = true;
-    cb_reserve_back(cb_id_working, 1);
-    const uint32_t working_write_addr = get_write_ptr(cb_id_working);
+    cb_working.reserve_back(1);
+    const uint32_t working_write_addr = cb_working.get_write_ptr();
     for (uint32_t output_page_idx = start_output_page; output_page_idx < end_output_page; ++output_page_idx) {
-        cb_wait_front(cb_id_mapping, 1);
-        const uint32_t map_addr = get_read_ptr(cb_id_mapping);
+        cb_mapping.wait_front(1);
+        const uint32_t map_addr = cb_mapping.get_read_ptr();
         auto map_ptr = reinterpret_cast<volatile tt_l1_ptr SegmentMapData*>(map_addr);
         uint32_t input_base_addr, previous_input_page_idx = std::numeric_limits<uint32_t>::max();
         for (uint32_t seg_idx = 0; seg_idx < Max_Map_Entries; ++seg_idx) {
@@ -44,16 +48,16 @@ void kernel_main() {
             }
 
             if (first) {
-                cb_wait_front(cb_id_input, 1);
-                input_base_addr = get_read_ptr(cb_id_input);
+                cb_input.wait_front(1);
+                input_base_addr = cb_input.get_read_ptr();
                 previous_input_page_idx = map_ptr[seg_idx].input_page_index;
                 first = false;
 
             } else if (map_ptr[seg_idx].input_page_index != previous_input_page_idx) {
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_input, 1);
-                cb_wait_front(cb_id_input, 1);
-                input_base_addr = get_read_ptr(cb_id_input);
+                noc.async_write_barrier();
+                cb_input.pop_front(1);
+                cb_input.wait_front(1);
+                input_base_addr = cb_input.get_read_ptr();
                 previous_input_page_idx = map_ptr[seg_idx].input_page_index;
             }
             // TODO (maybe) pre calculate size and offsets in bytes on host
@@ -62,20 +66,20 @@ void kernel_main() {
             const uint32_t szbytes = map_ptr[seg_idx].num_elements * element_sz_bytes;
             tt_memmove<false, true, false, Tile_size_bytes>(noc, output_addr, input_addr, szbytes);
         }
-        noc_async_write_barrier();
+        noc.async_write_barrier();
 
         const uint64_t output_noc_addr = output_addrgen.get_noc_addr(output_page_idx);
         enhanced_noc_async_write<Tile_size_bytes, true>(noc, working_write_addr, output_noc_addr, Tile_size_bytes);
-        noc_async_write_barrier();
+        noc.async_write_barrier();
 
-        cb_pop_front(cb_id_mapping, 1);
+        cb_mapping.pop_front(1);
     }
     // The per-transition pop only releases the previous input page's tile, so the final input
     // tile waited inside the loop is still held here. Pop it once to leave the input CB balanced.
     // Gated on `first` so a core that processed no segments does not pop a tile it never waited.
     if (!first) {
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_input, 1);
+        noc.async_write_barrier();
+        cb_input.pop_front(1);
     }
-    cb_push_back(cb_id_working, 1);
+    cb_working.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_poly.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_poly.cpp
@@ -16,6 +16,7 @@
 #include "api/compute/binary_shift.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/gelu.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
@@ -25,14 +26,18 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_1;
     constexpr auto cb_grad_in = tt::CBIndex::c_2;
 
+    CircularBuffer cb_grad_out_cb(cb_grad_out);
+    CircularBuffer cb_input_cb(cb_input);
+    CircularBuffer cb_grad_in_cb(cb_grad_in);
+
     unary_op_init_common(cb_grad_out, cb_grad_in);
     gelu_derivative_tile_init<false>();
     mul_binary_tile_init();
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
-        cb_reserve_back(cb_grad_in, per_core_block_size);
-        cb_wait_front(cb_grad_out, per_core_block_size);
-        cb_wait_front(cb_input, per_core_block_size);
+        cb_grad_in_cb.reserve_back(per_core_block_size);
+        cb_grad_out_cb.wait_front(per_core_block_size);
+        cb_input_cb.wait_front(per_core_block_size);
 
         // Per-tile canonical pattern: acquire → compute → commit → wait → pack → release
         // Multi-tile batching in dest is not possible here because gelu_derivative_tile
@@ -53,8 +58,8 @@ void kernel_main() {
             tile_regs_release();
         }
 
-        cb_pop_front(cb_grad_out, per_core_block_size);
-        cb_pop_front(cb_input, per_core_block_size);
-        cb_push_back(cb_grad_in, per_core_block_size);
+        cb_grad_out_cb.pop_front(per_core_block_size);
+        cb_input_cb.pop_front(per_core_block_size);
+        cb_grad_in_cb.push_back(per_core_block_size);
     }
 }

--- a/ttnn/cpp/ttnn/operations/examples/example/device/kernels/compute/eltwise_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/kernels/compute/eltwise_sfpu.cpp
@@ -7,19 +7,23 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
+    CircularBuffer cb_in0(tt::CBIndex::c_0);
+    CircularBuffer cb_out(tt::CBIndex::c_2);
+
     init_sfpu(tt::CBIndex::c_0, tt::CBIndex::c_2);
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
-        cb_reserve_back(tt::CBIndex::c_2, per_core_block_dim);
+        cb_out.reserve_back(per_core_block_dim);
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
             tile_regs_acquire();
 
             // Pop tile after tile, copy to DST and pack
-            cb_wait_front(tt::CBIndex::c_0, 1);
+            cb_in0.wait_front(1);
 
             copy_tile(tt::CBIndex::c_0, 0, 0);
 
@@ -33,10 +37,10 @@ void kernel_main() {
 
             pack_tile(0, tt::CBIndex::c_2);
 
-            cb_pop_front(tt::CBIndex::c_0, 1);
+            cb_in0.pop_front(1);
 
             tile_regs_release();
         }
-        cb_push_back(tt::CBIndex::c_2, per_core_block_dim);
+        cb_out.push_back(per_core_block_dim);
     }
 }

--- a/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/reader_binary_diff_lengths.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/reader_binary_diff_lengths.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 
 void kernel_main() {
     uint32_t src0_addr = get_arg_val<uint32_t>(0);
@@ -23,39 +26,37 @@ void kernel_main() {
     uint32_t ublock_size_bytes_1 = get_tile_size(cb_id_in1);
     uint32_t ublock_size_tiles = 1;
 
-    uint32_t l1_write_addr_in0;
-    uint32_t l1_write_addr_in1;
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+    UnicastEndpoint src;
 
     uint32_t num_tiles = src0_num_tiles > src1_num_tiles ? src0_num_tiles : src1_num_tiles;
 
     // read ublocks from src0/src1 to CB0/CB1, then push ublocks to compute (unpacker)
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
         if (i < src0_num_tiles) {
-            uint64_t src0_noc_addr = get_noc_addr(src0_noc_x, src0_noc_y, src0_addr);
+            cb_in0.reserve_back(ublock_size_tiles);
 
-            cb_reserve_back(cb_id_in0, ublock_size_tiles);
-            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            noc.async_read(
+                src, cb_in0, ublock_size_bytes_0, {.noc_x = src0_noc_x, .noc_y = src0_noc_y, .addr = src0_addr}, {});
 
-            noc_async_read(src0_noc_addr, l1_write_addr_in0, ublock_size_bytes_0);
+            noc.async_read_barrier();
 
-            noc_async_read_barrier();
-
-            cb_push_back(cb_id_in0, ublock_size_tiles);
+            cb_in0.push_back(ublock_size_tiles);
 
             src0_addr += ublock_size_bytes_0;
         }
 
         if (i < src1_num_tiles) {
-            uint64_t src1_noc_addr = get_noc_addr(src1_noc_x, src1_noc_y, src1_addr);
+            cb_in1.reserve_back(ublock_size_tiles);
 
-            cb_reserve_back(cb_id_in1, ublock_size_tiles);
-            l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+            noc.async_read(
+                src, cb_in1, ublock_size_bytes_1, {.noc_x = src1_noc_x, .noc_y = src1_noc_y, .addr = src1_addr}, {});
 
-            noc_async_read(src1_noc_addr, l1_write_addr_in1, ublock_size_bytes_1);
+            noc.async_read_barrier();
 
-            noc_async_read_barrier();
-
-            cb_push_back(cb_id_in1, ublock_size_tiles);
+            cb_in1.push_back(ublock_size_tiles);
 
             src1_addr += ublock_size_bytes_1;
         }

--- a/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/reader_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/reader_unary.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -18,17 +21,18 @@ void kernel_main() {
     constexpr uint32_t ublock_size_tiles = 1;
     uint32_t ublock_size_bytes = get_tile_size(cb_id_in0) * ublock_size_tiles;
 
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    UnicastEndpoint src;
+
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        uint64_t src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, src_addr);
+        cb_in0.reserve_back(ublock_size_tiles);
+        noc.async_read(src, cb_in0, ublock_size_bytes, {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = src_addr}, {});
 
-        cb_reserve_back(cb_id_in0, ublock_size_tiles);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read(src_noc_addr, l1_write_addr, ublock_size_bytes);
+        noc.async_read_barrier();
 
-        noc_async_read_barrier();
-
-        cb_push_back(cb_id_in0, ublock_size_tiles);
+        cb_in0.push_back(ublock_size_tiles);
         src_addr += ublock_size_bytes;
     }
 }

--- a/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/writer_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/writer_unary.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -16,16 +19,18 @@ void kernel_main() {
     uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
     uint32_t ublock_size_tiles = 1;
 
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
+    UnicastEndpoint dst;
+
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        uint64_t dst_noc_addr = get_noc_addr(dst_noc_x, dst_noc_y, dst_addr);
+        cb_out0.wait_front(ublock_size_tiles);
+        noc.async_write(
+            cb_out0, dst, ublock_size_bytes, {}, {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = dst_addr});
 
-        cb_wait_front(cb_id_out0, ublock_size_tiles);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-        noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
+        noc.async_write_barrier();
 
-        noc_async_write_barrier();
-
-        cb_pop_front(cb_id_out0, ublock_size_tiles);
+        cb_out0.pop_front(ublock_size_tiles);
         dst_addr += ublock_size_bytes;
     }
 }

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 #include "api/debug/dprint.h"
 
 void kernel_main() {
@@ -17,24 +20,27 @@ void kernel_main() {
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
+
+    Noc noc;
+    CircularBuffer cb_out(cb_id_out);
+
     const auto s1 = TensorAccessor(dst1_args, dst_addr1);
     const auto s2 = TensorAccessor(dst2_args, dst_addr2);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_wait_front(cb_id_out, onetile);
+        cb_out.wait_front(onetile);
 
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
         if (dst_addr1 != 0) {
-            noc_async_write_page(i, s1, l1_read_addr);
-            noc_async_write_barrier();
+            noc.async_write(cb_out, s1, s1.get_aligned_page_size(), {.offset_bytes = 0}, {.page_id = i});
+            noc.async_write_barrier();
         }
 
         if (dst_addr2 != 0) {
-            noc_async_write_page(i, s2, l1_read_addr);
-            noc_async_write_barrier();
+            noc.async_write(cb_out, s2, s2.get_aligned_page_size(), {.offset_bytes = 0}, {.page_id = i});
+            noc.async_write_barrier();
         }
 
-        cb_pop_front(cb_id_out, onetile);
+        cb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 #include "full_kernel_common.hpp"
 
 void kernel_main() {
@@ -20,9 +23,12 @@ void kernel_main() {
     value val;
     val.u = fill_value;
 
-    cb_reserve_back(cb_value, onepage);
+    Noc noc;
+    CircularBuffer cb(cb_value);
 
-    uint32_t write_addr = get_write_ptr(cb_value);
+    cb.reserve_back(onepage);
+
+    uint32_t write_addr = cb.get_write_ptr();
 
     if (val.u == 0) {
         zero_buffer(cb_value, page_size);
@@ -47,18 +53,17 @@ void kernel_main() {
 #endif
     }
 
-    cb_push_back(cb_value, 1);
+    cb.push_back(1);
 
     const auto s = TensorAccessor(dst_args, output_addr);
 
-    cb_wait_front(cb_value, 1);
+    cb.wait_front(1);
 
     uint32_t end_id = start_id + num_pages_per_core;
     for (std::uint32_t i = start_id; i < end_id; i++) {
-        const auto cb_value_addr = get_read_ptr(cb_value);
-        noc_async_write_page(i, s, cb_value_addr);
+        noc.async_write(cb, s, s.get_aligned_page_size(), {}, {.page_id = i});
     }
-    noc_async_writes_flushed();
-    cb_pop_front(cb_value, 1);
-    noc_async_write_barrier();
+    noc.async_writes_flushed();
+    cb.pop_front(1);
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_nd_sharded.cpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 #include "full_kernel_common.hpp"
 
 void kernel_main() {
@@ -21,9 +24,12 @@ void kernel_main() {
     value val;
     val.u = fill_value;
 
-    cb_reserve_back(cb_value, onepage);
+    Noc noc;
+    CircularBuffer cb(cb_value);
 
-    uint32_t write_addr = get_write_ptr(cb_value);
+    cb.reserve_back(onepage);
+
+    uint32_t write_addr = cb.get_write_ptr();
 
     if (val.u == 0) {
         zero_buffer(cb_value, page_size);
@@ -48,22 +54,21 @@ void kernel_main() {
 #endif
     }
 
-    cb_push_back(cb_value, 1);
+    cb.push_back(1);
 
     const auto dst_accessor = TensorAccessor(dst_args, output_addr);
 
-    cb_wait_front(cb_value, 1);
+    cb.wait_front(1);
 
     for (uint32_t shard_id = start_shard_id; shard_id < num_shards; shard_id += num_cores) {
         auto shard_pages = dst_accessor.shard_pages(shard_id);
         for (auto page_iter = shard_pages.begin(); page_iter != shard_pages.end(); ++page_iter) {
             uint32_t page_id = page_iter->page_id();
-            const auto cb_value_addr = get_read_ptr(cb_value);
-            noc_async_write_page(page_id, dst_accessor, cb_value_addr);
+            noc.async_write(cb, dst_accessor, dst_accessor.get_aligned_page_size(), {}, {.page_id = page_id});
         }
     }
 
-    noc_async_writes_flushed();
-    cb_pop_front(cb_value, 1);
-    noc_async_write_barrier();
+    noc.async_writes_flushed();
+    cb.pop_front(1);
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_sharded.cpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 #include "full_kernel_common.hpp"
 
 void kernel_main() {
@@ -22,9 +25,12 @@ void kernel_main() {
     value val;
     val.u = fill_value;
 
-    cb_reserve_back(cb_value, onepage);
+    Noc noc;
+    CircularBuffer cb(cb_value);
 
-    uint32_t write_addr = get_write_ptr(cb_value);
+    cb.reserve_back(onepage);
+
+    uint32_t write_addr = cb.get_write_ptr();
 
     if (val.u == 0) {
         zero_buffer(cb_value, page_size);
@@ -49,23 +55,22 @@ void kernel_main() {
 #endif
     }
 
-    cb_push_back(cb_value, 1);
+    cb.push_back(1);
 
     const auto dst_accessor = TensorAccessor(dst_args, output_addr);
 
-    cb_wait_front(cb_value, 1);
+    cb.wait_front(1);
 
     for (uint32_t shard_row_id = 0; shard_row_id < num_pages_per_shard_col; ++shard_row_id) {
         uint32_t curr_page_id = start_page_id;
         for (uint32_t shard_col_id = 0; shard_col_id < num_pages_per_shard_row; ++shard_col_id) {
-            const auto cb_value_addr = get_read_ptr(cb_value);
-            noc_async_write_page(curr_page_id, dst_accessor, cb_value_addr);
+            noc.async_write(cb, dst_accessor, dst_accessor.get_aligned_page_size(), {}, {.page_id = curr_page_id});
             curr_page_id++;
         }
         start_page_id += tensor_width_in_pages;
     }
 
-    noc_async_writes_flushed();
-    cb_pop_front(cb_value, 1);
-    noc_async_write_barrier();
+    noc.async_writes_flushed();
+    cb.pop_front(1);
+    noc.async_write_barrier();
 }


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to issue #45003. Migrates additional data-movement + examples kernels to the Device 2.0 API

### Notes for reviewers

- `reader_all_to_all_combine.cpp` is a shared kernel under `ccl/all_to_all_combine/` borrowed by `moe_expert_token_remap`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-pr1-datamovement-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-pr1-datamovement-examples)
