### PR TITLE
[DRAFT] WAR-semaphore in generic all_gather_async (explore true root-cause fix for batch-32 sampling non-determinism)

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -634,6 +634,9 @@ class SeedManager:
         # True only for the most recent get_new_values() call when at least
         # one active slot used an explicit request seed.
         self._active_request_seed = False
+        # Last non-identity slot remap applied, used to ignore a steady-state
+        # remap that is (incorrectly) re-emitted verbatim every decode step.
+        self._last_applied_remap = None
         # Mesh mapper for sharding seeds across rows when sampling_dp > 1.
         if tt_sampling._sampling_dp > 1:
             self._seed_mapper = ttnn.ShardTensor2dMesh(
@@ -782,13 +785,32 @@ class SeedManager:
         no-ops. Only non-identity entries trigger a move.
         """
         if not self._seed_active:
+            self._last_applied_remap = None
             return
-        moves = [(int(remap[i]), i) for i in range(len(remap)) if int(remap[i]) != i]
+        remap_key = tuple(int(remap[i]) for i in range(len(remap)))
+        moves = [(remap_key[i], i) for i in range(len(remap_key)) if remap_key[i] != i]
         if not moves:
+            # Identity: nothing moved. Clear the dedupe guard so a later genuine
+            # condense with the same shape is still applied.
+            self._last_applied_remap = None
             _log_sampling_debug(
                 self._sampling_debug_enabled, "SeedManager slot remap identity", seed_active=self._seed_active
             )
             return
+        # A genuine condense emits a one-shot delta: vLLM pops the remap and
+        # resets it to identity, so the next step is identity. A non-identity
+        # remap repeated verbatim on consecutive steps is a steady-state
+        # replication/layout map, not a condense — re-applying it every token
+        # would keep relabelling slots and corrupt per-user RNG state. Apply it
+        # once and ignore the verbatim repeats.
+        if remap_key == self._last_applied_remap:
+            _log_sampling_debug(
+                self._sampling_debug_enabled,
+                "SeedManager slot remap skipped repeat",
+                seed_active=self._seed_active,
+            )
+            return
+        self._last_applied_remap = remap_key
         # Snapshot the state we're about to overwrite.
         _log_sampling_debug(
             self._sampling_debug_enabled,
@@ -799,8 +821,6 @@ class SeedManager:
         old_seeds = list(self.seeds)
         old_counters = list(self.seed_counters)
         old_rngs = list(self.rngs)
-        moved_sources = {old_slot for old_slot, _ in moves}
-        moved_destinations = {new_slot for _, new_slot in moves}
         for old_slot, new_slot in moves:
             self.seeds[new_slot] = old_seeds[old_slot]
             self.seed_counters[new_slot] = old_counters[old_slot]
@@ -808,9 +828,12 @@ class SeedManager:
             # independent object so the old slot reference does not alias
             # the new one.
             self.rngs[new_slot] = copy.copy(old_rngs[old_slot])
-        for old_slot in moved_sources - moved_destinations:
-            self.seeds[old_slot] = None
-            self.seed_counters[old_slot] = 0
+        # NOTE: deliberately do not clear "moved source" slots to None here.
+        # A source that was genuinely vacated by a condense is harmless to leave
+        # populated (an inactive slot is pushed MAX_UINT32/SKIP and is never read
+        # back, and a reused slot is reset via reset_seed). Clearing was unsafe
+        # because a replication map lists real, still-active requests as sources;
+        # zeroing them dropped reproducible seeds and broke determinism.
         self._seed_active = any(s is not None for s in self.seeds)
         _log_sampling_debug(
             self._sampling_debug_enabled,

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -326,9 +326,17 @@ class TTPenalties(LightweightModule):
         # Non-row-sharded: token shape is [1,1,1,batch] → shape[-1]==batch, shape[-2]==1
         # Row-sharded:     token shape is [1,1,batch,1] → shape[-2]==batch, shape[-1]==1
         batch = self.per_row_batch_size
-        if (new_tokens.shape[-1] == batch and new_tokens.shape[-2] == 1) or (
+        fast_path = (new_tokens.shape[-1] == batch and new_tokens.shape[-2] == 1) or (
             new_tokens.shape[-2] == batch and new_tokens.shape[-1] == 1
-        ):
+        )
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "TTPenalties update output tokens",
+            new_tokens_shape=list(new_tokens.shape),
+            per_row_batch=batch,
+            fast_path=fast_path,
+        )
+        if fast_path:
             new_tokens = ttnn.reshape(new_tokens, [batch, 1], **self._op_kwargs)
             src = self.decode_src
         else:

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -765,7 +765,11 @@ class TTSampling(LightweightModule):
             user_ids=self.user_ids_tt_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
         )
-        # Perform the actual sampling with top-k, top-p, and temperature
+        # Perform the actual sampling with top-k, top-p, and temperature. When the CCL layer provides a
+        # WAR semaphore (llama3_70b_galaxy decode), each sampling core multicast-signals it after its
+        # final read so the next step's SAMPLING_VALUES gather can safely reuse the persistent buffer.
+        war_semaphore = getattr(self.tt_ccl, "war_semaphore", None)
+        war_sem_drain_core = getattr(self.tt_ccl, "war_sem_drain_core", None)
         tt_out_tok = ttnn.sampling(
             topk_values_gathered_bf16_interleaved,
             topk_global_indices_interleaved_untilised,
@@ -774,6 +778,8 @@ class TTSampling(LightweightModule):
             temp=self.temp_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
             output_tensor=tt_out_tok,
+            war_semaphore=war_semaphore,
+            war_sem_drain_core=war_sem_drain_core,
         )
 
         # Compute logprobs if enabled

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -452,13 +452,46 @@ class TTSampling(LightweightModule):
             sub_core_grids=self.sub_core_grids,
         )
 
-    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+    def _perform_all_gather(
+        self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None, enable_war=False
+    ):
         """
         Flexible all-gather that works across different CCL implementations.
 
         - If `tt_ccl` exposes `line_all_gather`, prefer it (enables persistent buffer usage on some stacks).
         - Otherwise fall back to `ttnn.all_gather`.
+
+        WAR-hazard demo (#48222/#48469): when TT_SAMPLING_WAR_DEMO=1, route the tt-transformers gather
+        through all_gather_async so it can (a) reproduce the broken batch-32 timing by dropping the
+        cross-device barrier, and (b) optionally gate buffer reuse on a WAR semaphore signaled by the
+        downstream ttnn.sampling op. Only the first (values) gather is gated (`enable_war`): once its
+        WAR-wait clears, the prior step's sampling read is provably complete, so the subsequent indices
+        overwrite in the same step is also safe from one signal. See the draft PR (#49353).
         """
+        import os
+
+        if os.environ.get("TT_SAMPLING_WAR_DEMO") == "1" and not callable(self._line_all_gather):
+            war_semaphore = getattr(self.tt_ccl, "war_semaphore", None) if enable_war else None
+            war_wait_value = getattr(self.tt_ccl, "war_sem_wait_value", None) if enable_war else None
+            use_barrier = os.environ.get("TT_SAMPLING_WAR_NOBARRIER") != "1"
+            barrier_semaphore = (
+                self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis) if use_barrier else None
+            )
+            return ttnn.experimental.all_gather_async(
+                tensor,
+                persistent_output_buffer=None,
+                dim=dim,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+                num_links=num_links,
+                memory_config=memory_config,
+                cluster_axis=cluster_axis,
+                topology=ttnn.Topology.Linear,
+                barrier_semaphore=barrier_semaphore,
+                num_buffers_per_channel=2,
+                war_semaphore=war_semaphore,
+                war_wait_value=war_wait_value,
+            )
+
         if callable(self._line_all_gather):
             # Some implementations accept `buffer_key` (for persistent buffers), others may not.
             line_all_gather_kwargs = {
@@ -700,6 +733,7 @@ class TTSampling(LightweightModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 num_links=self.num_gather_links,
                 buffer_key="SAMPLING_VALUES",
+                enable_war=True,
             )
 
             ttnn.deallocate(topk_values)

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -325,13 +325,25 @@ class TTSampling(LightweightModule):
         self._invalid_vocab_tail_width = 0
 
         vocab_shard_dims = get_vocab_shard_dims(self.cluster_shape, self.sampling_all_gather_axis)
-        tail_mask = build_tail_invalid_vocab_mask(
-            self.vocab_size,
-            self.padded_vocab_size,
-            self.max_batch_size,
-            self.cluster_shape,
-            self.sampling_all_gather_axis,
-            tile_size=ttnn.TILE_SIZE,
+        # The compact tail-mask path slices off the valid region, masks the tail,
+        # and concats back. That reassembly is only safe when sampling runs on the
+        # full compute grid: on a sampling sub-core grid (e.g. Llama TG) the slice
+        # and concat are placed on different cores and the columns are stitched back
+        # incorrectly, so padded-vocab tokens (id >= vocab_size) survive into top-k
+        # and get sampled -> garbage / non-deterministic output. Fall back to the
+        # plain full-width additive mask (a single elementwise add, no reassembly)
+        # whenever a sub-core grid is in use.
+        tail_mask = (
+            build_tail_invalid_vocab_mask(
+                self.vocab_size,
+                self.padded_vocab_size,
+                self.max_batch_size,
+                self.cluster_shape,
+                self.sampling_all_gather_axis,
+                tile_size=ttnn.TILE_SIZE,
+            )
+            if self.sub_core_grids is None
+            else None
         )
         if tail_mask is not None:
             self._invalid_vocab_tail_width = tail_mask.tail_width
@@ -375,7 +387,10 @@ class TTSampling(LightweightModule):
             return self._mask_invalid_vocab_tail_logits(logits)
         if self.tt_invalid_vocab_mask is None:
             return logits
-        return ttnn.add(logits, self.tt_invalid_vocab_mask, memory_config=logits.memory_config())
+        op_kwargs = {"sub_core_grids": self.sub_core_grids} if self.sub_core_grids is not None else {}
+        return ttnn.add(
+            logits, self.tt_invalid_vocab_mask, memory_config=logits.memory_config(), **op_kwargs
+        )
 
     def _mask_invalid_vocab_tail_logits(self, logits):
         tail_width = self._invalid_vocab_tail_width

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -407,6 +407,11 @@ class TTSampling(LightweightModule):
             [valid_logits, masked_tail_logits],
             dim=3,
             memory_config=logits.memory_config(),
+            # Match the slices above: run concat on the sampling sub-device cores,
+            # otherwise the concat program is placed on the full Tensix grid and
+            # fails with "Kernel group cores do not match sub device cores"
+            # (TT_FATAL num_intersections == num_cores).
+            sub_core_grids=self.sub_core_grids,
         )
         ttnn.deallocate(valid_logits)
         ttnn.deallocate(tail_logits)

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -90,6 +90,58 @@ def test_seed_counter_position_alignment_skips_out_of_bounds_slots():
     assert seed_manager.seed_counters == [6, 0, 0, 0]
 
 
+def test_slot_remap_repeated_steady_state_preserves_seeds():
+    """A non-identity remap re-emitted verbatim every decode step (a steady-state
+    replication/layout map, not a condense) must not corrupt per-user seeds.
+
+    Regression for the Galaxy determinism failures: vLLM replicated rank 0's
+    requests across DP ranks and re-emitted the same remap every token. The old
+    code cleared the (still-active) source slots to None each step, so seeded
+    requests silently became unseeded and lost reproducibility.
+    """
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([42, 43], [0, 1])  # slots 0,1 seeded; 2,3 unseeded
+    assert seed_manager.seeds == [42, 43, None, None]
+
+    # remap[2]=0, remap[3]=1: slots 2,3 replicate slots 0,1 (sources stay active).
+    remap = torch.tensor([0, 1, 0, 1], dtype=torch.int32)
+    for _ in range(50):  # the bug applied this 1400+ times
+        seed_manager.apply_slot_remap(remap)
+
+    # Source slots keep their real seeds; replicas mirror them.
+    assert seed_manager.seeds[0] == 42
+    assert seed_manager.seeds[1] == 43
+    assert seed_manager.seeds[2] == 42
+    assert seed_manager.seeds[3] == 43
+    assert seed_manager._seed_active is True
+
+
+def test_slot_remap_genuine_condense_relabels_and_repeats_when_spaced():
+    """A real one-shot condense still relabels, and an identity step in between
+    re-arms the dedupe so a later same-shape condense is applied again."""
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([42, 99], [0, 3])  # slot0=42, slot3=99
+    assert seed_manager.seeds == [42, None, None, 99]
+
+    # Condense: request leaves slot1; slot3 moves into slot1. remap[1]=3.
+    condense = torch.tensor([0, 3, 2, 3], dtype=torch.int32)
+    seed_manager.apply_slot_remap(condense)
+    assert seed_manager.seeds[1] == 99  # relabelled
+
+    # Verbatim repeat is ignored (no re-relabel needed, state already correct).
+    seed_manager.apply_slot_remap(condense)
+    assert seed_manager.seeds[1] == 99
+
+    # An identity remap clears the dedupe guard...
+    identity = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+    seed_manager.apply_slot_remap(identity)
+    # ...so a genuinely new condense with the same shape applies again.
+    seed_manager.seeds[1] = None  # pretend slot1 emptied again
+    seed_manager._seed_active = any(s is not None for s in seed_manager.seeds)
+    seed_manager.apply_slot_remap(condense)
+    assert seed_manager.seeds[1] == 99
+
+
 def test_broadcast_sampling_params_preserves_none_list_fields():
     params = SamplingParams(temperature=[1.0, 1.0], top_k=[1, 1], top_p=[1.0, 1.0], seed=[None, 42])
 

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -739,10 +739,14 @@ class Generator(WarmupForwardMixin):
             if not work_use_batched_prefill:
                 prefill_kwargs["num_cached_tokens"] = num_cached_tokens_list[request_idx]
 
-            # Save output logits (PCC check / return_logits path)
+            # Save output logits (PCC check / return_logits path). Batched prefill fills
+            # one row per slot (padded_batch rows); non-batched fills a single row.
+            # (Previously always 1 row, which silently dropped all but the last batched
+            # user's logits -> garbage host-sampled tokens/logprobs for the rest.)
             tt_out_logits_saved = None
             if save_logits_to_host:
-                tt_out_logits_saved = torch.zeros(1, self.model.args.padded_vocab_size)
+                num_logit_rows = padded_batch if use_batched_prefill else 1
+                tt_out_logits_saved = torch.zeros(num_logit_rows, self.model.args.padded_vocab_size)
                 prefill_kwargs["tt_out_logits_saved"] = tt_out_logits_saved
 
             # With prefix caching, trace output has only prefill_seq_len positions (the chunk).
@@ -774,7 +778,12 @@ class Generator(WarmupForwardMixin):
                     output_toks[request_idx] = tt_tok
 
                 if tt_out_logits_all_users is not None and tt_out_logits_saved is not None:
-                    tt_out_logits_all_users[request_idx] = tt_out_logits_saved
+                    if use_batched_prefill:
+                        # tt_out_logits_saved holds one row per slot; pick each request's
+                        # slot row into its output row, mirroring the token scatter above.
+                        tt_out_logits_all_users[:, 0, :] = tt_out_logits_saved[empty_slots]
+                    else:
+                        tt_out_logits_all_users[request_idx] = tt_out_logits_saved
             else:
                 # Process prefill output to get logits (before all-gather) for on-device sampling
                 # Returns list of logits in sharded format (same as decode)

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -40,17 +40,6 @@ class TT_CCL:
         self.model_config = model_args.model_config
         self.weight_cache_path = model_args.weight_cache_path(ttnn.bfloat8_b)
         self.num_cbs = 2
-        # When a persistent output buffer is reused across non-blocking decode
-        # trace replays, line_all_gather normally drops the barrier semaphore
-        # (persistent buffer treated as a substitute for barrier syncing). That
-        # is unsafe for the sampling gathers (SAMPLING_VALUES/SAMPLING_INDICES):
-        # their consumers (ttnn.add offset / ttnn.sampling) run on the sampling
-        # sub-core grid, a different sub-device than the gather worker, so without
-        # a barrier the next step's gather can overwrite the buffer before the
-        # current step finishes reading it -> a few of 32 slots get stale
-        # candidates -> non-deterministic first decode token (flaky for months).
-        # Keep the barrier for these gathers even with a persistent buffer.
-        self._barrier_buffer_keys = {"SAMPLING_VALUES", "SAMPLING_INDICES", "SAMPLING"}
         self.from_remote_semaphore_handles = []
         self.to_remote_semaphore_handles = []
         self.all_gather_concat_inter_tensor = self.get_all_gather_concat_inter_buffer()
@@ -108,6 +97,27 @@ class TT_CCL:
         self.barrier_semaphore_idx = [0, 0]
         self.persistent_buffers = {}
         self.all_gather_buffers = {}
+        # WAR-hazard semaphore for safe reuse of the persistent SAMPLING_VALUES/INDICES all-gather
+        # buffers under decode trace. After its final read, the downstream sampling op increments this
+        # (once per user core) on the SAMPLING_VALUES gather's drain core; that gather waits on it
+        # before overwriting the buffer, closing the cross-sub-device Write-After-Read race that made
+        # the first decode token non-deterministic under trace. Created on sub_device_crs (a superset
+        # of the CCL worker cores, so the drain core's local copy is allocated).
+        #
+        # war_sem_drain_core is the gather's drain core = choose_worker_cores(worker_sub_device_id)[0]
+        # = first row-wise core of worker_cores_range_set (model_config.get_core_ranges), which is
+        # (1, 0). If that worker-core layout ever changes, update this coordinate to match.
+        self.war_semaphore = None
+        self.war_sem_drain_core = None
+        self.war_sem_wait_value = self.max_batch_size
+        if mode == "decode":
+            self.war_sem_drain_core = ttnn.CoreCoord(1, 0)
+            # Init value == wait value so the very first decode step's gather wait passes immediately
+            # (no prior sampling has signalled yet); each step then rebalances (32 signals -> reset 0).
+            self.war_semaphore = ttnn.create_global_semaphore(
+                self.mesh_device, self.sub_device_crs, self.war_sem_wait_value
+            )
+
         if mode == "decode":
             self.persistent_buffers = self.get_persistent_buffers()
             self.all_gather_buffers = self.get_all_gather_buffers()
@@ -1134,11 +1144,7 @@ class TT_CCL:
             persistent_buffer = self.all_gather_buffers.get(buffer_key, None)
         # ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.worker_sub_device_id])
         barrier_semaphore = None
-        if persistent_buffer is None or buffer_key in self._barrier_buffer_keys:
-            # persistent_buffer is None -> normal barrier. buffer_key in the
-            # sampling set -> persistent buffer present but reused cross-step by a
-            # different sub-device consumer, so keep the barrier to enforce
-            # consume-before-overwrite ordering and restore deterministic sampling.
+        if persistent_buffer is None:
             barrier_semaphore = self.get_and_cycle_barrier_semaphore_handle(cluster_axis)
         semaphores = (
             self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]][0]
@@ -1148,6 +1154,11 @@ class TT_CCL:
                 self.gather_semaphore_handles[cluster_axis][(self.gather_idx[cluster_axis] + 1) % self.num_cbs],
             ]
         )
+        # Only the SAMPLING_VALUES gather (first sampling gather of the decode step) waits on the WAR
+        # semaphore; being first on the worker sub-device it program-orders the whole sampling section
+        # after the previous step's ttnn.sampling, so the later SAMPLING_INDICES gather is safe too.
+        war_semaphore = self.war_semaphore if buffer_key == "SAMPLING_VALUES" else None
+        war_wait_value = self.war_sem_wait_value if buffer_key == "SAMPLING_VALUES" else None
         ttnn_tensor_out = ttnn.experimental.all_gather_async(
             input_tensor_mesh,
             dim,
@@ -1161,6 +1172,8 @@ class TT_CCL:
             memory_config=memory_config,
             subdevice_id=self.worker_sub_device_id,
             use_optimal_ccl_for_llama=use_optimal_ccl_for_llama,
+            war_semaphore=war_semaphore,
+            war_wait_value=war_wait_value,
         )
         if self.mode == "prefill" and buffer_key is not None:
             # reshape input back

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -40,6 +40,17 @@ class TT_CCL:
         self.model_config = model_args.model_config
         self.weight_cache_path = model_args.weight_cache_path(ttnn.bfloat8_b)
         self.num_cbs = 2
+        # When a persistent output buffer is reused across non-blocking decode
+        # trace replays, line_all_gather normally drops the barrier semaphore
+        # (persistent buffer treated as a substitute for barrier syncing). That
+        # is unsafe for the sampling gathers (SAMPLING_VALUES/SAMPLING_INDICES):
+        # their consumers (ttnn.add offset / ttnn.sampling) run on the sampling
+        # sub-core grid, a different sub-device than the gather worker, so without
+        # a barrier the next step's gather can overwrite the buffer before the
+        # current step finishes reading it -> a few of 32 slots get stale
+        # candidates -> non-deterministic first decode token (flaky for months).
+        # Keep the barrier for these gathers even with a persistent buffer.
+        self._barrier_buffer_keys = {"SAMPLING_VALUES", "SAMPLING_INDICES", "SAMPLING"}
         self.from_remote_semaphore_handles = []
         self.to_remote_semaphore_handles = []
         self.all_gather_concat_inter_tensor = self.get_all_gather_concat_inter_buffer()
@@ -1123,7 +1134,11 @@ class TT_CCL:
             persistent_buffer = self.all_gather_buffers.get(buffer_key, None)
         # ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.worker_sub_device_id])
         barrier_semaphore = None
-        if persistent_buffer is None:
+        if persistent_buffer is None or buffer_key in self._barrier_buffer_keys:
+            # persistent_buffer is None -> normal barrier. buffer_key in the
+            # sampling set -> persistent buffer present but reused cross-step by a
+            # different sub-device consumer, so keep the barrier to enforce
+            # consume-before-overwrite ordering and restore deterministic sampling.
             barrier_semaphore = self.get_and_cycle_barrier_semaphore_handle(cluster_axis)
         semaphores = (
             self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]][0]

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -614,11 +614,16 @@ class TtTransformer(LightweightModule):
             toks = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[output_device_idx]).float()[0, 0, 0, :1]
             toks_list.append(toks)
 
-        if tt_out_logits_saved is not None:
-            # make sure tt_out_logits_saved is mutable
-            logits_saved = ttnn.to_torch(ttnn.get_device_tensors(tt_logits)[output_device_idx]).float()[0, 0, :, :]
-
-            tt_out_logits_saved.copy_(logits_saved)
+            # Save each user's logits INSIDE the loop. Previously this was done once
+            # after the loop and captured only the last iteration's tt_logits, so in a
+            # batched prefill every other user's row in the caller's host buffer stayed
+            # zero-initialized. When logprobs are requested the batch is host-sampled
+            # from those rows, so the affected users got a garbage token (argmax over a
+            # uniform vector) and -log(vocab) logprobs. tt_out_logits_saved has one row
+            # per split entry; row i corresponds to x_split[i] (slot i for batched).
+            if tt_out_logits_saved is not None:
+                logits_saved = ttnn.to_torch(ttnn.get_device_tensors(tt_logits)[output_device_idx]).float()[0, 0, :, :]
+                tt_out_logits_saved[i : i + 1].copy_(logits_saved)
 
         return toks_list if isinstance(last_token_idx, list) else toks
 

--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import ttnn
 from models.common.modules.tt_ccl import get_num_links as get_common_num_links
 
@@ -72,6 +74,24 @@ class TT_CCL:
                 self.rs_semaphore_handles[i].append(
                     [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(3)]
                 )
+
+        # WAR-hazard demo (#48222/#48469, draft PR #49353): the sampling gather reuses a fixed
+        # (trace-pinned) output buffer every decode step. Under contention the next step's gather can
+        # overwrite it before the current step's ttnn.sampling finishes reading -> batch-32 gibberish.
+        # When enabled, ttnn.sampling signals `war_semaphore` at `war_sem_drain_core` once per user core
+        # (war_sem_wait_value total), and the gather's writer waits on it before overwriting. Init value
+        # == wait value bootstraps step 1 (no prior signal to wait for). Gated behind an env var so the
+        # semaphore is only allocated when the demo runs. `war_sem_drain_core` (1,0) must match the PF's
+        # hardcoded anchor core in all_gather_async_default_program_factory.cpp.
+        self.war_semaphore = None
+        self.war_sem_drain_core = None
+        self.war_sem_wait_value = None
+        if os.environ.get("TT_SAMPLING_WAR_DEMO") == "1" and os.environ.get("TT_SAMPLING_WAR_ENABLE") == "1":
+            self.war_sem_wait_value = int(os.environ.get("TT_SAMPLING_WAR_WAIT_VALUE", "32"))
+            self.war_sem_drain_core = ttnn.CoreCoord(1, 0)
+            self.war_semaphore = ttnn.create_global_semaphore(
+                self.mesh_device, self.sub_device_crs, self.war_sem_wait_value
+            )
 
     def get_num_links(self, cluster_axis=None):
         """

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -488,7 +488,7 @@
   model: mixtral-8x7b
   skus:
     wh_llmbox_perf:
-      timeout: 90
+      timeout: 60
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -481,12 +481,14 @@
 - name: Mixtral-8x7B e2e tests
   cmd: |
     export HF_MODEL=mistralai/Mixtral-8x7B-Instruct-v0.1 TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/mistralai/Mixtral-8x7B-Instruct-v0.1
-    pytest --timeout 4200 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
-    pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
+    echo "===== WAR-demo ARM A (all_gather_async, no barrier, NO WAR) — expect FAIL if no-barrier reproduces ====="
+    TT_SAMPLING_WAR_DEMO=1 TT_SAMPLING_WAR_NOBARRIER=1 pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32" || echo "ARM_A_EXIT=$?"
+    echo "===== WAR-demo ARM B (all_gather_async, no barrier, +WAR) — expect PASS ====="
+    TT_SAMPLING_WAR_DEMO=1 TT_SAMPLING_WAR_NOBARRIER=1 TT_SAMPLING_WAR_ENABLE=1 pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: mixtral-8x7b
   skus:
     wh_llmbox_perf:
-      timeout: 20
+      timeout: 90
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models

--- a/tools/vllm/test_non_uniform_seeding.py
+++ b/tools/vllm/test_non_uniform_seeding.py
@@ -1,0 +1,120 @@
+import asyncio
+import json
+import os
+import urllib.error
+import urllib.request
+
+
+BASE_URL = os.environ.get("VLLM_BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+MODEL = os.environ.get("VLLM_MODEL")
+REQUEST_TIMEOUT_SECONDS = float(os.environ.get("VLLM_REQUEST_TIMEOUT_SECONDS", "60"))
+TOTAL_REQUESTS = int(os.environ.get("VLLM_TOTAL_REQUESTS", "32"))
+
+
+def _request_json(method, path, payload=None):
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+
+    api_key = os.environ.get("VLLM_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    request = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=body,
+        headers=headers,
+        method=method,
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        response_body = error.read().decode("utf-8", errors="replace")
+        raise AssertionError(f"{method} {path} failed with HTTP {error.code}: {response_body}") from error
+    except urllib.error.URLError as error:
+        raise AssertionError(f"{method} {path} failed against {BASE_URL}: {error}") from error
+
+
+def _get_model():
+    if MODEL:
+        return MODEL
+
+    response = _request_json("GET", "/v1/models")
+    models = response.get("data", [])
+    if not models:
+        raise AssertionError(f"No models returned from {BASE_URL}/v1/models: {response}")
+
+    return models[0]["id"]
+
+
+def test_non_uniform_seeding_against_running_vllm():
+    """
+    Run with:
+        python -m pytest tools/vllm/test_non_uniform_seeding.py
+
+    Optional overrides:
+        VLLM_BASE_URL=http://127.0.0.1:8000
+        VLLM_MODEL=<model id>
+        VLLM_API_KEY=<token>
+        VLLM_TOTAL_REQUESTS=32
+    """
+    asyncio.run(_run_non_uniform_seeding_check())
+
+
+async def _run_non_uniform_seeding_check():
+    assert TOTAL_REQUESTS % 2 == 0, "VLLM_TOTAL_REQUESTS must be even"
+
+    model = _get_model()
+    seeds = []
+
+    # Generate pattern: 1, 0, 2, 0, 3, 0...
+    for seed in range(1, (TOTAL_REQUESTS // 2) + 1):
+        seeds.append(seed)
+        seeds.append(0)
+
+    async def get_chat_response(seed_val):
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": "Generate a list of 10 random colors."}],
+            "max_tokens": 50,
+            "temperature": 0.9,
+            "seed": seed_val,
+        }
+        response = await asyncio.to_thread(_request_json, "POST", "/v1/chat/completions", payload)
+
+        try:
+            content = response["choices"][0]["message"]["content"].strip()
+            response_id = response["id"]
+        except (KeyError, IndexError, TypeError) as error:
+            raise AssertionError(f"Unexpected chat completion response for seed {seed_val}: {response}") from error
+
+        return {"seed": seed_val, "content": content, "id": response_id}
+
+    # Fire all requests concurrently. This floods the server, forcing dynamic
+    # batching if enabled on vLLM.
+    results = await asyncio.gather(*(get_chat_response(seed) for seed in seeds))
+
+    zero_seed_contents = [result["content"] for result in results if result["seed"] == 0]
+    unique_seed_contents = [result["content"] for result in results if result["seed"] != 0]
+    assert len(zero_seed_contents) == TOTAL_REQUESTS // 2
+    assert len(unique_seed_contents) == TOTAL_REQUESTS // 2
+
+    unique_zero_outputs = set(zero_seed_contents)
+    assert len(unique_zero_outputs) == 1, (
+        "Determinism Failed for seed=0.\n"
+        f"Expected 1 unique output, found {len(unique_zero_outputs)}.\n"
+        f"Outputs: {unique_zero_outputs}"
+    )
+
+    unique_varied_outputs = set(unique_seed_contents)
+    assert len(unique_varied_outputs) == len(unique_seed_contents), (
+        "Entropy Failed for non-zero seeds.\n"
+        f"Expected {len(unique_seed_contents)} unique outputs, found {len(unique_varied_outputs)}.\n"
+        f"Collisions detected in: {unique_seed_contents}"
+    )
+
+
+if __name__ == "__main__":
+    test_non_uniform_seeding_against_running_vllm()
+    print(f"PASS: non-uniform seeding check passed against {BASE_URL}")

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -210,7 +210,9 @@ ttnn::Tensor all_gather_async(
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
     std::optional<uint32_t> num_workers_per_link,
-    std::optional<uint32_t> num_buffers_per_channel) {
+    std::optional<uint32_t> num_buffers_per_channel,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    std::optional<uint32_t> war_wait_value) {
     uint32_t resolved_links =
         num_preferred_links.value_or(ttnn::operations::ccl::common::get_num_links(mesh_device, cluster_axis));
     tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis);
@@ -244,7 +246,9 @@ ttnn::Tensor all_gather_async(
         /*num_buffers_per_channel*/ num_buffers_per_channel,
         reverse_order,
         sub_core_grid,
-        &mesh_device);
+        &mesh_device,
+        war_semaphore,
+        war_wait_value);
 }
 
 // Reversed: overload with sub-core grids

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -89,7 +89,9 @@ ttnn::Tensor all_gather_async(
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
     bool reverse_order,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    std::optional<uint32_t> war_wait_value) {
     auto* mesh_device_ptr = input_tensor.device();
     TT_FATAL(mesh_device_ptr != nullptr, "Mesh device is required for all_gather_async operation");
     uint32_t resolved_num_links =
@@ -125,7 +127,9 @@ ttnn::Tensor all_gather_async(
         num_buffers_per_channel,
         reverse_order,
         sub_core_grid,
-        /*mesh_device*/ nullptr);
+        /*mesh_device*/ nullptr,
+        war_semaphore,
+        war_wait_value);
 }
 
 // Overload with multi-device input

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -83,7 +83,9 @@ ttnn::Tensor all_gather_async(
     bool reverse_order = false,
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
     std::optional<uint32_t> num_workers_per_link = std::nullopt,
-    std::optional<uint32_t> num_buffers_per_channel = std::nullopt);
+    std::optional<uint32_t> num_buffers_per_channel = std::nullopt,
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    std::optional<uint32_t> war_wait_value = std::nullopt);
 
 // Reversed: overload with sub-core grids
 ttnn::Tensor all_gather_async_reversed(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -45,7 +45,11 @@ ttnn::Tensor all_gather_async(
     std::optional<uint32_t> num_workers_per_link = std::nullopt,
     std::optional<uint32_t> num_buffers_per_channel = std::nullopt,
     bool reverse_order = false,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    // WAR-hazard (demo #48222/#48469): forwarded to the device op so the generic default PF can gate
+    // buffer reuse on the downstream sampling read. Non-null only for the sampling gather.
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    std::optional<uint32_t> war_wait_value = std::nullopt);
 
 // Overload with multi-device input
 std::vector<ttnn::Tensor> all_gather_async(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
@@ -156,7 +156,9 @@ ttnn::Tensor all_gather_async_wrapper_mesh_device(
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     const std::optional<CoreRangeSet>& sub_core_grids,
     std::optional<uint32_t> num_workers_per_link,
-    std::optional<uint32_t> num_buffers_per_channel) {
+    std::optional<uint32_t> num_buffers_per_channel,
+    [[maybe_unused]] const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    [[maybe_unused]] std::optional<uint32_t> war_wait_value = std::nullopt) {
     if constexpr (Reversed) {
         return ttnn::experimental::all_gather_async_reversed(
             input_tensor,
@@ -194,7 +196,9 @@ ttnn::Tensor all_gather_async_wrapper_mesh_device(
             false,
             sub_core_grids,
             num_workers_per_link,
-            num_buffers_per_channel);
+            num_buffers_per_channel,
+            war_semaphore,
+            war_wait_value);
     }
 }
 
@@ -296,7 +300,9 @@ void bind_all_gather_async(nb::module_& mod) {
             nb::arg("barrier_semaphore") = nb::none(),
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("num_workers_per_link") = nb::none(),
-            nb::arg("num_buffers_per_channel") = nb::none()));
+            nb::arg("num_buffers_per_channel") = nb::none(),
+            nb::arg("war_semaphore") = nb::none(),
+            nb::arg("war_wait_value") = nb::none()));
 
     const auto* all_gather_async_reversed_doc = R"doc(
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
@@ -97,7 +97,9 @@ ttnn::Tensor all_gather_async_wrapper_persistent_buffer(
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    [[maybe_unused]] const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    [[maybe_unused]] std::optional<uint32_t> war_wait_value = std::nullopt) {
     if constexpr (Reversed) {
         return ttnn::experimental::all_gather_async_reversed(
             input_tensor,
@@ -135,7 +137,9 @@ ttnn::Tensor all_gather_async_wrapper_persistent_buffer(
             num_workers_per_link,
             num_buffers_per_channel,
             false,
-            sub_core_grids);
+            sub_core_grids,
+            war_semaphore,
+            war_wait_value);
     }
 }
 
@@ -281,7 +285,9 @@ void bind_all_gather_async(nb::module_& mod) {
             nb::arg("chunks_per_sync") = nb::none(),
             nb::arg("num_workers_per_link") = nb::none(),
             nb::arg("num_buffers_per_channel") = nb::none(),
-            nb::arg("sub_core_grids") = std::nullopt),
+            nb::arg("sub_core_grids") = std::nullopt,
+            nb::arg("war_semaphore") = nb::none(),
+            nb::arg("war_wait_value") = nb::none()),
         ttnn::overload_t(
             &all_gather_async_wrapper_mesh_device<false>,
             nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -95,7 +95,9 @@ DefaultMeshWorkloadFactory::cached_program_t DefaultMeshWorkloadFactory::create_
                 num_buffers_per_channel,
                 core_grid_offset,
                 reverse_order,
-                sub_core_grid);
+                sub_core_grid,
+                operation_attributes.war_semaphore,
+                operation_attributes.war_wait_value);
 
     return {
         std::move(program),
@@ -230,7 +232,9 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
     std::optional<uint32_t> num_buffers_per_channel,
     const CoreCoord core_grid_offset,
     const bool reverse_order,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    std::optional<uint32_t> war_wait_value) {
     // Tensor Info
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
     const auto& input_tensor_shape = input_tensor.padded_shape();
@@ -743,6 +747,17 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
                     start_pages_read_in_row,  // start_pages_read_in_row
                     start_row_offset,         // start_row_offset
                     chunks_per_sync_val};     // chunks_per_sync
