### PR TITLE
Add FLUX.1-Kontext-dev pipeline to tt_dit (edit + generate + LoRA)

### DIFF
--- a/models/tt_dit/blocks/attention.py
+++ b/models/tt_dit/blocks/attention.py
@@ -10,7 +10,7 @@ import torch
 
 import ttnn
 
-from ..layers.linear import ColParallelLinear
+from ..layers.linear import ColParallelLinear, LoRAColParallelLinear
 from ..layers.module import Module, Parameter, UnregisteredModule
 from ..layers.normalization import RMSNorm
 from ..utils.padding import PaddingConfig, pad_weight_tensor
@@ -45,6 +45,7 @@ class Attention(Module):
         k_chunk_size: int = 512,
         q_chunk_size: int = 128,
         is_fsdp: bool = False,
+        lora_enabled: bool = False,
     ) -> None:
         super().__init__()
 
@@ -67,6 +68,12 @@ class Attention(Module):
 
         common_args = dict(mesh_device=mesh_device, ccl_manager=ccl_manager, fsdp_mesh_axis=fsdp_mesh_axis)
 
+        # LoRA-aware Linear substitution (fuse mode). Default off keeps every
+        # non-LoRA caller on the identical base path. The q/k/v and out
+        # projections are the standard LoRA targets; adapters are registered and
+        # bound by the FLUX adapter loader (experimental/lora/flux_adapter_loader.py).
+        ColCls = LoRAColParallelLinear if lora_enabled else ColParallelLinear
+
         self.sdpa_worker_grid = (
             self.mesh_device.compute_with_storage_grid_size().x,
             self.mesh_device.compute_with_storage_grid_size().y - 1,
@@ -84,16 +91,12 @@ class Attention(Module):
             fp32_dest_acc_en=False,  # NOTE: Set to True if there's a correctness issue
         )
 
-        self.to_qkv = ColParallelLinear(query_dim, 3 * padded_inner_dim, mesh_axis=tp_axis, **common_args)
+        self.to_qkv = ColCls(query_dim, 3 * padded_inner_dim, mesh_axis=tp_axis, **common_args)
 
         self.norm_q = RMSNorm(embedding_dim=head_dim, norm_eps=eps, bias=False, mesh_device=mesh_device)
         self.norm_k = RMSNorm(embedding_dim=head_dim, norm_eps=eps, bias=False, mesh_device=mesh_device)
 
-        self.to_out = (
-            ColParallelLinear(padded_inner_dim, out_dim, mesh_axis=tp_axis, **common_args)
-            if not self.pre_only
-            else None
-        )
+        self.to_out = ColCls(padded_inner_dim, out_dim, mesh_axis=tp_axis, **common_args) if not self.pre_only else None
 
         if use_spatial_weights_for_prompt:
             self.add_qkv_proj = UnregisteredModule(self.to_qkv)
@@ -101,17 +104,13 @@ class Attention(Module):
             self.norm_added_k = UnregisteredModule(self.norm_k)
             self.to_add_out = UnregisteredModule(self.to_out) if self.to_out is not None else None
         elif added_kv_proj_dim > 0:
-            self.add_qkv_proj = ColParallelLinear(
-                added_kv_proj_dim, 3 * padded_inner_dim, mesh_axis=tp_axis, **common_args
-            )
+            self.add_qkv_proj = ColCls(added_kv_proj_dim, 3 * padded_inner_dim, mesh_axis=tp_axis, **common_args)
 
             self.norm_added_q = RMSNorm(embedding_dim=head_dim, norm_eps=eps, bias=False, mesh_device=mesh_device)
             self.norm_added_k = RMSNorm(embedding_dim=head_dim, norm_eps=eps, bias=False, mesh_device=mesh_device)
 
             self.to_add_out = (
-                ColParallelLinear(padded_inner_dim, out_dim, mesh_axis=tp_axis, **common_args)
-                if not context_pre_only
-                else None
+                ColCls(padded_inner_dim, out_dim, mesh_axis=tp_axis, **common_args) if not context_pre_only else None
             )
         else:
             self.add_qkv_proj = None

--- a/models/tt_dit/blocks/transformer_block.py
+++ b/models/tt_dit/blocks/transformer_block.py
@@ -43,6 +43,7 @@ class TransformerBlock(Module):
         attention_k_chunk_size: int = 512,
         attention_q_chunk_size: int = 128,
         is_fsdp: bool = False,
+        lora_enabled: bool = False,
     ) -> None:
         super().__init__()
 
@@ -118,6 +119,7 @@ class TransformerBlock(Module):
             k_chunk_size=attention_k_chunk_size,
             q_chunk_size=attention_q_chunk_size,
             is_fsdp=is_fsdp,
+            lora_enabled=lora_enabled,
         )
 
         self.norm2 = DistributedLayerNorm(
@@ -138,6 +140,7 @@ class TransformerBlock(Module):
             mesh_axis=parallel_config.tensor_parallel.mesh_axis,
             fsdp_mesh_axis=fsdp_mesh_axis,
             ccl_manager=ccl_manager,
+            lora_enabled=lora_enabled,
         )
 
         self.norm2_context = None
@@ -161,6 +164,7 @@ class TransformerBlock(Module):
                 mesh_axis=parallel_config.tensor_parallel.mesh_axis,
                 fsdp_mesh_axis=fsdp_mesh_axis,
                 ccl_manager=ccl_manager,
+                lora_enabled=lora_enabled,
             )
 
         device_grid = self.mesh_device.compute_with_storage_grid_size()

