### PR TITLE
Feature/Testing - Quasar Int8→Int32 reduce support and tests

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -16,14 +16,20 @@
  *
  * @tparam pool_type: Type of reduce pool op, values = [MAX, SUM, AVG]
  * @tparam reduce_dim: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
- * tparam EN_32BIT_DEST: Set to true to use 32bit destination register mode
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit destination register mode
  * @tparam math_fidelity: Only works for AVG/SUM pool types,  0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls
  * precision of multiplication
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, skip MOP programming (runtime int FPU path)
  * @param operandA: The input operand Data Flow Buffer identifier
  * @param operandB: The scaler input operand Data Flow Buffer identifier
  *
  */
-template <PoolType pool_type, ReduceDim reduce_dim, const bool EN_32BIT_DEST, ckernel::MathFidelity math_fidelity>
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    const bool EN_32BIT_DEST,
+    ckernel::MathFidelity math_fidelity,
+    bool is_int_fpu_en = false>
 inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
@@ -32,12 +38,18 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
     const DataFormat srcB_format = static_cast<DataFormat>(unpack_dst_format[operandB_id]);
 
     _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
-    _llk_math_reduce_init_<pool_type, reduce_dim, math_fidelity>(tensor_shape);
+    _llk_math_reduce_init_<pool_type, reduce_dim, math_fidelity, is_int_fpu_en>(tensor_shape);
 }
 
 /**
  * @brief Perform a reduce operation
  *
+ * @tparam type: Type of reduce pool op, values = [MAX, SUM, AVG]
+ * @tparam dim: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, runs the runtime int FPU path instead of the MOP
  * @param dst_index: Tile index into the destination register.
  */
-inline void llk_math_reduce(const std::uint32_t dst_index) { _llk_math_reduce_(dst_index); }
+template <PoolType type, ReduceDim dim, bool is_int_fpu_en = false>
+inline void llk_math_reduce(const std::uint32_t dst_index) {
+    _llk_math_reduce_<type, dim, is_int_fpu_en>(dst_index);
+}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -19,7 +19,7 @@
  * @tparam EN_32BIT_DEST: Set to true to use 32bit destination register mode
  * @tparam math_fidelity: Only works for AVG/SUM pool types,  0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls
  * precision of multiplication
- * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, skip MOP programming (runtime int FPU path)
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW, skip MOP programming (runtime int FPU path)
  * @param operandA: The input operand Data Flow Buffer identifier
  * @param operandB: The scaler input operand Data Flow Buffer identifier
  *
@@ -46,7 +46,7 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
  *
  * @tparam type: Type of reduce pool op, values = [MAX, SUM, AVG]
  * @tparam dim: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
- * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, runs the runtime int FPU path instead of the MOP
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW, runs the runtime int FPU path instead of the MOP
  * @param dst_index: Tile index into the destination register.
  */
 template <PoolType type, ReduceDim dim, bool is_int_fpu_en = false>

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -51,5 +51,5 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
  */
 template <PoolType type, ReduceDim dim, bool is_int_fpu_en = false>
 inline void llk_math_reduce(const std::uint32_t dst_index) {
-    _llk_math_reduce_<type, dim, is_int_fpu_en>(dst_index);
+    _llk_math_reduce_<type, dim, is_int_fpu_en>(dst_index, ckernel::DEFAULT_TENSOR_SHAPE);
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -48,8 +48,24 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
  * @tparam dim: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  * @tparam is_int_fpu_en: When true for REDUCE_ROW, runs the runtime int FPU path instead of the MOP
  * @param dst_index: Tile index into the destination register.
+ * @param tensor_shape: Tile shape determining face count and dest stride. int FPU path requires default 32x32.
  */
 template <PoolType type, ReduceDim dim, bool is_int_fpu_en = false>
-inline void llk_math_reduce(const std::uint32_t dst_index) {
-    _llk_math_reduce_<type, dim, is_int_fpu_en>(dst_index, ckernel::DEFAULT_TENSOR_SHAPE);
+inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+    if constexpr (is_int_fpu_en) {
+        LLK_ASSERT(
+            tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim &&
+                tensor_shape.face_c_dim == DEFAULT_TENSOR_SHAPE.face_c_dim &&
+                tensor_shape.num_faces_r_dim == DEFAULT_TENSOR_SHAPE.num_faces_r_dim &&
+                tensor_shape.num_faces_c_dim == DEFAULT_TENSOR_SHAPE.num_faces_c_dim,
+            "Int reduce: only default 32x32 tensor_shape supported");
+    }
+    _llk_math_reduce_<type, dim, is_int_fpu_en>(dst_index, tensor_shape);
+}
+
+template <PoolType type, ReduceDim dim, bool is_int_fpu_en = false>
+inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
+    const std::uint32_t operand_id = get_operand_id(operandA);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
+    llk_math_reduce<type, dim, is_int_fpu_en>(dst_index, tensor_shape);
 }

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -152,7 +152,7 @@ ALWI void reduce_tile(
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB_reduce<reduce_type, reduce_dim>(icb, icb_scaler, itile, itile_scaler)));
 #else
-    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim>(icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB_reduce(icb, icb_scaler, itile, itile_scaler)));
 #endif
 }