+
+                // WAR-hazard (demo #48222/#48469): writer args idx 14/15. Non-zero only on the anchor
+                // core (logical (1,0) = the local-writing dir==1 worker under choose_worker_cores
+                // row-major layout); the writer kernel waits there before overwriting the reused
+                // buffer. 0 on every other core disables the wait, so a coord that is not a writer
+                // core is a harmless no-op (never a deadlock). Must be pushed here (idx 14/15), before
+                // the conditional mux/shard/fabric args, to match the kernel's fixed-prefix read.
+                const bool is_war_anchor = war_semaphore.has_value() && core.x == 1 && core.y == 0;
+                writer_rt_args.push_back(
+                    is_war_anchor ? static_cast<uint32_t>(war_semaphore.value().address()) : 0);
+                writer_rt_args.push_back(is_war_anchor ? war_wait_value.value_or(0) : 0);
 
                 if (num_mux_cores_per_direction_per_link) {
                     ccl::fabric_mux_connection_rt_args(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
@@ -73,7 +73,11 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
     std::optional<uint32_t> num_buffers_per_channel,
     CoreCoord core_grid_offset,
     bool reverse_order,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    // WAR-hazard (demo #48222/#48469): gate reuse of the gathered buffer on the downstream sampling
+    // op finishing its read. Non-null only for the sampling gather; the writer waits on the anchor core.
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    std::optional<uint32_t> war_wait_value = std::nullopt);
 
 // Runtime argument override function
 void all_gather_async_minimal_default_helper_override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
@@ -301,7 +301,9 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device) {
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    const std::optional<uint32_t>& war_wait_value) {
     // Combine 3 implementations of the old all_gather_async_op.cpp::all_gather_async_impl
     // 1. only input_tensor, no output or optional mesh device
     // 2. has input tensor and output tensor but not optional mesh device
@@ -358,7 +360,9 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
             num_workers_per_link,
             num_buffers_per_channel,
             reverse_order,
-            sub_core_grid),
+            sub_core_grid,
+            war_semaphore,
+            war_wait_value),
         AllGatherAsyncInputs{.input_tensor = input_tensor, .persistent_output_buffer = persistent_output_buffer}};
 }
 
