### PR TITLE
Bug fix: chunk large-unicast RTAs by prefetch command size (fixes on_eth hang, #49336)

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
-#include <limits>
 #include <map>
 #include <memory>
 #include <cstddef>
@@ -719,9 +718,9 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
             mesh_device, core_range_set, 0, 0);  // Kernel isn't run here.
         auto& program = workload.get_programs().at(device_range);
 
-        // The enforced TENSIX ceiling is bounded by the uint16_t RTA offset field (see
-        // Kernel::validate_runtime_args_size). Mirror that here.
-        const uint32_t tensix_max_rt_args = std::numeric_limits<uint16_t>::max() / sizeof(uint32_t);
+        // The enforced TENSIX ceiling is the dispatch-core-independent large-unicast cap (see
+        // Kernel::validate_runtime_args_size and kernel_types.hpp:max_runtime_args_tensix). Mirror that here.
+        const uint32_t tensix_max_rt_args = tt::tt_metal::max_runtime_args_tensix;
 
         // Set 100 unique args, then try to set enough common args to overflow the combined ceiling and fail.
         std::vector<uint32_t> initial_runtime_args(100);

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -718,20 +718,21 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
             mesh_device, core_range_set, 0, 0);  // Kernel isn't run here.
         auto& program = workload.get_programs().at(device_range);
 
-        // The enforced TENSIX ceiling is the dispatch-core-independent large-unicast cap (see
-        // Kernel::validate_runtime_args_size and kernel_types.hpp:max_runtime_args_tensix). Mirror that here.
-        const uint32_t tensix_max_rt_args = tt::tt_metal::max_runtime_args_tensix;
+        // A count comfortably above the enforced TENSIX ceiling (see Kernel::validate_runtime_args_size).
+        // 16384 words = the uint16_t RTA-offset field's hard maximum, so it exceeds any valid TENSIX ceiling
+        // regardless of the exact enforced cap.
+        constexpr uint32_t over_tensix_ceiling_rt_args = 16384;
 
         // Set 100 unique args, then try to set enough common args to overflow the combined ceiling and fail.
         std::vector<uint32_t> initial_runtime_args(100);
         SetRuntimeArgs(program, kernel, core_range_set, initial_runtime_args);
-        std::vector<uint32_t> common_runtime_args(tensix_max_rt_args + 1);
+        std::vector<uint32_t> common_runtime_args(over_tensix_ceiling_rt_args);
         EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, common_runtime_args));
 
         // Set 100 common args, then try to set enough unique args to overflow the combined ceiling and fail.
         std::vector<uint32_t> more_common_runtime_args(100);
         SetCommonRuntimeArgs(program, kernel, more_common_runtime_args);
-        std::vector<uint32_t> more_unique_args(tensix_max_rt_args + 1);
+        std::vector<uint32_t> more_unique_args(over_tensix_ceiling_rt_args);
         EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, core_range_set, more_unique_args));
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -719,8 +719,9 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
         auto& program = workload.get_programs().at(device_range);
 
         // A count comfortably above the enforced TENSIX ceiling (see Kernel::validate_runtime_args_size).