--- a/models/tt_dit/experimental/lora/flux_adapter_loader.py
+++ b/models/tt_dit/experimental/lora/flux_adapter_loader.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Adapter loader for FLUX.1 (Kontext) LoRAs, mirroring the Wan 2.2 loader
+(``adapter_loader.py``) but for the FLUX transformer's module tree and the
+diffusers FLUX key convention.
+
+Reads a LoRA safetensors file, parses A/B pairs, and uploads them into the
+LoRA-aware Linear modules of a ``Flux1Transformer`` built with
+``lora_enabled=True``.
+
+Fused-QKV handling (identical shape problem to Wan):
+  FLUX attention uses a single fused ``to_qkv`` (spatial stream) and, in the
+  double-stream blocks, a fused ``add_qkv_proj`` (context stream). Diffusers
+  adapters ship separate ``to_q`` / ``to_k`` / ``to_v`` (and
+  ``add_q_proj`` / ``add_k_proj`` / ``add_v_proj``) pairs. We combine them into
+  one LoRA pair on the fused module by stacking A on the rank dim and building
+  a head-interleaved block-diagonal B, matching how
+  ``blocks.attention.Attention._reshape_and_merge_qkv`` interleaves the base
+  Q/K/V weight. This is done by ``_register_fused`` + ``_head_interleave_lora_B``
+  (reused from ``adapter_loader``).
+
+v0 scope / limitations (warn + skip, never silently miswire):
+  - Diffusers-style keys only (``transformer_blocks.N.attn.to_q.lora_A.weight``,
+    optionally prefixed ``transformer.``/``diffusion_model.``). kohya
+    ``lora_unet_*`` FLUX keys are not converted yet.
+  - ``single_transformer_blocks.N.proj_out`` (the re-fused-input projection)
+    and modulation ``norm*.linear`` adapters are skipped — rare targets whose
+    weight layout needs extra handling.
+  - Head padding on a LoRA-targeted attention (``padding_config`` with
+    ``head_padding > 0``) is unsupported; the loader raises rather than
+    produce a shape-mismatched delta. FLUX's common head counts divide the
+    usual TP factors, so this does not trigger in practice.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import torch
+from loguru import logger
+from safetensors.torch import load_file
+
+from ...layers.lora import LoRAMixin
+from .adapter_loader import AdapterHandle, _head_interleave_lora_B
+
+_STRIP_PREFIXES = ("diffusion_model.", "transformer.", "lora_transformer.", "unet.", "model.")
+_LOW_RANK_RE = re.compile(r"^(?P<base>.*)\.lora_(?P<slot>A|B|down|up)(?:\.[^.]+)?\.weight$")
+_SLOT_MAP = {"A": "A", "down": "A", "B": "B", "up": "B"}
+
+# diffusers FLUX qkv sub-projection names, per stream, in the fixed q,k,v order
+# the fused weight expects.
+_SPATIAL_QKV = ("to_q", "to_k", "to_v")
+_CONTEXT_QKV = ("add_q_proj", "add_k_proj", "add_v_proj")
+
+
+def _strip_known_prefixes(key: str) -> str:
+    for prefix in _STRIP_PREFIXES:
+        if key.startswith(prefix):
+            return key[len(prefix) :]
+    return key
+
+
+def _is_lora_key(raw: str) -> bool:
+    key = _strip_known_prefixes(raw)
+    return bool(_LOW_RANK_RE.match(key)) or key.endswith((".diff", ".diff_b"))
+
+
+def _collect_pairs(raw: dict[str, torch.Tensor]):
+    """Returns ({base_path: {'A': T, 'B': T}}, {base_path: alpha}, num_skipped_direct)."""
+    pairs: dict[str, dict[str, torch.Tensor]] = {}
+    alphas: dict[str, float] = {}
+    skipped_direct = 0
+    unrecognized: list[str] = []
+
+    for raw_key, tensor in raw.items():
+        key = _strip_known_prefixes(raw_key)
+        m = _LOW_RANK_RE.match(key)
+        if m:
+            pairs.setdefault(m.group("base"), {})[_SLOT_MAP[m.group("slot")]] = tensor
+        elif key.endswith(".alpha"):
+            alphas[key[: -len(".alpha")]] = float(tensor.item())
+        elif key.endswith((".diff", ".diff_b")):
+            skipped_direct += 1
+        else:
+            unrecognized.append(raw_key)
+
+    if unrecognized:
+        sample = ", ".join(unrecognized[:5])
+        more = "" if len(unrecognized) <= 5 else f" (+{len(unrecognized) - 5} more)"
+        logger.warning(
+            f"flux adapter loader: {len(unrecognized)} key(s) matched no known "
+            f"pattern (lora_A/B, lora_down/up, .alpha, .diff/.diff_b) and were dropped. "
+            f"Samples: {sample}{more}"
+        )
+    return pairs, alphas, skipped_direct
+
+
+# --------------------------------------------------------------------
+# base-path parsing → structured target
+# --------------------------------------------------------------------
+_RE_ATTN_QKV = re.compile(r"^transformer_blocks\.(\d+)\.attn\.(to_q|to_k|to_v)$")
+_RE_ATTN_ADD_QKV = re.compile(r"^transformer_blocks\.(\d+)\.attn\.(add_q_proj|add_k_proj|add_v_proj)$")
+_RE_ATTN_TO_OUT = re.compile(r"^transformer_blocks\.(\d+)\.attn\.to_out\.0$")
+_RE_ATTN_TO_ADD_OUT = re.compile(r"^transformer_blocks\.(\d+)\.attn\.to_add_out$")
+_RE_FF = re.compile(r"^transformer_blocks\.(\d+)\.ff\.net\.(0\.proj|2)$")
+_RE_FF_CTX = re.compile(r"^transformer_blocks\.(\d+)\.ff_context\.net\.(0\.proj|2)$")
+_RE_SINGLE_QKV = re.compile(r"^single_transformer_blocks\.(\d+)\.attn\.(to_q|to_k|to_v)$")
+_RE_SINGLE_PROJ_MLP = re.compile(r"^single_transformer_blocks\.(\d+)\.proj_mlp$")
+_RE_SINGLE_PROJ_OUT = re.compile(r"^single_transformer_blocks\.(\d+)\.proj_out$")
+
+
+def load_flux_adapter_into(
+    transformer,  # Flux1Transformer built with lora_enabled=True
+    path: str,
+    *,
+    scale: float = 1.0,
+    name: str = "",
+) -> AdapterHandle:
+    """Load a single FLUX LoRA safetensors file into ``transformer``.
+
+    Returns an ``AdapterHandle`` recording the bank index assigned to each
+    LoRA-targeted Linear (keyed by a stable tt-dit dotted path). Bind it with
+    the pipeline's bind walker (``bind_active`` per module) to activate.
+    """
+    raw = load_file(str(path))
+    if not any(_is_lora_key(k) for k in raw):
+        raise RuntimeError(f"no LoRA-style keys (lora_A/lora_B, lora_down/lora_up) in {path}")
+
+    pairs, alphas, skipped_direct = _collect_pairs(raw)
+    if skipped_direct:
+        logger.warning(f"{path}: skipping {skipped_direct} direct (.diff/.diff_b) deltas — not supported.")
+
+    # Grouping: fused QKV pairs collect per (block, stream); everything else is a singleton.
+    #   fused key: (kind, block_idx) where kind in {'spatial','context','single'}
+    fused: dict[tuple[str, int], dict[str, dict[str, torch.Tensor]]] = {}
+    singletons: list[tuple[str, dict[str, torch.Tensor], str]] = []  # (dotted_path, ab, alpha_key)
+    skipped_unmapped = 0
+
+    for base_path, ab in pairs.items():
+        if "A" not in ab or "B" not in ab:
+            logger.warning(f"{path}: {base_path} has an unpaired A/B ({list(ab)}); skipping")
+            continue
+
+        m = _RE_ATTN_QKV.match(base_path)
+        if m:
+            fused.setdefault(("spatial", int(m.group(1))), {})[m.group(2)] = ab
+            continue
+        m = _RE_ATTN_ADD_QKV.match(base_path)
+        if m:
+            fused.setdefault(("context", int(m.group(1))), {})[m.group(2)] = ab
+            continue
+        m = _RE_SINGLE_QKV.match(base_path)
+        if m:
+            fused.setdefault(("single", int(m.group(1))), {})[m.group(2)] = ab
+            continue
+
+        m = _RE_ATTN_TO_OUT.match(base_path)
+        if m:
+            i = int(m.group(1))
+            singletons.append((f"transformer_blocks.{i}.attn.to_out", ab, base_path))
+            continue
+        m = _RE_ATTN_TO_ADD_OUT.match(base_path)
+        if m:
+            i = int(m.group(1))
+            singletons.append((f"transformer_blocks.{i}.attn.to_add_out", ab, base_path))
+            continue
+        m = _RE_FF.match(base_path)
+        if m:
+            i, which = int(m.group(1)), m.group(2)
+            ff_attr = "ff1" if which == "0.proj" else "ff2"
+            singletons.append((f"transformer_blocks.{i}.ff.{ff_attr}", ab, base_path))
+            continue
+        m = _RE_FF_CTX.match(base_path)
+        if m:
+            i, which = int(m.group(1)), m.group(2)
+            ff_attr = "ff1" if which == "0.proj" else "ff2"
+            singletons.append((f"transformer_blocks.{i}.ff_context.{ff_attr}", ab, base_path))
+            continue
+        m = _RE_SINGLE_PROJ_MLP.match(base_path)
+        if m:
+            i = int(m.group(1))
+            singletons.append((f"single_transformer_blocks.{i}.proj_mlp", ab, base_path))
+            continue
+        if _RE_SINGLE_PROJ_OUT.match(base_path) or base_path.endswith(
+            (".norm1.linear", ".norm1_context.linear", ".norm.linear")
+        ):
+            logger.warning(f"{path}: skipping unsupported v0 LoRA target {base_path!r} (proj_out / modulation).")
+            skipped_unmapped += 1
+            continue
+
+        skipped_unmapped += 1
+        logger.warning(f"{path}: unmapped LoRA target {base_path!r} — no matching module in the FLUX tree.")
+
+    if skipped_unmapped:
+        logger.warning(f"{path}: {skipped_unmapped} LoRA target group(s) skipped (see warnings above).")
+
+    target_indices: dict[str, int] = {}
+    ranks: list[int] = []
+
+    # ---- fused QKV / add-QKV ----
+    for (kind, block_idx), qkvs in fused.items():
+        names = _CONTEXT_QKV if kind == "context" else _SPATIAL_QKV
+        if kind == "single":
+            attn = transformer.single_transformer_blocks[block_idx].attn
+            target = attn.to_qkv
+            dotted = f"single_transformer_blocks.{block_idx}.attn.to_qkv"
+        elif kind == "spatial":
+            attn = transformer.transformer_blocks[block_idx].attn
+            target = attn.to_qkv
+            dotted = f"transformer_blocks.{block_idx}.attn.to_qkv"
+        else:  # context
+            attn = transformer.transformer_blocks[block_idx].attn
+            target = attn.add_qkv_proj
+            dotted = f"transformer_blocks.{block_idx}.attn.add_qkv_proj"
+
+        bank_idx, fused_rank = _register_fused(attn, target, dotted, names, qkvs, alphas, scale, name)
+        if bank_idx is None:
+            continue
+        target_indices[dotted] = bank_idx
+        ranks.append(fused_rank)
+
+    # ---- singletons ----
+    for dotted, ab, alpha_key in singletons:
+        target = _path_to_module(transformer, dotted)
+        if not isinstance(target, LoRAMixin):
+            logger.warning(f"{path}: {dotted} is not a LoRA-aware module (lora_enabled=False?); skipping")
+            continue
+        A, B = ab["A"], ab["B"]
+        rank = A.shape[0]
+        alpha = alphas.get(alpha_key, float(rank))
+        eff_scale = scale * (alpha / rank)
+        idx = target.register_lora(A, B, scale=eff_scale, name=name)
+        target_indices[dotted] = idx
+        ranks.append(rank)
+
+    if not ranks:
+        raise RuntimeError(f"{path}: no LoRA targets registered")
+
+    return AdapterHandle(name=name or Path(path).stem, rank=max(ranks), target_indices=target_indices)
+
+
+# --------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------
+def _path_to_module(transformer, dotted: str):
+    """Resolve a tt-dit dotted path like ``transformer_blocks.0.attn.to_out`` or
+    ``single_transformer_blocks.3.proj_mlp`` to the module instance."""
+    obj = transformer
+    for seg in dotted.split("."):
+        obj = obj[int(seg)] if seg.isdigit() else getattr(obj, seg)
+    return obj
+
+
+def _register_fused(attn, target, dotted, names, qkvs, alphas, scale, name):
+    """Stack the three (A,B) pairs named in ``names`` onto the fused ``target``
+    Linear. Returns (bank_idx, fused_rank) or (None, 0) on skip."""
+    if not isinstance(target, LoRAMixin):
+        logger.warning(f"{dotted} is not a LoRA-aware module (lora_enabled=False?); skipping fused group")
+        return None, 0
+
+    missing = [n for n in names if n not in qkvs]
+    if missing:
+        logger.warning(f"fused LoRA on {dotted} missing {missing}; need all of {list(names)} — skipping")
+        return None, 0
+
+    A_per = [qkvs[n]["A"] for n in names]
+    B_per = [qkvs[n]["B"] for n in names]
+    rank_set = {A.shape[0] for A in A_per}
+    if len(rank_set) != 1:
+        raise ValueError(f"{dotted}: QKV LoRA ranks must match; got {[A.shape[0] for A in A_per]}")
+    r = A_per[0].shape[0]
+    n = len(names)
+
+    in_dim = target.in_features
+    per_out = target.out_features // n  # each of Q/K/V contributes 1/n of the fused output
+
+    n_dev = attn.parallel_config.tensor_parallel.factor
+    n_local_heads = attn.n_local_heads
+    head_dim = attn.head_dim
+    expected_out = n_dev * n_local_heads * head_dim
+    if per_out != expected_out:
+        # Head padding (padding_config.head_padding > 0) makes the fused output
+        # larger than the adapter's per-projection output; the interleave below
+        # would misalign. Refuse rather than miswire.
+        raise NotImplementedError(
+            f"{dotted}: fused-QKV LoRA with head padding is unsupported "
+            f"(fused per-proj out={per_out} != heads*head_dim={expected_out}); "
+            "use a mesh/TP config where num_heads is divisible by the TP factor."
+        )
+    for i, (A, B) in enumerate(zip(A_per, B_per)):
+        if A.shape != (r, in_dim):
+            raise ValueError(f"{dotted}: {names[i]} A must be [{r},{in_dim}]; got {tuple(A.shape)}")
+        if B.shape != (per_out, r):
+            raise ValueError(f"{dotted}: {names[i]} B must be [{per_out},{r}]; got {tuple(B.shape)}")
+
+    # A stacked on the rank dim → [n*r, in]
+    A_fused = torch.cat(A_per, dim=0)
+
+    # Each per-source B ([per_out, r]) is embedded into a [per_out, n*r] tile
+    # (zeros for other sources' rank columns), then the n tiles are
+    # head-interleaved on the output dim → [n*per_out, n*r], matching the fused
+    # base weight's head layout.
+    B_tiles: list[torch.Tensor] = []
+    for i, B in enumerate(B_per):
+        tile = torch.zeros(per_out, n * r, dtype=B.dtype)
+        tile[:, i * r : (i + 1) * r] = B
+        B_tiles.append(tile)
+    B_fused = _head_interleave_lora_B(B_tiles, n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim)
+    assert B_fused.shape == (n * per_out, n * r), f"{dotted}: B_fused {B_fused.shape}"
+
+    # alphas are usually identical across Q/K/V; take the first available.
+    alpha = next((alphas[k] for k in names if k in alphas), float(r))
+    eff_scale = scale * (alpha / r)
+
+    bank_idx = target.register_lora(A_fused, B_fused, scale=eff_scale, name=name)
+    return bank_idx, n * r

