### PR TITLE
emule: translate raw persistent-L1 reinterpret_casts in JIT kernels

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -731,6 +731,26 @@ static void apply_x86_rewrites(std::string& src) {
         l1_named_arg_ptr_re,
         "reinterpret_cast<$1>((uintptr_t)__emule_local_l1_to_ptr(static_cast<uint32_t>(get_arg($2))))");
 
+    // Persistent / compile-time L1 addresses dereferenced directly:
+    // `reinterpret_cast<volatile tt_l1_ptr T*>(<bare identifier>)` where the operand
+    // is a ct-arg/constexpr L1 offset (e.g. dm1::metadata_persistent_addr,
+    // core::q_arrival_sem_addr, dm0::indices_addr — from a tensor buffer_address()).
+    // Silicon derefs that raw L1 offset directly; on the host the offset is an
+    // unmapped address → SIGSEGV (or, when it happens to land in a mapped page, a
+    // stale read → downstream CB deadlock). Route it through the __emule_local_l1_to_ptr
+    // chokepoint like the get_arg forms above.
+    //
+    // The operand is restricted to a bare (optionally ::-qualified) identifier ON
+    // PURPOSE: it must NOT match `&cb_config[...]` (a real host pointer — translating
+    // it would corrupt the address) or `get_write_ptr(cb)` (already an absolute host
+    // address). A bare identifier is either a ct-arg constant (an offset, needs
+    // translation) or a local holding a get_*_ptr result (absolute → __emule_l1_translate
+    // returns it unchanged, so the wrap is a no-op). Both are safe.
+    static const std::regex l1_ptr_cast_re(
+        R"(reinterpret_cast<([^>;]*tt_l1_ptr[^>;]*\*)>\s*\(\s*([A-Za-z_][A-Za-z0-9_:]*)\s*\))");
+    src = emule_line_preserving_replace(
+        src, l1_ptr_cast_re, "reinterpret_cast<$1>((uintptr_t)__emule_local_l1_to_ptr(static_cast<uint32_t>($2)))");
+
     // reinterpret_cast<uint32_t>(ptr): an L1 pointer collapsed to its 32-bit
     // device address (no-op on silicon, "cast loses information" on the host).
     // emule L1 addresses are the low 32 bits of host pointers, so truncate via
