### PR TITLE
[CI] Cap Gemma4 12B/26B vLLM nightly max_model_len at KV-cache capacity

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -182,7 +182,7 @@ jobs:
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 400000000}",
-              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "additional-server-args": "--max_model_len 131072 --max_num_seqs 1 --async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"
             },
@@ -196,7 +196,7 @@ jobs:
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 300000000}",
-              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "additional-server-args": "--max_model_len 131072 --max_num_seqs 1 --async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"
             },


### PR DESCRIPTION
## Problem

The `[BH-QB-2] Gemma4-12B` and `[BH-QB-2] Gemma4-26B-A4B` vLLM nightly entries are red with:

```
ValueError: TT KV cache cannot hold one request at max_model_len. Maximum concurrency
for 262,144 tokens per request is 0.50x, but must be at least 1.00x. num_blocks=2049,
corresponding to approximately 131,136 tokens, Increase max_tokens_all_users or reduce max_model_len.
```

With token-chunked prefill disabled in the TT vLLM plugin, `max_num_batched_tokens` is pinned to `max_model_len`. vLLM derives `max_model_len` from the HF config's `max_position_embeddings` (262,144), which exceeds the KV-cache capacity (~131,136 tokens = num_blocks 2049 × block_size 64), so the concurrency-≥-1.00x admission check fails and the server never comes up.

This surfaced now because tenstorrent/vllm#438 (fixing tenstorrent/vllm#436) added early validation of `max_num_scheduled_tokens >= max_model_len`, turning what used to be a stuck request into a hard config error.

Fixes #49323.

## Fix

Add `--max_model_len 131072` to the `additional-server-args` for both entries (same mechanism an existing entry already uses). 131072 sits just under KV-cache capacity (1.0005×), clearing admission.

Passing CI Run : https://github.com/tenstorrent/tt-metal/actions/runs/28957069807/job/85924159038

## Notes

- Serving config is loaded via HF `AutoConfig` from the hub checkpoint, so the local `models/demos/gemma4/configs/*/config.json` files are **not** on the serving path — editing `max_position_embeddings` there has no effect. The workflow flag is the correct knob.
- **Stopgap**: this trades away half the advertised context. The real fix is token-chunked prefill, tracked in tt-metal#49257 (Metal side) and tenstorrent/vllm#439 (plugin side); `max_model_len` can be restored once that lands.
- The still-disabled WH-T3K Gemma4-26B-A4B and Gemma4-31B entries will likely need the same flag when re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dwadhwani/fix-gemma4-max-model-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dwadhwani/fix-gemma4-max-model-len)