### PR TITLE
[exabox] run_validation.sh: stream tt-smi reset log tagged with hostname

### DIFF
--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | sed -u "s/\x1b\[[0-9;]*[a-zA-Z]//g; /^[[:space:]]*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr -d "\000" | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | sed -u "s/\x1b\[[0-9;]*[a-zA-Z]//g; /^[[:space:]]*$/d" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr "\r" "\n" | while IFS= read -r line; do [[ -z "$line" ]] && continue; printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        tt-smi -glx_reset
+        bash -c 'set -o pipefail; h=$(hostname); tt-smi -glx_reset 2>&1 | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -393,7 +393,7 @@ if [[ "$SKIP_RESET" == false ]]; then
     mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr -d "\000" | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done'
+        tt-smi -glx_reset
 
     echo ""
     echo "Sleeping ${SLEEP_DURATION}s..."

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -287,7 +287,7 @@ run_board_reset() {
 set -o pipefail
 h=$(hostname)
 script -qefc "tt-smi -glx_reset" /dev/null |
-    tr -d '\000' |
+    tr -d '\000-\010\013\014\016-\032\034-\037' |
     sed -u 's/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d' |
     awk '{
         key = $0

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -279,10 +279,34 @@ run_board_reset() {
     local output_file="$2"
     local msg_prefix="$3"
 
+    # Each rank host-tags the reset log and streams it to stderr (shown live + tee'd), then prints one
+    # "RESET_RESULT|<host>|<exit_code>" line to stdout for the retry logic below. tt-smi writes key
+    # progress to the tty (not stdout) so it runs under `script`; the tr/sed/awk pipeline collapses its
+    # animated \r/spinner output and keeps colors (pipefail+`script -e` give the real exit code).
+    read -r -d '' RESET_CMD <<'RESET_CMD' || true
+set -o pipefail
+h=$(hostname)
+script -qefc "tt-smi -glx_reset" /dev/null |
+    tr -d '\000' |
+    sed -u 's/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d' |
+    awk '{
+        key = $0
+        gsub(/\033\[[0-9;]*[a-zA-Z]/, "", key)    # ignore color codes when comparing
+        sub(/[0-9]+[[:space:]]*$/, "", key)       # ignore trailing counter
+        if (seen && key == prev) { buf = $0 }     # same template -> keep only the latest
+        else { if (seen) print buf; buf = $0; prev = key; seen = 1 }
+    }
+    END { if (seen) print buf }' |
+    while IFS= read -r line; do
+        printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line"
+    done >&2
+ec=${PIPESTATUS[0]}
+echo "RESET_RESULT|$h|$ec"
+RESET_CMD
     mpirun --host "$host_list" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr -d "\000" | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done >&2; ec=${PIPESTATUS[0]}; echo "RESET_RESULT|$h|$ec"' > "$output_file"
+        bash -c "$RESET_CMD" > "$output_file"
     mpirun_exit_code=$?
 
    # Check if mpirun failed

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -288,7 +288,7 @@ set -o pipefail
 h=$(hostname)
 script -qefc "tt-smi -glx_reset" /dev/null |
     tr -d '\000-\010\013\014\016-\032\034-\037' |
-    sed -u 's/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d' |
+    sed -u 's/\r$//; s/.*\r//; s/\^@//g; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d' |
     awk '{
         key = $0
         gsub(/\033\[[0-9;]*[a-zA-Z]/, "", key)    # ignore color codes when comparing

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -279,15 +279,10 @@ run_board_reset() {
     local output_file="$2"
     local msg_prefix="$3"
 
-    # Convert host list to array
-    IFS=',' read -ra host_array <<< "$host_list"
-
-    # Run reset
     mpirun --host "$host_list" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        --tag-output \
-        bash -c 'tt-smi -glx_reset > /dev/null 2>&1; echo "RESET_EXIT_CODE=$?"' > "$output_file"
+        bash -c 'set -o pipefail; h=$(hostname); script -qefc "tt-smi -glx_reset" /dev/null | tr -d "\000" | sed -u "s/\r$//; s/.*\r//; /^\(\x1b\[[0-9;]*[a-zA-Z]\|[[:space:]]\)*$/d" | awk "{ cb=\$0; gsub(/\033\[[0-9;]*[a-zA-Z]/,\"\",cb); sub(/[0-9]+[[:space:]]*\$/,\"\",cb); if (have && cb==bb) { buf=\$0 } else { if (have) print buf; buf=\$0; bb=cb; have=1 } } END { if (have) print buf }" | while IFS= read -r line; do printf "[%s][%(%H:%M:%S)T] %s\n" "$h" -1 "$line"; done >&2; ec=${PIPESTATUS[0]}; echo "RESET_RESULT|$h|$ec"' > "$output_file"
     mpirun_exit_code=$?
 
    # Check if mpirun failed
@@ -297,25 +292,17 @@ run_board_reset() {
         return 1  # Signal mpirun infrastructure failure
     fi
 
-    # Parse and display results, collect failures
+    # Parse per-host results (RESET_RESULT|<host>|<exit_code>), collect failures
     local failed_hosts=()
     while IFS= read -r line; do
-        if [[ $line =~ ^\[([0-9]+),([0-9]+)\]\<stdout\>:RESET_EXIT_CODE=([0-9]+)$ ]]; then
-            local job_id="${BASH_REMATCH[1]}"
-            local mpi_rank="${BASH_REMATCH[2]}"
-            local exit_code="${BASH_REMATCH[3]}"
-
-            # Use mpi_rank to index host_array
-            if [[ $mpi_rank -lt ${#host_array[@]} ]]; then
-                local hostname="${host_array[$mpi_rank]}"
-                if [[ $exit_code -eq 0 ]]; then
-                    echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset completed successfully" >&2
-                else
-                    echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset failed | Exit code: $exit_code" >&2
-                    failed_hosts+=("$hostname")
-                fi
+        if [[ $line =~ ^RESET_RESULT\|(.+)\|([0-9]+)$ ]]; then
+            local hostname="${BASH_REMATCH[1]}"
+            local exit_code="${BASH_REMATCH[2]}"
+            if [[ $exit_code -eq 0 ]]; then
+                echo "$hostname: ${msg_prefix}Reset completed successfully" >&2
             else
-                echo "Warning: MPI rank $mpi_rank exceeds host array size ${#host_array[@]}" >&2
+                echo "$hostname: ${msg_prefix}Reset failed | Exit code: $exit_code" >&2
+                failed_hosts+=("$hostname")
             fi
         fi
     done < "$output_file"


### PR DESCRIPTION
## Summary
Follow-up to the `recover.sh` hostname change [PR](https://github.com/tenstorrent/tt-metal/pull/49367). `run_validation.sh`'s per-iteration reset discarded `tt-smi -glx_reset` output entirely (`> /dev/null 2>&1`) and only printed a per-host pass/fail summary. It now streams the full reset log, with every line prefixed `[hostname][time]`, so failures like `Error when re-initializing chips!` are visible and attributable in the iteration log.

## Details
- `run_board_reset` runs `tt-smi` under `script` (pty) to capture the native pyluwen/UMD output that goes to the controlling terminal, prefixes each line with `[host][time]`, and streams it to stderr (shown live + tee'd to the iteration log).
- Collapses the `\r` countdown, de-dups the per-tick `Detected Chips` spinner, strips NUL/blank frames; colors preserved.
- Retry logic preserved: each rank emits `RESET_RESULT|<host>|<exit_code>` on stdout (via `set -o pipefail` + `script -e`), parsed to collect failed hosts. Host now comes straight from `$(hostname)` instead of the old `--tag-output` rank→host mapping (dropped the unused `host_array`).

## Test
Ran on a quad

without this pr's change:
```
Running tt-smi -glx_reset (this may take a few minutes)...
[1,2]bh-glx-120-d03u14: Reset completed successfully
[1,0]bh-glx-120-d03u02: Reset completed successfully
[1,3]bh-glx-120-d03u20: Reset completed successfully
[1,1]bh-glx-120-d03u08: Reset completed successfully
```
(No chip output at all)

output with this pr's change: https://gist.github.com/jpanasiukTT/0e2d95ee6e1e97b8212a63d9cef30859
```
Running tt-smi -glx_reset (this may take a few minutes)...
[bh-glx-120-d03u20][15:42:17]  Hint: tt-smi -r is now supported on Galaxy 6U.
[bh-glx-120-d03u20][15:42:17]  Resetting WH Galaxy trays with reset command...
[bh-glx-120-d03u20][15:42:17]  Issuing USER_RESET on 32 devices before IPMI reset...
[bh-glx-120-d03u20][15:42:17] 2026-07-08 15:41:17.219 | info     |             UMD | Starting reset. Executing command: sudo ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf (warm_reset.cpp:372)
[bh-glx-120-d03u20][15:42:17] 2026-07-08 15:41:17.667 | info     |             UMD | Reset successfully completed. Exit code: 0 (warm_reset.cpp:400)
[bh-glx-120-d03u20][15:42:17] Waiting for 30 seconds: 30
[bh-glx-120-d03u20][15:42:17] All 32 chips found in "/dev/tenstorrent"
[bh-glx-120-d03u20][15:42:17]  Issuing POST_RESET on 32 devices after IPMI reset...
[bh-glx-120-d03u20][15:42:17]  Re-initializing boards after reset....
[bh-glx-120-d03u20][15:42:17]  Detected Chips: 32
[bh-glx-120-d03u20][15:42:17]  Re-initialized 32 boards after reset. Exiting...
[bh-glx-120-d03u14][15:42:17]  Hint: tt-smi -r is now supported on Galaxy 6U.
[bh-glx-120-d03u14][15:42:17]  Resetting WH Galaxy trays with reset command...
[bh-glx-120-d03u14][15:42:17]  Issuing USER_RESET on 32 devices before IPMI reset...
[bh-glx-120-d03u14][15:42:17] 2026-07-08 15:41:17.217 | info     |             UMD | Starting reset. Executing command: sudo ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf (warm_reset.cpp:372)
[bh-glx-120-d03u14][15:42:17] 2026-07-08 15:41:17.684 | info     |             UMD | Reset successfully completed. Exit code: 0 (warm_reset.cpp:400)
[bh-glx-120-d03u14][15:42:17] Waiting for 30 seconds: 30
[bh-glx-120-d03u14][15:42:17] All 32 chips found in "/dev/tenstorrent"
[bh-glx-120-d03u14][15:42:17]  Issuing POST_RESET on 32 devices after IPMI reset...
[bh-glx-120-d03u14][15:42:17]  Re-initializing boards after reset....
[bh-glx-120-d03u14][15:42:17]  Detected Chips: 32
[bh-glx-120-d03u14][15:42:17]  Re-initialized 32 boards after reset. Exiting...
[bh-glx-120-d03u08][15:42:17]  Hint: tt-smi -r is now supported on Galaxy 6U.
[bh-glx-120-d03u08][15:42:17]  Resetting WH Galaxy trays with reset command...
[bh-glx-120-d03u08][15:42:17]  Issuing USER_RESET on 32 devices before IPMI reset...
[bh-glx-120-d03u08][15:42:17] 2026-07-08 15:41:17.214 | info     |             UMD | Starting reset. Executing command: sudo ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf (warm_reset.cpp:372)
[bh-glx-120-d03u08][15:42:17] 2026-07-08 15:41:17.697 | info     |             UMD | Reset successfully completed. Exit code: 0 (warm_reset.cpp:400)
[bh-glx-120-d03u08][15:42:17] Waiting for 30 seconds: 30
[bh-glx-120-d03u08][15:42:17] All 32 chips found in "/dev/tenstorrent"
[bh-glx-120-d03u08][15:42:17]  Issuing POST_RESET on 32 devices after IPMI reset...
[bh-glx-120-d03u08][15:42:17]  Re-initializing boards after reset....
[bh-glx-120-d03u08][15:42:17]  Detected Chips: 32
[bh-glx-120-d03u08][15:42:17]  Re-initialized 32 boards after reset. Exiting...
[bh-glx-120-d03u02][15:42:17]  Hint: tt-smi -r is now supported on Galaxy 6U.
[bh-glx-120-d03u02][15:42:17]  Resetting WH Galaxy trays with reset command...
[bh-glx-120-d03u02][15:42:17]  Issuing USER_RESET on 32 devices before IPMI reset...
[bh-glx-120-d03u02][15:42:17] 2026-07-08 15:41:17.217 | info     |             UMD | Starting reset. Executing command: sudo ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf (warm_reset.cpp:372)
[bh-glx-120-d03u02][15:42:17] 2026-07-08 15:41:17.724 | info     |             UMD | Reset successfully completed. Exit code: 0 (warm_reset.cpp:400)
[bh-glx-120-d03u02][15:42:17] Waiting for 30 seconds: 30
[bh-glx-120-d03u02][15:42:17] All 32 chips found in "/dev/tenstorrent"
[bh-glx-120-d03u02][15:42:17]  Issuing POST_RESET on 32 devices after IPMI reset...
[bh-glx-120-d03u02][15:42:17]  Re-initializing boards after reset....
[bh-glx-120-d03u02][15:42:17]  Detected Chips: 32
[bh-glx-120-d03u02][15:42:17]  Re-initialized 32 boards after reset. Exiting...
bh-glx-120-d03u20: Reset completed successfully
bh-glx-120-d03u14: Reset completed successfully
bh-glx-120-d03u08: Reset completed successfully
bh-glx-120-d03u02: Reset completed successfully
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/run_val_tt_smi_host_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/run_val_tt_smi_host_print)