### PR TITLE
sparse_mla: fix DSA nightly — rotated test needs bf16/RM kvpe cache

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -463,6 +463,8 @@ def run_sparse_mla_rotated_case(
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
     shard_dims = [None, None]
     shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2


### PR DESCRIPTION
## What

Resolves #49344. Fixes the `bh_lb_DeepSeek_DSA` nightly failure ([run](https://github.com/tenstorrent/tt-metal/actions/runs/28908044485/job/85778652210)) introduced by #48888.

#48888 added a `forward()` guard requiring the sparse-MLA KVPE cache to be **uncompressed** (`bf16` or `fp8_e4m3`, `ROW_MAJOR`) — `sparse_sdpa` reads it natively, so the bf8/TILE round-trip was dropped. That PR updated the `init_kvpe_cache(...)` calls in the `accuracy`, `determinism`, and `chunked` sparse test cases to pass `dtype=ttnn.bfloat16` + `layout=ttnn.ROW_MAJOR_LAYOUT`, but **missed `run_sparse_mla_rotated_case`**, which fell back to the `init_kvpe_cache` default (`bfloat8_b` / TILE) and tripped the new assertion:

```
AssertionError: sparse MLA requires an uncompressed KVPE cache (bf16 or fp8_e4m3)
that sparse_sdpa reads natively, got DataType.BFLOAT8_B
```

This broke `test_sparse_mla_rotated` for both `glm_5_1` and `deepseek_v32` (4 passed / 1 failed per model on the DSA nightly).

## Fix

Pass the same `dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT` in `run_sparse_mla_rotated_case` as the three sibling cases. Two-line, test-only change.

## Testing

8xP150 LoudBox (2x4, `line` fabric), reproducing the nightly commands after a fresh build of `main`:

| selection | before | after |
| --- | --- | --- |
| `glm_5_1 and 2x4 and line` | 4 passed, 1 failed (`rotated`) | **5 passed** |
| `deepseek_v32 and 2x4 and line` | 4 passed, 1 failed (`rotated`) | **5 passed** |

`test_sparse_mla_rotated[...glm_5_1...]` and `[...deepseek_v32...]` now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/fix-sparse-mla-rotated-cache-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/fix-sparse-mla-rotated-cache-dtype)