@@ -501,7 +505,9 @@ Tensor all_gather_async(
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device) {
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    const std::optional<uint32_t>& war_wait_value) {
     auto [params, inputs] = experimental::prim::all_gather_async_build_operation_args(
         input_tensor,
         persistent_output_buffer,
@@ -521,7 +527,9 @@ Tensor all_gather_async(
         num_buffers_per_channel,
         reverse_order,
         sub_core_grid,
-        optional_mesh_device);
+        optional_mesh_device,
+        war_semaphore,
+        war_wait_value);
     return ttnn::device_operation::launch<experimental::prim::AllGatherAsyncDeviceOperation>(params, inputs);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
@@ -57,7 +57,9 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device);
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<uint32_t>& war_wait_value = std::nullopt);
 
 enum class AllGatherAsyncVersion {
     LLAMA_MINIMAL_SHARDED = 0,
@@ -90,6 +92,8 @@ Tensor all_gather_async(
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device);
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<uint32_t>& war_wait_value = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
@@ -37,6 +37,11 @@ struct AllGatherAsyncParams {
     std::optional<uint32_t> num_buffers_per_channel;
     bool reverse_order = false;
     std::optional<CoreRangeSet> sub_core_grid;
+    // WAR-hazard semaphore for safe reuse of a persistent output buffer under trace: the drain core
+    // waits until `war_wait_value` increments arrive (one per downstream consumer core, e.g. the
+    // sampling op) before overwriting the persistent buffer. See the llama3_70b_galaxy TT_CCL war_sem.
+    std::optional<GlobalSemaphore> war_semaphore;
+    std::optional<uint32_t> war_wait_value;
 
     AllGatherAsyncParams(
         int32_t dim,
@@ -56,7 +61,9 @@ struct AllGatherAsyncParams {
         std::optional<uint32_t> num_workers_per_link,
         std::optional<uint32_t> num_buffers_per_channel,
         bool reverse_order,
-        const std::optional<CoreRangeSet>& sub_core_grid) :
+        const std::optional<CoreRangeSet>& sub_core_grid,
+        const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+        std::optional<uint32_t> war_wait_value = std::nullopt) :
         dim(dim),
         num_links(num_links),
         ring_size(ring_size),
@@ -74,7 +81,9 @@ struct AllGatherAsyncParams {
         num_workers_per_link(num_workers_per_link),
         num_buffers_per_channel(num_buffers_per_channel),
         reverse_order(reverse_order),
-        sub_core_grid(sub_core_grid) {}
+        sub_core_grid(sub_core_grid),
+        war_semaphore(war_semaphore),
+        war_wait_value(war_wait_value) {}
 
     // Add attributes method for reflection
     auto attributes() const {
@@ -99,6 +108,8 @@ struct AllGatherAsyncParams {
         attrs.emplace_back("num_buffers_per_channel", num_buffers_per_channel);
         attrs.emplace_back("reverse_order", reverse_order);
         attrs.emplace_back("sub_core_grid", sub_core_grid);
+        attrs.emplace_back("war_semaphore", war_semaphore);
+        attrs.emplace_back("war_wait_value", war_wait_value);
         return attrs;
     }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
@@ -280,8 +280,16 @@ LlamaShardedMeshWorkloadFactory::cached_program_t LlamaShardedMeshWorkloadFactor
                 ? barrier_semaphore.value().address()
                 : 0,
             barrier_core.x,  // barrier_sem_noc0_x
-            barrier_core.y   // barrier_sem_noc0_y
-        };
+            barrier_core.y,  // barrier_sem_noc0_y
+            // WAR-hazard wait: only the drain core (link 0) waits on the war semaphore before
+            // overwriting the reused persistent buffer. war_sem_addr==0 disables the wait on all
+            // other cores; the drain core's existing out_ready_sem sync fans the release out.
+            (operation_attributes.war_semaphore.has_value() && link == 0)  // war_sem_addr
+                ? static_cast<uint32_t>(operation_attributes.war_semaphore.value().address())
+                : 0,
+            (operation_attributes.war_semaphore.has_value() && link == 0)  // war_wait_value
+                ? operation_attributes.war_wait_value.value_or(0)
+                : 0};
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_x.begin(), output_tensor_cores_x.end());
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_y.begin(), output_tensor_cores_y.end());
         log_trace(tt::LogOp, "Writer Runtime Args:");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -59,6 +59,10 @@ void kernel_main() {
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    // WAR-hazard wait (drain core only; war_sem_addr==0 on all other cores). Blocks until the
+    // downstream sampling op signals it is done reading the reused persistent buffer.
+    const uint32_t war_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t war_wait_value = get_arg_val<uint32_t>(arg_idx++);
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
     tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
@@ -116,6 +120,15 @@ void kernel_main() {
 
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
+    }
+
+    // WAR-hazard wait: on the drain core (war_sem_addr != 0), block until all downstream sampling
+    // consumers of the previous decode step have signalled `war_sem` (>= war_wait_value), then reset
+    // it for the next step. This gates the persistent-buffer overwrite on consume-complete, closing
+    // the cross-sub-device Write-After-Read race that only manifests under trace.
+    if (war_sem_addr != 0) {
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), war_wait_value);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), 0);
     }
 
     // 1. mcast via fabric to remote tensor addresses

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -117,6 +117,10 @@ void kernel_main() {
     const auto start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
     const auto start_row_offset = get_arg_val<uint32_t>(arg_idx++);
     const auto chunks_per_sync = get_arg_val<uint32_t>(arg_idx++);
+    // WAR-hazard wait (demo, #48222/#48469): fixed-prefix args (idx 14/15). Non-zero only on the
+    // gather's drain/anchor core; 0 elsewhere disables the wait. See minimal_default writer note below.
+    const uint32_t war_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t war_wait_value = get_arg_val<uint32_t>(arg_idx++);
 #ifdef USE_WORKER_MUX
     bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
     const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++);