@@ -237,8 +237,7 @@ ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = 4) {
         (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<std::uint8_t>(num_faces) : MAX_NUM_FACES_C_DIM};
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
 #else
-    LLK_ASSERT(num_faces == 4, "non-default num_faces not supported on Quasar");
-    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst, tensor_shape)));
 #endif
 }
 
@@ -259,13 +258,7 @@ ALWI void reduce_tile_math(std::uint32_t idst, const ckernel::TensorShape& tenso
 #ifndef ARCH_QUASAR
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
 #else
-    LLK_ASSERT(
-        tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim &&
-            tensor_shape.face_c_dim == DEFAULT_TENSOR_SHAPE.face_c_dim &&
-            tensor_shape.num_faces_r_dim == DEFAULT_TENSOR_SHAPE.num_faces_r_dim &&
-            tensor_shape.num_faces_c_dim == DEFAULT_TENSOR_SHAPE.num_faces_c_dim,
-        "non-default tensor_shape not supported on Quasar");
-    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst, tensor_shape)));
 #endif
 }
 

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -152,7 +152,7 @@ ALWI void reduce_tile(
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB_reduce<reduce_type, reduce_dim>(icb, icb_scaler, itile, itile_scaler)));
 #else
-    MATH((llk_math_reduce(idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst)));
     UNPACK((llk_unpack_AB_reduce(icb, icb_scaler, itile, itile_scaler)));
 #endif
 }
@@ -238,7 +238,7 @@ ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = 4) {
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
 #else
     LLK_ASSERT(num_faces == 4, "non-default num_faces not supported on Quasar");
-    MATH((llk_math_reduce(idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst)));
 #endif
 }
 
@@ -265,7 +265,7 @@ ALWI void reduce_tile_math(std::uint32_t idst, const ckernel::TensorShape& tenso
             tensor_shape.num_faces_r_dim == DEFAULT_TENSOR_SHAPE.num_faces_r_dim &&
             tensor_shape.num_faces_c_dim == DEFAULT_TENSOR_SHAPE.num_faces_c_dim,
         "non-default tensor_shape not supported on Quasar");
-    MATH((llk_math_reduce(idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim>(idst)));
 #endif
 }
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -4047,6 +4047,14 @@ class ReduceGapoolGolden(FidelityMasking):
     ):
         if tile_shape is None:
             tile_shape = construct_tile_shape()
+            
+        # Integer reduce (e.g. Int8 -> Int32) is exact-integer accumulation.
+        # Int8 reduce is LoFi-only: there is no mantissa multi-pass, so fidelity
+        # masking does not apply, and the gapool matmul is an exact integer sum.
+        if input_format is not None and input_format.is_integer():
+            return self._reduce_integer(
+                operand1, operand2, data_format, reduce_dim, tile_cnt, input_format
+            )
 
         # Quantize MX format inputs to match hardware behavior
         if input_format is not None and input_format.is_mx_format():
@@ -4248,6 +4256,75 @@ class ReduceGapoolGolden(FidelityMasking):
             result[0] = pool_result[0][0]
 
         return result
+
+    def _reduce_integer(
+        self, operand1, operand2, data_format, reduce_dim, tile_cnt, input_format
+    ):
+        return torch.cat(
+            [
+                self._process_tile_integer(
+                    operand1, operand2, data_format, reduce_dim, tile, input_format
+                )
+                for tile in range(tile_cnt)
+            ]
+        )
+
+    def _process_tile_integer(
+        self, operand1, operand2, data_format, reduce_dim, tile_idx, input_format
+    ):
+        tile_start = tile_idx * ELEMENTS_PER_TILE
+        src_a = to_tensor(
+            operand1[tile_start : tile_start + ELEMENTS_PER_TILE], input_format
+        ).to(torch.int64)
+        src_b = to_tensor(operand2[:ELEMENTS_PER_FACE], input_format).to(torch.int64)
+
+        # Row reduce: transpose within each face of SrcA (models unpacker behavior)
+        if reduce_dim == ReduceDimension.Row:
+            src_a = (
+                src_a.view(FACES_PER_TILE, FACE_DIM, FACE_DIM).transpose(1, 2).flatten()
+            )
+
+        face_results = self._compute_gapool_integer(src_a, src_b)
+        return self._accumulate_gapool_results_integer(
+            face_results, src_b, data_format, reduce_dim
+        )
+
+    def _compute_gapool_integer(self, src_a, src_b, num_faces=FACES_PER_TILE):
+        """Exact integer D = srcB @ srcA per face (single LoFi pass)."""
+        a_faces = src_a.view(num_faces, FACE_DIM, FACE_DIM)
+        b_face = src_b.view(1, FACE_DIM, FACE_DIM)
+        return torch.matmul(b_face, a_faces).view(num_faces, -1)
+
+    def _accumulate_gapool_results_integer(
+        self, face_results, src_b, data_format, reduce_dim
+    ):
+        """Place pooled integer results in the output tile"""
+        torch_format = format_dict[data_format]
+        face_shape = (FACE_DIM, FACE_DIM)
+        f0, f1, f2, f3 = face_results
+        result = torch.zeros(ELEMENTS_PER_TILE, dtype=torch.int64)
+
+        if reduce_dim == ReduceDimension.Column:
+            # Sum left faces (f0+f2) → face0 row 0, right faces (f1+f3) → face1 row 0
+            result[:FACE_DIM] = (f0 + f2)[:FACE_DIM]
+            result[ELEMENTS_PER_FACE : ELEMENTS_PER_FACE + FACE_DIM] = (f1 + f3)[
+                :FACE_DIM
+            ]
+
+        elif reduce_dim == ReduceDimension.Row:
+            # Sum top faces (f0+f1) → face0 col 0, bottom faces (f2+f3) → face2 col 0
+            result[0:ELEMENTS_PER_FACE:FACE_DIM] = (f0 + f1)[:FACE_DIM]
+            result[2 * ELEMENTS_PER_FACE : 3 * ELEMENTS_PER_FACE : FACE_DIM] = (
+                f2 + f3
+            )[:FACE_DIM]
+
+        elif reduce_dim == ReduceDimension.Scalar:
+            # Sum all faces, transpose, pool again to get single scalar
+            all_faces = (f0 + f1 + f2 + f3).view(face_shape).T.flatten()
+            pool_result = self._compute_gapool_integer(all_faces, src_b, num_faces=1)
+            result[0] = pool_result[0][0]
+
+        return saturate_integer(result, data_format, torch_format)
 
 
 @register_golden

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -4047,10 +4047,11 @@ class ReduceGapoolGolden(FidelityMasking):
     ):
         if tile_shape is None:
             tile_shape = construct_tile_shape()
