### PR TITLE
Refactor matmul validation and clean up error messages

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -22,6 +22,549 @@ namespace {
 using tt::constants::TILE_HEIGHT;
 using tt::constants::TILE_WIDTH;
 
+// Universal Block-1: basic operand check. Inputs must be on the same device, tilized,
+// have a 32-wide inner tile dim (the hardware matmul works on 32x32 tiles), and both
+// be floating-point.
+void validate_matmul_operand_basics(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile) {
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Operands to matmul need to be on device!");
+    TT_FATAL(
+        input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
+        "Operands to matmul need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
+    TT_FATAL(
+        (input_tensor_a.layout() == Layout::TILE && input_tensor_b.layout() == Layout::TILE),
+        "Inputs to matmul must be tilized");
+    TT_FATAL(
+        (in0_tile.get_width() == TILE_WIDTH && in1_tile.get_height() == TILE_WIDTH),
+        "Matmul inner tile dim must be 32 (hardware constraint): got in0 tile width {}, in1 tile height {}",
+        in0_tile.get_width(),
+        in1_tile.get_height());
+    TT_FATAL(
+        is_floating_point(input_tensor_a.dtype()), "Unsupported data format for input A: {}", input_tensor_a.dtype());
+    TT_FATAL(
+        is_floating_point(input_tensor_b.dtype()), "Unsupported data format for input B: {}", input_tensor_b.dtype());
+}
+
+// Universal Block-2: matrix dimension check. Ranks, K/M/N > 0, and A's K equals B's K.
+// K is asymmetric: A's K is its last dim (width); B's K is at [-2] (height), so B's K
+// is read manually after b.rank >= 2 is verified.
+void validate_matmul_matrix_dimensions(
+    const ttnn::Shape& a_shape,
+    const ttnn::Shape& b_shape,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile) {
+    TT_FATAL(b_shape.rank() >= 2, "Matmul expects input B rank >= 2, got {}", b_shape.rank());
+    TT_FATAL(a_shape[-1] > 0, "K dimension must be positive, got {}", a_shape[-1]);
+    TT_FATAL(
+        a_shape[-1] == b_shape[-2],
+        "The width of the first tensor must be equal to the height of the second tensor. Mismatch: width={} height={}",
+        a_shape[-1],
+        b_shape[-2]);
+    TT_FATAL(b_shape[-1] > 0, "Matmul requires N (columns of B) > 0, got {}", b_shape[-1]);
+    if (a_shape.rank() >= 2) {
+        TT_FATAL(a_shape[-2] > 0, "Matmul requires M (rows of A) > 0, got {}", a_shape[-2]);
+    }
+    const uint32_t Kt_a = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+    const uint32_t Kt_b = b_shape_padded[-2] / in1_tile.get_height();
+    TT_FATAL(
+        Kt_a > 0 && Kt_b > 0,
+        "K dimension in tiles must be positive (input A: {} K-tiles, input B: {} K-tiles)",
+        Kt_a,
+        Kt_b);
+    TT_FATAL(Kt_a == Kt_b, "K dimension in tiles must match between input A ({}) and input B ({})", Kt_a, Kt_b);
+}
+
+// Universal Block-3: bfloat4 tile-size check. A bfloat4 input needs a tile dim >= 4.
+// A only checks height — its width is K, which Block-1 already forces to 32.
+void validate_matmul_bfloat4_tile_dims(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile) {
+    constexpr uint32_t bfloat4_min_tile_height = 4;
+    if (input_tensor_a.dtype() == DataType::BFLOAT4_B) {
+        TT_FATAL(
+            in0_tile.get_height() >= bfloat4_min_tile_height,
+            "BFLOAT4_B matmul requires in0 tile height >= {} (got {})",
+            bfloat4_min_tile_height,
+            in0_tile.get_height());
+    }
+    if (input_tensor_b.dtype() == DataType::BFLOAT4_B) {
+        TT_FATAL(
+            in1_tile.get_width() >= bfloat4_min_tile_height,
+            "BFLOAT4_B matmul requires in1 tile width >= {} (got {})",
+            bfloat4_min_tile_height,
+            in1_tile.get_width());
+    }
+}
+
+// Universal Block-4: optional tensor check. At most one optional input (bias). A
+// caller-provided output tensor must match the computed spec; otherwise the requested
+// output mem-config must be compatible with it (1D block-sharded == HEIGHT/WIDTH sharded).
+void validate_matmul_optional_tensors(
+    const MatmulParams& attributes, const MatmulDeviceOperation::tensor_args_t& args) {
+    const auto& optional_output_tensors = args.optional_output_tensors;
+    const auto& optional_input_tensors = args.optional_input_tensors;
+    const bool is_optional_output_tensor =
+        !optional_output_tensors.empty() && optional_output_tensors.at(0).has_value();
+
+    TT_FATAL(
+        optional_input_tensors.size() == 1,
+        "Must have exactly 1 optional input tensor, got: {}",
+        optional_input_tensors.size());
+
+    const auto output_tensor_spec = MatmulDeviceOperation::compute_output_specs(attributes, args).at(0);
+    if (is_optional_output_tensor) {
+        const auto& optional_output_tensor_c = optional_output_tensors.at(0);
+        const auto& optional_output_tensor_shape = optional_output_tensor_c->logical_shape();
+        TT_FATAL(
+            optional_output_tensor_shape == output_tensor_spec.logical_shape(),
+            "Shape of Optional Output Tensor {} doesn't match Output Tensor {}",
+            optional_output_tensor_shape,
+            output_tensor_spec.logical_shape());
+        TT_FATAL(
+            optional_output_tensor_c->dtype() == attributes.output_dtype.value(),
+            "Type mismatch between optional output tensor {} & output tensor {}",
+            optional_output_tensor_c->dtype(),
+            attributes.output_dtype.value());
+        TT_FATAL(
+            optional_output_tensor_c->memory_config() == attributes.output_mem_config,
+            "Memory config mismatch between optional output tensor {} & output "
+            "tensor {}",
+            optional_output_tensor_c->memory_config(),
+            attributes.output_mem_config);
+    } else {
+        // A BLOCK_SHARDED request on a 1D grid is the same layout as HEIGHT/WIDTH sharded
+        // (1-column grid = HEIGHT_SHARDED, 1-row grid = WIDTH_SHARDED). Work it out once here
+        // and reuse it below for both the layout check and the warning.
+        bool is_1d_column = false;
+        bool is_1d_row = false;
+        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+            attributes.output_mem_config.shard_spec().has_value()) {
+            const auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+            is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+        }
+
+        // Layouts must match, unless it is one of those equivalent 1D block conversions.
+        bool memory_layout_compatible =
+            output_tensor_spec.memory_config().memory_layout() == attributes.output_mem_config.memory_layout();
+        if (!memory_layout_compatible) {
+            memory_layout_compatible =
+                (is_1d_column &&
+                 output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                (is_1d_row && output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED);
+        }
+        TT_FATAL(
+            memory_layout_compatible,
+            "Mismatch between computed {} and provided {} mem config memory layout",
+            output_tensor_spec.memory_config().memory_layout(),
+            attributes.output_mem_config.memory_layout());
+        TT_FATAL(
+            output_tensor_spec.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
+            "Mismatch between computed {} and provided {} mem config buffer type",
+            output_tensor_spec.memory_config().buffer_type(),
+            attributes.output_mem_config.buffer_type());
+
+        // A real 1D conversion (exactly one direction, not a single 1x1 core) is expected -
+        // don't warn about it. Any other mismatch still warns.
+        const bool is_single_core = is_1d_column && is_1d_row;
+        const bool is_intentional_1d_conversion = !is_single_core && (is_1d_column || is_1d_row);
+        if (attributes.output_mem_config.shard_spec().has_value() &&
+            output_tensor_spec.memory_config() != attributes.output_mem_config && !is_intentional_1d_conversion) {
+            log_warning(
+                tt::LogOp,
+                "Mismatch between computed {} and provided {} mem config. Using computed config.",
+                output_tensor_spec.memory_config(),
+                attributes.output_mem_config);
+        }
+    }
+}
+
+// Universal Block-5: batch compatibility. bcast -> B must be single-batch; non-bcast
+// -> A and B must match rank + batch dims, unless A's batch is 1 and reused across B
+// (the Mcast1D in0-reuse exception).
+void validate_matmul_batch_compatibility(
+    const MatmulParams& attributes,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape,
+    const ttnn::Shape& b_shape,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    TT_FATAL(attributes.bcast_batch.has_value(), "bcast_batch must be populated before matmul validation");
+    if (attributes.bcast_batch.value()) {
+        TT_FATAL(
+            get_batch_size(b_shape) == 1,
+            "Batch-broadcast matmul requires input B batch size 1 (shapes BCMK*11KN=BCMN), got B batch size {}",
+            get_batch_size(b_shape));
+    }
+
+    // Validate batch dimensions for non-bcast matmul
+    if (!attributes.bcast_batch.value()) {
+        TT_FATAL(
+            a_shape.rank() == b_shape.rank(),
+            "Batched (non-bcast) matmul requires inputs of the same rank, got a_shape rank: {} vs b_shape rank: {}",
+            a_shape.rank(),
+            b_shape.rank());
+
+        // Check if in0 reuse optimization can be applied
+        // This optimization keeps input A (batch=1) in L1 and reuses it across all input B batches
+        // 1. Program config requirements: must use 1D mcast with specific settings
+        // 2. Shape requirements: must be rank >= 3 (to have at least one batch dimension)
+        // 3. Batch dimension requirement: all batch dimensions of input A must be size 1
+        // 4. Memory layout requirement: inputs must not be sharded
+        auto in0_reuse = [&]() {
+            if (!std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+                    chosen_program_config)) {
+                return false;
+            }
+            const auto& config =
+                std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config);
+            if (config.fuse_batch || config.fused_activation.has_value() || config.mcast_in0) {
+                return false;
+            }
+            if (a_shape.rank() < 3 || b_shape.rank() < 3) {
+                return false;
+            }
+            for (auto j = 0; j < a_shape.rank() - 2; j++) {
+                if (a_shape[j] != 1) {
+                    return false;
+                }
+            }
+            return !input_tensor_a.is_sharded() && !input_tensor_b.is_sharded();
+        };
+
+        for (auto i = 0; i < a_shape.rank() - 2; i++) {
+            TT_FATAL(
+                a_shape[i] == b_shape[i] || (a_shape[i] == 1 && in0_reuse()),
+                "bmm (non-bcast matmul) expects input tensors of shapes "
+                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed "
+                "when all batch dimensions of a are size 1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig "
+                "with fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 "
+                "reuse optimization)",
+                i,
+                a_shape[i],
+                b_shape[i]);
+        }
+    }
+}
+
+// Universal Block-6: input tensor count. Normally exactly 2 inputs (activation +
+// weight). Exception: the Mcast1D multi-tensor path (global_cb + DRAM-sharded weight)
+// allows 1 activation + N weights, which must share shape/spec/layout/dtype.
+void validate_matmul_input_count(
+    const MatmulParams& attributes,
+    const std::vector<Tensor>& input_tensors,
+    const Tensor& input_tensor_b,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const auto config_name = ttsl::get_active_type_name_in_variant(chosen_program_config);
+    if (std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            chosen_program_config) &&
+        attributes.global_cb.has_value() && input_tensor_b.is_sharded() && input_tensor_b.buffer()->is_dram()) {
+        for (uint32_t i = 1; i < input_tensors.size(); ++i) {
+            TT_FATAL(
+                input_tensor_b.logical_shape() == input_tensors[i].logical_shape(),
+                "{}: for multi-tensor matmul, all weight tensors must have the same logical_shape, {} is not equal to "
+                "{}",
+                config_name,
+                input_tensor_b.logical_shape(),
+                input_tensors[i].logical_shape());
+            TT_FATAL(
+                input_tensor_b.padded_shape() == input_tensors[i].padded_shape(),
+                "{}: for multi-tensor matmul, all weight tensors must have the same padded_shape {} is not equal to {}",
+                config_name,
+                input_tensor_b.padded_shape(),
+                input_tensors[i].padded_shape());
+            TT_FATAL(
+                input_tensor_b.tensor_spec() == input_tensors[i].tensor_spec(),
+                "{}: for multi-tensor matmul, all weight tensors must have the same tensor_spec {} is not equal to {}",
+                config_name,
+                input_tensor_b.tensor_spec(),
+                input_tensors[i].tensor_spec());
+            TT_FATAL(
+                input_tensor_b.layout() == input_tensors[i].layout(),
+                "{}: for multi-tensor matmul, all weight tensors must have the same layout {} is not equal to {}",
+                config_name,
+                input_tensor_b.layout(),
+                input_tensors[i].layout());
+            TT_FATAL(
+                input_tensor_b.dtype() == input_tensors[i].dtype(),
+                "{}: for multi-tensor matmul, all weight tensors must have the same dtype {} is not equal to {}",
+                config_name,
+                input_tensor_b.dtype(),
+                input_tensors[i].dtype());
+        }
+    } else {
+        TT_FATAL(
+            input_tensors.size() == 2,
+            "{}: Must have exactly 2 input tensors, got: {}",
+            config_name,
+            input_tensors.size());
+    }
+}
+
+// Universal Block-7: bias shape check. Runs only when a bias is present. A valid bias
+// is a single tile-row, N-wide, batch-1, tilized row vector whose tile size and width
+// line up with the matmul output.
+void validate_matmul_bias_shape(
+    const std::optional<const Tensor>& optional_bias,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const ttnn::Shape& b_shape,
+    const ttnn::Shape& b_shape_padded) {
+    if (!optional_bias.has_value()) {
+        return;
+    }
+    const auto& bias = optional_bias.value();
+    auto bias_tile_shape = bias.tensor_spec().tile().get_tile_shape();
+    TT_FATAL(
+        (bias_tile_shape[0] == in0_tile.get_height() && bias_tile_shape[1] == in1_tile.get_width()),
+        "Unsupported bias tile shape: bias tile ({}, {}) has to be (in0 tile height {}, in1 tile width {})",
+        bias_tile_shape[0],
+        bias_tile_shape[1],
+        in0_tile.get_height(),
+        in1_tile.get_width());
+    TT_FATAL(bias.layout() == Layout::TILE, "Unsupported bias layout: {}, has to be TILE", bias.layout());
+    const auto& bias_shape = bias.logical_shape();
+    const auto& bias_shape_padded = bias.padded_shape();
+    uint32_t bias_batch_size = get_batch_size(bias_shape);
+    TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size must be 1, got {}", bias_batch_size);
+    TT_FATAL(
+        bias_shape_padded[-2] == in0_tile.get_height(),
+        "Unsupported bias shape: padded second last dimension of bias, "
+        "{}, not equal to tile height, {}",
+        bias_shape_padded[-2],
+        in0_tile.get_height());
+    TT_FATAL(
+        bias_shape_padded[-1] == b_shape_padded[-1],
+        "Unsupported bias shape: padded last dimension of bias, {}, not "
+        "equal to second input's padded last "
+        "dimension, {}.",
+        bias_shape_padded[-1],
+        b_shape_padded[-1]);
+    TT_FATAL(
+        bias_shape[-1] >= b_shape[-1],
+        "Unsupported bias shape: last dimension of bias, {}, not equal to "
+        "or greater than second input's last "
+        "dimension, {}.",
+        bias_shape[-1],
+        b_shape[-1]);
+}
+
+// Universal Block-8: untilize_out check. untilize_out means "give me row-major output."
+// Allowed only with an explicit BF16/FP32 output dtype on the Mcast1D config;
+// runs for every config so it can reject untilize_out on the other five.
+void validate_matmul_untilize_out(
+    const MatmulParams& attributes, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    if (!attributes.untilize_out) {
+        return;
+    }
+    const auto config_name = ttsl::get_active_type_name_in_variant(chosen_program_config);
+    TT_FATAL(
+        attributes.output_dtype.has_value(),
+        "{}: Output dtype must be specified when untilize_out is true",
+        config_name);
+    TT_FATAL(
+        (attributes.output_dtype.value() == DataType::BFLOAT16) ||
+            (attributes.output_dtype.value() == DataType::FLOAT32),
+        "{}: Unsupported data type: {}, only BFLOAT16 and FLOAT32 are supported",
+        config_name,
+        attributes.output_dtype.value());
+    TT_FATAL(
+        std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config),
+        "{}: Untilize out is not supported for this program config: {}, only supported for "
+        "MatmulMultiCoreReuseMultiCast1DProgramConfig",
+        config_name,
+        ttsl::get_active_type_name_in_variant(chosen_program_config));
+}
+
+// ===========================================================================
+// SHARED-SUBSET BLOCKS: each runs for several (but not all) configs, branching
+// internally per config. Messages are config-named.
+// ===========================================================================
+
+// Block-9: block/subblock configuration. Runs for Reuse, Mcast2D, Mcast1D; MultiCore,
+// DRAMSharded, and BatchedDRAMSharded skip it. Mcast2D/Mcast1D have an out_block level;
+// Reuse divides per_core by out_subblock directly. Keeps its own in0_block_w != 0 guard
+// so its Kt-divide is self-contained (Block-10 also checks it — a harmless overlap).
+void validate_matmul_block_and_subblock_configuration(
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const auto config_name = ttsl::get_active_type_name_in_variant(chosen_program_config);
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (
+                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
+                std::is_same_v<
+                    ProgramConfigType,
+                    operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                return;
+            }
+            if constexpr (
+                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
+                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                const uint32_t Kt = a_shape_padded[-1] / in0_tile.get_width();
+                TT_FATAL(program_config.in0_block_w != 0, "{}: in0_block_w is 0, which is not valid", config_name);
+                TT_FATAL(
+                    Kt % program_config.in0_block_w == 0,
+                    "{}: Kt ({}) must be divisible by in0_block_w ({})",
+                    config_name,
+                    Kt,
+                    program_config.in0_block_w);
+                TT_FATAL(
+                    program_config.out_subblock_h != 0, "{}: out_subblock_h is 0, which is not valid", config_name);
+                TT_FATAL(
+                    program_config.out_subblock_w != 0, "{}: out_subblock_w is 0, which is not valid", config_name);
+                if constexpr (
+                    std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                    std::is_same_v<
+                        ProgramConfigType,
+                        operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                    TT_FATAL(program_config.out_block_h != 0, "{}: out_block_h is 0, which is not valid", config_name);
+                    TT_FATAL(program_config.out_block_w != 0, "{}: out_block_w is 0, which is not valid", config_name);
+                    TT_FATAL(
+                        program_config.out_block_h % program_config.out_subblock_h == 0,
+                        "{}: out_block_h ({}) must be divisible by out_subblock_h ({})",
+                        config_name,
+                        program_config.out_block_h,
+                        program_config.out_subblock_h);
+                    TT_FATAL(
+                        program_config.out_block_w % program_config.out_subblock_w == 0,
+                        "{}: out_block_w ({}) must be divisible by out_subblock_w ({})",
+                        config_name,
+                        program_config.out_block_w,
+                        program_config.out_subblock_w);
+                    TT_FATAL(
+                        program_config.per_core_M % program_config.out_block_h == 0,
+                        "{}: per_core_M ({}) must be divisible by out_block_h ({})",
+                        config_name,
+                        program_config.per_core_M,
+                        program_config.out_block_h);
+                    TT_FATAL(
+                        program_config.per_core_N % program_config.out_block_w == 0,
+                        "{}: per_core_N ({}) must be divisible by out_block_w ({})",
+                        config_name,
+                        program_config.per_core_N,
+                        program_config.out_block_w);
+                }
+                if constexpr (std::
+                                  is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                    TT_FATAL(
+                        program_config.per_core_M % program_config.out_subblock_h == 0,
+                        "{}: per_core_M ({}) must be divisible by out_subblock_h ({})",
+                        config_name,
+                        program_config.per_core_M,
+                        program_config.out_subblock_h);
+                    TT_FATAL(
+                        program_config.per_core_N % program_config.out_subblock_w == 0,
+                        "{}: per_core_N ({}) must be divisible by out_subblock_w ({})",
+                        config_name,
+                        program_config.per_core_N,
+                        program_config.out_subblock_w);
+                }
+                TT_FATAL(
+                    attributes.compute_kernel_config.has_value(),
+                    "{}: compute_kernel_config must be set for matmul subblock validation",
+                    config_name);
+                TT_FATAL(
+                    attributes.output_tile.has_value(),
+                    "{}: output_tile must be set for matmul subblock validation",
+                    config_name);
+                const uint32_t available_reg_count = ttnn::get_dest_reg_count(
+                    attributes.compute_kernel_config.value(), attributes.output_tile.value().get_tile_shape());
+                TT_FATAL(
+                    program_config.out_subblock_h * program_config.out_subblock_w <= available_reg_count,
+                    "{}: out_subblock_w {} times out_subblock_h {} needs to be at most {} to fit in hardware",
+                    config_name,
+                    program_config.out_subblock_w,
+                    program_config.out_subblock_h,
+                    available_reg_count);
+            }
+        },
+        chosen_program_config);
+}
+
+// Block-10: compute-grid + per-core dims. MultiCore skips. Reuse/Mcast2D/Mcast1D check
+// the program grid is non-zero and fits the device (Mcast1D gather_in0 skips it — its
+// grid comes from the input shard grid). All non-MultiCore configs check in0_block_w /
+// per_core_M / per_core_N are non-zero (via the helper below).
+
+// Checks in0_block_w / per_core_M / per_core_N are non-zero. Block-9's Kt-divide relies on this.
+void validate_matmul_nonzero_block_dims(
+    std::string_view config_name, std::size_t in0_block_w, std::size_t per_core_M, std::size_t per_core_N) {
+    TT_FATAL(in0_block_w != 0, "{}: in0_block_w is 0, which is not valid", config_name);
+    TT_FATAL(per_core_M != 0, "{}: per_core_M is 0, which is not valid", config_name);
+    TT_FATAL(per_core_N != 0, "{}: per_core_N is 0, which is not valid", config_name);
+}
+
+void validate_matmul_compute_grid_and_per_core_dims(
+    const Tensor& input_tensor_a, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+    const auto config_name = ttsl::get_active_type_name_in_variant(chosen_program_config);
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig>) {
+                return;  // C1: no program grid / block dims to check
+            } else {
+                // C2-C6. Grid-bounds check applies to C2/C3/C4 only (C5/C6 map to DRAM banks).
+                if constexpr (
+                    std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
+                    std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                    std::is_same_v<
+                        ProgramConfigType,
+                        operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                    bool skip_grid_check = false;
+                    if constexpr (std::is_same_v<
+                                      ProgramConfigType,
+                                      operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                        skip_grid_check = program_config.gather_in0;
+                    }
+                    if (!skip_grid_check) {
+                        const auto& grid = program_config.compute_with_storage_grid_size;
+                        TT_FATAL(
+                            grid.x > 0 && grid.y > 0,
+                            "{}: compute_with_storage_grid_size must be non-zero, got ({}, {})",
+                            config_name,
+                            grid.x,
+                            grid.y);
+                        TT_FATAL(
+                            grid.x <= device_grid.x && grid.y <= device_grid.y,
+                            "{}: compute_with_storage_grid_size ({}, {}) must fit within device grid ({}, {})",
+                            config_name,
+                            grid.x,
+                            grid.y,
+                            device_grid.x,
+                            device_grid.y);
+                    }
+                }
+                validate_matmul_nonzero_block_dims(
+                    config_name, program_config.in0_block_w, program_config.per_core_M, program_config.per_core_N);
+            }
+        },
+        chosen_program_config);
+}
+
+// Block-11: grid-containment helpers. Check that a sharded tensor's shard grid fits
+// inside the compute grid. Two helpers — one for a tensor input, one for the output
+// mem-config; only L1-sharded tensors are checked (DRAM is skipped).
+
+// Orig 25-43.
 void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     // Validate tensor is within grid if sharded and not in DRAM
     if (tensor.memory_config().is_sharded() && tensor.memory_config().buffer_type() != BufferType::DRAM) {
@@ -42,177 +585,8 @@ void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     }
 }
 
