### PR TITLE
[SD1.4] Lower transformer-block LayerNorm math fidelity HiFi4->HiFi2

### DIFF
--- a/models/demos/vision/generative/stable_diffusion/wormhole/tt/ttnn_functional_basic_transformer_block.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tt/ttnn_functional_basic_transformer_block.py
@@ -85,7 +85,7 @@ class basic_transformer_block:
             bias=self.parameters.norm1.bias,
             memory_config=sharded_mem_cfg,
             program_config=program_config,
-            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi2),
         )
         hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_cfg)
         # 1. Self-Attention
@@ -128,7 +128,7 @@ class basic_transformer_block:
                 bias=self.parameters.norm2.bias,
                 memory_config=sharded_mem_cfg,
                 program_config=program_config,
-                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi2),
             )
             hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_cfg)
             # 2. Cross-Attention
@@ -165,7 +165,7 @@ class basic_transformer_block:
             bias=self.parameters.norm3.bias,
             memory_config=sharded_mem_cfg,
             program_config=program_config,
-            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi2),
         )
         hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_cfg)
         if use_ada_layer_norm_zero:


### PR DESCRIPTION
## Problem
SD1.4 UNet device-perf goes red on the nightly *Device perf regressions* run (P150 BH `test_stable_diffusion_device_perf[24.4]`, e.g. run [28838820206](https://github.com/tenstorrent/tt-metal/actions/runs/28838820206)). Root-caused to **#47311** (`0c6d81a9a73`, LLK reduce-row rewrite), which slowed the reduce path that `ttnn.layer_norm` uses. By lowering fidelity without meaningful losses in pcc we are compensating lost perf.

## Change
The three `basic_transformer_block` LayerNorms (`norm1`/`norm2`/`norm3`) were pinned to **HiFi4** while every other op in the model runs at LoFi — so they're the only fidelity headroom. Dropping them to **HiFi2** recovers the multiply/scale portion of the regressed reduce cost. Shared code path, so it applies to both WH and BH runs.

### CI Status

- [ ] [Single card Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/28950359148)
- [ ] [Frequent models](https://github.com/tenstorrent/tt-metal/actions/runs/28950720059)