### PR TITLE
[Cleanup] Migrate experimental SSM / reduction / CNN ops to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
@@ -71,12 +71,17 @@ void kernel_main() {
 
                 // dst_offset_bytes is already relative to block buffer start (includes channel * block_size + column)
                 if constexpr (is_input_in_dram) {
-                    // DRAM bank-id path stays on legacy noc_async_read: get_noc_addr_from_bank_id returns a packed
-                    // uint64_t NOC address, and Noc::async_read does not expose a clean way to
-                    // decompose it back into UnicastEndpoint {noc_x, noc_y, addr} fields.
-                    const uint64_t src_addr_base = get_noc_addr_from_bank_id<true>(bank_id, dram_base_read_addr);
-                    const uint32_t dst_addr = cb_in_batch_obj.get_write_ptr() + dst_offset_bytes;
-                    noc_async_read(src_addr_base + src_offset_bytes, dst_addr, transfer_size_bytes);
+                    // DRAM bank-id read via the AllocatorBank<DRAM> endpoint. Folding src_offset_bytes into the
+                    // bank address offset is equivalent to the legacy bank-id addr-gen result plus
+                    // src_offset_bytes: both land the offset in the NOC address's low bits below
+                    // NOC_ADDR_COORD_SHIFT (see the DRAM bank-id addr-gen in dataflow_api_addrgen.h).
+                    AllocatorBank<AllocatorBankType::DRAM> dram_bank;
+                    noc.async_read(
+                        dram_bank,
+                        cb_in_batch_obj,
+                        transfer_size_bytes,
+                        {.bank_id = bank_id, .addr = dram_base_read_addr + src_offset_bytes},
+                        {.offset_bytes = dst_offset_bytes});
                 } else {
                     UnicastEndpoint src_ep;
                     noc.async_read(

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_common.hpp
@@ -106,12 +106,14 @@ FORCE_INLINE void load_to_cb(
     CircularBuffer cb_obj(cb);
     cb_obj.reserve_back(ONE_PAGE);
 
-    const uint64_t source_noc_address = addr_gtor.get_noc_addr(FIRST_STICK);
-    const uint32_t l1_write_address = cb_obj.get_write_ptr();
     const uint32_t subchunk_size_bytes = subchunk_size * datum_size;
     const uint32_t offset_bytes = offset * datum_size;
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-    noc_async_read(source_noc_address + offset_bytes, l1_write_address, subchunk_size_bytes);
+    noc.async_read(
+        addr_gtor,
+        cb_obj,
+        subchunk_size_bytes,
+        {.page_id = FIRST_STICK, .offset_bytes = offset_bytes},
+        {.offset_bytes = 0});
     noc.async_read_barrier();
 
     cb_obj.push_back(ONE_PAGE);
@@ -129,12 +131,14 @@ FORCE_INLINE void write_to_dram(
     CircularBuffer cb_obj(cb);
     cb_obj.wait_front(ONE_PAGE);
 
-    const uint64_t destination_noc_address = addr_gtor.get_noc_addr(FIRST_STICK);
-    const uint32_t l1_read_address = cb_obj.get_read_ptr();
     const uint32_t subchunk_size_bytes = subchunk_size * datum_size;
     const uint32_t offset_bytes = offset * datum_size;
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-    noc_async_write(l1_read_address, destination_noc_address + offset_bytes, subchunk_size_bytes);
+    noc.async_write(
+        cb_obj,
+        addr_gtor,
+        subchunk_size_bytes,
+        {.offset_bytes = 0},
+        {.page_id = FIRST_STICK, .offset_bytes = offset_bytes});
     noc.async_write_barrier();
 
     cb_obj.pop_front(ONE_PAGE);

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_reader.cpp
@@ -100,6 +100,8 @@ void kernel_main() {
         ctas.test_elements_size * test_elements_element_size);
 
     Noc noc;
+    CircularBuffer elements_cb(ctas.elements_cb);
+    CircularBuffer test_elements_cb(ctas.test_elements_cb);
     CircularBuffer output_cb(ctas.output_cb);
 
     /*
@@ -119,11 +121,11 @@ void kernel_main() {
             std::min(ctas.elements_size - elements_offset, ctas.single_fetch_subchunk_size);
         load_to_cb(
             ctas.elements_cb, elements_addr_gtor, elements_offset, elements_subchunk_size, elements_element_size);
-        cb_wait_front(ctas.elements_cb, ONE_PAGE);
+        elements_cb.wait_front(ONE_PAGE);
         // prepare output mask for writing
-        cb_reserve_back(ctas.output_cb, ONE_PAGE);
-        const uint32_t elements_l1_read_addr = get_read_ptr(ctas.elements_cb);
-        const uint32_t output_l1_write_addr = get_write_ptr(ctas.output_cb);
+        output_cb.reserve_back(ONE_PAGE);
+        const uint32_t elements_l1_read_addr = elements_cb.get_read_ptr();
+        const uint32_t output_l1_write_addr = output_cb.get_write_ptr();
         prefill_output<elements_number_type>(noc, output_cb, elements_subchunk_size, ctas.invert);
 
         // for every subchunk of the test_elements stick
@@ -139,8 +141,8 @@ void kernel_main() {
                 test_elements_offset,
                 test_elements_subchunk_size,
                 test_elements_element_size);
-            cb_wait_front(ctas.test_elements_cb, ONE_PAGE);
-            const uint32_t test_elements_l1_read_addr = get_read_ptr(ctas.test_elements_cb);
+            test_elements_cb.wait_front(ONE_PAGE);
+            const uint32_t test_elements_l1_read_addr = test_elements_cb.get_read_ptr();
 
             // exhaustively perform isin on a given elements' subchunks (one elements' subchunk vs all test_elements'
             // subchunks)
@@ -152,11 +154,11 @@ void kernel_main() {
                 test_elements_subchunk_size,
                 ctas.invert);
 
-            cb_pop_front(ctas.test_elements_cb, ONE_PAGE);
+            test_elements_cb.pop_front(ONE_PAGE);
         }
 
         // push the output subchunk once it's been checked against test_elements
-        cb_push_back(ctas.output_cb, ONE_PAGE);
-        cb_pop_front(ctas.elements_cb, ONE_PAGE);
+        output_cb.push_back(ONE_PAGE);
+        elements_cb.pop_front(ONE_PAGE);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
@@ -6,11 +6,11 @@
 // Device-side NoC logic is unchanged; resource access uses Metal 2.0 named handles. Self-loop DFBs are
 // no longer permitted on data-movement kernels, so:
 //   - The input shard is read via tensor::input (a TensorAccessor over the resident shard): its local L1
-//     base address is recovered with NOC_LOCAL_ADDR_OFFSET(get_noc_addr(0)) and used as the source offset
+//     base address is recovered with NOC_LOCAL_ADDR_OFFSET(s.get_noc_addr(0)) and used as the source offset
 //     for the remote NoC reads against neighbouring shards. (No more cb_in0 borrowed fake-CB self-loop.)
 //   - cb_pad is now a CROSS-KERNEL DFB: this reader PRODUCES the pad-value stick once (fill moved here
 //     from the writer); the writer CONSUMES it. (No more writer self-loop.)
-//   - c_16 output shard is written in place via tensor::output (NOC_LOCAL_ADDR_OFFSET(get_noc_addr(0)));
+//   - c_16 output shard is written in place via tensor::output (NOC_LOCAL_ADDR_OFFSET(s_out.get_noc_addr(0)));
 //     the reader writes the gathered real sticks, the writer writes the pad sticks (no borrowed DFB).
 //   - The legacy variable-length arg tail (read_noc_x/y, num_stick_chunks, chunk lists) is runtime varargs.
 #include <stdint.h>

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
@@ -6,7 +6,7 @@
 // Self-loop DFBs are no longer permitted on data-movement kernels, so cb_pad is now a CROSS-KERNEL DFB:
 // the reader PRODUCES the pad-value stick (the fill logic moved there); this writer CONSUMES it (wait_front
 // -> read its address -> broadcast pad sticks -> pop_front). The c_16 output shard is written in place
-// via tensor::output (NOC_LOCAL_ADDR_OFFSET(get_noc_addr(0))) — no borrowed co-write DFB. start_dim_offset
+// via tensor::output (NOC_LOCAL_ADDR_OFFSET(s_out.get_noc_addr(0))) — no borrowed co-write DFB. start_dim_offset
 // is read by constant indices so it is three named scalar RTAs.
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common_dataflow.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common_dataflow.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+
 #include "common.hpp"
 
 template <typename addr_gen_t>
@@ -11,9 +14,15 @@ FORCE_INLINE void write_to_dram(
     uint32_t cb, const addr_gen_t& addr_gtor, uint32_t write_tile_id, uint32_t num_tiles = ONE_TILE) {
     ReadCBGuard read_guard{cb, num_tiles};
 
-    uint32_t l1_read_addr{get_read_ptr(cb)};
-    noc_async_write_page(write_tile_id, addr_gtor, l1_read_addr);
-    noc_async_write_barrier();
+    Noc noc;
+    CircularBuffer cb_obj{cb};
+    noc.async_write(
+        cb_obj,
+        addr_gtor,
+        addr_gtor.get_aligned_page_size(),
+        {.offset_bytes = 0},
+        {.page_id = write_tile_id, .offset_bytes = 0});
+    noc.async_write_barrier();
 }
 
 template <typename addr_gen_type>
@@ -21,9 +30,15 @@ FORCE_INLINE void load_from_dram(
     uint32_t cb, const addr_gen_type& addr_gtor, uint32_t read_tile_id, uint32_t num_tiles = ONE_TILE) {
     WriteCBGuard write_guard{cb, num_tiles};
 
-    uint32_t l1_write_addr{get_write_ptr(cb)};
-    noc_async_read_page(read_tile_id, addr_gtor, l1_write_addr);
-    noc_async_read_barrier();
+    Noc noc;
+    CircularBuffer cb_obj{cb};
+    noc.async_read(
+        addr_gtor,
+        cb_obj,
+        addr_gtor.get_aligned_page_size(),
+        {.page_id = read_tile_id, .offset_bytes = 0},
+        {.offset_bytes = 0});
+    noc.async_read_barrier();
 }
 
 template <typename InputAccessorArgs, typename OutputAccessorArgs>

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
+#include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
 
 constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
@@ -30,11 +31,19 @@ void kernel_main() {
 
     cb_out_obj.wait_front(num_tiles_per_core);
 
-    // Write accumulated hidden state back to the h_prev shard (in-place update)
-    uint32_t src_addr = cb_h_acc_obj.get_read_ptr();
-    uint64_t dst_addr = get_noc_addr(h_shard_l1_addr);
-    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-    noc_async_write(src_addr, dst_addr, hidden_state_len_bytes);
+    // Write accumulated hidden state back to the h_prev shard (in-place update).
+    // The shard lives in this core's own L1, so the write is a NOC unicast to the local
+    // core's coordinates (mirrors the reader's UnicastEndpoint read of the same shard).
+    const uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    const uint32_t local_noc_y = my_y[noc.get_noc_id()];
+    CoreLocalMem<uint32_t> h_acc_src(cb_h_acc_obj.get_read_ptr());
+    UnicastEndpoint h_shard_dst;
+    noc.async_write(
+        h_acc_src,
+        h_shard_dst,
+        hidden_state_len_bytes,
+        {},
+        {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = h_shard_l1_addr});
     noc.async_write_barrier();
 
     // cb_out is waited only as an output-ready handshake (the write above sources from cb_h_acc);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
@@ -160,25 +160,6 @@ void kernel_main() {
                 tile_regs_release();
                 cb_out.push_back(onetile);
                 cb_out_transposed_buf.pop_front(onetile);
-
-                /* TODO: Transpose directly on tiles in DST; is something like this possible?
-                cb_reserve_back(cb_id_out, onetile);
-
-                tile_regs_acquire();
-                tile_regs_wait();
-                mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
-                mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
-
-                MATH(( llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, BroadcastType::NONE, DST_ACCUM_MODE>(cb_id_out)));
-                MATH(( llk_math_eltwise_unary_datacopy<DataCopyType::A2D, BroadcastType::NONE, DST_ACCUM_MODE>(0) ));
-
-                pack_tile(0, cb_id_out);
-
-                tile_regs_commit();
-                tile_regs_release();
-                cb_push_back(cb_id_out, onetile);
-                cb_pop_front(cb_in1_bcast_row, onetile);
-                */
             }
 
             cb_in1_transposed_buf.pop_front(onetile);


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. A batch of ops migration to Device 2.0 API: the experimental SSM / reduction / CNN kernels

### Notes for reviewers

- Some ops contain irreducible legacy API primitives that have no clean Device 2.0 form yet:  intra-core L1 to L1 loopbacks and the TRID-based noc calls

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-pr2-ssm-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-pr2-ssm-reduction)
