### PR TITLE
Bound sparse MLA indexer score + top-k to written prefix (kv_len)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -579,16 +579,13 @@ class TtIndexer:
             # straddle for a non-slab-aligned start_pos (padded chunk). Scores the FULL preallocated width T:
             # positions past each query are causally -inf, and top-k below drops those (-inf -> sentinel).
             #
-            # TODO(perf, indexer kv_len): on an over-allocated cache (T >> written extent, e.g. a 55k slot
-            # with a 5k chunk written) this scores the whole T. The op supports bounding the scored logical
-            # prefix via kv_len (the tightest legal value is end_pos = start_pos + chunk_global; it cannot go
-            # lower because the pad query rows push the fullest-device causal window to end_pos, and the op
-            # TT_FATALs on kv_len < that). Wiring kv_len=end_pos here is NOT correct on its own: kv_len only
-            # writes logits[:, :, :, :end_pos] and leaves the tail [end_pos, T) STALE (not -inf), so the
-            # downstream top-k over full-T then picks garbage columns (observed: rotated-prefill PCC -> 0.0).
-            # It also needs the logits sliced to [0, end_pos) before top-k (that path validated correct at the
-            # OP level, but is deferred). Investigate: slice-vs-stale-tail interaction + whether the extra
-            # slice/copy is cheaper than the saved score/top-k work before turning this on.
+            # Bound the score to the real written prefix (kv_len=end_pos) rather than the full preallocated
+            # width T: end_pos = start_pos + chunk_global is the tightest legal value (the pad query rows
+            # push the fullest-device causal window to end_pos; the op TT_FATALs on kv_len < that). kv_len
+            # only WRITES logits[:, :, :, :end_pos] and leaves the tail [end_pos, T) STALE (not -inf); the
+            # top-k below is told the valid length (valid_length=end_pos) so it never reads or ranks that
+            # stale tail — which is the future top-k would drop anyway (causally -inf), so the selection is
+            # unchanged.
             k_full = self._gather_index_kbuf(index_kv_cache)  # [num_users, 1, T, D_idx] bf16 TILE, block-cyclic
             logits = ttnn.experimental.indexer_score_dsa(
                 q_dev,
@@ -600,6 +597,7 @@ class TtIndexer:
                 cache_batch_idx=cache_user_id,
                 block_cyclic_sp_axis=self.sp_axis,
                 block_cyclic_chunk_local=seq_len,  # per-chip chunk == chunk_size_global / sp
+                kv_len=end_pos,
             )
             ttnn.deallocate(k_full)
         else:
@@ -625,7 +623,13 @@ class TtIndexer:
         # index_topk is a multiple of 16, so k is too iff end_pos is — assert it at the caller contract
         # (current chunk sizing guarantees tile alignment) rather than failing deep inside the op.
         assert end_pos % 16 == 0, f"indexer top-k requires a tile-aligned key count; got end_pos={end_pos}"
-        return ttnn.experimental.topk_large_indices(logits, k=min(self.index_args.index_topk, end_pos))
+        # Block-cyclic logits are the full preallocated width T with a stale [end_pos, T) tail (kv_len only
+        # wrote the real prefix); valid_length bounds top-k to that prefix so the tail is never read or ranked.
+        # The natural path's cache is exact-sized (no tail), so it needs no bound.
+        topk_valid_length = end_pos if self._blockcyclic else None
+        return ttnn.experimental.topk_large_indices(
+            logits, k=min(self.index_args.index_topk, end_pos), valid_length=topk_valid_length
+        )
 
 
 class NullIndexer:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -124,7 +124,7 @@ def test_topk_large_indices_supported_ranks(device, shape, k):
 
 def test_topk_large_indices_requires_explicit_k(device):
     torch_input = _make_bf16_exact_input(num_rows=1, n=512)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError):  # allow-pytest.raises: host binding TypeError (missing kwarg), not a device fault
         ttnn.experimental.topk_large_indices(_to_device(torch_input, device))
 
 
@@ -268,3 +268,136 @@ def test_topk_large_indices_row_major_mixed_negative_infinity_indices_are_sentin
     expected = expected_row.unsqueeze(0).repeat(2, 1)
 
     _assert_indices(tt_indices, expected, [2, k])