-            
+
         # Integer reduce (e.g. Int8 -> Int32) is exact-integer accumulation.
         # Int8 reduce is LoFi-only: there is no mantissa multi-pass, so fidelity
         # masking does not apply, and the gapool matmul is an exact integer sum.
+        # Full 32x32 tiles only
         if input_format is not None and input_format.is_integer():
             return self._reduce_integer(
                 operand1, operand2, data_format, reduce_dim, tile_cnt, input_format

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
@@ -25,7 +25,7 @@ from helpers.llk_params import (
 )
 from helpers.param_config import input_output_formats, parametrize
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
@@ -74,6 +74,14 @@ def generate_pool_type_and_math_fidelity_combinations():
     ]
 
 
+def generate_int8_pool_type_and_math_fidelity_combinations():
+    # Int8 reduce is exact-integer accumulation: only LoFi
+    return [
+        (ReducePool.Max, MathFidelity.LoFi),
+        (ReducePool.Sum, MathFidelity.LoFi),
+    ]
+
+
 @pytest.mark.quasar
 @parametrize(
     formats=input_output_formats(
@@ -85,6 +93,19 @@ def generate_pool_type_and_math_fidelity_combinations():
             DataFormat.MxInt4,
             DataFormat.MxInt2,
         ],
+    )
+    + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)],
+    # Int8 reduce uses int32 dest accumulation
+    dest_acc=lambda formats: (
+        [DestAccumulation.Yes]
+        if formats.input_format == DataFormat.Int8
+        else [DestAccumulation.No, DestAccumulation.Yes]
+    ),
+    reduce_dim=[ReduceDimension.Column, ReduceDimension.Row, ReduceDimension.Scalar],
+    pool_type_and_math_fidelity=lambda formats: (
+        generate_int8_pool_type_and_math_fidelity_combinations()
+        if formats.input_format == DataFormat.Int8
+        else generate_pool_type_and_math_fidelity_combinations()
     ),
     tile_dimensions=lambda formats: [
         td
@@ -93,15 +114,16 @@ def generate_pool_type_and_math_fidelity_combinations():
             formats.input_format, formats.output_format, td
         )
     ],
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
-    pool_type_and_math_fidelity=generate_pool_type_and_math_fidelity_combinations(),
     dest_sync_mode=[DestSync.Half, DestSync.Full],
     # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline)
     implied_math_format=lambda formats: (
-        [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
-        if not formats.input_format.is_mx_format()
-        else [ImpliedMathFormat.Yes]
+        [ImpliedMathFormat.No]
+        if formats.input_format == DataFormat.Int8
+        else (
+            [ImpliedMathFormat.Yes]
+            if formats.input_format.is_mx_format()
+            else [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+        )
     ),
 )
 def test_reduce_quasar(
@@ -116,6 +138,13 @@ def test_reduce_quasar(
 
     pool_type, math_fidelity = pool_type_and_math_fidelity
     tile_shape = construct_tile_shape(tile_dimensions)
+
+    if (
+        formats.input_format == DataFormat.Int8
+        and reduce_dim == ReduceDimension.Scalar
+        and pool_type in (ReducePool.Sum, ReducePool.Average)
+    ):
+        pytest.skip("Int8->Int32 scalar SUM/AVG reduce is not supported yet on Quasar ")
 
     if (
         formats.input_format == DataFormat.MxInt8
@@ -138,12 +167,18 @@ def test_reduce_quasar(
 
     input_dimensions = [tile_dimensions[0] * 2, tile_dimensions[1] * 2]
 
+    if formats.input_format == DataFormat.Int8:
+        stimuli_spec = StimuliSpec.uniform(low=-127, high=127)
+    else:
+        stimuli_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt, _, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=tile_dimensions,
         tile_dimensions=tile_dimensions,
+        spec_A=stimuli_spec,
+        spec_B=stimuli_spec,
     )
 
     if pool_type in [
@@ -226,10 +261,7 @@ def test_reduce_quasar(
         ),
         dest_acc=dest_acc,
         # MX formats require disable_format_inference to match C++ IMPLIED_MATH_FORMAT setting
-        disable_format_inference=(
-            implied_math_format == ImpliedMathFormat.Yes
-            and formats.input_format.is_mx_format()
-        ),
+        disable_format_inference=formats.input_format.is_mx_format(),
     )
 
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
@@ -107,13 +107,18 @@ def generate_int8_pool_type_and_math_fidelity_combinations():
         if formats.input_format == DataFormat.Int8
         else generate_pool_type_and_math_fidelity_combinations()
     ),
-    tile_dimensions=lambda formats: [
-        td
-        for td in SUPPORTED_TILE_SIZES
-        if not is_mx_unsupported_tile_dims(
-            formats.input_format, formats.output_format, td
-        )
-    ],
+    # Int8→Int32 FPU reduce is 32x32-only for now (no tiny-tile int path yet).
+    tile_dimensions=lambda formats: (
+        [(32, 32)]
+        if formats.input_format == DataFormat.Int8
+        else [
+            td
+            for td in SUPPORTED_TILE_SIZES
+            if not is_mx_unsupported_tile_dims(
+                formats.input_format, formats.output_format, td
+            )
+        ]
+    ),
     dest_sync_mode=[DestSync.Half, DestSync.Full],
     # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline)
     implied_math_format=lambda formats: (

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -85,10 +85,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if (is_int_fpu_en)
     {
-        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, true /*is_int_fpu_en*/>(tensor_shape_A);
-        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        // Int Scalar SUM is unsupported, see SFPU reduce.
+        if constexpr (!(REDUCE_DIM == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM))
         {
-            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, true /*is_int_fpu_en*/>(i, tensor_shape_A);
+            _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, true /*is_int_fpu_en*/>(tensor_shape_A);
+            for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+            {
+                _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, true /*is_int_fpu_en*/>(i, tensor_shape_A);
+            }
         }
     }
     else

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -67,15 +67,37 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Setup data valid scheme
     set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    DataFormat src_format         = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format    = static_cast<DataFormat>(formats.pack_src);
+    const bool use_int32_dest_alu = is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32;
+    const bool is_int_fpu_en      = use_int32_dest_alu && (REDUCE_DIM == ReduceDim::REDUCE_ROW || REDUCE_DIM == ReduceDim::REDUCE_SCALAR);
 
     const auto tensor_shape_A = tensor_shape_from_params(params);
 
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /* int32 dest */>(src_format, src_format);
-    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY>(tensor_shape_A);
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    if (use_int32_dest_alu)
     {
-        _llk_math_reduce_(i);
+        _llk_math_srcAB_hw_configure_<false, false /*fp32_dest*/, true /*int32_dest*/>(src_format, src_format);
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(src_format, src_format);
+    }
+
+    if (is_int_fpu_en)
+    {
+        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, true /*is_int_fpu_en*/>(tensor_shape_A);
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, true /*is_int_fpu_en*/>(i, tensor_shape_A);
+        }
+    }
+    else
+    {
+        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, false /*is_int_fpu_en*/>(tensor_shape_A);
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, false /*is_int_fpu_en*/>(i, tensor_shape_A);
+        }
     }
     _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -86,7 +86,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         _llk_math_wait_for_dest_available_();
-        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(0 /*dest_idx*/);
+        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(0 /*dest_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
         _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -86,7 +86,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         _llk_math_wait_for_dest_available_();
-        _llk_math_reduce_(0 /*dest_idx*/);
+        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(0 /*dest_idx*/);
         _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -102,7 +102,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_reduce_(i);
+        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(i);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -102,7 +102,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(i);
+        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(i, ckernel::DEFAULT_TENSOR_SHAPE);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -539,25 +539,20 @@ inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& tensor_shape)
 {
+    static_assert(
+        !(is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM),
+        "Integer Scalar SUM/AVG (Int32 dest) unsupported on FPU: after the first GAPOOL, "
+        "partials cannot fit back into Src for the final GAPOOL");
+
     _set_dst_write_addr_by_rows_(tile_idx);
 
     if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
     {
         _llk_math_reduce_row_int32_fpu_<POOL_TYPE>(tensor_shape);
     }
-    else if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::MAX)
-    {
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-    }
-    else if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
-    {
-        LLK_ASSERT(
-            false,
-            "Scalar SUM/AVG (Int32 dest) unsupported on FPU: after the first GAPOOL, "
-            "partials cannot fit back into Src for the final GAPOOL");
-    }
     else
     {
+        // Non-int paths and the int32 scalar-MAX path both run the MOP configured in the init.
         ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
     }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -552,7 +552,7 @@ inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& t
     }
     else
     {
-        // Non-int paths and the int32 scalar-MAX path both run the MOP configured in the init.
+        // RUN MOP
         ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
     }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -64,6 +64,7 @@ inline void _reduce_row_transpose_alu_cfg_exit_()
  *
  * Required whenever reading/writing int32 dest datums: each 32-bit value is split across
  * DEST_NORM (hi16) and DEST_32B_LOW (lo16). A single MOVD2B cannot see the full word.
