### PR TITLE
[exabox] recover.sh: tag tt-smi reset output with hostname

### DIFF
--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | sed -u "s/\x1b\[[0-9;]*[a-zA-Z]//g; /^[[:space:]]*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr -d "\000" | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -390,10 +390,30 @@ echo ""
 # Note: tt-smi -glx_reset is deprecated as of tt-smi 3.1.1; use tt-smi -r if available
 if [[ "$SKIP_RESET" == false ]]; then
     echo "Running tt-smi -glx_reset..."
+    # Host-tag every reset line for attribution. tt-smi writes key progress to the tty (not stdout) so
+    # run under `script`; the tr/sed/awk pipeline collapses its animated \r/spinner output, keeps colors.
+    read -r -d '' RESET_CMD <<'RESET_CMD' || true
+set -o pipefail
+h=$(hostname)
+script -qefc "tt-smi -glx_reset" /dev/null |
+    tr -d '\000' |
+    sed -u 's/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d' |
+    awk '{
+        key = $0
+        gsub(/\033\[[0-9;]*[a-zA-Z]/, "", key)    # ignore color codes when comparing
+        sub(/[0-9]+[[:space:]]*$/, "", key)       # ignore trailing counter
+        if (seen && key == prev) { buf = $0 }     # same template -> keep only the latest
+        else { if (seen) print buf; buf = $0; prev = key; seen = 1 }
+    }
+    END { if (seen) print buf }' |
+    while IFS= read -r line; do
+        printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line"
+    done
+RESET_CMD
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr -d "\000" | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c "$RESET_CMD"
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | sed -u "s/\x1b\[[0-9;]*[a-zA-Z]//g; /^[[:space:]]*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -397,7 +397,7 @@ set -o pipefail
 h=$(hostname)
 script -qefc "tt-smi -glx_reset" /dev/null |
     tr -d '\000' |
-    sed -u 's/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d' |
+    sed -u 's/\r$//; s/.*\r//; s/\^@//g; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d' |
     awk '{
         key = $0
         gsub(/\033\[[0-9;]*[a-zA-Z]/, "", key)    # ignore color codes when comparing
@@ -409,6 +409,12 @@ script -qefc "tt-smi -glx_reset" /dev/null |
     while IFS= read -r line; do
         printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line"
     done
+ec=${PIPESTATUS[0]}
+if [[ $ec -eq 0 ]]; then
+    printf '[%s][%(%H:%M:%S)T] Reset completed successfully\n' "$h" -1
+else
+    printf '[%s][%(%H:%M:%S)T] Reset failed | Exit code: %s\n' "$h" -1 "$ec"
+fi
 RESET_CMD
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        tt-smi -glx_reset
+        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."


### PR DESCRIPTION
## Summary
Per [DIIM-182](https://tenstorrent.atlassian.net/browse/DIIM-182), `recover.sh`'s `tt-smi -glx_reset` output was interleaved across hosts with no attribution, so a line like `Error when re-initializing chips!` couldn't be traced to a machine. Each reset line is now prefixed with `[hostname][time]`.

## Details
- Run the reset under `script` (pty) so tt-smi's native pyluwen/UMD progress written to the controlling terminal, not stdout/stderr is captured too.
- Collapse the `\r` countdown and de-dup the per-tick `Detected Chips` spinner, strip stray NUL bytes, and drop blank frames; colors preserved.
- `set -o pipefail` + `script -e` keep tt-smi's real exit code so reset failures still propagate.

## Test
Ran on a 4-host bh-glx cluster

before this PR: https://gist.github.com/jpanasiukTT/2c9bddcf1e1dc40be13fa90c211e20e7
```
Detected Chips: 6
 Detected Chips: 32
 Re-initialized 32 boards after reset. Exiting...
 Detected Chips: 10
 Detected Chips: 32
 Re-initialized 32 boards after reset. Exiting...
 Detected Chips: 32
 Re-initialized 32 boards after reset. Exiting...
 Detected Chips: 32
```
tt-smi -glx_reset output with this PR: https://gist.github.com/jpanasiukTT/222414a39c7be68df8c02597ee064c44
```
[bh-glx-120-d03u08][14:33:31] 2026-07-08 14:32:31.039 | info     |             UMD | Reset successfully completed. Exit code: 0 (warm_reset.cpp:400)
[bh-glx-120-d03u08][14:33:31] Waiting for 30 seconds: 30
[bh-glx-120-d03u08][14:33:31] All 32 chips found in "/dev/tenstorrent"
[bh-glx-120-d03u08][14:33:31]  Issuing POST_RESET on 32 devices after IPMI reset...
[bh-glx-120-d03u08][14:33:31]  Re-initializing boards after reset....
[bh-glx-120-d03u08][14:33:31]  Detected Chips: 32
[bh-glx-120-d03u08][14:33:31]  Re-initialized 32 boards after reset. Exiting...
[bh-glx-120-d03u02][14:33:31]  Hint: tt-smi -r is now supported on Galaxy 6U.
[bh-glx-120-d03u02][14:33:31]  Resetting WH Galaxy trays with reset command...
[bh-glx-120-d03u02][14:33:31]  Issuing USER_RESET on 32 devices before IPMI reset...
[bh-glx-120-d03u02][14:33:31] 2026-07-08 14:32:30.567 | info     |             UMD | Starting reset. Executing command: sudo ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf (warm_reset.cpp:372)
[bh-glx-120-d03u02][14:33:31] ^@
[bh-glx-120-d03u02][14:33:31] 2026-07-08 14:32:31.044 | info     |             UMD | Reset successfully completed. Exit code: 0 (warm_reset.cpp:400)
[bh-glx-120-d03u02][14:33:31] Waiting for 30 seconds: 30
[bh-glx-120-d03u02][14:33:31] All 32 chips found in "/dev/tenstorrent"
[bh-glx-120-d03u02][14:33:31]  Issuing POST_RESET on 32 devices after IPMI reset...
[bh-glx-120-d03u02][14:33:31]  Re-initializing boards after reset....
[bh-glx-120-d03u02][14:33:31]  Detected Chips: 32
[bh-glx-120-d03u02][14:33:31]  Re-initialized 32 boards after reset. Exiting...
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/recover_reset_hostnames_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/recover_reset_hostnames_print)