--- a/models/tt_dit/experimental/tests/test_flux_adapter_loader.py
+++ b/models/tt_dit/experimental/tests/test_flux_adapter_loader.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only tests for the FLUX LoRA adapter loader.
+
+The load path itself uploads deltas to a device, but the *hard* part — the
+fused-QKV A/B stacking + head-interleave — is pure host tensor math. These
+tests validate it against the ground truth: fusing the per-projection LoRA
+deltas into the base weight and then merging Q/K/V exactly the way
+``blocks.attention.Attention._reshape_and_merge_qkv`` does must equal the
+single fused delta the loader builds for ``to_qkv``. No Tenstorrent device is
+required.
+"""
+from __future__ import annotations
+
+import torch
+
+from models.tt_dit.experimental.lora.flux_adapter_loader import _SPATIAL_QKV, _register_fused, load_flux_adapter_into
+from models.tt_dit.layers.lora import LoRAMixin
+
+
+# --------------------------------------------------------------------
+# stubs
+# --------------------------------------------------------------------
+class _StubTP:
+    def __init__(self, factor):
+        self.tensor_parallel = type("tp", (), {"factor": factor})()
+
+
+class _StubAttn:
+    def __init__(self, *, n_dev, n_local_heads, head_dim):
+        self.parallel_config = _StubTP(n_dev)
+        self.n_local_heads = n_local_heads
+        self.head_dim = head_dim
+
+
+class _StubLinear(LoRAMixin):
+    """Captures the (A, B, scale) that ``register_lora`` would receive."""
+
+    def __init__(self, in_features, out_features):
+        self.in_features = in_features
+        self.out_features = out_features
+        self.captured = None
+
+    def register_lora(self, A, B, scale=1.0, name=""):
+        self.captured = {"A": A, "B": B, "scale": scale, "name": name}
+        return 0
+
+
+def _merge_qkv_base(q, k, v, *, n_dev, n_local_heads, head_dim):
+    """Reference: mirror Attention._reshape_and_merge_qkv (no head padding).
+
+    Each input is a diffusers-layout weight/delta [out, in]. Returns the fused
+    tt-layout weight [3*out, in] with the output dim head-interleaved.
+    """
+
+    def one(t):
+        t = t.T  # [in, out]
+        t = t.reshape(t.shape[0], n_dev, n_local_heads, head_dim)
+        return t
+
+    q, k, v = one(q), one(k), one(v)
+    qkv = torch.cat([q, k, v], dim=2)  # [in, n_dev, 3*n_local_heads, head_dim]
+    qkv = qkv.reshape(qkv.shape[0], 3 * n_dev * n_local_heads * head_dim)  # [in, 3*out]
+    return qkv.T  # [3*out, in]
+
+
+def test_fused_qkv_interleave_matches_base_merge():
+    torch.manual_seed(0)
+    n_dev, n_local_heads, head_dim = 2, 3, 8
+    heads = n_dev * n_local_heads
+    in_dim = heads * head_dim  # self-attn: query_dim == inner == out
+    per_out = in_dim
+    rank = 4
+    lora_alpha = float(rank)  # → alpha/rank == 1
+    lora_scale = 1.0
+
+    # Per-projection adapter tensors (diffusers convention: A[r,in], B[out,r]).
+    qkvs = {}
+    deltas = {}
+    for nm in _SPATIAL_QKV:
+        A = torch.randn(rank, in_dim, dtype=torch.float64)
+        B = torch.randn(per_out, rank, dtype=torch.float64)
+        qkvs[nm] = {"A": A, "B": B}
+        deltas[nm] = B @ A  # diffusers delta on weight [out, in] (alpha/rank == 1)
+
+    attn = _StubAttn(n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim)
+    target = _StubLinear(in_features=in_dim, out_features=3 * per_out)
+    alphas = {nm: lora_alpha for nm in _SPATIAL_QKV}
+
+    bank_idx, fused_rank = _register_fused(
+        attn, target, "transformer_blocks.0.attn.to_qkv", _SPATIAL_QKV, qkvs, alphas, lora_scale, "t"
+    )
+    assert bank_idx == 0
+    assert fused_rank == 3 * rank
+
+    cap = target.captured
+    A_fused, B_fused, eff_scale = cap["A"], cap["B"], cap["scale"]
+    assert A_fused.shape == (3 * rank, in_dim)
+    assert B_fused.shape == (3 * per_out, 3 * rank)
+    assert eff_scale == lora_scale * (lora_alpha / rank)
+
+    # Loader's fused delta in tt weight layout [3*out, in] = eff * B_fused @ A_fused.
+    loader_delta = eff_scale * (B_fused.to(torch.float64) @ A_fused.to(torch.float64))
+
+    # Ground truth: fuse each per-proj delta into a base weight, merge Q/K/V the
+    # way the attention layer does, and take the difference. Base cancels, so we
+    # can merge the deltas directly.
+    ref_delta = _merge_qkv_base(
+        deltas["to_q"], deltas["to_k"], deltas["to_v"], n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim
+    )
+
+    assert loader_delta.shape == ref_delta.shape == (3 * per_out, in_dim)
+    torch.testing.assert_close(loader_delta, ref_delta, rtol=1e-9, atol=1e-9)
+
+
+def test_head_padding_is_refused():
+    """A fused output larger than heads*head_dim (head padding) must raise, not miswire."""
+    n_dev, n_local_heads, head_dim = 1, 2, 8
+    in_dim = n_dev * n_local_heads * head_dim
+    rank = 2
+    qkvs = {nm: {"A": torch.randn(rank, in_dim), "B": torch.randn(in_dim, rank)} for nm in _SPATIAL_QKV}
+    attn = _StubAttn(n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim)
+    # out_features implies a per-proj out of in_dim + 8 (i.e. one padded head) → mismatch.
+    target = _StubLinear(in_features=in_dim, out_features=3 * (in_dim + head_dim))
+    try:
+        _register_fused(attn, target, "transformer_blocks.0.attn.to_qkv", _SPATIAL_QKV, qkvs, {}, 1.0, "t")
+    except NotImplementedError:
+        return
+    raise AssertionError("expected NotImplementedError for head-padded fused-QKV LoRA")
+
+
+# --------------------------------------------------------------------
+# key routing (stub transformer records which module each key hits)
+# --------------------------------------------------------------------
+class _StubFF:
+    def __init__(self, in_f, out_f):
+        self.ff1 = _StubLinear(in_f, out_f)
+        self.ff2 = _StubLinear(out_f, in_f)
+
+
+class _StubAttnFull(_StubAttn):
+    def __init__(self, *, n_dev, n_local_heads, head_dim, context=False):
+        super().__init__(n_dev=n_dev, n_local_heads=n_local_heads, head_dim=head_dim)
+        inner = n_dev * n_local_heads * head_dim
+        self.to_qkv = _StubLinear(inner, 3 * inner)
+        self.to_out = _StubLinear(inner, inner)
+        if context:
+            self.add_qkv_proj = _StubLinear(inner, 3 * inner)
+            self.to_add_out = _StubLinear(inner, inner)
+
+
+class _StubDoubleBlock:
+    def __init__(self, **kw):
+        inner = kw["n_dev"] * kw["n_local_heads"] * kw["head_dim"]
+        self.attn = _StubAttnFull(context=True, **kw)
+        self.ff = _StubFF(inner, 4 * inner)
+        self.ff_context = _StubFF(inner, 4 * inner)
+
+
+class _StubSingleBlock:
+    def __init__(self, **kw):
+        inner = kw["n_dev"] * kw["n_local_heads"] * kw["head_dim"]
+        self.attn = _StubAttnFull(context=False, **kw)
+        self.proj_mlp = _StubLinear(inner, 4 * inner)
+        self.proj_out = _StubLinear(inner + 4 * inner, inner)
+
+
+class _StubTransformer:
+    def __init__(self, **kw):
+        self.transformer_blocks = [_StubDoubleBlock(**kw)]
+        self.single_transformer_blocks = [_StubSingleBlock(**kw)]
+
+
+def _lora_ab(rank, in_f, out_f):
+    return {"lora_A.weight": torch.randn(rank, in_f), "lora_B.weight": torch.randn(out_f, rank)}
+
+
+def test_key_routing(tmp_path):
+    from safetensors.torch import save_file
+
+    kw = dict(n_dev=1, n_local_heads=4, head_dim=8)
+    inner = kw["n_dev"] * kw["n_local_heads"] * kw["head_dim"]
+    rank = 2
+
+    state: dict[str, torch.Tensor] = {}
+
+    def add(prefix, in_f, out_f):
+        for k, v in _lora_ab(rank, in_f, out_f).items():
+            state[f"transformer.{prefix}.{k}"] = v
+
+    # double-stream block 0
+    for p in ("to_q", "to_k", "to_v", "add_q_proj", "add_k_proj", "add_v_proj"):
+        add(f"transformer_blocks.0.attn.{p}", inner, inner)
+    add("transformer_blocks.0.attn.to_out.0", inner, inner)
+    add("transformer_blocks.0.attn.to_add_out", inner, inner)
+    add("transformer_blocks.0.ff.net.0.proj", inner, 4 * inner)
+    add("transformer_blocks.0.ff.net.2", 4 * inner, inner)
+    add("transformer_blocks.0.ff_context.net.0.proj", inner, 4 * inner)
+    add("transformer_blocks.0.ff_context.net.2", 4 * inner, inner)
+    # single-stream block 0
+    for p in ("to_q", "to_k", "to_v"):
+        add(f"single_transformer_blocks.0.attn.{p}", inner, inner)
+    add("single_transformer_blocks.0.proj_mlp", inner, 4 * inner)
+    # proj_out should be skipped (v0)
+    add("single_transformer_blocks.0.proj_out", inner + 4 * inner, inner)
+
+    path = tmp_path / "flux_lora.safetensors"
+    save_file(state, str(path))
+
+    tr = _StubTransformer(**kw)
+    handle = load_flux_adapter_into(tr, str(path), scale=1.0, name="unit")
+
+    expected = {
+        "transformer_blocks.0.attn.to_qkv",
+        "transformer_blocks.0.attn.add_qkv_proj",
+        "transformer_blocks.0.attn.to_out",
+        "transformer_blocks.0.attn.to_add_out",
+        "transformer_blocks.0.ff.ff1",
+        "transformer_blocks.0.ff.ff2",
+        "transformer_blocks.0.ff_context.ff1",
+        "transformer_blocks.0.ff_context.ff2",
+        "single_transformer_blocks.0.attn.to_qkv",
+        "single_transformer_blocks.0.proj_mlp",
+    }
+    assert set(handle.target_indices) == expected
+    # proj_out must NOT be registered in v0
+    assert "single_transformer_blocks.0.proj_out" not in handle.target_indices

--- a/models/tt_dit/models/Flux1Kontext.md
+++ b/models/tt_dit/models/Flux1Kontext.md
@@ -1,0 +1,81 @@
+# FLUX.1 Kontext [dev]
+
+## Introduction
+
+[FLUX.1 Kontext [dev]](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev) is a
+12B rectified-flow transformer from Black Forest Labs for **instruction-based image editing**:
+given an input (reference) image and a text instruction (e.g. *"Add a hat to the cat"*), it
+produces an edited image.
+
+This port reuses the tt-metal FLUX.1 [dev] implementation. Kontext shares the exact same
+`FluxTransformer2DModel`, CLIP-L + T5-XXL text encoders, `AutoencoderKL` VAE, and
+`FlowMatchEulerDiscreteScheduler` as FLUX.1 [dev]; the only differences are in the pipeline.
+
+## How Kontext differs from FLUX.1 [dev]
+
+All conditioning happens in the pipeline layer — the transformer weights and forward are
+unchanged (see [Flux1.md](Flux1.md) for the base architecture):
+
+1. **Reference image → latents.** The input image is VAE-encoded (deterministic mode),
+   normalized `(z - shift_factor) * scaling_factor`, and packed into tokens.
+2. **RoPE id offset.** Generated (noise) tokens keep position-id channel 0 = `0`; reference
+   image tokens set channel 0 = `1`. Row/column coordinates deliberately overlap — the two
+   token sets are separated purely by channel 0.
+3. **In-context concatenation.** Each denoising step feeds the transformer the concatenated
+   sequence `[noise_tokens, image_tokens]` (noise first) with the matching concatenated RoPE.
+4. **Output slice.** After the forward, only the noise tokens are kept for the scheduler step;
+   the reference-image tokens are discarded.
+
+Default `guidance_scale = 3.5` (guidance-distilled, no CFG), same as [dev].
+
+## Implementation
+
+- Pipeline: `models/tt_dit/pipelines/flux1/pipeline_flux1_kontext.py`
+  (`Flux1KontextPipeline`, `Flux1KontextPipelineConfig`)
+- Transformer / text encoder / VAE decoder / scheduler: reused unchanged from FLUX.1 [dev].
+- Reference-image VAE **encoder**: host-side torch (`diffusers.AutoencoderKL`) in the initial
+  port — one encode per request is negligible next to the denoising loop. A future
+  optimization can move it on-device (see `models/demos/stable_diffusion_xl_base/vae/tt`).
+
+### Sequence-parallel handling
+
+With sequence parallelism the noise and image sequences are fractured *separately* on the sp
+axis and concatenated *on device* so each shard holds `[noise_shard | image_shard]`; slicing
+the first `n // sp` tokens per shard then recovers the global noise sequence. For `sp == 1`
+this reduces to a plain concat + `[:, :n]` slice. **Bring up `sp == 1` (tp-only) first**, then
+enable sp after verifying ring-attention position handling over the combined sequence.
+
+## Prerequisites
+- Cloned [tt-metal](https://github.com/tenstorrent/tt-metal) + installed TT-Metalium / TT-NN
+- HuggingFace access to gated weights:
+  1. Grant access at https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev
+  2. `huggingface-cli login`
+
+## How to Run
+
+```bash
+export TT_DIT_CACHE_DIR=/your/cache/path
+# optional: a reference image (otherwise a synthetic gradient is used)
+export KONTEXT_INPUT_IMAGE=/path/to/input.png
+
+# Start with sp=1 (tp only) to validate correctness
+pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1_kontext.py -k "1x2sp0tp1"
+
+# 2x4 mesh (QuietBox)
+pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1_kontext.py -k "2x4sp0tp1"
+```
+
+## Status / roadmap
+
+- [x] Pipeline scaffolding (host VAE encode, id offset, concat/slice, SP-safe layout)
+- [ ] Numerical bring-up on Wormhole (`sp=1` tp-only) — PCC vs diffusers reference
+- [ ] Sequence-parallel enablement (verify ring attention over combined sequence)
+- [ ] Variable aspect ratio (`PREFERRED_KONTEXT_RESOLUTIONS`)
+- [ ] On-device VAE encoder
+- [ ] Performance tuning + tracing
+- [ ] tt-inference-server registration (`TTFluxKontextRunner`, `/v1/images/edits`)
+
+## Scalability
+
+Same parallelism model as FLUX.1 [dev] (SP + TP; no CFG parallelism). See
+[Flux1.md](Flux1.md) for mesh/parallel-config details.

--- a/models/tt_dit/models/Flux1Kontext.md
+++ b/models/tt_dit/models/Flux1Kontext.md
@@ -70,7 +70,7 @@ pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1_kontext.py -k "2x4sp
 - [x] Pipeline scaffolding (host VAE encode, id offset, concat/slice, SP-safe layout)
 - [ ] Numerical bring-up on Wormhole (`sp=1` tp-only) — PCC vs diffusers reference
 - [ ] Sequence-parallel enablement (verify ring attention over combined sequence)
-- [ ] Variable aspect ratio (`PREFERRED_KONTEXT_RESOLUTIONS`)
+- [x] Preferred-resolution snapping / variable aspect ratio (`PREFERRED_KONTEXT_RESOLUTIONS`)
 - [ ] On-device VAE encoder
 - [ ] Performance tuning + tracing
 - [ ] tt-inference-server registration (`TTFluxKontextRunner`, `/v1/images/edits`)

--- a/models/tt_dit/models/transformers/transformer_flux1.py
+++ b/models/tt_dit/models/transformers/transformer_flux1.py
@@ -16,7 +16,13 @@ from models.common.utility_functions import is_blackhole
 from ...blocks.attention import Attention
 from ...blocks.transformer_block import TransformerBlock, _chunk_time3d
 from ...layers.embeddings import CombinedTimestepGuidanceTextProjEmbeddings
-from ...layers.linear import ColParallelLinear, Linear, RowParallelLinear, prepare_chunked_linear_output
+from ...layers.linear import (
+    ColParallelLinear,
+    Linear,
+    LoRAColParallelLinear,
+    RowParallelLinear,
+    prepare_chunked_linear_output,
+)
 from ...layers.module import Module, ModuleList
 from ...layers.normalization import DistributedLayerNorm
 from ...utils import cache
@@ -44,6 +50,7 @@ class Flux1SingleTransformerBlock(Module):
         padding_config: PaddingConfig | None,
         attention_k_chunk_size: int = 512,
         attention_q_chunk_size: int = 128,
+        lora_enabled: bool = False,
     ) -> None:
         super().__init__()
 
@@ -67,6 +74,7 @@ class Flux1SingleTransformerBlock(Module):
             use_spatial_weights_for_prompt=True,
             k_chunk_size=attention_k_chunk_size,
             q_chunk_size=attention_q_chunk_size,
+            lora_enabled=lora_enabled,
         )
 
         self.norm = DistributedLayerNorm(
@@ -88,7 +96,10 @@ class Flux1SingleTransformerBlock(Module):
         )
 
         # Shard output, since size of input dimension << size of output dimension.
-        self.proj_mlp = ColParallelLinear(
+        # proj_mlp is a LoRA target (single-block FF-in); swap to the LoRA-aware
+        # variant when enabled so the adapter loader can register/bind it.
+        ProjMlpCls = LoRAColParallelLinear if lora_enabled else ColParallelLinear
+        self.proj_mlp = ProjMlpCls(
             dim,
             mlp_hidden_dim,
             mesh_device=mesh_device,
@@ -254,6 +265,7 @@ class Flux1Transformer(Module):
         ccl_manager: CCLManager | None,
         parallel_config: DiTParallelConfig,
         padding_config: PaddingConfig | None,
+        lora_enabled: bool = False,
     ) -> None:
         super().__init__()
 
@@ -309,6 +321,7 @@ class Flux1Transformer(Module):
                 mesh_device=mesh_device,
                 attention_k_chunk_size=k_chunk_size,
                 attention_q_chunk_size=q_chunk_size,
+                lora_enabled=lora_enabled,
             )
             for i in range(num_layers)
         )
@@ -324,6 +337,7 @@ class Flux1Transformer(Module):
                 mesh_device=mesh_device,
                 attention_k_chunk_size=k_chunk_size,
                 attention_q_chunk_size=q_chunk_size,
+                lora_enabled=lora_enabled,
             )
             for i in range(num_single_layers)
         )
@@ -430,24 +444,20 @@ class Flux1Checkpoint:
 
     def __init__(self, name: str, *, lora_path: str | None = None, lora_scale: float = 1.0) -> None:
         self._name = name
+        # LoRA is applied through the shared tt-dit LoRA framework (LoRA-aware
+        # Linears + adapter loader), fused into the on-device weights at build
+        # time — NOT via a diffusers host-side fuse. So the extracted state dict
+        # is always the base transformer; the adapter delta is merged after the
+        # base weights are loaded (see `build`). The base weights therefore cache
+        # once and are shared across every LoRA variant.
+        self._lora_path = lora_path
+        self._lora_scale = lora_scale
         torch_transformer = FluxTransformer2DModel.from_pretrained(
             name,
             subfolder="transformer",
             torch_dtype=torch.bfloat16,
         )
         torch_transformer.eval()
-        # Optional LoRA: fuse a FLUX.1 LoRA adapter into the transformer weights on
-        # host before extracting the state_dict, so the fused weights are what gets
-        # loaded onto device. No runtime LoRA path is needed on-device. FLUX.1-dev
-        # LoRAs target the same layers Kontext shares, so they generally apply.
-        if lora_path:
-            from loguru import logger
-
-            logger.info(f"fusing LoRA adapter {lora_path!r} (scale={lora_scale})...")
-            torch_transformer.load_lora_adapter(lora_path)
-            torch_transformer.fuse_lora(lora_scale=lora_scale)
-            torch_transformer.unload_lora()  # drop adapter modules; keep fused weights
-            torch_transformer.eval()
         self._config = torch_transformer.config
         self._state_dict = torch_transformer.state_dict()
 
@@ -479,6 +489,7 @@ class Flux1Checkpoint:
         else:
             padding_config = None
 
+        lora_enabled = self._lora_path is not None
         model = Flux1Transformer(
             patch_size=c.patch_size,
             in_channels=c.in_channels,
@@ -495,6 +506,7 @@ class Flux1Checkpoint:
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
             padding_config=padding_config,
+            lora_enabled=lora_enabled,
         )
         cache.load_model(
             model,
@@ -504,4 +516,21 @@ class Flux1Checkpoint:
             parallel_config=parallel_config,
             mesh_shape=tuple(device.shape),
         )
+        if lora_enabled:
+            self._load_and_bind_lora(model)
         return model
+
+    def _load_and_bind_lora(self, model: Flux1Transformer) -> None:
+        """Register the configured LoRA adapter into the (LoRA-aware) transformer
+        and bind it in fuse mode, merging the delta into the on-device base
+        weights. Runs after the base weights are loaded so ``bind_active`` has a
+        materialized ``weight.data`` to add the delta into."""
+        from loguru import logger
+
+        from ...experimental.lora.flux_adapter_loader import _path_to_module, load_flux_adapter_into
+
+        logger.info(f"loading FLUX LoRA adapter {self._lora_path!r} (scale={self._lora_scale}) via tt-dit framework...")
+        handle = load_flux_adapter_into(model, self._lora_path, scale=self._lora_scale, name="active")
+        for dotted, bank_idx in handle.target_indices.items():
+            _path_to_module(model, dotted).bind_active(bank_idx)
+        logger.info(f"bound LoRA into {len(handle.target_indices)} modules (rank≤{handle.rank}).")

--- a/models/tt_dit/models/transformers/transformer_flux1.py
+++ b/models/tt_dit/models/transformers/transformer_flux1.py
@@ -428,7 +428,7 @@ class Flux1Transformer(Module):
 class Flux1Checkpoint:
     """A Flux.1 checkpoint: fetches weights and builds loaded transformers."""
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, *, lora_path: str | None = None, lora_scale: float = 1.0) -> None:
         self._name = name
         torch_transformer = FluxTransformer2DModel.from_pretrained(
             name,
@@ -436,6 +436,18 @@ class Flux1Checkpoint:
             torch_dtype=torch.bfloat16,
         )
         torch_transformer.eval()
+        # Optional LoRA: fuse a FLUX.1 LoRA adapter into the transformer weights on
+        # host before extracting the state_dict, so the fused weights are what gets
+        # loaded onto device. No runtime LoRA path is needed on-device. FLUX.1-dev
+        # LoRAs target the same layers Kontext shares, so they generally apply.
+        if lora_path:
+            import loguru
+
+            loguru.logger.info(f"fusing LoRA adapter {lora_path!r} (scale={lora_scale})...")
+            torch_transformer.load_lora_adapter(lora_path)
+            torch_transformer.fuse_lora(lora_scale=lora_scale)
+            torch_transformer.unload_lora()  # drop adapter modules; keep fused weights
+            torch_transformer.eval()
         self._config = torch_transformer.config
         self._state_dict = torch_transformer.state_dict()
 

--- a/models/tt_dit/models/transformers/transformer_flux1.py
+++ b/models/tt_dit/models/transformers/transformer_flux1.py
@@ -441,9 +441,9 @@ class Flux1Checkpoint:
         # loaded onto device. No runtime LoRA path is needed on-device. FLUX.1-dev
         # LoRAs target the same layers Kontext shares, so they generally apply.
         if lora_path:
-            import loguru
+            from loguru import logger
 
-            loguru.logger.info(f"fusing LoRA adapter {lora_path!r} (scale={lora_scale})...")
+            logger.info(f"fusing LoRA adapter {lora_path!r} (scale={lora_scale})...")
             torch_transformer.load_lora_adapter(lora_path)
             torch_transformer.fuse_lora(lora_scale=lora_scale)
             torch_transformer.unload_lora()  # drop adapter modules; keep fused weights

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1_kontext.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1_kontext.py
@@ -1,0 +1,573 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""FLUX.1-Kontext-dev pipeline (instruction-based image editing).
+
+This extends the text-to-image ``Flux1Pipeline`` with the four pipeline-layer
+deltas that turn FLUX.1-dev into FLUX.1-Kontext-dev. The transformer, text
+encoders, VAE decoder, and scheduler are reused unchanged (Kontext shares the
+diffusers ``FluxTransformer2DModel`` with dev, so ``Flux1Checkpoint`` loads the
+Kontext weights via ``checkpoint_name`` alone).
+
+Deltas vs ``pipeline_flux1.py`` (see design doc for the diffusers ground truth):
+  D1  VAE-encode the reference image (mode/argmax), normalize with
+      (z - shift_factor) * scaling_factor, pack -> ``image_latents``.
+  D2  RoPE ids: noise tokens keep channel 0 = 0; reference-image tokens set
+      channel 0 = 1 (row/col coords deliberately overlap).
+  D3  Each step feed the transformer ``cat([noise, image_latents], dim=seq)``
+      (noise first) with the correspondingly concatenated RoPE.
+  D4  Slice the transformer output back to the noise tokens before the solver.
+
+Sequence-parallel note (design doc §4): noise and image are fractured
+*separately* on the sp axis and concatenated *on device* so that each shard is
+``[noise_shard | image_shard]``. Slicing the first ``n // sp`` tokens per shard
+then recovers exactly the global noise sequence. For ``sp == 1`` this reduces to
+a plain concat + ``[:, :n]`` slice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+import tqdm
+from diffusers import AutoencoderKL
+from diffusers.image_processor import VaeImageProcessor
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+from models.tt_dit.models.transformers.transformer_flux1 import Flux1Checkpoint
+from models.tt_dit.models.vae.vae_sd35 import VAEDecoderAdapter
+from models.tt_dit.parallel.config import DiTParallelConfig, EncoderParallelConfig, VAEParallelConfig
+from models.tt_dit.parallel.manager import CCLManager
+from models.tt_dit.pipelines.cfg import CFGCombiner, create_submeshes, distribute_cfg
+from models.tt_dit.pipelines.events import PipelineEventCallback, SectionEnd, SectionStart, null_callback
+from models.tt_dit.pipelines.flux1.pipeline_flux1 import (
+    _PRESETS_BH,
+    _PRESETS_WH,
+    _VAE_SCALE_FACTOR,
+    _calculate_shift,
+    _latent_image_ids,
+    _pack_latents,
+    _unpack_latents,
+)
+from models.tt_dit.pipelines.flux1.text_encoder import TextEncoder
+from models.tt_dit.pipelines.pipeline_api import PipelineAPIMixin
+from models.tt_dit.solvers import EulerSolver
+from models.tt_dit.utils.tensor import from_torch_to_devices
+from models.tt_dit.utils.tracing import Tracer
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from PIL import Image
+
+# Kontext preferred resolutions (diffusers PREFERRED_KONTEXT_RESOLUTIONS).
+PREFERRED_KONTEXT_RESOLUTIONS: tuple[tuple[int, int], ...] = (
+    (672, 1568),
+    (688, 1504),
+    (720, 1456),
+    (752, 1392),
+    (800, 1328),
+    (832, 1248),
+    (880, 1184),
+    (944, 1104),
+    (1024, 1024),
+    (1104, 944),
+    (1184, 880),
+    (1248, 832),
+    (1328, 800),
+    (1392, 752),
+    (1456, 720),
+    (1504, 688),
+    (1568, 672),
+)
+
+
+def _snap_to_preferred_resolution(width: int, height: int) -> tuple[int, int]:
+    """Snap (width, height) to the closest-aspect Kontext preferred resolution."""
+    aspect = width / height
+    _, best_w, best_h = min((abs(aspect - w / h), w, h) for w, h in PREFERRED_KONTEXT_RESOLUTIONS)
+    return best_w, best_h
+
+
+@dataclass(frozen=True, kw_only=True)
+class Flux1KontextPipelineConfig:
+    topology: ttnn.Topology
+    num_links: int
+
+    dit_parallel_config: DiTParallelConfig
+    encoder_parallel_config: EncoderParallelConfig
+    vae_parallel_config: VAEParallelConfig
+
+    enable_t5_text_encoder: bool
+    use_torch_t5_text_encoder: bool
+    use_torch_clip_text_encoder: bool
+
+    height: int
+    width: int
+    cfg_enabled: bool
+
+    checkpoint_name: str
+
+    # Optional FLUX.1 LoRA fused into the transformer weights at load time.
+    lora_path: str | None = None
+    lora_scale: float = 1.0
+
+    @classmethod
+    def default(
+        cls,
+        *,
+        mesh_shape: ttnn.MeshShape,
+        topology: ttnn.Topology = ttnn.Topology.Linear,
+        num_links: int | None = None,
+        dit_parallel_config: DiTParallelConfig | None = None,
+        encoder_parallel_config: EncoderParallelConfig | None = None,
+        vae_parallel_config: VAEParallelConfig | None = None,
+        enable_t5_text_encoder: bool = True,
+        use_torch_t5_text_encoder: bool = False,
+        use_torch_clip_text_encoder: bool = False,
+        height: int = 1024,
+        width: int = 1024,
+        cfg_enabled: bool = False,
+        checkpoint_name: str,
+        lora_path: str | None = None,
+        lora_scale: float = 1.0,
+    ) -> Flux1KontextPipelineConfig:
+        preset_dict = _PRESETS_BH if is_blackhole() else _PRESETS_WH
+        preset = preset_dict.get(tuple(mesh_shape), {})
+
+        if dit_parallel_config is None:
+            dit_parallel_config = DiTParallelConfig.from_tuples(cfg=(1, 0), sp=preset["sp"], tp=preset["tp"])
+        if encoder_parallel_config is None:
+            encoder_parallel_config = EncoderParallelConfig.from_tuple(preset["encoder_tp"])
+        if vae_parallel_config is None:
+            vae_parallel_config = VAEParallelConfig.from_tuple(preset["vae_tp"])
+
+        return cls(
+            topology=topology,
+            num_links=num_links if num_links is not None else preset["num_links"],
+            dit_parallel_config=dit_parallel_config,
+            encoder_parallel_config=encoder_parallel_config,
+            vae_parallel_config=vae_parallel_config,
+            enable_t5_text_encoder=enable_t5_text_encoder,
+            use_torch_t5_text_encoder=use_torch_t5_text_encoder,
+            use_torch_clip_text_encoder=use_torch_clip_text_encoder,
+            height=height,
+            width=width,
+            cfg_enabled=cfg_enabled,
+            checkpoint_name=checkpoint_name,
+            lora_path=lora_path,
+            lora_scale=lora_scale,
+        )
+
+
+class Flux1KontextPipeline(PipelineAPIMixin):
+    """FLUX.1-Kontext-dev: edit an input image following a text instruction."""
+
+    @classmethod
+    def create_pipeline(
+        cls,
+        *,
+        mesh_device: ttnn.MeshDevice,
+        width: int = 1024,
+        height: int = 1024,
+        cfg_enabled: bool = False,
+        checkpoint_name: str,
+        lora_path: str | None = None,
+        lora_scale: float = 1.0,
+    ) -> Flux1KontextPipeline:
+        config = Flux1KontextPipelineConfig.default(
+            mesh_shape=mesh_device.shape,
+            width=width,
+            height=height,
+            cfg_enabled=cfg_enabled,
+            checkpoint_name=checkpoint_name,
+            lora_path=lora_path,
+            lora_scale=lora_scale,
+        )
+        return cls(device=mesh_device, config=config)
+
+    def __init__(self, *, device: ttnn.MeshDevice, config: Flux1KontextPipelineConfig) -> None:
+        self._mesh_device = device
+        self._parallel_config = config.dit_parallel_config
+        self._encoder_parallel_config = config.encoder_parallel_config
+        self._vae_parallel_config = config.vae_parallel_config
+        self._height = config.height
+        self._width = config.width
+        self._cfg_enabled = config.cfg_enabled
+
+        logger.info(f"Parallel config: {config.dit_parallel_config}")
+        self._submesh_devices = create_submeshes(self._mesh_device, config.dit_parallel_config)
+
+        self._ccl_managers = [
+            CCLManager(submesh_device, num_links=config.num_links, topology=config.topology)
+            for submesh_device in self._submesh_devices
+        ]
+        self._cfg_combiner = CFGCombiner(self._submesh_devices)
+
+        self.encoder_device = self._submesh_devices[0]
+        self.vae_device = self._submesh_devices[0]
+        self.encoder_submesh_idx = 0
+        self.vae_submesh_idx = 0
+
+        logger.info("creating TT-NN transformer...")
+        checkpoint_name = config.checkpoint_name
+        checkpoint = Flux1Checkpoint(checkpoint_name, lora_path=config.lora_path, lora_scale=config.lora_scale)
+        self.transformers = [
+            checkpoint.build(ccl_manager=mgr, parallel_config=config.dit_parallel_config) for mgr in self._ccl_managers
+        ]
+        self.synchronize_devices()
+
+        self._tracers = [Tracer(self._traced_step, device=device, prep_run=False) for device in self._submesh_devices]
+        self._scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(checkpoint_name, subfolder="scheduler")
+        self._solvers = [EulerSolver() for _ in self._submesh_devices]
+
+        self._pos_embed = checkpoint.pos_embed
+        self._num_channels_latents = checkpoint.num_channels_latents
+        self._joint_attention_dim = checkpoint.joint_attention_dim
+        self._patch_size = checkpoint.patch_size
+        self._with_guidance_embeds = checkpoint.with_guidance_embeds
+
+        self._image_processor = VaeImageProcessor(vae_scale_factor=_VAE_SCALE_FACTOR)
+
+        logger.info("creating text encoder...")
+        self._text_encoder = TextEncoder(
+            checkpoint_name=checkpoint_name,
+            device=self.encoder_device,
+            ccl_manager=self._ccl_managers[self.encoder_submesh_idx],
+            parallel_config=self._encoder_parallel_config,
+            enable_t5=config.enable_t5_text_encoder,
+            joint_attention_dim=self._joint_attention_dim,
+            use_torch_clip=config.use_torch_clip_text_encoder,
+            use_torch_t5=config.use_torch_t5_text_encoder,
+        )
+        ttnn.synchronize_device(self.encoder_device)
+
+        logger.info("creating VAE decoder...")
+        self._vae = VAEDecoderAdapter(
+            checkpoint_name=checkpoint_name,
+            parallel_config=self._vae_parallel_config,
+            ccl_manager=self._ccl_managers[self.vae_submesh_idx],
+            use_torch=False,
+        )
+
+        # D1: reference-image VAE *encoder*. Host-side torch for the first port
+        # (one encode per request is negligible vs the denoising loop). A future
+        # optimization can move this on-device (see stable_diffusion_xl_base tt_encoder).
+        logger.info("creating host VAE encoder (reference image)...")
+        self._vae_encoder = AutoencoderKL.from_pretrained(
+            checkpoint_name, subfolder="vae", torch_dtype=torch.bfloat16
+        ).eval()
+        self._vae_shift = self._vae_encoder.config.shift_factor
+        self._vae_scale = self._vae_encoder.config.scaling_factor
+
+        logger.info("Pipeline allocation run...")
+        # Warmup with a blank reference image to trigger compile/trace allocation.
+        from PIL import Image as _Image
+
+        self(
+            image=_Image.new("RGB", (self._width, self._height)),
+            prompts=[""],
+            num_inference_steps=2,
+            cfg_scale=2 if config.cfg_enabled else 1,
+            traced=False,
+        )
+
+    # ------------------------------------------------------------------ #
+    def __call__(
+        self,
+        *,
+        image: Image.Image | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        num_images_per_prompt: int = 1,
+        cfg_scale: float = 1,
+        guidance_scale: float = 3.5,  # Kontext default
+        prompts: Sequence[str],
+        prompts_2: Sequence[str] | None = None,
+        negative_prompts: Sequence[str] | None = None,
+        negative_prompts_2: Sequence[str] | None = None,
+        num_inference_steps: int,
+        seed: int = 0,
+        traced: bool = False,
+        vae_traced: bool | None = False,
+        encoder_traced: bool | None = None,
+        clip_skip: int = 0,
+        on_event: PipelineEventCallback | None = None,
+    ) -> list[Image.Image]:
+        on_event = on_event if on_event is not None else null_callback
+        prompts_2 = prompts_2 if prompts_2 is not None else prompts
+        negative_prompts = negative_prompts if negative_prompts is not None else [""] * len(prompts)
+        negative_prompts_2 = negative_prompts_2 if negative_prompts_2 is not None else negative_prompts
+
+        vae_traced = vae_traced if vae_traced is not None else traced
+        encoder_traced = encoder_traced if encoder_traced is not None else traced
+        prompt_count = len(prompts)
+        # Per-request resolution: default to the configured size, then snap to the
+        # nearest Kontext preferred bucket. Untraced runs recompile kernels for a
+        # new shape on first use, so any preferred resolution is usable.
+        width = width if width is not None else self._width
+        height = height if height is not None else self._height
+        width, height = _snap_to_preferred_resolution(width, height)
+        # image is optional: with a reference image this is instruction editing
+        # (concat noise+image, D1-D4); without one it degrades to plain FLUX.1-dev
+        # text-to-image (noise-only sequence, no image concat/ids/slice offset).
+        has_image = image is not None
+
+        sp_axis = self._parallel_config.sequence_parallel.mesh_axis
+        sp_factor = self._parallel_config.sequence_parallel.factor
+
+        assert num_images_per_prompt == 1, "generating multiple images is not supported"
+        assert prompt_count == 1, "generating multiple images is not supported"
+        if cfg_scale > 1 and not self._cfg_enabled:
+            raise ValueError("cfg_scale > 1 requires CFG to be enabled")
+
+        on_event(SectionStart("total"))
+        assert height % (_VAE_SCALE_FACTOR * self._patch_size) == 0
+        assert width % (_VAE_SCALE_FACTOR * self._patch_size) == 0
+
+        latents_height = height // _VAE_SCALE_FACTOR
+        latents_width = width // _VAE_SCALE_FACTOR
+        latents_sequence_length = latents_height * latents_width  # noise token count (n)
+
+        # ---- encode prompts (unchanged) ----
+        logger.info("encoding prompts...")
+        on_event(SectionStart("encoder"))
+        torch_context, torch_pooled = self._text_encoder.encode_cfg(
+            (prompts, prompts_2),
+            (negative_prompts, negative_prompts_2),
+            num_images_per_prompt=num_images_per_prompt,
+            cfg_enabled=self._cfg_enabled,
+            clip_skip=clip_skip,
+            traced=encoder_traced,
+            on_event=on_event,
+        )
+        _, prompt_sequence_length, _ = torch_context.shape
+        on_event(SectionEnd("encoder"))
+
+        # ---- D1: VAE-encode the reference image on host, pack (edit mode only) ----
+        if has_image:
+            logger.info("encoding reference image (host VAE)...")
+            image_latents_torch, img_h, img_w = self._encode_reference_image(image, height, width)
+            image_sequence_length = img_h * img_w
+        else:
+            logger.info("no reference image -> text-to-image generation")
+            image_latents_torch, img_h, img_w = None, 0, 0
+            image_sequence_length = 0
+
+        # ---- timesteps (unchanged; scheduler shift uses noise seq len) ----
+        self._scheduler.set_timesteps(
+            sigmas=np.linspace(1.0, 1 / num_inference_steps, num_inference_steps),
+            mu=_calculate_shift(latents_sequence_length, self._scheduler),
+        )
+        sigmas = self._scheduler.sigmas.tolist()
+        for solver in self._solvers:
+            solver.set_schedule(sigmas)
+        timesteps = self._scheduler.timesteps
+
+        torch_guidance = (
+            torch.full([prompt_count * num_images_per_prompt], fill_value=guidance_scale)
+            if self._with_guidance_embeds
+            else None
+        )
+
+        # ---- D2: ids. text=0, noise ch0=0, image ch0=1 (row/col overlap) ----
+        logger.info("preparing latents & rope ids...")
+        text_ids = torch.zeros([prompt_sequence_length, 3])
+        latent_ids = _latent_image_ids(height=latents_height, width=latents_width)  # ch0 = 0
+        if has_image:
+            image_ids = _latent_image_ids(height=img_h, width=img_w)
+            image_ids[..., 0] = 1  # the single Kontext-specific line
+            ids = torch.cat((text_ids, latent_ids, image_ids), dim=0)
+        else:
+            ids = torch.cat((text_ids, latent_ids), dim=0)
+        torch_rope_cos, torch_rope_sin = self._pos_embed.forward(ids)
+
+        p = prompt_sequence_length
+        n = latents_sequence_length
+        prompt_cos, prompt_sin = torch_rope_cos[:p], torch_rope_sin[:p]
+        noise_cos, noise_sin = torch_rope_cos[p : p + n], torch_rope_sin[p : p + n]
+        image_cos, image_sin = torch_rope_cos[p + n :], torch_rope_sin[p + n :]  # empty when no image
+
+        # ---- distribute to devices ----
+        context = distribute_cfg(torch_context, devices=self._submesh_devices)
+        pooled = distribute_cfg(torch_pooled, devices=self._submesh_devices)
+        latents = self._random_latents(
+            batch_size=prompt_count * num_images_per_prompt, seed=seed, width=width, height=height
+        )  # noise (updated)
+
+        # image latents fractured on the sp axis exactly like noise, kept constant across steps.
+        if has_image:
+            image_latents = from_torch_to_devices(
+                image_latents_torch, devices=self._submesh_devices, mesh_axes=[None, sp_axis, None]
+            )
+        else:
+            image_latents = [None] * len(self._submesh_devices)
+
+        guidance = (
+            from_torch_to_devices(torch_guidance.unsqueeze(-1), devices=self._submesh_devices)
+            if torch_guidance is not None
+            else [None] * len(self._submesh_devices)
+        )
+
+        # D3: combined spatial RoPE = per-shard [noise | image] (§4 SP-safe).
+        # Text-to-image (no reference) uses the noise-only RoPE with no image concat.
+        noise_cos_dev = from_torch_to_devices(noise_cos, devices=self._submesh_devices, mesh_axes=[sp_axis, None])
+        noise_sin_dev = from_torch_to_devices(noise_sin, devices=self._submesh_devices, mesh_axes=[sp_axis, None])
+        if has_image:
+            image_cos_dev = from_torch_to_devices(image_cos, devices=self._submesh_devices, mesh_axes=[sp_axis, None])
+            image_sin_dev = from_torch_to_devices(image_sin, devices=self._submesh_devices, mesh_axes=[sp_axis, None])
+            spatial_cos = [
+                ttnn.concat([noise_cos_dev[i], image_cos_dev[i]], dim=0) for i in range(len(self._submesh_devices))
+            ]
+            spatial_sin = [
+                ttnn.concat([noise_sin_dev[i], image_sin_dev[i]], dim=0) for i in range(len(self._submesh_devices))
+            ]
+        else:
+            spatial_cos = noise_cos_dev
+            spatial_sin = noise_sin_dev
+
+        prompt_rope_cos = from_torch_to_devices(prompt_cos, devices=self._submesh_devices)
+        prompt_rope_sin = from_torch_to_devices(prompt_sin, devices=self._submesh_devices)
+
+        combined_sequence_length = n + image_sequence_length
+        noise_local_len = n // sp_factor  # tokens to keep per shard after forward (D4)
+
+        # ---- denoising ----
+        logger.info("denoising...")
+        on_event(SectionStart("denoising"))
+        for i, t in enumerate(tqdm.tqdm(timesteps)):
+            on_event(SectionStart(f"denoising_step_{i}"))
+            velocity_preds = []
+            for idx, tracer in enumerate(self._tracers):
+                timestep = ttnn.full(
+                    [1, 1],
+                    fill_value=t,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.float32,
+                    device=self._submesh_devices[idx],
+                )
+                inputs = tracer.inputs
+                velocity_preds.append(
+                    tracer(
+                        cfg_enabled=self._cfg_enabled,
+                        submesh_idx=idx,
+                        latents=latents[idx],  # noise only; updated each step
+                        image_latents=image_latents[idx] if i == 0 else inputs["image_latents"],
+                        prompt=context[idx] if i == 0 else inputs["prompt"],
+                        pooled=pooled[idx] if i == 0 else inputs["pooled"],
+                        timestep=timestep,
+                        guidance=guidance[idx] if i == 0 and guidance else inputs["guidance"],
+                        spatial_rope=(spatial_cos[idx], spatial_sin[idx]) if i == 0 else inputs["spatial_rope"],
+                        prompt_rope=(prompt_rope_cos[idx], prompt_rope_sin[idx]) if i == 0 else inputs["prompt_rope"],
+                        combined_sequence_length=combined_sequence_length,
+                        prompt_sequence_length=prompt_sequence_length,
+                        noise_local_len=noise_local_len,
+                        traced=traced,
+                        tracer_blocking_execution=False,
+                    )
+                )
+                latents[idx] = tracer.inputs["latents"]
+
+            if self._cfg_enabled:
+                velocity_preds = self._cfg_combiner.combine(velocity_preds, cfg_scale)
+
+            latents = [
+                solver.step(step=i, latent=latents[idx], velocity_pred=velocity_preds[idx])
+                for idx, solver in enumerate(self._solvers)
+            ]
+            self.synchronize_devices()
+            on_event(SectionEnd(f"denoising_step_{i}"))
+        on_event(SectionEnd("denoising"))
+
+        # ---- decode (unchanged) ----
+        logger.info("decoding image...")
+        on_event(SectionStart("vae"))
+        output = self._decode_latents(latents[self.vae_submesh_idx], traced=vae_traced, width=width, height=height)
+        on_event(SectionEnd("vae"))
+        on_event(SectionEnd("total"))
+        return output
+
+    # ------------------------------------------------------------------ #
+    def _encode_reference_image(self, image: Image.Image, height: int, width: int) -> tuple[torch.Tensor, int, int]:
+        """D1: preprocess -> VAE encode (mode) -> normalize -> pack. Returns (packed, img_h, img_w)."""
+        ref = self._image_processor.preprocess(image, height=height, width=width)  # [-1,1], BCHW float
+        with torch.no_grad():
+            z = self._vae_encoder.encode(ref.to(torch.bfloat16)).latent_dist.mode()
+        z = (z - self._vae_shift) * self._vae_scale
+        b, c, h2, w2 = z.shape
+        img_h, img_w = h2 // 2, w2 // 2
+        packed = _pack_latents(z, b, self._num_channels_latents, img_h, img_w)  # [B, img_h*img_w, C*4]
+        return packed, img_h, img_w
+
+    def synchronize_devices(self) -> None:
+        for submesh_device in self._submesh_devices:
+            ttnn.synchronize_device(submesh_device)
+
+    def _random_latents(
+        self, *, batch_size: int, seed: int, width: int | None = None, height: int | None = None
+    ) -> list[ttnn.Tensor]:
+        torch.manual_seed(seed)
+        latents_height = (height if height is not None else self._height) // _VAE_SCALE_FACTOR
+        latents_width = (width if width is not None else self._width) // _VAE_SCALE_FACTOR
+        shape = [batch_size, self._num_channels_latents, latents_height * 2, latents_width * 2]
+        latents = _pack_latents(
+            torch.randn(shape, dtype=torch.bfloat16),
+            batch_size,
+            self._num_channels_latents,
+            latents_height,
+            latents_width,
+        )
+        sp_axis = self._parallel_config.sequence_parallel.mesh_axis
+        return from_torch_to_devices(latents, devices=self._submesh_devices, mesh_axes=[None, sp_axis, None])
+
+    def _decode_latents(
+        self, tt_latents: ttnn.Tensor, *, traced: bool, width: int | None = None, height: int | None = None
+    ) -> list[Image.Image]:
+        ttnn.synchronize_device(self.vae_device)
+        sp_axis = self._parallel_config.sequence_parallel.mesh_axis
+        tt_latents = self._ccl_managers[self.vae_submesh_idx].all_gather_persistent_buffer(
+            tt_latents, dim=1, mesh_axis=sp_axis, use_hyperparams=True
+        )
+        torch_latents = ttnn.to_torch(ttnn.get_device_tensors(tt_latents)[0])
+        unpack_h = height if height is not None else self._height
+        unpack_w = width if width is not None else self._width
+        torch_latents = _unpack_latents(torch_latents, unpack_h, unpack_w, _VAE_SCALE_FACTOR)
+        torch_latents = torch_latents.permute(0, 2, 3, 1)  # BCHW -> NHWC
+        decoded_output = self._vae.decode(torch_latents, traced=traced)
+        image = self._image_processor.postprocess(decoded_output, output_type="pt")
+        assert isinstance(image, torch.Tensor)
+        return self._image_processor.numpy_to_pil(self._image_processor.pt_to_numpy(image))
+
+    def _traced_step(
+        self,
+        *,
+        cfg_enabled: bool,
+        submesh_idx: int,
+        latents: ttnn.Tensor,
+        image_latents: ttnn.Tensor,
+        spatial_rope: tuple[ttnn.Tensor, ttnn.Tensor],
+        combined_sequence_length: int,
+        noise_local_len: int,
+        **kwargs: Any,
+    ) -> ttnn.Tensor:
+        # D3: concat noise + reference-image tokens on device (noise first).
+        # Text-to-image has no image tokens, so the sequence is noise-only.
+        spatial = ttnn.concat([latents, image_latents], dim=1) if image_latents is not None else latents
+        if cfg_enabled and not self._parallel_config.cfg_parallel.factor > 1:
+            spatial = ttnn.concat([spatial, spatial])
+
+        velocity = self.transformers[submesh_idx].forward(
+            spatial=spatial,
+            spatial_rope=spatial_rope,
+            spatial_sequence_length=combined_sequence_length,
+            **kwargs,
+        )
+        # D4: keep only the noise tokens (per-shard first noise_local_len).
+        return velocity[:, :noise_local_len]

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1_kontext.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1_kontext.py
@@ -551,7 +551,7 @@ class Flux1KontextPipeline(PipelineAPIMixin):
         cfg_enabled: bool,
         submesh_idx: int,
         latents: ttnn.Tensor,
-        image_latents: ttnn.Tensor,
+        image_latents: ttnn.Tensor | None,
         spatial_rope: tuple[ttnn.Tensor, ttnn.Tensor],
         combined_sequence_length: int,
         noise_local_len: int,

--- a/models/tt_dit/tests/models/flux1/test_kontext_lora.py
+++ b/models/tt_dit/tests/models/flux1/test_kontext_lora.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate FLUX.1 LoRA fuse-in-load on the Kontext pipeline.
+
+Set LORA_PATH (a FLUX.1 LoRA .safetensors) and optionally LORA_SCALE. The LoRA
+is fused into the transformer weights at load time (Flux1Checkpoint), then a
+text-to-image generation is run so the style change is visible. Run with an
+empty LORA_PATH for the no-LoRA baseline (same prompt/seed) to A/B compare.
+"""
+
+import os
+
+import pytest
+from loguru import logger
+
+import ttnn
+
+from ....parallel.config import DiTParallelConfig, EncoderParallelConfig, VAEParallelConfig
+from ....pipelines.flux1.pipeline_flux1_kontext import Flux1KontextPipeline, Flux1KontextPipelineConfig
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": 32768,
+            "trace_region_size": 50000000,
+            "require_exact_physical_num_devices": True,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("mesh_device", "sp", "tp", "encoder_tp", "vae_tp", "topology", "num_links", "mesh_test_id"),
+    [pytest.param((1, 2), (1, 0), (2, 1), (2, 1), (2, 1), ttnn.Topology.Linear, 2, "1x2sp0tp1", id="1x2sp0tp1")],
+    indirect=["mesh_device"],
+)
+def test_flux1_kontext_lora(
+    *, mesh_device, sp, tp, encoder_tp, vae_tp, topology, num_links, mesh_test_id, model_location_generator
+) -> None:
+    lora_path = os.environ.get("LORA_PATH") or None
+    lora_scale = float(os.environ.get("LORA_SCALE", "1.0"))
+    tag = os.environ.get("LORA_TAG", "lora" if lora_path else "base")
+    logger.info(f"LoRA test: lora_path={lora_path!r} scale={lora_scale} tag={tag}")
+
+    pipeline = Flux1KontextPipeline(
+        device=mesh_device,
+        config=Flux1KontextPipelineConfig.default(
+            mesh_shape=mesh_device.shape,
+            dit_parallel_config=DiTParallelConfig.from_tuples(cfg=(1, 0), sp=sp, tp=tp),
+            encoder_parallel_config=EncoderParallelConfig.from_tuple(encoder_tp),
+            vae_parallel_config=VAEParallelConfig.from_tuple(vae_tp),
+            num_links=num_links,
+            topology=topology,
+            width=1024,
+            height=1024,
+            checkpoint_name=model_location_generator("black-forest-labs/FLUX.1-Kontext-dev"),
+            lora_path=lora_path,
+            lora_scale=lora_scale,
+        ),
+    )
+
+    prompt = os.environ.get("PROMPT", "portrait of a young woman with long hair, upper body, simple background")
+    imgs = pipeline(prompts=[prompt], num_inference_steps=24, guidance_scale=3.5, seed=0, traced=False)
+    assert len(imgs) == 1
+    out = f"kontext_lora_{tag}.png"
+    imgs[0].save(out)
+    logger.info(f"saved {out}  (LoRA fuse-in-load {'ON' if lora_path else 'OFF'})")
+    logger.info("KONTEXT_LORA_OK")

