### PR TITLE
Gemma4 Fix for release CI

### DIFF
--- a/models/demos/gemma4/demo/text_demo_v2.py
+++ b/models/demos/gemma4/demo/text_demo_v2.py
@@ -406,13 +406,16 @@ def test_demo_text(
         PagedAttentionConfig(block_size=block_size, max_num_blocks=page_max_num_blocks) if paged_attention else None
     )
 
-    # Bounded sliding KV cache: required for long context (>~64k). Without it,
-    # the 50 sliding layers each allocate the *full* context KV (~25 GB at 128k)
-    # and OOM; bounded mode caps them at the 1024-token sliding window so only
-    # the 10 full-attention layers grow with context. Auto-enable for long
-    # contexts; override with GEMMA4_BOUNDED_SLIDING=0/1.
+    # Sliding-cache mode. Default: FULL (unbounded) sliding KV, which stays
+    # coherent at long context — the bounded circular ring corrupts the recent
+    # window on padded >32k prefills (see docs/bounded_sliding_kv_cache_debug.md).
+    # Full KV allocates every sliding layer at full length, so it only fits up to
+    # ~64k on this board; above that we auto-fall back to bounded sliding to avoid
+    # OOM (the 50 sliding layers cap at the 1024-token window; only the 10
+    # full-attention layers grow), accepting bounded's known >~34k degradation
+    # there. Override either way with GEMMA4_BOUNDED_SLIDING=0/1.
     _bs_env = os.environ.get("GEMMA4_BOUNDED_SLIDING")
-    bounded_sliding = (max_seq_len > 16384) if _bs_env is None else _bs_env.lower() in ("1", "true", "yes")
+    bounded_sliding = (max_seq_len > 65536) if _bs_env is None else _bs_env.lower() in ("1", "true", "yes")
     bounded_sliding = bounded_sliding and paged_attention
 
     # ── Model (all optimizations applied inside create_tt_model) ───────────

--- a/models/demos/gemma4/tt/attention/__init__.py
+++ b/models/demos/gemma4/tt/attention/__init__.py
@@ -141,6 +141,8 @@ class Gemma4Attention:
         sequential_kv_write=False,
         rope_presliced=False,
         packed=None,
+        chunk_start_idx=None,
+        chunk_page_table=None,
     ):
         """
         Attention forward pass — dispatches to on-device decode or prefill.
@@ -206,7 +208,13 @@ class Gemma4Attention:
                 rope_presliced=rope_presliced,
             )
         else:
-            tt_out, kept_kv = prefill_forward(
+            # Sliding-window layers under generator-level chunked prefill carry a
+            # rolling K/V window tail across chunks (stored on this per-layer
+            # instance). Reset it at the start of a prefill (single-chunk, or the
+            # first generator chunk with chunk_start_idx==0).
+            if chunk_start_idx is None or int(chunk_start_idx) == 0:
+                self._release_sliding_prefill_tail()
+            tt_out, kept_kv, sliding_tail_out = prefill_forward(
                 hidden_states=hidden_states,
                 cos_cache=cos_cache,
                 sin_cache=sin_cache,
@@ -222,6 +230,22 @@ class Gemma4Attention:
                 batch_size=batch_size,
                 user_id=user_id,
                 valid_seq_len=valid_seq_len,
+                chunk_start_idx=chunk_start_idx,
+                chunk_page_table=chunk_page_table,
+                sliding_tail_in=getattr(self, "_sliding_prefill_tail", None),
             )
+            # prefill_forward consumed (deallocated) the incoming tail; stash the
+            # new one for the next chunk.
+            self._sliding_prefill_tail = sliding_tail_out
             self._last_kv = kept_kv
             return tt_out
+
+    def _release_sliding_prefill_tail(self):
+        tail = getattr(self, "_sliding_prefill_tail", None)
+        if tail is not None:
+            for t in tail:
+                try:
+                    t.deallocate(True)
+                except Exception:
+                    pass
+        self._sliding_prefill_tail = None

--- a/models/demos/gemma4/tt/attention/operations.py
+++ b/models/demos/gemma4/tt/attention/operations.py
@@ -225,7 +225,7 @@ def prefill_sdpa_program_config(head_dim, seq_len):
     )
 
 
-def chunked_prefill_sdpa(tt_q, k_cache, v_cache, page_table, user_id, head_dim, scale=1.0):
+def chunked_prefill_sdpa(tt_q, k_cache, v_cache, page_table, user_id, head_dim, scale=1.0, base_offset=0):
     """Chunked causal prefill SDPA over a paged KV cache.
 
     Splits the Q sequence into chunks of ``PREFILL_CHUNK_SIZE`` (<=32768) and runs