+
+
+# ---------------------------------------------------------------------------
+# valid_length: bound the search to the first N columns of each (wider) row.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "k,n,valid_length",
+    [
+        (512, 1024, 512),
+        (256, 2048, 512),
+        (16, 4096, 64),
+        (512, 4096, 1024),
+        (1024, 4096, 2048),
+        (2048, 4096, 2048),
+        (256, 2048, 600),  # valid_length not a multiple of the LLK window
+        (512, 4096, 513),  # odd valid_length (partial tail chunk)
+    ],
+)
+def test_topk_large_indices_valid_length_ignores_stale_tail(device, k, n, valid_length):
+    # _make_bf16_exact_input rows are strictly increasing, so the LARGEST values of the full row live in the
+    # tail [valid_length:n]. A correct valid_length must return only indices < valid_length (matching a top-k
+    # over the prefix); if the tail leaked, indices >= valid_length would appear. This is the core guarantee.
+    num_rows = 2
+    torch_input = _make_bf16_exact_input(num_rows, n)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+    _, ref_indices = torch.topk(torch_input[:, :valid_length].float(), k, dim=-1, largest=True, sorted=True)
+    assert int(ref_indices.max()) < valid_length
+    _assert_indices(tt_indices, ref_indices, [num_rows, k])
+
+
+@pytest.mark.parametrize(
+    "k,num_rows,n,valid_length",
+    [
+        (512, 2, 1024, 512),
+        (1536, 2, 3000, 2000),
+        (2048, 2, 4096, 2049),
+        (16, 1, 8192, 100),
+        (1536, 2, 102400, 56320),  # the production case: 100K allocated, 50K+5K written
+    ],
+)
+def test_topk_large_indices_valid_length_matches_sliced_input(device, k, num_rows, n, valid_length):
+    # valid_length=L must be numerically identical to physically slicing the row to [0, L) and running the
+    # full-width op. Both compute top-k over the exact same prefix, so the indices are bit-identical.
+    torch.manual_seed(0)
+    torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
+
+    bounded = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+    sliced = ttnn.experimental.topk_large_indices(_to_device(torch_input[:, :valid_length].contiguous(), device), k=k)
+
+    bounded_t = ttnn.to_torch(bounded, dtype=torch.uint32).to(torch.int64)
+    sliced_t = ttnn.to_torch(sliced, dtype=torch.uint32).to(torch.int64)
+    _assert_index_metadata(bounded, [num_rows, k])
+    assert_equal(bounded_t, sliced_t)
+
+
+def test_topk_large_indices_valid_length_full_width_is_noop(device):
+    # valid_length == n must behave exactly like omitting valid_length.
+    num_rows, n, k = 2, 4096, 1024
+    torch_input = _make_bf16_exact_input(num_rows, n)
+    with_arg = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=n)
+    without = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    assert_equal(
+        ttnn.to_torch(with_arg, dtype=torch.uint32).to(torch.int64),
+        ttnn.to_torch(without, dtype=torch.uint32).to(torch.int64),
+    )
+
+
+@pytest.mark.parametrize("k", [16, 512, 1024])
+def test_topk_large_indices_valid_length_all_neginf_prefix_is_sentinel(device, k):
+    # Prefix [0, k) is all -inf while the ignored tail holds large FINITE values. A correct bound returns
+    # k sentinels (the tail must never be selected even though it is finite and larger).
+    sentinel = 0xFFFFFFFF
+    n = k + 64
+    torch_input = torch.full((2, n), -float("inf"), dtype=torch.bfloat16)
+    torch_input[:, k:] = 5.0  # large finite values living in the ignored tail
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=k)
+    _assert_indices(tt_indices, torch.full((2, k), sentinel, dtype=torch.int64), [2, k])
+
+
+@pytest.mark.parametrize("k", [16, 512, 1024])
+def test_topk_large_indices_valid_length_mixed_prefix_ignores_finite_tail(device, k):
+    # 16 finite values at the start of the valid prefix, the rest of the prefix -inf, and a large finite tail.
+    # Expect the 16 real indices then sentinels -- never the tail.
+    sentinel = 0xFFFFFFFF
+    n = k + 64
+    valid_length = k
+    finite_count = 16
+    torch_input = torch.full((2, n), -float("inf"), dtype=torch.bfloat16)
+    torch_input[:, :finite_count] = torch.arange(finite_count, dtype=torch.float32).to(torch.bfloat16)
+    torch_input[:, valid_length:] = 100.0  # large finite tail that must be ignored
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+    expected_prefix = torch.arange(finite_count - 1, -1, -1, dtype=torch.int64)
+    expected_suffix = torch.full((k - finite_count,), sentinel, dtype=torch.int64)
+    expected = torch.cat([expected_prefix, expected_suffix]).unsqueeze(0).repeat(2, 1)
+    _assert_indices(tt_indices, expected, [2, k])
+
+
+def test_topk_large_indices_valid_length_program_cache_reuse_while_growing(device):
+    # A serving loop grows valid_length each step; because valid_length is a runtime arg (hash-excluded),
+    # every step must reuse a single cached program.
+    k = 1536
+    n = 102400
+    torch_input = _make_large_index_input(num_rows=2, n=n, k=k)
+    tt_input = _to_device(torch_input, device)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        entries = []
+        for valid_length in (2048, 20480, 56320, n):
+            ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+            entries.append(device.num_program_cache_entries())
+        assert entries[0] > 0
+        assert max(entries) == min(entries)  # no recompile as valid_length grew
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+@pytest.mark.parametrize(
+    "k,n,valid_length",
+    [
+        (512, 1024, 496),  # valid_length < k
+        (512, 1024, 2048),  # valid_length > n
+    ],
+)
+def test_topk_large_indices_valid_length_out_of_range_raises(device, expect_error, k, n, valid_length):
+    torch_input = _make_bf16_exact_input(num_rows=1, n=n)
+    with expect_error(RuntimeError, "valid_length"):
+        ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -58,6 +58,18 @@ void validate_runtime_args(const operation_attributes_t& attrs, const tensor_arg
         input_row_bytes <= std::numeric_limits<uint32_t>::max(),
         "topk_large_indices input row size must fit in uint32_t bytes; got {} bytes",
         input_row_bytes);
