### PR TITLE
[Bug fix] Avoid FD Mesh CQ teardown race

### DIFF
--- a/tt_metal/common/multi_producer_single_consumer_queue.hpp
+++ b/tt_metal/common/multi_producer_single_consumer_queue.hpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <tt_stl/assert.hpp>
 #include <tt_stl/tt_pause.hpp>
 
 template <typename T>
@@ -87,7 +88,10 @@ public:
     }
 
     std::shared_ptr<T> pop() {
+        // Precondition: this non-blocking pop must only be called when the
+        // single consumer knows an entry is available.
         Node* oldHead = pop_head();
+        TT_FATAL(oldHead != nullptr, "Cannot pop from an empty MultiProducerSingleConsumerQueue.");
         std::shared_ptr<T> result(oldHead->data);
         // Does not actually delete oldHead->data.
         // Just mark is to null to mark prev node as empty.

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -184,15 +184,14 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
     }
 
     // Log warnings instead of aborting - destructors should never throw or abort.
-    // These conditions indicate a problem but the process should be allowed to continue
-    // so that subsequent tests can run and the device can be properly reset.
+    // Only observe reader-owned state here: the completion reader thread may still
+    // pop completion_queue_reads_ and update num_outstanding_reads_ until join().
     if (!is_mock) {
         if (!completion_queue_reads_.empty()) {
             log_warning(
                 LogMetal,
                 "FDMeshCommandQueue destructor: completion reader queue is not empty. "
                 "This may indicate a device hang or timeout occurred.");
-            completion_queue_reads_.clear();
         }
 
         for (const auto& queue : read_descriptors_) {
@@ -205,7 +204,7 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
             }
         }
 
-        if (auto reads = num_outstanding_reads_.exchange(0); reads != 0) {
+        if (auto reads = num_outstanding_reads_.load(); reads != 0) {
             log_warning(
                 LogMetal,
                 "FDMeshCommandQueue destructor: {} outstanding reads remaining. "
@@ -221,6 +220,11 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
         reader_thread_cv_.notify_one();
     }
     completion_queue_reader_thread_.join();
+
+    // After join(), this destructor has exclusive ownership of reader state and
+    // can safely perform destructive cleanup.
+    completion_queue_reads_.clear();
+    num_outstanding_reads_.store(0);
 }
 
 void FDMeshCommandQueue::populate_read_descriptor_queue() {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/49286

1. Prevent `FDMeshCommandQueue` teardown from consuming completion reader queues while the completion reader thread may still be running. The destructor now only observes outstanding reader state before `join()`, and performs destructive cleanup after the reader thread has exited.
2. Also adds an explicit empty pop guard to `MultiProducerSingleConsumerQueue::pop()` so queue/count desyncs fail with a clear `TT_FATAL` instead of a null dereference.

### Notes for reviewers
 - Focus on the shutdown ordering in `FDMeshCommandQueue::~FDMeshCommandQueue()`: The intent is to preserve pre-join() diagnostics for hang/timeout cases, while avoiding mutation of reader-owned state until after `completion_queue_reader_thread_.join()`. The pop() guard is a secondary defensive check for an existing implicit precondition.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/28911950833

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_fd_mpsc_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_fd_mpsc_bug)