--- a/models/tt_dit/tests/models/flux1/test_kontext_lora.py
+++ b/models/tt_dit/tests/models/flux1/test_kontext_lora.py
@@ -1,12 +1,19 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Validate FLUX.1 LoRA fuse-in-load on the Kontext pipeline.
+"""Validate FLUX.1 LoRA on the Kontext pipeline (on-device, needs hardware).
 
-Set LORA_PATH (a FLUX.1 LoRA .safetensors) and optionally LORA_SCALE. The LoRA
-is fused into the transformer weights at load time (Flux1Checkpoint), then a
-text-to-image generation is run so the style change is visible. Run with an
-empty LORA_PATH for the no-LoRA baseline (same prompt/seed) to A/B compare.
+Set LORA_PATH (a FLUX.1 LoRA .safetensors) and optionally LORA_SCALE. The
+adapter is loaded through the shared tt-dit LoRA framework — the transformer is
+built with LoRA-aware Linears and the adapter is registered + bound in fuse
+mode, merging the delta into the on-device base weights (Flux1Checkpoint._load_and_bind_lora
+→ experimental/lora/flux_adapter_loader.load_flux_adapter_into). A text-to-image
+generation is then run so the style change is visible; run with an empty
+LORA_PATH for the no-LoRA baseline (same prompt/seed) to A/B compare.
+
+The device-free correctness of the fused-QKV A/B stacking + head-interleave is
+covered separately by
+models/tt_dit/experimental/tests/test_flux_adapter_loader.py.
 """
 
 import os