+
+    // Optional bounded search width: top-k scans only the first valid_length columns of each row (the rest
+    // of the physically-wider row is ignored, not read). Must hold at least k values and fit within the row.
+    if (attrs.valid_length.has_value()) {
+        const uint32_t valid_length = attrs.valid_length.value();
+        TT_FATAL(valid_length >= attrs.k, "topk_large_indices valid_length {} must be >= k {}", valid_length, attrs.k);
+        TT_FATAL(
+            valid_length <= n,
+            "topk_large_indices valid_length {} must be <= the input last dimension {}",
+            valid_length,
+            n);
+    }
 }
 
 }  // namespace
@@ -110,17 +122,18 @@ tensor_return_value_t TopkLargeIndicesDeviceOperation::create_output_tensors(
 }
 
 std::tuple<TopkLargeIndicesDeviceOperation::operation_attributes_t, TopkLargeIndicesDeviceOperation::tensor_args_t>
-TopkLargeIndicesDeviceOperation::invoke(const Tensor& input_tensor, uint32_t k) {
-    return {operation_attributes_t{.k = k}, tensor_args_t{.input_tensor = input_tensor}};
+TopkLargeIndicesDeviceOperation::invoke(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length) {
+    return {operation_attributes_t{.k = k, .valid_length = valid_length}, tensor_args_t{.input_tensor = input_tensor}};
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices
 
 namespace ttnn::experimental {
 
-Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k) {
+Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length) {
     auto [operation_attributes, tensor_args] =
-        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation::invoke(input_tensor, k);
+        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation::invoke(
+            input_tensor, k, valid_length);
     return ttnn::device_operation::launch<
         operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation>(
         operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <tuple>
 #include <variant>
 
@@ -32,13 +33,14 @@ struct TopkLargeIndicesDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor, uint32_t k);
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length);
 };
 
 }  // namespace ttnn::operations::experimental::topk_large_indices
 
 namespace ttnn::experimental {
 
-Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k);
+Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <limits>
+#include <optional>
 
 #include <tt_stl/assert.hpp>
 