-void validate_matmul_matrix_dimensions(
-    const ttnn::Shape& a_shape,
-    const ttnn::Shape& b_shape,
-    const ttnn::Shape& a_shape_padded,
-    const ttnn::Shape& b_shape_padded,
-    const tt::tt_metal::Tile& in0_tile,
-    const tt::tt_metal::Tile& in1_tile) {
-    TT_FATAL(b_shape.rank() >= 2, "Matmul expects input B rank >= 2, got {}", b_shape.rank());
-    TT_FATAL(a_shape[-1] > 0, "K dimension must be positive, got {}", a_shape[-1]);
-    TT_FATAL(
-        a_shape[-1] == b_shape[-2],
-        "The width of the first tensor must be equal to the height of the second tensor. Mismatch: width={} height={}",
-        a_shape[-1],
-        b_shape[-2]);
-    TT_FATAL(b_shape[-1] > 0, "Matmul requires N (columns of B) > 0, got {}", b_shape[-1]);
-    if (a_shape.rank() >= 2) {
-        TT_FATAL(a_shape[-2] > 0, "Matmul requires M (rows of A) > 0, got {}", a_shape[-2]);
-    }
-
-    // Shapes are post-transpose: K is at [-1] for A and [-2] for B.
-    const uint32_t Kt_a = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
-    const uint32_t Kt_b = b_shape_padded[-2] / in1_tile.get_height();
-    TT_FATAL(
-        Kt_a > 0 && Kt_b > 0,
-        "K dimension in tiles must be positive (input A: {} K-tiles, input B: {} K-tiles)",
-        Kt_a,
-        Kt_b);
-    TT_FATAL(Kt_a == Kt_b, "K dimension in tiles must match between input A ({}) and input B ({})", Kt_a, Kt_b);
-}
-
-void validate_matmul_tile_constraints(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const tt::tt_metal::Tile& in0_tile,
-    const tt::tt_metal::Tile& in1_tile,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    // minimum tile_h = 4: shared exponents are packed into a uint32 (4 exponents minimum)
-    constexpr uint32_t bfloat4_min_tile_height = 4;
-    if (input_tensor_a.dtype() == DataType::BFLOAT4_B) {
-        TT_FATAL(
-            in0_tile.get_height() >= bfloat4_min_tile_height,
-            "BFLOAT4_B matmul requires in0 tile height >= {} (got {})",
-            bfloat4_min_tile_height,
-            in0_tile.get_height());
-    }
-    if (input_tensor_b.dtype() == DataType::BFLOAT4_B) {
-        TT_FATAL(
-            in1_tile.get_height() >= bfloat4_min_tile_height,
-            "BFLOAT4_B matmul requires in1 tile height >= {} (got {})",
-            bfloat4_min_tile_height,
-            in1_tile.get_height());
-        TT_FATAL(
-            in1_tile.get_width() >= bfloat4_min_tile_height,
-            "BFLOAT4_B matmul requires in1 tile width >= {} (got {})",
-            bfloat4_min_tile_height,
-            in1_tile.get_width());
-    }
-
-    const bool uses_tiny_outer_tile = (in0_tile.get_height() != TILE_HEIGHT || in1_tile.get_width() != TILE_WIDTH);
-    if (!uses_tiny_outer_tile) {
-        return;
-    }
-
-    if (std::holds_alternative<operations::matmul::MatmulMultiCoreProgramConfig>(chosen_program_config)) {
-        TT_FATAL(
-            false,
-            "matmul with non-optimized program config does not support tiny tile "
-            "(in0 tile height={}, in1 tile width={}, expected TILE_HEIGHT={}, TILE_WIDTH={})",
-            in0_tile.get_height(),
-            in1_tile.get_width(),
-            TILE_HEIGHT,
-            TILE_WIDTH);
-    }
-}
-
-void validate_matmul_block_and_subblock_configuration(
-    const MatmulParams& attributes,
-    const ttnn::Shape& a_shape_padded,
-    const tt::tt_metal::Tile& in0_tile,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    std::visit(
-        [&attributes, &a_shape_padded, &in0_tile](const auto& program_config) {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig> ||
-                std::is_same_v<
-                    ProgramConfigType,
-                    operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
-                std::is_same_v<
-                    ProgramConfigType,
-                    operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-                return;
-            }
-            if constexpr (
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                TT_FATAL(program_config.in0_block_w != 0, "in0_block_w is 0, which is not valid");
-                const uint32_t Kt = a_shape_padded[-1] / in0_tile.get_width();
-                TT_FATAL(
-                    Kt % program_config.in0_block_w == 0,
-                    "Kt ({}) must be divisible by in0_block_w ({})",
-                    Kt,
-                    program_config.in0_block_w);
-                TT_FATAL(program_config.out_subblock_h != 0, "out_subblock_h is 0, which is not valid");
-                TT_FATAL(program_config.out_subblock_w != 0, "out_subblock_w is 0, which is not valid");
-                if constexpr (
-                    std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
-                    std::is_same_v<
-                        ProgramConfigType,
-                        operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                    TT_FATAL(program_config.out_block_h != 0, "out_block_h is 0, which is not valid");
-                    TT_FATAL(program_config.out_block_w != 0, "out_block_w is 0, which is not valid");
-                    TT_FATAL(
-                        program_config.out_block_h % program_config.out_subblock_h == 0,
-                        "out_block_h ({}) must be divisible by out_subblock_h ({})",
-                        program_config.out_block_h,
-                        program_config.out_subblock_h);
-                    TT_FATAL(
-                        program_config.out_block_w % program_config.out_subblock_w == 0,
-                        "out_block_w ({}) must be divisible by out_subblock_w ({})",
-                        program_config.out_block_w,
-                        program_config.out_subblock_w);
-                    TT_FATAL(
-                        program_config.per_core_M % program_config.out_block_h == 0,
-                        "per_core_M ({}) must be divisible by out_block_h ({})",
-                        program_config.per_core_M,
-                        program_config.out_block_h);
-                    TT_FATAL(
-                        program_config.per_core_N % program_config.out_block_w == 0,
-                        "per_core_N ({}) must be divisible by out_block_w ({})",
-                        program_config.per_core_N,
-                        program_config.out_block_w);
-                }
-                if constexpr (std::
-                                  is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                    TT_FATAL(
-                        program_config.per_core_M % program_config.out_subblock_h == 0,
-                        "per_core_M ({}) must be divisible by out_subblock_h ({})",
-                        program_config.per_core_M,
-                        program_config.out_subblock_h);
-                    TT_FATAL(
-                        program_config.per_core_N % program_config.out_subblock_w == 0,
-                        "per_core_N ({}) must be divisible by out_subblock_w ({})",
-                        program_config.per_core_N,
-                        program_config.out_subblock_w);
-                }
-                TT_FATAL(
-                    attributes.compute_kernel_config.has_value(),
-                    "compute_kernel_config must be set for matmul subblock validation");
-                TT_FATAL(attributes.output_tile.has_value(), "output_tile must be set for matmul subblock validation");
-                const uint32_t available_reg_count = ttnn::get_dest_reg_count(
-                    attributes.compute_kernel_config.value(), attributes.output_tile.value().get_tile_shape());
-                TT_FATAL(
-                    program_config.out_subblock_h * program_config.out_subblock_w <= available_reg_count,
-                    "out_subblock_w {} times out_subblock_h {} needs to be at "
-                    "most {} to fit in hardware",
-                    program_config.out_subblock_w,
-                    program_config.out_subblock_h,
-                    available_reg_count);
-            }
-        },
-        chosen_program_config);
-}
-
-void validate_matmul_nonzero_block_dims(std::size_t in0_block_w, std::size_t per_core_M, std::size_t per_core_N) {
-    TT_FATAL(in0_block_w != 0, "in0_block_w is 0, which is not valid");
-    TT_FATAL(per_core_M != 0, "per_core_M is 0, which is not valid");
-    TT_FATAL(per_core_N != 0, "per_core_N is 0, which is not valid");
-}
-
+// Orig 216-236. Keeps its original context_label param (the config name / a
+// descriptive tag); the extent-non-zero message is now also prefixed with it.
 void check_output_shard_grid_within_extent(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::CoreCoord& extent,
@@ -224,7 +598,12 @@ void check_output_shard_grid_within_extent(
         return;
     }
     const auto& shard_grid = output_mem_config.shard_spec().value().grid;
-    TT_FATAL(extent.x > 0 && extent.y > 0, "device grid extent must be non-zero, got ({}, {})", extent.x, extent.y);
+    TT_FATAL(
+        extent.x > 0 && extent.y > 0,
+        "{}: device grid extent must be non-zero, got ({}, {})",
+        context_label,
+        extent.x,
+        extent.y);
     const tt::tt_metal::CoreRange bbox(
         tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(extent.x - 1, extent.y - 1));
     TT_FATAL(
@@ -235,61 +614,151 @@ void check_output_shard_grid_within_extent(
         extent);
 }
 
-void validate_matmul_compute_grid_and_per_core_dims(
-    const Tensor& input_tensor_a, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    const CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
-
+// Block-12: work distribution + gather ring topology. Runs for Reuse/Mcast2D/Mcast1D.
+// Checks output blocks fit the cores (Mcast1D uses a 1D total count, Mcast2D a 2D
+// per-axis check), and for Mcast1D gather_in0 the ring setup (A sharded, sub-device
+// present, hop cores not overlapping).
+void validate_matmul_work_distribution_and_gather_ring_topology(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    bool transpose_a,
+    bool transpose_b,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const auto config_name = ttsl::get_active_type_name_in_variant(chosen_program_config);
     std::visit(
-        [device_grid](const auto& program_config) {
+        [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig>) {
-                return;
-            }
-            if constexpr (
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
-                std::is_same_v<
-                    ProgramConfigType,
-                    operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
-                std::is_same_v<
-                    ProgramConfigType,
-                    operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-                if constexpr (
-                    std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
-                    std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
-                    std::is_same_v<
-                        ProgramConfigType,
-                        operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                    bool skip_grid_check = false;
-                    if constexpr (std::is_same_v<
-                                      ProgramConfigType,
-                                      operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                        skip_grid_check = program_config.gather_in0;
-                    }
-                    if (!skip_grid_check) {
-                        const auto& grid = program_config.compute_with_storage_grid_size;
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                const tt::tt_metal::CoreCoord device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
+                const auto& grid = program_config.compute_with_storage_grid_size;
+                const auto Mt =
+                    operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
+                const auto Nt = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                const uint32_t per_core_M = program_config.per_core_M;
+                const uint32_t per_core_N = program_config.per_core_N;
+                const uint32_t num_cores = grid.x * grid.y;
+
+                if (program_config.gather_in0) {
+                    TT_FATAL(!transpose_a, "{}: transpose_a is not supported with gather_in0", config_name);
+                    TT_FATAL(!transpose_b, "{}: transpose_b is not supported with gather_in0", config_name);
+                    TT_FATAL(input_tensor_a.is_sharded(), "{}: gather_in0 requires input A to be sharded", config_name);
+                    auto* device = input_tensor_a.device();
+                    const auto& sub_device_ids = device->get_sub_device_ids();
+                    TT_FATAL(
+                        !sub_device_ids.empty(),
+                        "{}: gather_in0 matmul requires at least one sub-device id on the device",
+                        config_name);
+                    if (!program_config.hop_cores.empty()) {
+                        const tt::tt_metal::CoreRangeSet& worker_cores = input_tensor_a.shard_spec().value().grid;
                         TT_FATAL(
-                            grid.x > 0 && grid.y > 0,
-                            "compute_with_storage_grid_size must be non-zero, got ({}, {})",
-                            grid.x,
-                            grid.y);
-                        TT_FATAL(
-                            grid.x <= device_grid.x && grid.y <= device_grid.y,
-                            "compute_with_storage_grid_size ({}, {}) must fit within device grid ({}, {})",
-                            grid.x,
-                            grid.y,
-                            device_grid.x,
-                            device_grid.y);
+                            !program_config.hop_cores.intersects(worker_cores),
+                            "{}: hop_cores must not overlap with input A shard grid. hop_cores={}, workers={}",
+                            config_name,
+                            program_config.hop_cores,
+                            worker_cores);
                     }
+                    check_output_shard_grid_within_extent(
+                        output_mem_config,
+                        device_extent,
+                        "MatmulMultiCoreReuseMultiCast1DProgramConfig (gather_in0 output vs device grid)");
+                } else {
+                    TT_FATAL(
+                        program_config.hop_cores.empty(),
+                        "{}: Hop cores are not supported for any mode besides gather_in0.",
+                        config_name);
+                    TT_FATAL(
+                        Mt > 0 && Nt > 0,
+                        "{}: Mt and Nt must be greater than zero in tiles (got Mt={}, Nt={})",
+                        config_name,
+                        Mt,
+                        Nt);
+                    const uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+                    const uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+                    const uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+                    TT_FATAL(
+                        num_blocks_total <= num_cores,
+                        "{}: Number of blocks exceeds number of cores: {} blocks > {} cores",
+                        config_name,
+                        num_blocks_total,
+                        num_cores);
+                    if (program_config.mcast_in0) {
+                        TT_FATAL(
+                            num_blocks_y == 1,
+                            "{}: mcast_in0 requires M ({}) to fit within a single per_core_M block ({}), got "
+                            "num_blocks_y={}",
+                            config_name,
+                            Mt,
+                            per_core_M,
+                            num_blocks_y);
+                    }
+                    check_output_shard_grid_within_extent(
+                        output_mem_config, grid, "MatmulMultiCoreReuseMultiCast1DProgramConfig");
                 }
-                validate_matmul_nonzero_block_dims(
-                    program_config.in0_block_w, program_config.per_core_M, program_config.per_core_N);
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                const auto& grid = program_config.compute_with_storage_grid_size;
+                const auto Mt =
+                    operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
+                const auto Nt = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                TT_FATAL(
+                    Mt > 0 && Nt > 0,
+                    "{}: Mt and Nt must be greater than zero in tiles (got Mt={}, Nt={})",
+                    config_name,
+                    Mt,
+                    Nt);
+                uint32_t num_blocks_y = ((Mt - 1) / program_config.per_core_M) + 1;
+                uint32_t num_blocks_x = ((Nt - 1) / program_config.per_core_N) + 1;
+                if (program_config.transpose_mcast) {
+                    std::swap(num_blocks_x, num_blocks_y);
+                }
+                TT_FATAL(
+                    num_blocks_x <= grid.x,
+                    "{}: Num output blocks along x ({}) must be smaller than or equal to the number of columns in "
+                    "compute grid ({})!",
+                    config_name,
+                    num_blocks_x,
+                    grid.x);
+                TT_FATAL(
+                    num_blocks_y <= grid.y,
+                    "{}: Num output blocks along y ({}) must be smaller than or equal to the number of rows in compute "
+                    "grid ({})!",
+                    config_name,
+                    num_blocks_y,
+                    grid.y);
+                check_output_shard_grid_within_extent(
+                    output_mem_config, grid, "MatmulMultiCoreReuseMultiCastProgramConfig");
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // The factory selects all_cores from the first available shard spec: in0, then in1,
+                // then output. Any of those can produce an offset grid (e.g. column 1 in a fused
+                // chain). Use the device grid as the extent whenever any operand is sharded so we
+                // don't incorrectly reject those grids against the origin-anchored config rect.
+                const auto device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
+                const bool any_sharded = input_tensor_a.memory_config().is_sharded() ||
+                                         input_tensor_b.memory_config().is_sharded() || output_mem_config.is_sharded();
+                const auto effective_extent =
+                    any_sharded ? device_extent : program_config.compute_with_storage_grid_size;
+                check_output_shard_grid_within_extent(
+                    output_mem_config, effective_extent, "MatmulMultiCoreReuseProgramConfig");
+            } else {
+                (void)transpose_a;
+                (void)transpose_b;
             }
         },
         chosen_program_config);
 }
 
+// Block-10a — Reuse config only. Sharded operand grids must fit within the program
+// compute grid.
 void validate_matmul_sharded_operand_grids_within_program_compute_grid(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -316,6 +785,7 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
         chosen_program_config);
 }
 
+// Block-10b — Reuse config only. Checks sharded output block divisibility.
 void validate_matmul_reuse_sharded_output_block_divisibility(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -358,127 +828,7 @@ void validate_matmul_reuse_sharded_output_block_divisibility(
         chosen_program_config);
 }
 
-void validate_matmul_work_distribution_and_gather_ring_topology(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const ttnn::Shape& a_shape_padded,
-    const ttnn::Shape& b_shape_padded,
-    const tt::tt_metal::Tile& in0_tile,
-    const tt::tt_metal::Tile& in1_tile,
-    bool transpose_a,
-    bool transpose_b,
-    const tt::tt_metal::MemoryConfig& output_mem_config,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    std::visit(
-        [&](const auto& program_config) {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (std::is_same_v<
-                              ProgramConfigType,
-                              operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                const tt::tt_metal::CoreCoord device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
-                const auto& grid = program_config.compute_with_storage_grid_size;
-                const auto Mt =
-                    operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
-                const auto Nt = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
-                const uint32_t per_core_M = program_config.per_core_M;
-                const uint32_t per_core_N = program_config.per_core_N;
-                const uint32_t num_cores = grid.x * grid.y;
-
-                if (program_config.gather_in0) {
-                    TT_FATAL(!transpose_a, "transpose_a is not supported with gather_in0");
-                    TT_FATAL(!transpose_b, "transpose_b is not supported with gather_in0");
-                    TT_FATAL(input_tensor_a.is_sharded(), "gather_in0 requires input A to be sharded");
-                    auto* device = input_tensor_a.device();
-                    const auto& sub_device_ids = device->get_sub_device_ids();
-                    TT_FATAL(
-                        !sub_device_ids.empty(), "gather_in0 matmul requires at least one sub-device id on the device");
-                    if (!program_config.hop_cores.empty()) {
-                        const tt::tt_metal::CoreRangeSet& worker_cores = input_tensor_a.shard_spec().value().grid;
-                        TT_FATAL(
-                            !program_config.hop_cores.intersects(worker_cores),
-                            "hop_cores must not overlap with input A shard grid. hop_cores={}, workers={}",
-                            program_config.hop_cores,
-                            worker_cores);
-                    }
-                    check_output_shard_grid_within_extent(
-                        output_mem_config,
-                        device_extent,
-                        "MatmulMultiCoreReuseMultiCast1DProgramConfig (gather_in0 output vs device grid)");
-                } else {
-                    TT_FATAL(
-                        program_config.hop_cores.empty(),
-                        "Hop cores are not supported for any mode besides gather_in0.");
-                    TT_FATAL(
-                        Mt > 0 && Nt > 0, "Mt and Nt must be greater than zero in tiles (got Mt={}, Nt={})", Mt, Nt);
-                    const uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
-                    const uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
-                    const uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
-                    TT_FATAL(
-                        num_blocks_total <= num_cores,
-                        "Number of blocks exceeds number of cores: {} blocks > {} cores",
-                        num_blocks_total,
-                        num_cores);
-                    if (program_config.mcast_in0) {
-                        TT_FATAL(
-                            num_blocks_y == 1,
-                            "mcast_in0 requires M ({}) to fit within a single per_core_M block ({}), got "
-                            "num_blocks_y={}",
-                            Mt,
-                            per_core_M,
-                            num_blocks_y);
-                    }
-                    check_output_shard_grid_within_extent(
-                        output_mem_config, grid, "MatmulMultiCoreReuseMultiCast1DProgramConfig");
-                }
-            } else if constexpr (std::is_same_v<
-                                     ProgramConfigType,
-                                     operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
-                const auto& grid = program_config.compute_with_storage_grid_size;
-                const auto Mt =
-                    operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
-                const auto Nt = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
-                TT_FATAL(Mt > 0 && Nt > 0, "Mt and Nt must be greater than zero in tiles (got Mt={}, Nt={})", Mt, Nt);
-                uint32_t num_blocks_y = ((Mt - 1) / program_config.per_core_M) + 1;
-                uint32_t num_blocks_x = ((Nt - 1) / program_config.per_core_N) + 1;
-                if (program_config.transpose_mcast) {
-                    std::swap(num_blocks_x, num_blocks_y);
-                }
-                TT_FATAL(
-                    num_blocks_x <= grid.x,
-                    "Num output blocks along x ({}) must be smaller than or equal to the number of columns in compute "
-                    "grid ({})!",
-                    num_blocks_x,
-                    grid.x);
-                TT_FATAL(
-                    num_blocks_y <= grid.y,
-                    "Num output blocks along y ({}) must be smaller than or equal to the number of rows in compute "
-                    "grid ({})!",
-                    num_blocks_y,
-                    grid.y);
-                check_output_shard_grid_within_extent(
-                    output_mem_config, grid, "MatmulMultiCoreReuseMultiCastProgramConfig");
-            } else if constexpr (std::is_same_v<
-                                     ProgramConfigType,
-                                     operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                // The factory selects all_cores from the first available shard spec: in0, then in1,
-                // then output. Any of those can produce an offset grid (e.g. column 1 in a fused
-                // chain). Use the device grid as the extent whenever any operand is sharded so we
-                // don't incorrectly reject those grids against the origin-anchored config rect.
-                const auto device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
-                const bool any_sharded = input_tensor_a.memory_config().is_sharded() ||
-                                         input_tensor_b.memory_config().is_sharded() || output_mem_config.is_sharded();
-                const auto effective_extent =
-                    any_sharded ? device_extent : program_config.compute_with_storage_grid_size;
-                check_output_shard_grid_within_extent(
-                    output_mem_config, effective_extent, "MatmulMultiCoreReuseProgramConfig");
-            } else {
-                (void)transpose_a;
-                (void)transpose_b;
-            }
-        },
-        chosen_program_config);
-}
-
+// Block-10c — bias support by config. Reuse rejects bias; other configs allow it.
 void validate_matmul_bias(
     const std::optional<const Tensor>& optional_bias,
     const operations::matmul::MatmulProgramConfig& chosen_program_config) {
@@ -500,70 +850,6 @@ void validate_matmul_bias(
         !optional_bias.has_value() || config_supports_bias,
         "Bias is not supported for this matmul program config: {}",
         ttsl::get_active_type_name_in_variant(chosen_program_config));
-}
-
-bool get_broadcast_batch(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const bool transpose_a,
-    const bool transpose_b,
-    const std::optional<const operations::matmul::MatmulProgramConfig>& matmul_program_config) {
-    const auto& b_shape_padded =
-        operations::matmul::utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
-    uint32_t batch_size_b = get_batch_size(b_shape_padded);
-    bool broadcast_batch = batch_size_b == 1;
-    if (!matmul_program_config.has_value()) {
-        return broadcast_batch;
-    }
-
-    bool is_multi_core_reuse = std::visit(
-        [](const auto& program_config) -> bool {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            return static_cast<bool>(
-                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>);
-        },
-        matmul_program_config.value());
-    if (is_multi_core_reuse) {
-        const auto& a_shape_padded =
-            operations::matmul::utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a);
-        uint32_t batch_size_a = get_batch_size(a_shape_padded);
-        broadcast_batch &= batch_size_a > 1;
-    }
-    return broadcast_batch;
-}
-
-// Warns if a caller of MatmulDeviceOperation's static API hasn't populated allowed_worker_cores
-// on a program_config variant that supports the field. ttnn::prim::matmul() normalizes its
-// attributes before launch, but direct callers (e.g. CCL fused ops in
-// ttnn/operations/experimental/ccl) need to invoke
-// ttnn::operations::matmul::normalize_program_config() themselves. Downstream code in this file
-// auto-populates via normalize_program_config on the chosen_program_config local, so this is
-// currently advisory.
-// TODO(#44529): convert this back to TT_FATAL once all callers have been updated.
-void warn_if_allowed_worker_cores_missing(
-    const std::optional<operations::matmul::MatmulProgramConfig>& program_config,
-    [[maybe_unused]] std::string_view entry_point) {
-    if (!program_config.has_value()) {
-        return;
-    }
-    /* The following spammed CI logs too much; leave it in place to convert to TT_FATAL in the future.
-    std::visit(
-        [&](const auto& pc) {
-            if constexpr (requires { pc.allowed_worker_cores; }) {
-                if (!pc.allowed_worker_cores.has_value()) {
-                    log_warning(
-                        tt::LogOp,
-                        "{}: program_config.allowed_worker_cores not populated on a MatmulProgramConfig variant "
-                        "that supports the field. Auto-populating from compute_with_storage_grid_size. Callers "
-                        "that bypass ttnn::prim::matmul() should invoke "
-                        "ttnn::operations::matmul::normalize_program_config() on the program config first. "
-                        "This will become a hard error in a future release.",
-                        entry_point);
-                }
-            }
-        },
-        program_config.value());
-        */
 }
 
 // Cross-validate a DRAM-sender global_cb's geometry against the matmul + weight shape.
@@ -672,12 +958,6 @@ void validate_dram_sender_global_cb_gather_in0_geometry(
         recv_per_bank);
 }
 