+ *
  */
 inline void _reduce_row_transpose_fpu_()
 {
@@ -103,7 +104,6 @@ inline void _reduce_row_transpose_fpu_()
 /**
  * @brief Pool one pair of input faces (one output face row) into dest at an explicit row offset.
  *
- * Int32-dest reduce only (LoFi exact-integer accumulation; no fidelity multi-pass).
  */
 template <PoolType POOL_TYPE, std::uint8_t DST_ADDR>
 inline void _reduce_row_pool_face_pair_()
@@ -114,10 +114,17 @@ inline void _reduce_row_pool_face_pair_()
 
 /**
  * @brief Perform reduce-row at runtime for Int32 dest using FPU transpose.
+ *
+ * Full 32x32 tiles only — tiny tiles are not supported for Int8→Int32 reduce.
  */
 template <PoolType POOL_TYPE>
 inline void _llk_math_reduce_row_int32_fpu_(const TensorShape& tensor_shape)
 {
+    LLK_ASSERT(
+        tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim && tensor_shape.face_c_dim == DEFAULT_TENSOR_SHAPE.face_c_dim &&
+            tensor_shape.num_faces_r_dim == DEFAULT_TENSOR_SHAPE.num_faces_r_dim && tensor_shape.num_faces_c_dim == DEFAULT_TENSOR_SHAPE.num_faces_c_dim,
+        "Int8 reduce-row: tiny tiles not supported (requires 32x32)");
+
     _reduce_row_pool_face_pair_<POOL_TYPE, 0>();
     TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
     _reduce_row_transpose_fpu_();
@@ -140,10 +147,16 @@ inline void _llk_math_reduce_row_int32_fpu_(const TensorShape& tensor_shape)
  *
  * MAX: MOVD2B(transpose) -> MOVB2A -> GMPOOL (FPU path, Int8-range exact).
  * SUM/AVG: unsupported on FPU — first GAPOOL partials cannot reload into Src for the final GAPOOL; use SFPU.
+ * Full 32x32 tiles only — tiny tiles are not supported for Int8→Int32 reduce.
  */
 template <PoolType POOL_TYPE>
 inline void _llk_math_reduce_scalar_int32_fpu_(const TensorShape& tensor_shape)
 {
+    LLK_ASSERT(
+        tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim && tensor_shape.face_c_dim == DEFAULT_TENSOR_SHAPE.face_c_dim &&
+            tensor_shape.num_faces_r_dim == DEFAULT_TENSOR_SHAPE.num_faces_r_dim && tensor_shape.num_faces_c_dim == DEFAULT_TENSOR_SHAPE.num_faces_c_dim,
+        "Int8 reduce-scalar: tiny tiles not supported (requires 32x32)");
+
     constexpr std::uint32_t scratch_dst_addr = 16;
 
     for (std::uint32_t face = 0; face < static_cast<std::uint32_t>(tensor_shape.total_num_faces() - 1); face++)
@@ -569,7 +582,7 @@ inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& tensor_shape)
 {
-
+    _set_dst_write_addr_by_rows_(tile_idx);
 
     if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -143,13 +143,13 @@ inline void _llk_math_reduce_row_int32_fpu_(const TensorShape& tensor_shape)
 }
 
 /**
- * @brief Perform reduce-scalar at runtime for Int32 dest.
+ * @brief Perform reduce-scalar MAX at runtime for Int32 dest.
  *
- * MAX: MOVD2B(transpose) -> MOVB2A -> GMPOOL (FPU path, Int8-range exact).
- * SUM/AVG: unsupported on FPU — first GAPOOL partials cannot reload into Src for the final GAPOOL; use SFPU.
+ * MOVD2B(transpose) -> MOVB2A -> GMPOOL (FPU path, Int8-range exact).
+ * SUM/AVG are not supported on FPU (partials cannot reload into Src for the final
+ * GAPOOL) -> use SFPU
  * Full 32x32 tiles only — tiny tiles are not supported for Int8→Int32 reduce.
  */
-template <PoolType POOL_TYPE>
 inline void _llk_math_reduce_scalar_int32_fpu_(const TensorShape& tensor_shape)
 {
     LLK_ASSERT(
@@ -161,25 +161,19 @@ inline void _llk_math_reduce_scalar_int32_fpu_(const TensorShape& tensor_shape)
 
     for (std::uint32_t face = 0; face < static_cast<std::uint32_t>(tensor_shape.total_num_faces() - 1); face++)
     {
-        tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
+        tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
     }
-    tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
 
-    if constexpr (POOL_TYPE == PoolType::MAX)
-    {
-        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, scratch_dst_addr);
-        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 0);
-        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 8);
-        TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_0, scratch_dst_addr);
-        tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-    }
-    else
-    {
-        static_assert(
-            POOL_TYPE == PoolType::MAX,
-            "Scalar SUM/AVG (Int32 dest) unsupported on FPU: after the first GAPOOL, partials cannot fit back into Src for the final GAPOOL");
-    }
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+
+    // Transpose scratch face-row into SrcB[32:47], then copy to SrcA for GMPOOL.
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, scratch_dst_addr);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 0);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 8);
+
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_0, scratch_dst_addr);
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
 }
 
 /**
@@ -584,33 +578,26 @@ inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& t
 {
     _set_dst_write_addr_by_rows_(tile_idx);
 
-    if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
+    if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
     {
-        if constexpr (is_int_fpu_en)
-        {
-            _llk_math_reduce_row_int32_fpu_<POOL_TYPE>(tensor_shape);
-        }
-        else
-        {
-            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-        }
+        _llk_math_reduce_row_int32_fpu_<POOL_TYPE>(tensor_shape);
     }
-    else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
+    else if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::MAX)
     {
-        if constexpr (is_int_fpu_en)
-        {
-            _llk_math_reduce_scalar_int32_fpu_<POOL_TYPE>(tensor_shape);
-        }
-        else
-        {
-            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-        }
+        _llk_math_reduce_scalar_int32_fpu_(tensor_shape);
+    }
+    else if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
+    {
+        LLK_ASSERT(
+            false,
+            "Scalar SUM/AVG (Int32 dest) unsupported on FPU: after the first GAPOOL, "
+            "partials cannot fit back into Src for the final GAPOOL");
     }
     else
     {
-        // Run MOP
         ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
     }
+
     // Since only 1 face of srcB is used for constant values,
     // can clear data valid after all operations are done
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -539,6 +539,7 @@ inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& tensor_shape)
 {
+    // TODO: Add SFPU reduce for INT8->Int32 Scalar SUM (https://github.com/tenstorrent/tt-metal/issues/50161)
     static_assert(
         !(is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM),
         "Integer Scalar SUM/AVG (Int32 dest) unsupported on FPU: after the first GAPOOL, "

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -143,40 +143,6 @@ inline void _llk_math_reduce_row_int32_fpu_(const TensorShape& tensor_shape)
 }
 
 /**
- * @brief Perform reduce-scalar MAX at runtime for Int32 dest.
- *
- * MOVD2B(transpose) -> MOVB2A -> GMPOOL (FPU path, Int8-range exact).
- * SUM/AVG are not supported on FPU (partials cannot reload into Src for the final
- * GAPOOL) -> use SFPU
- * Full 32x32 tiles only — tiny tiles are not supported for Int8→Int32 reduce.
- */
-inline void _llk_math_reduce_scalar_int32_fpu_(const TensorShape& tensor_shape)
-{
-    LLK_ASSERT(
-        tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim && tensor_shape.face_c_dim == DEFAULT_TENSOR_SHAPE.face_c_dim &&
-            tensor_shape.num_faces_r_dim == DEFAULT_TENSOR_SHAPE.num_faces_r_dim && tensor_shape.num_faces_c_dim == DEFAULT_TENSOR_SHAPE.num_faces_c_dim,
-        "Int8 reduce-scalar: tiny tiles not supported (requires 32x32)");
-
-    constexpr std::uint32_t scratch_dst_addr = 16;
-
-    for (std::uint32_t face = 0; face < static_cast<std::uint32_t>(tensor_shape.total_num_faces() - 1); face++)
-    {
-        tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
-    }
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
-
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
-
-    // Transpose scratch face-row into SrcB[32:47], then copy to SrcA for GMPOOL.
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, scratch_dst_addr);
-    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 0);
-    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 8);
-
-    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_0, scratch_dst_addr);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-}
-
-/**
  * @brief Sets up mop config for reduce column operations.
  *
  * For reduce Col, in a 32 x 32 tile, faces layout would be the following:
@@ -524,7 +490,7 @@ inline void _llk_math_reduce_addrmod_(const TensorShape& tensor_shape)
  * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam MATH_FIDELITY_TYPE: Only works for AVG/SUM pool types; sets how many loops to use full precision of Source register datums with multiplies, values =
  * <LoFi/HiFi2/HiFi3/HiFi4>
- * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, skip MOP programming (runtime int FPU path).
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW, skip MOP programming (runtime int FPU path).
  * @param tensor_shape: Contains all the information of the tile shape: num faces, face row/col dim, etc
  * @note On the unpack thread, pair with @ref _llk_unpack_reduce_init_ (T0); on the pack thread, pair with @ref _llk_pack_reduce_mask_config_ (T2).
  * @note @ref _llk_math_reduce_ runs the configured reduction with matching template args.
@@ -548,10 +514,7 @@ inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
     }
     else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
     {
-        if constexpr (!is_int_fpu_en)
-        {
-            _llk_math_reduce_scalar_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
-        }
+        _llk_math_reduce_scalar_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
     }
 
     // For face_r_dim >= 8, dest is dense with tiles. For face_r_dim < 8, dest is sparse with tiles and tiles are placed every 8 rows.
@@ -567,10 +530,10 @@ inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
  *
  * @tparam POOL_TYPE: Type of reduce pool op, values = <MAX/SUM/AVG>
  * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
- * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, runs the runtime int FPU path instead of the MOP.
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW, runs the runtime int FPU path instead of the MOP.
  * @param tile_idx: Tile index into the destination register. If dest reg in 16-bit mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in
  * full mode. If dest reg in 32-bit mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
- * @param tensor_shape: Tile shape; required when is_int_fpu_en is true for REDUCE_ROW/REDUCE_SCALAR.
+ * @param tensor_shape: Tile shape; required when is_int_fpu_en is true for REDUCE_ROW.
  * @note Call @ref _llk_math_reduce_init_ with matching template args before this function.
  */
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, bool is_int_fpu_en = false>
@@ -584,7 +547,7 @@ inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& t
     }
     else if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::MAX)
     {
-        _llk_math_reduce_scalar_int32_fpu_(tensor_shape);
+        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
     }
     else if constexpr (is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -36,6 +36,140 @@ void tti_pool_instr_func()
 }
 
 /**
+ * @brief Scope dest-format override around the reduce-row transpose.
+ */
+inline void _reduce_row_transpose_alu_cfg_enter_()
+{
+    constexpr std::uint8_t dstacc_override_rmw_b3_mask = static_cast<std::uint8_t>(1u << (ALU_FORMAT_SPEC_REG_Dstacc_override_SHAMT % 8));
+
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
+
+    TTI_RMWCIB3(ALU_FORMAT_SPEC_REG_Dstacc_override_ADDR32, dstacc_override_rmw_b3_mask, dstacc_override_rmw_b3_mask);
+}
+
+/**
+ * @brief Disable dest-format override after reduce-row transpose.
+ */
+inline void _reduce_row_transpose_alu_cfg_exit_()
+{
+    constexpr std::uint8_t dstacc_override_rmw_b3_mask = static_cast<std::uint8_t>(1u << (ALU_FORMAT_SPEC_REG_Dstacc_override_SHAMT % 8));
+
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
+
+    TTI_RMWCIB3(ALU_FORMAT_SPEC_REG_Dstacc_override_ADDR32, dstacc_override_rmw_b3_mask, 0);
+}
+
+/**
+ * @brief Int32 half-dest row transpose at dest row 0 (row-reduce result row).
+ *
+ * Required whenever reading/writing int32 dest datums: each 32-bit value is split across
+ * DEST_NORM (hi16) and DEST_32B_LOW (lo16). A single MOVD2B cannot see the full word.
+ */
+inline void _reduce_row_transpose_fpu_()
+{
+    _configure_mov_ops_explicit_alu_data_format_state_<true>(DataFormat::Int32, DataFormat::Int32);
+    _reduce_row_transpose_alu_cfg_enter_();
+
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
+
+    // Step 1: Read lo16 from dest into SrcB rows 16-31 and transpose.
+    TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
+    TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+
+    // Step 2: Cache transposed lo16 from SrcB rows 16-31 into SrcA rows 0-15.
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
+
+    // Step 3: Read hi16 from dest into SrcB rows 16-31 and transpose.
+    TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
+    TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+
+    // Step 4: Write transposed hi16 back to dest from SrcB rows 16-31.
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 0);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 4);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 8);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 12);
+
+    // Step 5: Write cached lo16 from SrcA back to dest lo16 address space.
+    TTI_MOVA2D(p_mov::DEST_32B_LOW, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0);
+    TTI_MOVA2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 8);
+
+    _reduce_row_transpose_alu_cfg_exit_();
+    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, true /* EN_32BIT_DEST */>(DataFormat::Int8, DataFormat::Int8);
+}
+
+/**
+ * @brief Pool one pair of input faces (one output face row) into dest at an explicit row offset.
+ *
+ * Int32-dest reduce only (LoFi exact-integer accumulation; no fidelity multi-pass).
+ */
+template <PoolType POOL_TYPE, std::uint8_t DST_ADDR>
+inline void _reduce_row_pool_face_pair_()
+{
+    tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, DST_ADDR>();
+    tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, DST_ADDR>();
+}
+
+/**
+ * @brief Perform reduce-row at runtime for Int32 dest using FPU transpose.
+ */
+template <PoolType POOL_TYPE>
+inline void _llk_math_reduce_row_int32_fpu_(const TensorShape& tensor_shape)
+{
+    _reduce_row_pool_face_pair_<POOL_TYPE, 0>();
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+    _reduce_row_transpose_fpu_();
+
+    if (tensor_shape.num_faces_r_dim > 1)
+    {
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 32, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_D, 0, p_setrwc::SET_B);
+
+        _reduce_row_pool_face_pair_<POOL_TYPE, 0>();
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+        _reduce_row_transpose_fpu_();
+    }
+
+    TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD);
+}
+
+/**
+ * @brief Perform reduce-scalar at runtime for Int32 dest.
+ *
+ * MAX: MOVD2B(transpose) -> MOVB2A -> GMPOOL (FPU path, Int8-range exact).
+ * SUM/AVG: unsupported on FPU — first GAPOOL partials cannot reload into Src for the final GAPOOL; use SFPU.
+ */
+template <PoolType POOL_TYPE>
+inline void _llk_math_reduce_scalar_int32_fpu_(const TensorShape& tensor_shape)
+{
+    constexpr std::uint32_t scratch_dst_addr = 16;
+
+    for (std::uint32_t face = 0; face < static_cast<std::uint32_t>(tensor_shape.total_num_faces() - 1); face++)
+    {
+        tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
+    }
+    tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, scratch_dst_addr>();
+
+    if constexpr (POOL_TYPE == PoolType::MAX)
+    {
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+        TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, scratch_dst_addr);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 0);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_8_ROWS, p_movb2a::SRCB_ROW32_OFFSET + 8);
+        TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_0, scratch_dst_addr);
+        tti_pool_instr_func<POOL_TYPE, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+    }
+    else
+    {
+        static_assert(
+            POOL_TYPE == PoolType::MAX,
+            "Scalar SUM/AVG (Int32 dest) unsupported on FPU: after the first GAPOOL, partials cannot fit back into Src for the final GAPOOL");
+    }
+}
+
+/**
  * @brief Sets up mop config for reduce column operations.
  *
  * For reduce Col, in a 32 x 32 tile, faces layout would be the following:
@@ -383,11 +517,12 @@ inline void _llk_math_reduce_addrmod_(const TensorShape& tensor_shape)
  * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @tparam MATH_FIDELITY_TYPE: Only works for AVG/SUM pool types; sets how many loops to use full precision of Source register datums with multiplies, values =
  * <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, skip MOP programming (runtime int FPU path).
  * @param tensor_shape: Contains all the information of the tile shape: num faces, face row/col dim, etc
  * @note On the unpack thread, pair with @ref _llk_unpack_reduce_init_ (T0); on the pack thread, pair with @ref _llk_pack_reduce_mask_config_ (T2).
  * @note @ref _llk_math_reduce_ runs the configured reduction with matching template args.
  */