@@ -270,6 +274,15 @@ void kernel_main() {
         }
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
+    }
+
+    // WAR-hazard wait (demo): on the drain/anchor core (war_sem_addr != 0), block until the
+    // downstream sampling op has signalled it finished reading the reused output buffer, then reset
+    // for the next decode step. Independent of use_barrier_sem (which is off under persistent buffers).
+    // Placed after the barrier and before any output write, so it gates the buffer overwrite.
+    if (war_sem_addr != 0) {
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), war_wait_value);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), 0);
     }
 
     uint32_t slice_writes = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -76,12 +76,20 @@ void kernel_main() {
                             (is_even_chunk && reduce_even_chunks) || (!is_even_chunk && reduce_odd_chunks);
 
                         if (reduce_interm) {
+                            // DETERMINISM: reserve the output slot BEFORE the reduce and pop the input
+                            // slots AFTER the pack (the original popped inputs before packing and
+                            // reserved the output after). This pins the compute<->reader/writer CB
+                            // handshake so the cross-device partials are consumed in a fixed order,
+                            // making the ring reduce run-to-run deterministic. Without it the near-tie
+                            // Llama-70B greedy logits flip (test_topk/test_seeding nondeterminism); the
+                            // reduce is scheduling/accumulation-order sensitive, not a precision issue.
                             // If reduce_output, add 3 tensors. Else add 2 tensors.
                             if (reduce_output) {
                                 cb_wait_front(cb_interm2_id, tile_granularity);
                             }
                             cb_wait_front(cb_input_id, tile_granularity);
                             cb_wait_front(cb_interm_id, tile_granularity);
+                            cb_reserve_back(cb_compute_output_id, tile_granularity);
 
                             tile_regs_acquire();  // acquire DST registers for MATH thread, resets DST to 0
                             if (reduce_output) {
@@ -98,19 +106,18 @@ void kernel_main() {
                             }
                             tile_regs_commit();  // release lock on DST by MATH thread, signal the PACK thread
 
-                            if (reduce_output) {
-                                cb_pop_front(cb_interm2_id, tile_granularity);
-                            }
-                            cb_pop_front(cb_input_id, tile_granularity);
-                            cb_pop_front(cb_interm_id, tile_granularity);
-
-                            cb_reserve_back(cb_compute_output_id, tile_granularity);
                             tile_regs_wait();  // acquire lock on DST for PACK thread
                             for (uint32_t tile_id = 0; tile_id < tiles_to_read; ++tile_id) {
                                 pack_tile(tile_id, cb_compute_output_id, tile_id);  // pack results from DST registers
                                                                                     // to output circular buffers
                             }
                             tile_regs_release();  // release lock on DST by PACK thread
+
+                            if (reduce_output) {
+                                cb_pop_front(cb_interm2_id, tile_granularity);
+                            }
+                            cb_pop_front(cb_input_id, tile_granularity);
+                            cb_pop_front(cb_interm_id, tile_granularity);
                             cb_push_back(cb_compute_output_id, tile_granularity);
                         }
                         tiles_read += tiles_to_read;

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -70,6 +71,14 @@ void kernel_main() {
     // Number of running cores / users. The final-indices CB holds one stick per user (no longer
     // hard-coded to 32), so this kernel waits/pops exactly `num_users` sticks.
     constexpr uint32_t num_users = get_compile_time_arg_val(args_base + 17);
+    // WAR-hazard signal: when enabled, increment `war_sem_addr` on the gather's drain core once at
+    // the very end of the op so the next decode step's SAMPLING_VALUES all-gather can safely reuse
+    // the persistent buffer. Closes a cross-sub-device Write-After-Read race that only shows up under
+    // trace (see models/common/sampling and the llama3_70b_galaxy TT_CCL war_sem).
+    constexpr uint32_t signal_war_sem = get_compile_time_arg_val(args_base + 18);
+    constexpr uint32_t war_sem_addr = get_compile_time_arg_val(args_base + 19);
+    constexpr uint32_t war_drain_noc_x = get_compile_time_arg_val(args_base + 20);
+    constexpr uint32_t war_drain_noc_y = get_compile_time_arg_val(args_base + 21);
     constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
     constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
@@ -245,4 +254,15 @@ void kernel_main() {
         {.offset_bytes = core_id * 4},
         {.page_id = 0, .offset_bytes = core_id * 4});
     noc.async_write_barrier();
+
+    // Signal WAR completion: this core is done reading the gathered SAMPLING_VALUES/INDICES for this
+    // step. Increment the war semaphore on the gather's drain core; the next step's SAMPLING_VALUES
+    // all-gather waits until all `num_users` sampling cores have signalled before overwriting the
+    // reused persistent buffer.
+    if constexpr (signal_war_sem != 0) {
+        const uint64_t war_noc_addr =
+            get_noc_addr(war_drain_noc_x, war_drain_noc_y, war_sem_addr, noc.get_noc_id());
+        noc_semaphore_inc(war_noc_addr, 1, noc.get_noc_id());
+        noc.async_atomic_barrier();
+    }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -197,9 +197,15 @@ ttnn::Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
-    const std::optional<Tensor>& preallocated_output_tensor) {
+    const std::optional<Tensor>& preallocated_output_tensor,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core) {
     return ttnn::device_operation::launch<SamplingDeviceOperation>(
-        SamplingParams{.seed = seed, .sub_core_grids = sub_core_grids},
+        SamplingParams{
+            .seed = seed,
+            .sub_core_grids = sub_core_grids,
+            .war_semaphore = war_semaphore,
+            .war_sem_drain_core = war_sem_drain_core},
         SamplingInputs{
             .input_values = input_values_tensor,
             .input_indices = input_indices_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
@@ -38,5 +38,7 @@ ttnn::Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<Tensor>& preallocated_output_tensor = std::nullopt);
+    const std::optional<Tensor>& preallocated_output_tensor = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
@@ -8,12 +8,23 @@
 #include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/core_coord.hpp>
 
 namespace ttnn::prim {
 
 struct SamplingParams {
     std::optional<uint32_t> seed;
     std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
+    // WAR-hazard semaphore for safe reuse of a persistent all-gather buffer under trace.
+    // When set, each sampling writer core increments `war_semaphore` (at the gather's drain core,
+    // `war_sem_drain_core`) once at the very end of the op, signalling that this step's reads of the
+    // SAMPLING_VALUES/INDICES buffers are complete. The next decode step's SAMPLING_VALUES all-gather
+    // waits on its local copy at that core before overwriting the buffer, closing the cross-sub-device
+    // Write-After-Read race that only manifests under trace. See models/common/sampling and the
+    // llama3_70b_galaxy TT_CCL.
+    std::optional<tt::tt_metal::GlobalSemaphore> war_semaphore;
+    std::optional<tt::tt_metal::CoreCoord> war_sem_drain_core;
 };
 
 struct SamplingInputs {

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -373,6 +373,24 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     }
     desc.kernels.push_back(std::move(reader_desc));
 
+    // WAR-hazard signal: when a war_semaphore is provided, each sampling writer core increments it
+    // once at the very end of the op (after its final write) on the gather's drain core. The drain
+    // core of the next decode step's SAMPLING_VALUES all-gather waits on its local copy before
+    // overwriting the reused persistent buffer, closing the cross-sub-device Write-After-Read race
+    // that only manifests under trace.
+    const bool signal_war_sem =
+        operation_attributes.war_semaphore.has_value() && operation_attributes.war_sem_drain_core.has_value();
+    uint32_t war_sem_addr = 0;
+    uint32_t war_drain_noc_x = 0;
+    uint32_t war_drain_noc_y = 0;
+    if (signal_war_sem) {
+        war_sem_addr = static_cast<uint32_t>(operation_attributes.war_semaphore.value().address());
+        const auto war_drain_noc =
+            device->worker_core_from_logical_core(operation_attributes.war_sem_drain_core.value());
+        war_drain_noc_x = static_cast<uint32_t>(war_drain_noc.x);
+        war_drain_noc_y = static_cast<uint32_t>(war_drain_noc.y);
+    }
+
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const auto& core = cores[i];
         CoreRangeSet single_core{CoreRange(core, core)};
@@ -403,6 +421,10 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
                 num_cores,
                 static_cast<uint32_t>(use_32bit_index),
                 num_users,
+                static_cast<uint32_t>(signal_war_sem),
+                war_sem_addr,
+                war_drain_noc_x,
+                war_drain_noc_y,
             });
 
         KernelDescriptor writer_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
@@ -16,9 +16,20 @@ Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
-    const std::optional<Tensor>& output_tensor) {
+    const std::optional<Tensor>& output_tensor,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core) {
     return ttnn::prim::sampling(
-        input_values_tensor, input_indices_tensor, k, p, temp, seed, sub_core_grids, output_tensor);
+        input_values_tensor,
+        input_indices_tensor,
+        k,
+        p,
+        temp,
+        seed,
+        sub_core_grids,
+        output_tensor,
+        war_semaphore,
+        war_sem_drain_core);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
@@ -10,6 +10,8 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/core_coord.hpp>
 
 namespace ttnn {
 
@@ -21,6 +23,8 @@ Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<Tensor>& output_tensor = std::nullopt);
+    const std::optional<Tensor>& output_tensor = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -126,7 +126,9 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("seed") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
-        nb::arg("output_tensor") = nb::none());
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("war_semaphore") = nb::none(),
+        nb::arg("war_sem_drain_core") = nb::none());
 }
 
 }  // namespace ttnn::operations::reduction::detail