-// Receiver-contiguous counterpart of the cross-check above. The recv-contig weight is an
-// NdShardSpec tensor (num_shards == ring_size) with a strided bank->ring mapping, so the
-// K-row-major "bank b owns ring positions [b*rpb, (b+1)*rpb)" convention does not apply and
-// the bank-walk assertion is intentionally omitted. The two silent-hang guards still hold:
-// the weight K-tiles must divide ring_size, and per_core_N must equal the per-receiver N
-// (N_tiles / ring_size) so the matmul's in1 page size matches what the prefetcher pushes.
 void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
     const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
     const Tensor& input_tensor_a,
@@ -719,6 +999,1019 @@ void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
         ring_size);
 }
 
+// Warns if a caller of MatmulDeviceOperation's static API hasn't populated allowed_worker_cores
+// on a program_config variant that supports the field. ttnn::prim::matmul() normalizes its
+// attributes before launch, but direct callers (e.g. CCL fused ops in
+// ttnn/operations/experimental/ccl) need to invoke
+// ttnn::operations::matmul::normalize_program_config() themselves. Downstream code in this file
+// auto-populates via normalize_program_config on the chosen_program_config local, so this is
+// currently advisory.
+// TODO(#44529): convert this back to TT_FATAL once all callers have been updated.
+void warn_if_allowed_worker_cores_missing(
+    const std::optional<operations::matmul::MatmulProgramConfig>& program_config,
+    [[maybe_unused]] std::string_view entry_point) {
+    if (!program_config.has_value()) {
+        return;
+    }
+    /* The following spammed CI logs too much; leave it in place to convert to TT_FATAL in the future.
+    std::visit(
+        [&](const auto& pc) {
+            if constexpr (requires { pc.allowed_worker_cores; }) {
+                if (!pc.allowed_worker_cores.has_value()) {
+                    log_warning(
+                        tt::LogOp,
+                        "{}: program_config.allowed_worker_cores not populated on a MatmulProgramConfig variant "
+                        "that supports the field. Auto-populating from compute_with_storage_grid_size. Callers "
+                        "that bypass ttnn::prim::matmul() should invoke "
+                        "ttnn::operations::matmul::normalize_program_config() on the program config first. "
+                        "This will become a hard error in a future release.",
+                        entry_point);
+                }
+            }
+        },
+        program_config.value());
+        */
+}
+
+// Runs for Mcast1D on a sub-device (non-gather). The sub-device's cores must form a
+// solid block with no gaps, and the matmul's grid must fit within that block.
+void validate_matmul_mcast1d_subdevice_worker_grid(
+    const Tensor& input_tensor_a,
+    const MatmulParams& attributes,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    // matmul_multicore_reuse_mcast_1d (both program- and descriptor-based) targets a single
+    // bounding-box rectangle for the in0/in1 multicast and expects the sub-device's worker
+    // cores to form one contiguous row-major rectangle. Reject non-rectangular sub-device
+    // grids early with a clear message.
+    if (std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            chosen_program_config) &&
+        attributes.sub_device_id.has_value()) {
+        const auto config_name = ttsl::get_active_type_name_in_variant(chosen_program_config);
+        const auto& program_config_1d =
+            std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config);
+        if (!program_config_1d.gather_in0) {
+            auto* device = input_tensor_a.device();
+            auto sub_device_cores =
+                device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, attributes.sub_device_id.value());
+            auto bbox = sub_device_cores.bounding_box();
+            TT_FATAL(
+                sub_device_cores.num_cores() == bbox.size(),
+                "{}: matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+                "Got sub-device worker cores: {} (bounding box: {})",
+                config_name,
+                sub_device_cores,
+                bbox);
+            auto grid_size_1d = program_config_1d.allowed_worker_cores.value().bounding_box().grid_size();
+            TT_FATAL(
+                bbox.start_coord.x + grid_size_1d.x - 1 <= bbox.end_coord.x &&
+                    bbox.start_coord.y + grid_size_1d.y - 1 <= bbox.end_coord.y,
+                "{}: matmul grid_size {} anchored at sub-device start {} "
+                "extends past the sub-device's worker bounding box {}",
+                config_name,
+                grid_size_1d,
+                bbox.start_coord,
+                bbox);
+        }
+    }
+}
+
+// Shared block: input A and output must agree on buffer type + memory layout. Used by
+// Reuse/Mcast2D/Mcast1D/DRAMSharded/BatchedDRAMSharded.
+void validate_input_a_output_mem_config_match(
+    std::string_view config_name, const Tensor& input_tensor_a, const tt::tt_metal::MemoryConfig& output_mem_config) {
+    TT_FATAL(
+        input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
+        "{}: input A and output buffer types must match, got input: {} vs output: {}",
+        config_name,
+        input_tensor_a.memory_config().buffer_type(),
+        output_mem_config.buffer_type());
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(),
+        "{}: input A and output memory layouts must match, got input: {} vs output: {}",
+        config_name,
+        input_tensor_a.memory_config().memory_layout(),
+        output_mem_config.memory_layout());
+}
+
+// Shared block: output subblock/block width must divide per_core_N. Used by
+// Mcast2D/Mcast1D (Reuse keeps its own inline variant).
+void validate_output_subblock_block_divides_per_core_n(
+    std::string_view config_name,
+    uint32_t out_subblock_w,
+    uint32_t out_subblock_h,
+    uint32_t out_block_w,
+    uint32_t out_block_h,
+    uint32_t per_core_N) {
+    TT_FATAL(
+        out_subblock_w == per_core_N || out_subblock_h == 1,
+        "{}: out_subblock_w ({}) must equal per_core_N ({}) or out_subblock_h ({}) must be 1",
+        config_name,
+        out_subblock_w,
+        per_core_N,
+        out_subblock_h);
+    TT_FATAL(
+        out_block_w == per_core_N || out_block_h == 1,
+        "{}: out_block_w ({}) must equal per_core_N ({}) or out_block_h ({}) must be 1",
+        config_name,
+        out_block_w,
+        per_core_N,
+        out_block_h);
+}
+
+// ===========================================================================
+// PER-CONFIG VALIDATORS. One function per program config, holding the checks that
+// fire for that config only. Dispatched from validate_on_program_cache_miss via one
+// std::visit.
+// ===========================================================================
+
+// MultiCore config — the un-optimized fallback. Rejects tiny outer tiles and requires
+// all operands + output to be INTERLEAVED.
+void validate_matmul_c1_multicore_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MatmulParams& attributes,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile) {
+    constexpr auto config_name = ttsl::get_type_name<operations::matmul::MatmulMultiCoreProgramConfig>();
+    const bool uses_tiny_outer_tile = (in0_tile.get_height() != TILE_HEIGHT || in1_tile.get_width() != TILE_WIDTH);
+    if (uses_tiny_outer_tile) {
+        TT_FATAL(
+            false,
+            "{}: matmul with non-optimized program config does not support tiny tile "
+            "(in0 tile height={}, in1 tile width={}, expected TILE_HEIGHT={}, TILE_WIDTH={})",
+            config_name,
+            in0_tile.get_height(),
+            in1_tile.get_width(),
+            TILE_HEIGHT,
+            TILE_WIDTH);
+    }
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "{}: Input A memory layout must be INTERLEAVED, got: {}",
+        config_name,
+        input_tensor_a.memory_config().memory_layout());
+    TT_FATAL(
+        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "{}: Input B memory layout must be INTERLEAVED, got: {}",
+        config_name,
+        input_tensor_b.memory_config().memory_layout());
+    TT_FATAL(
+        attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "{}: Output memory layout must be INTERLEAVED, got: {}",
+        config_name,
+        attributes.output_mem_config.memory_layout());
+}
+
+// DRAMSharded config. in0 width-sharded in L1, in1 width-sharded in DRAM; height must
+// be a single tile (M == 1) and K/shard dims divide in0_block_w.
+void validate_matmul_c5_dram_sharded_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig& program_config) {
+    const auto config_name = ttsl::get_type_name(program_config);
+    TT_FATAL(
+        input_tensor_a.is_sharded(), "{}: Input tensor A must be sharded for DRAM sharded program config", config_name);
+    TT_FATAL(
+        attributes.output_mem_config.is_sharded(),
+        "{}: Output memory config must be sharded for DRAM sharded program config",
+        config_name);
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+        "{}: Input A memory layout must be WIDTH_SHARDED, got: {}",
+        config_name,
+        input_tensor_a.memory_config().memory_layout());
+    validate_input_a_output_mem_config_match(config_name, input_tensor_a, attributes.output_mem_config);
+    TT_FATAL(
+        input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+        "{}: Input A shard orientation must be ROW_MAJOR, got: {}",
+        config_name,
+        input_tensor_a.shard_spec().value().orientation);
+    const auto M = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/false);
+    const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+    uint32_t per_core_M = program_config.per_core_M;
+    auto shard_shape = input_tensor_a.shard_spec().value().shape;
+
+    // No padding
+    TT_FATAL(M == per_core_M, "{}: M ({}) must equal per_core_M ({})", config_name, M, per_core_M);
+    TT_FATAL(M == 1, "{}: currently only support in0 tensor height of tile height", config_name);
+    TT_FATAL(
+        per_core_M == (shard_shape[0] / in0_tile.get_height()),
+        "{}: per_core_M ({}) must equal shard_shape[0] / in0_tile.get_height() ({})",
+        config_name,
+        per_core_M,
+        (shard_shape[0] / in0_tile.get_height()));
+    TT_FATAL(
+        K % program_config.in0_block_w == 0,
+        "{}: K ({}) must be divisible by in0_block_w ({})",
+        config_name,
+        K,
+        program_config.in0_block_w);
+    TT_FATAL(
+        (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
+        "{}: shard_shape[1] / in0_tile.get_width() ({}) must be divisible by in0_block_w ({})",
+        config_name,
+        (shard_shape[1] / in0_tile.get_width()),
+        program_config.in0_block_w);
+
+    // tensor in1
+    TT_FATAL(
+        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+        "{}: Input B memory layout must be WIDTH_SHARDED, got: {}",
+        config_name,
+        input_tensor_b.memory_config().memory_layout());
+}
+
+// BatchedDRAMSharded config. [1,B,M,K] x [1,B,K,N]: A height-sharded in L1, B height-
+// sharded in DRAM, output height-sharded in L1; contracted dim divides in0_block_w.
+void validate_matmul_c6_batched_dram_sharded_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig& program_config) {
+    const auto config_name = ttsl::get_type_name(program_config);
+    // Batch-sharded DRAM matmul validations
+    // For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
+    // Sharded by batch dimension - each worker handles B/num_workers complete matmuls
+    // Input A: HEIGHT_SHARDED in L1 (batch-sharded, each core has B/12 complete [M, N] matrices)
+    // Input B: HEIGHT_SHARDED in DRAM (batch-sharded, each bank has B/12 complete [N, K] matrices)
+    // Output: HEIGHT_SHARDED in L1 (batch-sharded, each core outputs B/12 complete [M, K] matrices)
+    TT_FATAL(
+        input_tensor_a.is_sharded(), "{}: Input tensor A must be sharded for batch-sharded DRAM matmul", config_name);
+    TT_FATAL(
+        attributes.output_mem_config.is_sharded(),
+        "{}: Output memory config must be sharded for batch-sharded DRAM matmul",
+        config_name);
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+        "{}: Input A memory layout must be HEIGHT_SHARDED for batch-sharded DRAM matmul, got: {}",
+        config_name,
+        input_tensor_a.memory_config().memory_layout());
+    validate_input_a_output_mem_config_match(config_name, input_tensor_a, attributes.output_mem_config);
+    TT_FATAL(
+        input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+        "{}: Input A shard orientation must be ROW_MAJOR, got: {}",
+        config_name,
+        input_tensor_a.shard_spec().value().orientation);
+
+    // For batch sharding, the contracted dimension (N in A, N in B) must be divisible by in0_block_w
+    const auto N_dim = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);  // K dim of A = N
+    TT_FATAL(
+        N_dim % program_config.in0_block_w == 0,
+        "{}: N dimension ({}) must be divisible by in0_block_w ({})",
+        config_name,
+        N_dim,
+        program_config.in0_block_w);
+
+    // tensor in1: HEIGHT_SHARDED in DRAM (batch-sharded)
+    TT_FATAL(
+        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+        "{}: Input B memory layout must be HEIGHT_SHARDED for batch-sharded DRAM matmul, got: {}",
+        config_name,
+        input_tensor_b.memory_config().memory_layout());
+}
+
+// Mcast2D config — block-sharded 2D multicast. Validates that sharded input A, input B,
+// and the output have layouts, grids, and orientations consistent with a 2D multicast.
+void validate_matmul_c3_mcast2d_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig& program_config) {
+    using namespace tt;  // BufferType/div_up were unqualified in the original std::visit scope
+    const auto config_name = ttsl::get_type_name(program_config);
+    const tt::tt_metal::CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+    check_tensor_in_grid(input_tensor_a, device_grid);
+    check_tensor_in_grid(input_tensor_b, device_grid);
+    if (input_tensor_a.memory_config().is_sharded()) {
+        TT_FATAL(program_config.fuse_batch, "{}: Batch fusion is required when input A is sharded", config_name);
+        auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
+        const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+        uint32_t per_core_M = program_config.per_core_M;
+        auto shard_shape = input_tensor_a.shard_spec().value().shape;
+
+        TT_FATAL(
+            tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
+                tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+            "{}: Unsupported memory layout {}.",
+            config_name,
+            tensor_a_memory_layout);
+
+        if (tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+            if (program_config.transpose_mcast) {
+                TT_FATAL(
+                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR,
+                    "{}: Input tensor A must have COL_MAJOR shard orientation for transpose MCAST, got: {}",
+                    config_name,
+                    input_tensor_a.shard_spec().value().orientation);
+            } else {
+                TT_FATAL(
+                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                    "{}: Input tensor A must have ROW_MAJOR shard orientation for non-transpose MCAST, got: {}",
+                    config_name,
+                    input_tensor_a.shard_spec().value().orientation);
+            }
+            if (attributes.output_mem_config.is_sharded()) {
+                validate_input_a_output_mem_config_match(config_name, input_tensor_a, attributes.output_mem_config);
+            }
+
+        } else if (tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            TT_FATAL(
+                !program_config.transpose_mcast,
+                "{}: Transpose MCAST not supported with HEIGHT_SHARDED layout",
+                config_name);
+            TT_FATAL(
+                K == program_config.in0_block_w,
+                "{}: K ({}) must equal in0_block_w ({})",
+                config_name,
+                K,
+                program_config.in0_block_w);
+            TT_FATAL(
+                program_config.in0_block_w == (shard_shape[1] / in0_tile.get_width()),
+                "{}: in0_block_w ({}) must equal shard_shape[1] / in0_tile.get_width() ({})",
+                config_name,
+                program_config.in0_block_w,
+                (shard_shape[1] / in0_tile.get_width()));
+            TT_FATAL(
+                input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
+                    input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x,
+                "{}: HEIGHT_SHARDED input A must have a single-column shard grid (got x={} to x={}); use "
+                "MatmulMultiCoreReuseProgramConfig for multi-column HEIGHT_SHARDED inputs",
+                config_name,
+                input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x,
+                input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
+        }
+
+        TT_FATAL(
+            per_core_M == (shard_shape[0] / in0_tile.get_height()),
+            "{}: per_core_M ({}) must equal shard_shape[0] / in0_tile.get_height() ({})",
+            config_name,
+            per_core_M,
+            (shard_shape[0] / in0_tile.get_height()));
+        TT_FATAL(
+            (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
+            "{}: shard_shape[1] / in0_tile.get_width() ({}) must be divisible by in0_block_w ({})",
+            config_name,
+            (shard_shape[1] / in0_tile.get_width()),
+            program_config.in0_block_w);
+    }
+
+    if (input_tensor_b.memory_config().is_sharded()) {
+        TT_FATAL(
+            !program_config.transpose_mcast, "{}: Transpose MCAST not supported when input B is sharded", config_name);
+        auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout();
+        // ND_SHARDED in1 in DRAM is read via the generic TensorAccessor path: the program
+        // factory's in1_is_sharded only covers WIDTH/HEIGHT, so ND falls through to the
+        // interleaved-style reader, which addresses the NdShardSpec layout from the accessor
+        // args. The width/height-specific validation below is gated on those layouts, so ND
+        // DRAM in1 skips it (no shard_spec() access).
+        const bool in1_is_nd_dram = tensor_b_memory_layout == TensorMemoryLayout::ND_SHARDED &&
+                                    input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
+        TT_FATAL(
+            tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
+                tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || in1_is_nd_dram,
+            "{}: Input B memory layout must be WIDTH_SHARDED, HEIGHT_SHARDED, or DRAM ND_SHARDED, got: {}",
+            config_name,
+            tensor_b_memory_layout);
+        if (tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            // Height-sharded in1 is only supported for DRAM batched matmuls
+            TT_FATAL(
+                input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM,
+                "{}: HEIGHT_SHARDED input B is only supported in DRAM, got: {}",
+                config_name,
+                input_tensor_b.buffer()->buffer_type());
+            TT_FATAL(
+                !program_config.fuse_batch,
+                "{}: HEIGHT_SHARDED input B requires fuse_batch=false for batched matmul",
+                config_name);
+            // Each DRAM bank must hold complete [K, N] matrices stacked vertically
+            // K is the contracted dim: last dim of A, second-to-last of B
+            const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+            const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+            const auto& in1_shard_spec = input_tensor_b.shard_spec().value();
+            uint32_t in1_shard_height_in_tiles = in1_shard_spec.shape[0] / in1_tile.get_height();
+            uint32_t in1_shard_width_in_tiles = in1_shard_spec.shape[1] / in1_tile.get_width();
+            uint32_t num_banks = in1_shard_spec.grid.num_cores();
+            TT_FATAL(
+                in1_shard_width_in_tiles == N,
+                "{}: HEIGHT_SHARDED input B shard width ({} tiles) must equal N ({} tiles)",
+                config_name,
+                in1_shard_width_in_tiles,
+                N);
+            TT_FATAL(
+                in1_shard_height_in_tiles >= K,
+                "{}: HEIGHT_SHARDED input B shard height ({} tiles) must be >= K ({} tiles)",
+                config_name,
+                in1_shard_height_in_tiles,
+                K);
+            TT_FATAL(
+                in1_shard_height_in_tiles % K == 0,
+                "{}: HEIGHT_SHARDED input B shard height ({} tiles) must be divisible by K ({} tiles) "
+                "so each bank holds complete [K, N] matrices",
+                config_name,
+                in1_shard_height_in_tiles,
+                K);
+            uint32_t batches_per_bank = in1_shard_height_in_tiles / K;
+            uint32_t B = get_batch_size(b_shape_padded);
+            // The kernel addresses batch b via: bank_id = b / batches_per_bank.
+            // Total shard capacity (batches_per_bank * num_banks) must be >= B
+            // to ensure all batches map to valid banks. It may exceed B when the
+            // batch dimension is padded up to distribute evenly across banks.
+            TT_FATAL(
+                batches_per_bank * num_banks >= B,
+                "{}: HEIGHT_SHARDED input B: batches_per_bank ({}) * num_banks ({}) = {} must be >= "
+                "batch size B ({})",
+                config_name,
+                batches_per_bank,
+                num_banks,
+                batches_per_bank * num_banks,
+                B);
+        }
+        if (input_tensor_b.buffer()->buffer_type() != tt_metal::BufferType::DRAM) {
+            const auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
+            TT_FATAL(
+                (input_tensor_a.memory_config().is_sharded() &&
+                 tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                    tensor_a_memory_layout == TensorMemoryLayout::INTERLEAVED,
+                "{}: Error - non-DRAM width sharded input B requires input A to be interleaved or height "
+                "sharded, rather than {}",
+                config_name,
+                tensor_a_memory_layout);
+            TT_FATAL(
+                program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()),
+                "{}: per_core_N ({}) must equal input tensor B shard shape[1] / in1_tile.get_width() ({})",
+                config_name,
+                program_config.per_core_N,
+                (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()));
+        }
+        if (tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            TT_FATAL(
+                input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y ==
+                    input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y,
+                "{}: Width-sharded input tensor B grid bounding box must have equal start and end y "
+                "coordinates, got start: {} vs end: {}",
+                config_name,
+                input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y,
+                input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
+        }
+    }
+
+    if (attributes.output_mem_config.is_sharded()) {
+        TT_FATAL(
+            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED,
+            "{}: Output memory layout must be BLOCK_SHARDED, got: {}",
+            config_name,
+            attributes.output_mem_config.memory_layout());
+        uint32_t per_core_N = program_config.per_core_N;
+
+        validate_output_subblock_block_divides_per_core_n(
+            config_name,
+            program_config.out_subblock_w,
+            program_config.out_subblock_h,
+            program_config.out_block_w,
+            program_config.out_block_h,
+            per_core_N);
+    }
+}
+
+// Reuse config — non-multicast block reuse. Validates per_core_M/N divisibility vs M/N,
+// sharded A/B/output layouts, grid/shard-shape agreement, and rejects batch broadcast.
+// (The post-visit work-split check is also Reuse-only, wired at the dispatch.)
+void validate_matmul_c2_reuse_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulMultiCoreReuseProgramConfig& program_config) {
+    const auto config_name = ttsl::get_type_name(program_config);
+    const auto M = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/false);
+    const auto total_M = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/true);
+    const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+    const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, /*tile=*/std::nullopt);
+    uint32_t per_core_M = program_config.per_core_M;
+    uint32_t per_core_N = program_config.per_core_N;
+    if (per_core_M > M) {
+        TT_FATAL(
+            per_core_M % M == 0,
+            "{}: per_core_M, {}, must be a multiple of M, {} if "
+            "per_core_M > M!",
+            config_name,
+            per_core_M,
+            M);
+        TT_FATAL(
+            total_M % per_core_M == 0,
+            "{}: input a total height, {}, must be divisible by "
+            "per_core_M, {}!",
+            config_name,
+            total_M,
+            per_core_M);
+    } else {
+        TT_FATAL(
+            M % per_core_M == 0,
+            "{}: per_core_M, {}, must divide M, {}, if per_core_M < M!",
+            config_name,
+            per_core_M,
+            M);
+    }
+    TT_FATAL(N == per_core_N, "{}: N ({}) must equal per_core_N ({})", config_name, N, per_core_N);
+    if (input_tensor_a.is_sharded()) {
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            "{}: input A memory layout must not be WIDTH_SHARDED, got: {}",
+            config_name,
+            input_tensor_a.memory_config().memory_layout());
+        auto in0_shard_shape = input_tensor_a.shard_spec().value().shape;
+
+        TT_FATAL(
+            K == in0_shard_shape[1],
+            "{}: K ({}) must equal in0 shard_shape[1] ({})",
+            config_name,
+            K,
+            in0_shard_shape[1]);
+        TT_FATAL(
+            in0_shard_shape[1] == program_config.in0_block_w * in0_tile.get_width(),
+            "{}: in0 shard_shape[1] ({}) must equal in0_block_w ({}) * in0_tile width ({})",
+            config_name,
+            in0_shard_shape[1],
+            program_config.in0_block_w,
+            in0_tile.get_width());
+        TT_FATAL(
+            per_core_M * in0_tile.get_height() == in0_shard_shape[0],
+            "{}: per_core_M ({}) * in0_tile height ({}) must equal in0 shard_shape[0] ({})",
+            config_name,
+            per_core_M,
+            in0_tile.get_height(),
+            in0_shard_shape[0]);
+
+        if (input_tensor_b.is_sharded()) {
+            TT_FATAL(
+                input_tensor_a.memory_config().buffer_type() == input_tensor_b.memory_config().buffer_type(),
+                "{}: Input tensors A and B must have matching buffer types, got A: {} vs B: {}",
+                config_name,
+                input_tensor_a.memory_config().buffer_type(),
+                input_tensor_b.memory_config().buffer_type());
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == input_tensor_b.memory_config().memory_layout(),
+                "{}: Input tensors A and B must have matching memory layouts, got A: {} vs B: {}",
+                config_name,
+                input_tensor_a.memory_config().memory_layout(),
+                input_tensor_b.memory_config().memory_layout());
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
+                "{}: input A and B must have matching shard grids, got A: {} vs B: {}",
+                config_name,
+                input_tensor_a.shard_spec().value().grid,
+                input_tensor_b.shard_spec().value().grid);
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation,
+                "{}: Input tensors A and B must have matching shard orientations, got A: {} vs B: {}",
+                config_name,
+                input_tensor_a.shard_spec().value().orientation,
+                input_tensor_b.shard_spec().value().orientation);
+        }
+        if (attributes.output_mem_config.is_sharded()) {
+            validate_input_a_output_mem_config_match(config_name, input_tensor_a, attributes.output_mem_config);
+        }
+    }
+
+    const auto batch_size_a = get_batch_size(a_shape_padded);
+    const auto batch_size_b = get_batch_size(b_shape_padded);
+    bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
+    TT_FATAL(!broadcast_batch, "{}: Batch broadcasting is not supported for the chosen program config", config_name);
+    if (batch_size_a > 1 && batch_size_b > 1) {
+        TT_FATAL(
+            M % program_config.out_subblock_h == 0,
+            "{}: out_subblock_h ({}) needs to divide M ({}) evenly and does not. "
+            "Please update your program config.",
+            config_name,
+            program_config.out_subblock_h,
+            M);
+    }
+
+    if (input_tensor_b.is_sharded()) {
+        TT_FATAL(
+            per_core_M % M == 0,
+            "{}: per_core_M ({}) must be a multiple of M ({}) when input B is sharded",
+            config_name,
+            per_core_M,
+            M);
+        TT_FATAL(
+            input_tensor_b.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            "{}: Input B memory layout must not be WIDTH_SHARDED, got: {}",
+            config_name,
+            input_tensor_b.memory_config().memory_layout());
+        auto in1_shard_shape = input_tensor_b.shard_spec().value().shape;
+        TT_FATAL(
+            in1_shard_shape[1] == b_shape_padded[-1],
+            "{}: Input B shard shape[1] ({}) must equal padded shape[-1] ({})",
+            config_name,
+            in1_shard_shape[1],
+            b_shape_padded[-1]);
+        TT_FATAL(
+            per_core_N * in1_tile.get_width() == in1_shard_shape[1],
+            "{}: per_core_N * in1_tile.get_width() ({}) must equal in1_shard_shape[1] ({})",
+            config_name,
+            per_core_N * in1_tile.get_width(),
+            in1_shard_shape[1]);
+        TT_FATAL(
+            in1_shard_shape[0] % K == 0,
+            "{}: Input B shard shape[0] ({}) must be divisible by K ({})",
+            config_name,
+            in1_shard_shape[0],
+            K);
+    }
+    if (attributes.output_mem_config.is_sharded()) {
+        TT_FATAL(
+            attributes.output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            "{}: Output memory layout must not be WIDTH_SHARDED, got: {}",
+            config_name,
+            attributes.output_mem_config.memory_layout());
+        TT_FATAL(
+            program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
+            "{}: Either out_subblock_w ({}) must equal per_core_N ({}) or out_subblock_h ({}) must be 1",
+            config_name,
+            program_config.out_subblock_w,
+            per_core_N,
+            program_config.out_subblock_h);
+    }
+}
+
+// Mcast1D config — 1D multicast. Validates the mcast_in0 and gather_in0 paths, the
+// width-sharded and height-sharded in0 paths, and the output layout/subblock rules for
+// 1-row vs 1-column grids.
+void validate_matmul_c4_mcast1d_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const Tensor>& optional_bias,
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
+    using namespace tt;  // BufferType/div_up were unqualified in the original std::visit scope
+    const auto config_name = ttsl::get_type_name(program_config);
+    TT_FATAL(
+        !(program_config.mcast_in0 && program_config.gather_in0),
+        "{}: Matmul1D does not support mcast_in0 and gather_in0 at the "
+        "same time.",
+        config_name);
+
+    // Gather in0 specific validation
+    if (program_config.gather_in0) {
+        TT_FATAL(
+            program_config.num_global_cb_receivers > 0,
+            "{}: Num global CB receivers must be greater than 0.",
+            config_name);
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+            "{}: input A must be WIDTH_SHARDED for gather_in0, got: {}",
+            config_name,
+            input_tensor_a.memory_config().memory_layout());
+        TT_FATAL(
+            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+                (input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                 input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM) ||
+                // Receiver-contiguous Tensor prefetcher: in1 is an NdShardSpec DRAM
+                // weight (reported as ND_SHARDED) whose data is delivered via the
+                // global CB receivers, not read directly per its DRAM layout. The
+                // weight's own layout is irrelevant to the matmul in this case.
+                (attributes.global_cb.has_value() &&
+                 input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM),
+            "{}: Input tensor B must be width sharded, DRAM interleaved, or a DRAM weight fed "
+            "via a global circular buffer when using gather_in0.",
+            config_name);
+        if (!attributes.global_cb.has_value() && input_tensor_b.is_sharded()) {
+            if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1) {
+                TT_FATAL(
+                    input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
+                    "{}: input A and B must be sharded on the same cores for gather_in0, got A: {} vs B: {}",
+                    config_name,
+                    input_tensor_a.shard_spec().value().grid,
+                    input_tensor_b.shard_spec().value().grid);
+            }
+        }
+        TT_FATAL(
+            attributes.output_mem_config.is_sharded(),
+            "{}: Output tensor must be sharded when using gather_in0.",
+            config_name);
+        TT_FATAL(
+            attributes.output_mem_config.shard_spec().has_value(),
+            "{}: Output shard spec must be provided when using gather_in0.",
+            config_name);
+
+        if (!input_tensor_b.is_sharded()) {
+            TT_FATAL(
+                !attributes.global_cb.has_value(),
+                "{}: Global CB is not supported for DRAM_INTERLEAVED in1 when using gather_in0.",
+                config_name);
+            TT_FATAL(
+                input_tensor_b.layout() == Layout::TILE,
+                "{}: Input tensor B must be TILE_LAYOUT when DRAM_INTERLEAVED when using gather_in0.",
+                config_name);
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().grid == attributes.output_mem_config.shard_spec().value().grid,
+                "{}: Input tensor A and output tensor must be sharded on the same cores when using gather_in0 "
+                "and in1 is DRAM_INTERLEAVED.",
+                config_name);
+        }
+
+        if (!attributes.global_cb.has_value()) {
+            TT_FATAL(
+                program_config.num_global_cb_receivers == 1,
+                "{}: Num global CB receivers must be 1 when global CB is not provided.",
+                config_name);
+        }
+
+        // Cross-check program_config against the in1 weight shape (silent-hang guards),
+        // gated on the DRAM-sender path. The two DRAM-sender weight layouts have
+        // different bank->ring conventions, so dispatch per in1 memory_layout():
+        //   * WIDTH_SHARDED (K-row-major): each bank holds one wide (K, N/num_banks)
+        //     shard feeding the contiguous ring positions [b*rpb, (b+1)*rpb).
+        //   * ND_SHARDED (receiver-contiguous): an NdShardSpec weight with round-robin
+        //     shard placement and a strided bank->ring mapping.
+        // NdShardSpec reports memory_layout() == ND_SHARDED (see MemoryConfig(BufferType,
+        // NdShardSpec)); the prefetcher manager and validator key on the same enum.
+        if (attributes.global_cb.has_value() && input_tensor_a.is_sharded() &&
+            tt::tt_metal::experimental::sender_core_type(attributes.global_cb.value()) ==
+                tt::tt_metal::experimental::SenderCoreType::Dram) {
+            const auto in1_layout = input_tensor_b.memory_config().memory_layout();
+            if (in1_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+                validate_dram_sender_global_cb_gather_in0_geometry(
+                    attributes.global_cb.value(), input_tensor_a, b_shape_padded, in1_tile, program_config);
+            } else if (in1_layout == TensorMemoryLayout::ND_SHARDED) {
+                validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
+                    attributes.global_cb.value(), input_tensor_a, b_shape_padded, in1_tile, program_config);
+            } else {
+                TT_FATAL(
+                    false,
+                    "{}: gather_in0 matmul with a DRAM-sender global CB requires in1 to be WIDTH_SHARDED "
+                    "(K-row-major) or ND_SHARDED (receiver-contiguous), but got {}.",
+                    config_name,
+                    in1_layout);
+            }
+        }
+
+        TT_FATAL(!optional_bias.has_value(), "{}: Bias is not supported when using gather_in0.", config_name);
+    } else {
+        const auto device_grid_1d = input_tensor_a.device()->compute_with_storage_grid_size();
+        check_tensor_in_grid(input_tensor_a, device_grid_1d);
+        check_tensor_in_grid(input_tensor_b, device_grid_1d);
+    }
+    if (program_config.mcast_in0 || program_config.gather_in0) {
+        if (input_tensor_a.is_sharded()) {
+            TT_FATAL(program_config.fuse_batch, "{}: fuse_batch must be enabled when input A is sharded", config_name);
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                "{}: input A must be WIDTH_SHARDED when mcast_in0 or gather_in0 is set, got: {}",
+                config_name,
+                input_tensor_a.memory_config().memory_layout());
+            if (attributes.output_mem_config.is_sharded()) {
+                validate_input_a_output_mem_config_match(config_name, input_tensor_a, attributes.output_mem_config);
+            }
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                "{}: input A shard orientation must be ROW_MAJOR, got: {}",
+                config_name,
+                input_tensor_a.shard_spec().value().orientation);
+            const auto M =
+                operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
+            const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+            uint32_t per_core_M = program_config.per_core_M;
+            auto shard_shape = input_tensor_a.shard_spec().value().shape;
+
+            // No padding
+            TT_FATAL(M == per_core_M, "{}: M ({}) must equal per_core_M ({})", config_name, M, per_core_M);
+            TT_FATAL(
+                per_core_M == (shard_shape[0] / in0_tile.get_height()),
+                "{}: per_core_M ({}) must equal shard_shape[0] ({}) / in0_tile height ({})",
+                config_name,
+                per_core_M,
+                shard_shape[0],
+                in0_tile.get_height());
+            TT_FATAL(
+                K % program_config.in0_block_w == 0,
+                "{}: K ({}) must be divisible by in0_block_w ({})",
+                config_name,
+                K,
+                program_config.in0_block_w);
+            if (!program_config.gather_in0) {  // Padding allowed for gather_in0
+                TT_FATAL(
+                    (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
+                    "{}: shard_shape[1] ({}) / in0_tile width ({}) must be divisible by in0_block_w ({})",
+                    config_name,
+                    shard_shape[1],
+                    in0_tile.get_width(),
+                    program_config.in0_block_w);
+            }
+        }
+        if (attributes.output_mem_config.is_sharded()) {
+            // Allow BLOCK_SHARDED on 1-row grids (equivalent to WIDTH_SHARDED)
+            bool is_width_sharded = attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+            bool is_block_sharded_1d_row = false;
+            if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+                attributes.output_mem_config.shard_spec().has_value()) {
+                auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+                is_block_sharded_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+            }
+            TT_FATAL(
+                is_width_sharded || is_block_sharded_1d_row,
+                "{}: output memory layout must be WIDTH_SHARDED or BLOCK_SHARDED on a 1-row grid, got: {}",
+                config_name,
+                attributes.output_mem_config.memory_layout());
+            const auto M =
+                operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
+            uint32_t per_core_M = program_config.per_core_M;
+            uint32_t per_core_N = program_config.per_core_N;
+
+            // No padding
+            TT_FATAL(M == per_core_M, "{}: M ({}) must equal per_core_M ({})", config_name, M, per_core_M);
+
+            validate_output_subblock_block_divides_per_core_n(
+                config_name,
+                program_config.out_subblock_w,
+                program_config.out_subblock_h,
+                program_config.out_block_w,
+                program_config.out_block_h,
+                per_core_N);
+        }
+        if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1 &&
+            input_tensor_b.memory_config().is_sharded()) {
+            TT_FATAL(
+                input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                "{}: input B in L1 must be WIDTH_SHARDED, got: {}",
+                config_name,
+                input_tensor_b.memory_config().memory_layout());
+            TT_FATAL(
+                program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()),
+                "{}: input B shard width in tiles ({}) must equal per_core_N ({})",
+                config_name,
+                input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width(),
+                program_config.per_core_N);
+            if (optional_bias.has_value()) {
+                TT_FATAL(
+                    input_tensor_b.shard_spec().value().shape[1] == optional_bias.value().shard_spec().value().shape[1],
+                    "{}: bias shard width ({}) must match input B shard width ({})",
+                    config_name,
+                    optional_bias.value().shard_spec().value().shape[1],
+                    input_tensor_b.shard_spec().value().shape[1]);
+            }
+        }
+    } else {
+        if (input_tensor_a.memory_config().is_sharded()) {
+            TT_FATAL(program_config.fuse_batch, "{}: fuse_batch must be enabled when input A is sharded", config_name);
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+                "{}: input A must be HEIGHT_SHARDED, got: {}",
+                config_name,
+                input_tensor_a.memory_config().memory_layout());
+            if (attributes.output_mem_config.is_sharded()) {
+                validate_input_a_output_mem_config_match(config_name, input_tensor_a, attributes.output_mem_config);
+            }
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                "{}: input A shard orientation must be ROW_MAJOR, got: {}",
+                config_name,
+                input_tensor_a.shard_spec().value().orientation);
+            const auto M =
+                operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
+            const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
+            uint32_t per_core_M = program_config.per_core_M;
+            auto shard_shape = input_tensor_a.shard_spec().value().shape;
+            TT_FATAL(
+                div_up(M, per_core_M) <= input_tensor_a.shard_spec().value().grid.num_cores(),
+                "{}: number of M blocks ceil(M/per_core_M)={} must not exceed input A shard grid cores ({})",
+                config_name,
+                div_up(M, per_core_M),
+                input_tensor_a.shard_spec().value().grid.num_cores());
+            TT_FATAL(
+                per_core_M == (shard_shape[0] / in0_tile.get_height()),
+                "{}: per_core_M ({}) must equal shard_shape[0] ({}) / in0_tile height ({})",
+                config_name,
+                per_core_M,
+                shard_shape[0],
+                in0_tile.get_height());
+            TT_FATAL(
+                K % program_config.in0_block_w == 0,
+                "{}: K ({}) must be divisible by in0_block_w ({})",
+                config_name,
+                K,
+                program_config.in0_block_w);
+            TT_FATAL(
+                K == (shard_shape[1] / in0_tile.get_width()),
+                "{}: K ({}) must equal shard_shape[1] ({}) / in0_tile width ({})",
+                config_name,
+                K,
+                shard_shape[1],
+                in0_tile.get_width());
+        }
+        if (attributes.output_mem_config.is_sharded()) {
+            // Allow BLOCK_SHARDED on 1-column grids (equivalent to HEIGHT_SHARDED)
+            bool is_height_sharded = attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+            bool is_block_sharded_1d_column = false;
+            if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+                attributes.output_mem_config.shard_spec().has_value()) {
+                auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+                is_block_sharded_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            }
+            TT_FATAL(
+                is_height_sharded || is_block_sharded_1d_column,
+                "{}: output memory layout must be HEIGHT_SHARDED or BLOCK_SHARDED on a 1-column grid, got: {}",
+                config_name,
+                attributes.output_mem_config.memory_layout());
+            const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+            uint32_t per_core_N = program_config.per_core_N;
+
+            TT_FATAL(N == per_core_N, "{}: N ({}) must equal per_core_N ({})", config_name, N, per_core_N);
+            validate_output_subblock_block_divides_per_core_n(
+                config_name,
+                program_config.out_subblock_w,
+                program_config.out_subblock_h,
+                program_config.out_block_w,
+                program_config.out_block_h,
+                per_core_N);
+        }
+        TT_FATAL(
+            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "{}: input B must be INTERLEAVED, got: {}",
+            config_name,
+            input_tensor_b.memory_config().memory_layout());
+    }
+}
+
+// Shared Mcast2D/Mcast1D preamble — the fuse_batch gate. Fused batch requires B batch==1,
+// and transpose_a is unsupported when real batch dims survive with M_per_batch > 1.
+void validate_matmul_mcast_fuse_batch_preamble(
+    std::string_view config_name,
+    bool fuse_batch,
+    const MatmulParams& attributes,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile) {
+    if (fuse_batch) {
+        TT_FATAL(
+            get_batch_size(b_shape_padded) == 1,
+            "{}: Matmul with fused batch requires input tensors of shapes BCMK*11KN=BCMN "
+            "or equivalent. Please change the second input tensor or adjust the program config.",
+            config_name);
+        if (attributes.transpose_a) {
+            uint32_t batch_size_a = get_batch_size(a_shape_padded);
+            uint32_t M_per_batch = a_shape_padded[-2] / in0_tile.get_height();
+            TT_FATAL(
+                batch_size_a == 1 || M_per_batch == 1,
+                "{}: transpose_a with fuse_batch is not supported when batch dimensions "
+                "exist and M_per_batch > 1 (batch_size={}, M_per_batch={}, a_shape_padded={})",
+                config_name,
+                batch_size_a,
+                M_per_batch,
+                a_shape_padded);
+        }
+    }
+}
+
+// Returns whether batch broadcasting applies: true when input B has batch size 1 (B is
+// reused across A's batches). Used by compute_output_specs, not by validate.
+bool get_broadcast_batch(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const std::optional<const operations::matmul::MatmulProgramConfig>& matmul_program_config) {
+    const auto& b_shape_padded =
+        operations::matmul::utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+    uint32_t batch_size_b = get_batch_size(b_shape_padded);
+    bool broadcast_batch = batch_size_b == 1;
+    if (!matmul_program_config.has_value()) {
+        return broadcast_batch;
+    }
+
+    bool is_multi_core_reuse = std::visit(
+        [](const auto& program_config) -> bool {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            return static_cast<bool>(
+                std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>);
+        },
+        matmul_program_config.value());
+    if (is_multi_core_reuse) {
+        const auto& a_shape_padded =
+            operations::matmul::utilities::get_matmul_tensor_padded_shape(input_tensor_a, transpose_a);
+        uint32_t batch_size_a = get_batch_size(a_shape_padded);
+        broadcast_batch &= batch_size_a > 1;
+    }
+    return broadcast_batch;
+}
+
 }  // namespace
 
 MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_factory(
@@ -754,6 +2047,10 @@ MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_f
         config);
 }
 
