### PR TITLE
[Bug fix] Remove orphan cb_in1_obj.pop_front from prod_nc compute kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
@@ -51,7 +51,4 @@ void kernel_main() {
         cb_out0_obj.push_back(onetile);
         tile_regs_release();
     }
-    // cb_in1 holds a single broadcast scaler tile waited once and reused across all output
-    // tiles; pop it at the end so the CB is left balanced.
-    cb_in1_obj.pop_front(onetile);
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The compute-kernel rewrite in #47409 (Extend `ttnn.prod` to support float32) removed the declarations of `cb_in1_obj` and `cb_intermed0_obj` from `prod_nc.cpp`, but a trailing `cb_in1_obj.pop_front(onetile);` (with an obsolete comment about a broadcast scaler tile) at the bottom of the file was left behind. The new kernel keeps the running product in DEST via `binary_dest_reuse_tiles<ELWMUL, DEST_TO_SRCA>`, so no `c_1` or `c_2` CB is configured by the program factory (`prod_nc_program_factory.cpp` only allocates `c_0` input + `c_3` output), and the reader kernel only writes `c_0`.

Because `prod_nc.cpp` is JIT-compiled, the orphan reference only surfaces at runtime the first time `ttnn.prod(..., dim)` is invoked, failing with:

```
prod_nc.cpp:56:5: error: cb_in1_obj was not declared in this scope; did you mean cb_in0_obj?
   56 |     cb_in1_obj.pop_front(onetile);
      |     ^~~~~~~~~~
      |     cb_in0_obj
```

Dropping the three orphan lines restores the JIT build. Both `bfloat16` and `bfloat8_b` variants of `ttnn.prod(x, dim=-1, keepdim=True)` pass on WH n300 with the fix applied.

### Scope
- `ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp` — remove `cb_in1_obj.pop_front(onetile);` and the two-line stale comment above it. No host-side change; no ABI change.

### Blast-radius check
Grepped every file touched by #47409 on `main` for `cb_in1|cb_intermed0|CBIndex::c_1|CBIndex::c_2` — only `prod_nc.cpp` has the leftover. `prod_all.cpp`, `reader_prod_nc.cpp`, and both program factories are clean.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AshAI/fix-prod-nc-orphan-cb-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AshAI/fix-prod-nc-orphan-cb-in1)