--- a/models/tt_dit/tests/models/flux1/test_kontext_lora.py
+++ b/models/tt_dit/tests/models/flux1/test_kontext_lora.py
@@ -40,10 +40,11 @@ from ....pipelines.flux1.pipeline_flux1_kontext import Flux1KontextPipeline, Flu
 def test_flux1_kontext_lora(
     *, mesh_device, sp, tp, encoder_tp, vae_tp, topology, num_links, mesh_test_id, model_location_generator
 ) -> None:
-    lora_path = os.environ.get("LORA_PATH") or None
+    lora_path = os.environ.get("LORA_PATH")
+    if not lora_path:
+        pytest.skip("Set LORA_PATH to a FLUX.1 LoRA .safetensors to exercise fuse-in-load path")
     lora_scale = float(os.environ.get("LORA_SCALE", "1.0"))
-    tag = os.environ.get("LORA_TAG", "lora" if lora_path else "base")
-    logger.info(f"LoRA test: lora_path={lora_path!r} scale={lora_scale} tag={tag}")
+    tag = os.environ.get("LORA_TAG", "lora")
 
     pipeline = Flux1KontextPipeline(
         device=mesh_device,

--- a/models/tt_dit/tests/models/flux1/test_kontext_modes.py
+++ b/models/tt_dit/tests/models/flux1/test_kontext_modes.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate the FLUX.1-Kontext-dev pipeline extensions in one device session:
+
+  A) edit @ 1024x1024        (regression — reference image + instruction)
+  B) generate @ 1024x1024    (image=None -> plain text-to-image)
+  C) edit @ 1104x944         (per-request resolution, a Kontext preferred bucket)
+
+The pipeline (12B) is created once and reused across the three calls, so weights
+load a single time. Each new (mode, resolution) shape triggers a first-call
+kernel recompile (untraced), which is expected.
+"""
+
+
+import pytest
+from loguru import logger
+from PIL import Image
+
+import ttnn
+
+from ....parallel.config import DiTParallelConfig, EncoderParallelConfig, VAEParallelConfig
+from ....pipelines.flux1.pipeline_flux1_kontext import Flux1KontextPipeline, Flux1KontextPipelineConfig
+
+
+def _gradient(width: int, height: int) -> Image.Image:
+    img = Image.new("RGB", (width, height))
+    px = img.load()
+    for x in range(width):
+        for y in range(height):
+            px[x, y] = (int(255 * x / width), int(255 * y / height), 128)
+    return img
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": 32768,
+            "trace_region_size": 50000000,
+            "require_exact_physical_num_devices": True,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("mesh_device", "sp", "tp", "encoder_tp", "vae_tp", "topology", "num_links", "mesh_test_id"),
+    [
+        pytest.param((1, 2), (1, 0), (2, 1), (2, 1), (2, 1), ttnn.Topology.Linear, 2, "1x2sp0tp1", id="1x2sp0tp1"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_flux1_kontext_modes(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    sp,
+    tp,
+    encoder_tp,
+    vae_tp,
+    topology,
+    num_links,
+    mesh_test_id,
+    model_location_generator,
+) -> None:
+    parallel_config = DiTParallelConfig.from_tuples(cfg=(1, 0), sp=sp, tp=tp)
+
+    pipeline = Flux1KontextPipeline(
+        device=mesh_device,
+        config=Flux1KontextPipelineConfig.default(
+            mesh_shape=mesh_device.shape,
+            dit_parallel_config=parallel_config,
+            encoder_parallel_config=EncoderParallelConfig.from_tuple(encoder_tp),
+            vae_parallel_config=VAEParallelConfig.from_tuple(vae_tp),
+            num_links=num_links,
+            topology=topology,
+            width=1024,
+            height=1024,
+            checkpoint_name=model_location_generator("black-forest-labs/FLUX.1-Kontext-dev"),
+        ),
+    )
+
+    def run(**kw):
+        imgs = pipeline(num_inference_steps=20, guidance_scale=3.5, seed=0, traced=False, **kw)
+        assert len(imgs) == 1
+        return imgs[0]
+
+    # A) edit @ 1024 (regression)
+    a = run(image=_gradient(1024, 1024), prompts=["Add a small red hat to the subject"])
+    a.save("kontext_mode_edit_1024.png")
+    assert a.size == (1024, 1024)
+    logger.info("A edit@1024 OK")
+
+    # B) text-to-image @ 1024 (no reference image)
+    b = run(image=None, prompts=["A photo of a red vintage car on a mountain road, golden hour"])
+    b.save("kontext_mode_generate_1024.png")
+    assert b.size == (1024, 1024)
+    logger.info("B generate@1024 OK")
+
+    # C) edit @ 1104x944 (per-request preferred resolution)
+    c = run(image=_gradient(1104, 944), width=1104, height=944, prompts=["Make it a watercolor painting"])
+    c.save("kontext_mode_edit_1104x944.png")
+    assert c.size == (1104, 944)
+    logger.info("C edit@1104x944 OK")
+
+    logger.info("ALL KONTEXT MODES PASSED")

--- a/models/tt_dit/tests/models/flux1/test_pipeline_flux1_kontext.py
+++ b/models/tt_dit/tests/models/flux1/test_pipeline_flux1_kontext.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end test for the FLUX.1-Kontext-dev editing pipeline.
+
+Mirrors ``test_pipeline_flux1.py`` but supplies a reference image and a
+single-line edit instruction. Start from the ``1x2sp0tp1`` / ``2x4sp0tp1``
+configs (sp reduces to a plain concat/slice; see pipeline_flux1_kontext §4).
+
+Provide a reference image via the ``KONTEXT_INPUT_IMAGE`` env var; otherwise a
+synthetic gradient image is generated so the test is self-contained.
+"""
+
+import os
+
+import pytest
+from loguru import logger
+from PIL import Image
+
+import ttnn
+from models.perf.benchmarking_utils import BenchmarkProfiler
+
+from ....parallel.config import DiTParallelConfig, EncoderParallelConfig, VAEParallelConfig
+from ....pipelines.events import profiler_event_callback
+from ....pipelines.flux1.pipeline_flux1_kontext import Flux1KontextPipeline, Flux1KontextPipelineConfig
+
+
+def _load_reference_image(width: int, height: int) -> Image.Image:
+    path = os.environ.get("KONTEXT_INPUT_IMAGE")
+    if path and os.path.isfile(path):
+        return Image.open(path).convert("RGB").resize((width, height))
+    # Synthetic fallback: horizontal RGB gradient.
+    img = Image.new("RGB", (width, height))
+    px = img.load()
+    for x in range(width):
+        for y in range(height):
+            px[x, y] = (int(255 * x / width), int(255 * y / height), 128)
+    return img
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": 32768,
+            "trace_region_size": 50000000,
+            "require_exact_physical_num_devices": True,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("width", "height", "num_inference_steps"),
+    [(1024, 1024, 28)],
+    ids=["kontext_dev"],
+)
+@pytest.mark.parametrize(
+    ("mesh_device", "sp", "tp", "encoder_tp", "vae_tp", "topology", "num_links", "mesh_test_id"),
+    [
+        # Start with sp=1 (tp only): concat/slice reduces to the simple path.
+        pytest.param((1, 2), (1, 0), (2, 1), (2, 1), (2, 1), ttnn.Topology.Linear, 2, "1x2sp0tp1", id="1x2sp0tp1"),
+        pytest.param((2, 4), (2, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1, "2x4sp0tp1", id="2x4sp0tp1"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize("traced", [False], ids=["untraced"])
+def test_flux1_kontext_pipeline(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    width: int,
+    height: int,
+    num_inference_steps: int,
+    sp: tuple[int, int],
+    tp: tuple[int, int],
+    encoder_tp: tuple[int, int],
+    vae_tp: tuple[int, int],
+    topology: ttnn.Topology,
+    num_links: int,
+    mesh_test_id: str,
+    traced: bool,
+    model_location_generator,
+    is_ci_env: bool,
+) -> None:
+    if is_ci_env and traced:
+        pytest.skip("Skipping traced test in CI environment.")
+
+    parallel_config = DiTParallelConfig.from_tuples(cfg=(1, 0), sp=sp, tp=tp)
+    encoder_parallel_config = EncoderParallelConfig.from_tuple(encoder_tp)
+    vae_parallel_config = VAEParallelConfig.from_tuple(vae_tp)
+
+    logger.info(f"Mesh device shape: {mesh_device.shape}")
+
+    pipeline = Flux1KontextPipeline(
+        device=mesh_device,
+        config=Flux1KontextPipelineConfig.default(
+            mesh_shape=mesh_device.shape,
+            dit_parallel_config=parallel_config,
+            encoder_parallel_config=encoder_parallel_config,
+            vae_parallel_config=vae_parallel_config,
+            num_links=num_links,
+            topology=topology,
+            width=width,
+            height=height,
+            checkpoint_name=model_location_generator("black-forest-labs/FLUX.1-Kontext-dev"),
+        ),
+    )
+
+    reference_image = _load_reference_image(width, height)
+    prompt = "Add a small red hat to the subject"
+
+    benchmark_profiler = BenchmarkProfiler()
+    with benchmark_profiler("run", iteration=0):
+        images = pipeline(
+            image=reference_image,
+            prompts=[prompt],
+            num_inference_steps=num_inference_steps,
+            guidance_scale=3.5,
+            seed=0,
+            traced=traced,
+            vae_traced=False,
+            encoder_traced=False,
+            on_event=profiler_event_callback(benchmark_profiler, 0),
+        )
+
+    assert len(images) == 1
+    out = f"flux_kontext_{width}_{height}_{mesh_test_id}.png"
+    images[0].save(out)
+    logger.info(f"Edited image saved as {out}")
+    logger.info(f"Total pipeline time: {benchmark_profiler.get_duration('total', 0):.2f}s")


### PR DESCRIPTION
## Summary
Port **FLUX.1-Kontext-dev** (instruction-based image editing DiT) onto `tt_dit`,
reusing the existing FLUX.1-dev transformer / VAE / text encoders (config-driven
via `Flux1Checkpoint`, no transformer changes needed).

## What's added
- `models/tt_dit/pipelines/flux1/pipeline_flux1_kontext.py`
  - **D1** reference-image VAE encode + pack, **D2** RoPE id offset for image
    tokens, **D3** per-step `cat([noise, image], dim=seq)` forward, **D4** slice
    output back to the noise tokens. `guidance_scale=3.5`.
  - `image` is optional: with a reference → editing; without → plain FLUX.1-dev
    text-to-image. Per-request `width`/`height` snap to Kontext preferred buckets.
- `models/tt_dit/models/transformers/transformer_flux1.py`: `Flux1Checkpoint`
  optionally fuses a FLUX.1 LoRA (`load_lora_adapter` + `fuse_lora`) into the
  transformer weights on host before device load (no on-device LoRA path).
- Tests: E2E pipeline, mode matrix (edit / generate / resolution), LoRA fuse.
- `models/tt_dit/models/Flux1Kontext.md`: design notes.

## Validation
End-to-end on Blackhole **P300 (1x2)**: edit + text-to-image both produce correct
images; real-weight logic PCC vs diffusers `FluxKontextPipeline` (D1 VAE
encode→pack PCC ≈ 1.0); FLUX.1 LoRA fuse visibly restyles output.

> Draft: branch is based on an older `main`; will rebase before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yito/flux1-kontext-dev)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yito/flux1-kontext-dev)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yito/flux1-kontext-dev)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yito/flux1-kontext-dev)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yito/flux1-kontext-dev)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yito/flux1-kontext-dev)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yito/flux1-kontext-dev)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yito/flux1-kontext-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yito/flux1-kontext-dev)