+// ===========================================================================
+// Entry point. Runs the universal validators, then the config-based shared validators,
+// then the per-config dispatch (std::visit) below.
+// ===========================================================================
 void MatmulDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& args) {
     using namespace tt::constants;
@@ -763,7 +2060,6 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensors = args.input_tensors;
     const auto& input_tensor_a = args.input_tensors.at(0);
     const auto& input_tensor_b = args.input_tensors.at(1);
-    const auto& optional_output_tensors = args.optional_output_tensors;
     const auto& optional_input_tensors = args.optional_input_tensors;
 
     const auto& a_shape =
@@ -776,112 +2072,14 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         operations::matmul::utilities::get_matmul_tensor_padded_shape(input_tensor_b, attributes.transpose_b);
     auto in0_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_a, attributes.transpose_a);
     auto in1_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_b, attributes.transpose_b);
-    TT_FATAL(
-        input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE,
-        "Operands to matmul need to be on device!");
-    TT_FATAL(
-        (in0_tile.get_width() == TILE_WIDTH && in1_tile.get_height() == TILE_WIDTH),
-        "Input tile dims must have inner dim equal to 32 due to llk constraints");
 
-    TT_FATAL(
-        (input_tensor_a.layout() == Layout::TILE && input_tensor_b.layout() == Layout::TILE),
-        "Inputs to matmul must be tilized");
+    // ---- universal checks, part 1: independent of the chosen program config ----
+    validate_matmul_operand_basics(input_tensor_a, input_tensor_b, in0_tile, in1_tile);
     validate_matmul_matrix_dimensions(a_shape, b_shape, a_shape_padded, b_shape_padded, in0_tile, in1_tile);