### PR DESCRIPTION
## What / why (DRAFT — exploration, not for merge)

Explores a **true root-cause fix** for the batch-32 on-device-sampling non-determinism
(#48037 / #48222 / #48356 / #47823, discussion in #48469), separate from the barrier
mitigation in #48404 (which stays intact).

**Hypothesis (WAR hazard).** Under trace, the sampling gather reuses a fixed (trace-pinned)
output buffer every decode step. With enough contention, the *next* step's gather overwrites
that buffer before the *current* step's `ttnn.sampling` has finished reading it — a
Write-After-Read hazard that corrupts the top-k values/indices → gibberish. It is
deterministic per-config and trace-only, which matches a cross-step buffer-reuse race.

A colleague's `llama_70b_sampling_fixes` already solves this for the **llama-sharded** gather
with a WAR semaphore: `ttnn.sampling` signals a `war_semaphore` once per user core at a drain
core; the gather's writer `noc_semaphore_wait_min`s on it before overwriting, then resets.
Qwen / Mixtral / Coder use the **generic `all_gather_async`** (`minimal_default` kernel), which
did **not** have the WAR *wait*. This PR ports the wait into that generic path.

## Change

- **Writer kernel** (`minimal_default_writer.cpp`, shared by prim `ttnn.all_gather` and
  `all_gather_async`): read WAR args at fixed rt-arg idx 14/15; if `war_sem_addr != 0`,
  `noc_semaphore_wait_min(war_wait_value)` then reset — placed after the barrier block and
  before any output write, independent of `use_barrier_sem`.
- **Default program factory**: thread `operation_attributes.war_semaphore` / `war_wait_value`
  into `build_all_gather_async_minimal_default_program_artifacts`; push writer args 14/15,
  **non-zero only on the anchor core** (logical `(1,0)` = the local-writing `dir==1` worker
  under `choose_worker_cores` row-major layout). Zero on every other core ⇒ the wait is a
  no-op there, so a coord that is not a writer core is harmless (**never a deadlock**). The prim
  caller uses the `nullopt` defaults, so its path is unchanged (pushes 0/0).
- **`tt_sampling._perform_all_gather`**: env-gated `all_gather_async` demo path
  (`TT_SAMPLING_WAR_DEMO`), optional barrier drop (`TT_SAMPLING_WAR_NOBARRIER`) to reproduce the
  broken timing, WAR gate applied to the **first (values) gather only** — once its WAR-wait
  clears, the prior step's sampling read is provably complete, so the same-step indices
  overwrite is also safe from one signal (avoids a two-gather / one-signal deadlock).
- **`tt_transformers` `TT_CCL`**: allocate `war_semaphore` with **init == wait_value** (bootstraps
  step 1, which has no prior signal), `war_sem_drain_core=(1,0)` (matches the PF anchor),
  `war_sem_wait_value=32`, behind `TT_SAMPLING_WAR_ENABLE`. The `ttnn.sampling` *signal* side was
  already wired on the colleague's branch.

## A/B validation matrix (Mixtral, `wh_llmbox_perf`, `performance-ci-eval-32`)

One build, three env configs on the same branch (env injected via the test `cmd`):

| Arm | Env | Gather | Expect |
|-----|-----|--------|--------|
| 0 (control) | *(none)* | prim `ttnn.all_gather` (main behavior) | known-broken baseline |
| A (repro) | `WAR_DEMO=1 NOBARRIER=1` | `all_gather_async`, no barrier, **no WAR** | fail (if no-barrier reproduces) |
| B (fix) | `WAR_DEMO=1 NOBARRIER=1 ENABLE=1` | `all_gather_async`, no barrier, **+WAR** | pass |

If A fails and B passes → WAR-wait is the real fix. If A already passes → the op-switch (not the
WAR) is doing the work; pivot.

## Known caveats (why this is a demo, not a merge)

- Correct only for the near-degenerate `num_links=1` / one-local-writer case; remote-device writes
  into the local buffer are not gated by a *local* WAR-wait.
- Anchor core is hardcoded `(1,0)` in both the PF and Python; if that is not the local-writing
  writer core for a given config, the wait is silently a no-op (safe, but no fix) → iterate.
- `war_sem_wait_value=32` assumes the batch-32 signal count; a mismatch stalls arm B.

Intent is to hand the CCL team a concrete repro + a working WAR-wait in the generic gather so
they can implement the production version (num_links-generic, remote-write-aware). #48404 remains
the shippable mitigation.
