### PR TITLE
[Cleanup] Migrate experimental/reduction/deepseek_moe_fast_reduce_nc to Device 2.0 API

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -270,6 +270,9 @@ run_t3000_ccl_tests() {
   pytest tests/nightly/t3000/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_1d -k "zeros_width_dim-check"
   pytest tests/nightly/t3000/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_2d -k "small_5d_h0w1"
 
+  # deepseek moe reduce scatter: exercises the deepseek_moe_fast_reduce_nc(+_fused) writer (Device 2.0 migration)
+  pytest tests/nightly/t3000/ccl/test_deepseek_moe_reduce_scatter.py::test_deepseek_moe_reduce_scatter
+
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -270,9 +270,6 @@ run_t3000_ccl_tests() {
   pytest tests/nightly/t3000/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_1d -k "zeros_width_dim-check"
   pytest tests/nightly/t3000/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_2d -k "small_5d_h0w1"
 
-  # deepseek moe reduce scatter: exercises the deepseek_moe_fast_reduce_nc(+_fused) writer (Device 2.0 migration)
-  pytest tests/nightly/t3000/ccl/test_deepseek_moe_reduce_scatter.py::test_deepseek_moe_reduce_scatter
-
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/kernels/deepseek_moe_fast_reduce_nc_writer.cpp
@@ -50,12 +50,14 @@ void kernel_main() {
     uint32_t tiles_to_read = start_tiles_to_read;
     while (tiles_read < tiles_to_read) {
         uint32_t normalized_page_id = slice_row_offset + intra_slice_offset;
-        uint64_t noc_addr = output_slice_tensor_accessors[slice_id].get_noc_addr(normalized_page_id);
 
         cb_compute_output.wait_front(one_tile);
-        uint32_t l1_read_addr = cb_compute_output.get_read_ptr();
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-        noc_async_write(l1_read_addr, noc_addr, page_size);
+        noc.async_write(
+            cb_compute_output,
+            output_slice_tensor_accessors[slice_id],
+            page_size,
+            {.offset_bytes = 0},
+            {.page_id = normalized_page_id});
         noc.async_writes_flushed();
         cb_compute_output.pop_front(one_tile);
 


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to #45003. Split out from (#49334) for easier validation, because this op's tests require a multi-device mesh configuration.

### Notes for reviewers

The modified call was marked as un-migratable, because it uses pre-computed 64-bit NoC address, it actually can be moved to the Device 2.0 API. That address is simply a page base plus a byte offset. Since page_id is known, it can be expressed in the new API as {.page_id, .offset_bytes}.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-deepseek-moe-fast-reduce-nc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-deepseek-moe-fast-reduce-nc)