@@ -788,10 +808,19 @@ static void preprocess_tu_recursive(
     const std::filesystem::path out_dir_canon = std::filesystem::weakly_canonical(out_dir);
 
     static const std::regex include_re(R"RE(#[ \t]*include[ \t]*"([^"]+)")RE");
+    // Directive rewrites for includes patched into a mirror path (see the escaping
+    // branch below): applied to `src` after the loop, back-to-front so offsets stay valid.
+    struct IncDirectiveRewrite {
+        size_t pos;
+        size_t len;
+        std::string text;
+    };
+    std::vector<IncDirectiveRewrite> directive_rewrites;
     for (std::sregex_iterator it(src.begin(), src.end(), include_re), end; it != end; ++it) {
-        const std::string inc_name = (*it)[1].str();
+        const std::smatch& m = *it;
+        const std::string inc_name = m[1].str();
         std::error_code ec;
-        const std::filesystem::path candidate = src_dir / inc_name;
+        const std::filesystem::path candidate = src_dir / inc_name;  // absolute inc_name → itself
         if (!std::filesystem::exists(candidate, ec)) {
             // Resolved via a -I path (emule api/, system headers, repo-rooted kernel-common). Not ours
             // to patch — pointer-truncation idioms there are handled by -fms-extensions (see the JIT
@@ -799,19 +828,68 @@ static void preprocess_tu_recursive(
             continue;
         }
         const std::string canon = std::filesystem::weakly_canonical(candidate, ec).string();
-        if (canon.empty() || !done.insert(canon).second) {
-            continue;  // cycle / already patched
-        }
-        const std::filesystem::path out_inc = std::filesystem::weakly_canonical(
-            std::filesystem::path(out_dir) / inc_name);
-        // Refuse to write outside the temp dir (e.g. inc_name with leading "..").
-        const std::string out_inc_str = out_inc.string();
-        if (out_inc_str.compare(0, out_dir_canon.string().size(), out_dir_canon.string()) != 0) {
-            done.erase(canon);
+        if (canon.empty()) {
             continue;
         }
-        std::filesystem::create_directories(out_inc.parent_path(), ec);
-        preprocess_tu_recursive(candidate.string(), out_inc_str, out_dir, done);
+        const std::filesystem::path out_inc =
+            std::filesystem::weakly_canonical(std::filesystem::path(out_dir) / inc_name);
+        const std::string out_inc_str = out_inc.string();
+        const std::string& out_dir_str = out_dir_canon.string();
+        if (out_inc_str.compare(0, out_dir_str.size(), out_dir_str) == 0) {
+            // Maps cleanly UNDER out_dir (relative include): write the shadow copy and
+            // let `-I out_dir` make the compiler find it before the original. Directive
+            // stays as-is.
+            if (!done.insert(canon).second) {
+                continue;  // cycle / already patched
+            }
+            std::filesystem::create_directories(out_inc.parent_path(), ec);
+            preprocess_tu_recursive(candidate.string(), out_inc_str, out_dir, done);
+        } else {
+            // ESCAPES out_dir — an absolute include (blaze.kernel_codegen emits
+            // `#include "/abs/.../op.hpp"`) or a ".." path. The compiler resolves the
+            // absolute directive directly, bypassing `-I out_dir`, so a shadow copy
+            // can't redirect it. Mirror the real file under out_dir and REPOINT the
+            // #include directive at the patched mirror — otherwise blaze op headers
+            // keep their raw `reinterpret_cast<tt_l1_ptr T*>(<persistent L1 addr>)`
+            // derefs, which segfault on the host. The mirror's `#line` still names the
+            // real file, so DWARF / ASAN backtraces are unaffected.
+            if (canon[0] != '/') {
+                continue;  // only mirror real absolute paths
+            }
+            // Only mirror an escaping include that the L1 rewrite above will actually
+            // change — i.e. one carrying a bare-identifier `reinterpret_cast<tt_l1_ptr
+            // T*>(ident)` persistent-address deref (blaze op.hpp). Mirroring a shared
+            // header reached elsewhere via -I (e.g. kernel_utils.hpp, whose only
+            // tt_l1_ptr cast takes `&cb_config[..]` and is deliberately NOT rewritten)
+            // would create a second copy that `#pragma once` can't dedupe against the
+            // original → redefinition errors. Probe with the SAME operand constraint
+            // as l1_ptr_cast_re so the two stay in lockstep.
+            {
+                std::ifstream probe(canon);
+                std::stringstream pss;
+                pss << probe.rdbuf();
+                const std::string content = pss.str();
+                static const std::regex l1cast_probe(
+                    R"(reinterpret_cast<[^>;]*tt_l1_ptr[^>;]*\*>\s*\(\s*[A-Za-z_][A-Za-z0-9_:]*\s*\))");
+                if (!std::regex_search(content, l1cast_probe)) {
+                    continue;  // no translatable L1 cast — leave the directive; shared original used
+                }
+            }
+            const std::filesystem::path mirror = std::filesystem::path(out_dir) / "_patched_inc" / canon.substr(1);
+            const std::string mirror_str = mirror.string();
+            directive_rewrites.push_back(
+                {static_cast<size_t>(m.position(0)),
+                 static_cast<size_t>(m.length(0)),
+                 "#include \"" + mirror_str + "\""});
+            if (!done.insert(canon).second) {
+                continue;  // already patched via another includer; directive repointed above
+            }
+            std::filesystem::create_directories(mirror.parent_path(), ec);
+            preprocess_tu_recursive(canon, mirror_str, out_dir, done);
+        }
+    }
+    for (auto rit = directive_rewrites.rbegin(); rit != directive_rewrites.rend(); ++rit) {
+        src.replace(rit->pos, rit->len, rit->text);
     }
 
     std::ofstream out(out_path);

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -835,7 +835,12 @@ static void preprocess_tu_recursive(
             std::filesystem::weakly_canonical(std::filesystem::path(out_dir) / inc_name);
         const std::string out_inc_str = out_inc.string();
         const std::string& out_dir_str = out_dir_canon.string();
-        if (out_inc_str.compare(0, out_dir_str.size(), out_dir_str) == 0) {
+        // Path-boundary-aware containment: a bare string-prefix compare would treat
+        // /tmp/dir2/x as under /tmp/dir, so require the match to end on a separator.
+        const bool under_out_dir = out_inc_str.size() > out_dir_str.size() &&
+                                   out_inc_str.compare(0, out_dir_str.size(), out_dir_str) == 0 &&
+                                   out_inc_str[out_dir_str.size()] == '/';
+        if (under_out_dir) {
             // Maps cleanly UNDER out_dir (relative include): write the shadow copy and
             // let `-I out_dir` make the compiler find it before the original. Directive
             // stays as-is.
@@ -845,27 +850,32 @@ static void preprocess_tu_recursive(
             std::filesystem::create_directories(out_inc.parent_path(), ec);
             preprocess_tu_recursive(candidate.string(), out_inc_str, out_dir, done);
         } else {
-            // ESCAPES out_dir — an absolute include (blaze.kernel_codegen emits
+            // ESCAPES out_dir — an absolute include (kernel codegen can emit
             // `#include "/abs/.../op.hpp"`) or a ".." path. The compiler resolves the
             // absolute directive directly, bypassing `-I out_dir`, so a shadow copy
             // can't redirect it. Mirror the real file under out_dir and REPOINT the
-            // #include directive at the patched mirror — otherwise blaze op headers
-            // keep their raw `reinterpret_cast<tt_l1_ptr T*>(<persistent L1 addr>)`
-            // derefs, which segfault on the host. The mirror's `#line` still names the
-            // real file, so DWARF / ASAN backtraces are unaffected.
-            if (canon[0] != '/') {
+            // #include directive at the patched mirror — otherwise op headers keep
+            // their raw `reinterpret_cast<tt_l1_ptr T*>(<persistent L1 addr>)` derefs,
+            // which segfault on the host. The mirror's `#line` still names the real
+            // file, so DWARF / ASAN backtraces are unaffected.
+            if (!std::filesystem::path(canon).is_absolute()) {
                 continue;  // only mirror real absolute paths
             }
             // Only mirror an escaping include that the L1 rewrite above will actually
             // change — i.e. one carrying a bare-identifier `reinterpret_cast<tt_l1_ptr
-            // T*>(ident)` persistent-address deref (blaze op.hpp). Mirroring a shared
-            // header reached elsewhere via -I (e.g. kernel_utils.hpp, whose only
-            // tt_l1_ptr cast takes `&cb_config[..]` and is deliberately NOT rewritten)
-            // would create a second copy that `#pragma once` can't dedupe against the
-            // original → redefinition errors. Probe with the SAME operand constraint
-            // as l1_ptr_cast_re so the two stay in lockstep.
+            // T*>(ident)` persistent-address deref (an op header). Mirroring a shared
+            // header reached elsewhere via -I (whose only tt_l1_ptr cast takes `&buf[i]`
+            // and is deliberately NOT rewritten) would create a second copy that
+            // `#pragma once` can't dedupe against the original → redefinition errors.
+            // Probe with the SAME operand constraint as l1_ptr_cast_re so the two stay
+            // in lockstep. The file exists (checked above); if it cannot be read here,
+            // do NOT silently skip — that would leave a persistent-L1 deref unpatched
+            // and reintroduce the segfault — so fail loudly instead.
             {
                 std::ifstream probe(canon);
+                if (!probe) {
+                    throw std::runtime_error("preprocess_kernel_source_for_x86: cannot read " + canon);
+                }
                 std::stringstream pss;
                 pss << probe.rdbuf();
                 const std::string content = pss.str();


### PR DESCRIPTION
## Summary

Working branch for **emule JIT-runtime fixes** in `tt_metal/impl/emulation/`. This
first commit lands the persistent-L1 `reinterpret_cast` translation; further emule
runtime changes will stack on this same branch so the emulator pin bump is
coordinated in one place.

## Problem

Some emule JIT kernels dereference persistent L1 addresses directly —
`reinterpret_cast<volatile tt_l1_ptr T*>(<compile-time offset>)` for per-op
metadata, ready-semaphores, index tables, and sharded-buffer bases (the offsets
come from a tensor's `buffer_address()`, baked into the kernel as a compile-time
constant). On silicon that raw L1 offset is a valid address; under emule it is an
unmapped host address, so the deref **SIGSEGVs** (or, when the offset happens to
land in a mapped page, reads stale data → a downstream circular-buffer deadlock).

The existing x86 source-rewriter only routes the `get_arg_val` / `get_arg`
runtime-arg cast forms through `__emule_local_l1_to_ptr`; the constexpr-operand
form was unhandled. And kernel codegen can emit the op header via an **absolute**
`#include`, which the recursive patcher skipped (a patched copy under `out_dir`
would escape it), so that header's body was never rewritten.

## Change (`emulated_program_runner.cpp`)

1. **`apply_x86_rewrites`** — add an L1-pointer-cast rule for
   `reinterpret_cast<...tt_l1_ptr...*>(<bare ::-qualified identifier>)`, wrapping the
   operand in `__emule_local_l1_to_ptr`. The bare-identifier restriction is
   deliberate: it must not match `&buf[i]` (a real host pointer) or `get_write_ptr(cb)`
   (already absolute). A bare identifier is either a compile-time offset (needs
   translation) or a local holding a `get_*_ptr` result (absolute →
   `__emule_l1_translate` returns it unchanged, so the wrap is a no-op). Both safe.

2. **`preprocess_tu_recursive`** — mirror an ESCAPING (absolute / `..`) `#include`
   under `out_dir` and repoint the directive at the patched mirror, so
   absolute-included op headers get patched. Gated on a probe for the same
   bare-identifier cast so shared headers (whose only `tt_l1_ptr` casts take
   `&buf[i]`) are NOT mirrored — a second copy would defeat their `#pragma once`
   against the `-I`-reached original and cause redefinition errors.

## Verification

Slow-dispatch emule (single-chip, P150): op kernels that dereferenced persistent
L1 addresses go from native segfault to compiling and running — two previously
crashing ops now fully pass, others advance to runtime; **no regression** in the
previously-green set. A standalone `clang -fsyntax-only` check force-instantiating
all the new cast shapes passes with zero warnings.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-runtime-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-runtime-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:xchin/emule-runtime-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-runtime-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-runtime-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-runtime-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-runtime-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-runtime-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-runtime-support)