-        // 16384 words = the uint16_t RTA-offset field's hard maximum, so it exceeds any valid TENSIX ceiling
-        // regardless of the exact enforced cap.
+        // The RTA-offset field is a uint16_t region size in bytes, so its hard maximum is 65535 B = 16383 words;
+        // 16384 words (65536 B) is one word past that, so it exceeds any valid TENSIX ceiling regardless of the
+        // exact enforced cap.
         constexpr uint32_t over_tensix_ceiling_rt_args = 16384;
 
         // Set 100 unique args, then try to set enough common args to overflow the combined ceiling and fail.

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -48,6 +48,14 @@ enum NOC_MODE : uint8_t {
 // kernel-config space for the target core type (see Kernel::validate_runtime_args_size).
 constexpr uint32_t max_runtime_args = 341;
 
+// Enforced ceiling on the combined (unique + common) runtime-arg count per Tensix kernel. Args above
+// `max_runtime_args` are dispatched via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST, which sends a single
+// core's payload inline in one prefetcher command. The smallest dispatch prefetch command size is the
+// ethernet dispatcher's 32 KB (~8176 words), and the dispatch core type is not known this early, so this
+// cap is dispatch-core-independent and set conservatively below that limit (with margin so several cores'
+// commands still fit the ethernet cmddat queue). The actual L1 fit is still enforced at program finalize.
+constexpr uint32_t max_runtime_args_tensix = 4096;
+
 using KernelHandle = std::uint32_t;
 
 // Option that controls build optimization level

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -48,14 +48,6 @@ enum NOC_MODE : uint8_t {
 // kernel-config space for the target core type (see Kernel::validate_runtime_args_size).
 constexpr uint32_t max_runtime_args = 341;
 
-// Enforced ceiling on the combined (unique + common) runtime-arg count per Tensix kernel. Args above
-// `max_runtime_args` are dispatched via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST, which sends a single
-// core's payload inline in one prefetcher command. The smallest dispatch prefetch command size is the
-// ethernet dispatcher's 32 KB (~8176 words), and the dispatch core type is not known this early, so this
-// cap is dispatch-core-independent and set conservatively below that limit (with margin so several cores'
-// commands still fit the ethernet cmddat queue). The actual L1 fit is still enforced at program finalize.
-constexpr uint32_t max_runtime_args_tensix = 4096;
-
 using KernelHandle = std::uint32_t;
 
 // Option that controls build optimization level

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
-#include <limits>
 #include <set>
 #include <string_view>
 #include <type_traits>
@@ -631,14 +630,16 @@ void Kernel::validate_runtime_args_size(
 
     // The enforced ceiling is no longer the conservative public floor (kernel_types.hpp:max_runtime_args).
     // Large unique RTAs are dispatched via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST, so they are no longer
-    // bounded by a single dispatch page. The RTA/CRTA region offset is stored in a uint16_t launch-message
-    // field (dev_msgs.h rta_offset_t), which caps the region at uint16_t max bytes.
+    // bounded by a single dispatch page.
     switch (this->get_kernel_programmable_core_type()) {
         case HalProgrammableCoreType::TENSIX:
             // The TENSIX kernel-config L1 size is device-dependent (derived from the allocator at program
-            // finalize, not available from the HAL here), so bound only by the uint16_t RTA offset field.
-            // The actual L1 fit is enforced later against the kernel-config ring buffer.
-            expected_max_rt_args = std::numeric_limits<uint16_t>::max() / sizeof(uint32_t);
+            // finalize, not available from the HAL here), so bound by the dispatch-core-independent
+            // large-unicast cap. A single core's RTA payload is sent inline in one prefetcher command; this
+            // cap keeps it within the smallest dispatch prefetch command size (ethernet's 32 KB) regardless
+            // of where the dispatcher runs. The actual L1 fit is enforced later against the kernel-config
+            // ring buffer (see kernel_types.hpp:max_runtime_args_tensix).
+            expected_max_rt_args = max_runtime_args_tensix;
             break;
         case HalProgrammableCoreType::ACTIVE_ETH:
         case HalProgrammableCoreType::IDLE_ETH:

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -621,6 +621,15 @@ std::vector<uint32_t>& Kernel::common_runtime_args() { return this->common_runti
 
 RuntimeArgsData& Kernel::common_runtime_args_data() { return this->common_runtime_args_data_; }
 
+// Enforced ceiling on the combined (unique + common) runtime-arg count for a Tensix kernel. Args above
+// max_runtime_args are dispatched via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST, which sends a single core's
+// payload inline in one prefetcher command. The smallest dispatch prefetch command size is the ethernet
+// dispatcher's 32 KB (~8176 words), and the dispatch core type is not known when validate_runtime_args_size
+// runs (SetRuntimeArgs time), so this cap is dispatch-core-independent and set conservatively below that limit
+// (with margin so several cores' commands still fit the ethernet cmddat queue). The actual L1 fit is still
+// enforced at program finalize.
+constexpr uint32_t max_runtime_args_tensix = 4096;
+
 // Ensure that unique and common runtime args do not overflow reserved region in L1.
 // num_unique_rt_args and num_common_rt_args are user-visible arg counts (excluding any watcher count words).
 void Kernel::validate_runtime_args_size(
@@ -635,10 +644,8 @@ void Kernel::validate_runtime_args_size(
         case HalProgrammableCoreType::TENSIX:
             // The TENSIX kernel-config L1 size is device-dependent (derived from the allocator at program
             // finalize, not available from the HAL here), so bound by the dispatch-core-independent
-            // large-unicast cap. A single core's RTA payload is sent inline in one prefetcher command; this
-            // cap keeps it within the smallest dispatch prefetch command size (ethernet's 32 KB) regardless
-            // of where the dispatcher runs. The actual L1 fit is enforced later against the kernel-config
-            // ring buffer (see kernel_types.hpp:max_runtime_args_tensix).
+            // large-unicast cap (see max_runtime_args_tensix above). The actual L1 fit is enforced later
+            // against the kernel-config ring buffer.
             expected_max_rt_args = max_runtime_args_tensix;
             break;
         case HalProgrammableCoreType::ACTIVE_ETH:

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -616,12 +616,48 @@ void generate_runtime_args_cmds(
     }
 }
 
+// Max cores whose RTA payloads fit in one large-unicast command. The command is inline: every core's
+// payload is embedded in the prefetcher command, so the whole command (relay-inline header + sub-cmds +
+// all per-core payloads) must fit max_prefetch_command_size — not just the 35-sub-cmd cap. On eth dispatch
+// max_prefetch_command_size is only 32KB (vs 128KB on worker) and the eth cmddat queue is 64KB (vs 256KB),
+// so a large per-core payload forces far fewer than 35 cores per command; exceeding it silently overflows
+// the eth cmddat queue and hangs the device. Returns >=1 (a single core's payload is L1-fit-checked at
+// finalize, so it is expected to fit).
+uint32_t max_cores_per_large_unicast_cmd(uint32_t rta_payload_sizeB, uint32_t max_prefetch_command_size) {
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
+    for (uint32_t n = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS; n >= 1; --n) {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_packed_large_unicast(n, n * aligned_core_payload);
+        if (calculator.write_offset_bytes() <= max_prefetch_command_size) {
+            return n;
+        }
+    }
+    // Even a single core's inline payload does not fit one prefetcher command. This path embeds the RTA
+    // payload inline in the command, so it cannot be split across commands (only across cores). Fail loudly
+    // here rather than emit an oversized command that silently hangs the device (the fetch_queue_write size
+    // guard is a TT_ASSERT and compiles out in release builds). The kernel-side RTA ceiling
+    // (validate_runtime_args_size) is set before the dispatch core type is known, so this is the first point
+    // that can enforce the dispatch-core-specific prefetch command size.
+    DeviceCommandCalculator single_core;
+    single_core.add_dispatch_write_packed_large_unicast(1, aligned_core_payload);
+    TT_FATAL(
+        false,
+        "A single core's unique runtime args ({} B payload -> {} B prefetcher command) exceed the max prefetch "
+        "command size ({} B) for this dispatch core type. The large-unicast RTA path sends the payload inline and "
+        "cannot split one core across commands. Reduce the number of unique runtime args for this kernel.",
+        rta_payload_sizeB,
+        single_core.write_offset_bytes(),
+        max_prefetch_command_size);
+    return 1;  // unreachable
+}
+
 // Emit unique runtime args for a kernel group using CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST instead of
 // CQ_DISPATCH_CMD_WRITE_PACKED. Unlike the packed path, the large-unicast dispatch handler wraps CB pages
 // per sub-command, so a single core's RTA payload is no longer limited to one dispatch page. Used when a
 // kernel group's per-core payload exceeds that page (see assemble_runtime_args_commands). The command
 // layout mirrors BatchedTransferGenerator: one sub-command (core) per unicast destination, up to
-// CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS per command, with each core's payload laid out
+// max_cores_per_large_unicast_cmd() per command, with each core's payload laid out
 // exactly as the packed path lays out its per-core data region so the RTA-update pointers stay valid.
 void generate_runtime_args_cmds_large_unicast(
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
@@ -633,18 +669,20 @@ void generate_runtime_args_cmds_large_unicast(
     std::vector<std::vector<
         std::pair<std::reference_wrapper<RuntimeArgsData>, std::reference_wrapper<const std::vector<uint32_t>>>>>&
         rt_args_data,
+    uint32_t max_prefetch_command_size,
     uint32_t write_offset_index) {
     const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     // Device reads rta_payload_sizeB bytes per sub-command, then pads the read pointer to `alignment`, so
     // consecutive per-core payloads in the command stream are separated by this aligned size.
     const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
     const uint32_t count_word_offset = is_watcher_assert_enabled() ? 1 : 0;
+    // Cap cores/command by the prefetcher command size, not just the sub-cmd count (see helper above).
+    const uint32_t max_cores_per_cmd = max_cores_per_large_unicast_cmd(rta_payload_sizeB, max_prefetch_command_size);
 
     const uint32_t num_cores = sub_cmds.size();
     uint32_t offset_idx = 0;
     while (offset_idx < num_cores) {
-        const uint32_t num_in_chunk =
-            std::min<uint32_t>(num_cores - offset_idx, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+        const uint32_t num_in_chunk = std::min<uint32_t>(num_cores - offset_idx, max_cores_per_cmd);
 
         std::vector<CQDispatchWritePackedLargeUnicastSubCmd> large_sub_cmds(num_in_chunk);
         // Per-core payload backing storage. Must outlive the add_dispatch call (memcpy'd into the command).
@@ -773,7 +811,9 @@ BatchedTransfers assemble_runtime_args_commands(
             if (kg->total_rta_size != 0) {
                 uint32_t num_sub_cmds = kg->core_ranges.num_cores();
                 if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
-                    command_count += div_up(num_sub_cmds, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+                    command_count += div_up(
+                        num_sub_cmds,
+                        max_cores_per_large_unicast_cmd(kg->total_rta_size, constants.max_prefetch_command_size));
                 } else {
                     uint32_t max_runtime_args_len = kg->total_rta_size / sizeof(uint32_t);
                     uint32_t max_packed_cmds =
@@ -928,6 +968,7 @@ BatchedTransfers assemble_runtime_args_commands(
                         unique_rt_data_and_sizes,
                         kg->total_rta_size,
                         unique_rt_args_data,
+                        constants.max_prefetch_command_size,
                         get_dispatch_write_offset(programmable_core_type));
                 } else {
                     generate_runtime_args_cmds(


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #49336.

`TensixLargeUniqueRuntimeArgsLargeUnicast` (added with the WRITE_PACKED_LARGE_UNICAST feature in #48686) hangs the device in CI, but **only** on `runtime_fast_dispatch_on_eth` (`wh_n150`), cascading into ETH-heartbeat timeouts in every subsequent test in the binary.

Root cause: `generate_runtime_args_cmds_large_unicast()` chunked cores only by the sub-command cap (`CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS` = 35) and never bounded the command by `max_prefetch_command_size`. This RTA path is **inline** — the whole payload is embedded in the prefetcher command — so a 35-core chunk at 1100 words/core builds a ~154 KB command.

- Worker/Tensix (and Blackhole) dispatch tolerates it: `cmddat_q` = 256 KB physically holds the command even though it exceeds the nominal 128 KB `max_prefetch_command_size`. That's why it passed PR CI and local Blackhole verification.
- ETH dispatch has `max_prefetch_command_size` = 32 KB and `cmddat_q` = 64 KB. The ~154 KB command overflows the queue, the prefetcher wedges, the dispatcher never signals completion, and the reader hangs in `FDMeshCommandQueue::read_completion_queue` (`system_memory_manager.cpp:757`).

The host-side guard `TT_ASSERT(command_size_B <= max_prefetch_command_size)` in `fetch_queue_write` is compiled out in release CI builds, so the oversized command reached the device silently instead of failing cleanly.

Fix, two parts:

1. Chunk by prefetch command size (`tt_metal/impl/program/dispatch.cpp`): new `max_cores_per_large_unicast_cmd()` caps cores/command so the full inline command fits `max_prefetch_command_size`; used in both the `command_count` sizing (`assemble_runtime_args_commands`) and the emission chunk loop. If even a single core's payload cannot fit one prefetch command, `TT_FATAL` (defense-in-depth) rather than emitting an oversized command that hangs.

2. Enforce a dispatch-core-independent per-kernel ceiling early (`Kernel::validate_runtime_args_size`): the TENSIX ceiling was the `uint16_t` RTA-offset bound (16383 words), larger than ETH dispatch can deliver inline. Since `validate_runtime_args_size` runs at `SetRuntimeArgs` time — before the dispatch core type is known — enforce a conservative constant `max_runtime_args_tensix = 4096` words (defined file-locally in `kernel.cpp`, not in the public `kernel_types.hpp`), comfortably below the ETH 32 KB (~8176 word) prefetch-command limit. This turns the failure into a clear, early host-side error and makes the deep `TT_FATAL` in the command generator effectively unreachable. The actual L1 fit is still enforced at program finalize.

Verified on WH n300:
- `TensixLargeUniqueRuntimeArgsLargeUnicast` under `TT_METAL_GTEST_ETH_DISPATCH=1` → PASSED (was the hang).
- All 17 RTA tests under ETH dispatch → PASSED (packed path + all three large tests; no cascade).
- Large-RTA tests on worker dispatch → PASSED (no regression).
- `unit_tests_api` RTA validation tests (`TensixIllegalTooManyRuntimeArgs`, `ActiveEth*`, `IdleEth*`, `TensixIllegallyModifyRTArgs`) in slow dispatch → PASSED.

### Notes for reviewers
- Correctness hinge is `max_cores_per_large_unicast_cmd()` and that it is used consistently for both the reserved `command_count` and the actual emission chunking — the two must agree or `runtime_args_command_sequences.reserve()` will be wrong.
- The `TT_FATAL` (not `TT_ASSERT`) is deliberate: the compiled-out `TT_ASSERT` in `fetch_queue_write` is exactly what let the original oversized command hang silently in release CI.
- This surfaces that the raised RTA ceiling (16383 words ≈ 64 KB from #48686) is larger than ETH dispatch can deliver per single core (~8176 words at 32 KB); such a kernel now fails loudly at `SetRuntimeArgs` instead of hanging.
- `max_runtime_args_tensix = 4096` is an arbitrary conservative constant (12× the old `max_runtime_args` floor, ~half the ETH single-command limit) — easy to raise later if a config-aware limit is wired in. Happy to adjust the value in review.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-large-unicast-rta-eth-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-large-unicast-rta-eth-dispatch)