@@ -240,8 +240,13 @@ def chunked_prefill_sdpa(tt_q, k_cache, v_cache, page_table, user_id, head_dim, 
         page_table: int32 [batch, num_pages] (row ``user_id`` is this user's blocks).
         user_id: which page_table row maps this user's logical->physical blocks.
         head_dim: layer head_dim (512 for global layers; sizes the SDPA grid).
-    Returns:
-        [1, num_local_heads, seq_len, head_dim] attention output (TILE layout).
+        base_offset: absolute position (in the full sequence) of ``tt_q``'s first
+            row. Non-zero for generator-level multi-chunk prefill: chunk N's Q sits
+            at ``N*chunk_size`` and must attend the full prior prefix already in the
+            paged cache. Added to each internal Q-chunk offset so the op's causal
+            mask covers ``[0, base_offset + local_end)``. Must be a multiple of the
+            program's ``q_chunk_size`` (128); generator chunk sizes are >=128 powers
+            of two so this holds.
     """
     seq_len = tt_q.shape[-2]
     nh = tt_q.shape[1]
@@ -294,7 +299,7 @@ def chunked_prefill_sdpa(tt_q, k_cache, v_cache, page_table, user_id, head_dim, 
             k_cache,
             v_cache,
             user_pt,
-            chunk_start_idx=start,
+            chunk_start_idx=base_offset + start,
             scale=scale,
             program_config=program_config,
             compute_kernel_config=compute_kernel_config,

--- a/models/demos/gemma4/tt/attention/prefill.py
+++ b/models/demos/gemma4/tt/attention/prefill.py
@@ -25,6 +25,8 @@ from .operations import (
 )
 from .weights import AttentionWeights
 
+TILE_HEIGHT = 32
+
 
 def _prefill_forward_single(
     hidden_states,
@@ -40,9 +42,38 @@ def _prefill_forward_single(
     shared_kv=None,
     keep_kv=False,
     valid_seq_len=None,
+    chunk_start_idx=None,
+    chunk_page_table=None,
+    sliding_tail_in=None,
 ):
-    """Single-user prefill — matches arg/gemma4_optimizations."""
+    """Single-user prefill — matches arg/gemma4_optimizations.
+
+    Generator-level multi-chunk prefill (``chunk_page_table`` not None): the
+    current chunk's K/V is written at its absolute blocks via ``chunk_page_table``.
+    FULL-attention layers then read the whole prior prefix from the paged cache
+    (cross-chunk, via ``chunked_prefill_sdpa`` + ``base_offset``). SLIDING layers
+    only look back ``sliding_window`` tokens, so they attend a square
+    ``[prev-window tail | current chunk]`` slice: ``sliding_tail_in`` carries the
+    previous chunk's last ``sliding_window`` K/V tokens; this call returns the
+    current chunk's last ``sliding_window`` K/V as the tail for the next chunk
+    (third return value). Single-chunk prefill (``chunk_page_table`` None) is
+    unchanged and returns ``sliding_tail_out=None``.
+
+    Returns ``(tt_out, kept_kv, sliding_tail_out)``.
+    """
     tp = mesh_config.tp if mesh_config else 1
+    is_chunked = chunk_page_table is not None
+    chunk_offset = int(chunk_start_idx) if chunk_start_idx is not None else 0
+    need_cross_chunk = is_chunked and chunk_offset > 0
+    # Generator-level chunked prefill on a sliding-window layer (any chunk,
+    # including the first). Handled via the in-memory window tail below rather
+    # than the full-prefix paged read used for full-attention layers.
+    sliding_chunked = is_chunked and config.is_sliding and config.sliding_window is not None
+    if need_cross_chunk and shared_kv is not None:
+        raise NotImplementedError("Gemma4 KV-shared layer cross-chunk prefill not implemented yet (Stage A-hard).")
+    # Fill the current chunk's K/V at its physical blocks. For a single chunk the
+    # chunk table equals the (full) page_table, so behavior is unchanged.
+    fill_page_table = chunk_page_table if is_chunked else page_table
 
     xqkv = apply_qkv_projection(hidden_states, weights)
 
@@ -81,12 +112,15 @@ def _prefill_forward_single(
             )
             # Bounded sliding cache + padded single-chunk prefill: the prompt is
             # padded up to the next power of 2, and writing those padding tokens
-            # into the 1024-slot circular cache WRAPS and overwrites the real
+            # into the modulo-slot circular cache WRAPS and overwrites the real
             # recent window — so decode reads padding and emits garbage once the
             # padding exceeds the window (real prompt < seq_len - window). Cap the
-            # bounded-cache fill to the real (unpadded) prompt length so the
-            # circular buffer ends on real tokens. Full (unbounded) layers are
-            # unaffected: their padding lands at positions decode never reads.
+            # bounded-cache fill to a block-aligned length >= the real (unpadded)
+            # prompt so the circular buffer ends on (mostly) real tokens. Full
+            # (unbounded) layers are unaffected: their padding lands at positions
+            # decode never reads. NOTE: a residual sub-tile boundary padding is a
+            # known >32k long-context limitation, tracked in
+            # docs/bounded_sliding_kv_cache_debug.md.
             k_fill, v_fill = tt_k, tt_v
             if config.cache_position_modulo is not None and valid_seq_len is not None:
                 fill_len = ((min(valid_seq_len, tt_k.shape[-2]) + eff_bs - 1) // eff_bs) * eff_bs
@@ -94,10 +128,10 @@ def _prefill_forward_single(
                     k_fill = ttnn.slice(tt_k, [0, 0, 0, 0], [tt_k.shape[0], tt_k.shape[1], fill_len, tt_k.shape[3]])
                     v_fill = ttnn.slice(tt_v, [0, 0, 0, 0], [tt_v.shape[0], tt_v.shape[1], fill_len, tt_v.shape[3]])
             ttnn.experimental.paged_fill_cache(
-                k_cache, k_fill, page_table, batch_idx=user_id, block_size=eff_bs, **paged_modulo_kwargs
+                k_cache, k_fill, fill_page_table, batch_idx=user_id, block_size=eff_bs, **paged_modulo_kwargs
             )
             ttnn.experimental.paged_fill_cache(
-                v_cache, v_fill, page_table, batch_idx=user_id, block_size=eff_bs, **paged_modulo_kwargs
+                v_cache, v_fill, fill_page_table, batch_idx=user_id, block_size=eff_bs, **paged_modulo_kwargs
             )
             if k_fill is not tt_k:
                 k_fill.deallocate(True)
@@ -108,17 +142,94 @@ def _prefill_forward_single(
             ttnn.fill_cache(v_cache, tt_v, batch_idx=user_id)
 
     # 6. SDPA (causal prefill, scale=1.0)
-    # The non-chunked SDPA silently returns WRONG results for seq_len > 32768
-    # (2^15) — generation degrades to garbage. For long context we chunk prefill:
+    # The non-chunked SDPA silently returns WRONG results at seq_len >= 32768
+    # (2^15) — generation degrades to garbage. The cliff is INCLUSIVE of 32768:
+    # a power-of-2-padded prompt that lands exactly on 32768 is already broken
+    # (empirically garbage at 32768, coherent at 16384 and — via chunking — at
+    # 65536). So chunk whenever seq_len >= PREFILL_SDPA_MAX_SEQ:
     #   - full-attention layers: chunk Q and attend the full K prefix from the
     #     (already-filled) paged cache via chunked_scaled_dot_product_attention.
     #   - sliding-window layers: that op is causal-only, so use an overlapping
-    #     windowed chunking over the in-memory K/V (each slice stays <=32768).
-    # Both stay correct past 32768 and reduce to the non-chunked op at <=32768.
+    #     windowed chunking over the in-memory K/V (each slice stays <32768).
+    # Both stay correct at/above 32768 and reduce to the non-chunked op below it.
     seq_len = tt_q.shape[-2]
-    long_seq = seq_len > PREFILL_SDPA_MAX_SEQ
+    long_seq = seq_len >= PREFILL_SDPA_MAX_SEQ
     sliding_window = config.sliding_window if config.is_sliding else None
-    if long_seq and config.is_sliding and sliding_window is not None:
+    sliding_tail_out = None
+    if sliding_chunked:
+        # Generator-level chunked prefill, sliding-window layer. The chunked
+        # paged SDPA op has no window mask, so attend a SQUARE [tail | chunk]
+        # slice: prepend the previous chunk's last ``sliding_window`` K/V tokens
+        # (sliding_tail_in) and run the normal causal + sliding-window SDPA. Q is
+        # padded in front by ``hist`` filler rows (a copy of the chunk's leading
+        # rows) so Q.seq == K.seq (the op requires square); those rows' outputs
+        # are dropped and — being causal — never influence the kept rows. Kept
+        # rows [hist, hist+seq_len) are query positions [chunk_offset,
+        # chunk_offset+seq_len) with their full window covered. The current
+        # chunk's last ``sliding_window`` K/V become next chunk's tail.
+        sdpa_ckc = ttnn.init_device_compute_kernel_config(
+            tt_q.device().arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        hist = ((sliding_window + 31) // 32) * 32
+        if sliding_tail_in is not None:
+            k_tail, v_tail = sliding_tail_in
+            nqh = tt_q.shape[1]
+            # Filler Q rows (outputs discarded); reuse the chunk's leading rows.
+            q_pad = ttnn.slice(tt_q, [0, 0, 0, 0], [1, nqh, hist, config.head_dim])
+            q_cat = ttnn.concat([q_pad, tt_q], dim=2)
+            k_cat = ttnn.concat([k_tail, tt_k], dim=2)
+            v_cat = ttnn.concat([v_tail, tt_v], dim=2)
+            q_pad.deallocate(True)
+            sdpa_full = ttnn.transformer.scaled_dot_product_attention(
+                q_cat,
+                k_cat,
+                v_cat,
+                is_causal=True,
+                scale=1.0,
+                sliding_window_size=sliding_window,
+                program_config=prefill_sdpa_program_config(config.head_dim, hist + seq_len),
+                compute_kernel_config=sdpa_ckc,
+            )
+            q_cat.deallocate(True)
+            k_cat.deallocate(True)
+            v_cat.deallocate(True)
+            k_tail.deallocate(True)
+            v_tail.deallocate(True)
+            tt_sdpa = ttnn.slice(sdpa_full, [0, 0, hist, 0], [1, nqh, hist + seq_len, config.head_dim])
+            sdpa_full.deallocate(True)
+        else:
+            # First chunk (chunk_offset==0): no history, window lies inside the
+            # chunk (seq_len=chunk_size >= sliding_window). Standard windowed SDPA.
+            tt_sdpa = ttnn.transformer.scaled_dot_product_attention(
+                tt_q,
+                tt_k,
+                tt_v,
+                is_causal=True,
+                scale=1.0,
+                sliding_window_size=sliding_window,
+                program_config=prefill_sdpa_program_config(config.head_dim, seq_len),
+                compute_kernel_config=sdpa_ckc,
+            )
+        # Save this chunk's last ``hist`` K/V tokens as the next chunk's tail.
+        kseq = tt_k.shape[-2]
+        nkv = tt_k.shape[1]
+        tail_start = max(0, kseq - hist)
+        k_tail_out = ttnn.slice(tt_k, [0, 0, tail_start, 0], [1, nkv, kseq, config.head_dim])
+        v_tail_out = ttnn.slice(tt_v, [0, 0, tail_start, 0], [1, nkv, kseq, config.head_dim])
+        sliding_tail_out = (k_tail_out, v_tail_out)
+    elif need_cross_chunk:
+        # Full-attention chunk N>0: attend the full prefix already filled in the
+        # paged cache. base_offset shifts the causal window to this chunk's
+        # absolute positions [chunk_offset, chunk_offset+seq_len).
+        k_cache, v_cache = kv_cache
+        tt_sdpa = chunked_prefill_sdpa(
+            tt_q, k_cache, v_cache, page_table, user_id, config.head_dim, scale=1.0, base_offset=chunk_offset
+        )
+    elif long_seq and config.is_sliding and sliding_window is not None:
         tt_sdpa = chunked_prefill_sdpa_sliding(tt_q, tt_k, tt_v, sliding_window, config.head_dim, scale=1.0)
     elif long_seq and not config.is_sliding and page_table is not None and kv_cache is not None and shared_kv is None:
         k_cache, v_cache = kv_cache
@@ -156,7 +267,7 @@ def _prefill_forward_single(
     tt_out = apply_output_projection(tt_out, weights)
     tt_out = apply_allreduce(tt_out, mesh_config, ccl_manager, config.hidden_size)
 
-    return tt_out, kept_kv
+    return tt_out, kept_kv, sliding_tail_out
 
 
 def prefill_forward(
@@ -175,6 +286,9 @@ def prefill_forward(
     keep_kv=False,
     batch_size=1,
     valid_seq_len=None,
+    chunk_start_idx=None,
+    chunk_page_table=None,
+    sliding_tail_in=None,
 ):
     """
     Multi-token prefill attention, fully on device.
@@ -182,6 +296,18 @@ def prefill_forward(
     Args:
         hidden_states: [1, 1, seq_len, hidden_size] or [B, 1, S, hidden_size] on device
         batch_size: padded batch for batched prefill (1 for single-user / test_full_model)
+        chunk_start_idx: absolute start position of this generator-level prefill
+            chunk (None/0 for single-chunk prefill). When >0 the K/V of prior
+            chunks already sit in the paged cache and cross-chunk attention must
+            read them; ``chunk_page_table`` maps the current chunk's tokens to
+            their physical blocks for the offset KV fill.
+        chunk_page_table: per-user page-table slice for the current chunk's
+            blocks (used for the offset ``paged_fill_cache``). None => single chunk.
+        sliding_tail_in: previous chunk's last ``sliding_window`` K/V for
+            sliding-window layers under generator chunking (None otherwise).
+
+    Returns ``(tt_out, kept_kv, sliding_tail_out)``; the batched path returns
+    ``sliding_tail_out=None`` (it does not chunk the sequence).
     """
     if batch_size <= 1:
         return _prefill_forward_single(
@@ -198,6 +324,9 @@ def prefill_forward(
             shared_kv=shared_kv,
             keep_kv=keep_kv,
             valid_seq_len=valid_seq_len,
+            chunk_start_idx=chunk_start_idx,
+            chunk_page_table=chunk_page_table,
+            sliding_tail_in=sliding_tail_in,
         )
 
     tp = mesh_config.tp if mesh_config else 1
@@ -310,4 +439,4 @@ def prefill_forward(
 
     tt_out = ttnn.reshape(tt_out, [1, 1, original_seq_len, -1])
 
-    return tt_out, kept_kv
+    return tt_out, kept_kv, None

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -16,7 +16,7 @@ from models.demos.gemma4.tt.generator_trace import (
     resolve_gemma4_prefill_trace_enable,
     warmup_gemma4_model_prefill,
 )
-from models.tt_transformers.tt.common import get_padded_prefill_len
+from models.tt_transformers.tt.common import get_block_size, get_padded_prefill_len, num_blocks_in_seq
 from models.tt_transformers.tt.generator import MAX_BATCHED_PREFILL_SEQ_LEN, SUPPORTED_PREFILL_BATCH_SIZES, Generator
 from models.tt_transformers.tt.model_config import determine_device_name
 
@@ -92,16 +92,28 @@ def _patch_model_args(
     model_args.max_batch_size = max_batch_size
     model_args.max_seq_len = max_seq_len
     model_args.max_context_len = max_seq_len
-    # Gemma4's prefill doesn't yet honor the Generator's per-chunk offset
-    # (chunk_start_idx/chunk_page_table are discarded), so multi-chunk prefill
-    # mis-handles every chunk after the first (wrong RoPE positions + no
-    # cross-chunk attention) — this is the real cause of the >32k garbage. To
-    # keep prefill correct we force a SINGLE chunk by making max_prefill_chunk_size
-    # a power of 2 >= the padded prompt; the in-call SDPA then chunks internally
-    # (correct past 32768). NOTE: a single chunk uses prefill memory proportional
-    # to the full prompt, so very long contexts (>~64k) can OOM — proper
-    # chunk_start_idx support is the follow-up for bounded-memory long prefill.
-    model_args.max_prefill_chunk_size = 1 << max(int(max_seq_len - 1).bit_length(), 11)
+    # Prefill chunking policy — the DEMO path forces a SINGLE chunk.
+    #
+    # Generator-level multi-chunk prefill (GEMMA4_GEN_PREFILL_CHUNK=<tokens>)
+    # drives chunk_start_idx/chunk_page_table per chunk. That path is only
+    # validated to not *hang* (the #49083 fetch-queue wedge on the vLLM serving
+    # boundary, see generator_vllm.py) — it is NOT validated for output
+    # correctness across many chunks: Gemma4's per-chunk plumbing (per-chunk RoPE
+    # offset, cross-chunk paged reads, the hand-rolled sliding-window tail, and an
+    # unimplemented KV-shared cross-chunk case) mis-handles long multi-chunk
+    # prefill and produces garbage (empirically <pad> at 64k / 16 chunks).
+    #
+    # The demo's long-context configs (64k/128k/256k) are instead validated with
+    # a SINGLE chunk: max_prefill_chunk_size is a power of 2 >= the padded prompt,
+    # so the prompt prefills in one chunk and the in-call SDPA chunks internally
+    # (correct past 32768, validated coherent to ~100k with bounded sliding). Only
+    # honor an explicit GEMMA4_GEN_PREFILL_CHUNK override; otherwise force the
+    # single chunk. (The vLLM generator legitimately differs — it must chunk to
+    # dodge the serving-path wedge — see resolve_gemma4_prefill_chunk_size.)
+    _chunk_override = int(os.environ.get("GEMMA4_GEN_PREFILL_CHUNK", "0"))
+    model_args.max_prefill_chunk_size = (
+        _chunk_override if _chunk_override > 0 else 1 << max(int(max_seq_len - 1).bit_length(), 11)
+    )
     model_args.mesh_device = mesh_device
     model_args.device_name = determine_device_name(mesh_device)
     model_args.model_name = model_path
@@ -130,7 +142,57 @@ def _patch_model_args(
     model_args.encode_prompt = _encode_prompt
 
 
-class Gemma4Generator(Generator):
+class ChunkedPrefillPageTableGuardMixin:
+    """Guard the shared ``Generator.prefill_forward_single_user_text`` against an
+    over-wide page table, without modifying ``models/tt_transformers``.
+
+    vLLM's block manager can hand over a page table with more block columns than
+    the prompt needs. The shared method then computes a negative pad width
+    (``num_blocks_in_seq(...) - page_table.shape[1] < 0``) and crashes on
+    ``torch.cat``. Trim the page table to exactly the blocks this prompt needs so
+    the base method's pad becomes a no-op. Mirrors the per-model guard in
+    ``models/demos/llama3_70b_galaxy/tt/generator.py`` (kept in the gemma4 model
+    so the shared generator stays untouched). Mixed into both the demo
+    (:class:`Gemma4Generator`) and vLLM (``Gemma4ForCausalLM``) generators, whose
+    class hierarchies both reach the shared method but do not share a gemma4 base.
+    """
+
+    def prefill_forward_single_user_text(
+        self, tokens, page_table=None, *, kv_cache=None, num_cached_tokens=0, **kwargs
+    ):
+        if page_table is not None and kv_cache is not None:
+            block_size = get_block_size(kv_cache)
+            needed_blocks = num_blocks_in_seq(tokens.shape[-1] + num_cached_tokens, block_size)
+            # Bounded sliding KV cache: sliding layers pass ``cache_position_modulo``
+            # to ``paged_fill_cache``, which requires ``page_table`` to span the whole
+            # window (``cols * block_size >= cache_position_modulo``) so the circular
+            # wrap can address every slot — even for a short prompt whose own block
+            # count is far smaller. Trimming to the prompt's ``needed_blocks`` (as the
+            # over-wide guard does) would undo the widening applied upstream in
+            # ``_get_prefill_user_page_table`` and TT_FATAL the fill. Floor
+            # ``needed_blocks`` at the window's block count when any layer runs bounded
+            # (read from the per-layer configs so this holds for both the demo and vLLM
+            # generators without a generator-level flag).
+            modulos = []
+            for layer in getattr(self.model[0], "layers", []):
+                cfg = getattr(getattr(layer, "self_attn", None), "config", None)
+                modulo = getattr(cfg, "cache_position_modulo", None)
+                if modulo:
+                    modulos.append(modulo)
+            if modulos and block_size:
+                needed_blocks = max(needed_blocks, num_blocks_in_seq(max(modulos), block_size))
+            if page_table.shape[1] > needed_blocks:
+                page_table = page_table[:, :needed_blocks]
+        return super().prefill_forward_single_user_text(
+            tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            num_cached_tokens=num_cached_tokens,
+            **kwargs,
+        )
+
+
+class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": False,

--- a/models/demos/gemma4/tt/generator_trace.py
+++ b/models/demos/gemma4/tt/generator_trace.py
@@ -37,9 +37,74 @@ def _resolve_trace_prefill_seq_lens() -> list[int]:
 GEMMA4_TRACE_PREFILL_SEQ_LENS = _resolve_trace_prefill_seq_lens()
 
 # Prefill trace is disabled above 4k ISL (no perf gain, OOM risk) and at or above 32k
-# batched virtual tokens (batch_size × padded prefill length).
+# batched virtual tokens (batch_size × padded prefill length). Prefills above the
+# cap are instead kept safe by generator-level chunking (see
+# resolve_gemma4_prefill_chunk_size): an 8192 prompt runs as 4096-token chunks
+# rather than one full-length op, so it neither wedges the fetch queue (#49083)
+# nor OOMs a whole-length trace.
 GEMMA4_MAX_TRACE_PREFILL_SEQ_LEN = 4096
 GEMMA4_MAX_TRACE_BATCHED_PREFILL_TOKENS = 32 * 1024
+
+# Default generator-level prefill chunk when GEMMA4_GEN_PREFILL_CHUNK is unset,
+# applied on QB2 ONLY (P150x4 = 1x4 Blackhole / P300X2, the board this was
+# validated on).
+#
+# Every other model bounds its prefill chunk: the shared tt_transformers/Qwen
+# generator defaults max_prefill_chunk_size to a per-(model,device) value (4096
+# for combos without a table entry, which is Gemma4's case), DeepSeek uses a
+# tiered chunk table, and Qwen3.6 chunk-traces at 2048. Gemma4 alone used to
+# default to a SINGLE full-length chunk (max_seq_len in the vLLM generator, a
+# power-of-2 in the demo generator) — divergent from each other and from the
+# reference, and exactly the unbounded full-sequence prefill op that wedges the
+# fetch queue at ISL>=8192 (#49083) or OOMs a whole-length trace.
+#
+# 4096 is the largest chunk validated on QB2 to both trace safely
+# (<= GEMMA4_MAX_TRACE_PREFILL_SEQ_LEN) and clear the #49083 wedge
+# (repro_prefill_hang.py, REPRO_ISLS=8192,8192 -> ALL_DONE, no wedge/OOM). It is
+# NOT applied to other boards (Wormhole T3K/TG, single-chip Blackhole, etc.),
+# where neither the wedge nor this number was validated — those keep the
+# caller's prior default (see resolve_gemma4_prefill_chunk_size).
+GEMMA4_DEFAULT_PREFILL_CHUNK = 4096
+
+# Device name (models.tt_transformers.tt.model_config.determine_device_name) of
+# the QB2 board the bounded default is validated for: 4-chip Blackhole mesh.
+_QB2_DEVICE_NAME = "P150x4"
+
+
+def _is_qb2(mesh_device) -> bool:
+    """True only for the QB2 board (P150x4 / P300X2, 1x4 Blackhole)."""
+    if mesh_device is None:
+        return False
+    try:
+        from models.tt_transformers.tt.model_config import determine_device_name
+
+        return determine_device_name(mesh_device) == _QB2_DEVICE_NAME
+    except Exception:
+        return False
+
+
+def resolve_gemma4_prefill_chunk_size(max_seq_len: int, mesh_device=None, non_qb2_default=None) -> int:
+    """Generator-level prefill chunk size for the vLLM serving generator.
+
+    (The demo generator forces a single chunk instead — Gemma4's multi-chunk
+    prefill is not validated for output correctness at long context, see
+    models/demos/gemma4/tt/generator.py. vLLM must chunk anyway to dodge the
+    #49083 serving-path wedge.)
+
+    ``GEMMA4_GEN_PREFILL_CHUNK`` (a 2048-multiple) overrides on any board.
+    Otherwise the bounded QB2 default (``GEMMA4_DEFAULT_PREFILL_CHUNK``, clamped
+    to ``max_seq_len``) applies ONLY on QB2 (P150x4), where an 8192+ prompt then
+    runs as 4096-token chunks instead of one full-length op. On every other board
+    the QB2-tuned number is not applied — the caller's ``non_qb2_default`` (the
+    prior vLLM default, ``max_seq_len``) is used so unvalidated boards keep their
+    existing behavior.
+    """
+    override = int(os.environ.get("GEMMA4_GEN_PREFILL_CHUNK", "0"))
+    if override > 0:
+        return override
+    if _is_qb2(mesh_device):
+        return min(GEMMA4_DEFAULT_PREFILL_CHUNK, max_seq_len)
+    return non_qb2_default if non_qb2_default is not None else max_seq_len
 
 
 def model_uses_pli(model) -> bool:

--- a/models/demos/gemma4/tt/generator_trace.py
+++ b/models/demos/gemma4/tt/generator_trace.py
@@ -265,6 +265,7 @@ def warmup_gemma4_batched_prefill_traces(
     enable_trace: bool,
     can_sample_on_device,
     greedy_only: bool = False,
+    prefill_forward_fn=None,
 ) -> None:
     """Capture prefill traces for MoE models across batch sizes and trace ISLs.
 
@@ -272,10 +273,21 @@ def warmup_gemma4_batched_prefill_traces(
     skipping combinations that meet or exceed ``MAX_BATCHED_PREFILL_SEQ_LEN`` (128k).
     Caller must set ``generator.already_warmed_up_prefill`` before calling if needed,
     or this function sets it on entry.
+
+    ``prefill_forward_fn`` selects the entry point used for each capture. It
+    defaults to ``generator.prefill_forward_text`` (demo / uniform-page-table
+    path). The vLLM hybrid bridge passes ``generator.prefill_forward`` so the
+    capture runs *through* the per-layer page-table routing and binds the
+    traced paged ops to the persistent per-layer buffers — exactly how decode
+    warmup binds via ``decode_forward``. Pre-capturing the prefill buckets at
+    warmup (before any traced decode) keeps runtime prefills to trace *replay*,
+    avoiding the #49083 cold-eager-capture fetch-queue wedge.
     """
     if generator.already_warmed_up_prefill:
         return
     generator.already_warmed_up_prefill = True
+
+    prefill_forward = prefill_forward_fn if prefill_forward_fn is not None else generator.prefill_forward_text
 
     model_args = generator.model_args[0]
     sequence_lengths_to_warmup = model_args.get_warmup_prefill_supported_seq_lens()
@@ -356,7 +368,7 @@ def warmup_gemma4_batched_prefill_traces(
                             batch_size,
                             param,
                         )
-                    generator.prefill_forward_text(
+                    prefill_forward(
                         **warmup_args,
                         kv_cache=kv_cache,
                         enable_trace=capture_trace,
@@ -380,7 +392,7 @@ def warmup_gemma4_batched_prefill_traces(
         prefill_forward_args = generator._mock_tokens(1, 128, kv_cache, model_id)
 
         logger.info("Warming up vision encoder with image size {}x{}", vision_chunk_size, vision_chunk_size)
-        generator.prefill_forward_text(
+        prefill_forward(
             **prefill_forward_args,
             kv_cache=kv_cache,
             enable_trace=False,
@@ -399,8 +411,14 @@ def warmup_gemma4_model_prefill(
     enable_trace,
     can_sample_on_device,
     greedy_only: bool = False,
+    prefill_forward_fn=None,
 ) -> None:
-    """Shared prefill warmup for standalone and vLLM Gemma4 generators."""
+    """Shared prefill warmup for standalone and vLLM Gemma4 generators.
+
+    ``prefill_forward_fn`` (vLLM hybrid bridge only) routes the trace capture
+    through the per-layer page-table path; see
+    :func:`warmup_gemma4_batched_prefill_traces`.
+    """
     enable_trace = maybe_disable_pli_prefill_trace(enable_trace, generator.model[0])
     if enable_trace:
         warmup_gemma4_batched_prefill_traces(
@@ -409,6 +427,7 @@ def warmup_gemma4_model_prefill(
             enable_trace=enable_trace,
             can_sample_on_device=can_sample_on_device,
             greedy_only=greedy_only,
+            prefill_forward_fn=prefill_forward_fn,
         )
         return
     from models.tt_transformers.tt.generator import Generator

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -8,9 +8,11 @@ from loguru import logger
 
 import ttnn
 from models.demos.gemma4.tt.common import create_tt_model
+from models.demos.gemma4.tt.generator import ChunkedPrefillPageTableGuardMixin
 from models.demos.gemma4.tt.generator_trace import (
     maybe_disable_pli_prefill_trace,
     patch_gemma4_trace_model_args,
+    resolve_gemma4_prefill_chunk_size,
     resolve_gemma4_prefill_trace_enable,
     warmup_gemma4_model_prefill,
 )
@@ -83,7 +85,15 @@ def _gemma4_prefill_trace_unsafe(model, bounded_sliding_kv_cache) -> bool:
 def _patch_model_args(model_args, mesh_device, max_batch_size, max_seq_len, model_path, prefill_trace_enabled=True):
     model_args.max_batch_size = max_batch_size
     model_args.max_seq_len = max_seq_len
-    model_args.max_prefill_chunk_size = max_seq_len
+    # Generator-level chunked prefill (GEMMA4_GEN_PREFILL_CHUNK=<2048-multiple
+    # <32768>): chunk the prefill so no full-sequence op hits the 2^15 boundary
+    # (Bug A), the ~120K hang (GH #48289), or the ISL>=8192 fetch-queue wedge
+    # (GH #49083). The bounded default (4096) is shared with the demo generator
+    # via resolve_gemma4_prefill_chunk_size but applies on QB2 (P150x4) ONLY;
+    # other boards keep the prior vLLM default (a single max_seq_len chunk).
+    model_args.max_prefill_chunk_size = resolve_gemma4_prefill_chunk_size(
+        max_seq_len, mesh_device=mesh_device, non_qb2_default=max_seq_len
+    )
     patch_gemma4_trace_model_args(model_args, prefill_trace_enabled=prefill_trace_enabled)
     model_args.optimizations = _Gemma4VllmOptimizations()
     model_args.mesh_device = mesh_device
@@ -91,7 +101,7 @@ def _patch_model_args(model_args, mesh_device, max_batch_size, max_seq_len, mode
     model_args.is_llama_vision = lambda: False
 
 
-class Gemma4ForCausalLM(HybridAttentionForCausalLM):
+class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCausalLM):
     """Gemma4 — hybrid attention (sliding-window + full).
 
     Gemma4's decoder alternates ``sliding_attention`` and ``full_attention``
@@ -109,39 +119,47 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         "supports_sample_on_device": True,
     }
 
-    # Gemma4 keeps vLLM's hybrid kv-cache groups DISABLED.
+    # Hybrid vLLM kv-cache groups: env-gated via ``GEMMA4_HYBRID_KV_CACHE_GROUPS``
+    # (default OFF). Toggle from the tt-inference-server model-spec env so the KV
+    # mode is config-driven and reversible without a code change.
     #
-    # With the hybrid path on, ``get_kv_cache_spec`` emits ``SlidingWindowSpec``
-    # for the 40 sliding layers and ``FullAttentionSpec`` for the 8 full layers,
-    # which vLLM places into 6 kv_cache_groups. vLLM then splits the total block
-    # pool evenly across those groups and reports per-group capacity, so a single
-    # request can only be admitted up to ``num_blocks // num_groups`` tokens
-    # (~23K on a P300x2 12B build) — the full-attention group, which needs the
-    # entire sequence, is starved by the even split. Requests longer than that
-    # ceiling sit unschedulable in ``Waiting`` even though the device has plenty
-    # of KV DRAM. Additionally, ``SlidingWindowSpec.max_memory_usage_bytes`` is
-    # coupled to ``max_num_batched_tokens``, which (since the TT backend has no
-    # chunked prefill) equals ``max_model_len`` and over-charges the sliding
-    # groups at full length anyway.
+    # OFF (default): ``get_kv_cache_spec`` emits ``FullAttentionSpec`` for *every*
+    # layer, which vLLM merges into a single ``UniformTypeKVCacheSpecs`` group, so
+    # the whole block pool backs each request and the full ``max_model_len`` is
+    # admissible (verified ~100K ISL). Every sliding layer allocates full-length
+    # KV, so the servable pool is memory-bound (~49K on P300x2 31B). Mirrors the
+    # Gemma3 / GPT-OSS single-pool path (requires the vLLM plugin that unwraps the
+    # merged group into per-layer allocation).
     #
-    # Emitting ``FullAttentionSpec`` for *every* layer (see
-    # ``get_kv_cache_spec`` below) collapses them into a single
-    # ``UniformTypeKVCacheSpecs`` group, so the whole block pool backs each
-    # request and the full ``max_model_len`` becomes admissible (verified up to
-    # ~100K ISL). This mirrors the Gemma3 / GPT-OSS single-pool path. It does
-    # require the legacy unbounded sliding KV path on the device (bounded sliding
-    # assumes a windowed ``SlidingWindowSpec``), so ``bounded_sliding_kv_cache``
-    # defaults off below.
-    _HYBRID_KV_CACHE_GROUPS_ENABLED = False
+    # ON (``GEMMA4_HYBRID_KV_CACHE_GROUPS=1``): sliding layers emit
+    # ``SlidingWindowSpec`` and form their own kv_cache_groups, so the 40 sliding
+    # layers only allocate the 1024-token window (``cache_position_modulo`` bounded
+    # ring on device) — far less KV DRAM, higher concurrency/throughput. Tradeoffs:
+    # vLLM splits the block pool across groups, so a single request is capped at
+    # ~``num_blocks // num_groups`` tokens (long-context admission regresses), and
+    # bounded sliding's known >~34k degradation applies. Bounded sliding is tied to
+    # this flag (below). This is the pre-#48283 path, restored behind the env gate.
+    #
+    # KNOWN BLOCKER (why ON is not the default yet): the hybrid path serves
+    # correctly up to ISL 4096 — including the single-user 2048 prefill that used
+    # to hang (#49083) — but crashes at ISL >= 8192. The full-attention layers'
+    # long-context chunked-prefill SDPA
+    # (``ttnn.transformer.chunked_scaled_dot_product_attention``) TT_FATALs on
+    # ``k_shape[3] == DH``: under the shared kv-cache group the full-attn K/V is
+    # stored at the sliding head_dim (256) while full attention needs DH=512. The
+    # non-chunked paged ops reconcile this via the ``effective_block_size`` override
+    # (see attention/operations.py), but the chunked SDPA op takes no such block/
+    # head_dim knob — fixing it (an op/kernel change, or allocating full-attn its
+    # own head_dim buffer) is the remaining work to make ON viable end-to-end.
+    _HYBRID_KV_CACHE_GROUPS_ENABLED = os.environ.get("GEMMA4_HYBRID_KV_CACHE_GROUPS", "0") != "0"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Mirrors the env-var check in :meth:`initialize_vllm_model`. With hybrid
-        # kv-cache groups disabled all layers use ``FullAttentionSpec`` and the
-        # device must allocate/read full-length KV, so bounded sliding defaults
-        # OFF. Set ``GEMMA4_BOUNDED_SLIDING_KV_CACHE=1`` only alongside the
-        # hybrid ``SlidingWindowSpec`` path.
-        self._bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", "0") != "0"
+        # Bounded sliding KV defaults to match the hybrid-groups mode — bounded is
+        # only correct alongside the ``SlidingWindowSpec`` layout. Override with
+        # ``GEMMA4_BOUNDED_SLIDING_KV_CACHE=0/1``.
+        _bounded_default = "1" if self._HYBRID_KV_CACHE_GROUPS_ENABLED else "0"
+        self._bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", _bounded_default) != "0"
 
     @classmethod
     def get_max_tokens_all_users(cls, model_name: str = "", **kwargs) -> int:
@@ -424,7 +442,7 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         between groups is the spec — block_size stays uniform.
         """
         from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
-        from vllm.v1.kv_cache_interface import FullAttentionSpec
+        from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
 
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
@@ -466,21 +484,32 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
                         f"layer_types[{i}] is 'sliding_attention' but "
                         f"hf_config.sliding_window is None on {cls.__name__}"
                     )
-                # Hybrid kv-cache groups are disabled
-                # (``_HYBRID_KV_CACHE_GROUPS_ENABLED = False``): emit
-                # ``FullAttentionSpec`` for sliding layers too, keeping their
-                # own (sliding) num_kv_heads/head_size. vLLM then merges all
-                # same-type specs into one ``UniformTypeKVCacheSpecs`` group, so
-                # the full block pool backs every request instead of being split
-                # across 6 groups and capped at ~23K tokens. The device runs the
-                # legacy unbounded sliding path (bounded sliding defaults off),
-                # which matches this full-length allocation.
-                spec_per_layer[name] = FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=sliding_kv_heads_per_dev,
-                    head_size=sliding_head_dim,
-                    dtype=dtype,
-                )
+                if cls._HYBRID_KV_CACHE_GROUPS_ENABLED:
+                    # Hybrid ON: windowed ``SlidingWindowSpec`` so sliding layers
+                    # form their own kv_cache_group(s) and only allocate the
+                    # bounded window on device (memory-efficient; see the class
+                    # docstring for the single-request ISL-cap tradeoff).
+                    spec_per_layer[name] = SlidingWindowSpec(
+                        block_size=block_size,
+                        num_kv_heads=sliding_kv_heads_per_dev,
+                        head_size=sliding_head_dim,
+                        dtype=dtype,
+                        sliding_window=sliding_window,
+                    )
+                else:
+                    # Hybrid OFF: ``FullAttentionSpec`` for sliding layers too,
+                    # keeping their own (sliding) num_kv_heads/head_size. vLLM
+                    # merges all same-type specs into one ``UniformTypeKVCacheSpecs``
+                    # group, so the full block pool backs every request instead of
+                    # being split across groups and capped. The device runs the
+                    # legacy unbounded sliding path (bounded sliding defaults off),
+                    # which matches this full-length allocation.
+                    spec_per_layer[name] = FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=sliding_kv_heads_per_dev,
+                        head_size=sliding_head_dim,
+                        dtype=dtype,
+                    )
             elif lt == "full_attention":
                 spec_per_layer[name] = FullAttentionSpec(
                     block_size=block_size,
@@ -513,14 +542,14 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         model_path = hf_config._name_or_path
         submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
 
-        # Bounded sliding-window KV cache defaults OFF, consistent with hybrid
-        # kv-cache groups being disabled: ``get_kv_cache_spec`` emits
-        # ``FullAttentionSpec`` for every layer, so vLLM hands full-length
-        # (non-windowed) page tables and the device must allocate/read the full
-        # pool. The bounded path (``cache_position_modulo=sliding_window``) is
-        # only correct alongside the hybrid ``SlidingWindowSpec`` layout; set
-        # ``GEMMA4_BOUNDED_SLIDING_KV_CACHE=1`` to re-enable it in that mode.
-        bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", "0") != "0"
+        # Bounded sliding KV defaults to match the hybrid-groups mode — the
+        # bounded path (``cache_position_modulo=sliding_window``) is only correct
+        # alongside the hybrid ``SlidingWindowSpec`` layout. With hybrid OFF every
+        # layer is ``FullAttentionSpec`` and the device allocates/reads the full
+        # pool. Override with ``GEMMA4_BOUNDED_SLIDING_KV_CACHE=0/1``. See the
+        # class docstring.
+        _bounded_default = "1" if cls._HYBRID_KV_CACHE_GROUPS_ENABLED else "0"
+        bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", _bounded_default) != "0"
 
         model_args = []
         model = []
@@ -540,14 +569,33 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
                 bounded_sliding_kv_cache=bounded_sliding_kv_cache,
             )
             prefill_trace_unsafe = _gemma4_prefill_trace_unsafe(model_i, bounded_sliding_kv_cache)
+            # GH #49083 fix: enable the RUNTIME prefill device trace even for the
+            # hybrid per-layer case. A cold *eager* prefill dispatched right after
+            # a shared-Generator traced decode wedges the fetch queue
+            # (nlp_concat_heads); replaying the prefill from a trace instead (as
+            # Qwen does) avoids it — confirmed on-device.
+            #
+            # This is SAFE because the runtime prefill trace is captured *lazily*
+            # inside ``Gemma4ForCausalLM.prefill_forward`` — i.e. after per-layer
+            # page-table routing is active and the persistent per-layer buffers
+            # are populated — so the captured paged ops bind those per-layer
+            # buffers (exactly how decode_forward captures the decode trace). Only
+            # the *warmup* pre-capture is unsafe (it drives ``prefill_forward_text``
+            # directly, before routing, binding one broadcast table); that path is
+            # kept eager by ``warmup_model_prefill`` (the ``_gemma4_prefill_trace_unsafe``
+            # gate there), so warmup never captures the corrupting broadcast trace.
+            # The first runtime prefill of each bucket therefore pays the one-time
+            # capture cost; size ``trace_region_size`` for the prefill buckets served.
+            # GEMMA4_DISABLE_PREFILL_TRACE=1 restores the old fully-eager prefill.
+            prefill_trace_enabled = os.environ.get("GEMMA4_DISABLE_PREFILL_TRACE", "0") != "1"
             if prefill_trace_unsafe:
                 logger.info(
-                    "Gemma4 vLLM: disabling prefill device trace for {} — hybrid "
-                    "per-layer page tables (bounded sliding / kv-share) diverge from "
-                    "the single broadcast table captured at prefill-trace warmup, which "
-                    "would corrupt prefill KV on replay. Prefill runs eager; decode "
-                    "trace is unaffected.",
+                    "Gemma4 vLLM: prefill device trace for {} runs hybrid per-layer "
+                    "page tables — warmup stays eager (no broadcast-table pre-capture); "
+                    "the runtime trace is captured lazily inside prefill_forward with "
+                    "per-layer routing active (#49083 fix). prefill_trace_enabled={}.",
                     model_path,
+                    prefill_trace_enabled,
                 )
             _patch_model_args(
                 model_args_i,
@@ -555,7 +603,7 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
                 max_batch_size=max_batch_size // tt_data_parallel,
                 max_seq_len=max_seq_len,
                 model_path=model_path,
-                prefill_trace_enabled=not prefill_trace_unsafe,
+                prefill_trace_enabled=prefill_trace_enabled,
             )
             # The shared TT vLLM cache allocator reads ``model.args.optimizations``;
             # mirror the text-transformer wrappers by exposing model_args here.

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -30,15 +30,14 @@ class _Gemma4VllmOptimizations:
 
 def _gemma4_prefill_trace_unsafe(model, bounded_sliding_kv_cache) -> bool:
     """True when the hybrid bridge feeds *non-uniform* per-layer page tables
-    to the paged ops, which makes the vLLM prefill device trace unsafe.
+    to the paged ops, so a prefill-trace capture must run *through* the
+    per-layer page-table routing rather than the plain ``prefill_forward_text``.
 
-    Prefill-trace capture (the gemma4 warmup sweep / direct
-    ``prefill_forward_text`` callers) runs *before* the per-layer routing
-    that :meth:`Gemma4ForCausalLM.prefill_forward` applies at runtime, so it
-    binds the traced paged ops to the single full page_table shared by every
-    layer. That only matches runtime when every layer truly uses that one
-    table. It diverges — and the captured trace then addresses the wrong KV
-    slots, corrupting prefill output — whenever:
+    A direct ``prefill_forward_text`` capture binds the traced paged ops to the
+    single full page_table shared by every layer. That only matches runtime
+    when every layer truly uses that one table. It diverges — and the captured
+    trace then addresses the wrong KV slots, corrupting prefill output —
+    whenever:
 
       * bounded sliding is on and the model has ``sliding_attention`` layers
         (:meth:`_pad_sliding_page_tables_for_bounded` widens only the sliding
@@ -46,12 +45,13 @@ def _gemma4_prefill_trace_unsafe(model, bounded_sliding_kv_cache) -> bool:
       * the model kv-shares layers (``kv_shared_layer_map`` re-points a shared
         layer's table at its source's).
 
-    Decode is unaffected: decode warmup goes through ``decode_forward``, which
-    sets up the per-layer routing before capture — so disabling *only* the
-    prefill trace keeps the throughput-critical decode path traced. Models
-    without sliding layers (or with bounded sliding off and no kv-share) keep
-    their prefill trace, so the gate is structural and self-scoping rather
-    than a hard-coded model list.
+    When this returns True, :meth:`warmup_model_prefill` routes the warmup
+    capture through :meth:`prefill_forward` (which populates the persistent
+    per-layer buffers before capture) — exactly how decode warmup routes
+    through ``decode_forward``. Models without sliding layers (or with bounded
+    sliding off and no kv-share) can capture directly via
+    ``prefill_forward_text``, so the gate is structural and self-scoping
+    rather than a hard-coded model list.
     """
     if getattr(model, "kv_shared_layer_map", None):
         return True
@@ -186,21 +186,35 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
         can_sample_on_device,
         greedy_only: bool = False,
     ):
-        # Mirror the runtime gate (``can_enable_trace`` was already forced off
-        # in ``_patch_model_args``): warm up prefill *eagerly* — compiled, no
-        # trace capture — when the hybrid per-layer page tables diverge from
-        # the single broadcast table this warmup path would otherwise capture.
-        # Without this the sweep would try to capture a corrupting prefill
-        # trace; with it, the else-branch of ``warmup_gemma4_model_prefill``
-        # runs the eager prefill warmup instead.
+        # #49083 fix: pre-capture the prefill-bucket traces here, at warmup,
+        # rather than lazily on the first runtime prefill. A cold *eager*
+        # prefill dispatched after a shared-Generator traced-decode session
+        # (the release workflow's evals phase) wedges the fetch queue
+        # (nlp_concat_heads) at ISL=2048 — capturing every bucket up front so
+        # runtime only *replays* removes that trace->eager transition.
+        #
+        # The hybrid per-layer page tables diverge from the single broadcast
+        # table a direct ``prefill_forward_text`` capture would bind, so route
+        # the capture through ``prefill_forward`` (``prefill_forward_fn`` below).
+        # That sets up per-layer routing and populates the persistent per-layer
+        # buffers *before* the traced forward, so the captured paged ops bind
+        # those buffers — identical to how decode warmup binds via
+        # ``decode_forward``. Runtime ``prefill_forward`` then just refreshes the
+        # same buffers' block IDs out-of-trace and replays. ``_mock_tokens``
+        # sizes the warmup page table to the runtime width, so the persistent
+        # buffers match runtime (and decode-warmup) shapes.
+        #
+        # GEMMA4_DISABLE_PREFILL_TRACE=1 keeps prefill fully eager (no capture).
+        prefill_forward_fn = None
         if enable_trace and _gemma4_prefill_trace_unsafe(self.model[0], self._bounded_sliding_kv_cache):
-            enable_trace = False
+            prefill_forward_fn = self.prefill_forward
         warmup_gemma4_model_prefill(
             self,
             kv_cache,
             enable_trace=enable_trace,
             can_sample_on_device=can_sample_on_device,
             greedy_only=greedy_only,
+            prefill_forward_fn=prefill_forward_fn,
         )
 
     def prefill_forward_text(self, *args, enable_trace=True, **kwargs):
@@ -569,31 +583,23 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
                 bounded_sliding_kv_cache=bounded_sliding_kv_cache,
             )
             prefill_trace_unsafe = _gemma4_prefill_trace_unsafe(model_i, bounded_sliding_kv_cache)
-            # GH #49083 fix: enable the RUNTIME prefill device trace even for the
-            # hybrid per-layer case. A cold *eager* prefill dispatched right after
-            # a shared-Generator traced decode wedges the fetch queue
-            # (nlp_concat_heads); replaying the prefill from a trace instead (as
-            # Qwen does) avoids it — confirmed on-device.
-            #
-            # This is SAFE because the runtime prefill trace is captured *lazily*
-            # inside ``Gemma4ForCausalLM.prefill_forward`` — i.e. after per-layer
-            # page-table routing is active and the persistent per-layer buffers
-            # are populated — so the captured paged ops bind those per-layer
-            # buffers (exactly how decode_forward captures the decode trace). Only
-            # the *warmup* pre-capture is unsafe (it drives ``prefill_forward_text``
-            # directly, before routing, binding one broadcast table); that path is
-            # kept eager by ``warmup_model_prefill`` (the ``_gemma4_prefill_trace_unsafe``
-            # gate there), so warmup never captures the corrupting broadcast trace.
-            # The first runtime prefill of each bucket therefore pays the one-time
-            # capture cost; size ``trace_region_size`` for the prefill buckets served.
-            # GEMMA4_DISABLE_PREFILL_TRACE=1 restores the old fully-eager prefill.
+            # GH #49083 fix: pre-capture the prefill device traces at *warmup*
+            # (see ``warmup_model_prefill``), routed through ``prefill_forward``
+            # for the hybrid per-layer case. A cold *eager* prefill dispatched
+            # after a shared-Generator traced-decode session (the release
+            # workflow's evals phase) wedges the fetch queue (nlp_concat_heads)
+            # at ISL=2048; capturing every bucket up front so runtime only
+            # *replays* removes that trace->eager transition. Capturing at warmup
+            # (before any traced decode) is what makes it safe — a lazy
+            # first-runtime capture still hits the wedge.
+            # GEMMA4_DISABLE_PREFILL_TRACE=1 restores the fully-eager prefill.
             prefill_trace_enabled = os.environ.get("GEMMA4_DISABLE_PREFILL_TRACE", "0") != "1"
             if prefill_trace_unsafe:
                 logger.info(
                     "Gemma4 vLLM: prefill device trace for {} runs hybrid per-layer "
-                    "page tables — warmup stays eager (no broadcast-table pre-capture); "
-                    "the runtime trace is captured lazily inside prefill_forward with "
-                    "per-layer routing active (#49083 fix). prefill_trace_enabled={}.",
+                    "page tables — warmup pre-captures each bucket through "
+                    "prefill_forward (per-layer routing active), so runtime replays "
+                    "instead of cold-eager capturing (#49083 fix). prefill_trace_enabled={}.",
                     model_path,
                     prefill_trace_enabled,
                 )

--- a/models/demos/gemma4/tt/layer.py
+++ b/models/demos/gemma4/tt/layer.py
@@ -213,6 +213,8 @@ class Gemma4DecoderLayer:
         sequential_kv_write=False,
         rope_presliced=False,
         packed=None,
+        chunk_start_idx=None,
+        chunk_page_table=None,
     ):
         """
         Decoder layer forward pass.
@@ -256,6 +258,8 @@ class Gemma4DecoderLayer:
             sequential_kv_write=sequential_kv_write,
             rope_presliced=rope_presliced,
             packed=packed,
+            chunk_start_idx=chunk_start_idx,
+            chunk_page_table=chunk_page_table,
         )
 
         if isinstance(attn_output, torch.Tensor):

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -588,20 +588,25 @@ class Gemma4Model:
         # Return as list of per-layer tensors
         return [per_layer_inputs[:, :, i, :].to(torch.bfloat16) for i in range(n_layers)]
 
-    def _get_rope_mats(self, layer_idx, seq_len=None, for_decode=False):
+    def _get_rope_mats(self, layer_idx, seq_len=None, for_decode=False, start_pos=0):
         """Get (cos, sin) for a given layer.
 
         Args:
             seq_len: If set, slice 4D cache to this length (prefill).
             for_decode: If True, return 2D caches [max_seq_len, head_dim] for embedding lookup.
+            start_pos: Absolute position of the first token in this prefill call.
+                Non-zero only for generator-level multi-chunk prefill (chunk N starts
+                at ``N*chunk_size``); the RoPE slice must cover
+                ``[start_pos, start_pos+seq_len)`` so chunk tokens get their true
+                positions instead of restarting at 0.
         """
         layer_type = self.hf_config.layer_types[layer_idx]
         if for_decode:
             return self.rope_caches_2d[layer_type]
         cos, sin = self.rope_caches[layer_type]
         if seq_len is not None:
-            cos = cos[:, :, :seq_len, :]
-            sin = sin[:, :, :seq_len, :]
+            cos = cos[:, :, start_pos : start_pos + seq_len, :]
+            sin = sin[:, :, start_pos : start_pos + seq_len, :]
         return (cos, sin)
 
     def __call__(
@@ -625,6 +630,8 @@ class Gemma4Model:
         return_hidden=False,
         sequential_kv_write=False,
         packed=None,
+        chunk_start_idx=None,
+        chunk_page_table=None,
     ):
         """
         Forward pass through decoder layers + final norm + lm_head + softcapping.
@@ -743,7 +750,11 @@ class Gemma4Model:
                 # Decode fallback: return 2D caches for on-device embedding lookup
                 layer_rope = self._get_rope_mats(i, for_decode=True)
             else:
-                layer_rope = self._get_rope_mats(i, seq_len=rope_seq_len)
+                # Generator-level multi-chunk prefill: chunk N's tokens occupy
+                # absolute positions [chunk_start_idx, chunk_start_idx+seq_len);
+                # offset the RoPE slice so they aren't re-encoded from 0.
+                rope_start_pos = int(chunk_start_idx) if chunk_start_idx is not None else 0
+                layer_rope = self._get_rope_mats(i, seq_len=rope_seq_len, start_pos=rope_start_pos)
 
             # Convert per-layer input to device tensor if available
             pli_tt = None
@@ -816,6 +827,8 @@ class Gemma4Model:
                 sequential_kv_write=sequential_kv_write,
                 rope_presliced=rope_presliced,
                 packed=layer_packed,
+                chunk_start_idx=chunk_start_idx,
+                chunk_page_table=chunk_page_table,
             )
 
             # For KV source layers during prefill, capture the K/V from the attention
@@ -1433,7 +1446,7 @@ class Gemma4Model:
         *before* lm_head — slicing after would still allocate full-seq
         logits first.
         """
-        del rot_mats_global, rot_mats_local, chunk_page_table, chunk_start_idx, kwargs
+        del rot_mats_global, rot_mats_local, kwargs
         if input_ids_torch is None:
             input_ids_torch = self._prefill_input_ids_torch
         if embeds_torch is None:
@@ -1454,6 +1467,8 @@ class Gemma4Model:
             page_tables_per_layer=page_tables_per_layer,
             batch_size=batch_size,
             user_id=user_id,
+            chunk_start_idx=chunk_start_idx,
+            chunk_page_table=chunk_page_table,
         )
 
     def process_output_prefill(self, tt_out, last_token_idx):


### PR DESCRIPTION
### PR Category
Fixes for Gemma4 PR

1. Runs default full cache mode inference on demos. (non bounded)
2. Includes changes for non bounded inference on vLLM inference server 

issues: https://github.com/tenstorrent/tt-metal/issues/49083 https://github.com/tenstorrent/tt-metal/issues/48838

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arg/gemma4_31b_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arg/gemma4_31b_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arg/gemma4_31b_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arg/gemma4_31b_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arg/gemma4_31b_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arg/gemma4_31b_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arg/gemma4_31b_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arg/gemma4_31b_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arg/gemma4_31b_stable)