+    validate_matmul_bfloat4_tile_dims(input_tensor_a, input_tensor_b, in0_tile, in1_tile);
+    validate_matmul_optional_tensors(attributes, args);
 
-    const bool is_optional_output_tensor =
-        !optional_output_tensors.empty() && optional_output_tensors.at(0).has_value();
-
-    TT_FATAL(
-        optional_input_tensors.size() == 1,
-        "Must have exactly 1 optional input tensor, got: {}",
-        optional_input_tensors.size());
-
-    const auto output_tensor_spec = compute_output_specs(attributes, args).at(0);
-    if (is_optional_output_tensor) {
-        const auto& optional_output_tensor_c = optional_output_tensors.at(0);
-        const auto& optional_output_tensor_shape = optional_output_tensor_c->logical_shape();
-        TT_FATAL(
-            optional_output_tensor_shape == output_tensor_spec.logical_shape(),
-            "Shape of Optional Output Tensor {} doesn't match Output Tensor {}",
-            optional_output_tensor_shape,
-            output_tensor_spec.logical_shape());
-        TT_FATAL(
-            optional_output_tensor_c->dtype() == attributes.output_dtype.value(),
-            "Type mismatch between optional output tensor {} & output tensor {}",
-            optional_output_tensor_c->dtype(),
-            attributes.output_dtype.value());
-        TT_FATAL(
-            optional_output_tensor_c->memory_config() == attributes.output_mem_config,
-            "Memory config mismatch between optional output tensor {} & output "
-            "tensor {}",
-            optional_output_tensor_c->memory_config(),
-            attributes.output_mem_config);
-    } else {
-        // Allow BLOCK_SHARDED on 1D grids to be converted to HEIGHT_SHARDED or WIDTH_SHARDED
-        bool memory_layout_compatible =
-            output_tensor_spec.memory_config().memory_layout() == attributes.output_mem_config.memory_layout();
-        if (!memory_layout_compatible &&
-            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
-            attributes.output_mem_config.shard_spec().has_value()) {
-            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
-            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
-            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
-            if ((is_1d_column &&
-                 output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) ||
-                (is_1d_row &&
-                 output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
-                memory_layout_compatible = true;
-            }
-        }
-        TT_FATAL(
-            memory_layout_compatible,
-            "Mismatch between computed {} and provided {} mem config memory layout",
-            output_tensor_spec.memory_config().memory_layout(),
-            attributes.output_mem_config.memory_layout());
-        TT_FATAL(
-            output_tensor_spec.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
-            "Mismatch between computed {} and provided {} mem config buffer type",
-            output_tensor_spec.memory_config().buffer_type(),
-            attributes.output_mem_config.buffer_type());
-        // Don't warn when BLOCK_SHARDED on 1D grid is intentionally converted to HEIGHT/WIDTH_SHARDED
-        bool is_intentional_1d_conversion = false;
-        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
-            attributes.output_mem_config.shard_spec().has_value()) {
-            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
-            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
-            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
-            bool is_single_core = is_1d_column && is_1d_row;
-            // Only 1D grids (not single-core) trigger intentional conversion
-            if (!is_single_core && (is_1d_column || is_1d_row)) {
-                is_intentional_1d_conversion = true;
-            }
-        }
-        if (attributes.output_mem_config.shard_spec().has_value() &&
-            output_tensor_spec.memory_config() != attributes.output_mem_config && !is_intentional_1d_conversion) {
-            log_warning(
-                tt::LogOp,
-                "Mismatch between computed {} and provided {} mem config. Using computed config.",
-                output_tensor_spec.memory_config(),
-                attributes.output_mem_config);
-        }
-    }
-
-    TT_FATAL(attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been automatically populated");
-    TT_FATAL(attributes.output_tile.has_value(), "Error: output_tile field should have been automatically populated");
-    if (attributes.bcast_batch.value()) {
-        TT_FATAL(
-            get_batch_size(b_shape) == 1,
-            "The batch bcast variant of matmul requires input tensors of shapes BCMK*11KN=BCMN "
-            "or equivalent. Please change the second input tensor or adjust the program config.");
-    }
-
-    TT_FATAL(is_floating_point(input_tensor_a.dtype()), "Unsupported data format");
-
-    TT_FATAL(
-        input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
-        "Operands to matmul need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
-
+    // ---- choose + normalize the program config ----
     const auto& optional_bias = optional_input_tensors.at(0);
     uint32_t bias_single_tile_size = 0;
     if (optional_bias.has_value()) {
@@ -895,12 +2093,11 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         attributes.transpose_b,
         bias_single_tile_size,
         attributes);
-    // Soft-normalize so downstream variant code can safely read allowed_worker_cores; the warning
-    // for missing allowed_worker_cores was emitted at the entry point above.
     operations::matmul::normalize_program_config(
         chosen_program_config, input_tensor_a.device()->compute_with_storage_grid_size());
 
-    validate_matmul_tile_constraints(input_tensor_a, input_tensor_b, in0_tile, in1_tile, chosen_program_config);
+    // ---- universal checks, part 2: need the chosen program config ----
+    // Config-based shared validators (each self-filters by config via std::visit).
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
     validate_matmul_bias(optional_bias, chosen_program_config);
@@ -920,893 +2117,80 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         attributes.output_mem_config,
         chosen_program_config);
 
-    // Validate batch dimensions for non-bcast matmul
-    if (!attributes.bcast_batch.value()) {
-        TT_FATAL(
-            a_shape.rank() == b_shape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank",
-            "Input tensors must have the same rank, got a_shape rank: {} vs b_shape rank: {}",
-            a_shape.rank(),
-            b_shape.rank());
+    validate_matmul_batch_compatibility(
+        attributes, input_tensor_a, input_tensor_b, a_shape, b_shape, chosen_program_config);
+    validate_matmul_mcast1d_subdevice_worker_grid(input_tensor_a, attributes, chosen_program_config);
+    validate_matmul_input_count(attributes, input_tensors, input_tensor_b, chosen_program_config);
+    validate_matmul_bias_shape(optional_bias, in0_tile, in1_tile, b_shape, b_shape_padded);
+    validate_matmul_untilize_out(attributes, chosen_program_config);
 
-        // Check if in0 reuse optimization can be applied
-        // This optimization keeps input A (batch=1) in L1 and reuses it across all input B batches
-        // 1. Program config requirements: must use 1D mcast with specific settings
-        // 2. Shape requirements: must be rank >= 3 (to have at least one batch dimension)
-        // 3. Batch dimension requirement: all batch dimensions of input A must be size 1
-        // 4. Memory layout requirement: inputs must not be sharded
-        auto in0_reuse = [&]() {
-            if (!std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
-                    chosen_program_config)) {
-                return false;
-            }
-            const auto& config =
-                std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config);
-            if (config.fuse_batch || config.fused_activation.has_value() || config.mcast_in0) {
-                return false;
-            }
-            if (a_shape.rank() < 3 || b_shape.rank() < 3) {
-                return false;
-            }
-            for (auto j = 0; j < static_cast<int>(a_shape.rank()) - 2; j++) {
-                if (a_shape[j] != 1) {
-                    return false;
-                }
-            }
-            return !input_tensor_a.is_sharded() && !input_tensor_b.is_sharded();
-        };
-
-        for (auto i = 0; i < a_shape.rank() - 2; i++) {
-            TT_FATAL(
-                a_shape[i] == b_shape[i] || (a_shape[i] == 1 && in0_reuse()),
-                "bmm (non-bcast matmul) expects input tensors of shapes "
-                "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed "
-                "when all batch dimensions of a are size 1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig "
-                "with fuse_batch=false, fused_activation=none, mcast_in0=false, and non-sharded inputs for in0 "
-                "reuse optimization)",
-                i,
-                a_shape[i],
-                b_shape[i]);
-        }
-    }
-
-    // matmul_multicore_reuse_mcast_1d (both program- and descriptor-based) targets a single
-    // bounding-box rectangle for the in0/in1 multicast and expects the sub-device's worker
-    // cores to form one contiguous row-major rectangle. Reject non-rectangular sub-device
-    // grids early with a clear message.
-    if (std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
-            chosen_program_config) &&
-        attributes.sub_device_id.has_value()) {
-        const auto& program_config_1d =
-            std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config);
-        if (!program_config_1d.gather_in0) {
-            auto* device = input_tensor_a.device();
-            auto sub_device_cores =
-                device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, attributes.sub_device_id.value());
-            auto bbox = sub_device_cores.bounding_box();
-            TT_FATAL(
-                sub_device_cores.num_cores() == bbox.size(),
-                "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
-                "Got sub-device worker cores: {} (bounding box: {})",
-                sub_device_cores,
-                bbox);
-            auto grid_size_1d = program_config_1d.allowed_worker_cores.value().bounding_box().grid_size();
-            TT_FATAL(
-                bbox.start_coord.x + grid_size_1d.x - 1 <= bbox.end_coord.x &&
-                    bbox.start_coord.y + grid_size_1d.y - 1 <= bbox.end_coord.y,
-                "matmul grid_size {} anchored at sub-device start {} "
-                "extends past the sub-device's worker bounding box {}",
-                grid_size_1d,
-                bbox.start_coord,
-                bbox);
-        }
-    }
-
-    if (std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
-            chosen_program_config) &&
-        attributes.global_cb.has_value() && input_tensor_b.is_sharded() && input_tensor_b.buffer()->is_dram()) {
-        for (uint32_t i = 1; i < input_tensors.size(); ++i) {
-            TT_FATAL(
-                input_tensor_b.logical_shape() == input_tensors[i].logical_shape(),
-                "for multi-tensor matmul, all weight tensors must have the same logical_shape, {} is not equal to {}",
-                input_tensor_b.logical_shape(),
-                input_tensors[i].logical_shape());
-            TT_FATAL(
-                input_tensor_b.padded_shape() == input_tensors[i].padded_shape(),
-                "for multi-tensor matmul, all weight tensors must have the same padded_shape {} is not equal to {}",
-                input_tensor_b.padded_shape(),
-                input_tensors[i].padded_shape());
-            TT_FATAL(
-                input_tensor_b.tensor_spec() == input_tensors[i].tensor_spec(),
-                "for multi-tensor matmul, all weight tensors must have the same tensor_spec {} is not equal to {}",
-                input_tensor_b.tensor_spec(),
-                input_tensors[i].tensor_spec());
-            TT_FATAL(
-                input_tensor_b.layout() == input_tensors[i].layout(),
-                "for multi-tensor matmul, all weight tensors must have the same layout {} is not equal to {}",
-                input_tensor_b.layout(),
-                input_tensors[i].layout());
-            TT_FATAL(
-                input_tensor_b.dtype() == input_tensors[i].dtype(),
-                "for multi-tensor matmul, all weight tensors must have the same _dtype {} is not equal to {}",
-                input_tensor_b.dtype(),
-                input_tensors[i].dtype());
-        }
-    } else {
-        TT_FATAL(input_tensors.size() == 2, "Must have exactly 2 input tensors, got: {}", input_tensors.size());
-    }
-
-    if (optional_bias.has_value()) {
-        const auto& bias = optional_bias.value();
-        auto bias_tile_shape = bias.tensor_spec().tile().get_tile_shape();
-        TT_FATAL(
-            (bias_tile_shape[0] == in0_tile.get_height() && bias_tile_shape[1] == in1_tile.get_width()),
-            "Input tile dims must have inner dim equal to 32 due to llk "
-            "constraints");
-        TT_FATAL(bias.layout() == Layout::TILE, "Unsupported input layout");
-        const auto& bias_shape = bias.logical_shape();
-        const auto& bias_shape_padded = bias.padded_shape();
-        uint32_t bias_batch_size = get_batch_size(bias_shape);
-        TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size not equal to 1.");
-        TT_FATAL(
-            bias_shape_padded[-2] == in0_tile.get_height(),
-            "Unsupported bias shape: padded second last dimension of bias, "
-            "{}, not equal to tile height, {}",
-            bias_shape_padded[-2],
-            in0_tile.get_height());
-        TT_FATAL(
-            bias_shape_padded[-1] == b_shape_padded[-1],
-            "Unsupported bias shape: padded last dimension of bias, {}, not "
-            "equal to second input's padded last "
-            "dimension, {}.",
-            bias_shape_padded[-1],
-            b_shape_padded[-1]);
-        TT_FATAL(
-            bias_shape[-1] >= b_shape[-1],
-            "Unsupported bias shape: last dimension of bias, {}, not equal to "
-            "or greater than second input's last "
-            "dimension, {}.",
-            bias_shape[-1],
-            b_shape[-1]);
-    }
-
-    if (attributes.untilize_out) {
-        TT_FATAL(attributes.output_dtype.has_value(), "Output dtype must be specified when untilize_out is true");
-        TT_FATAL(
-            (attributes.output_dtype.value() == DataType::BFLOAT16) ||
-                (attributes.output_dtype.value() == DataType::FLOAT32),
-            "Unsupported data type: {}",
-            attributes.output_dtype.value());
-        TT_FATAL(
-            std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
-                chosen_program_config),
-            "Untilize out is not supported for this program config: {}",
-            ttsl::get_active_type_name_in_variant(chosen_program_config));
-    }
-
-    using namespace tt;
+    // ---- per-config validation: one std::visit over the chosen program config ----
+    // Shared Mcast2D/Mcast1D fuse_batch preamble first, then dispatch to the matching
+    // per-config validator. The Reuse work-split check runs after the visit.
     std::visit(
-        [input_tensor_a,
-         input_tensor_b,
-         optional_bias,
-         a_shape_padded,
-         b_shape_padded,
-         in0_tile,
-         in1_tile,
-         &attributes](const auto& program_config) {
+        [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
                 std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                if (program_config.fuse_batch) {
-                    TT_FATAL(
-                        get_batch_size(b_shape_padded) == 1,
-                        "Matmul with fused batch requires input tensors of shapes BCMK*11KN=BCMN "
-                        "or equivalent. Please change the second input tensor or adjust the program config.");
-                    if (attributes.transpose_a) {
-                        uint32_t batch_size_a = get_batch_size(a_shape_padded);
-                        uint32_t M_per_batch = a_shape_padded[-2] / in0_tile.get_height();
-                        TT_FATAL(
-                            batch_size_a == 1 || M_per_batch == 1,
-                            "transpose_a with fuse_batch is not supported when batch dimensions "
-                            "exist and M_per_batch > 1 (batch_size={}, M_per_batch={}, a_shape_padded={})",
-                            batch_size_a,
-                            M_per_batch,
-                            a_shape_padded);
-                    }
-                }
+                validate_matmul_mcast_fuse_batch_preamble(
+                    ttsl::get_type_name(program_config),
+                    program_config.fuse_batch,
+                    attributes,
+                    a_shape_padded,
+                    b_shape_padded,
+                    in0_tile);
             }
-            // TODO: For 1D and 2D mcasts, we don't check if tensor is single core
-            // or single row/col We can uplift these variants to skip mcasting to
-            // support single core (1D) or single row/col (2D)
             if constexpr (std::is_same_v<
                               ProgramConfigType,
                               operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                TT_FATAL(
-                    !(program_config.mcast_in0 && program_config.gather_in0),
-                    "Matmul1D does not support mcast_in0 and gather_in0 at the "
-                    "same time.");
-
-                // Gather in0 specific validation
-                if (program_config.gather_in0) {
-                    TT_FATAL(
-                        program_config.num_global_cb_receivers > 0, "Num global CB receivers must be greater than 0.");
-                    TT_FATAL(
-                        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
-                        "Input tensor A must be width sharded when using gather_in0.");
-                    TT_FATAL(
-                        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-                            (input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
-                             input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM) ||
-                            // Receiver-contiguous Tensor prefetcher: in1 is an NdShardSpec DRAM
-                            // weight (reported as ND_SHARDED) whose data is delivered via the
-                            // global CB receivers, not read directly per its DRAM layout. The
-                            // weight's own layout is irrelevant to the matmul in this case.
-                            (attributes.global_cb.has_value() &&
-                             input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM),
-                        "Input tensor B must be width sharded, DRAM interleaved, or a DRAM weight fed "
-                        "via a global circular buffer when using gather_in0.");
-                    if (!attributes.global_cb.has_value() && input_tensor_b.is_sharded()) {
-                        if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1) {
-                            TT_FATAL(
-                                input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
-                                "Input tensor A and B must be sharded on the same cores "
-                                "when using gather_in0.");
-                        }
-                    }
-                    TT_FATAL(
-                        attributes.output_mem_config.is_sharded(),
-                        "Output tensor must be sharded when using gather_in0.");
-                    TT_FATAL(
-                        attributes.output_mem_config.shard_spec().has_value(),
-                        "Output shard spec must be provided when using gather_in0.");
-
-                    if (!input_tensor_b.is_sharded()) {
-                        TT_FATAL(
-                            !attributes.global_cb.has_value(),
-                            "Global CB is not supported for DRAM_INTERLEAVED in1 when using gather_in0.");
-                        TT_FATAL(
-                            input_tensor_b.layout() == Layout::TILE,
-                            "Input tensor B must be TILE_LAYOUT when DRAM_INTERLEAVED when using gather_in0.");
-                        TT_FATAL(
-                            input_tensor_a.shard_spec().value().grid ==
-                                attributes.output_mem_config.shard_spec().value().grid,
-                            "Input tensor A and output tensor must be sharded on the same cores when using gather_in0 "
-                            "and in1 is DRAM_INTERLEAVED.");
-                    }
-
-                    if (!attributes.global_cb.has_value()) {
-                        TT_FATAL(
-                            program_config.num_global_cb_receivers == 1,
-                            "Num global CB receivers must be 1 when global CB is not provided.");
-                    }
-
-                    // Cross-check program_config against the in1 weight shape (silent-hang guards),
-                    // gated on the DRAM-sender path. The two DRAM-sender weight layouts have
-                    // different bank->ring conventions, so dispatch per in1 memory_layout():
-                    //   * WIDTH_SHARDED (K-row-major): each bank holds one wide (K, N/num_banks)
-                    //     shard feeding the contiguous ring positions [b*rpb, (b+1)*rpb).
-                    //   * ND_SHARDED (receiver-contiguous): an NdShardSpec weight with round-robin
-                    //     shard placement and a strided bank->ring mapping.
-                    // NdShardSpec reports memory_layout() == ND_SHARDED (see MemoryConfig(BufferType,
-                    // NdShardSpec)); the prefetcher manager and validator key on the same enum.
-                    if (attributes.global_cb.has_value() && input_tensor_a.is_sharded() &&
-                        tt::tt_metal::experimental::sender_core_type(attributes.global_cb.value()) ==
-                            tt::tt_metal::experimental::SenderCoreType::Dram) {
-                        const auto in1_layout = input_tensor_b.memory_config().memory_layout();
-                        if (in1_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-                            validate_dram_sender_global_cb_gather_in0_geometry(
-                                attributes.global_cb.value(), input_tensor_a, b_shape_padded, in1_tile, program_config);
-                        } else if (in1_layout == TensorMemoryLayout::ND_SHARDED) {
-                            validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
-                                attributes.global_cb.value(), input_tensor_a, b_shape_padded, in1_tile, program_config);
-                        } else {
-                            TT_FATAL(
-                                false,
-                                "gather_in0 matmul with a DRAM-sender global CB requires in1 to be WIDTH_SHARDED "
-                                "(K-row-major) or ND_SHARDED (receiver-contiguous), but got {}.",
-                                in1_layout);
-                        }
-                    }
-
-                    TT_FATAL(!optional_bias.has_value(), "Bias is not supported when using gather_in0.");
-                } else {
-                    const auto device_grid_1d = input_tensor_a.device()->compute_with_storage_grid_size();
-                    check_tensor_in_grid(input_tensor_a, device_grid_1d);
-                    check_tensor_in_grid(input_tensor_b, device_grid_1d);
-                }
-                if (program_config.mcast_in0 || program_config.gather_in0) {
-                    if (input_tensor_a.is_sharded()) {
-                        TT_FATAL(program_config.fuse_batch, "Error: Batch fusion must be enabled.");
-                        TT_FATAL(
-                            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
-                            "Error: input_tensor_a must be width sharded. Provided tensor memory layout: {}",
-                            input_tensor_a.memory_config().memory_layout());
-                        if (attributes.output_mem_config.is_sharded()) {
-                            TT_FATAL(
-                                input_tensor_a.memory_config().buffer_type() ==
-                                    attributes.output_mem_config.buffer_type(),
-                                "Error: Buffer type mismatch.");
-                            TT_FATAL(
-                                input_tensor_a.memory_config().memory_layout() ==
-                                    attributes.output_mem_config.memory_layout(),
-                                "Error: Memory layout mismatch.");
-                        }
-                        TT_FATAL(
-                            input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
-                            "Error: Shard orientation must be ROW_MAJOR.");
-                        const auto M = operations::matmul::utilities::get_M_dim(
-                            a_shape_padded, in0_tile, program_config.fuse_batch);
-                        const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
-                        uint32_t per_core_M = program_config.per_core_M;
-                        auto shard_shape = input_tensor_a.shard_spec().value().shape;
-
-                        // No padding
-                        TT_FATAL(M == per_core_M, "Error: M ({}) must be equal to per_core_M ({}).", M, per_core_M);
-                        TT_FATAL(
-                            per_core_M == (shard_shape[0] / in0_tile.get_height()),
-                            "Error: per_core_M must be equal to shard_shape[0] ({}) / in0_tile.get_height() ({}).",
-                            shard_shape[0],
-                            in0_tile.get_height());
-                        TT_FATAL(
-                            K % program_config.in0_block_w == 0,
-                            "Error: K {} must be divisible by in0_block_w {}.",
-                            K,
-                            program_config.in0_block_w);
-                        if (!program_config.gather_in0) {  // Padding allowed for gather_in0
-                            TT_FATAL(
-                                (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
-                                "Error: shard_shape[1] ({}) / in0_tile.get_width() ({}) must be divisible by "
-                                "in0_block_w ({}).",
-                                shard_shape[1],
-                                in0_tile.get_width(),
-                                program_config.in0_block_w);
-                        }
-                    }
-                    if (attributes.output_mem_config.is_sharded()) {
-                        // Allow BLOCK_SHARDED on 1-row grids (equivalent to WIDTH_SHARDED)
-                        bool is_width_sharded =
-                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
-                        bool is_block_sharded_1d_row = false;
-                        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
-                            attributes.output_mem_config.shard_spec().has_value()) {
-                            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
-                            is_block_sharded_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
-                        }
-                        TT_FATAL(
-                            is_width_sharded || is_block_sharded_1d_row,
-                            "Error: Output memory layout must be WIDTH_SHARDED or BLOCK_SHARDED on a 1-row grid. "
-                            "Provided tensor memory layout: {}",
-                            attributes.output_mem_config.memory_layout());
-                        const auto M = operations::matmul::utilities::get_M_dim(
-                            a_shape_padded, in0_tile, program_config.fuse_batch);
-                        uint32_t per_core_M = program_config.per_core_M;
-                        uint32_t per_core_N = program_config.per_core_N;
-
-                        // No padding
-                        TT_FATAL(M == per_core_M, "Error: M {} must be equal to per_core_M {}.", M, per_core_M);
-
-                        TT_FATAL(
-                            program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
-                            "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
-                        TT_FATAL(
-                            program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
-                            "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
-                    }
-                    if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1 &&
-                        input_tensor_b.memory_config().is_sharded()) {
-                        TT_FATAL(
-                            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
-                            "Operand B can only be interleaved or L1 width sharded.");
-                        TT_FATAL(
-                            program_config.per_core_N ==
-                                (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()),
-                            "Shard width must match per core N.");
-                        if (optional_bias.has_value()) {
-                            TT_FATAL(
-                                input_tensor_b.shard_spec().value().shape[1] ==
-                                    optional_bias.value().shard_spec().value().shape[1],
-                                "Bias shard spec width must match second inputs shard spec "
-                                "width.");
-                        }
-                    }
-                } else {
-                    if (input_tensor_a.memory_config().is_sharded()) {
-                        TT_FATAL(program_config.fuse_batch, "Error: Batch fusion must be enabled.");
-                        TT_FATAL(
-                            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-                            "Error: input_tensor_a must be height sharded.");
-                        if (attributes.output_mem_config.is_sharded()) {
-                            TT_FATAL(
-                                input_tensor_a.memory_config().buffer_type() ==
-                                    attributes.output_mem_config.buffer_type(),
-                                "Error: Buffer type mismatch.");
-                            TT_FATAL(
-                                input_tensor_a.memory_config().memory_layout() ==
-                                    attributes.output_mem_config.memory_layout(),
-                                "Error: Memory layout mismatch.");
-                        }
-                        TT_FATAL(
-                            input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
-                            "Error: Shard orientation must be ROW_MAJOR.");
-                        const auto M = operations::matmul::utilities::get_M_dim(
-                            a_shape_padded, in0_tile, program_config.fuse_batch);
-                        const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
-                        uint32_t per_core_M = program_config.per_core_M;
-                        auto shard_shape = input_tensor_a.shard_spec().value().shape;
-                        TT_FATAL(
-                            div_up(M, per_core_M) <= input_tensor_a.shard_spec().value().grid.num_cores(),
-                            "Error: M must be divisible by per_core_M.");
-                        TT_FATAL(
-                            per_core_M == (shard_shape[0] / in0_tile.get_height()),
-                            "Error: per_core_M must be equal to shard_shape[0] / in0_tile.get_height().");
-                        TT_FATAL(K % program_config.in0_block_w == 0, "Error: K must be divisible by in0_block_w.");
-                        TT_FATAL(
-                            K == (shard_shape[1] / in0_tile.get_width()),
-                            "Error: K must be equal to shard_shape[1] / in0_tile.get_width().");
-                    }
-                    if (attributes.output_mem_config.is_sharded()) {
-                        // Allow BLOCK_SHARDED on 1-column grids (equivalent to HEIGHT_SHARDED)
-                        bool is_height_sharded =
-                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
-                        bool is_block_sharded_1d_column = false;
-                        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
-                            attributes.output_mem_config.shard_spec().has_value()) {
-                            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
-                            is_block_sharded_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
-                        }
-                        TT_FATAL(
-                            is_height_sharded || is_block_sharded_1d_column,
-                            "Error: Output memory layout must be HEIGHT_SHARDED or BLOCK_SHARDED on a 1-column grid.");
-                        const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
-                        uint32_t per_core_N = program_config.per_core_N;
-
-                        TT_FATAL(N == per_core_N, "Error: N must be equal to per_core_N.");
-                        TT_FATAL(
-                            program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
-                            "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
-                        TT_FATAL(
-                            program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
-                            "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
-                    }
-                    TT_FATAL(
-                        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-                        "Error: Operand B must be interleaved.");
-                }
+                validate_matmul_c4_mcast1d_config(
+                    input_tensor_a,
+                    input_tensor_b,
+                    optional_bias,
+                    attributes,
+                    a_shape_padded,
+                    b_shape_padded,
+                    in0_tile,
+                    in1_tile,
+                    program_config);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
-                TT_FATAL(input_tensor_a.is_sharded(), "Input tensor A must be sharded for DRAM sharded program config");
-                TT_FATAL(
-                    attributes.output_mem_config.is_sharded(),
-                    "Output memory config must be sharded for DRAM sharded program config");
-                TT_FATAL(
-                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
-                    "Input A memory layout must be WIDTH_SHARDED, got: {}",
-                    input_tensor_a.memory_config().memory_layout());
-                TT_FATAL(
-                    input_tensor_a.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
-                    "Input A and output buffer types must match, got input: {} vs output: {}",
-                    input_tensor_a.memory_config().buffer_type(),
-                    attributes.output_mem_config.buffer_type());
-                TT_FATAL(
-                    input_tensor_a.memory_config().memory_layout() == attributes.output_mem_config.memory_layout(),
-                    "Input A and output memory layouts must match, got input: {} vs output: {}",
-                    input_tensor_a.memory_config().memory_layout(),
-                    attributes.output_mem_config.memory_layout());
-                TT_FATAL(
-                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
-                    "Input A shard orientation must be ROW_MAJOR, got: {}",
-                    input_tensor_a.shard_spec().value().orientation);
-                const auto M = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/false);
-                const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
-                uint32_t per_core_M = program_config.per_core_M;
-                auto shard_shape = input_tensor_a.shard_spec().value().shape;
-
-                // No padding
-                TT_FATAL(M == per_core_M, "M ({}) must equal per_core_M ({})", M, per_core_M);
-                TT_FATAL(M == 1, "currently only support in0 tensor height of tile height");
-                TT_FATAL(
-                    per_core_M == (shard_shape[0] / in0_tile.get_height()),
-                    "per_core_M ({}) must equal shard_shape[0] / in0_tile.get_height() ({})",
-                    per_core_M,
-                    (shard_shape[0] / in0_tile.get_height()));
-                TT_FATAL(
-                    K % program_config.in0_block_w == 0,
-                    "K ({}) must be divisible by in0_block_w ({})",
-                    K,
-                    program_config.in0_block_w);
-                TT_FATAL(
-                    (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
-                    "shard_shape[1] / in0_tile.get_width() ({}) must be divisible by in0_block_w ({})",
-                    (shard_shape[1] / in0_tile.get_width()),
-                    program_config.in0_block_w);
-
-                // tensor in1
-                TT_FATAL(
-                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
-                    "Input B memory layout must be WIDTH_SHARDED, got: {}",
-                    input_tensor_b.memory_config().memory_layout());
+                validate_matmul_c5_dram_sharded_config(
+                    input_tensor_a, input_tensor_b, attributes, a_shape_padded, in0_tile, program_config);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::
                                          MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-                // Batch-sharded DRAM matmul validations
-                // For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
-                // Sharded by batch dimension - each worker handles B/num_workers complete matmuls
-                // Input A: HEIGHT_SHARDED in L1 (batch-sharded, each core has B/12 complete [M, N] matrices)
-                // Input B: HEIGHT_SHARDED in DRAM (batch-sharded, each bank has B/12 complete [N, K] matrices)
-                // Output: HEIGHT_SHARDED in L1 (batch-sharded, each core outputs B/12 complete [M, K] matrices)
-                TT_FATAL(input_tensor_a.is_sharded(), "Input tensor A must be sharded for batch-sharded DRAM matmul");
-                TT_FATAL(
-                    attributes.output_mem_config.is_sharded(),
-                    "Output memory config must be sharded for batch-sharded DRAM matmul");
-                TT_FATAL(
-                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-                    "Input A memory layout must be HEIGHT_SHARDED for batch-sharded DRAM matmul, got: {}",
-                    input_tensor_a.memory_config().memory_layout());
-                TT_FATAL(
-                    input_tensor_a.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
-                    "Input A and output buffer types must match, got input: {} vs output: {}",
-                    input_tensor_a.memory_config().buffer_type(),
-                    attributes.output_mem_config.buffer_type());
-                TT_FATAL(
-                    input_tensor_a.memory_config().memory_layout() == attributes.output_mem_config.memory_layout(),
-                    "Input A and output memory layouts must match, got input: {} vs output: {}",
-                    input_tensor_a.memory_config().memory_layout(),
-                    attributes.output_mem_config.memory_layout());
-                TT_FATAL(
-                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
-                    "Input A shard orientation must be ROW_MAJOR, got: {}",
-                    input_tensor_a.shard_spec().value().orientation);
-
-                // For batch sharding, the contracted dimension (N in A, N in B) must be divisible by in0_block_w
-                const auto N_dim =
-                    operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);  // K dim of A = N
-                TT_FATAL(
-                    N_dim % program_config.in0_block_w == 0,
-                    "N dimension ({}) must be divisible by in0_block_w ({})",
-                    N_dim,
-                    program_config.in0_block_w);
-
-                // tensor in1: HEIGHT_SHARDED in DRAM (batch-sharded)
-                TT_FATAL(
-                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-                    "Input B memory layout must be HEIGHT_SHARDED for batch-sharded DRAM matmul, got: {}",
-                    input_tensor_b.memory_config().memory_layout());
+                validate_matmul_c6_batched_dram_sharded_config(
+                    input_tensor_a, input_tensor_b, attributes, a_shape_padded, in0_tile, program_config);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
-                const tt::tt_metal::CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
-                check_tensor_in_grid(input_tensor_a, device_grid);
-                check_tensor_in_grid(input_tensor_b, device_grid);
-                if (input_tensor_a.memory_config().is_sharded()) {
-                    TT_FATAL(program_config.fuse_batch, "Batch fusion is required when input A is sharded");
-                    auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
-                    const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
-                    uint32_t per_core_M = program_config.per_core_M;
-                    auto shard_shape = input_tensor_a.shard_spec().value().shape;
-
-                    TT_FATAL(
-                        tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
-                            tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
-                        "Unsupported memory layout {}.",
-                        tensor_a_memory_layout);
-
-                    if (tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-                        if (program_config.transpose_mcast) {
-                            TT_FATAL(
-                                input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR,
-                                "Input tensor A must have COL_MAJOR shard orientation for transpose MCAST, got: {}",
-                                input_tensor_a.shard_spec().value().orientation);
-                        } else {
-                            TT_FATAL(
-                                input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
-                                "Input tensor A must have ROW_MAJOR shard orientation for non-transpose MCAST, got: {}",
-                                input_tensor_a.shard_spec().value().orientation);
-                        }
-                        if (attributes.output_mem_config.is_sharded()) {
-                            TT_FATAL(
-                                input_tensor_a.memory_config().buffer_type() ==
-                                    attributes.output_mem_config.buffer_type(),
-                                "Input tensor A and output buffer types must match, got input: {} vs output: {}",
-                                input_tensor_a.memory_config().buffer_type(),
-                                attributes.output_mem_config.buffer_type());
-                            TT_FATAL(
-                                input_tensor_a.memory_config().memory_layout() ==
-                                    attributes.output_mem_config.memory_layout(),
-                                "Input tensor A and output memory layouts must match, got input: {} vs output: {}",
-                                input_tensor_a.memory_config().memory_layout(),
-                                attributes.output_mem_config.memory_layout());
-                        }
-
-                    } else if (tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-                        TT_FATAL(
-                            !program_config.transpose_mcast,
-                            "Transpose MCAST not supported with HEIGHT_SHARDED layout");
-                        TT_FATAL(
-                            K == program_config.in0_block_w,
-                            "K ({}) must equal in0_block_w ({})",
-                            K,
-                            program_config.in0_block_w);
-                        TT_FATAL(
-                            program_config.in0_block_w == (shard_shape[1] / in0_tile.get_width()),
-                            "in0_block_w ({}) must equal shard_shape[1] / in0_tile.get_width() ({})",
-                            program_config.in0_block_w,
-                            (shard_shape[1] / in0_tile.get_width()));
-                        TT_FATAL(
-                            input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
-                                input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x,
-                            "When input tensor A is HEIGHT_SHARDED, it must have a single-column shard grid for "
-                            "MatmulMultiCoreReuseMultiCastProgramConfig (got x={} to x={}). Use "
-                            "MatmulMultiCoreReuseProgramConfig for multi-column HEIGHT_SHARDED inputs.",
-                            input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x,
-                            input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
-                    }
-
-                    TT_FATAL(
-                        per_core_M == (shard_shape[0] / in0_tile.get_height()),
-                        "per_core_M ({}) must equal shard_shape[0] / in0_tile.get_height() ({})",
-                        per_core_M,
-                        (shard_shape[0] / in0_tile.get_height()));
-                    TT_FATAL(
-                        (shard_shape[1] / in0_tile.get_width()) % program_config.in0_block_w == 0,
-                        "shard_shape[1] / in0_tile.get_width() ({}) must be divisible by in0_block_w ({})",
-                        (shard_shape[1] / in0_tile.get_width()),
-                        program_config.in0_block_w);
-                }
-
-                if (input_tensor_b.memory_config().is_sharded()) {
-                    TT_FATAL(!program_config.transpose_mcast, "Transpose MCAST not supported when input B is sharded");
-                    auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout();
-                    // ND_SHARDED in1 in DRAM is read via the generic TensorAccessor path: the program
-                    // factory's in1_is_sharded only covers WIDTH/HEIGHT, so ND falls through to the
-                    // interleaved-style reader, which addresses the NdShardSpec layout from the accessor
-                    // args. The width/height-specific validation below is gated on those layouts, so ND
-                    // DRAM in1 skips it (no shard_spec() access).
-                    const bool in1_is_nd_dram = tensor_b_memory_layout == TensorMemoryLayout::ND_SHARDED &&
-                                                input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
-                    TT_FATAL(
-                        tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
-                            tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || in1_is_nd_dram,
-                        "Input B memory layout must be WIDTH_SHARDED, HEIGHT_SHARDED, or DRAM ND_SHARDED, got: {}",
-                        tensor_b_memory_layout);
-                    if (tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-                        // Height-sharded in1 is only supported for DRAM batched matmuls
-                        TT_FATAL(
-                            input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM,
-                            "HEIGHT_SHARDED input B is only supported in DRAM, got: {}",
-                            input_tensor_b.buffer()->buffer_type());
-                        TT_FATAL(
-                            !program_config.fuse_batch,
-                            "HEIGHT_SHARDED input B requires fuse_batch=false for batched matmul");
-                        // Each DRAM bank must hold complete [K, N] matrices stacked vertically
-                        // K is the contracted dim: last dim of A, second-to-last of B
-                        const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, in0_tile);
-                        const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
-                        const auto& in1_shard_spec = input_tensor_b.shard_spec().value();
-                        uint32_t in1_shard_height_in_tiles = in1_shard_spec.shape[0] / in1_tile.get_height();
-                        uint32_t in1_shard_width_in_tiles = in1_shard_spec.shape[1] / in1_tile.get_width();
-                        uint32_t num_banks = in1_shard_spec.grid.num_cores();
-                        TT_FATAL(
-                            in1_shard_width_in_tiles == N,
-                            "HEIGHT_SHARDED input B shard width ({} tiles) must equal N ({} tiles)",
-                            in1_shard_width_in_tiles,
-                            N);
-                        TT_FATAL(
-                            in1_shard_height_in_tiles >= K,
-                            "HEIGHT_SHARDED input B shard height ({} tiles) must be >= K ({} tiles)",
-                            in1_shard_height_in_tiles,
-                            K);
-                        TT_FATAL(
-                            in1_shard_height_in_tiles % K == 0,
-                            "HEIGHT_SHARDED input B shard height ({} tiles) must be divisible by K ({} tiles) "
-                            "so each bank holds complete [K, N] matrices",
-                            in1_shard_height_in_tiles,
-                            K);
-                        uint32_t batches_per_bank = in1_shard_height_in_tiles / K;
-                        uint32_t B = get_batch_size(b_shape_padded);
-                        // The kernel addresses batch b via: bank_id = b / batches_per_bank.
-                        // Total shard capacity (batches_per_bank * num_banks) must be >= B
-                        // to ensure all batches map to valid banks. It may exceed B when the
-                        // batch dimension is padded up to distribute evenly across banks.
-                        TT_FATAL(
-                            batches_per_bank * num_banks >= B,
-                            "HEIGHT_SHARDED input B: batches_per_bank ({}) * num_banks ({}) = {} must be >= "
-                            "batch size B ({})",
-                            batches_per_bank,
-                            num_banks,
-                            batches_per_bank * num_banks,
-                            B);
-                    }
-                    if (input_tensor_b.buffer()->buffer_type() != tt_metal::BufferType::DRAM) {
-                        const auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
-                        TT_FATAL(
-                            (input_tensor_a.memory_config().is_sharded() &&
-                             tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) ||
-                                tensor_a_memory_layout == TensorMemoryLayout::INTERLEAVED,
-                            "Error - non-DRAM width sharded input B requires input A to be interleaved or height "
-                            "sharded, rather than {}",
-                            tensor_a_memory_layout);
-                        TT_FATAL(
-                            program_config.per_core_N ==
-                                (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()),
-                            "per_core_N ({}) must equal input tensor B shard shape[1] / in1_tile.get_width() ({})",
-                            program_config.per_core_N,
-                            (input_tensor_b.shard_spec().value().shape[1] / in1_tile.get_width()));
-                    }
-                    if (tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-                        TT_FATAL(
-                            input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y ==
-                                input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y,
-                            "Width-sharded input tensor B grid bounding box must have equal start and end y "
-                            "coordinates, got start: {} vs end: {}",
-                            input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y,
-                            input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
-                    }
-                }
-
-                if (attributes.output_mem_config.is_sharded()) {
-                    TT_FATAL(
-                        attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED,
-                        "Output memory layout must be BLOCK_SHARDED, got: {}",
-                        attributes.output_mem_config.memory_layout());
-                    uint32_t per_core_N = program_config.per_core_N;
-
-                    TT_FATAL(
-                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
-                        "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
-                    TT_FATAL(
-                        program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
-                        "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
-                }
+                validate_matmul_c3_mcast2d_config(
+                    input_tensor_a,
+                    input_tensor_b,
+                    attributes,
+                    a_shape_padded,
+                    b_shape_padded,
+                    in0_tile,
+                    in1_tile,
+                    program_config);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                const auto M = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/false);
-                const auto total_M =
-                    operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/true);
-                const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
-                const auto K = operations::matmul::utilities::get_K_dim(a_shape_padded, /*tile=*/std::nullopt);
-                uint32_t per_core_M = program_config.per_core_M;
-                uint32_t per_core_N = program_config.per_core_N;
-                if (per_core_M > M) {
-                    TT_FATAL(
-                        per_core_M % M == 0,
-                        "per_core_M, {}, must be a multiple of M, {} if "
-                        "per_core_M > M!",
-                        per_core_M,
-                        M);
-                    TT_FATAL(
-                        total_M % per_core_M == 0,
-                        "input a total height, {}, must be divisible by "
-                        "per_core_M, {}!",
-                        total_M,
-                        per_core_M);
-                } else {
-                    TT_FATAL(
-                        M % per_core_M == 0, "per_core_M, {}, must divide M, {}, if per_core_M < M!", per_core_M, M);
-                }
-                TT_FATAL(N == per_core_N, "Error: N, {}, is not equal to per_core_N, {}", N, per_core_N);
-                if (input_tensor_a.is_sharded()) {
-                    TT_FATAL(
-                        input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                        "Error: memory layout, {}, is not width sharded",
-                        input_tensor_a.memory_config().memory_layout());
-                    auto in0_shard_shape = input_tensor_a.shard_spec().value().shape;
-
-                    TT_FATAL(K == in0_shard_shape[1], "Error: K, {}, needs to be equal to {}", K, in0_shard_shape[1]);
-                    TT_FATAL(
-                        in0_shard_shape[1] == program_config.in0_block_w * in0_tile.get_width(),
-                        "Error: {} needs to equal {} * {}",
-                        in0_shard_shape[1],
-                        program_config.in0_block_w,
-                        in0_tile.get_width());
-                    TT_FATAL(
-                        per_core_M * in0_tile.get_height() == in0_shard_shape[0],
-                        "Error: {} * {} needs to equal {}",
-                        per_core_M,
-                        in0_tile.get_height(),
-                        in0_shard_shape[0]);
-
-                    if (input_tensor_b.is_sharded()) {
-                        TT_FATAL(
-                            input_tensor_a.memory_config().buffer_type() ==
-                                input_tensor_b.memory_config().buffer_type(),
-                            "Input tensors A and B must have matching buffer types, got A: {} vs B: {}",
-                            input_tensor_a.memory_config().buffer_type(),
-                            input_tensor_b.memory_config().buffer_type());
-                        TT_FATAL(
-                            input_tensor_a.memory_config().memory_layout() ==
-                                input_tensor_b.memory_config().memory_layout(),
-                            "Input tensors A and B must have matching memory layouts, got A: {} vs B: {}",
-                            input_tensor_a.memory_config().memory_layout(),
-                            input_tensor_b.memory_config().memory_layout());
-                        TT_FATAL(
-                            input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
-                            "Input tensors A and B must have matching shard spec grids");
-                        TT_FATAL(
-                            input_tensor_a.shard_spec().value().orientation ==
-                                input_tensor_b.shard_spec().value().orientation,
-                            "Input tensors A and B must have matching shard orientations, got A: {} vs B: {}",
-                            input_tensor_a.shard_spec().value().orientation,
-                            input_tensor_b.shard_spec().value().orientation);
-                    }
-                    if (attributes.output_mem_config.is_sharded()) {
-                        TT_FATAL(
-                            input_tensor_a.memory_config().buffer_type() == attributes.output_mem_config.buffer_type(),
-                            "Input tensor A and output buffer types must match, got input: {} vs output: {}",
-                            input_tensor_a.memory_config().buffer_type(),
-                            attributes.output_mem_config.buffer_type());
-                        TT_FATAL(
-                            input_tensor_a.memory_config().memory_layout() ==
-                                attributes.output_mem_config.memory_layout(),
-                            "Input tensor A and output memory layouts must match, got input: {} vs output: {}",
-                            input_tensor_a.memory_config().memory_layout(),
-                            attributes.output_mem_config.memory_layout());
-                    }
-                }
-
-                const auto batch_size_a = get_batch_size(a_shape_padded);
-                const auto batch_size_b = get_batch_size(b_shape_padded);
-                bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
-                TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported for the chosen program config");
-                if (batch_size_a > 1 && batch_size_b > 1) {
-                    TT_FATAL(
-                        M % program_config.out_subblock_h == 0,
-                        "out_subblock_h ({}) needs to divide M ({}) evenly and does not. "
-                        "Please update your program config.",
-                        program_config.out_subblock_h,
-                        M);
-                }
-
-                if (input_tensor_b.is_sharded()) {
-                    TT_FATAL(per_core_M % M == 0, "per_core_M must be a multiple of M if input b is sharded!");
-                    TT_FATAL(
-                        input_tensor_b.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                        "Input B memory layout must not be WIDTH_SHARDED, got: {}",
-                        input_tensor_b.memory_config().memory_layout());
-                    auto in1_shard_shape = input_tensor_b.shard_spec().value().shape;
-                    TT_FATAL(
-                        in1_shard_shape[1] == b_shape_padded[-1],
-                        "Input B shard shape[1] ({}) must equal padded shape[-1] ({})",
-                        in1_shard_shape[1],
-                        b_shape_padded[-1]);
-                    TT_FATAL(
-                        per_core_N * in1_tile.get_width() == in1_shard_shape[1],
-                        "per_core_N * in1_tile.get_width() ({}) must equal in1_shard_shape[1] ({})",
-                        per_core_N * in1_tile.get_width(),
-                        in1_shard_shape[1]);
-                    TT_FATAL(
-                        in1_shard_shape[0] % K == 0,
-                        "Input B shard shape[0] ({}) must be divisible by K ({})",
-                        in1_shard_shape[0],
-                        K);
-                }
-                if (attributes.output_mem_config.is_sharded()) {
-                    TT_FATAL(
-                        attributes.output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                        "Output memory layout must not be WIDTH_SHARDED, got: {}",
-                        attributes.output_mem_config.memory_layout());
-                    TT_FATAL(
-                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
-                        "Either out_subblock_w ({}) must equal per_core_N ({}) or out_subblock_h ({}) must be 1",
-                        program_config.out_subblock_w,
-                        per_core_N,
-                        program_config.out_subblock_h);
-                }
+                validate_matmul_c2_reuse_config(
+                    input_tensor_a,
+                    input_tensor_b,
+                    attributes,
+                    a_shape_padded,
+                    b_shape_padded,
+                    in0_tile,
+                    in1_tile,
+                    program_config);
             } else {
-                TT_FATAL(
-                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-                    "Input A memory layout must be INTERLEAVED, got: {}",
-                    input_tensor_a.memory_config().memory_layout());
-                TT_FATAL(
-                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-                    "Input B memory layout must be INTERLEAVED, got: {}",
-                    input_tensor_b.memory_config().memory_layout());
-                TT_FATAL(
-                    attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
-                    "Output memory layout must be INTERLEAVED, got: {}",
-                    attributes.output_mem_config.memory_layout());
+                validate_matmul_c1_multicore_config(input_tensor_a, input_tensor_b, attributes, in0_tile, in1_tile);
             }
         },
         chosen_program_config);
