### PR TITLE
ds_prefill - Remove extract OP from routed expert

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -56,7 +56,7 @@ def test_deepseek_v3_moe_perf_loudbox():
         # Recalibrated 2026-06-24 on BH LoudBox 2x4 for the same in-place direct-write
         # change (no full-buffer device fill per layer): 35.13 ms -> 32.31 ms. UP_SPLIT
         # was already baked in (39_194_517 -> 35_127_772). Was 35_127_772.
-        expected_ns_2x4=32_308_487,
+        expected_ns_2x4=31_331_606,
         model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -73,7 +73,7 @@ _SUBTORUS_Y4_ENV = {
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            49_760_000,  # Re-centered 2026-06-25 for two stacked speedups now in the tree -- BOTH
+            48_248_396,  # Re-centered 2026-07-09 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (drop the separate output buffer + per-layer fill;
             # measured 50.61 ms alone) AND #47536 (update_padded_kv_cache RM/fp8; measured 51.29 ms
             # alone). The combined 2x4-2link number can't be measured on the galaxy, so the target is

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -101,7 +101,7 @@ _SUBTORUS_Y4_ENV = {
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-8x4 and layer3 and gate_device and no_ref and isl_25k'",
-            79_276_954,  # Recalibrated 2026-07-05 (perf improvement, was 87_100_959).
+            76_706_230,  # Recalibrated 2026-07-05 (perf improvement, was 87_100_959).
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer3_moe_fabric2d",
             1,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -7,8 +7,10 @@
 // Per-core responsibilities, sequenced over `effective_chunks` chunks
 // (effective_chunks = ceil(this expert's token count / chunk_M_tiles)):
 //   - Read counts/idx_table scratch once at kernel start to discover this
-//     expert's active token count. x is the already-extracted per-expert
-//     token tensor — tile reads always start at row 0.
+//     expert's active token count. x tile reads start at row 0 unless
+//     read_x_at_offset is set, in which case x is a shared buffer and this
+//     expert's rows begin at start[global_id] (fusing what ttnn::extract did);
+//     the reader adds (start / TILE) * K_gate_tiles to every x page index.
 //   - Phase 1 (gate matmul, fused with phase 2): per K-block, sender at
 //     gx=0 NoC-mcasts the x K-block to its M-row receivers (in0 mcast);
 //     sender at gy=0 NoC-mcasts the gate+up K-block to its N-col
@@ -118,6 +120,11 @@ void kernel_main() {
     // NoC 1 into cb_in1_up); both 0 = UP_WRITER_MCAST, reader skips up.
     constexpr uint32_t reader_reads_up = get_compile_time_arg_val(23);
     constexpr uint32_t reader_mcasts_up = get_compile_time_arg_val(24);
+    // read_x_at_offset: x is a shared buffer; offset x reads by this expert's
+    // region start (start[global_id]/TILE tile-rows). 0 => x is per-expert,
+    // reads start at row 0. cb_start_scratch holds the fetched `start` page.
+    constexpr uint32_t read_x_at_offset = get_compile_time_arg_val(25);
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(26);
     // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
@@ -128,7 +135,7 @@ void kernel_main() {
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t num_blocks_d = K_down_tiles_padded / in0_block_w_d;
 
-    constexpr uint32_t x_accessor_offset = 25;
+    constexpr uint32_t x_accessor_offset = 27;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
 
@@ -152,6 +159,14 @@ void kernel_main() {
     constexpr auto idx_args = TensorAccessorArgs<idx_accessor_offset>();
     const auto idx_acc = TensorAccessor(idx_args, idx_table_addr);
 
+    // `start` (= expert_region_offsets) accessor. Appended last in the reader's
+    // accessor stream; read only when read_x_at_offset. start_addr is the final
+    // runtime arg, after the GRID_X-pair M-row NoC table at M_ROW_NOC_RT_OFFSET.
+    const uint32_t start_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC);
+    constexpr uint32_t start_accessor_offset = idx_args.next_compile_time_args_offset();
+    constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
+    const auto start_acc = TensorAccessor(start_args, start_addr);
+
     // D2.0 NoC handles. `noc` uses default noc_index for mcasts/sem ops.
     // `noc_read` forces NoC 0 for DRAM weight/page reads — the kernel issues
     // those concurrently with mcast traffic on the kernel's default NoC for
@@ -168,6 +183,7 @@ void kernel_main() {
     CircularBuffer cb_in0_down_full_obj(cb_in0_down_full);
     CircularBuffer cb_counts_scratch_obj(cb_counts_scratch);
     CircularBuffer cb_idx_scratch_obj(cb_idx_scratch);
+    CircularBuffer cb_start_scratch_obj(cb_start_scratch);
     CircularBuffer cb_activated_obj(cb_activated);
 
     // D2.0 Semaphore wrappers.
@@ -212,6 +228,23 @@ void kernel_main() {
     const uint32_t effective_chunks_runtime = (count_tiles + chunk_M_tiles - 1) / chunk_M_tiles;
     // Clamp to compile-time num_chunks just in case (defensive against bad input).
     const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
+
+    // x-read row offset. Zero unless read_x_at_offset: then x is a shared buffer
+    // and this expert's rows begin at start[global_id]. Fetch the start page and
+    // convert the token row to a tile-page offset (row_tile * K_gate_tiles), the
+    // exact source rebase ttnn::extract used to perform. Must agree with the
+    // writer's row_offset_tiles so x is read and y is written to the same region.
+    uint32_t x_start_tile_idx = 0;
+    if constexpr (read_x_at_offset != 0) {
+        cb_start_scratch_obj.reserve_back(1);
+        const uint32_t start_l1 = cb_start_scratch_obj.get_write_ptr();
+        noc_read.async_read(
+            start_acc, CoreLocalMem<uint32_t>(start_l1), start_acc.get_aligned_page_size(), {.page_id = 0}, {});
+        noc_read.async_read_barrier();
+        cb_start_scratch_obj.push_back(1);
+        const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
+        x_start_tile_idx = (start_ptr[global_expert_id] / 32) * K_gate_tiles;
+    }
 
     // Per-chunk pre-zero bookkeeping. For each chunk we decide whether
     // THIS core (as in0 sender) needs to zero its cb_in0_x slots before
@@ -344,7 +377,9 @@ void kernel_main() {
                     if (row_valid) {
                         for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
                             const uint32_t col = kb * in0_block_w_gu + k;
-                            const uint32_t tile_idx = row * K_gate_tiles + col;
+                            // x_start_tile_idx offsets into this expert's region
+                            // of a shared buffer (0 when x is per-expert).
+                            const uint32_t tile_idx = x_start_tile_idx + row * K_gate_tiles + col;
                             noc_read.async_read(
                                 x_acc, CoreLocalMem<uint32_t>(l1_x), x_tile_bytes, {.page_id = tile_idx}, {});
                             l1_x += x_tile_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -253,6 +253,7 @@ ttnn::Tensor unified_routed_expert_ffn(
             .m_tiles = m_tiles,
             .local_expert_id = local_expert_id,
             .read_x_at_offset = read_x_at_offset,
+            .activation = activation,
             .compute_kernel_config = compute_kernel_config},
         OperationType::tensor_args_t{
             .x = x,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -61,6 +61,12 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
     constexpr uint32_t TILE = tt::constants::TILE_HEIGHT;
     TT_FATAL(x_shape[-2] % TILE == 0, "x M ({}) must be tile-aligned", x_shape[-2]);
     TT_FATAL(op.chunk_M_tiles > 0, "chunk_M_tiles must be > 0");
+    // m_tiles is this expert's M (grid/chunk/CB sizing). x may be a shared
+    // buffer spanning many experts, so its allocated M only bounds m_tiles from
+    // above — the reader/writer index into x at the region offset.
+    TT_FATAL(op.m_tiles > 0, "m_tiles must be > 0");
+    TT_FATAL(
+        op.m_tiles <= x_shape[-2] / TILE, "m_tiles ({}) must be <= x M in tiles ({})", op.m_tiles, x_shape[-2] / TILE);
 
     // Weight tensors share x's storage / layout / memory contract — fail
     // host-side if the caller forgot to upload one, picked the wrong layout,
@@ -229,6 +235,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& global_expert_idx_table,
     uint32_t local_expert_id,
     uint32_t chunk_M_tiles,
+    uint32_t m_tiles,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
@@ -238,6 +245,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .chunk_M_tiles = chunk_M_tiles,
+            .m_tiles = m_tiles,
             .local_expert_id = local_expert_id,
             .activation = activation,
             .compute_kernel_config = compute_kernel_config},

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -67,6 +67,10 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(op.m_tiles > 0, "m_tiles must be > 0");
     TT_FATAL(
         op.m_tiles <= x_shape[-2] / TILE, "m_tiles ({}) must be <= x M in tiles ({})", op.m_tiles, x_shape[-2] / TILE);
+    // read_x_at_offset needs expert_region_offsets to locate this expert's x
+    // rows in the shared buffer (the reader fetches start[global_id]).
+    TT_FATAL(
+        !op.read_x_at_offset || t.expert_region_offsets.has_value(), "read_x_at_offset requires expert_region_offsets");
 
     // Weight tensors share x's storage / layout / memory contract — fail
     // host-side if the caller forgot to upload one, picked the wrong layout,
@@ -236,6 +240,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t local_expert_id,
     uint32_t chunk_M_tiles,
     uint32_t m_tiles,
+    bool read_x_at_offset,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
@@ -247,7 +252,7 @@ ttnn::Tensor unified_routed_expert_ffn(
             .chunk_M_tiles = chunk_M_tiles,
             .m_tiles = m_tiles,
             .local_expert_id = local_expert_id,
-            .activation = activation,
+            .read_x_at_offset = read_x_at_offset,
             .compute_kernel_config = compute_kernel_config},
         OperationType::tensor_args_t{
             .x = x,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
@@ -42,6 +42,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t local_expert_id,
     uint32_t chunk_M_tiles,
     uint32_t m_tiles,
+    bool read_x_at_offset,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
@@ -41,6 +41,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& global_expert_idx_table,
     uint32_t local_expert_id,
     uint32_t chunk_M_tiles,
+    uint32_t m_tiles,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -50,6 +50,9 @@ constexpr uint32_t CB_PARTIALS_UP = tt::CBIndex::c_13;
 // page in direct-write mode. Allocated unconditionally (negligible L1) so
 // the CB-index layout is stable across both write modes.
 constexpr uint32_t CB_START_SCRATCH = tt::CBIndex::c_14;
+// Reader's own `start` scratch, used when read_x_at_offset (x is a shared
+// buffer). Separate from the writer's so the two RISCs don't share one L1 page.
+constexpr uint32_t CB_START_SCRATCH_READER = tt::CBIndex::c_15;
 }  // namespace
 
 UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnProgramFactory::create(
@@ -586,6 +589,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH, tt::DataFormat::UInt32}})
             .set_page_size(CB_START_SCRATCH, start_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_cb_cfg);
+    // Reader's `start` scratch (read_x_at_offset). Same sizing; separate CB so
+    // reader (BRISC) and writer (NCRISC) never share one scratch page.
+    tt::tt_metal::CircularBufferConfig start_reader_cb_cfg =
+        tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH_READER, tt::DataFormat::UInt32}})
+            .set_page_size(CB_START_SCRATCH_READER, start_scratch_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_reader_cb_cfg);
 
     // -------------------------- kernel build ------------------------------
     // Reader compile-time args. Order must exactly match the layout the reader
@@ -624,6 +633,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         static_cast<uint32_t>(reader_reads_up),
         // reader_mcasts_up — 1 in LEGACY and UP_SPLIT (reader NoC-0 mcasts up).
         static_cast<uint32_t>(reader_mcasts_up),
+        // read_x_at_offset — 1 => x is a shared buffer, offset x reads by this
+        // expert's region start; 0 => x is per-expert, reads start at row 0.
+        static_cast<uint32_t>(op.read_x_at_offset),
+        // CB_START_SCRATCH_READER — L1 page holding the fetched `start` vector.
+        CB_START_SCRATCH_READER,
     };
     tt::tt_metal::TensorAccessorArgs(x_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(gate_buffer).append_to(reader_ct_args);
@@ -631,6 +645,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     tt::tt_metal::TensorAccessorArgs(down_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(idx_buffer).append_to(reader_ct_args);
+    // `start` accessor — appended last, matching the reader's accessor stream.
+    // Points at expert_region_offsets in direct/offset mode, else out_buffer
+    // (unread when read_x_at_offset is 0), keeping the CT-arg layout stable.
+    tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(reader_ct_args);
 
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -852,7 +870,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         //  19..28: in0 multicast args
         //  29: act_ready_sem_id  30: act_valid_sem_id
         //  31: up_go_sem_id  32: up_done_sem_id
-        //  33+: M-row NoC coord table (GRID_X pairs of x, y)
+        //  33..33+2*GRID_X-1: M-row NoC coord table (GRID_X pairs of x, y)
+        //  33+2*GRID_X: start_addr (expert_region_offsets; read only when
+        //     read_x_at_offset, else points at out_buffer and is unread)
         std::vector<uint32_t> reader_args = {
             x_buffer->address(),
             gate_buffer->address(),
@@ -898,6 +918,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             reader_args.push_back(static_cast<uint32_t>(noc.x));
             reader_args.push_back(static_cast<uint32_t>(noc.y));
         }
+        // start_addr — last reader arg (see layout comment). Same buffer the
+        // writer gets; read by the reader only when read_x_at_offset.
+        reader_args.push_back(start_buffer->address());
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
 
         // Writer runtime arg layout (must match unified_routed_expert_ffn_writer.cpp):
@@ -957,6 +980,8 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
         reader_args[3] = down_addr;
         reader_args[4] = counts_addr;
         reader_args[5] = idx_addr;
+        // start_addr is the last reader arg (after the M-row NoC table).
+        reader_args[reader_args.size() - 1] = start_addr;
 
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -62,7 +62,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const auto& gate_shape = t.gate_proj.padded_shape();
     const auto& down_shape = t.down_proj.padded_shape();
 
-    const uint32_t M_tiles_full = x_shape[-2] / TILE;
+    // This expert's M (not x's allocated M): x may be a shared buffer wider
+    // than one expert's region. K still comes from x's last dim (emb).
+    const uint32_t M_tiles_full = op.m_tiles;
     const uint32_t K_gate_tiles = x_shape[-1] / TILE;            // = N_gate K = emb / TILE
     const uint32_t N_gate_tiles_full = gate_shape[-1] / TILE;    // = hidden / TILE
     const uint32_t K_down_tiles = down_shape[-2] / TILE;         // = hidden / TILE

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -64,12 +64,17 @@ struct UnifiedRoutedExpertFfnParams {
     // ttnn::extract did. Requires expert_region_offsets. False => x is per-expert.
     bool read_x_at_offset = false;
 
+    // Per-expert FFN activation variant. Baked into the compute kernel as a
+    // compile-time define, so each variant caches as a distinct program — hence
+    // it is part of the program-cache key below.
+    RoutedExpertActivation activation = RoutedExpertActivation::Silu;
+
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
     static constexpr auto attribute_names =
-        std::forward_as_tuple("chunk_M_tiles", "m_tiles", "local_expert_id", "read_x_at_offset");
+        std::forward_as_tuple("chunk_M_tiles", "m_tiles", "local_expert_id", "read_x_at_offset", "activation");
     auto attribute_values() const {
-        return std::forward_as_tuple(chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset);
+        return std::forward_as_tuple(chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset, activation);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -59,15 +59,18 @@ struct UnifiedRoutedExpertFfnParams {
     // counts[global_id]).
     uint32_t local_expert_id = 0;
 
-    // Activation variant (see RoutedExpertActivation). Default Silu = DeepSeek
-    // path, kernel unchanged. SwiGluOai drives the SWIGLU_OAI compile-time define
-    // in the compute kernel.
-    RoutedExpertActivation activation = RoutedExpertActivation::Silu;
+    // When true, x is a shared buffer and the reader offsets its x reads by this
+    // expert's region start (expert_region_offsets[global_id]) — fusing what
+    // ttnn::extract did. Requires expert_region_offsets. False => x is per-expert.
+    bool read_x_at_offset = false;
 
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("chunk_M_tiles", "m_tiles", "local_expert_id");
-    auto attribute_values() const { return std::forward_as_tuple(chunk_M_tiles, m_tiles, local_expert_id); }
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("chunk_M_tiles", "m_tiles", "local_expert_id", "read_x_at_offset");
+    auto attribute_values() const {
+        return std::forward_as_tuple(chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset);
+    }
 };
 
 // Tensors fed into the op.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -47,6 +47,13 @@ struct UnifiedRoutedExpertFfnParams {
     // keeps DeepSeek V3 routed-expert dims inside Blackhole L1.
     uint32_t chunk_M_tiles = 64;
 
+    // This expert's M dimension in tiles — the row count the matmul grid,
+    // chunk loop, and CB sizes are built for. Decoupled from x's shape so x
+    // may be a shared buffer larger than one expert's region: the reader/writer
+    // index into it at the region offset while the op still sizes its work to a
+    // single expert. When x IS the per-expert tensor this equals x_padded[-2]/TILE.
+    uint32_t m_tiles = 0;
+
     // Local expert id used to index `global_expert_idx_table` at runtime
     // (kernel reads global_id = idx_table[local_expert_id], then count =
     // counts[global_id]).
@@ -59,8 +66,8 @@ struct UnifiedRoutedExpertFfnParams {
 
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("chunk_M_tiles", "local_expert_id", "activation");
-    auto attribute_values() const { return std::forward_as_tuple(chunk_M_tiles, local_expert_id, activation); }
+    static constexpr auto attribute_names = std::forward_as_tuple("chunk_M_tiles", "m_tiles", "local_expert_id");
+    auto attribute_values() const { return std::forward_as_tuple(chunk_M_tiles, m_tiles, local_expert_id); }
 };
 
 // Tensors fed into the op.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -7,7 +7,6 @@
 #include "device/unified_routed_expert_ffn_device_operation.hpp"
 #include "tt-metalium/math.hpp"
 #include "ttnn/operations/creation/creation.hpp"
-#include "ttnn/operations/experimental/deepseek_prefill/extract/extract.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn {
@@ -103,47 +102,41 @@ ttnn::Tensor unified_routed_expert_moe(
     const uint32_t experts_per_chip = static_cast<uint32_t>(gate_projs.size());
     TT_FATAL(experts_per_chip > 0, "Need at least one expert per chip");
 
-    // Per-expert composite: extract this expert's tokens out of the dispatched
-    // buffer, run the unified FFN on them, and have the FFN's writer place the
-    // result DIRECTLY back into the SAME dispatched buffer at the expert's
-    // region offset (in-place direct-write mode). This fuses what used to be a
-    // separate ttnn::insert op into the FFN writer — the FFN no longer writes a
-    // per-expert temp buffer that insert then copies elsewhere; it writes the
-    // dispatched buffer in place once. Same loop applies regardless of
-    // `num_routed_experts`, and the (mutated) dispatched buffer is returned.
+    // Per-expert composite: run the unified FFN on this expert's slice of the
+    // dispatched buffer IN PLACE. The FFN reads x directly from the dispatched
+    // buffer at the expert's region offset (read_x_at_offset) and its writer
+    // places the result back into the SAME buffer at the same offset
+    // (expert_region_offsets). This fuses what used to be a separate
+    // ttnn::extract (input slice) + ttnn::insert (output placement) pair into
+    // the FFN's reader and writer — no per-expert temp buffer, no extra DRAM
+    // round-trip. Same loop regardless of `num_routed_experts`; the (mutated)
+    // dispatched buffer is returned.
     //
-    // In-place is safe across the loop: extract for expert i copies region i out
-    // into a fresh `tokens` tensor before the FFN overwrites region i, and each
-    // expert only touches its own (non-overlapping) region, so a later expert's
-    // extract still reads its original dispatched rows.
+    // x is the whole shared buffer, so pass this expert's row count
+    // (max_dispatched_tokens_per_expert in tiles) as input_m_tiles — the op
+    // sizes its grid/chunks to one expert, not the buffer.
     //
-    // `tokens` from extract is a per-expert (max_dispatched_tokens_per_expert,
-    // emb) tensor with rows starting at 0. The FFN reads from row 0 of its
-    // inputs; passing expert_region_offsets makes the writer add
-    // expert_region_offsets[global_expert_id]/TILE tile-rows so the output lands
-    // back in this expert's slice of the dispatched buffer.
+    // In-place read+write of one region is safe: within the op the reader reads
+    // x in phase 1 and the writer drains cb_out only after compute consumes it,
+    // so the write of a row is ordered after its read via the CB chain; chunks
+    // cover disjoint rows. Across the loop each expert touches only its own
+    // (non-overlapping) region, so the read/write of expert i cannot disturb
+    // expert j's rows.
     //
-    // No separate output allocation or zero-fill: because the FFN writes back
-    // into the existing dispatched buffer (instead of a freshly-allocated
-    // output), there is no per-call DRAM allocation and no up-front fill. Rows
-    // the FFN writer does not touch (tile-aligned slack within a region, regions
-    // of zero-count experts, and the tail of the buffer) retain their original
-    // dispatched-buffer contents, which are never read by downstream `combine`
-    // (bounded per expert to [offset, offset + ceil_tile(count))).
+    // No separate output allocation or zero-fill: the FFN writes back into the
+    // existing dispatched buffer, so there is no per-call DRAM allocation and no
+    // up-front fill. Rows the writer does not touch (tile-aligned slack within a
+    // region, regions of zero-count experts, and the tail of the buffer) retain
+    // their original contents, which downstream `combine` never reads (bounded
+    // per expert to [offset, offset + ceil_tile(count))).
+    const uint32_t m_tiles = (max_dispatched_tokens_per_expert + 31) / 32;
     for (uint32_t local_expert = 0; local_expert < experts_per_chip; ++local_expert) {
-        auto tokens = ttnn::extract(
-            dispatched_buffer,
-            expert_region_offsets,
-            expert_token_counts,
-            global_expert_idx_table,
-            local_expert,
-            max_dispatched_tokens_per_expert);
-        // In-place direct-write: output == dispatched_buffer, with
-        // expert_region_offsets so the writer offsets into this expert's region
-        // of that same buffer. The op mutates dispatched_buffer in place; its
+        // output == dispatched_buffer with expert_region_offsets => writer
+        // offsets into this expert's region; read_x_at_offset => reader reads x
+        // from that same region. The op mutates dispatched_buffer in place; its
         // return value is unused (the composite returns dispatched_buffer below).
         unified_routed_expert_ffn(
-            tokens,
+            dispatched_buffer,
             gate_projs[local_expert],
             up_projs[local_expert],
             down_projs[local_expert],
@@ -153,7 +146,8 @@ ttnn::Tensor unified_routed_expert_moe(
             compute_kernel_config,
             dispatched_buffer,
             expert_region_offsets,
-            activation);
+            m_tiles,
+            /*read_x_at_offset=*/true);
     }
     return dispatched_buffer;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -23,7 +23,8 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<ttnn::Tensor>& output,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
     const std::optional<uint32_t>& input_m_tiles,
-    bool read_x_at_offset) {
+    bool read_x_at_offset,
+    RoutedExpertActivation activation) {
     // Single-op fused per-expert FFN. One device Program runs gate matmul,
     // up matmul, silu, multiply, down matmul as four phases inside the same
     // kernel. The kernel reads counts[global_expert_idx_table[local_expert_id]]
@@ -147,7 +148,8 @@ ttnn::Tensor unified_routed_expert_moe(
             dispatched_buffer,
             expert_region_offsets,
             m_tiles,
-            /*read_x_at_offset=*/true);
+            /*read_x_at_offset=*/true,
+            activation);
     }
     return dispatched_buffer;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -23,7 +23,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& output,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
-    RoutedExpertActivation activation) {
+    const std::optional<uint32_t>& input_m_tiles) {
     // Single-op fused per-expert FFN. One device Program runs gate matmul,
     // up matmul, silu, multiply, down matmul as four phases inside the same
     // kernel. The kernel reads counts[global_expert_idx_table[local_expert_id]]
@@ -46,7 +46,9 @@ ttnn::Tensor unified_routed_expert_ffn(
     constexpr uint32_t kGridY = 8;
     constexpr uint32_t kMinChunkMTiles = 16;  // per_core_M >= 2
     constexpr uint32_t kMaxChunkMTiles = 64;  // per_core_M <= 8 (L1 cap)
-    const uint32_t M_tiles_full = x.padded_shape()[-2] / 32;
+    // This expert's M in tiles. Defaults to x's allocated M; a caller passing a
+    // shared x buffer (wider than one region) supplies the per-expert value.
+    const uint32_t M_tiles_full = input_m_tiles.value_or(x.padded_shape()[-2] / 32);
     uint32_t chunk_M_tiles = kMaxChunkMTiles;
     uint32_t best_num_chunks = (M_tiles_full + kMinChunkMTiles - 1) / kMinChunkMTiles + 1;
     uint32_t best_waste = kMaxChunkMTiles + 1;
@@ -71,6 +73,7 @@ ttnn::Tensor unified_routed_expert_ffn(
         global_expert_idx_table,
         local_expert_id,
         chunk_M_tiles,
+        M_tiles_full,
         compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
                                           : std::nullopt,
         output,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -23,7 +23,8 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& output,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
-    const std::optional<uint32_t>& input_m_tiles) {
+    const std::optional<uint32_t>& input_m_tiles,
+    bool read_x_at_offset) {
     // Single-op fused per-expert FFN. One device Program runs gate matmul,
     // up matmul, silu, multiply, down matmul as four phases inside the same
     // kernel. The kernel reads counts[global_expert_idx_table[local_expert_id]]
@@ -74,6 +75,7 @@ ttnn::Tensor unified_routed_expert_ffn(
         local_expert_id,
         chunk_M_tiles,
         M_tiles_full,
+        read_x_at_offset,
         compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
                                           : std::nullopt,
         output,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -52,6 +52,9 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 //   input_m_tiles: optional per-expert M in tiles. Defaults to x's allocated
 //      M (x_padded[-2]/TILE). Supply it when x is a shared buffer wider than
 //      one expert's region so the op sizes its grid/chunks to this expert only.
+//   read_x_at_offset: when true, x is a shared buffer and the reader offsets
+//      its x reads by expert_region_offsets[global_id] (fusing ttnn::extract).
+//      Requires expert_region_offsets. False => x is per-expert (rows at 0).
 ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& x,
     const ttnn::Tensor& gate_proj,
@@ -63,7 +66,8 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     const std::optional<ttnn::Tensor>& output = std::nullopt,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
-    const std::optional<uint32_t>& input_m_tiles = std::nullopt);
+    const std::optional<uint32_t>& input_m_tiles = std::nullopt,
+    bool read_x_at_offset = false);
 
 // MoE-level composite: takes the dispatched buffer + ALL local experts'
 // weights and loops over local experts in C++, calling

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -67,7 +67,8 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<ttnn::Tensor>& output = std::nullopt,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
     const std::optional<uint32_t>& input_m_tiles = std::nullopt,
-    bool read_x_at_offset = false);
+    bool read_x_at_offset = false,
+    RoutedExpertActivation activation = RoutedExpertActivation::Silu);
 
 // MoE-level composite: takes the dispatched buffer + ALL local experts'
 // weights and loops over local experts in C++, calling

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -49,6 +49,9 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 //      writer places this expert's output directly into `output` (the shared
 //      buffer) at start[global_id]/TILE tile-rows, fusing the ttnn::insert
 //      step (no temp-buffer DRAM round-trip). Requires `output` to be set.
+//   input_m_tiles: optional per-expert M in tiles. Defaults to x's allocated
+//      M (x_padded[-2]/TILE). Supply it when x is a shared buffer wider than
+//      one expert's region so the op sizes its grid/chunks to this expert only.
 ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& x,
     const ttnn::Tensor& gate_proj,
@@ -60,7 +63,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     const std::optional<ttnn::Tensor>& output = std::nullopt,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
-    RoutedExpertActivation activation = RoutedExpertActivation::Silu);
+    const std::optional<uint32_t>& input_m_tiles = std::nullopt);
 
 // MoE-level composite: takes the dispatched buffer + ALL local experts'
 // weights and loops over local experts in C++, calling

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -72,6 +72,9 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
             input_m_tiles (int, optional): this expert's M in tiles. Defaults to
                 x's allocated M. Supply it when x is a shared buffer wider than
                 one expert's region so the op sizes its work to this expert.
+            read_x_at_offset (bool, optional): when True, x is a shared buffer
+                and the reader offsets x reads by expert_region_offsets[global_id]
+                (fusing ttnn::extract). Requires expert_region_offsets. Default False.
 
         Returns:
             ttnn.Tensor: (M_max, K=emb).
@@ -88,7 +91,8 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("output") = nb::none(),
         nb::arg("expert_region_offsets") = nb::none(),
-        nb::arg("input_m_tiles") = nb::none());
+        nb::arg("input_m_tiles") = nb::none(),
+        nb::arg("read_x_at_offset") = false);
 
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -75,6 +75,8 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
             read_x_at_offset (bool, optional): when True, x is a shared buffer
                 and the reader offsets x reads by expert_region_offsets[global_id]
                 (fusing ttnn::extract). Requires expert_region_offsets. Default False.