@@ -27,6 +28,11 @@ inline uint32_t flattened_rows_excluding_last_dim(const ttnn::Shape& shape) {
 
 struct operation_attributes_t {
     uint32_t k{};
+    // Restrict the search to the first `valid_length` columns of each row instead of the full last
+    // dimension. Lets top-k run over the real prefix of an over-allocated row (whose tail may be stale)
+    // without physically slicing the input. nullopt = search the full width. Runtime-only (hash-excluded,
+    // validated on cache hit) so a serving loop growing valid_length reuses one program.
+    std::optional<uint32_t> valid_length{};
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
@@ -42,12 +42,17 @@ LlkTargetK snap_to_llk_target_k(uint32_t k) {
     return LlkTargetK::K2048;
 }
 
-RuntimeShapeArgs get_runtime_shape_args(const Tensor& input, LlkTargetK llk_target_k) {
+RuntimeShapeArgs get_runtime_shape_args(
+    const Tensor& input, LlkTargetK llk_target_k, std::optional<uint32_t> valid_length) {
     const uint32_t llk_k = to_uint32(llk_target_k);
     const auto& shape = input.logical_shape();
     const uint32_t n = shape[shape.rank() - 1];
-    const uint32_t num_chunks = tt::div_up(n, llk_k);
-    const uint32_t tail_elements = n - ((num_chunks - 1) * llk_k);
+    // Number of columns to actually read and scan per row. Defaults to the full physical width n; a
+    // valid_length bounds it to the real prefix so the stale tail is never read or ranked. The row STRIDE
+    // (input_row_bytes) stays n so per-row addressing is unchanged — only how much we pull from each row shrinks.
+    const uint32_t search_len = valid_length.value_or(n);
+    const uint32_t num_chunks = tt::div_up(search_len, llk_k);
+    const uint32_t tail_elements = search_len - ((num_chunks - 1) * llk_k);
     return RuntimeShapeArgs{
         .num_rows = flattened_rows_excluding_last_dim(shape),
         .num_chunks = num_chunks,
@@ -81,8 +86,9 @@ void set_runtime_args(
     const TopkLargeIndicesSharedVariables& shared,
     const Tensor& input,
     const Tensor& indices,
-    LlkTargetK llk_target_k) {
-    const auto runtime_args = get_runtime_shape_args(input, llk_target_k);
+    LlkTargetK llk_target_k,
+    std::optional<uint32_t> valid_length) {
+    const auto runtime_args = get_runtime_shape_args(input, llk_target_k, valid_length);
     const auto work_split = tt::tt_metal::split_work_to_cores(
         input.device()->compute_with_storage_grid_size(), runtime_args.num_rows, true);
     const auto num_active_cores = std::get<0>(work_split);
@@ -224,7 +230,7 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
         .compute_kernel_id = compute_kernel,
         .writer_kernel_id = writer_kernel,
         .cores = cores};
-    set_runtime_args(program, shared, input, indices, llk_target_k);
+    set_runtime_args(program, shared, input, indices, llk_target_k, operation_attributes.valid_length);
 
     return cached_program_t{std::move(program), std::move(shared)};
 }
@@ -239,7 +245,8 @@ void TopkLargeIndicesProgramFactory::override_runtime_arguments(
         cached_program.shared_variables,
         tensor_args.input_tensor,
         tensor_return_value,
-        snap_to_llk_target_k(operation_attributes.k));
+        snap_to_llk_target_k(operation_attributes.k),
+        operation_attributes.valid_length);
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::program

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
@@ -40,14 +40,23 @@ void bind_topk_large_indices(nb::module_& mod) {
             * the flattened row count must be > 0;
             * the last dimension must be >= k and <= 1,073,741,824 elements.
 
+        valid_length (optional):
+            * restricts the search to the first ``valid_length`` columns of each row;
+            * the remaining columns are ignored -- neither read nor ranked -- so an
+              over-allocated row whose tail is stale can be searched without slicing it;
+            * must be in [k, last dimension]; defaults to the full last dimension;
+            * applied at runtime (no recompile), so a loop growing valid_length reuses one program.
+
         Args:
             input_tensor: device tensor with ROW_MAJOR layout and BFLOAT16 dtype.
             k: required number of indices to return.
+            valid_length: optional number of leading columns to search (default: full width).
         )doc",
         &ttnn::experimental::topk_large_indices,
         nb::arg("input_tensor"),
         nb::kw_only(),
-        nb::arg("k"));
+        nb::arg("k"),
+        nb::arg("valid_length") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::detail


### PR DESCRIPTION
### Key changes
- **`indexer_score_dsa` bounded to the written prefix** — pass `kv_len=end_pos` so the block-cyclic indexer scores only the real prefix of the over-allocated key cache instead of the full width `T`.
- **New optional `valid_length` on `topk_large_indices`** — top-k searches only the first `valid_length` columns of a row, skipping the stale tail `kv_len` leaves behind. Runtime arg (hash-excluded, program-cache-safe); no kernel change (reuses the existing chunk/tail machinery, row stride stays the physical width).
- **Indexer top-k bounded via `valid_length=end_pos`** — so the indexer's cost grows with real cache depth instead of a constant `O(T)`, with no logits copy.

### Result (cold prefill to 100K, Blackhole LoudBox proxy, SP2×TP4)
- top-k **17.5 → 9.4 ms**; total prefill **209 → 199 ms**.

### Correctness
- sparse-MLA chunked reference PCC **0.996** (deepseek_v32, glm_5_1).
- `topk_large_indices`: **96** unit tests pass (incl. new `valid_length` cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### CI runs (this branch)
- [(Galaxy) DeepSeek Prefill tests — dsa_mla, dsa_mla_glm](https://github.com/tenstorrent/tt-metal/actions/runs/28956553926)
- [Blackhole sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/28956555999)