@@ -1863,7 +2247,8 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
     auto tile_width_ratio = output_tile.get_tile_shape()[1] / in1_tile.get_width();
     auto output_layout = attributes.untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
 
-    TT_FATAL(attributes.output_dtype.has_value(), "Error: output_dtype field should have been populated");
+    TT_FATAL(
+        attributes.output_dtype.has_value(), "output_dtype must be populated before computing matmul output specs");
     if (attributes.output_mem_config.is_sharded()) {
         const auto& optional_bias = !optional_input_tensors.empty() && optional_input_tensors[0].has_value()
                                         ? optional_input_tensors[0]
@@ -1898,7 +2283,10 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
 
                     TT_FATAL(
                         per_core_N % tile_width_ratio == 0,
-                        "per_core_N must be divisible by override output tile width");
+                        "per_core_N ({}) must be a multiple of the output/in1 tile-width ratio ({}) so "
+                        "columns fill whole output tiles",
+                        per_core_N,
+                        tile_width_ratio);
                     auto mem_config = attributes.output_mem_config;
                     if (!program_config.gather_in0) {
                         // Check if BLOCK_SHARDED on 1D grid - if so, use user's shard spec with converted memory layout
@@ -1967,7 +2355,10 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
 
                     TT_FATAL(
                         per_core_N % tile_width_ratio == 0,
-                        "per_core_N must be divisible by override output tile width");
+                        "per_core_N ({}) must be a multiple of the output/in1 tile-width ratio ({}) so "
+                        "columns fill whole output tiles",
+                        per_core_N,
+                        tile_width_ratio);
 
                     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
                     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