+            activation (ttnn.RoutedExpertActivation, optional):
+                Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 / gpt-oss).
 
         Returns:
             ttnn.Tensor: (M_max, K=emb).
@@ -92,7 +94,8 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         nb::arg("output") = nb::none(),
         nb::arg("expert_region_offsets") = nb::none(),
         nb::arg("input_m_tiles") = nb::none(),
-        nb::arg("read_x_at_offset") = false);
+        nb::arg("read_x_at_offset") = false,
+        nb::arg("activation") = RoutedExpertActivation::Silu);
 
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -69,10 +69,9 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
                 start[global_id]/TILE tile-rows (direct-write mode), fusing the
                 ttnn::insert step. Requires ``output`` to be set. Defaults to
                 None (standalone per-expert output, rows start at 0).
-            activation (ttnn.RoutedExpertActivation, optional):
-                Silu (default) = plain SiLU SwiGLU (DeepSeek). SwiGluOai = clamped
-                swigluoai (MiniMax-M3 / gpt-oss): (clamp(up,+/-L)+1)*clamp(gate,max=L)*
-                sigmoid(alpha*clamp(gate,max=L)), alpha=1.702/L=7.0 baked in.
+            input_m_tiles (int, optional): this expert's M in tiles. Defaults to
+                x's allocated M. Supply it when x is a shared buffer wider than
+                one expert's region so the op sizes its work to this expert.
 
         Returns:
             ttnn.Tensor: (M_max, K=emb).
