### PR TITLE
[draft] Revert #48758 (pipeline builder shape fix) — Qwen3-32B Galaxy Top-1 0.0% regression

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/pipeline_builder.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/pipeline_builder.hpp
@@ -76,18 +76,9 @@ struct GraphLayoutResult {
 ///                      (if present) is the return path from the last stage to stage 0.
 /// @param submesh_chips For each submesh: list of (mesh_id, chip_id, row, col) chips.
 ///                      Index in the outer vector is the submesh index.
-/// @param node_chip_counts Optional per-node expected chip count (rows*cols of the
-///                      node's declared shape).  When supplied for a node, that node
-///                      may only be assigned to a submesh with exactly that many chips,
-///                      so a stage declared 4x2 cannot be placed on a 1x2 submesh of a
-///                      different mesh just because ethernet connectivity allows it.
-///                      Nodes absent from the map are unconstrained.  An empty map
-///                      disables the shape filter entirely (legacy behavior).
 /// @returns             GraphLayoutResult with physical coords for every edge and
 ///                      unclaimed H2D/D2H chip coords in stage-0's submesh.
 GraphLayoutResult resolve_graph_layout(
-    const std::vector<EdgeInputTuple>& edges,
-    const std::vector<std::vector<ChipTuple>>& submesh_chips,
-    const std::map<std::string, uint32_t>& node_chip_counts = {});
+    const std::vector<EdgeInputTuple>& edges, const std::vector<std::vector<ChipTuple>>& submesh_chips);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/pipeline_builder.cpp
+++ b/tt_metal/fabric/pipeline_builder.cpp
@@ -161,9 +161,7 @@ std::map<std::string, size_t> assign_submeshes(
     const std::vector<std::string>& stage_order,
     const std::vector<EdgeInputTuple>& edges,
     const std::map<ConnectionKey, ConnectionInfo>& connections,
-    size_t num_submeshes,
-    const std::map<std::string, uint32_t>& node_chip_counts,
-    const std::vector<std::vector<InternalChip>>& chips) {
+    size_t num_submeshes) {
     // Build reverse-lookup: dst -> [src] for non-loopback edges
     std::map<std::string, std::vector<std::string>> parents;
     for (const auto& [src, dst, is_lb] : edges) {
@@ -229,22 +227,6 @@ std::map<std::string, size_t> assign_submeshes(
             }
         }
 
-        // Shape constraint: a node may only land on a submesh whose chip count
-        // matches the node's declared shape (rows*cols).  Without this, a stage
-        // declared 4x2 can be placed on a 1x2 submesh of a different mesh whenever
-        // ethernet connectivity allows, silently mis-placing it (e.g. the final-
-        // layer / loopback stage landing on a 1x2 instead of its 4x2 mesh).
-        auto cc_it = node_chip_counts.find(node);
-        if (cc_it != node_chip_counts.end()) {
-            std::set<size_t> filtered;
-            for (size_t s : candidates) {
-                if (chips[s].size() == cc_it->second) {
-                    filtered.insert(s);
-                }
-            }
-            candidates = std::move(filtered);
-        }
-
         for (size_t sub : candidates) {
             node_to_sub[node] = sub;
             used.insert(sub);
@@ -260,8 +242,7 @@ std::map<std::string, size_t> assign_submeshes(
     if (!solve(0)) {
         throw std::runtime_error(
             "resolve_graph_layout: no valid submesh assignment found — "
-            "physical connectivity (and per-node shape, if constrained) does not "
-            "match the graph topology");
+            "physical connectivity does not match the graph topology");
     }
     return node_to_sub;
 }
@@ -269,9 +250,7 @@ std::map<std::string, size_t> assign_submeshes(
 }  // anonymous namespace
 
 GraphLayoutResult resolve_graph_layout(
-    const std::vector<EdgeInputTuple>& edges,
-    const std::vector<std::vector<ChipTuple>>& submesh_chips,
-    const std::map<std::string, uint32_t>& node_chip_counts) {
+    const std::vector<EdgeInputTuple>& edges, const std::vector<std::vector<ChipTuple>>& submesh_chips) {
     // ------------------------------------------------------------------
     // 0. Convert chip tuples to internal representation
     // ------------------------------------------------------------------
@@ -312,7 +291,7 @@ GraphLayoutResult resolve_graph_layout(
     // ------------------------------------------------------------------
     // 4. Assign submeshes to nodes via backtracking
     // ------------------------------------------------------------------
-    auto node_to_sub = assign_submeshes(stage_order, edges, connections, num_submeshes, node_chip_counts, chips);
+    auto node_to_sub = assign_submeshes(stage_order, edges, connections, num_submeshes);
 
     // ------------------------------------------------------------------
     // 5. Resolve physical coords for every edge

--- a/ttnn/cpp/ttnn-nanobind/pipeline_module_nanobind.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pipeline_module_nanobind.cpp
@@ -236,13 +236,10 @@ void bind_pipeline_builder(nb::module_& mod) {
     mod.def(
         "resolve_graph_layout",
         [](const std::vector<tt::tt_fabric::EdgeInputTuple>& edges,
-           const std::vector<std::vector<tt::tt_fabric::ChipTuple>>& submesh_chips,
-           const std::map<std::string, uint32_t>& node_chip_counts) -> tt::tt_fabric::GraphLayoutResult {
-            return tt::tt_fabric::resolve_graph_layout(edges, submesh_chips, node_chip_counts);
-        },
+           const std::vector<std::vector<tt::tt_fabric::ChipTuple>>& submesh_chips)
+            -> tt::tt_fabric::GraphLayoutResult { return tt::tt_fabric::resolve_graph_layout(edges, submesh_chips); },
         nb::arg("edges"),
         nb::arg("submesh_chips"),
-        nb::arg("node_chip_counts") = std::map<std::string, uint32_t>{},
         R"(
             Auto-discover the physical layout of a pipeline graph.
 
@@ -256,12 +253,6 @@ void bind_pipeline_builder(nb::module_& mod) {
                                edge from the last stage back to stage 0.
                 submesh_chips: For each submesh, a list of (mesh_id, chip_id, row, col)
                                tuples (obtained from submesh.get_fabric_node_id()).
-                node_chip_counts: Optional {node_name: expected_chip_count} map. When a
-                               node is present, it may only be assigned to a submesh with
-                               exactly that many chips (rows*cols of its declared shape),
-                               so e.g. a 4x2 stage cannot land on a 1x2 submesh. Nodes
-                               absent from the map are unconstrained; an empty map (default)
-                               disables the shape filter.
 
             Returns:
                 GraphLayoutResult with physical coords for every edge and the H2D/D2H


### PR DESCRIPTION
## Summary (draft — bisect-identified revert; validation in flight)

CI bisect identified **`96563e65` — "Add fixes to pipeline builder to match shape" (#48758)** as the first-bad commit for the **Qwen3-32B e2e (Galaxy) Top-1 accuracy 0.0%** regression (issue #49266). This draft reverts it to confirm/restore accuracy.

## ⚠️ Update: the revert is very likely NOT the real fix (code review)

On inspecting the actual diff, **#48758 is a no-op-by-default change and its modified code has no callers**:
- It adds an **optional** `node_chip_counts` param to `resolve_graph_layout` / `assign_submeshes`. The shape filter runs **only** for nodes present in that map.
- The default is an **empty map at both layers** — C++ (`= {}`) and the nanobind binding (`nb::arg("node_chip_counts") = {}`) — which explicitly **disables the filter (legacy behavior)**.
- #48758 added **no caller** that passes a non-empty map, and in fact `grep` finds **no caller of `resolve_graph_layout` anywhere** in `tt_metal`/`ttnn`/`models`/`tests`. The touched path is not exercised by the model.

⇒ #48758 is essentially incapable of changing Qwen3-32B numerics. The bisect most likely **mis-converged on Galaxy board-reset / ETH-heartbeat flakiness** (a non-accuracy infra failure scored as "bad"), which the good/bad window (07-03→07-06 all died on board-reset before accuracy was measured) is highly prone to.

## Decision this PR is gating on
The 3 validation runs below are the decisive experiment:
- **If the revert branch still shows Top-1 0.0%** → #48758 was a false positive; **close this PR** and re-bisect with an infra-aware wrapper (exit 125 / `git bisect skip` on board-reset, so only genuine accuracy failures count as "bad").
- **If it recovers to ~92%** (unexpected given the above) → investigate what indirect effect the revert had before landing.

## Validation runs (wh_galaxy_perf / `topology-6u`, `test_qwen_accuracy.py`, 3× for flakiness)
| Run | Link |
|-----|------|
| 28933698343 | https://github.com/tenstorrent/tt-metal/actions/runs/28933698343 |
| 28933732129 | https://github.com/tenstorrent/tt-metal/actions/runs/28933732129 |
| 28933738313 | https://github.com/tenstorrent/tt-metal/actions/runs/28933738313 |

## Bisect evidence (issue #49266)
- good=`3d132def0b2` (2026-07-02, Top-1 **92%**), bad=`338995ab39b` (2026-07-07, Top-1 **0.0%**)
- Automated `bisect-dispatch` on `topology-6u` (wh_galaxy_perf), `test_qwen_accuracy.py`, attempts=5: reported first-bad = `96563e65` (#48758) ([bisect run 28883220335](https://github.com/tenstorrent/tt-metal/actions/runs/28883220335)) — **now suspected a flakiness artifact, see above.**
- Reverts cleanly (3 files).

Closes-when-verified: #49266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/revert-48758-qwen-galaxy-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/revert-48758-qwen-galaxy-accuracy)