@@ -1999,7 +2390,10 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
 
                     TT_FATAL(
                         per_core_N % tile_width_ratio == 0,
-                        "per_core_N must be divisible by override output tile width");
+                        "per_core_N ({}) must be a multiple of the output/in1 tile-width ratio ({}) so "
+                        "columns fill whole output tiles",
+                        per_core_N,
+                        tile_width_ratio);
 
                     // Use the user-provided shard spec directly
                     auto mem_config = attributes.output_mem_config;
@@ -2018,7 +2412,10 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
 
                     TT_FATAL(
                         per_core_N % tile_width_ratio == 0,
-                        "per_core_N must be divisible by override output tile width");
+                        "per_core_N ({}) must be a multiple of the output/in1 tile-width ratio ({}) so "
+                        "columns fill whole output tiles",
+                        per_core_N,
+                        tile_width_ratio);
 
                     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
                     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
@@ -2065,7 +2462,10 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
 
                     TT_FATAL(
                         per_core_N % tile_width_ratio == 0,
-                        "per_core_N must be divisible by override output tile width");
+                        "per_core_N ({}) must be a multiple of the output/in1 tile-width ratio ({}) so "
+                        "columns fill whole output tiles",
+                        per_core_N,
+                        tile_width_ratio);
 
                     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
                     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -22,6 +22,10 @@ namespace {
 using tt::constants::TILE_HEIGHT;
 using tt::constants::TILE_WIDTH;
 
+// ===========================================================================
+// UNIVERSAL BLOCKS: run for every program config (independent of which config is chosen).
+// ===========================================================================
+
 // Universal Block-1: basic operand check. Inputs must be on the same device, tilized,
 // have a 32-wide inner tile dim (the hardware matmul works on 32x32 tiles), and both
 // be floating-point.
@@ -52,8 +56,8 @@ void validate_matmul_operand_basics(
 }
 
 // Universal Block-2: matrix dimension check. Ranks, K/M/N > 0, and A's K equals B's K.
-// K is asymmetric: A's K is its last dim (width); B's K is at [-2] (height), so B's K
-// is read manually after b.rank >= 2 is verified.
+// The a_shape/b_shape passed in are already transpose-adjusted, so K sits at [-1] for A
+// (width) and [-2] for B (height); B's K is read manually after b.rank >= 2 is verified.
 void validate_matmul_matrix_dimensions(
     const ttnn::Shape& a_shape,
     const ttnn::Shape& b_shape,
@@ -82,8 +86,9 @@ void validate_matmul_matrix_dimensions(
     TT_FATAL(Kt_a == Kt_b, "K dimension in tiles must match between input A ({}) and input B ({})", Kt_a, Kt_b);
 }
 
-// Universal Block-3: bfloat4 tile-size check. A bfloat4 input needs a tile dim >= 4.
-// A only checks height — its width is K, which Block-1 already forces to 32.
+// Universal Block-3: bfloat4 tile-size check. A bfloat4 input needs each tile dim >= 4.
+// Only A's height and B's width are checked; the other two dims (A's width, B's height)
+// are the K axis, already forced to 32 by Universal Block-1, so they can't be < 4.
 void validate_matmul_bfloat4_tile_dims(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -380,10 +385,9 @@ void validate_matmul_untilize_out(
         attributes.output_dtype.value());
     TT_FATAL(
         std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config),
-        "{}: Untilize out is not supported for this program config: {}, only supported for "
+        "{}: untilize_out is not supported for this program config, only supported for "
         "MatmulMultiCoreReuseMultiCast1DProgramConfig",
-        config_name,
-        ttsl::get_active_type_name_in_variant(chosen_program_config));
+        config_name);
 }
 
 // ===========================================================================
@@ -391,10 +395,8 @@ void validate_matmul_untilize_out(
 // internally per config. Messages are config-named.
 // ===========================================================================
 
-// Block-9: block/subblock configuration. Runs for Reuse, Mcast2D, Mcast1D; MultiCore,
-// DRAMSharded, and BatchedDRAMSharded skip it. Mcast2D/Mcast1D have an out_block level;
-// Reuse divides per_core by out_subblock directly. Keeps its own in0_block_w != 0 guard
-// so its Kt-divide is self-contained (Block-10 also checks it — a harmless overlap).
+// Shared Block-1: block/subblock configuration. Runs for Reuse, Mcast2D, Mcast1D
+// (MultiCore, DRAMSharded, BatchedDRAMSharded skip it).
 void validate_matmul_block_and_subblock_configuration(
     const MatmulParams& attributes,
     const ttnn::Shape& a_shape_padded,
@@ -499,12 +501,7 @@ void validate_matmul_block_and_subblock_configuration(
         chosen_program_config);
 }
 
-// Block-10: compute-grid + per-core dims. MultiCore skips. Reuse/Mcast2D/Mcast1D check
-// the program grid is non-zero and fits the device (Mcast1D gather_in0 skips it — its
-// grid comes from the input shard grid). All non-MultiCore configs check in0_block_w /
-// per_core_M / per_core_N are non-zero (via the helper below).
-
-// Checks in0_block_w / per_core_M / per_core_N are non-zero. Block-9's Kt-divide relies on this.
+// Helper: checks in0_block_w / per_core_M / per_core_N are non-zero.
 void validate_matmul_nonzero_block_dims(
     std::string_view config_name, std::size_t in0_block_w, std::size_t per_core_M, std::size_t per_core_N) {
     TT_FATAL(in0_block_w != 0, "{}: in0_block_w is 0, which is not valid", config_name);
@@ -512,6 +509,10 @@ void validate_matmul_nonzero_block_dims(
     TT_FATAL(per_core_N != 0, "{}: per_core_N is 0, which is not valid", config_name);
 }
 
+// Shared Block-2: compute-grid + per-core dims. Skips MultiCore. For every other config it
+// checks in0_block_w / per_core_M / per_core_N are non-zero (via the helper above); Reuse/
+// Mcast2D/Mcast1D also check the program grid is non-zero and fits the device (Mcast1D
+// gather_in0 skips that grid check — its grid comes from the input A shard grid).
 void validate_matmul_compute_grid_and_per_core_dims(
     const Tensor& input_tensor_a, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     const CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
@@ -520,9 +521,10 @@ void validate_matmul_compute_grid_and_per_core_dims(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreProgramConfig>) {
-                return;  // C1: no program grid / block dims to check
+                return;  // MultiCore: no program grid / block dims to check
             } else {
-                // C2-C6. Grid-bounds check applies to C2/C3/C4 only (C5/C6 map to DRAM banks).
+                // Non-MultiCore. Grid-bounds check applies to Reuse/Mcast2D/Mcast1D only
+                // (DRAMSharded/BatchedDRAMSharded map to DRAM banks).
                 if constexpr (
                     std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig> ||
                     std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
@@ -560,13 +562,8 @@ void validate_matmul_compute_grid_and_per_core_dims(
         chosen_program_config);
 }
 
-// Block-11: grid-containment helpers. Check that a sharded tensor's shard grid fits
-// inside the compute grid. Two helpers — one for a tensor input, one for the output
-// mem-config; only L1-sharded tensors are checked (DRAM is skipped).
-
-// Orig 25-43.
+// Helper: an L1-sharded tensor's shard grid must fit within the given grid (DRAM skipped).
 void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
-    // Validate tensor is within grid if sharded and not in DRAM
     if (tensor.memory_config().is_sharded() && tensor.memory_config().buffer_type() != BufferType::DRAM) {
         const auto& shard_spec = tensor.memory_config().shard_spec().value();
         const auto& shard_grid = shard_spec.grid;
@@ -585,12 +582,11 @@ void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     }
 }
 
-// Orig 216-236. Keeps its original context_label param (the config name / a
-// descriptive tag); the extent-non-zero message is now also prefixed with it.
+// Helper: an L1-sharded output's shard grid must fit within the given extent (DRAM skipped).
 void check_output_shard_grid_within_extent(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::CoreCoord& extent,
-    const char* context_label) {
+    std::string_view config_name) {
     if (!output_mem_config.is_sharded() || output_mem_config.buffer_type() == tt::tt_metal::BufferType::DRAM) {
         return;
     }
@@ -601,7 +597,7 @@ void check_output_shard_grid_within_extent(
     TT_FATAL(
         extent.x > 0 && extent.y > 0,
         "{}: device grid extent must be non-zero, got ({}, {})",
-        context_label,
+        config_name,
         extent.x,
         extent.y);
     const tt::tt_metal::CoreRange bbox(
@@ -609,15 +605,14 @@ void check_output_shard_grid_within_extent(
     TT_FATAL(
         bbox.contains(shard_grid),
         "{}: output shard grid {} must lie within extent {}",
-        context_label,
+        config_name,
         shard_grid,
         extent);
 }
 
-// Block-12: work distribution + gather ring topology. Runs for Reuse/Mcast2D/Mcast1D.
-// Checks output blocks fit the cores (Mcast1D uses a 1D total count, Mcast2D a 2D
-// per-axis check), and for Mcast1D gather_in0 the ring setup (A sharded, sub-device
-// present, hop cores not overlapping).
+// Shared Block-3: work distribution + gather ring topology. Runs for Reuse/Mcast2D/Mcast1D.
+// Checks output blocks fit the cores; for Mcast1D gather_in0 also checks the ring setup
+// (A sharded, sub-device present, hop cores not overlapping).
 void validate_matmul_work_distribution_and_gather_ring_topology(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -664,10 +659,7 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                             program_config.hop_cores,
                             worker_cores);
                     }
-                    check_output_shard_grid_within_extent(
-                        output_mem_config,
-                        device_extent,
-                        "MatmulMultiCoreReuseMultiCast1DProgramConfig (gather_in0 output vs device grid)");
+                    check_output_shard_grid_within_extent(output_mem_config, device_extent, config_name);
                 } else {
                     TT_FATAL(
                         program_config.hop_cores.empty(),
@@ -698,8 +690,7 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                             per_core_M,
                             num_blocks_y);
                     }
-                    check_output_shard_grid_within_extent(
-                        output_mem_config, grid, "MatmulMultiCoreReuseMultiCast1DProgramConfig");
+                    check_output_shard_grid_within_extent(output_mem_config, grid, config_name);
                 }
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
@@ -733,8 +724,7 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                     config_name,
                     num_blocks_y,
                     grid.y);
-                check_output_shard_grid_within_extent(
-                    output_mem_config, grid, "MatmulMultiCoreReuseMultiCastProgramConfig");
+                check_output_shard_grid_within_extent(output_mem_config, grid, config_name);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
@@ -747,8 +737,7 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                                          input_tensor_b.memory_config().is_sharded() || output_mem_config.is_sharded();
                 const auto effective_extent =
                     any_sharded ? device_extent : program_config.compute_with_storage_grid_size;
-                check_output_shard_grid_within_extent(
-                    output_mem_config, effective_extent, "MatmulMultiCoreReuseProgramConfig");
+                check_output_shard_grid_within_extent(output_mem_config, effective_extent, config_name);
             } else {
                 (void)transpose_a;
                 (void)transpose_b;
@@ -757,8 +746,8 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
         chosen_program_config);
 }
 
-// Block-10a — Reuse config only. Sharded operand grids must fit within the program
-// compute grid.
+// Shared Block-4 — Reuse config only. Each L1-sharded input's shard grid must fit within
+// the device grid. Non-sharded inputs and DRAM inputs are not checked.
 void validate_matmul_sharded_operand_grids_within_program_compute_grid(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -772,8 +761,7 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
                 // against the origin-anchored compute_with_storage_grid_size rectangle incorrectly
                 // rejects grids that don't start at (0,0) (e.g. column 1 in a multi-chain fused op).
                 // The only physical constraint is that the shard grid fits within the device grid.
-                // For non-sharded inputs the config grid drives split_work_to_cores, so the
-                // origin-anchored check is still correct there.
+                // Non-sharded inputs are not checked here (the check only applies to L1-sharded tensors).
                 const auto& config_grid = program_config.compute_with_storage_grid_size;
                 const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
                 auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
@@ -785,7 +773,9 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
         chosen_program_config);
 }
 
-// Block-10b — Reuse config only. Checks sharded output block divisibility.
+// Shared Block-5 — Reuse config only. If an input is sharded across N cores, the total
+// number of output blocks must be a multiple of N so the work splits evenly across those
+// cores; otherwise the program factory can't distribute it and fails.
 void validate_matmul_reuse_sharded_output_block_divisibility(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -828,7 +818,7 @@ void validate_matmul_reuse_sharded_output_block_divisibility(
         chosen_program_config);
 }
 