@@ -89,7 +88,7 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("output") = nb::none(),
         nb::arg("expert_region_offsets") = nb::none(),
-        nb::arg("activation") = RoutedExpertActivation::Silu);
+        nb::arg("input_m_tiles") = nb::none());
 
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(
         mod,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/48706

### Problem description
Currently extract OP is separated from routed expert and called before doing unified routed expert OP for every single local expert on every chip, which is not most efficient.

### What's changed
- Removed extract OP from unified routed expert, instead of writing data of each local expert to separate temporary DRAM Interleaved buffer, `reader kernel` of unified routed expert now directly reads data for each expert for whole `dispatched_buffer`.
- Reader kernel knows where to start reading data of `dispatched_buffer` for every expert, based on its `expert_region_offset` value.

### Performance

## DeepSeek V3 Prefill 5K
<img width="2148" height="724" alt="image" src="https://github.com/user-attachments/assets/ad7cb08a-ca72-4db0-abf1-ce33c0b78de0" />

## Kimi K2.6 Prefill 5K
<img width="2082" height="752" alt="image" src="https://github.com/user-attachments/assets/1a541970-c581-477e-9655-c17029e6ac6c" />

All measurements were done on `bh-glx-110-c09u08`

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/48706-extract-unifiedRE-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/48706-extract-unifiedRE-removal)