### PR TITLE
ci: add pytest-repeat to dev requirements

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -549,6 +549,36 @@ std::map<FabricNodeId, ChipId> get_physical_chip_mapping_from_eth_coords_mapping
     const std::vector<std::vector<EthCoord>>& mesh_graph_eth_coords, uint32_t local_mesh_id) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     std::map<FabricNodeId, ChipId> physical_chip_ids_mapping;
+
+    // On UBB/T3K systems, chip_locations (EthCoords) are not populated by the UMD topology
+    // discovery. In this case, fall back to mapping user-visible chip IDs directly to
+    // FabricNodeId positions for the local mesh. The visible chips are already constrained
+    // by TT_VISIBLE_DEVICES (set via rank binding) and N300 board expansion.
+    const auto& all_eth_coords = cluster.get_all_chip_ethernet_coordinates();
+    if (all_eth_coords.empty()) {
+        const auto& visible_chips = cluster.user_exposed_chip_ids();
+        TT_FATAL(
+            local_mesh_id < mesh_graph_eth_coords.size(),
+            "local_mesh_id {} out of range (num meshes: {})",
+            local_mesh_id,
+            mesh_graph_eth_coords.size());
+        TT_FATAL(
+            visible_chips.size() == mesh_graph_eth_coords[local_mesh_id].size(),
+            "Number of visible chips ({}) does not match expected mesh size ({}) for mesh_id {}. "
+            "EthCoords are not available on this system (UBB board). "
+            "Ensure TT_VISIBLE_DEVICES is configured correctly in the rank binding.",
+            visible_chips.size(),
+            mesh_graph_eth_coords[local_mesh_id].size(),
+            local_mesh_id);
+        uint32_t chip_idx = 0;
+        for (const auto& physical_chip_id : visible_chips) {
+            physical_chip_ids_mapping.insert(
+                {FabricNodeId(MeshId{local_mesh_id}, chip_idx), physical_chip_id});
+            chip_idx++;
+        }
+        return physical_chip_ids_mapping;
+    }
+
     for (std::uint32_t mesh_id = 0; mesh_id < mesh_graph_eth_coords.size(); mesh_id++) {
         if (mesh_id == local_mesh_id) {
             for (std::uint32_t chip_id = 0; chip_id < mesh_graph_eth_coords[mesh_id].size(); chip_id++) {

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
@@ -112,12 +112,36 @@ void MeshSocketTestContext::initialize_and_validate_custom_physical_config(
 
     // ethernet coordinate chip mapping, which should be migrated away from
     std::map<FabricNodeId, ChipId> chip_to_eth_coord_mapping;
-    for (std::uint32_t mesh_id = 0; mesh_id < eth_coord_mapping.size(); mesh_id++) {
-        if (mesh_id == *local_mesh_id_) {
-            for (std::uint32_t chip_id = 0; chip_id < eth_coord_mapping[mesh_id].size(); chip_id++) {
-                const auto& eth_coord = eth_coord_mapping[mesh_id][chip_id];
-                chip_to_eth_coord_mapping.insert(
-                    {FabricNodeId(MeshId{mesh_id}, chip_id), cluster.get_physical_chip_id_from_eth_coord(eth_coord)});
+    const auto& all_eth_coords = cluster.get_all_chip_ethernet_coordinates();
+    if (all_eth_coords.empty()) {
+        // UBB/T3K fallback: EthCoords not available, use visible chip IDs directly
+        const auto& visible_chips = cluster.user_exposed_chip_ids();
+        TT_FATAL(
+            *local_mesh_id_ < eth_coord_mapping.size(),
+            "local_mesh_id {} out of range (num meshes: {})",
+            *local_mesh_id_,
+            eth_coord_mapping.size());
+        TT_FATAL(
+            visible_chips.size() == eth_coord_mapping[*local_mesh_id_].size(),
+            "Number of visible chips ({}) does not match expected mesh size ({}) for mesh_id {}. "
+            "EthCoords are not available on this system (UBB board).",
+            visible_chips.size(),
+            eth_coord_mapping[*local_mesh_id_].size(),
+            *local_mesh_id_);
+        uint32_t chip_idx = 0;
+        for (const auto& physical_chip_id : visible_chips) {
+            chip_to_eth_coord_mapping.insert(
+                {FabricNodeId(MeshId{*local_mesh_id_}, chip_idx), physical_chip_id});
+            chip_idx++;
+        }
+    } else {
+        for (std::uint32_t mesh_id = 0; mesh_id < eth_coord_mapping.size(); mesh_id++) {
+            if (mesh_id == *local_mesh_id_) {
+                for (std::uint32_t chip_id = 0; chip_id < eth_coord_mapping[mesh_id].size(); chip_id++) {
+                    const auto& eth_coord = eth_coord_mapping[mesh_id][chip_id];
+                    chip_to_eth_coord_mapping.insert(
+                        {FabricNodeId(MeshId{mesh_id}, chip_id), cluster.get_physical_chip_id_from_eth_coord(eth_coord)});
+                }
             }
         }
     }

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -109,6 +109,36 @@ std::map<FabricNodeId, ChipId> get_physical_chip_mapping_from_eth_coords_mapping
     const std::vector<std::vector<EthCoord>>& mesh_graph_eth_coords) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     std::map<FabricNodeId, ChipId> physical_chip_ids_mapping;
+
+    // On UBB/T3K systems, chip_locations (EthCoords) are not populated by the UMD topology
+    // discovery. In this case, fall back to mapping user-visible chip IDs directly to
+    // FabricNodeId positions. The visible chips are already constrained by TT_VISIBLE_DEVICES
+    // (set via rank binding) and N300 board expansion.
+    const auto& all_eth_coords = cluster.get_all_chip_ethernet_coordinates();
+    if (all_eth_coords.empty()) {
+        const auto& visible_chips = cluster.user_exposed_chip_ids();
+        uint32_t total_expected_chips = 0;
+        for (const auto& mesh_chips : mesh_graph_eth_coords) {
+            total_expected_chips += mesh_chips.size();
+        }
+        TT_FATAL(
+            visible_chips.size() == total_expected_chips,
+            "Number of visible chips ({}) does not match expected total mesh size ({}) across all meshes. "
+            "EthCoords are not available on this system (UBB board). "
+            "Ensure TT_VISIBLE_DEVICES is configured correctly in the rank binding.",
+            visible_chips.size(),
+            total_expected_chips);
+        auto chip_it = visible_chips.begin();
+        for (std::uint32_t mesh_id = 0; mesh_id < mesh_graph_eth_coords.size(); mesh_id++) {
+            for (std::uint32_t chip_id = 0; chip_id < mesh_graph_eth_coords[mesh_id].size(); chip_id++) {
+                physical_chip_ids_mapping.insert(
+                    {FabricNodeId(MeshId{mesh_id}, chip_id), *chip_it});
+                ++chip_it;
+            }
+        }
+        return physical_chip_ids_mapping;
+    }
+
     for (std::uint32_t mesh_id = 0; mesh_id < mesh_graph_eth_coords.size(); mesh_id++) {
         for (std::uint32_t chip_id = 0; chip_id < mesh_graph_eth_coords[mesh_id].size(); chip_id++) {
             const auto& eth_coord = mesh_graph_eth_coords[mesh_id][chip_id];

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -69,4 +69,5 @@ set(UNIT_TESTS_API_SOURCES
     test_duplicate_kernel.cpp
     test_core_local_mem_api.cpp
     disaggregation/test_kv_chunk_address_table.cpp
+    test_named_runtime_args.cpp
 )

--- a/tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for named args (CT and RT) with generated header.
+//
+// Verifies:
+// 1. Named common runtime args delivered via rt_args::get<>()
+// 2. Named per-core runtime args deliver different values per core
+// 3. Named compile-time args accessible via ct_args:: namespace
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "device_fixture.hpp"
+#include "multi_device_fixture.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+using NamedArgsTest = GenericMeshDeviceFixture;
+
+TEST_F(NamedArgsTest, TensixTestNamedCommonAndPerCoreRuntimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core0 = {0, 0};
+    CoreCoord core1 = {1, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core0, core1)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const uint32_t expected_marker = 0xCAFE;
+    const uint32_t core0_idx = 10;
+    const uint32_t core1_idx = 20;
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .named_compile_time_args = {{"my_kernel.param_a", 0}, {"my_kernel.param_b", 0}},
+        .defines = {{"WRITE_ADDRESS", std::to_string(write_addr)}},
+        .named_common_runtime_args = {{"my_kernel.marker", expected_marker}},
+        .named_per_core_runtime_args = {{"my_kernel.core_idx", {{core0, core0_idx}, {core1, core1_idx}}}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results_core0;
+    detail::ReadFromDeviceL1(device, core0, write_addr, 2 * sizeof(uint32_t), results_core0);
+    std::vector<uint32_t> results_core1;
+    detail::ReadFromDeviceL1(device, core1, write_addr, 2 * sizeof(uint32_t), results_core1);
+
+    EXPECT_EQ(results_core0[0], expected_marker) << "Core (0,0): marker should be 0xCAFE";
+    EXPECT_EQ(results_core1[0], expected_marker) << "Core (1,0): marker should be 0xCAFE";
+    EXPECT_EQ(results_core0[1], core0_idx) << "Core (0,0): core_idx should be 10";
+    EXPECT_EQ(results_core1[1], core1_idx) << "Core (1,0): core_idx should be 20";
+}
+
+TEST_F(NamedArgsTest, TensixTestNamedArrayRuntimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core = {0, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core, core)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const uint32_t prefix_val = 10;
+    const std::vector<uint32_t> array_data = {100, 200, 300, 400};
+    const uint32_t num_elements = static_cast<uint32_t>(array_data.size());
+
+    // Expected: prefix + sum(array_data) = 10 + 100 + 200 + 300 + 400 = 1010
+    uint32_t expected_sum = prefix_val;
+    for (auto v : array_data) {
+        expected_sum += v;
+    }
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_array_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .defines =
+            {
+                {"WRITE_ADDRESS", std::to_string(write_addr)},
+                {"NUM_ELEMENTS", std::to_string(num_elements)},
+            },
+        // Scalar named common RT arg
+        .named_common_runtime_args = {{"my_kernel.prefix", prefix_val}},
+        // Array named common RT arg
+        .named_common_runtime_arg_arrays = {{"my_kernel.data", array_data}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results;
+    detail::ReadFromDeviceL1(device, core, write_addr, sizeof(uint32_t), results);
+
+    EXPECT_EQ(results[0], expected_sum) << "Sum should be prefix(" << prefix_val << ") + sum(data) = " << expected_sum
+                                        << ", got " << results[0];
+}
+
+TEST_F(NamedArgsTest, TensixTestNamedCompileTimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core = {0, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core, core)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const uint32_t param_a = 42;
+    const uint32_t param_b = 0xBEEF;
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .named_compile_time_args = {{"my_kernel.param_a", param_a}, {"my_kernel.param_b", param_b}},
+        .defines = {{"WRITE_ADDRESS", std::to_string(write_addr)}},
+        .named_common_runtime_args = {{"my_kernel.marker", 0}},
+        .named_per_core_runtime_args = {{"my_kernel.core_idx", {{core, 0}}}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results;
+    detail::ReadFromDeviceL1(device, core, write_addr, 4 * sizeof(uint32_t), results);
+
+    EXPECT_EQ(results[2], param_a) << "ct_args::my_kernel::param_a should be 42";
+    EXPECT_EQ(results[3], param_b) << "ct_args::my_kernel::param_b should be 0xBEEF";
+}
+
+TEST_F(NamedArgsTest, TensixTestNamedPerCoreArrayRuntimeArgs) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core0 = {0, 0};
+    CoreCoord core1 = {1, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core0, core1)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const std::vector<uint32_t> core0_weights = {10, 20, 30};
+    const std::vector<uint32_t> core1_weights = {100, 200, 300};
+    const uint32_t num_elements = static_cast<uint32_t>(core0_weights.size());
+
+    uint32_t expected_sum_core0 = 0;
+    for (auto v : core0_weights) {
+        expected_sum_core0 += v;
+    }
+    uint32_t expected_sum_core1 = 0;
+    for (auto v : core1_weights) {
+        expected_sum_core1 += v;
+    }
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/misc/named_per_core_array_runtime_args_kernel.cpp",
+        .core_ranges = cores,
+        .defines =
+            {
+                {"WRITE_ADDRESS", std::to_string(write_addr)},
+                {"NUM_ELEMENTS", std::to_string(num_elements)},
+            },
+        .named_per_core_runtime_arg_arrays = {{"my_kernel.weights", {{core0, core0_weights}, {core1, core1_weights}}}},
+        .config = DataMovementConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results_core0;
+    detail::ReadFromDeviceL1(device, core0, write_addr, sizeof(uint32_t), results_core0);
+    std::vector<uint32_t> results_core1;
+    detail::ReadFromDeviceL1(device, core1, write_addr, sizeof(uint32_t), results_core1);
+
+    EXPECT_EQ(results_core0[0], expected_sum_core0)
+        << "Core (0,0): sum should be " << expected_sum_core0 << ", got " << results_core0[0];
+    EXPECT_EQ(results_core1[0], expected_sum_core1)
+        << "Core (1,0): sum should be " << expected_sum_core1 << ", got " << results_core1[0];
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -1861,13 +1861,37 @@ private:
 
         // ethernet coordinate chip mapping, which should be migrated away from
         std::map<FabricNodeId, ChipId> chip_to_eth_coord_mapping;
-        for (std::uint32_t mesh_id = 0; mesh_id < eth_coord_mapping.size(); mesh_id++) {
-            if (mesh_id == *local_mesh_id) {
-                for (std::uint32_t chip_id = 0; chip_id < eth_coord_mapping[mesh_id].size(); chip_id++) {
-                    const auto& eth_coord = eth_coord_mapping[mesh_id][chip_id];
-                    chip_to_eth_coord_mapping.insert(
-                        {FabricNodeId(MeshId{mesh_id}, chip_id),
-                         cluster.get_physical_chip_id_from_eth_coord(eth_coord)});
+        const auto& all_eth_coords = cluster.get_all_chip_ethernet_coordinates();
+        if (all_eth_coords.empty()) {
+            // UBB/T3K fallback: EthCoords not available, use visible chip IDs directly
+            const auto& visible_chips = cluster.user_exposed_chip_ids();
+            TT_FATAL(
+                *local_mesh_id < eth_coord_mapping.size(),
+                "local_mesh_id {} out of range (num meshes: {})",
+                *local_mesh_id,
+                eth_coord_mapping.size());
+            TT_FATAL(
+                visible_chips.size() == eth_coord_mapping[*local_mesh_id].size(),
+                "Number of visible chips ({}) does not match expected mesh size ({}) for mesh_id {}. "
+                "EthCoords are not available on this system (UBB board).",
+                visible_chips.size(),
+                eth_coord_mapping[*local_mesh_id].size(),
+                *local_mesh_id);
+            uint32_t chip_idx = 0;
+            for (const auto& physical_chip_id : visible_chips) {
+                chip_to_eth_coord_mapping.insert(
+                    {FabricNodeId(MeshId{*local_mesh_id}, chip_idx), physical_chip_id});
+                chip_idx++;
+            }
+        } else {
+            for (std::uint32_t mesh_id = 0; mesh_id < eth_coord_mapping.size(); mesh_id++) {
+                if (mesh_id == *local_mesh_id) {
+                    for (std::uint32_t chip_id = 0; chip_id < eth_coord_mapping[mesh_id].size(); chip_id++) {
+                        const auto& eth_coord = eth_coord_mapping[mesh_id][chip_id];
+                        chip_to_eth_coord_mapping.insert(
+                            {FabricNodeId(MeshId{mesh_id}, chip_id),
+                             cluster.get_physical_chip_id_from_eth_coord(eth_coord)});
+                    }
                 }
             }
         }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/named_array_runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/named_array_runtime_args_kernel.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel for array named runtime args.
+// Reads a scalar Arg (prefix) and an ArrayArg (data[NUM_ELEMENTS]),
+// sums prefix + all data elements, writes the sum to L1 at WRITE_ADDRESS.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)WRITE_ADDRESS;
+
+    // Scalar named RT arg
+    uint32_t prefix = rt_args::get<ct_args::my_kernel::prefix>();
+
+    // Array named RT arg — read NUM_ELEMENTS values and sum them
+    uint32_t sum = prefix;
+    for (uint32_t i = 0; i < NUM_ELEMENTS; i++) {
+        sum += rt_args::get<ct_args::my_kernel::data>(i);
+    }
+
+    l1_ptr[0] = sum;
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/named_per_core_array_runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/named_per_core_array_runtime_args_kernel.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel for per-core array named runtime args.
+// Reads a per-core ArrayArg (weights[NUM_ELEMENTS]) with PER_CORE dispatch,
+// sums all elements, writes the sum to L1 at WRITE_ADDRESS.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)WRITE_ADDRESS;
+
+    // Per-core array named RT arg — each core receives its own array
+    uint32_t sum = 0;
+    for (uint32_t i = 0; i < NUM_ELEMENTS; i++) {
+        sum += rt_args::get<ct_args::my_kernel::weights>(i);
+    }
+
+    l1_ptr[0] = sum;
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/named_runtime_args_kernel.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel for named args (both CT and RT) with generated header.
+// Reads named compile-time and runtime args, writes them to L1
+// at WRITE_ADDRESS so the host can verify the values.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)WRITE_ADDRESS;
+
+    // Named runtime args — dispatch type hidden by rt_args::get<>()
+    l1_ptr[0] = rt_args::get<ct_args::my_kernel::marker>();
+    l1_ptr[1] = rt_args::get<ct_args::my_kernel::core_idx>();
+
+    // Named compile-time args — plain constexpr from ct_args:: namespace
+    l1_ptr[2] = ct_args::my_kernel::param_a;
+    l1_ptr[3] = ct_args::my_kernel::param_b;
+}

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
@@ -95,7 +95,7 @@ public:
         const MeshGraph& mesh_graph,
         const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
         const LocalMeshBinding& local_mesh_binding,
-        std::chrono::duration<float> timeout = std::chrono::duration<float>(60.0f));
+        std::chrono::duration<float> timeout = std::chrono::duration<float>(120.0f));
 
     // Construct a TopologyMapper with fixed ASIC-position pinnings.
     // Each pinning maps a FabricNodeId to one or more ASIC positions (tray, location).
@@ -108,7 +108,7 @@ public:
         const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
         const LocalMeshBinding& local_mesh_binding,
         const std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>>& fixed_asic_position_pinnings,
-        std::chrono::duration<float> timeout = std::chrono::duration<float>(60.0f));
+        std::chrono::duration<float> timeout = std::chrono::duration<float>(120.0f));
 
     // Construct a TopologyMapper from a pre-provided logical mesh chip to physical chip mapping.
     // Skips discovery and builds fabric node id to asic id mapping directly from the provided mapping.
@@ -119,7 +119,7 @@ public:
         const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
         const LocalMeshBinding& local_mesh_binding,
         const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping,
-        std::chrono::duration<float> timeout = std::chrono::duration<float>(60.0f));
+        std::chrono::duration<float> timeout = std::chrono::duration<float>(120.0f));
 
     /**
      * @brief Get logical mesh graph connectivity

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -102,18 +102,6 @@ public:
     virtual ~IGraphHooks() = default;
 };
 
-// Process-wide singleton that fans out op-dispatch events to registered
-// processors and consults an optional hook to intercept buffer / program
-// operations.
-//
-// Threading contract:
-//   * The processor stack (`processors`) and `hook` are *per-thread*. A
-//     `push_processor` / capture / `pop_processor` sequence is scoped to the
-//     calling thread; ops dispatched on other threads are not observed by
-//     that capture.
-//   * `hooked_buffers` is process-wide and guarded by `hooked_buffers_mutex`.
-//     This is the only piece of GraphTracker state that is shared across
-//     threads.
 class GraphTracker {
 public:
     GraphTracker(const GraphTracker&) = delete;
@@ -203,9 +191,9 @@ private:
     GraphTracker() = default;
     ~GraphTracker() = default;
 
-    // Per-thread state. See the class-level threading contract above.
-    static thread_local std::vector<std::shared_ptr<IGraphProcessor>> processors;
-    static thread_local std::shared_ptr<IGraphHooks> hook;
+    std::vector<std::shared_ptr<IGraphProcessor>> processors;
+
+    std::shared_ptr<IGraphHooks> hook;
 
     std::mutex hooked_buffers_mutex;
     std::unordered_set<const Buffer*> hooked_buffers;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -145,9 +145,48 @@ struct KernelDescriptor {
     Defines defines;
 
     // vector of pairs, where runtime_args[i].first is the core coord and runtime_args[i].second is the vector of
+    // Named runtime args use "ns.field" convention (e.g. "demo.num_tiles").
+    // The name is split on '.' to produce namespace hierarchy in the generated header.
+    // Common: same value on all cores. Per-core: different value per core.
+    struct NamedCommonRuntimeArg {
+        std::string name;
+        uint32_t value;
+    };
+    using NamedCommonRuntimeArgs = std::vector<NamedCommonRuntimeArg>;
+    struct NamedPerCoreRuntimeArg {
+        std::string name;
+        std::vector<std::pair<CoreCoord, uint32_t>> core_values;
+    };
+    using NamedPerCoreRuntimeArgs = std::vector<NamedPerCoreRuntimeArg>;
+
+    // Array variant: named RT arg that occupies N contiguous slots.
+    // Generates ArrayArg (with length) in the kernel header instead of Arg.
+    struct NamedCommonRuntimeArgArray {
+        std::string name;
+        std::vector<uint32_t> values;
+    };
+    using NamedCommonRuntimeArgArrays = std::vector<NamedCommonRuntimeArgArray>;
+    // Per-core array variant: each core gets its own array of N contiguous RT arg slots.
+    struct NamedPerCoreRuntimeArgArray {
+        std::string name;
+        std::vector<std::pair<CoreCoord, std::vector<uint32_t>>> core_values;
+    };
+    using NamedPerCoreRuntimeArgArrays = std::vector<NamedPerCoreRuntimeArgArray>;
+
     // runtime args for that core
     RuntimeArgs runtime_args;
     CommonRuntimeArgs common_runtime_args;
+    // Named common runtime args: ordered (name, value) pairs.
+    // Names define the index mapping compiled into the kernel for compile-time resolution.
+    // Values are set as common runtime args (appended after any positional common_runtime_args).
+    NamedCommonRuntimeArgs named_common_runtime_args;
+    // Per-core named runtime args: each entry has a name and per-core values.
+    // Values are merged into runtime_args by program.cpp; indices auto-assigned by position.
+    NamedPerCoreRuntimeArgs named_per_core_runtime_args;
+    // Array variant: each entry occupies N contiguous common RT arg slots.
+    NamedCommonRuntimeArgArrays named_common_runtime_arg_arrays;
+    // Per-core array variant: each core gets its own array of N contiguous RT arg slots.
+    NamedPerCoreRuntimeArgArrays named_per_core_runtime_arg_arrays;
 
     std::optional<KernelBuildOptLevel> opt_level = std::nullopt;
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -592,7 +592,7 @@ void ControlPlane::init_control_plane_auto_discovery() {
 
     auto topology_mapping_timeout = rtoptions.get_timeout_duration_for_operations();
     if (topology_mapping_timeout.count() <= 0.0f) {
-        topology_mapping_timeout = std::chrono::duration<float>(60.0f);
+        topology_mapping_timeout = std::chrono::duration<float>(120.0f);
     }
     // Pin the start of the mesh to match the Galaxy Topology, ensuring that external QSFP links align with the
     // corner node IDs of the fabric mesh. This is a performance optimization to ensure that MGD mapping does not

--- a/tt_metal/hw/inc/api/compute/common.h
+++ b/tt_metal/hw/inc/api/compute/common.h
@@ -110,6 +110,22 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
     return *((tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }
 
+#include "api/rt_arg.h"
+
+// Unified accessor for named runtime args (works for both Arg and ArrayArg).
+// Scalar:  uint32_t n = rt_args::get<rt_args::my_op::num_tiles>();
+// Array:   uint32_t a = rt_args::get<rt_args::my_op::worker_sem_addr>(i);
+namespace rt_args {
+template <auto arg, typename T = uint32_t>
+FORCE_INLINE T get(uint32_t i = 0) {
+    if constexpr (arg.dispatch == Dispatch::COMMON) {
+        return get_common_arg_val<T>(arg.index + i);
+    } else {
+        return get_arg_val<T>(arg.index + i);
+    }
+}
+}  // namespace rt_args
+
 // clang-format off
 /**
  * Returns the absolute logical X coordinate value that this kernel is running on. The absolute coordinate

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -10,6 +10,7 @@
 #define DATA_FORMATS_DEFINED
 #endif
 
+#include <algorithm>
 #include <stdint.h>
 #include <tuple>
 #include <utility>
@@ -170,6 +171,22 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
     static_assert("Error: only 4B args are supported" && sizeof(T) == 4);
     return *((tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }
+
+#include "api/rt_arg.h"
+
+// Unified accessor for named runtime args (works for both Arg and ArrayArg).
+// Scalar:  uint32_t n = rt_args::get<rt_args::my_op::num_tiles>();
+// Array:   uint32_t a = rt_args::get<rt_args::my_op::worker_sem_addr>(i);
+namespace rt_args {
+template <auto arg, typename T = uint32_t>
+FORCE_INLINE T get(uint32_t i = 0) {
+    if constexpr (arg.dispatch == Dispatch::COMMON) {
+        return get_common_arg_val<T>(arg.index + i);
+    } else {
+        return get_arg_val<T>(arg.index + i);
+    }
+}
+}  // namespace rt_args
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/rt_arg.h
+++ b/tt_metal/hw/inc/api/rt_arg.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Named runtime arg types for device kernels.
+//
+// Defines rt_args::Dispatch and rt_args::Arg used by the JIT-generated header
+// (named_args_generated.h) and by rt_args::get<>() in the API headers.
+//
+// This file is safe to -include before any API headers because it only
+// defines types (no functions that depend on get_arg_val etc.).
+
+#pragma once
+
+#include <cstdint>
+
+namespace rt_args {
+
+enum class Dispatch : uint8_t { COMMON, PER_CORE };
+
+struct Arg {
+    uint32_t index;
+    Dispatch dispatch;
+};
+
+struct ArrayArg {
+    uint32_t index;
+    uint32_t length;
+    Dispatch dispatch;
+};
+
+}  // namespace rt_args

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -1,4 +1,5 @@
 set(HW_JIT_API_HEADERS
+    inc/api/rt_arg.h
     inc/api/alignment.h
     inc/api/compile_time_args.h
     inc/api/remote_circular_buffer.h

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -75,13 +75,13 @@ Device::Device(
     MetalEnv* env,
     MetalContext* context,
     ChipId device_id,
-    const uint8_t num_hw_cqs,
+    const std::uint8_t num_hw_cqs,
     size_t l1_small_size,
     size_t trace_region_size,
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool minimal,
-    uint32_t /*worker_thread_core*/,
-    uint32_t /*completion_queue_reader_core*/,
+    std::uint32_t /*worker_thread_core*/,
+    std::uint32_t /*completion_queue_reader_core*/,
     size_t worker_l1_size) :
     context_(context), env_(env), id_(device_id) {
     ZoneScoped;
@@ -110,7 +110,7 @@ bool Device::is_inactive_ethernet_core(CoreCoord logical_core) const {
     return inactive_ethernet_cores.contains(logical_core);
 }
 
-uint32_t Device::num_virtual_eth_cores(SubDeviceId sub_device_id) {
+std::uint32_t Device::num_virtual_eth_cores(SubDeviceId sub_device_id) {
     return this->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
 }
 
@@ -132,7 +132,7 @@ CoreRangeSet Device::worker_cores(HalProgrammableCoreType /*core_type*/, SubDevi
     return CoreRangeSet{};
 }
 
-uint32_t Device::num_worker_cores(HalProgrammableCoreType /*core_type*/, SubDeviceId /*sub_device_id*/) const {
+std::uint32_t Device::num_worker_cores(HalProgrammableCoreType /*core_type*/, SubDeviceId /*sub_device_id*/) const {
     TT_FATAL(false, "num_worker_cores is deprecated for device");
     return 0U;
 }
@@ -172,55 +172,57 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
     ChipId device_id = this->id();
     ChipId mmio_device_id = MetalEnvAccessor(*env_).impl().get_cluster().get_associated_mmio_device(device_id);
 
-    std::vector<uint32_t> zero = {0x0};  // Reset state in case L1 Clear is disabled.
-    std::vector<uint32_t> pointers;
-    uint32_t cq_size = this->sysmem_manager().get_cq_size();
+    std::vector<std::uint32_t> zero = {0x0};  // Reset state in case L1 Clear is disabled.
+    std::vector<std::uint32_t> pointers;
+    std::uint32_t cq_size = this->sysmem_manager().get_cq_size();
     TT_ASSERT(this->command_queue_programs_.size() == 1);
 
     Program& command_queue_program = *this->command_queue_programs_[0];
-    uint8_t num_hw_cqs = this->num_hw_cqs();
+    std::uint8_t num_hw_cqs = this->num_hw_cqs();
 
     // Reset host-side command queue pointers for all channels controlled by this mmio device
     if (this->is_mmio_capable()) {
         for (ChipId serviced_device_id :
              MetalEnvAccessor(*env_).impl().get_cluster().get_devices_controlled_by_mmio_device(device_id)) {
-            uint16_t channel =
+            std::uint16_t channel =
                 MetalEnvAccessor(*env_).impl().get_cluster().get_assigned_channel_for_device(serviced_device_id);
-            uint32_t host_issue_q_rd_ptr =
+            std::uint32_t host_issue_q_rd_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
-            uint32_t host_issue_q_wr_ptr =
+            std::uint32_t host_issue_q_wr_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
-            uint32_t host_completion_q_wr_ptr =
+            std::uint32_t host_completion_q_wr_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
-            uint32_t host_completion_q_rd_ptr =
+            std::uint32_t host_completion_q_rd_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
-            uint32_t cq_start =
+            std::uint32_t cq_start =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-            pointers.resize(cq_start / sizeof(uint32_t));
-            for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+            pointers.resize(cq_start / sizeof(std::uint32_t));
+            for (std::uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
                 // Reset the host manager's pointer for this command queue
                 this->sysmem_manager_->reset(cq_id);
 
-                const uint32_t cq_offset =
+                const std::uint32_t cq_offset =
                     this->sysmem_manager_->is_dram_backed()
                         ? get_absolute_cq_offset(
                               channel, cq_id, cq_size, this->sysmem_manager_->get_dram_region_base_addr())
                         : get_absolute_cq_offset(channel, cq_id, cq_size);
 
-                pointers[host_issue_q_rd_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
-                pointers[host_issue_q_wr_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
-                pointers[host_completion_q_wr_ptr / sizeof(uint32_t)] =
+                pointers[host_issue_q_rd_ptr / sizeof(std::uint32_t)] = (cq_start + cq_offset) >> 4;
+                pointers[host_issue_q_wr_ptr / sizeof(std::uint32_t)] = (cq_start + cq_offset) >> 4;
+                pointers[host_completion_q_wr_ptr / sizeof(std::uint32_t)] =
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
-                pointers[host_completion_q_rd_ptr / sizeof(uint32_t)] =
+                pointers[host_completion_q_rd_ptr / sizeof(std::uint32_t)] =
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
 
                 if (this->sysmem_manager_->is_dram_backed()) {
+                    const std::uint32_t dram_channel = this->allocator_impl()->get_dram_channel_from_bank_id(
+                        this->sysmem_manager_->get_dram_region_bank_id());
                     MetalEnvAccessor(*env_).impl().get_cluster().write_dram_vec(
-                        pointers.data(), pointers.size() * sizeof(uint32_t), this->id(), 0, cq_offset);
+                        pointers.data(), pointers.size() * sizeof(std::uint32_t), this->id(), dram_channel, cq_offset);
                 } else {
                     MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
                         pointers.data(),
-                        pointers.size() * sizeof(uint32_t),
+                        pointers.size() * sizeof(std::uint32_t),
                         cq_offset,
                         mmio_device_id,
                         get_umd_channel(channel));
@@ -270,10 +272,11 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     // Device init. TODO: remove this once dispatch init moves to one-shot.
     auto reset_launch_message_rd_ptr_virtual = [&](const CoreCoord& virtual_core,
                                                    HalProgrammableCoreType programmable_core_type) {
-        uint64_t launch_msg_buffer_read_ptr_addr =
+        std::uint64_t launch_msg_buffer_read_ptr_addr =
             hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR);
-        uint32_t zero = 0;
-        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), launch_msg_buffer_read_ptr_addr);
+        std::uint32_t zero = 0;
+        cluster.write_core(
+            &zero, sizeof(std::uint32_t), tt_cxy_pair(id_, virtual_core), launch_msg_buffer_read_ptr_addr);
     };
     auto reset_launch_message_rd_ptr = [&](const CoreCoord& logical_core, const CoreType& core_type) {
         CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(id_, logical_core, core_type);
@@ -283,19 +286,20 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     auto reset_go_message_index = [&](const CoreCoord& logical_core, const CoreType& core_type) {
         CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(id_, logical_core, core_type);
         auto programmable_core_type = get_programmable_core_type(virtual_core);
-        uint64_t go_message_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
-        uint32_t zero = 0;
-        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
+        std::uint64_t go_message_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
+        std::uint32_t zero = 0;
+        cluster.write_core(&zero, sizeof(std::uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
         cluster.l1_barrier(id_);
-        uint64_t go_message_index_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
-        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
+        std::uint64_t go_message_index_addr =
+            hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
+        cluster.write_core(&zero, sizeof(std::uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
     };
     std::optional<std::unique_lock<std::mutex>> watcher_lock;
     if (MetalEnvAccessor(*env_).impl().get_rtoptions().get_watcher_enabled()) {
         watcher_lock = context_->watcher_server()->get_lock();
     }
-    for (uint32_t y = 0; y < logical_grid_size().y; y++) {
-        for (uint32_t x = 0; x < logical_grid_size().x; x++) {
+    for (std::uint32_t y = 0; y < logical_grid_size().y; y++) {
+        for (std::uint32_t x = 0; x < logical_grid_size().x; x++) {
             CoreCoord logical_core(x, y);
             reset_launch_message_rd_ptr(logical_core, CoreType::WORKER);
             reset_go_message_index(logical_core, CoreType::WORKER);
@@ -323,7 +327,7 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     }
 
     std::vector<std::vector<CoreCoord>> logical_cores = command_queue_program.impl().logical_cores();
-    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+    for (std::uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         const auto& logical_dispatch_cores = logical_cores[index];
         CoreType core_type = hal.get_core_type(index);
         for (const CoreCoord& logical_dispatch_core : logical_dispatch_cores) {
@@ -349,9 +353,9 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     }
 
     const NOC noc_index = context_->get_dispatch_query_manager().go_signal_noc();
-    uint32_t idx = 0U;
-    vector_aligned<uint32_t> noc_mcast_unicast_data;
-    for (uint32_t i = 0U; i < num_sub_devices(); ++i) {
+    std::uint32_t idx = 0U;
+    vector_aligned<std::uint32_t> noc_mcast_unicast_data;
+    for (std::uint32_t i = 0U; i < num_sub_devices(); ++i) {
         for (const auto& core_range : active_eth_core_ranges) {
             noc_mcast_unicast_data.resize(idx + core_range.size());
             for (const auto& core : core_range) {
@@ -392,7 +396,8 @@ void Device::configure_fabric() {
     env_impl.get_cluster().l1_barrier(this->id());
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->impl().logical_cores();
     const auto& hal = env_impl.get_hal();
-    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
+    for (std::uint32_t programmable_core_type_index = 0;
+         programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
         CoreType core_type = hal.get_core_type(programmable_core_type_index);
         for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
@@ -414,7 +419,7 @@ void Device::configure_fabric() {
 }
 
 bool Device::initialize(
-    const uint8_t num_hw_cqs,
+    const std::uint8_t num_hw_cqs,
     size_t l1_small_size,
     size_t trace_region_size,
     size_t worker_l1_size,
@@ -452,8 +457,9 @@ bool Device::initialize(
         max_worker_l1_size);
     log_debug(tt::LogMetal, "Worker L1 size: {} Max: {}", worker_l1_size, max_worker_l1_size);
 
-    const uint32_t max_alignment = std::max(hal.get_alignment(HalMemType::DRAM), hal.get_alignment(HalMemType::L1));
-    const uint32_t worker_l1_unreserved_start = tt::align(
+    const std::uint32_t max_alignment =
+        std::max(hal.get_alignment(HalMemType::DRAM), hal.get_alignment(HalMemType::L1));
+    const std::uint32_t worker_l1_unreserved_start = tt::align(
         hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
             hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - worker_l1_size,
         max_alignment);
@@ -465,20 +471,15 @@ bool Device::initialize(
         return true;
     }
 
-    // Create shared memory stats provider (enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1).
-    // Snapshot the SHM rtoptions once here -- they are process-wide debug toggles, so capturing
-    // them at construction time avoids the SHM helpers having to look up a MetalContext on every
-    // allocation (and avoids any "find any context" walk that mock+silicon coexistence forced).
-    const bool shm_tracking_disabled = context_->rtoptions().get_shm_tracking_disabled();
-    const bool shm_verbose = context_->rtoptions().get_shm_verbose();
-    if (!shm_tracking_disabled) {
+    // Create shared memory stats provider (enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1)
+    if (!MetalContext::instance().rtoptions().get_shm_tracking_disabled()) {
         // Use UMD's chip_unique_ids for globally unique chip identification.
         // This ID is computed by topology discovery from hardware-reported board_id and asic_location,
         // and is consistent across all board types (P300, N300, UBB Wormhole, UBB Blackhole, etc.).
-        uint64_t asic_id = 0;
+        std::uint64_t asic_id = 0;
 
         try {
-            const auto& cluster = context_->get_cluster();
+            const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
             auto* cluster_desc = cluster.get_cluster_desc();
 
             if (cluster_desc) {
@@ -512,17 +513,14 @@ bool Device::initialize(
             asic_id = this->id_;
         }
 
-        shm_stats_provider_ =
-            std::make_unique<SharedMemoryStatsProvider>(asic_id, this->id_, shm_tracking_disabled, shm_verbose);
+        shm_stats_provider_ = std::make_unique<SharedMemoryStatsProvider>(asic_id, this->id_);
         log_debug(tt::LogMetal, "Shared memory tracking enabled for device {}, asic_id=0x{:x}", this->id_, asic_id);
 
-        // Register ShmTrackingProcessor globally once (when first device with SHM is created).
-        // Verbose flag is captured here from this device's MetalContext for the same reason as
-        // SharedMemoryStatsProvider above.
+        // Register ShmTrackingProcessor globally once (when first device with SHM is created)
         static bool shm_processor_registered = false;
         if (!shm_processor_registered) {
             tt::tt_metal::GraphTracker::instance().push_processor(
-                std::make_shared<tt::tt_metal::ShmTrackingProcessor>(shm_verbose));
+                std::make_shared<tt::tt_metal::ShmTrackingProcessor>());
             log_debug(tt::LogMetal, "ShmTrackingProcessor registered with GraphTracker");
             shm_processor_registered = true;
         }
@@ -570,10 +568,10 @@ int Device::num_dram_channels() const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_num_dram_views();
 }
 
-uint32_t Device::l1_size_per_core() const {
+std::uint32_t Device::l1_size_per_core() const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).worker_l1_size;
 }
-uint32_t Device::dram_size_per_channel() const {
+std::uint32_t Device::dram_size_per_channel() const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).dram_view_size;
 }
 
@@ -594,7 +592,7 @@ CoreCoord Device::compute_with_storage_grid_size() const {
     return tt::get_compute_grid_size(MetalEnvAccessor(*env_).impl(), id_, num_hw_cqs_, dispatch_core_config);
 }
 
-CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
+CoreCoord Device::virtual_noc0_coordinate(std::uint8_t noc_index, CoreCoord coord) const {
     if (coord.x >= this->grid_size().x || coord.y >= this->grid_size().y || this->arch() == ARCH::BLACKHOLE) {
         // Coordinate already in virtual space: NOC0 and NOC1 are the same
         return coord;
@@ -654,12 +652,12 @@ CoreCoord Device::logical_core_from_ethernet_core(const CoreCoord& ethernet_core
         this->id(), ethernet_core);
 }
 
-uint32_t Device::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
+std::uint32_t Device::get_noc_unicast_encoding(std::uint8_t noc_index, const CoreCoord& core) const {
     auto virtual_noc_coord = this->virtual_noc0_coordinate(noc_index, core);
     return MetalEnvAccessor(*env_).impl().get_hal().noc_xy_encoding(virtual_noc_coord.x, virtual_noc_coord.y);
 }
 
-uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const {
+std::uint32_t Device::get_noc_multicast_encoding(std::uint8_t noc_index, const CoreRange& cores) const {
     auto virtual_noc_start = this->virtual_noc0_coordinate(noc_index, cores.start_coord);
     auto virtual_noc_end = this->virtual_noc0_coordinate(noc_index, cores.end_coord);
     const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
@@ -687,27 +685,27 @@ const std::unique_ptr<Allocator>& Device::allocator(SubDeviceId sub_device_id) c
     return allocator->view();
 }
 
-uint32_t Device::num_sub_devices() const { return 1U; }
+std::uint32_t Device::num_sub_devices() const { return 1U; }
 
-CoreCoord Device::dram_core_from_dram_channel(uint32_t dram_channel, NOC noc) const {
+CoreCoord Device::dram_core_from_dram_channel(std::uint32_t dram_channel, NOC noc) const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_preferred_worker_core_for_dram_view(
         dram_channel, noc);
 }
 
-CoreCoord Device::logical_core_from_dram_channel(uint32_t dram_channel) const {
+CoreCoord Device::logical_core_from_dram_channel(std::uint32_t dram_channel) const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_logical_core_for_dram_view(dram_channel);
 }
 
-uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
+std::uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_dram_channel_from_logical_core(
         logical_core);
 }
 
-uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
+std::uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
     const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
-    uint32_t num_nocs = MetalEnvAccessor(*env_).impl().get_hal().get_num_nocs();
-    for (uint32_t noc = 0; noc < num_nocs; noc++) {
-        for (uint32_t channel = 0; channel < this->num_dram_channels(); ++channel) {
+    std::uint32_t num_nocs = MetalEnvAccessor(*env_).impl().get_hal().get_num_nocs();
+    for (std::uint32_t noc = 0; noc < num_nocs; noc++) {
+        for (std::uint32_t channel = 0; channel < this->num_dram_channels(); ++channel) {
             if (soc_desc.get_preferred_worker_core_for_dram_view(channel, noc) == virtual_core) {
                 return channel;
             }
@@ -725,7 +723,7 @@ std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address(
     return default_allocator_->get_lowest_occupied_l1_address(0);
 }
 
-HWCommandQueue& Device::command_queue(std::optional<uint8_t> cq_id) {
+HWCommandQueue& Device::command_queue(std::optional<std::uint8_t> cq_id) {
     detail::DispatchStateCheck(using_fast_dispatch_);
     TT_FATAL(using_fast_dispatch_, "Fast dispatch must be enabled to use command_queue");
     auto actual_cq_id = cq_id.value_or(GetCurrentCommandQueueIdForThread());
@@ -772,19 +770,19 @@ bool Device::has_noc_mcast_txns(SubDeviceId /*sub_device_id*/) const {
     return false;
 }
 
-uint8_t Device::num_noc_unicast_txns(SubDeviceId /*sub_device_id*/) const {
+std::uint8_t Device::num_noc_unicast_txns(SubDeviceId /*sub_device_id*/) const {
     TT_FATAL(false, "num_noc_unicast_txns is deprecated for device");
     return 0U;
 }
 
-uint8_t Device::noc_data_start_index(SubDeviceId /*sub_device_id*/, bool unicast_data) const {
+std::uint8_t Device::noc_data_start_index(SubDeviceId /*sub_device_id*/, bool unicast_data) const {
     if (unicast_data) {
         TT_FATAL(false, "noc_data_start_index is deprecated for unicast mode for device");
     }
     return 0U;
 }
 
-CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
+CoreCoord Device::virtual_program_dispatch_core(std::uint8_t cq_id) const {
     if (cq_id >= this->command_queues_.size() || !this->command_queues_[cq_id]) {
         return CoreCoord{0, 0};  // Return default for mock devices
     }
@@ -846,14 +844,14 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
     // and passes them to logic in core_assignment.cpp to derive the most optimal core placement
     // based on architecture specific logic and Physical Grid configuration.
     if (this->optimal_dram_bank_to_logical_worker_assignment_.empty()) {
-        uint32_t full_grid_size_x = this->grid_size().x;
-        uint32_t full_grid_size_y = this->grid_size().y;
+        std::uint32_t full_grid_size_x = this->grid_size().x;
+        std::uint32_t full_grid_size_y = this->grid_size().y;
 
         auto compute_with_storage_grid_size = this->compute_with_storage_grid_size();
-        uint32_t num_cores_x = compute_with_storage_grid_size.x;
-        uint32_t num_cores_y = compute_with_storage_grid_size.y;
+        std::uint32_t num_cores_x = compute_with_storage_grid_size.x;
+        std::uint32_t num_cores_y = compute_with_storage_grid_size.y;
         // Get physical coordinates of DRAM Controller NOC end-points
-        uint32_t num_dram_banks = this->num_dram_channels();
+        std::uint32_t num_dram_banks = this->num_dram_channels();
 
         const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
         bool noc_translation_enabled = true;
@@ -883,13 +881,13 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
             }
         }
         // Get the physical rows and cols  (y, x) in the worker grid
-        std::vector<uint32_t> worker_phy_y;
+        std::vector<std::uint32_t> worker_phy_y;
         worker_phy_y.reserve(num_cores_y);
         for (int i = 0; i < num_cores_y; ++i) {
             auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(0, i));
             worker_phy_y.push_back(core_phy.y);
         }
-        std::vector<uint32_t> worker_phy_x;
+        std::vector<std::uint32_t> worker_phy_x;
         worker_phy_x.reserve(num_cores_x);
         for (int i = 0; i < num_cores_x; ++i) {
             auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(i, 0));
@@ -951,14 +949,14 @@ void Device::unregister_program(detail::ProgramImpl* program) {
     active_programs_.erase(program);
 }
 
-uint64_t Device::get_total_cb_allocated() const {
+std::uint64_t Device::get_total_cb_allocated() const {
     std::lock_guard<std::mutex> lock(active_programs_mutex_);
 
     // For PHYSICAL CB tracking accounting for address reuse:
     // Collect L1 regions per core and merge overlapping addresses
     // This handles cached/traced programs that share the same physical L1 addresses on the same core
 
-    std::map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>> device_regions_per_core;
+    std::map<CoreCoord, std::vector<std::pair<std::uint64_t, std::uint64_t>>> device_regions_per_core;
 
     for (const auto* program : active_programs_) {
         size_t num_devices = program->get_num_cb_devices();
@@ -974,7 +972,7 @@ uint64_t Device::get_total_cb_allocated() const {
     }
 
     // Merge overlapping regions per core to get actual physical usage
-    uint64_t total_physical = 0;
+    std::uint64_t total_physical = 0;
 
     for (auto& [core, regions] : device_regions_per_core) {
         if (regions.empty()) {
@@ -985,7 +983,7 @@ uint64_t Device::get_total_cb_allocated() const {
         std::sort(regions.begin(), regions.end());
 
         // Merge overlapping ranges
-        std::vector<std::pair<uint64_t, uint64_t>> merged;
+        std::vector<std::pair<std::uint64_t, std::uint64_t>> merged;
         merged.push_back(regions[0]);
 
         for (size_t i = 1; i < regions.size(); i++) {

--- a/tt_metal/impl/graph/graph_tracking.cpp
+++ b/tt_metal/impl/graph/graph_tracking.cpp
@@ -10,9 +10,6 @@
 
 namespace tt::tt_metal {
 
-thread_local std::vector<std::shared_ptr<IGraphProcessor>> GraphTracker::processors;
-thread_local std::shared_ptr<IGraphHooks> GraphTracker::hook;
-
 nlohmann::json IGraphProcessor::end_capture() { return nullptr; }
 
 GraphTracker& GraphTracker::instance() {
@@ -170,10 +167,7 @@ void GraphTracker::clear() {
 }
 
 void GraphTracker::clear_hook() {
-    {
-        std::lock_guard<std::mutex> lock(hooked_buffers_mutex);
-        hooked_buffers.clear();
-    }
+    hooked_buffers.clear();
     hook = nullptr;
 }
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -329,6 +329,18 @@ void Kernel::process_tensor_binding_handles(const std::function<void(
     }
 }
 
+void Kernel::process_named_runtime_args(std::function<void(const NamedRuntimeArgNamespaces&)> fn) const {
+    if (!named_runtime_arg_namespaces_.empty()) {
+        fn(named_runtime_arg_namespaces_);
+    }
+}
+
+void Kernel::process_named_ct_arg_namespaces(std::function<void(const NamedCTArgNamespaces&)> fn) const {
+    if (!named_ct_arg_namespaces_.empty()) {
+        fn(named_ct_arg_namespaces_);
+    }
+}
+
 void Kernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
     // For FILE_PATH kernels, add the kernel source directory to the include path.
     // This enables relative includes (e.g., #include "foo.inc") to work when the kernel

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -184,6 +184,12 @@ public:
     }
     KernelCrtaLayout get_crta_layout() const override { return crta_layout_; }
     bool is_metal2_kernel() const override { return is_metal2_kernel_; }
+
+    // Named runtime arg namespace support (ProgramDescriptor path).
+    void set_named_runtime_arg_namespaces(const NamedRuntimeArgNamespaces& ns) { named_runtime_arg_namespaces_ = ns; }
+    void set_named_ct_arg_namespaces(const NamedCTArgNamespaces& ns) { named_ct_arg_namespaces_ = ns; }
+    void process_named_runtime_args(std::function<void(const NamedRuntimeArgNamespaces&)> fn) const override;
+    void process_named_ct_arg_namespaces(std::function<void(const NamedCTArgNamespaces&)> fn) const override;
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     void validate_runtime_args_size(
@@ -269,6 +275,9 @@ protected:
     const std::vector<std::string> named_common_runtime_args_;
     const std::vector<TensorBindingHandle> tensor_binding_handles_;
     const KernelCrtaLayout crta_layout_;
+    // Named arg namespace maps, populated from ProgramDescriptor path.
+    NamedRuntimeArgNamespaces named_runtime_arg_namespaces_;
+    NamedCTArgNamespaces named_ct_arg_namespaces_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
@@ -29,18 +29,13 @@ class Allocator;
 
 // Implementation of SharedMemoryStatsProvider
 
-SharedMemoryStatsProvider::SharedMemoryStatsProvider(
-    uint64_t asic_id, int device_id, bool tracking_disabled, bool verbose) :
+SharedMemoryStatsProvider::SharedMemoryStatsProvider(uint64_t asic_id, int device_id) :
     asic_id_(asic_id),
     device_id_(device_id),
     shm_fd_(-1),
     region_(nullptr),
-    // Per-PID tracking is enabled by default and disabled by TT_METAL_SHM_TRACKING_DISABLED=1.
-    // The flag is captured once at construction (passed in by Device::initialize from its
-    // MetalContext's rtoptions) -- it's a process-wide debug toggle, no need to look it up
-    // again per allocation.
-    per_pid_tracking_enabled_(!tracking_disabled),
-    verbose_enabled_(verbose),
+    per_pid_tracking_enabled_(true)  // Enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1
+    ,
     is_creator_(false) {
     // Format: /tt_device_<chip_unique_id>_memory
     // chip_unique_id from UMD is globally unique and never changes
@@ -120,7 +115,16 @@ SharedMemoryStatsProvider::SharedMemoryStatsProvider(
     TT_ASSERT(device_id_ >= 0, "Negative device_id {} passed to SHM provider", device_id_);
     region_->device_id = static_cast<uint32_t>(device_id_);
 
-    if (verbose_enabled_) {
+    // Check if tracking should be disabled (enabled by default)
+    const auto& rtopts = MetalContext::instance().rtoptions();
+    if (rtopts.get_shm_tracking_disabled()) {
+        per_pid_tracking_enabled_ = false;
+    }
+
+    // Verbose logging for initialization
+    bool verbose_enabled = rtopts.get_shm_verbose();
+
+    if (verbose_enabled) {
         log_info(
             tt::LogMetal,
             "SHM Provider initialized: device_id={}, asic_id=0x{:x}, shm_name={}, is_creator={}, region_={}, "
@@ -295,8 +299,10 @@ void SharedMemoryStatsProvider::initialize_region() {
 }
 
 void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmBufferType type, uint32_t chip_id) {
+    bool verbose_enabled = MetalContext::instance().rtoptions().get_shm_verbose();
+
     if (!region_) {
-        if (verbose_enabled_) {
+        if (verbose_enabled) {
             log_warning(
                 tt::LogMetal,
                 "SHM record_allocation SKIPPED: region_ is nullptr (pid={}, size={} B, type={}, chip_id={})",
@@ -308,7 +314,7 @@ void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmB
         return;
     }
 
-    if (verbose_enabled_) {
+    if (verbose_enabled) {
         static const char* type_names[] = {"DRAM", "L1", "L1_SMALL", "TRACE", "CB"};
         auto type_idx = static_cast<size_t>(type);
         const char* type_name = (type_idx < 5) ? type_names[type_idx] : "UNKNOWN";
@@ -374,8 +380,10 @@ void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmB
 }
 
 void SharedMemoryStatsProvider::record_deallocation(pid_t pid, uint64_t size, ShmBufferType type, uint32_t chip_id) {
+    bool verbose_enabled = MetalContext::instance().rtoptions().get_shm_verbose();
+
     if (!region_) {
-        if (verbose_enabled_) {
+        if (verbose_enabled) {
             log_warning(
                 tt::LogMetal,
                 "SHM record_deallocation SKIPPED: region_ is nullptr (pid={}, size={} B, type={}, chip_id={})",
@@ -387,7 +395,7 @@ void SharedMemoryStatsProvider::record_deallocation(pid_t pid, uint64_t size, Sh
         return;
     }
 
-    if (verbose_enabled_) {
+    if (verbose_enabled) {
         static const char* type_names[] = {"DRAM", "L1", "L1_SMALL", "TRACE", "CB"};
         auto type_idx = static_cast<size_t>(type);
         const char* type_name = (type_idx < 5) ? type_names[type_idx] : "UNKNOWN";

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -101,11 +101,7 @@ public:
     // If first process, initializes the region; otherwise attaches to existing
     // asic_id: UMD chip_unique_id from ClusterDescriptor (globally unique per chip)
     // device_id: Logical Metal device ID (for internal tracking only)
-    // tracking_disabled: process-wide TT_METAL_SHM_TRACKING_DISABLED flag, captured at
-    //                    construction time from the owning Device's MetalContext rtoptions
-    //                    so the SHM provider does not need to walk MetalContext slots later
-    // verbose: process-wide TT_METAL_SHM_VERBOSE flag, captured the same way
-    SharedMemoryStatsProvider(uint64_t asic_id, int device_id, bool tracking_disabled, bool verbose);
+    explicit SharedMemoryStatsProvider(uint64_t asic_id, int device_id);
 
     // Destructor unmaps shared memory and closes file descriptor
     // NOTE: SHM file persists (like UMD locks) - not deleted on process exit
@@ -191,7 +187,6 @@ private:
     int shm_fd_;                     // Shared memory file descriptor
     DeviceMemoryRegion* region_;     // Mapped shared memory region
     bool per_pid_tracking_enabled_;  // Enable detailed per-PID tracking
-    bool verbose_enabled_;           // Cached TT_METAL_SHM_VERBOSE flag (process-wide)
     bool is_creator_;                // True if this process created the shared memory
 
     // Helper: Initialize shared memory region (first process only)

--- a/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
+++ b/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
@@ -4,6 +4,7 @@
 
 #include "impl/memory_tracking/shm_tracking_processor.hpp"
 #include "impl/memory_tracking/memory_stats_shm.hpp"
+#include "impl/context/metal_context.hpp"
 #include "impl/device/device_impl.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -24,7 +25,8 @@ static ShmBufferType to_shm_buffer_type(BufferType type) {
     }
 }
 
-ShmTrackingProcessor::ShmTrackingProcessor(bool verbose) : verbose_enabled_(verbose) {}
+ShmTrackingProcessor::ShmTrackingProcessor() :
+    verbose_enabled_(MetalContext::instance().rtoptions().get_shm_verbose()) {}
 
 void ShmTrackingProcessor::track_allocate(const Buffer* buffer) {
     if (!buffer || !buffer->device()) {

--- a/tt_metal/impl/memory_tracking/shm_tracking_processor.hpp
+++ b/tt_metal/impl/memory_tracking/shm_tracking_processor.hpp
@@ -16,10 +16,7 @@ class Device;
 // for real-time monitoring by external tools (e.g. tt-smi-ui)
 class ShmTrackingProcessor : public IGraphProcessor {
 public:
-    // verbose: process-wide TT_METAL_SHM_VERBOSE flag, captured at construction time from
-    // the owning Device's MetalContext rtoptions so the processor does not need to walk
-    // MetalContext slots later. The flag is process-wide, so capturing once is correct.
-    explicit ShmTrackingProcessor(bool verbose);
+    ShmTrackingProcessor();
     ~ShmTrackingProcessor() override = default;
 
     // ShmTrackingProcessor is a permanent background processor; it must not

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -384,10 +384,145 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                 ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
                 : CreateKernelFromString(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
 
-        for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
-            SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);
+        // Set per-core runtime args: positional values followed by named values.
+        if (!kernel_descriptor.named_per_core_runtime_args.empty() ||
+            !kernel_descriptor.named_per_core_runtime_arg_arrays.empty()) {
+            // Start with positional args per core
+            std::map<CoreCoord, std::vector<uint32_t>> core_to_args;
+            for (const auto& [core, positional] : kernel_descriptor.runtime_args) {
+                core_to_args[core] = positional;
+            }
+            // Append named per-core scalar values in order (index = position)
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_args) {
+                for (const auto& [core, value] : arg.core_values) {
+                    core_to_args[core].push_back(value);
+                }
+            }
+            // Append named per-core array values (N contiguous slots per core)
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_arg_arrays) {
+                for (const auto& [core, values] : arg.core_values) {
+                    core_to_args[core].insert(core_to_args[core].end(), values.begin(), values.end());
+                }
+            }
+            for (const auto& [core, merged] : core_to_args) {
+                SetRuntimeArgs(*this, kernel_handle, core, merged);
+            }
+        } else {
+            for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
+                SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);
+            }
         }
-        SetCommonRuntimeArgs(*this, kernel_handle, kernel_descriptor.common_runtime_args);
+
+        // Set common runtime args: positional values followed by named scalars, then named arrays.
+        if (!kernel_descriptor.named_common_runtime_args.empty() ||
+            !kernel_descriptor.named_common_runtime_arg_arrays.empty()) {
+            std::vector<uint32_t> merged_common_rt_args;
+            merged_common_rt_args.insert(
+                merged_common_rt_args.end(),
+                kernel_descriptor.common_runtime_args.begin(),
+                kernel_descriptor.common_runtime_args.end());
+            for (const auto& arg : kernel_descriptor.named_common_runtime_args) {
+                merged_common_rt_args.push_back(arg.value);
+            }
+            for (const auto& arg : kernel_descriptor.named_common_runtime_arg_arrays) {
+                merged_common_rt_args.insert(merged_common_rt_args.end(), arg.values.begin(), arg.values.end());
+            }
+            SetCommonRuntimeArgs(*this, kernel_handle, merged_common_rt_args);
+        } else {
+            SetCommonRuntimeArgs(*this, kernel_handle, kernel_descriptor.common_runtime_args);
+        }
+
+        // Build namespace maps for JIT header generation.
+        // Names use "ns.field" convention — split on '.' to produce namespace hierarchy.
+        auto validate_identifier = [](const std::string& id, const std::string& context) {
+            TT_FATAL(
+                !id.empty() && (std::isalpha((unsigned char)id[0]) || id[0] == '_') &&
+                    std::all_of(
+                        id.begin(), id.end(), [](char c) { return std::isalnum((unsigned char)c) || c == '_'; }),
+                "Named arg {}: '{}' is not a valid C++ identifier",
+                context,
+                id);
+        };
+        auto split_name = [&validate_identifier](const std::string& name) -> std::pair<std::string, std::string> {
+            auto dot = name.find('.');
+            if (dot == std::string::npos) {
+                validate_identifier(name, "field");
+                return {"", name};
+            }
+            auto ns = name.substr(0, dot);
+            auto field = name.substr(dot + 1);
+            validate_identifier(ns, "namespace");
+            validate_identifier(field, "field");
+            return {ns, field};
+        };
+
+        auto kernel = internal_->get_kernel(kernel_handle);
+
+        // RT namespace map: rt_args::get<rt_args::ns::field>()
+        if (!kernel_descriptor.named_common_runtime_args.empty() ||
+            !kernel_descriptor.named_per_core_runtime_args.empty() ||
+            !kernel_descriptor.named_common_runtime_arg_arrays.empty() ||
+            !kernel_descriptor.named_per_core_runtime_arg_arrays.empty()) {
+            NamedRuntimeArgNamespaces rt_ns_map;
+
+            // Common scalars: one slot each
+            uint32_t common_index = static_cast<uint32_t>(kernel_descriptor.common_runtime_args.size());
+            for (const auto& arg : kernel_descriptor.named_common_runtime_args) {
+                auto [ns, field] = split_name(arg.name);
+                rt_ns_map[ns].push_back({field, common_index, 1, RuntimeArgDispatch::COMMON});
+                common_index += 1;
+            }
+            // Common arrays: N contiguous slots each
+            for (const auto& arg : kernel_descriptor.named_common_runtime_arg_arrays) {
+                auto [ns, field] = split_name(arg.name);
+                uint32_t len = static_cast<uint32_t>(arg.values.size());
+                rt_ns_map[ns].push_back({field, common_index, len, RuntimeArgDispatch::COMMON});
+                common_index += len;
+            }
+
+            // Per-core scalars: one slot each
+            uint32_t per_core_index = 0;
+            if (!kernel_descriptor.runtime_args.empty()) {
+                per_core_index = static_cast<uint32_t>(kernel_descriptor.runtime_args[0].second.size());
+            }
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_args) {
+                auto [ns, field] = split_name(arg.name);
+                rt_ns_map[ns].push_back({field, per_core_index, 1, RuntimeArgDispatch::PER_CORE});
+                per_core_index += 1;
+            }
+            // Per-core arrays: N contiguous slots each
+            for (const auto& arg : kernel_descriptor.named_per_core_runtime_arg_arrays) {
+                auto [ns, field] = split_name(arg.name);
+                uint32_t len = arg.core_values.empty() ? 0 : static_cast<uint32_t>(arg.core_values[0].second.size());
+                rt_ns_map[ns].push_back({field, per_core_index, len, RuntimeArgDispatch::PER_CORE});
+                per_core_index += len;
+            }
+
+            kernel->set_named_runtime_arg_namespaces(rt_ns_map);
+        }
+
+        // CT namespace map: ct_args::ns::field (plain constexpr values)
+        if (!kernel_descriptor.named_compile_time_args.empty()) {
+            NamedCTArgNamespaces ct_ns_map;
+            std::unordered_map<std::string, uint32_t> seen_ct_args;
+            for (const auto& [name, value] : kernel_descriptor.named_compile_time_args) {
+                auto it = seen_ct_args.find(name);
+                if (it != seen_ct_args.end()) {
+                    TT_FATAL(
+                        it->second == value,
+                        "named_compile_time_arg '{}' is defined twice with conflicting values ({} vs {}). "
+                        "Each CT arg name must be unique across all sub-lists.",
+                        name,
+                        it->second,
+                        value);
+                    continue;  // same value — silently skip the duplicate
+                }
+                seen_ct_args.emplace(name, value);
+                auto [ns, field] = split_name(name);
+                ct_ns_map[ns].emplace_back(field, value);
+            }
+            kernel->set_named_ct_arg_namespaces(ct_ns_map);
+        }
     }
 }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -19,7 +19,9 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <map>
 #include <mutex>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -534,6 +536,80 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
                 ss << "\"";
                 defines += ss.str() + " ";
             });
+
+        // Generate named_args_generated.h: each namespace becomes a struct with
+        // both CT constexpr values and RT arg descriptors (rt_args::Arg/ArrayArg).
+        {
+            // Accumulate RT entries per namespace.
+            std::map<std::string, std::vector<NamedRuntimeArgEntry>> rt_by_ns;
+            settings->process_named_runtime_args([&rt_by_ns](const NamedRuntimeArgNamespaces& namespaces) {
+                for (const auto& [ns, entries] : namespaces) {
+                    rt_by_ns[ns].insert(rt_by_ns[ns].end(), entries.begin(), entries.end());
+                }
+            });
+
+            // Accumulate CT entries per namespace.
+            std::map<std::string, std::vector<std::pair<std::string, uint32_t>>> ct_by_ns;
+            settings->process_named_ct_arg_namespaces([&ct_by_ns](const NamedCTArgNamespaces& namespaces) {
+                for (const auto& [ns, entries] : namespaces) {
+                    ct_by_ns[ns].insert(ct_by_ns[ns].end(), entries.begin(), entries.end());
+                }
+            });
+
+            // Collect all non-empty namespaces from both CT and RT maps.
+            std::set<std::string> all_ns;
+            for (const auto& [ns, unused] : ct_by_ns) {
+                all_ns.insert(ns);
+            }
+            for (const auto& [ns, unused] : rt_by_ns) {
+                if (!ns.empty()) {
+                    all_ns.insert(ns);
+                }
+            }
+
+            // Emit one struct per namespace containing both CT fields and RT descriptors.
+            std::ostringstream header_ct;
+            for (const auto& ns : all_ns) {
+                if (!ns.empty()) {
+                    header_ct << "struct " << ns << " {\n";
+                }
+                // CT fields
+                if (auto it = ct_by_ns.find(ns); it != ct_by_ns.end()) {
+                    for (const auto& [field, value] : it->second) {
+                        header_ct << "    static constexpr uint32_t " << field << " = " << value << ";\n";
+                    }
+                }
+                // RT descriptors
+                if (auto it = rt_by_ns.find(ns); it != rt_by_ns.end()) {
+                    for (const auto& entry : it->second) {
+                        const char* dispatch_str = entry.dispatch == RuntimeArgDispatch::COMMON
+                                                       ? "rt_args::Dispatch::COMMON"
+                                                       : "rt_args::Dispatch::PER_CORE";
+                        if (entry.length > 1) {
+                            header_ct << "    static constexpr rt_args::ArrayArg " << entry.field << " = {"
+                                      << entry.index << ", " << entry.length << ", " << dispatch_str << "};\n";
+                        } else {
+                            header_ct << "    static constexpr rt_args::Arg " << entry.field << " = {" << entry.index
+                                      << ", " << dispatch_str << "};\n";
+                        }
+                    }
+                }
+                if (!ns.empty()) {
+                    header_ct << "};\n";
+                }
+            }
+
+            auto ct_str = header_ct.str();
+            if (!ct_str.empty()) {
+                std::string header_path = out_dir + "named_args_generated.h";
+                std::ostringstream content;
+                content << "#pragma once\n#include \"api/rt_arg.h\"\n\n";
+                content << "namespace ct_args {\n" << ct_str << "}\n";
+                std::ofstream f(header_path);
+                f << content.str();
+                defines += fmt::format("-include {} ", header_path);
+            }
+        }
 
         cmd += fmt::format("-{} ", settings->get_compiler_opt_level());
     } else {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -204,12 +204,13 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     const vector<string>& rta_names = settings.get_named_runtime_args();
     const vector<string>& crta_names = settings.get_named_common_runtime_args();
 
-    // The kernel's CRTA buffer is laid out as three back-to-back sections:
-    //   [ user-named CRTAs | TensorBinding section | varargs ]
-    // The boundaries are precomputed at spec-resolution time and stored on the kernel,
-    // so we read them directly here. The vararg helpers below need the vararg-section
-    // start offset to skip past sections 1 and 2.
-    const KernelCrtaLayout crta_layout = settings.get_crta_layout();
+    // TensorBinding addresses occupy a structurally-separate, position-indexed section appended
+    // immediately after the user-named CRTAs in the kernel's CRTA buffer.
+    // We need to know how many there are so the vararg helpers below skip past the binding
+    // section to land at the first user vararg.
+    uint32_t tensor_binding_count = 0;
+    settings.process_tensor_binding_handles(
+        [&tensor_binding_count](const std::string&, uint32_t, uint32_t, uint32_t) { ++tensor_binding_count; });
 
     // Named CTAs come through the legacy unordered_map path (Kernel internal storage).
     // The order in which we emit them DOES matter!
@@ -266,13 +267,14 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     // indexing: get_vararg(0) is the first vararg, regardless of named-arg count. When
     // there are no named args, the offset is zero and these helpers are just thin wrappers
     // around get_arg_val / get_common_arg_val.
-    // CRTA-side note: the vararg section starts at crta_layout.vararg_section_offset,
-    // which already accounts for both the user-named CRTAs and the TensorBinding section.
+    // CRTA-side note: the kernel's CRTA buffer holds [user-named CRTAs, TensorBinding
+    // address section, varargs]. The vararg base must skip past the binding section as well.
     const uint32_t named_rta_words = static_cast<uint32_t>(rta_names.size());
+    const uint32_t named_crta_words = static_cast<uint32_t>(crta_names.size()) + tensor_binding_count;
     content << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { return get_arg_val<uint32_t>(" << named_rta_words
             << " + idx); }\n"
             << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { return get_common_arg_val<uint32_t>("
-            << crta_layout.vararg_section_offset << " + idx); }\n";
+            << named_crta_words << " + idx); }\n";
 
     write_file(path, content.str());
 }

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -6,9 +6,11 @@
 
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -36,6 +38,28 @@ struct KernelCrtaLayout {
     // and asserted against the derived sum if a consumer wants belt-and-suspenders verification.
     uint32_t vararg_section_offset = 0;
 };
+
+// Dispatch type for named runtime args — determines which device-side accessor to use.
+enum class RuntimeArgDispatch : uint8_t {
+    COMMON,   // get_common_arg_val (shared across all cores)
+    PER_CORE  // get_arg_val (unique per core)
+};
+
+// Entry in the named runtime arg namespace map.
+// length == 1: emits constexpr Arg (scalar).
+// length > 1:  emits constexpr ArrayArg (array of contiguous slots).
+struct NamedRuntimeArgEntry {
+    std::string field;
+    uint32_t index;
+    uint32_t length = 1;
+    RuntimeArgDispatch dispatch;
+};
+
+// Namespace → [entries] map for named runtime arg header generation.
+using NamedRuntimeArgNamespaces = std::map<std::string, std::vector<NamedRuntimeArgEntry>>;
+
+// Namespace → [(field, value)] map for named compile-time arg header generation.
+using NamedCTArgNamespaces = std::map<std::string, std::vector<std::pair<std::string, uint32_t>>>;
 
 // Abstract base class for kernel specialization
 // Higher levels of the SW derive from this and fill in build details not known to the build system
@@ -101,6 +125,11 @@ public:
     // Default is the all-zero layout (no named CRTAs, no bindings, varargs start at offset 0),
     // which matches the legacy-kernel case where the buffer has only varargs.
     virtual KernelCrtaLayout get_crta_layout() const { return {}; }
+
+    // Called to process named runtime arg namespaces for generated header (rt_args:: namespace)
+    virtual void process_named_runtime_args(std::function<void(const NamedRuntimeArgNamespaces&)>) const {}
+    // Called to process named compile-time arg namespaces for generated header (ct_args:: namespace)
+    virtual void process_named_ct_arg_namespaces(std::function<void(const NamedCTArgNamespaces&)>) const {}
 
     // Called to process additional include paths (e.g., kernel source directory for relative includes)
     virtual void process_include_paths(const std::function<void(const std::string& path)>&) const {}

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -521,12 +521,39 @@ std::unordered_map<ChipId, EthCoord> Cluster::get_all_chip_ethernet_coordinates(
 }
 
 ChipId Cluster::get_physical_chip_id_from_eth_coord(const EthCoord& eth_coord) const {
-    for (const auto& [physical_chip_id, coord] : this->get_all_chip_ethernet_coordinates()) {
+    const auto all_coords = this->get_all_chip_ethernet_coordinates();
+    for (const auto& [physical_chip_id, coord] : all_coords) {
         if (coord == eth_coord) {
             return physical_chip_id;
         }
     }
-    TT_FATAL(false, "Physical chip id not found for eth coord");
+    std::string available_coords_str;
+    if (all_coords.empty()) {
+        available_coords_str =
+            "No chip ethernet coordinates available (chip_locations is empty). "
+            "This typically happens on UBB/T3K systems where EthCoords are not populated by the UMD topology discovery.";
+    } else {
+        available_coords_str = "Available chip ethernet coordinates:\n";
+        for (const auto& [chip_id, coord] : all_coords) {
+            available_coords_str += fmt::format(
+                "  ChipId {} -> EthCoord(cluster_id={}, x={}, y={}, rack={}, shelf={})\n",
+                chip_id,
+                coord.cluster_id,
+                coord.x,
+                coord.y,
+                coord.rack,
+                coord.shelf);
+        }
+    }
+    TT_FATAL(
+        false,
+        "Physical chip id not found for eth coord (cluster_id={}, x={}, y={}, rack={}, shelf={}). {}",
+        eth_coord.cluster_id,
+        eth_coord.x,
+        eth_coord.y,
+        eth_coord.rack,
+        eth_coord.shelf,
+        available_coords_str);
     return 0;
 }
 

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -41,6 +41,7 @@ pytest-cov==7.0.0
 pytest-timeout==2.4.0
 pytest-split==0.11.0
 pytest-benchmark==5.2.3
+pytest-repeat==0.9.4
 jsbeautifier==1.14.7
 
 datasets>=2.20,<3


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #49400

The `--count=3` flag used in `run_t3000_unit_tests.sh` requires the `pytest-repeat` plugin, but it was never added to `tt_metal/python_env/requirements-dev.txt`. This caused CI to fail with:

```
pytest: error: unrecognized arguments: --count=3
```

Fix: add `pytest-repeat==0.9.4` to dev requirements.

### Notes for reviewers
Simple one-liner dep addition. The version `0.9.4` is the latest stable release and compatible with pytest 9.x.

### Test plan
- [x] CI t3k_ttnn_tests should pass once pytest-repeat is installed in the Docker image