-template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE>
+template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
@@ -399,11 +534,17 @@ inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
     }
     else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
     {
-        _llk_math_reduce_row_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
+        if constexpr (!is_int_fpu_en)
+        {
+            _llk_math_reduce_row_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
+        }
     }
     else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
     {
-        _llk_math_reduce_scalar_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
+        if constexpr (!is_int_fpu_en)
+        {
+            _llk_math_reduce_scalar_mop_config_<POOL_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
+        }
     }
 
     // For face_r_dim >= 8, dest is dense with tiles. For face_r_dim < 8, dest is sparse with tiles and tiles are placed every 8 rows.
@@ -417,17 +558,46 @@ inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
 /**
  * @brief Perform a reduce operation.
  *
+ * @tparam POOL_TYPE: Type of reduce pool op, values = <MAX/SUM/AVG>
+ * @tparam REDUCE_DIMENSION: Sets the reduce dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam is_int_fpu_en: When true for REDUCE_ROW/REDUCE_SCALAR, runs the runtime int FPU path instead of the MOP.
  * @param tile_idx: Tile index into the destination register. If dest reg in 16-bit mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in
  * full mode. If dest reg in 32-bit mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
+ * @param tensor_shape: Tile shape; required when is_int_fpu_en is true for REDUCE_ROW/REDUCE_SCALAR.
  * @note Call @ref _llk_math_reduce_init_ with matching template args before this function.
  */