-// Block-10c — bias support by config. Reuse rejects bias; other configs allow it.
+// Shared Block-6 — bias support by config. Reuse rejects bias; other configs allow it.
 void validate_matmul_bias(
     const std::optional<const Tensor>& optional_bias,
     const operations::matmul::MatmulProgramConfig& chosen_program_config) {
@@ -1033,8 +1023,8 @@ void warn_if_allowed_worker_cores_missing(
         */
 }
 
-// Runs for Mcast1D on a sub-device (non-gather). The sub-device's cores must form a
-// solid block with no gaps, and the matmul's grid must fit within that block.
+// Shared Block-7 — Mcast1D on a sub-device (non-gather). Checks the matmul grid fits on
+// the sub-device's cores.
 void validate_matmul_mcast1d_subdevice_worker_grid(
     const Tensor& input_tensor_a,
     const MatmulParams& attributes,
@@ -1075,7 +1065,7 @@ void validate_matmul_mcast1d_subdevice_worker_grid(
     }
 }
 
-// Shared block: input A and output must agree on buffer type + memory layout. Used by
+// Helper: input A and output must agree on buffer type + memory layout. Used by
 // Reuse/Mcast2D/Mcast1D/DRAMSharded/BatchedDRAMSharded.
 void validate_input_a_output_mem_config_match(
     std::string_view config_name, const Tensor& input_tensor_a, const tt::tt_metal::MemoryConfig& output_mem_config) {
@@ -1093,7 +1083,7 @@ void validate_input_a_output_mem_config_match(
         output_mem_config.memory_layout());
 }
 
-// Shared block: output subblock/block width must divide per_core_N. Used by
+// Helper: output subblock/block width must divide per_core_N. Used by
 // Mcast2D/Mcast1D (Reuse keeps its own inline variant).
 void validate_output_subblock_block_divides_per_core_n(
     std::string_view config_name,
@@ -1126,7 +1116,7 @@ void validate_output_subblock_block_divides_per_core_n(
 
 // MultiCore config — the un-optimized fallback. Rejects tiny outer tiles and requires
 // all operands + output to be INTERLEAVED.
-void validate_matmul_c1_multicore_config(
+void validate_matmul_multicore_config(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const MatmulParams& attributes,
@@ -1164,7 +1154,7 @@ void validate_matmul_c1_multicore_config(
 
 // DRAMSharded config. in0 width-sharded in L1, in1 width-sharded in DRAM; height must
 // be a single tile (M == 1) and K/shard dims divide in0_block_w.
-void validate_matmul_c5_dram_sharded_config(
+void validate_matmul_dram_sharded_config(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const MatmulParams& attributes,
@@ -1226,7 +1216,7 @@ void validate_matmul_c5_dram_sharded_config(
 
 // BatchedDRAMSharded config. [1,B,M,K] x [1,B,K,N]: A height-sharded in L1, B height-
 // sharded in DRAM, output height-sharded in L1; contracted dim divides in0_block_w.
-void validate_matmul_c6_batched_dram_sharded_config(
+void validate_matmul_batched_dram_sharded_config(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const MatmulParams& attributes,
@@ -1237,9 +1227,9 @@ void validate_matmul_c6_batched_dram_sharded_config(
     // Batch-sharded DRAM matmul validations
     // For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
     // Sharded by batch dimension - each worker handles B/num_workers complete matmuls
-    // Input A: HEIGHT_SHARDED in L1 (batch-sharded, each core has B/12 complete [M, N] matrices)
-    // Input B: HEIGHT_SHARDED in DRAM (batch-sharded, each bank has B/12 complete [N, K] matrices)
-    // Output: HEIGHT_SHARDED in L1 (batch-sharded, each core outputs B/12 complete [M, K] matrices)
+    // Input A: HEIGHT_SHARDED in L1 (batch-sharded, each core has B/num_workers complete [M, K] matrices)
+    // Input B: HEIGHT_SHARDED in DRAM (batch-sharded, each bank has B/num_workers complete [K, N] matrices)
+    // Output: HEIGHT_SHARDED in L1 (batch-sharded, each core outputs B/num_workers complete [M, N] matrices)
     TT_FATAL(
         input_tensor_a.is_sharded(), "{}: Input tensor A must be sharded for batch-sharded DRAM matmul", config_name);
     TT_FATAL(
@@ -1277,7 +1267,7 @@ void validate_matmul_c6_batched_dram_sharded_config(
 
 // Mcast2D config — block-sharded 2D multicast. Validates that sharded input A, input B,
 // and the output have layouts, grids, and orientations consistent with a 2D multicast.
-void validate_matmul_c3_mcast2d_config(
+void validate_matmul_mcast2d_config(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const MatmulParams& attributes,
@@ -1485,7 +1475,7 @@ void validate_matmul_c3_mcast2d_config(
 // Reuse config — non-multicast block reuse. Validates per_core_M/N divisibility vs M/N,
 // sharded A/B/output layouts, grid/shard-shape agreement, and rejects batch broadcast.
 // (The post-visit work-split check is also Reuse-only, wired at the dispatch.)
-void validate_matmul_c2_reuse_config(
+void validate_matmul_reuse_config(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const MatmulParams& attributes,
@@ -1650,7 +1640,7 @@ void validate_matmul_c2_reuse_config(
 // Mcast1D config — 1D multicast. Validates the mcast_in0 and gather_in0 paths, the
 // width-sharded and height-sharded in0 paths, and the output layout/subblock rules for
 // 1-row vs 1-column grids.
-void validate_matmul_c4_mcast1d_config(
+void validate_matmul_mcast1d_config(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const std::optional<const Tensor>& optional_bias,
@@ -2144,7 +2134,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             if constexpr (std::is_same_v<
                               ProgramConfigType,
                               operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                validate_matmul_c4_mcast1d_config(
+                validate_matmul_mcast1d_config(
                     input_tensor_a,
                     input_tensor_b,
                     optional_bias,
@@ -2157,18 +2147,18 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
-                validate_matmul_c5_dram_sharded_config(
+                validate_matmul_dram_sharded_config(
                     input_tensor_a, input_tensor_b, attributes, a_shape_padded, in0_tile, program_config);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::
                                          MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-                validate_matmul_c6_batched_dram_sharded_config(
+                validate_matmul_batched_dram_sharded_config(
                     input_tensor_a, input_tensor_b, attributes, a_shape_padded, in0_tile, program_config);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
-                validate_matmul_c3_mcast2d_config(
+                validate_matmul_mcast2d_config(
                     input_tensor_a,
                     input_tensor_b,
                     attributes,
@@ -2180,7 +2170,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                validate_matmul_c2_reuse_config(
+                validate_matmul_reuse_config(
                     input_tensor_a,
                     input_tensor_b,
                     attributes,
@@ -2190,7 +2180,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                     in1_tile,
                     program_config);
             } else {
-                validate_matmul_c1_multicore_config(input_tensor_a, input_tensor_b, attributes, in0_tile, in1_tile);
+                validate_matmul_multicore_config(input_tensor_a, input_tensor_b, attributes, in0_tile, in1_tile);
             }
         },
         chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -746,7 +746,7 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
         chosen_program_config);
 }
 
-// Shared Block-4 — Reuse config only. Each L1-sharded input's shard grid must fit within
+// Shared Block-4: Reuse config only. Each L1-sharded input's shard grid must fit within
 // the device grid. Non-sharded inputs and DRAM inputs are not checked.
 void validate_matmul_sharded_operand_grids_within_program_compute_grid(
     const Tensor& input_tensor_a,
@@ -773,7 +773,7 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
         chosen_program_config);
 }
 
-// Shared Block-5 — Reuse config only. If an input is sharded across N cores, the total
+// Shared Block-5: Reuse config only. If an input is sharded across N cores, the total
 // number of output blocks must be a multiple of N so the work splits evenly across those
 // cores; otherwise the program factory can't distribute it and fails.
 void validate_matmul_reuse_sharded_output_block_divisibility(
@@ -818,7 +818,7 @@ void validate_matmul_reuse_sharded_output_block_divisibility(
         chosen_program_config);
 }
 
-// Shared Block-6 — bias support by config. Reuse rejects bias; other configs allow it.
+// Shared Block-6: bias support by config. Reuse rejects bias; other configs allow it.
 void validate_matmul_bias(
     const std::optional<const Tensor>& optional_bias,
     const operations::matmul::MatmulProgramConfig& chosen_program_config) {
@@ -842,7 +842,7 @@ void validate_matmul_bias(
         ttsl::get_active_type_name_in_variant(chosen_program_config));
 }
 
-// Cross-validate a DRAM-sender global_cb's geometry against the matmul + weight shape.
+// Helper: cross-validate a DRAM-sender global_cb's geometry against the matmul + weight shape.
 // These catch silent-hang configs where the matmul reads more in1 pages than the prefetcher
 // pushes (e.g. activation K padded past weight K). Gated by the caller on the DRAM-sender path
 // because the worker-sender variant predates this work and uses different sizing/ordering
@@ -989,9 +989,9 @@ void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
         ring_size);
 }
 
-// Warns if a caller of MatmulDeviceOperation's static API hasn't populated allowed_worker_cores
-// on a program_config variant that supports the field. ttnn::prim::matmul() normalizes its
-// attributes before launch, but direct callers (e.g. CCL fused ops in
+// Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated
+// allowed_worker_cores on a program_config variant that supports the field. ttnn::prim::matmul()
+// normalizes its attributes before launch, but direct callers (e.g. CCL fused ops in
 // ttnn/operations/experimental/ccl) need to invoke
 // ttnn::operations::matmul::normalize_program_config() themselves. Downstream code in this file
 // auto-populates via normalize_program_config on the chosen_program_config local, so this is
@@ -1023,7 +1023,7 @@ void warn_if_allowed_worker_cores_missing(
         */
 }
 
-// Shared Block-7 — Mcast1D on a sub-device (non-gather). Checks the matmul grid fits on
+// Shared Block-7: Mcast1D on a sub-device (non-gather). Checks the matmul grid fits on
 // the sub-device's cores.
 void validate_matmul_mcast1d_subdevice_worker_grid(
     const Tensor& input_tensor_a,
@@ -1114,7 +1114,7 @@ void validate_output_subblock_block_divides_per_core_n(
 // std::visit.
 // ===========================================================================
 
-// MultiCore config — the un-optimized fallback. Rejects tiny outer tiles and requires
+// MultiCore config: the un-optimized fallback. Rejects tiny outer tiles and requires
 // all operands + output to be INTERLEAVED.
 void validate_matmul_multicore_config(
     const Tensor& input_tensor_a,
@@ -1152,7 +1152,7 @@ void validate_matmul_multicore_config(
         attributes.output_mem_config.memory_layout());
 }
 
-// DRAMSharded config. in0 width-sharded in L1, in1 width-sharded in DRAM; height must
+// DRAMSharded config: in0 width-sharded in L1, in1 width-sharded in DRAM; height must
 // be a single tile (M == 1) and K/shard dims divide in0_block_w.
 void validate_matmul_dram_sharded_config(
     const Tensor& input_tensor_a,
@@ -1214,7 +1214,7 @@ void validate_matmul_dram_sharded_config(
         input_tensor_b.memory_config().memory_layout());
 }
 
-// BatchedDRAMSharded config. [1,B,M,K] x [1,B,K,N]: A height-sharded in L1, B height-
+// BatchedDRAMSharded config: [1,B,M,K] x [1,B,K,N]: A height-sharded in L1, B height-
 // sharded in DRAM, output height-sharded in L1; contracted dim divides in0_block_w.
 void validate_matmul_batched_dram_sharded_config(
     const Tensor& input_tensor_a,
@@ -1265,7 +1265,7 @@ void validate_matmul_batched_dram_sharded_config(
         input_tensor_b.memory_config().memory_layout());
 }
 
-// Mcast2D config — block-sharded 2D multicast. Validates that sharded input A, input B,
+// Mcast2D config: block-sharded 2D multicast. Validates that sharded input A, input B,
 // and the output have layouts, grids, and orientations consistent with a 2D multicast.
 void validate_matmul_mcast2d_config(
     const Tensor& input_tensor_a,
@@ -1472,7 +1472,7 @@ void validate_matmul_mcast2d_config(
     }
 }
 
-// Reuse config — non-multicast block reuse. Validates per_core_M/N divisibility vs M/N,
+// Reuse config: non-multicast block reuse. Validates per_core_M/N divisibility vs M/N,
 // sharded A/B/output layouts, grid/shard-shape agreement, and rejects batch broadcast.
 // (The post-visit work-split check is also Reuse-only, wired at the dispatch.)
 void validate_matmul_reuse_config(
@@ -1637,7 +1637,7 @@ void validate_matmul_reuse_config(
     }
 }
 
-// Mcast1D config — 1D multicast. Validates the mcast_in0 and gather_in0 paths, the
+// Mcast1D config: 1D multicast. Validates the mcast_in0 and gather_in0 paths, the
 // width-sharded and height-sharded in0 paths, and the output layout/subblock rules for
 // 1-row vs 1-column grids.
 void validate_matmul_mcast1d_config(
@@ -1970,7 +1970,7 @@ void validate_matmul_mcast_fuse_batch_preamble(
     }
 }
 
-// Returns whether batch broadcasting applies: true when input B has batch size 1 (B is
+// Helper: returns whether batch broadcasting applies: true when input B has batch size 1 (B is
 // reused across A's batches). Used by compute_output_specs, not by validate.
 bool get_broadcast_batch(
     const Tensor& input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -23,10 +23,11 @@ using tt::constants::TILE_HEIGHT;
 using tt::constants::TILE_WIDTH;
 
 // ===========================================================================
-// UNIVERSAL BLOCKS: run for every program config (independent of which config is chosen).
+// VALIDATIONS FOR ALL CONFIGS: run for every program config, independent of which config
+// is chosen.
 // ===========================================================================
 
-// Universal Block-1: basic operand check. Inputs must be on the same device, tilized,
+// Operand Basics: inputs must be on the same device, tilized,
 // have a 32-wide inner tile dim (the hardware matmul works on 32x32 tiles), and both
 // be floating-point.
 void validate_matmul_operand_basics(
@@ -55,7 +56,7 @@ void validate_matmul_operand_basics(
         is_floating_point(input_tensor_b.dtype()), "Unsupported data format for input B: {}", input_tensor_b.dtype());
 }
 
-// Universal Block-2: matrix dimension check. Ranks, K/M/N > 0, and A's K equals B's K.
+// Matrix Dimensions: checks ranks, K/M/N > 0, and that A's K equals B's K.
 // The a_shape/b_shape passed in are already transpose-adjusted, so K sits at [-1] for A
 // (width) and [-2] for B (height); B's K is read manually after b.rank >= 2 is verified.
 void validate_matmul_matrix_dimensions(
@@ -86,9 +87,9 @@ void validate_matmul_matrix_dimensions(
     TT_FATAL(Kt_a == Kt_b, "K dimension in tiles must match between input A ({}) and input B ({})", Kt_a, Kt_b);
 }
 
-// Universal Block-3: bfloat4 tile-size check. A bfloat4 input needs each tile dim >= 4.
-// Only A's height and B's width are checked; the other two dims (A's width, B's height)
-// are the K axis, already forced to 32 by Universal Block-1, so they can't be < 4.
+// Bfloat4 Tile Size: checks that a bfloat4 input has each tile dim >= 4. Only A's height
+// and B's width are checked; the other two dims (A's width, B's height) are the K axis,
+// already forced to 32 by the Operand Basics check above, so they can't be < 4.
 void validate_matmul_bfloat4_tile_dims(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -111,9 +112,9 @@ void validate_matmul_bfloat4_tile_dims(
     }
 }
 
-// Universal Block-4: optional tensor check. At most one optional input (bias). A
-// caller-provided output tensor must match the computed spec; otherwise the requested
-// output mem-config must be compatible with it (1D block-sharded == HEIGHT/WIDTH sharded).
+// Optional Tensors: checks at most one optional input (bias). A caller-provided output
+// tensor must match the computed spec; otherwise the requested output mem-config must be
+// compatible with it (1D block-sharded == HEIGHT/WIDTH sharded).
 void validate_matmul_optional_tensors(
     const MatmulParams& attributes, const MatmulDeviceOperation::tensor_args_t& args) {
     const auto& optional_output_tensors = args.optional_output_tensors;
@@ -194,9 +195,9 @@ void validate_matmul_optional_tensors(
     }
 }
 
-// Universal Block-5: batch compatibility. bcast -> B must be single-batch; non-bcast
-// -> A and B must match rank + batch dims, unless A's batch is 1 and reused across B
-// (the Mcast1D in0-reuse exception).
+// Batch Compatibility: checks bcast -> B must be single-batch; non-bcast -> A and B must
+// match rank + batch dims, unless A's batch is 1 and reused across B (the Mcast1D
+// in0-reuse exception).
 void validate_matmul_batch_compatibility(
     const MatmulParams& attributes,
     const Tensor& input_tensor_a,
@@ -262,9 +263,9 @@ void validate_matmul_batch_compatibility(
     }
 }
 
-// Universal Block-6: input tensor count. Normally exactly 2 inputs (activation +
-// weight). Exception: the Mcast1D multi-tensor path (global_cb + DRAM-sharded weight)
-// allows 1 activation + N weights, which must share shape/spec/layout/dtype.
+// Input Count: checks there are normally exactly 2 inputs (activation + weight).
+// Exception: the Mcast1D multi-tensor path (global_cb + DRAM-sharded weight) allows
+// 1 activation + N weights, which must share shape/spec/layout/dtype.
 void validate_matmul_input_count(
     const MatmulParams& attributes,
     const std::vector<Tensor>& input_tensors,
@@ -316,9 +317,9 @@ void validate_matmul_input_count(
     }
 }
 
-// Universal Block-7: bias shape check. Runs only when a bias is present. A valid bias
-// is a single tile-row, N-wide, batch-1, tilized row vector whose tile size and width
-// line up with the matmul output.
+// Bias Shape: runs only when a bias is present. Checks the bias is a single tile-row,
+// N-wide, batch-1, tilized row vector whose tile size and width line up with the
+// matmul output.
 void validate_matmul_bias_shape(
     const std::optional<const Tensor>& optional_bias,
     const tt::tt_metal::Tile& in0_tile,
@@ -364,9 +365,9 @@ void validate_matmul_bias_shape(
         b_shape[-1]);
 }
 
-// Universal Block-8: untilize_out check. untilize_out means "give me row-major output."
-// Allowed only with an explicit BF16/FP32 output dtype on the Mcast1D config;
-// runs for every config so it can reject untilize_out on the other five.
+// Untilize Output: untilize_out means "give me row-major output." Allowed only with an
+// explicit BF16/FP32 output dtype on the Mcast1D config; this check runs for every
+// config so it can reject untilize_out on every other config.
 void validate_matmul_untilize_out(
     const MatmulParams& attributes, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     if (!attributes.untilize_out) {
@@ -391,12 +392,13 @@ void validate_matmul_untilize_out(
 }
 
 // ===========================================================================
-// SHARED-SUBSET BLOCKS: each runs for several (but not all) configs, branching
-// internally per config. Messages are config-named.
+// VALIDATIONS FOR MULTIPLE PROGRAM CONFIGS: each function here runs for several (but not
+// all) program configs that need the same checks, branching internally per config.
+// Messages are config-named.
 // ===========================================================================
 
-// Shared Block-1: block/subblock configuration. Runs for Reuse, Mcast2D, Mcast1D
-// (MultiCore, DRAMSharded, BatchedDRAMSharded skip it).
+// Block/Subblock Configuration: runs for Reuse, Mcast2D, Mcast1D (MultiCore, DRAMSharded,
+// BatchedDRAMSharded skip it).
 void validate_matmul_block_and_subblock_configuration(
     const MatmulParams& attributes,
     const ttnn::Shape& a_shape_padded,
@@ -509,8 +511,8 @@ void validate_matmul_nonzero_block_dims(
     TT_FATAL(per_core_N != 0, "{}: per_core_N is 0, which is not valid", config_name);
 }
 
-// Shared Block-2: compute-grid + per-core dims. Skips MultiCore. For every other config it
-// checks in0_block_w / per_core_M / per_core_N are non-zero (via the helper above); Reuse/
+// Compute Grid & Per-Core Dims: skips MultiCore. For every other config it checks
+// in0_block_w / per_core_M / per_core_N are non-zero (via the helper above); Reuse/
 // Mcast2D/Mcast1D also check the program grid is non-zero and fits the device (Mcast1D
 // gather_in0 skips that grid check — its grid comes from the input A shard grid).
 void validate_matmul_compute_grid_and_per_core_dims(
@@ -610,9 +612,9 @@ void check_output_shard_grid_within_extent(
         extent);
 }
 
-// Shared Block-3: work distribution + gather ring topology. Runs for Reuse/Mcast2D/Mcast1D.
-// Checks output blocks fit the cores; for Mcast1D gather_in0 also checks the ring setup
-// (A sharded, sub-device present, hop cores not overlapping).
+// Work Distribution & Gather Ring: runs for Reuse/Mcast2D/Mcast1D. Checks output blocks
+// fit the cores; for Mcast1D gather_in0 also checks the ring setup (A sharded, sub-device
+// present, hop cores not overlapping).
 void validate_matmul_work_distribution_and_gather_ring_topology(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -746,8 +748,8 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
         chosen_program_config);
 }
 
-// Shared Block-4: Reuse config only. Each L1-sharded input's shard grid must fit within
-// the device grid. Non-sharded inputs and DRAM inputs are not checked.
+// Sharded Operand Grids: Reuse config only. Each L1-sharded input's shard grid must fit
+// within the device grid. Non-sharded inputs and DRAM inputs are not checked.
 void validate_matmul_sharded_operand_grids_within_program_compute_grid(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -773,9 +775,9 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
         chosen_program_config);
 }
 
-// Shared Block-5: Reuse config only. If an input is sharded across N cores, the total
-// number of output blocks must be a multiple of N so the work splits evenly across those
-// cores; otherwise the program factory can't distribute it and fails.
+// Output Block Divisibility: Reuse config only. If an input is sharded across N cores,
+// the total number of output blocks must be a multiple of N so the work splits evenly
+// across those cores; otherwise the program factory can't distribute it and fails.
 void validate_matmul_reuse_sharded_output_block_divisibility(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -818,7 +820,7 @@ void validate_matmul_reuse_sharded_output_block_divisibility(
         chosen_program_config);
 }
 
-// Shared Block-6: bias support by config. Reuse rejects bias; other configs allow it.
+// Bias Support: checks bias support by config. Reuse rejects bias; other configs allow it.
 void validate_matmul_bias(
     const std::optional<const Tensor>& optional_bias,
     const operations::matmul::MatmulProgramConfig& chosen_program_config) {
@@ -1023,8 +1025,8 @@ void warn_if_allowed_worker_cores_missing(
         */
 }
 
-// Shared Block-7: Mcast1D on a sub-device (non-gather). Checks the matmul grid fits on
-// the sub-device's cores.
+// Sub-Device Worker Grid: Mcast1D on a sub-device (non-gather). Checks the matmul grid
+// fits on the sub-device's cores.
 void validate_matmul_mcast1d_subdevice_worker_grid(
     const Tensor& input_tensor_a,
     const MatmulParams& attributes,
@@ -1109,9 +1111,9 @@ void validate_output_subblock_block_divides_per_core_n(
 }
 
 // ===========================================================================
-// PER-CONFIG VALIDATORS. One function per program config, holding the checks that
-// fire for that config only. Dispatched from validate_on_program_cache_miss via one
-// std::visit.
+// PROGRAM CONFIG SPECIFIC VALIDATIONS: one function per program config, holding the
+// checks that fire for that config only. Dispatched from validate_on_program_cache_miss
+// via one std::visit.
 // ===========================================================================
 
 // MultiCore config: the un-optimized fallback. Rejects tiny outer tiles and requires


### PR DESCRIPTION
## Summary

- Resolves: #22180
- Resolves: #24163

Reworks matmul input validation across the file. The old monolithic validation is reorganized
into named `Universal` / `Shared` / per-config validator functions, and the `TT_FATAL` messages,
comments, and dead code are cleaned up throughout the validation logic (including
`compute_output_specs`), not just in `validate_on_program_cache_miss`. Behavior-preserving apart
from the intentional deltas noted below.

## Problem Description

- `#22180`: `validate_on_program_cache_miss` was over `1000` lines of one big `std::visit` - hard
  to read and maintain. The ask was to split it into separate parts (at least one per program
  config) and prefix each `TT_FATAL` with the config it belongs to.
- `#24163`: many matmul validation messages were cryptic or didn't print the offending values,
  some comments were stale or inaccurate, and there was redundant / dead validation code to remove.

## What's Changed

**Structure (`#22180`)**
- Reorganized the validation code into three tiers:
  - `Universal Block-1..8` - run for every program config.
  - `Shared Block-1..7` - run for several configs, each branching internally.
  - One per-config validator each: `MultiCore`, `Reuse`, `Mcast2D`, `Mcast1D`, `DRAMSharded`,
    `BatchedDRAMSharded`. Small leaf `// Helper:` functions are shared across the blocks.
- `validate_on_program_cache_miss` is now a ~`150`-line dispatcher over these validators.
- Every per-config `TT_FATAL` is prefixed with its config name, derived from the type via
  `ttsl::get_type_name`, so a failure says which config rejected the inputs.

**Messages & comments (`#24163`)**
- Rewrote cryptic / missing-value messages across the validators and `compute_output_specs` to
  name the quantities and print their values; dropped redundant `Error:` prefixes; fixed a
  `_dtype` typo.
- Fixed a misleading message whose text didn't match its check - it said "M must be divisible by
  `per_core_M`" but the check is actually `ceil(M/per_core_M) <= input-A shard-grid cores`.
- Made comments consistent throughout: `Block-N:` / `<Config> config:` headers, section banners,
  uniform `// Helper:` labels; corrected an inaccurate `BatchedDRAMSharded` shape comment.

**Dead code (`#24163`)**
- Removed an unreachable check (bfloat4 `in1` tile height `>= 4`) - `in1` tile height is already
  pinned to `32` by an earlier universal check.

**Intentional behavior deltas**
- Added a floating-point dtype check for input B (the original only checked input A).
- Removed the one dead check above. All other `TT_FATAL` conditions are unchanged; only message
  text changed.

## Tests

This is a behavior-preserving refactor, so the existing matmul suites are the proof:
- `test_matmul.py`, `test_linear.py`, `test_matmul_batch_mismatch.py`, `test_custom_grids.py` -
  all green on Wormhole B0.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/refactor-matmul-validations-22180)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/refactor-matmul-validations-22180)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/refactor-matmul-validations-22180)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/refactor-matmul-validations-22180)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/refactor-matmul-validations-22180)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/refactor-matmul-validations-22180)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/refactor-matmul-validations-22180)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/refactor-matmul-validations-22180)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/refactor-matmul-validations-22180)