### PR TITLE
Fix ttnn.outer TT_FATAL on row-major bf16 vectors (matmul dispatch not tilized)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -20,6 +20,7 @@
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/core/to_memory_config/to_memory_config_op.hpp"
+#include "ttnn/operations/core/to_layout/to_layout_op.hpp"
 #include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
 #include <variant>
@@ -625,7 +626,14 @@ Tensor outer(const Tensor& input_a, const Tensor& input_b, const std::optional<M
     const uint64_t batch = std::max<uint64_t>(leading_volume(input_a), leading_volume(input_b));
     const bool use_matmul = !is_integer && !is_fp32 && batch == 1;
     if (use_matmul) {
-        return ttnn::matmul(a_unsq, b_unsq, /*transpose_a=*/false, /*transpose_b=*/false, output_mem_config);
+        // matmul requires TILE inputs and, unlike the binary_ng multiply path,
+        // does not tilize row-major inputs on the way in. Tilize here so the
+        // documented "any layout" contract holds for the matmul dispatch.
+        const auto to_tile = [](const Tensor& t) {
+            return t.layout() == Layout::TILE ? t : ttnn::to_layout(t, Layout::TILE);
+        };
+        return ttnn::matmul(
+            to_tile(a_unsq), to_tile(b_unsq), /*transpose_a=*/false, /*transpose_b=*/false, output_mem_config);
     }
     return ttnn::multiply(a_unsq, b_unsq, std::nullopt, output_mem_config);
 }


### PR DESCRIPTION
**PR Category**
Bug fix

**Summary**

Fixes a `TT_FATAL` in `ttnn.outer` for row-major `BFLOAT16`/`BFLOAT8_B` vector inputs (`batch == 1`), introduced by #44484.

The composite dispatch in `binary_composite_op.cpp` routes bf16/bf8 + `batch == 1` to `ttnn::matmul`. Unlike the `binary_ng` multiply path (which auto-tilizes row-major inputs), `matmul` hard-requires `Layout::TILE` and does not tilize on the way in, so row-major inputs hit:

```
TT_FATAL @ matmul_device_operation.cpp:788: (input_tensor_a.layout() == Layout::TILE && input_tensor_b.layout() == Layout::TILE)
Inputs to matmul must be tilized
```

The fix tilizes both unsqueezed operands before the matmul call, restoring the documented any-layout contract for the matmul dispatch. The multiply path is unchanged.

**Failing test now covered**

`tests/ttnn/unit_tests/operations/eltwise/test_outer.py::test_outer_row_major_layout[dtype=DataType.BFLOAT16-a_shape=[32]-b_shape=[32]]`

Surfaced in the `Sanity tests` workflow (ttnn eltwise group 3, wh_n300) rather than required PR checks, which is why #44484 merged green.

Ref #44352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ashai/fix-outer-matmul-rm-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ashai/fix-outer-matmul-rm-tilize)