-inline void _llk_math_reduce_(const std::uint32_t tile_idx)
+template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, bool is_int_fpu_en = false>
+inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& tensor_shape)
 {
-    _set_dst_write_addr_by_rows_(tile_idx);
 
-    // Run MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
 
+    if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW)
+    {
+        if constexpr (is_int_fpu_en)
+        {
+            _llk_math_reduce_row_int32_fpu_<POOL_TYPE>(tensor_shape);
+        }
+        else
+        {
+            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        }
+    }
+    else if constexpr (REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR)
+    {
+        if constexpr (is_int_fpu_en)
+        {
+            _llk_math_reduce_scalar_int32_fpu_<POOL_TYPE>(tensor_shape);
+        }
+        else
+        {
+            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        }
+    }
+    else
+    {
+        // Run MOP
+        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    }
     // Since only 1 face of srcB is used for constant values,
     // can clear data valid after all operations are done
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);


### PR DESCRIPTION
### PR Category
Feature and Testing 

### Summary
Relates to #45777 
Implements Int8 → Int32 reduce on Quasar for:
- Column: SUM, MAX (uses MOP)
- Row: SUM, MAX 
- Scalar: MAX

 Ports the BH/WH int32-dest transpose approach: each 32-bit dest datum is split across hi/lo 16-bit halves, transposed separately, then written back. This is needed because a single MOVD2B cannot see the full int32 word.

### Notes for reviewers
Scalar SUM/AVG is not implemented on the FPU. After the first GAPOOL, partials cannot be reloaded into Src  for the final GAPOOL,  this needs SFPU, and its guarded with LLK_ASSERT

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmohammed/int8-testing-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmohammed/int8-testing-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nmohammed/int8-testing-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmohammed/int8-testing-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmohammed/int8-testing-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmohammed/int8-testing-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmohammed/int8-testing-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmohammed/int8-testing-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmohammed/int8-testing-reduce)