### PR TITLE
[Cleanup] Migrate eltwise Kernels from CircularBuffer to DataflowBuffer

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -7,7 +7,7 @@
 #include "api/compute/tile_move_copy.h"
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 
@@ -15,24 +15,24 @@ void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
     uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);
-    CircularBuffer cb_in1(tt::CBIndex::c_1);
-    CircularBuffer cb_out0(tt::CBIndex::c_2);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);
+    DataflowBuffer dfb_out0(tt::CBIndex::c_2);
 #ifdef SFPU_OP_INIT_PRE_IN0_0
-    CircularBuffer cb_inp0(tt::CBIndex::c_3);
+    DataflowBuffer dfb_inp0(tt::CBIndex::c_3);
 #else
-    CircularBuffer cb_inp0 = cb_in0;
+    DataflowBuffer dfb_inp0 = dfb_in0;
 #endif
 #ifdef SFPU_OP_INIT_PRE_IN1_0
-    CircularBuffer cb_inp1(tt::CBIndex::c_4);
+    DataflowBuffer dfb_inp1(tt::CBIndex::c_4);
 #else
-    CircularBuffer cb_inp1 = cb_in1;
+    DataflowBuffer dfb_inp1 = dfb_in1;
 #endif
 
-    binary_op_init_common(cb_inp0.get_cb_id(), cb_inp1.get_cb_id(), cb_out0.get_cb_id());
+    binary_op_init_common(dfb_inp0.get_id(), dfb_inp1.get_id(), dfb_out0.get_id());
 
 #if not PRE_SCALE
-    binary_tiles_init<false, ELTWISE_OP_TYPE>(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+    binary_tiles_init<false, ELTWISE_OP_TYPE>(dfb_inp0.get_id(), dfb_inp1.get_id());
 #endif
 
 #ifdef PACK_RELU
@@ -41,79 +41,79 @@ void kernel_main() {
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
 #if PRE_SCALE
-        copy_tile_to_dst_init_short(cb_in0.get_cb_id());  // need to copy from CB to DST to be able to run sfpu math
+        copy_tile_to_dst_init_short(dfb_in0.get_id());  // need to copy from CB to DST to be able to run sfpu math
 #endif
 
 #ifdef SFPU_OP_INIT_PRE_IN0_0
-        reconfig_data_format_srca(cb_inp0.get_cb_id(), cb_in0.get_cb_id());
-        pack_reconfig_data_format(cb_out0.get_cb_id(), cb_inp0.get_cb_id());
-        cb_in0.wait_front(per_core_block_size);
-        cb_inp0.reserve_back(per_core_block_size);
+        reconfig_data_format_srca(dfb_inp0.get_id(), dfb_in0.get_id());
+        pack_reconfig_data_format(dfb_out0.get_id(), dfb_inp0.get_id());
+        dfb_in0.wait_front(per_core_block_size);
+        dfb_inp0.reserve_back(per_core_block_size);
 
         tile_regs_acquire();
         SFPU_OP_INIT_PRE_IN0_0
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            copy_tile(cb_in0.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            copy_tile(dfb_in0.get_id(), i, i);  // copy from c_in[0] to DST[0]
             SFPU_OP_FUNC_PRE_IN0_0
         }
         tile_regs_commit();
 
         tile_regs_wait();
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            pack_tile(i, cb_inp0.get_cb_id());  // DST[0]->cb
+            pack_tile(i, dfb_inp0.get_id());  // DST[0]->cb
         }
         tile_regs_release();
 
-        cb_in0.pop_front(per_core_block_size);
-        cb_inp0.push_back(per_core_block_size);
+        dfb_in0.pop_front(per_core_block_size);
+        dfb_inp0.push_back(per_core_block_size);
 #ifndef SFPU_OP_INIT_PRE_IN1_0
-        reconfig_data_format_srca(cb_in0.get_cb_id(), cb_inp0.get_cb_id());
-        pack_reconfig_data_format(cb_inp0.get_cb_id(), cb_out0.get_cb_id());
+        reconfig_data_format_srca(dfb_in0.get_id(), dfb_inp0.get_id());
+        pack_reconfig_data_format(dfb_inp0.get_id(), dfb_out0.get_id());
 #endif
 #endif
 
 #ifdef SFPU_OP_INIT_PRE_IN1_0
 #ifndef SFPU_OP_INIT_PRE_IN0_0
-        reconfig_data_format_srca(cb_inp0.get_cb_id(), cb_in1.get_cb_id());
-        pack_reconfig_data_format(cb_out0.get_cb_id(), cb_inp1.get_cb_id());
+        reconfig_data_format_srca(dfb_inp0.get_id(), dfb_in1.get_id());
+        pack_reconfig_data_format(dfb_out0.get_id(), dfb_inp1.get_id());
 #else
-        reconfig_data_format_srca(cb_in0.get_cb_id(), cb_in1.get_cb_id());
-        pack_reconfig_data_format(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+        reconfig_data_format_srca(dfb_in0.get_id(), dfb_in1.get_id());
+        pack_reconfig_data_format(dfb_inp0.get_id(), dfb_inp1.get_id());
 #endif
-        cb_in1.wait_front(per_core_block_size);
-        cb_inp1.reserve_back(per_core_block_size);
+        dfb_in1.wait_front(per_core_block_size);
+        dfb_inp1.reserve_back(per_core_block_size);
 
         tile_regs_acquire();
         SFPU_OP_INIT_PRE_IN1_0
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            copy_tile(cb_in1.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            copy_tile(dfb_in1.get_id(), i, i);  // copy from c_in[0] to DST[0]
             SFPU_OP_FUNC_PRE_IN1_0
         }
         tile_regs_commit();
 
         tile_regs_wait();
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            pack_tile(i, cb_inp1.get_cb_id());  // DST[0]->cb
+            pack_tile(i, dfb_inp1.get_id());  // DST[0]->cb
         }
         tile_regs_release();
 
-        cb_in1.pop_front(per_core_block_size);
-        cb_inp1.push_back(per_core_block_size);
-        reconfig_data_format_srca(cb_in1.get_cb_id(), cb_inp0.get_cb_id());
-        pack_reconfig_data_format(cb_inp1.get_cb_id(), cb_out0.get_cb_id());
+        dfb_in1.pop_front(per_core_block_size);
+        dfb_inp1.push_back(per_core_block_size);
+        reconfig_data_format_srca(dfb_in1.get_id(), dfb_inp0.get_id());
+        pack_reconfig_data_format(dfb_inp1.get_id(), dfb_out0.get_id());
 #endif
 
-        cb_inp0.wait_front(per_core_block_size);
-        cb_inp1.wait_front(per_core_block_size);
-        cb_out0.reserve_back(per_core_block_size);
+        dfb_inp0.wait_front(per_core_block_size);
+        dfb_inp1.wait_front(per_core_block_size);
+        dfb_out0.reserve_back(per_core_block_size);
 
 #if PRE_SCALE
-        binary_tiles_init<true, ELTWISE_OP_TYPE>(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+        binary_tiles_init<true, ELTWISE_OP_TYPE>(dfb_inp0.get_id(), dfb_inp1.get_id());
 #endif
 
         tile_regs_acquire();
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            ELTWISE_OP(cb_inp0.get_cb_id(), cb_inp1.get_cb_id(), i, i, i);
+            ELTWISE_OP(dfb_inp0.get_id(), dfb_inp1.get_id(), i, i, i);
 
 #ifdef SFPU_OP_INIT_0
             SFPU_OP_INIT_0
@@ -128,12 +128,12 @@ void kernel_main() {
 
         tile_regs_wait();
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            pack_tile(i, cb_out0.get_cb_id());
+            pack_tile(i, dfb_out0.get_id());
         }
         tile_regs_release();
 
-        cb_inp0.pop_front(per_core_block_size);
-        cb_inp1.pop_front(per_core_block_size);
-        cb_out0.push_back(per_core_block_size);
+        dfb_inp0.pop_front(per_core_block_size);
+        dfb_inp1.pop_front(per_core_block_size);
+        dfb_out0.push_back(per_core_block_size);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -25,7 +25,7 @@
 #include "api/compute/gcd.h"
 #include "api/compute/lcm.h"
 #include "api/compute/binary_comp.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 
@@ -33,21 +33,21 @@ void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
     uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);
-    CircularBuffer cb_in1(tt::CBIndex::c_1);
-    CircularBuffer cb_out0(tt::CBIndex::c_2);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);
+    DataflowBuffer dfb_out0(tt::CBIndex::c_2);
 #ifdef SFPU_OP_INIT_PRE_IN0_0
-    CircularBuffer cb_inp0(tt::CBIndex::c_3);
+    DataflowBuffer dfb_inp0(tt::CBIndex::c_3);
 #else
-    CircularBuffer cb_inp0 = cb_in0;
+    DataflowBuffer dfb_inp0 = dfb_in0;
 #endif
 #ifdef SFPU_OP_INIT_PRE_IN1_0
-    CircularBuffer cb_inp1(tt::CBIndex::c_4);
+    DataflowBuffer dfb_inp1(tt::CBIndex::c_4);
 #else
-    CircularBuffer cb_inp1 = cb_in1;
+    DataflowBuffer dfb_inp1 = dfb_in1;
 #endif
 
-    unary_op_init_common(cb_in0.get_cb_id(), cb_out0.get_cb_id());
+    unary_op_init_common(dfb_in0.get_id(), dfb_out0.get_id());
 
 #ifdef PACK_RELU
     PACK((llk_pack_relu_config(ReluConfig::zero())));
@@ -56,65 +56,65 @@ void kernel_main() {
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
 
 #if PRE_SCALE
-        copy_tile_to_dst_init_short(cb_in0.get_cb_id());  // need to copy from CB to DST to be able to run sfpu math
+        copy_tile_to_dst_init_short(dfb_in0.get_id());  // need to copy from CB to DST to be able to run sfpu math
 #endif
 
 #ifdef SFPU_OP_INIT_PRE_IN0_0
-        cb_in0.wait_front(per_core_block_size);
-        cb_inp0.reserve_back(per_core_block_size);
+        dfb_in0.wait_front(per_core_block_size);
+        dfb_inp0.reserve_back(per_core_block_size);
 
         tile_regs_acquire();
         SFPU_OP_INIT_PRE_IN0_0
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            copy_tile(cb_in0.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            copy_tile(dfb_in0.get_id(), i, i);  // copy from c_in[0] to DST[0]
             SFPU_OP_FUNC_PRE_IN0_0
         }
         tile_regs_commit();
 
         tile_regs_wait();
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            pack_tile(i, cb_inp0.get_cb_id());  // DST[0]->cb
+            pack_tile(i, dfb_inp0.get_id());  // DST[0]->cb
         }
         tile_regs_release();
 
-        cb_in0.pop_front(per_core_block_size);
-        cb_inp0.push_back(per_core_block_size);
+        dfb_in0.pop_front(per_core_block_size);
+        dfb_inp0.push_back(per_core_block_size);
 #endif
 
 #ifdef SFPU_OP_INIT_PRE_IN1_0
-        cb_in1.wait_front(per_core_block_size);
-        cb_inp1.reserve_back(per_core_block_size);
+        dfb_in1.wait_front(per_core_block_size);
+        dfb_inp1.reserve_back(per_core_block_size);
 
         tile_regs_acquire();
         SFPU_OP_INIT_PRE_IN1_0
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            copy_tile(cb_in1.get_cb_id(), i, i);  // copy from c_in[0] to DST[0]
+            copy_tile(dfb_in1.get_id(), i, i);  // copy from c_in[0] to DST[0]
             SFPU_OP_FUNC_PRE_IN1_0
         }
         tile_regs_commit();
 
         tile_regs_wait();
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            pack_tile(i, cb_inp1.get_cb_id());  // DST[0]->cb
+            pack_tile(i, dfb_inp1.get_id());  // DST[0]->cb
         }
         tile_regs_release();
 
-        cb_in1.pop_front(per_core_block_size);
-        cb_inp1.push_back(per_core_block_size);
+        dfb_in1.pop_front(per_core_block_size);
+        dfb_inp1.push_back(per_core_block_size);
 #endif
-        cb_inp0.wait_front(per_core_block_size);
-        cb_inp1.wait_front(per_core_block_size);
-        cb_out0.reserve_back(per_core_block_size);
+        dfb_inp0.wait_front(per_core_block_size);
+        dfb_inp1.wait_front(per_core_block_size);
+        dfb_out0.reserve_back(per_core_block_size);
 
         tile_regs_acquire();
         tile_regs_wait();
-        copy_tile_to_dst_init_short_with_dt(cb_inp1.get_cb_id(), cb_inp0.get_cb_id());
+        copy_tile_to_dst_init_short_with_dt(dfb_inp1.get_id(), dfb_inp0.get_id());
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            copy_tile(cb_inp0.get_cb_id(), i, i * 2);
+            copy_tile(dfb_inp0.get_id(), i, i * 2);
         }
-        copy_tile_to_dst_init_short_with_dt(cb_inp0.get_cb_id(), cb_inp1.get_cb_id());
+        copy_tile_to_dst_init_short_with_dt(dfb_inp0.get_id(), dfb_inp1.get_id());
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            copy_tile(cb_inp1.get_cb_id(), i, i * 2 + 1);
+            copy_tile(dfb_inp1.get_id(), i, i * 2 + 1);
 
 #ifdef BINOP_INIT
             BINOP_INIT
@@ -185,13 +185,13 @@ void kernel_main() {
 #ifdef SFPU_OP_CHAIN_0
             SFPU_OP_CHAIN_0
 #endif
-            pack_tile(i * 2, cb_out0.get_cb_id());
+            pack_tile(i * 2, dfb_out0.get_id());
         }
         tile_regs_commit();
         tile_regs_release();
 
-        cb_inp0.pop_front(per_core_block_size);
-        cb_inp1.pop_front(per_core_block_size);
-        cb_out0.push_back(per_core_block_size);
+        dfb_inp0.pop_front(per_core_block_size);
+        dfb_inp1.pop_front(per_core_block_size);
+        dfb_out0.push_back(per_core_block_size);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_binary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_binary_interleaved_start_id.cpp
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -35,19 +35,19 @@ void kernel_main() {
 #endif
 
     Noc noc;
-    CircularBuffer cb0(cb_id_in0);
-    CircularBuffer cb1(cb_id_in1);
+    DataflowBuffer dfb0(cb_id_in0);
+    DataflowBuffer dfb1(cb_id_in1);
 
 #ifdef IN0_SHARDED
-    cb0.reserve_back(num_tiles);
-    cb0.push_back(num_tiles);
+    dfb0.reserve_back(num_tiles);
+    dfb0.push_back(num_tiles);
 #else
     uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 #endif
 #ifdef IN1_SHARDED
-    cb1.reserve_back(num_tiles);
-    cb1.push_back(num_tiles);
+    dfb1.reserve_back(num_tiles);
+    dfb1.push_back(num_tiles);
 #else
     uint32_t src1_tile_bytes = get_tile_size(cb_id_in1);
     const auto s1 = TensorAccessor(src1_args, src1_addr);
@@ -63,24 +63,24 @@ void kernel_main() {
             uint32_t tile_id = row_start_tile_id;
             for (uint32_t w = 0; w < block_width; w++) {
 #ifndef IN0_SHARDED
-                cb0.reserve_back(onetile);
-                noc.async_read(s0, cb0, src0_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+                dfb0.reserve_back(onetile);
+                noc.async_read(s0, dfb0, src0_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
 #endif
 
 #ifndef IN1_SHARDED
-                cb1.reserve_back(onetile);
-                noc.async_read(s1, cb1, src1_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+                dfb1.reserve_back(onetile);
+                noc.async_read(s1, dfb1, src1_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
 #endif
 
                 tile_id++;
                 noc.async_read_barrier();
 
 #ifndef IN0_SHARDED
-                cb0.push_back(onetile);
+                dfb0.push_back(onetile);
 #endif
 
 #ifndef IN1_SHARDED
-                cb1.push_back(onetile);
+                dfb1.push_back(onetile);
 #endif
             }
             row_start_tile_id += num_cores_y * block_width;
@@ -88,23 +88,23 @@ void kernel_main() {
     } else {
         for (uint32_t tile_id = start_id; tile_id < start_id + num_tiles; tile_id++) {
 #ifndef IN0_SHARDED
-            cb0.reserve_back(onetile);
-            noc.async_read(s0, cb0, src0_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+            dfb0.reserve_back(onetile);
+            noc.async_read(s0, dfb0, src0_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
 #endif
 
 #ifndef IN1_SHARDED
-            cb1.reserve_back(onetile);
-            noc.async_read(s1, cb1, src1_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+            dfb1.reserve_back(onetile);
+            noc.async_read(s1, dfb1, src1_tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
 #endif
 
             noc.async_read_barrier();
 
 #ifndef IN0_SHARDED
-            cb0.push_back(onetile);
+            dfb0.push_back(onetile);
 #endif
 
 #ifndef IN1_SHARDED
-            cb1.push_back(onetile);
+            dfb1.push_back(onetile);
 #endif
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
@@ -9,6 +9,7 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -17,28 +18,28 @@ void kernel_main() {
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);
-    CircularBuffer cb_in1(tt::CBIndex::c_1);
-    CircularBuffer cb_out(tt::CBIndex::c_2);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);
+    DataflowBuffer dfb_out(tt::CBIndex::c_2);
 
-    unary_op_init_common(cb_in0.get_cb_id(), cb_out.get_cb_id());
+    unary_op_init_common(dfb_in0.get_id(), dfb_out.get_id());
     BINARY_SFPU_INIT
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_in0.wait_front(num_tiles_per_cycle);
-        cb_in1.wait_front(num_tiles_per_cycle);
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in1.wait_front(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
-        copy_tile_to_dst_init_short(cb_in0.get_cb_id());
+        copy_tile_to_dst_init_short(dfb_in0.get_id());
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            copy_tile(cb_in0.get_cb_id(), i, i * 3);
+            copy_tile(dfb_in0.get_id(), i, i * 3);
         }
-        copy_tile_to_dst_init_short(cb_in1.get_cb_id());
+        copy_tile_to_dst_init_short(dfb_in1.get_id());
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             // TTS: tensor is true value, goes to dst_reg 1
 #if WHERE_TTS
-            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            copy_tile(dfb_in1.get_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
             fill_tile_init();
             // TTS: scalar is false value, goes to dst_reg 2
 #ifdef FILL_WITH_VALUE_FLOAT
@@ -51,7 +52,7 @@ void kernel_main() {
 
 // TST: tensor is false value, goes to dst_reg 2
 #if WHERE_TST
-            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            copy_tile(dfb_in1.get_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
             fill_tile_init();
             // TST: scalar is true value, goes to dst_reg 1
 #ifdef FILL_WITH_VALUE_FLOAT
@@ -69,12 +70,12 @@ void kernel_main() {
 
         tile_regs_wait();
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            pack_tile(i * 3, cb_out.get_cb_id());
+            pack_tile(i * 3, dfb_out.get_id());
         }
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_in0.pop_front(num_tiles_per_cycle);
-        cb_in1.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
+        dfb_in1.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_in0_id,
@@ -21,34 +22,34 @@ ALWI void process_tile(
     uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
 
-    CircularBuffer cb_in0(cb_in0_id);
-    CircularBuffer cb_in1(cb_in1_id);
-    CircularBuffer cb_out(cb_out_id);
+    DataflowBuffer dfb_in0(cb_in0_id);
+    DataflowBuffer dfb_in1(cb_in1_id);
+    DataflowBuffer dfb_out(cb_out_id);
 
 #if BCAST_INPUT  // BCAST_INPUT == 1 : input B ( true or false tensor) is broadcasted
-    CircularBuffer& cb_bcast = cb_in1;
-    CircularBuffer& cb_other = cb_in0;
+    DataflowBuffer& dfb_bcast = dfb_in1;
+    DataflowBuffer& dfb_other = dfb_in0;
 #else  // BCAST_INPUT == 0 : input A (condition tensor)  is broadcasted
-    CircularBuffer& cb_bcast = cb_in0;
-    CircularBuffer& cb_other = cb_in1;
+    DataflowBuffer& dfb_bcast = dfb_in0;
+    DataflowBuffer& dfb_other = dfb_in1;
 #endif
 
-    cb_bcast.wait_front(num_tiles_per_cycle);
+    dfb_bcast.wait_front(num_tiles_per_cycle);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
-        cb_other.wait_front(num_tiles_per_cycle);
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_other.wait_front(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
-        copy_tile_to_dst_init_short(cb_in0.get_cb_id());
+        copy_tile_to_dst_init_short(dfb_in0.get_id());
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            copy_tile(cb_in0.get_cb_id(), i, i * 3);
+            copy_tile(dfb_in0.get_id(), i, i * 3);
         }
-        copy_tile_to_dst_init_short(cb_in1.get_cb_id());
+        copy_tile_to_dst_init_short(dfb_in1.get_id());
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             // TTS: tensor is true value, goes to dst_reg 1
 #if WHERE_TTS
-            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            copy_tile(dfb_in1.get_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
             fill_tile_init();
 // TTS: scalar is false value, goes to dst_reg 2
 #ifdef FILL_WITH_VALUE_FLOAT
@@ -61,7 +62,7 @@ ALWI void process_tile(
 
 // TST: tensor is false value, goes to dst_reg 2
 #if WHERE_TST
-            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            copy_tile(dfb_in1.get_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
             fill_tile_init();
 // TST: scalar is true value, goes to dst_reg 1
 #ifdef FILL_WITH_VALUE_FLOAT
@@ -78,14 +79,14 @@ ALWI void process_tile(
 
         tile_regs_wait();
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            pack_tile(i * 3, cb_out.get_cb_id());
+            pack_tile(i * 3, dfb_out.get_id());
         }
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_other.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_other.pop_front(num_tiles_per_cycle);
     }
-    cb_bcast.pop_front(num_tiles_per_cycle);
+    dfb_bcast.pop_front(num_tiles_per_cycle);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar.cpp
@@ -9,6 +9,7 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -17,31 +18,31 @@ void kernel_main() {
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);
-    CircularBuffer cb_in1(tt::CBIndex::c_1);
-    CircularBuffer cb_out(tt::CBIndex::c_2);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);
+    DataflowBuffer dfb_out(tt::CBIndex::c_2);
 
-    unary_op_init_common(cb_in0.get_cb_id(), cb_out.get_cb_id());
+    unary_op_init_common(dfb_in0.get_id(), dfb_out.get_id());
 
     BINARY_SFPU_INIT
 
-    cb_in1.wait_front(num_tiles_per_cycle);
+    dfb_in1.wait_front(num_tiles_per_cycle);
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
-        copy_tile_to_dst_init_short(cb_in0.get_cb_id());
+        copy_tile_to_dst_init_short(dfb_in0.get_id());
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            copy_tile(cb_in0.get_cb_id(), i, i * 3);
+            copy_tile(dfb_in0.get_id(), i, i * 3);
         }
-        copy_tile_to_dst_init_short(cb_in1.get_cb_id());
+        copy_tile_to_dst_init_short(dfb_in1.get_id());
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             // TTS: tensor is true value, goes to dst_reg 1
 #if WHERE_TTS
-            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
+            copy_tile(dfb_in1.get_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
             fill_tile_init();
             // TTS: scalar is false value, goes to dst_reg 2
 #ifdef FILL_WITH_VALUE_FLOAT
@@ -54,7 +55,7 @@ void kernel_main() {
 
 // TST: tensor is false value, goes to dst_reg 2
 #if WHERE_TST
-            copy_tile(cb_in1.get_cb_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
+            copy_tile(dfb_in1.get_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
             fill_tile_init();
             // TST: scalar is true value, goes to dst_reg 1
 #ifdef FILL_WITH_VALUE_FLOAT
@@ -71,11 +72,11 @@ void kernel_main() {
 
         tile_regs_wait();
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            pack_tile(i * 3, cb_out.get_cb_id());
+            pack_tile(i * 3, dfb_out.get_id());
         }
         tile_regs_release();
 
-        cb_in0.pop_front(num_tiles_per_cycle);
-        cb_out.push_back(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -29,16 +29,16 @@ void kernel_main() {
     constexpr auto cb_id_src = tt::CBIndex::c_0;
 
     Noc noc;
-    CircularBuffer cb_src(cb_id_src);
+    DataflowBuffer dfb_src(cb_id_src);
 
 #if SRC_SHARDED
-    cb_src.reserve_back(src_num_tiles);
-    cb_src.push_back(src_num_tiles);
+    dfb_src.reserve_back(src_num_tiles);
+    dfb_src.push_back(src_num_tiles);
 #else
     constexpr uint32_t onetile = 1;
     constexpr auto src_args = TensorAccessorArgs<0, 0>();
     constexpr bool has_sharding = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
-    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const uint32_t src_tile_bytes = dfb_src.get_entry_size();
     const auto src = TensorAccessor(src_args, src_addr);
     const uint32_t HtWt = Ht * Wt;
 
@@ -73,11 +73,11 @@ void kernel_main() {
                     for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
                              ++tw, ++num_tiles_read) {
-                            cb_src.reserve_back(onetile);
+                            dfb_src.reserve_back(onetile);
                             noc.async_read(
-                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                                src, dfb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
                             noc.async_read_barrier();
-                            cb_src.push_back(onetile);
+                            dfb_src.push_back(onetile);
                         }
                         if constexpr (!has_sharding) {
                             // next row of tiles should start at the first column

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
@@ -9,6 +9,9 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+// DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
+// still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_bcast,
@@ -28,32 +31,32 @@ ALWI void process_tile(
 #define CB_POST_BCAST cb_post_rhs
 #define CB_PRE_OTHER cb_pre_lhs
 #define CB_POST_OTHER cb_post_lhs
-#define EXP_CB_POST_BCAST exp_cb_post_rhs
-#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#define EXP_CB_POST_BCAST exp_dfb_post_rhs
+#define EXP_CB_POST_OTHER exp_dfb_post_lhs
 #else
 #define CB_PRE_BCAST cb_pre_lhs
 #define CB_POST_BCAST cb_post_lhs
 #define CB_PRE_OTHER cb_pre_rhs
 #define CB_POST_OTHER cb_post_rhs
-#define EXP_CB_POST_BCAST exp_cb_post_lhs
-#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#define EXP_CB_POST_BCAST exp_dfb_post_lhs
+#define EXP_CB_POST_OTHER exp_dfb_post_rhs
 #endif
-    CircularBuffer exp_cb_bcast(cb_bcast);
-    CircularBuffer exp_cb_llk_post(cb_llk_post);
-    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
-    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
-    CircularBuffer exp_cb_out(cb_out);
+    DataflowBuffer exp_dfb_bcast(cb_bcast);
+    DataflowBuffer exp_dfb_llk_post(cb_llk_post);
+    DataflowBuffer exp_dfb_post_lhs(cb_post_lhs);
+    DataflowBuffer exp_dfb_post_rhs(cb_post_rhs);
+    DataflowBuffer exp_dfb_out(cb_out);
 
-    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    exp_dfb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
     unary_bcast_init<BroadcastType::COL>(cb_bcast, cb_llk_post);
-    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
     unary_bcast<BroadcastType::COL>(cb_bcast, 0, 0);
     tile_regs_commit();
     tile_regs_wait();
     pack_tile(0, cb_llk_post);
-    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.push_back(num_tiles_per_cycle);
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
@@ -82,7 +85,7 @@ ALWI void process_tile(
             num_tiles_per_cycle);
         EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
 
-        exp_cb_out.reserve_back(num_tiles_per_cycle);
+        exp_dfb_out.reserve_back(num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
         binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
@@ -96,10 +99,10 @@ ALWI void process_tile(
         pack_tile(0, cb_out);
         tile_regs_release();
 
-        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_dfb_out.push_back(num_tiles_per_cycle);
         EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
     }
-    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+    exp_dfb_bcast.pop_front(num_tiles_per_cycle);
     EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
@@ -9,6 +9,9 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+// DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
+// still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_bcast,
@@ -28,32 +31,32 @@ ALWI void process_tile(
 #define CB_POST_BCAST cb_post_rhs
 #define CB_PRE_OTHER cb_pre_lhs
 #define CB_POST_OTHER cb_post_lhs
-#define EXP_CB_POST_BCAST exp_cb_post_rhs
-#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#define EXP_CB_POST_BCAST exp_dfb_post_rhs
+#define EXP_CB_POST_OTHER exp_dfb_post_lhs
 #else
 #define CB_PRE_BCAST cb_pre_lhs
 #define CB_POST_BCAST cb_post_lhs
 #define CB_PRE_OTHER cb_pre_rhs
 #define CB_POST_OTHER cb_post_rhs
-#define EXP_CB_POST_BCAST exp_cb_post_lhs
-#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#define EXP_CB_POST_BCAST exp_dfb_post_lhs
+#define EXP_CB_POST_OTHER exp_dfb_post_rhs
 #endif
-    CircularBuffer exp_cb_bcast(cb_bcast);
-    CircularBuffer exp_cb_llk_post(cb_llk_post);
-    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
-    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
-    CircularBuffer exp_cb_out(cb_out);
+    DataflowBuffer exp_dfb_bcast(cb_bcast);
+    DataflowBuffer exp_dfb_llk_post(cb_llk_post);
+    DataflowBuffer exp_dfb_post_lhs(cb_post_lhs);
+    DataflowBuffer exp_dfb_post_rhs(cb_post_rhs);
+    DataflowBuffer exp_dfb_out(cb_out);
 
-    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    exp_dfb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
     unary_bcast_init<BroadcastType::SCALAR>(cb_bcast, cb_llk_post);
-    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
     unary_bcast<BroadcastType::SCALAR>(cb_bcast, 0, 0);
     tile_regs_commit();
     tile_regs_wait();
     pack_tile(0, cb_llk_post);
-    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.push_back(num_tiles_per_cycle);
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
@@ -82,7 +85,7 @@ ALWI void process_tile(
             num_tiles_per_cycle);
         EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
 
-        exp_cb_out.reserve_back(num_tiles_per_cycle);
+        exp_dfb_out.reserve_back(num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
         binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
@@ -96,10 +99,10 @@ ALWI void process_tile(
         pack_tile(0, cb_out);
         tile_regs_release();
 
-        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_dfb_out.push_back(num_tiles_per_cycle);
         EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
     }
-    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+    exp_dfb_bcast.pop_front(num_tiles_per_cycle);
     EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
 }
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -28,6 +28,9 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+// DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
+// still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_bcast,
@@ -47,33 +50,33 @@ ALWI void process_tile(
 #define CB_POST_BCAST cb_post_rhs
 #define CB_PRE_OTHER cb_pre_lhs
 #define CB_POST_OTHER cb_post_lhs
-#define EXP_CB_POST_BCAST exp_cb_post_rhs
-#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#define EXP_CB_POST_BCAST exp_dfb_post_rhs
+#define EXP_CB_POST_OTHER exp_dfb_post_lhs
 #else
 #define CB_PRE_BCAST cb_pre_lhs
 #define CB_POST_BCAST cb_post_lhs
 #define CB_PRE_OTHER cb_pre_rhs
 #define CB_POST_OTHER cb_post_rhs
-#define EXP_CB_POST_BCAST exp_cb_post_lhs
-#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#define EXP_CB_POST_BCAST exp_dfb_post_lhs
+#define EXP_CB_POST_OTHER exp_dfb_post_rhs
 #endif
-    CircularBuffer exp_cb_bcast(cb_bcast);
-    CircularBuffer exp_cb_llk_post(cb_llk_post);
-    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
-    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
-    CircularBuffer exp_cb_out(cb_out);
+    DataflowBuffer exp_dfb_bcast(cb_bcast);
+    DataflowBuffer exp_dfb_llk_post(cb_llk_post);
+    DataflowBuffer exp_dfb_post_lhs(cb_post_lhs);
+    DataflowBuffer exp_dfb_post_rhs(cb_post_rhs);
+    DataflowBuffer exp_dfb_out(cb_out);
 
-    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    exp_dfb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
     unary_bcast_init<BroadcastType::COL>(cb_bcast, cb_llk_post);
-    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
     unary_bcast<BroadcastType::COL>(cb_bcast, 0, 0);
     tile_regs_commit();
 
     tile_regs_wait();
     pack_tile(0, cb_llk_post);
-    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.push_back(num_tiles_per_cycle);
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
@@ -96,7 +99,7 @@ ALWI void process_tile(
             num_tiles_per_cycle);
         EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
 
-        exp_cb_out.reserve_back(num_tiles_per_cycle);
+        exp_dfb_out.reserve_back(num_tiles_per_cycle);
 
 #if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
         BINARY_SFPU_INIT
@@ -128,11 +131,11 @@ ALWI void process_tile(
         }
         tile_regs_release();
 
-        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_dfb_out.push_back(num_tiles_per_cycle);
         EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
     }
     EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
-    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+    exp_dfb_bcast.pop_front(num_tiles_per_cycle);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -28,6 +28,9 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+// DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
+// still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_bcast,
@@ -47,33 +50,33 @@ ALWI void process_tile(
 #define CB_POST_BCAST cb_post_rhs
 #define CB_PRE_OTHER cb_pre_lhs
 #define CB_POST_OTHER cb_post_lhs
-#define EXP_CB_POST_BCAST exp_cb_post_rhs
-#define EXP_CB_POST_OTHER exp_cb_post_lhs
+#define EXP_CB_POST_BCAST exp_dfb_post_rhs
+#define EXP_CB_POST_OTHER exp_dfb_post_lhs
 #else
 #define CB_PRE_BCAST cb_pre_lhs
 #define CB_POST_BCAST cb_post_lhs
 #define CB_PRE_OTHER cb_pre_rhs
 #define CB_POST_OTHER cb_post_rhs
-#define EXP_CB_POST_BCAST exp_cb_post_lhs
-#define EXP_CB_POST_OTHER exp_cb_post_rhs
+#define EXP_CB_POST_BCAST exp_dfb_post_lhs
+#define EXP_CB_POST_OTHER exp_dfb_post_rhs
 #endif
-    CircularBuffer exp_cb_bcast(cb_bcast);
-    CircularBuffer exp_cb_llk_post(cb_llk_post);
-    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
-    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
-    CircularBuffer exp_cb_out(cb_out);
+    DataflowBuffer exp_dfb_bcast(cb_bcast);
+    DataflowBuffer exp_dfb_llk_post(cb_llk_post);
+    DataflowBuffer exp_dfb_post_lhs(cb_post_lhs);
+    DataflowBuffer exp_dfb_post_rhs(cb_post_rhs);
+    DataflowBuffer exp_dfb_out(cb_out);
 
-    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    exp_dfb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
     unary_bcast_init<BroadcastType::SCALAR>(cb_bcast, cb_llk_post);
-    exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
     unary_bcast<BroadcastType::SCALAR>(cb_bcast, 0, 0);
     tile_regs_commit();
 
     tile_regs_wait();
     pack_tile(0, cb_llk_post);
-    exp_cb_llk_post.push_back(num_tiles_per_cycle);
+    exp_dfb_llk_post.push_back(num_tiles_per_cycle);
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
@@ -96,7 +99,7 @@ ALWI void process_tile(
             num_tiles_per_cycle);
         EXP_CB_POST_OTHER.wait_front(num_tiles_per_cycle);
 
-        exp_cb_out.reserve_back(num_tiles_per_cycle);
+        exp_dfb_out.reserve_back(num_tiles_per_cycle);
 
 #if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
         BINARY_SFPU_INIT
@@ -128,11 +131,11 @@ ALWI void process_tile(
         }
         tile_regs_release();
 
-        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_dfb_out.push_back(num_tiles_per_cycle);
         EXP_CB_POST_OTHER.pop_front(num_tiles_per_cycle);
     }
     EXP_CB_POST_BCAST.pop_front(num_tiles_per_cycle);
-    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+    exp_dfb_bcast.pop_front(num_tiles_per_cycle);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -10,7 +10,7 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -22,7 +22,7 @@ void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
     constexpr auto cb_in1 = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
-    CircularBuffer exp_cb_out(cb_out);
+    DataflowBuffer exp_dfb_out(cb_out);
 
 #if SRC_BCAST
     constexpr auto cb_bcast = cb_in0;
@@ -37,21 +37,21 @@ void kernel_main() {
     constexpr auto cb_right = tt::CBIndex::c_6;
 #endif
 
-    CircularBuffer exp_cb_in0(cb_in0);
-    CircularBuffer exp_cb_in1(cb_in1);
-    CircularBuffer exp_cb_bcast(cb_bcast);
-    CircularBuffer exp_cb_llk_post(cb_llk_post);
-    CircularBuffer exp_cb_left(cb_left);
-    CircularBuffer exp_cb_right(cb_right);
+    DataflowBuffer exp_dfb_in0(cb_in0);
+    DataflowBuffer exp_dfb_in1(cb_in1);
+    DataflowBuffer exp_dfb_bcast(cb_bcast);
+    DataflowBuffer exp_dfb_llk_post(cb_llk_post);
+    DataflowBuffer exp_dfb_left(cb_left);
+    DataflowBuffer exp_dfb_right(cb_right);
 
     unary_op_init_common(cb_in0, cb_out);
     BINARY_SFPU_INIT
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        exp_cb_in0.wait_front(num_tiles_per_cycle);
-        exp_cb_in1.wait_front(num_tiles_per_cycle);
+        exp_dfb_in0.wait_front(num_tiles_per_cycle);
+        exp_dfb_in1.wait_front(num_tiles_per_cycle);
 
-        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        exp_dfb_llk_post.reserve_back(num_tiles_per_cycle);
         pack_reconfig_data_format(cb_out, cb_llk_post);
         unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
 
@@ -61,16 +61,16 @@ void kernel_main() {
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        exp_dfb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
 
-        exp_cb_bcast.pop_front(num_tiles_per_cycle);
+        exp_dfb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
         PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
-        exp_cb_out.reserve_back(num_tiles_per_cycle);
-        exp_cb_llk_post.wait_front(num_tiles_per_cycle);
+        exp_dfb_out.reserve_back(num_tiles_per_cycle);
+        exp_dfb_llk_post.wait_front(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
@@ -117,8 +117,8 @@ void kernel_main() {
         }
         tile_regs_release();
 
-        exp_cb_out.push_back(num_tiles_per_cycle);
-        exp_cb_left.pop_front(num_tiles_per_cycle);
-        exp_cb_right.pop_front(num_tiles_per_cycle);
+        exp_dfb_out.push_back(num_tiles_per_cycle);
+        exp_dfb_left.pop_front(num_tiles_per_cycle);
+        exp_dfb_right.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -11,7 +11,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "api/compute/bcast.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_in0,
@@ -23,7 +23,7 @@ ALWI void process_tile(
     uint32_t tile_start,
     uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
-    CircularBuffer exp_cb_out(cb_out);
+    DataflowBuffer exp_dfb_out(cb_out);
 
 #if BCAST_INPUT  // ROW_A_COL_B
                  // BCAST_INPUT == 1 : input B ( true or false tensor) is broadcasted
@@ -41,18 +41,18 @@ ALWI void process_tile(
     constexpr auto cb_right = tt::CBIndex::c_6;
 #endif
 
-    CircularBuffer exp_cb_bcast(CB_BCAST);
-    CircularBuffer exp_cb_other(CB_OTHER);
-    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    DataflowBuffer exp_dfb_bcast(CB_BCAST);
+    DataflowBuffer exp_dfb_other(CB_OTHER);
+    DataflowBuffer exp_dfb_llk_post(cb_llk_post);
 
     unary_op_init_common(cb_left, cb_out);
     BINARY_SFPU_INIT
 
-    exp_cb_bcast.wait_front(num_tiles_per_cycle);
+    exp_dfb_bcast.wait_front(num_tiles_per_cycle);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
-        exp_cb_other.wait_front(num_tiles_per_cycle);
-        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        exp_dfb_other.wait_front(num_tiles_per_cycle);
+        exp_dfb_llk_post.reserve_back(num_tiles_per_cycle);
         pack_reconfig_data_format(cb_out, cb_llk_post);
         unary_bcast_init<BroadcastType::ROW>(CB_OTHER, cb_llk_post);
 
@@ -62,16 +62,16 @@ ALWI void process_tile(
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        exp_dfb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
 
-        exp_cb_other.pop_front(num_tiles_per_cycle);
+        exp_dfb_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(CB_OTHER);
         pack_reconfig_data_format(cb_llk_post, cb_out);
         PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
-        exp_cb_out.reserve_back(num_tiles_per_cycle);
-        exp_cb_llk_post.wait_front(num_tiles_per_cycle);
+        exp_dfb_out.reserve_back(num_tiles_per_cycle);
+        exp_dfb_llk_post.wait_front(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
@@ -118,10 +118,10 @@ ALWI void process_tile(
         }
         tile_regs_release();
 
-        exp_cb_out.push_back(num_tiles_per_cycle);
-        exp_cb_llk_post.pop_front(num_tiles_per_cycle);
+        exp_dfb_out.push_back(num_tiles_per_cycle);
+        exp_dfb_llk_post.pop_front(num_tiles_per_cycle);
     }
-    exp_cb_bcast.pop_front(num_tiles_per_cycle);
+    exp_dfb_bcast.pop_front(num_tiles_per_cycle);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -40,21 +40,21 @@ void kernel_main() {
         TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.next_common_runtime_args_offset()>();
 
     Noc noc;
-    CircularBuffer cb_src(cb_id_src);
-    CircularBuffer cb_src_b(cb_id_src_b);
+    DataflowBuffer dfb_src(cb_id_src);
+    DataflowBuffer dfb_src_b(cb_id_src_b);
 
 #if SRC_SHARDED
-    cb_src.reserve_back(src_num_tiles);
-    cb_src.push_back(src_num_tiles);
+    dfb_src.reserve_back(src_num_tiles);
+    dfb_src.push_back(src_num_tiles);
 #else
-    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const uint32_t src_tile_bytes = dfb_src.get_entry_size();
     const auto src = TensorAccessor(src_args, src_addr);
 #endif
 #if SRC_SHARDED_B
-    cb_src_b.reserve_back(src_num_tiles_b);
-    cb_src_b.push_back(src_num_tiles_b);
+    dfb_src_b.reserve_back(src_num_tiles_b);
+    dfb_src_b.push_back(src_num_tiles_b);
 #else
-    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const uint32_t src_tile_bytes_b = dfb_src_b.get_entry_size();
     const auto src_b = TensorAccessor(src_b_args, src_addr_b);
 #endif
 #if !SRC_SHARDED || !SRC_SHARDED_B
@@ -101,16 +101,16 @@ void kernel_main() {
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
                              ++tw, ++num_tiles_read) {
 #if !SRC_SHARDED
-                            cb_src.reserve_back(onetile);
+                            dfb_src.reserve_back(onetile);
                             noc.async_read(
-                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                                src, dfb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
 #endif
 #if !SRC_SHARDED_B
                             // read a tile from src_b
-                            cb_src_b.reserve_back(onetile);
+                            dfb_src_b.reserve_back(onetile);
                             noc.async_read(
                                 src_b,
-                                cb_src_b,
+                                dfb_src_b,
                                 src_tile_bytes_b,
                                 {.page_id = tile_offset_b + tw},
                                 {.offset_bytes = 0});
@@ -119,10 +119,10 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if !SRC_SHARDED
-                            cb_src.push_back(onetile);
+                            dfb_src.push_back(onetile);
 #endif
 #if !SRC_SHARDED_B
-                            cb_src_b.push_back(onetile);
+                            dfb_src_b.push_back(onetile);
 #endif
                         }
                         if constexpr (!has_sharding) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -27,11 +27,11 @@ void kernel_main() {
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
 
     Noc noc;
-    CircularBuffer cb_dst(cb_id_dst);
+    DataflowBuffer dfb_dst(cb_id_dst);
 
 #if !DST_SHARDED
     constexpr auto dst_args = TensorAccessorArgs<0, 0>();
-    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
+    const uint32_t dst_tile_bytes = dfb_dst.get_entry_size();
     const auto dst = TensorAccessor(dst_args, dst_addr);
 #endif
 
@@ -66,11 +66,11 @@ void kernel_main() {
                              ++tw, ++num_tiles_written) {
 #if !DST_SHARDED
                             //  write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                            cb_dst.wait_front(onetile);
+                            dfb_dst.wait_front(onetile);
                             noc.async_write(
-                                cb_dst, dst, dst_tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
+                                dfb_dst, dst, dst_tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
                             noc.async_write_barrier();
-                            cb_dst.pop_front(onetile);
+                            dfb_dst.pop_front(onetile);
 #endif
                         }
                         if constexpr (has_sharding) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -6,7 +6,7 @@
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 #include "api/core_local_mem.h"
 
@@ -33,7 +33,7 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<0>();
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_out);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_out);
@@ -77,9 +77,9 @@ void kernel_main() {
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
                             const uint32_t current_write_len = align(current_chunk_bytes, alignment);
 
-                            cb_out.wait_front(1);
+                            dfb_out.wait_front(1);
 
-                            uint32_t l1_read_addr = cb_out.get_read_ptr();
+                            uint32_t l1_read_addr = dfb_out.get_read_ptr();
                             for (uint32_t row = 0; row < limit; ++row) {
                                 const uint32_t row_abs_idx = row_block_base_row + row;
                                 noc.async_write(
@@ -92,7 +92,7 @@ void kernel_main() {
                             }
 
                             noc.async_write_barrier();
-                            cb_out.pop_front(1);
+                            dfb_out.pop_front(1);
                         }
 
                         row_blocks_written++;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu.cpp
@@ -6,7 +6,7 @@
 
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/tile_move_copy.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -15,28 +15,28 @@ void kernel_main() {
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
     const bool scalar_is_not_1 = scalar_arg != 1u;
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);  // input_a
-    CircularBuffer cb_in1(tt::CBIndex::c_1);  // input_b
-    CircularBuffer cb_in2(tt::CBIndex::c_2);  // input_c
-    CircularBuffer cb_out(tt::CBIndex::c_3);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);  // input_a
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);  // input_b
+    DataflowBuffer dfb_in2(tt::CBIndex::c_2);  // input_c
+    DataflowBuffer dfb_out(tt::CBIndex::c_3);
 
     // output = input_a + value * input_b * input_c
-    binary_op_init_common(cb_in1.get_cb_id(), cb_in2.get_cb_id(), cb_out.get_cb_id());
+    binary_op_init_common(dfb_in1.get_id(), dfb_in2.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         // Wait for input_b and input_c first (needed for first computation)
-        cb_in1.wait_front(num_tiles_per_cycle);
-        cb_in2.wait_front(num_tiles_per_cycle);
+        dfb_in1.wait_front(num_tiles_per_cycle);
+        dfb_in2.wait_front(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
         // (input_b * input_c)
-        mul_tiles_init(cb_in1.get_cb_id(), cb_in2.get_cb_id());
-        mul_tiles(cb_in1.get_cb_id(), cb_in2.get_cb_id(), 0, 0, 0);
+        mul_tiles_init(dfb_in1.get_id(), dfb_in2.get_id());
+        mul_tiles(dfb_in1.get_id(), dfb_in2.get_id(), 0, 0, 0);
 
-        // Done with cb_in1 and cb_in2, pop them early for pipeline efficiency
-        cb_in1.pop_front(num_tiles_per_cycle);
-        cb_in2.pop_front(num_tiles_per_cycle);
+        // Done with dfb_in1 and dfb_in2, pop them early for pipeline efficiency
+        dfb_in1.pop_front(num_tiles_per_cycle);
+        dfb_in2.pop_front(num_tiles_per_cycle);
 
         // Step 2: (input_b * input_c) * value -> DST[0]
         if (scalar_is_not_1) {
@@ -45,26 +45,26 @@ void kernel_main() {
         }
 
         // Now wait for input_a (only when we need it)
-        cb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
 
-        // Step 3: Load A and add with result DST[0] + cb_in0 -> DST[0]
+        // Step 3: Load A and add with result DST[0] + dfb_in0 -> DST[0]
         binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-            cb_in0.get_cb_id());
+            dfb_in0.get_id());
         binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-            cb_in0.get_cb_id(), 0, 0);
+            dfb_in0.get_id(), 0, 0);
 
         tile_regs_commit();
         tile_regs_wait();
 
         // Reserve output buffer only when ready to write
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         // Pack the result from DST[0] to output
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_in0.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_bcast.cpp
@@ -9,7 +9,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     uint32_t cb_in0_id,
@@ -22,44 +22,44 @@ ALWI void process_tile(
     uint32_t scalar_arg) {
     using namespace ckernel;
 
-    CircularBuffer cb_in0(cb_in0_id);
-    CircularBuffer cb_in1(cb_in1_id);
-    CircularBuffer cb_in2(cb_in2_id);
-    CircularBuffer cb_out(cb_out_id);
+    DataflowBuffer dfb_in0(cb_in0_id);
+    DataflowBuffer dfb_in1(cb_in1_id);
+    DataflowBuffer dfb_in2(cb_in2_id);
+    DataflowBuffer dfb_out(cb_out_id);
 
     const bool scalar_is_not_1 = scalar_arg != 1u;
     // 3-tensor broadcast-aware synchronization - wait for broadcast CBs outside loop
 #if BCAST_A
-    cb_in0.wait_front(num_tiles_per_cycle);  // input_a is broadcast
+    dfb_in0.wait_front(num_tiles_per_cycle);  // input_a is broadcast
 #endif
 #if BCAST_B
-    cb_in1.wait_front(num_tiles_per_cycle);  // input_b is broadcast
+    dfb_in1.wait_front(num_tiles_per_cycle);  // input_b is broadcast
 #endif
 #if BCAST_C
-    cb_in2.wait_front(num_tiles_per_cycle);  // input_c is broadcast
+    dfb_in2.wait_front(num_tiles_per_cycle);  // input_c is broadcast
 #endif
 
     for (uint32_t j = tile_start; j < freq; ++j) {
         // Wait for non-broadcast CBs inside loop
 #if !BCAST_B
-        cb_in1.wait_front(num_tiles_per_cycle);
+        dfb_in1.wait_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        cb_in2.wait_front(num_tiles_per_cycle);
+        dfb_in2.wait_front(num_tiles_per_cycle);
 #endif
 
         tile_regs_acquire();
 
         // (input_b * input_c)
-        mul_tiles_init(cb_in1.get_cb_id(), cb_in2.get_cb_id());
-        mul_tiles(cb_in1.get_cb_id(), cb_in2.get_cb_id(), 0, 0, 0);
+        mul_tiles_init(dfb_in1.get_id(), dfb_in2.get_id());
+        mul_tiles(dfb_in1.get_id(), dfb_in2.get_id(), 0, 0, 0);
 
-        // Done with cb_in1 and cb_in2, pop them early for pipeline efficiency
+        // Done with dfb_in1 and dfb_in2, pop them early for pipeline efficiency
 #if !BCAST_B
-        cb_in1.pop_front(num_tiles_per_cycle);
+        dfb_in1.pop_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        cb_in2.pop_front(num_tiles_per_cycle);
+        dfb_in2.pop_front(num_tiles_per_cycle);
 #endif
 
         // (input_b * input_c) * value -> DST[0]
@@ -70,43 +70,43 @@ ALWI void process_tile(
 
 // Now wait for input_a
 #if !BCAST_A
-        cb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
 #endif
 
-        // Step 3: Load A and add with result DST[0] + cb_in0 -> DST[0]
+        // Step 3: Load A and add with result DST[0] + dfb_in0 -> DST[0]
         binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-            cb_in0.get_cb_id());
+            dfb_in0.get_id());
         binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-            cb_in0.get_cb_id(), 0, 0);
+            dfb_in0.get_id(), 0, 0);
 
         tile_regs_commit();
         tile_regs_wait();
 
         // Reserve output buffer
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         // Pack the result from DST[0] to output
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
 
         // Pop non-broadcast CBs inside loop
 #if !BCAST_A
-        cb_in0.pop_front(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
 #endif
     }
 
     // Pop broadcast CBs outside loop
 #if BCAST_A
-    cb_in0.pop_front(num_tiles_per_cycle);
+    dfb_in0.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_B
-    cb_in1.pop_front(num_tiles_per_cycle);
+    dfb_in1.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_C
-    cb_in2.pop_front(num_tiles_per_cycle);
+    dfb_in2.pop_front(num_tiles_per_cycle);
 #endif
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_rowbcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_rowbcast.cpp
@@ -11,7 +11,7 @@
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_unary/addcmul.h"
 #include "api/compute/eltwise_unary/addcdiv.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -20,98 +20,98 @@ void kernel_main() {
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
     const bool scalar_is_not_1 = scalar_arg != 1u;
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);  // input_a
-    CircularBuffer cb_in1(tt::CBIndex::c_1);  // input_b
-    CircularBuffer cb_in2(tt::CBIndex::c_2);  // input_c
-    CircularBuffer cb_out(tt::CBIndex::c_3);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);  // input_a
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);  // input_b
+    DataflowBuffer dfb_in2(tt::CBIndex::c_2);  // input_c
+    DataflowBuffer dfb_out(tt::CBIndex::c_3);
 
     // LLK broadcast destination CBs (dedicated per-input):
-    CircularBuffer cb_llk_a(tt::CBIndex::c_4);  // broadcasted A (if used)
-    CircularBuffer cb_llk_b(tt::CBIndex::c_5);  // broadcasted B (if used)
-    CircularBuffer cb_llk_c(tt::CBIndex::c_6);  // broadcasted C (if used)
+    DataflowBuffer dfb_llk_a(tt::CBIndex::c_4);  // broadcasted A (if used)
+    DataflowBuffer dfb_llk_b(tt::CBIndex::c_5);  // broadcasted B (if used)
+    DataflowBuffer dfb_llk_c(tt::CBIndex::c_6);  // broadcasted C (if used)
 
 // Effective CBs chosen at compile-time depending on broadcast flags
 #if BCAST_A
-    CircularBuffer& cb_eff_a = cb_llk_a;
+    DataflowBuffer& dfb_eff_a = dfb_llk_a;
 #else
-    CircularBuffer& cb_eff_a = cb_in0;
+    DataflowBuffer& dfb_eff_a = dfb_in0;
 #endif
 #if BCAST_B
-    CircularBuffer& cb_eff_b = cb_llk_b;
+    DataflowBuffer& dfb_eff_b = dfb_llk_b;
 #else
-    CircularBuffer& cb_eff_b = cb_in1;
+    DataflowBuffer& dfb_eff_b = dfb_in1;
 #endif
 #if BCAST_C
-    CircularBuffer& cb_eff_c = cb_llk_c;
+    DataflowBuffer& dfb_eff_c = dfb_llk_c;
 #else
-    CircularBuffer& cb_eff_c = cb_in2;
+    DataflowBuffer& dfb_eff_c = dfb_in2;
 #endif
 
-    // Initialize binary unit for B*C path; output packer initialized with cb_out
-    binary_op_init_common(cb_eff_b.get_cb_id(), cb_eff_c.get_cb_id(), cb_out.get_cb_id());
+    // Initialize binary unit for B*C path; output packer initialized with dfb_out
+    binary_op_init_common(dfb_eff_b.get_id(), dfb_eff_c.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
 // 1) Prepare B and C (broadcast if required), then compute mul(B, C) -> DST[0]
 // Perform LLK row broadcast for B if requested
 #if BCAST_B
-        cb_in1.wait_front(num_tiles_per_cycle);
-        cb_llk_b.reserve_back(num_tiles_per_cycle);
-        unary_bcast_init<BroadcastType::ROW>(cb_in1.get_cb_id(), cb_llk_b.get_cb_id());
+        dfb_in1.wait_front(num_tiles_per_cycle);
+        dfb_llk_b.reserve_back(num_tiles_per_cycle);
+        unary_bcast_init<BroadcastType::ROW>(dfb_in1.get_id(), dfb_llk_b.get_id());
         tile_regs_acquire();
-        unary_bcast<BroadcastType::ROW>(cb_in1.get_cb_id(), 0, 0);
+        unary_bcast<BroadcastType::ROW>(dfb_in1.get_id(), 0, 0);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(0, cb_llk_b.get_cb_id());
-        cb_llk_b.push_back(num_tiles_per_cycle);
+        pack_tile(0, dfb_llk_b.get_id());
+        dfb_llk_b.push_back(num_tiles_per_cycle);
         tile_regs_release();
-        cb_in1.pop_front(num_tiles_per_cycle);
+        dfb_in1.pop_front(num_tiles_per_cycle);
 #endif
 
 // Perform LLK row broadcast for C if requested
 #if BCAST_C
-        cb_in2.wait_front(num_tiles_per_cycle);
-        cb_llk_c.reserve_back(num_tiles_per_cycle);
-        unary_bcast_init<BroadcastType::ROW>(cb_in2.get_cb_id(), cb_llk_c.get_cb_id());
+        dfb_in2.wait_front(num_tiles_per_cycle);
+        dfb_llk_c.reserve_back(num_tiles_per_cycle);
+        unary_bcast_init<BroadcastType::ROW>(dfb_in2.get_id(), dfb_llk_c.get_id());
         tile_regs_acquire();
-        unary_bcast<BroadcastType::ROW>(cb_in2.get_cb_id(), 0, 0);
+        unary_bcast<BroadcastType::ROW>(dfb_in2.get_id(), 0, 0);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(0, cb_llk_c.get_cb_id());
-        cb_llk_c.push_back(num_tiles_per_cycle);
+        pack_tile(0, dfb_llk_c.get_id());
+        dfb_llk_c.push_back(num_tiles_per_cycle);
         tile_regs_release();
-        cb_in2.pop_front(num_tiles_per_cycle);
+        dfb_in2.pop_front(num_tiles_per_cycle);
 #endif
 
 // Perform LLK row broadcast for A if requested (do this before compute regs session)
 #if BCAST_A
-        cb_in0.wait_front(num_tiles_per_cycle);
-        cb_llk_a.reserve_back(num_tiles_per_cycle);
-        unary_bcast_init<BroadcastType::ROW>(cb_in0.get_cb_id(), cb_llk_a.get_cb_id());
+        dfb_in0.wait_front(num_tiles_per_cycle);
+        dfb_llk_a.reserve_back(num_tiles_per_cycle);
+        unary_bcast_init<BroadcastType::ROW>(dfb_in0.get_id(), dfb_llk_a.get_id());
         tile_regs_acquire();
-        unary_bcast<BroadcastType::ROW>(cb_in0.get_cb_id(), 0, 0);
+        unary_bcast<BroadcastType::ROW>(dfb_in0.get_id(), 0, 0);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(0, cb_llk_a.get_cb_id());
-        cb_llk_a.push_back(num_tiles_per_cycle);
+        pack_tile(0, dfb_llk_a.get_id());
+        dfb_llk_a.push_back(num_tiles_per_cycle);
         tile_regs_release();
-        cb_in0.pop_front(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
 #endif
 
         // Ensure sources available
-        cb_eff_a.wait_front(num_tiles_per_cycle);
-        cb_eff_b.wait_front(num_tiles_per_cycle);
-        cb_eff_c.wait_front(num_tiles_per_cycle);
+        dfb_eff_a.wait_front(num_tiles_per_cycle);
+        dfb_eff_b.wait_front(num_tiles_per_cycle);
+        dfb_eff_c.wait_front(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
-        copy_tile_init(cb_eff_a.get_cb_id());
-        copy_tile(cb_eff_a.get_cb_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
+        copy_tile_init(dfb_eff_a.get_id());
+        copy_tile(dfb_eff_a.get_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
 
-        copy_tile_init(cb_eff_b.get_cb_id());
-        copy_tile(cb_eff_b.get_cb_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
+        copy_tile_init(dfb_eff_b.get_id());
+        copy_tile(dfb_eff_b.get_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
 
-        copy_tile_init(cb_eff_c.get_cb_id());
-        copy_tile(cb_eff_c.get_cb_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
+        copy_tile_init(dfb_eff_c.get_id());
+        copy_tile(dfb_eff_c.get_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
 
         TERNARY_SFPU_OP_INIT();
         TERNARY_SFPU_OP_FUNC(0, 1, 2, 0, scalar_arg);
@@ -120,16 +120,16 @@ void kernel_main() {
         tile_regs_wait();
 
         // Reserve output buffer only when ready to write
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         // Pack the result from DST[0] to output
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_eff_a.pop_front(num_tiles_per_cycle);
-        cb_eff_b.pop_front(num_tiles_per_cycle);
-        cb_eff_c.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_eff_a.pop_front(num_tiles_per_cycle);
+        dfb_eff_b.pop_front(num_tiles_per_cycle);
+        dfb_eff_c.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp
@@ -11,37 +11,37 @@
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/eltwise_unary/addcmul.h"
 #include "api/compute/eltwise_unary/addcdiv.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t scalar_arg = get_arg_val<uint32_t>(3);
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);  // input_a
-    CircularBuffer cb_in1(tt::CBIndex::c_1);  // input_b
-    CircularBuffer cb_in2(tt::CBIndex::c_2);  // input_c
-    CircularBuffer cb_out(tt::CBIndex::c_3);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);  // input_a
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);  // input_b
+    DataflowBuffer dfb_in2(tt::CBIndex::c_2);  // input_c
+    DataflowBuffer dfb_out(tt::CBIndex::c_3);
 
-    unary_op_init_common(cb_in0.get_cb_id(), cb_out.get_cb_id());
+    unary_op_init_common(dfb_in0.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_in0.wait_front(num_tiles_per_cycle);
-        cb_in1.wait_front(num_tiles_per_cycle);
-        cb_in2.wait_front(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in1.wait_front(num_tiles_per_cycle);
+        dfb_in2.wait_front(num_tiles_per_cycle);
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
-        copy_tile_init(cb_in0.get_cb_id());
-        copy_tile(cb_in0.get_cb_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
+        copy_tile_init(dfb_in0.get_id());
+        copy_tile(dfb_in0.get_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in1.get_cb_id());
-        copy_tile(cb_in1.get_cb_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
+        copy_tile_init(dfb_in1.get_id());
+        copy_tile(dfb_in1.get_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in2.get_cb_id());
-        copy_tile(cb_in2.get_cb_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
+        copy_tile_init(dfb_in2.get_id());
+        copy_tile(dfb_in2.get_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
 
         TERNARY_SFPU_OP_INIT();
         TERNARY_SFPU_OP_FUNC(0, 1, 2, 0, scalar_arg);
@@ -49,13 +49,13 @@ void kernel_main() {
         tile_regs_commit();
         tile_regs_wait();
 
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_in0.pop_front(num_tiles_per_cycle);
-        cb_in1.pop_front(num_tiles_per_cycle);
-        cb_in2.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
+        dfb_in1.pop_front(num_tiles_per_cycle);
+        dfb_in2.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu_bcast.cpp
@@ -8,7 +8,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/addcmul.h"
 #include "api/compute/eltwise_unary/addcdiv.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     uint32_t cb_in0_id,
@@ -21,47 +21,47 @@ ALWI void process_tile(
     uint32_t scalar_arg) {
     using namespace ckernel;
 
-    CircularBuffer cb_in0(cb_in0_id);
-    CircularBuffer cb_in1(cb_in1_id);
-    CircularBuffer cb_in2(cb_in2_id);
-    CircularBuffer cb_out(cb_out_id);
+    DataflowBuffer dfb_in0(cb_in0_id);
+    DataflowBuffer dfb_in1(cb_in1_id);
+    DataflowBuffer dfb_in2(cb_in2_id);
+    DataflowBuffer dfb_out(cb_out_id);
 
     // 3-tensor broadcast-aware synchronization - wait for broadcast CBs outside loop
 #if BCAST_A
-    cb_in0.wait_front(num_tiles_per_cycle);  // input_a is broadcast
+    dfb_in0.wait_front(num_tiles_per_cycle);  // input_a is broadcast
 #endif
 #if BCAST_B
-    cb_in1.wait_front(num_tiles_per_cycle);  // input_b is broadcast
+    dfb_in1.wait_front(num_tiles_per_cycle);  // input_b is broadcast
 #endif
 #if BCAST_C
-    cb_in2.wait_front(num_tiles_per_cycle);  // input_c is broadcast
+    dfb_in2.wait_front(num_tiles_per_cycle);  // input_c is broadcast
 #endif
 
     for (uint32_t j = tile_start; j < freq; ++j) {
         // Wait for non-broadcast CBs inside loop
 #if !BCAST_A
-        cb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_B
-        cb_in1.wait_front(num_tiles_per_cycle);
+        dfb_in1.wait_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        cb_in2.wait_front(num_tiles_per_cycle);
+        dfb_in2.wait_front(num_tiles_per_cycle);
 #endif
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
         // Load all three inputs into DST registers
-        copy_tile_init(cb_in0.get_cb_id());
-        copy_tile(cb_in0.get_cb_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
+        copy_tile_init(dfb_in0.get_id());
+        copy_tile(dfb_in0.get_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in1.get_cb_id());
-        copy_tile(cb_in1.get_cb_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
+        copy_tile_init(dfb_in1.get_id());
+        copy_tile(dfb_in1.get_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in2.get_cb_id());
-        copy_tile(cb_in2.get_cb_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
+        copy_tile_init(dfb_in2.get_id());
+        copy_tile(dfb_in2.get_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
 
         // Use direct addcmul kernel: computes input_a + scalar_arg * input_b * input_c -> DST[0]
         TERNARY_SFPU_OP_INIT();
@@ -71,33 +71,33 @@ ALWI void process_tile(
         tile_regs_wait();
 
         // Pack the result from DST[0] to output
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
 
         // Pop non-broadcast CBs inside loop
 #if !BCAST_A
-        cb_in0.pop_front(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_B
-        cb_in1.pop_front(num_tiles_per_cycle);
+        dfb_in1.pop_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        cb_in2.pop_front(num_tiles_per_cycle);
+        dfb_in2.pop_front(num_tiles_per_cycle);
 #endif
     }
 
     // Pop broadcast CBs outside loop
 #if BCAST_A
-    cb_in0.pop_front(num_tiles_per_cycle);
+    dfb_in0.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_B
-    cb_in1.pop_front(num_tiles_per_cycle);
+    dfb_in1.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_C
-    cb_in2.pop_front(num_tiles_per_cycle);
+    dfb_in2.pop_front(num_tiles_per_cycle);
 #endif
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
@@ -9,37 +9,37 @@
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/mul_int_sfpu.h"
 #include "api/compute/add_int_sfpu.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t scalar_arg = get_arg_val<uint32_t>(3);
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
 
-    CircularBuffer cb_in0(tt::CBIndex::c_0);  // input_a
-    CircularBuffer cb_in1(tt::CBIndex::c_1);  // input_b
-    CircularBuffer cb_in2(tt::CBIndex::c_2);  // input_c
-    CircularBuffer cb_out(tt::CBIndex::c_3);
+    DataflowBuffer dfb_in0(tt::CBIndex::c_0);  // input_a
+    DataflowBuffer dfb_in1(tt::CBIndex::c_1);  // input_b
+    DataflowBuffer dfb_in2(tt::CBIndex::c_2);  // input_c
+    DataflowBuffer dfb_out(tt::CBIndex::c_3);
 
-    unary_op_init_common(cb_in0.get_cb_id(), cb_out.get_cb_id());
+    unary_op_init_common(dfb_in0.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_in0.wait_front(num_tiles_per_cycle);
-        cb_in1.wait_front(num_tiles_per_cycle);
-        cb_in2.wait_front(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in1.wait_front(num_tiles_per_cycle);
+        dfb_in2.wait_front(num_tiles_per_cycle);
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
-        copy_tile_init(cb_in0.get_cb_id());
-        copy_tile(cb_in0.get_cb_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
+        copy_tile_init(dfb_in0.get_id());
+        copy_tile(dfb_in0.get_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in1.get_cb_id());
-        copy_tile(cb_in1.get_cb_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
+        copy_tile_init(dfb_in1.get_id());
+        copy_tile(dfb_in1.get_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in2.get_cb_id());
-        copy_tile(cb_in2.get_cb_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
+        copy_tile_init(dfb_in2.get_id());
+        copy_tile(dfb_in2.get_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
 
         fill_tile_init();
         fill_tile_int<ADDCMUL_DATA_FORMAT>(3, scalar_arg);
@@ -54,13 +54,13 @@ void kernel_main() {
         tile_regs_commit();
         tile_regs_wait();
 
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_in0.pop_front(num_tiles_per_cycle);
-        cb_in1.pop_front(num_tiles_per_cycle);
-        cb_in2.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
+        dfb_in1.pop_front(num_tiles_per_cycle);
+        dfb_in2.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp
@@ -9,7 +9,7 @@
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/mul_int_sfpu.h"
 #include "api/compute/add_int_sfpu.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_in0_id,
@@ -22,47 +22,47 @@ ALWI void process_tile(
     uint32_t scalar_arg) {
     using namespace ckernel;
 
-    CircularBuffer cb_in0(cb_in0_id);
-    CircularBuffer cb_in1(cb_in1_id);
-    CircularBuffer cb_in2(cb_in2_id);
-    CircularBuffer cb_out(cb_out_id);
+    DataflowBuffer dfb_in0(cb_in0_id);
+    DataflowBuffer dfb_in1(cb_in1_id);
+    DataflowBuffer dfb_in2(cb_in2_id);
+    DataflowBuffer dfb_out(cb_out_id);
 
     // 3-tensor broadcast-aware synchronization - wait for broadcast CBs outside loop
 #if BCAST_A
-    cb_in0.wait_front(num_tiles_per_cycle);  // input_a is broadcast
+    dfb_in0.wait_front(num_tiles_per_cycle);  // input_a is broadcast
 #endif
 #if BCAST_B
-    cb_in1.wait_front(num_tiles_per_cycle);  // input_b is broadcast
+    dfb_in1.wait_front(num_tiles_per_cycle);  // input_b is broadcast
 #endif
 #if BCAST_C
-    cb_in2.wait_front(num_tiles_per_cycle);  // input_c is broadcast
+    dfb_in2.wait_front(num_tiles_per_cycle);  // input_c is broadcast
 #endif
 
     for (uint32_t j = tile_start; j < freq; ++j) {
         // Wait for non-broadcast CBs inside loop
 #if !BCAST_A
-        cb_in0.wait_front(num_tiles_per_cycle);
+        dfb_in0.wait_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_B
-        cb_in1.wait_front(num_tiles_per_cycle);
+        dfb_in1.wait_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        cb_in2.wait_front(num_tiles_per_cycle);
+        dfb_in2.wait_front(num_tiles_per_cycle);
 #endif
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
         // Load all three inputs into DST registers
-        copy_tile_init(cb_in0.get_cb_id());
-        copy_tile(cb_in0.get_cb_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
+        copy_tile_init(dfb_in0.get_id());
+        copy_tile(dfb_in0.get_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in1.get_cb_id());
-        copy_tile(cb_in1.get_cb_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
+        copy_tile_init(dfb_in1.get_id());
+        copy_tile(dfb_in1.get_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
 
-        copy_tile_init(cb_in2.get_cb_id());
-        copy_tile(cb_in2.get_cb_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
+        copy_tile_init(dfb_in2.get_id());
+        copy_tile(dfb_in2.get_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
 
         fill_tile_init();
         fill_tile_int<ADDCMUL_DATA_FORMAT>(3, scalar_arg);
@@ -78,33 +78,33 @@ ALWI void process_tile(
         tile_regs_wait();
 
         // Pack the result from DST[0] to output
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
 
         // Pop non-broadcast CBs inside loop
 #if !BCAST_A
-        cb_in0.pop_front(num_tiles_per_cycle);
+        dfb_in0.pop_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_B
-        cb_in1.pop_front(num_tiles_per_cycle);
+        dfb_in1.pop_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        cb_in2.pop_front(num_tiles_per_cycle);
+        dfb_in2.pop_front(num_tiles_per_cycle);
 #endif
     }
 
     // Pop broadcast CBs outside loop
 #if BCAST_A
-    cb_in0.pop_front(num_tiles_per_cycle);
+    dfb_in0.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_B
-    cb_in1.pop_front(num_tiles_per_cycle);
+    dfb_in1.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_C
-    cb_in2.pop_front(num_tiles_per_cycle);
+    dfb_in2.pop_front(num_tiles_per_cycle);
 #endif
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/eltwise_unary/fill.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     uint32_t predicate_cb_id,
@@ -21,46 +22,46 @@ ALWI void process_tile(
     uint32_t scalar) {
     using namespace ckernel;
 
-    CircularBuffer predicate_cb(predicate_cb_id);
-    CircularBuffer tensor_cb(tensor_cb_id);
-    CircularBuffer cb_out(cb_out_id);
+    DataflowBuffer predicate_dfb(predicate_cb_id);
+    DataflowBuffer tensor_dfb(tensor_cb_id);
+    DataflowBuffer dfb_out(cb_out_id);
 
 #if BCAST_A
-    predicate_cb.wait_front(num_tiles_per_cycle);  // predicate_cb is broadcast
+    predicate_dfb.wait_front(num_tiles_per_cycle);  // predicate_dfb is broadcast
 #endif
 #if BCAST_B && !BCAST_C  // TTS case: true tensor is broadcast
-    tensor_cb.wait_front(num_tiles_per_cycle);
+    tensor_dfb.wait_front(num_tiles_per_cycle);
 #endif
 #if BCAST_C && !BCAST_B  // TST case: false tensor is broadcast
-    tensor_cb.wait_front(num_tiles_per_cycle);
+    tensor_dfb.wait_front(num_tiles_per_cycle);
 #endif
 
     for (uint32_t j = tile_start; j < freq; ++j) {
         // Wait for non-broadcast CBs inside loop
 #if !BCAST_A
-        predicate_cb.wait_front(num_tiles_per_cycle);
+        predicate_dfb.wait_front(num_tiles_per_cycle);
 #endif
 #if !(BCAST_B && !BCAST_C) && !(BCAST_C && !BCAST_B)  // Neither or both broadcast
-        tensor_cb.wait_front(num_tiles_per_cycle);
+        tensor_dfb.wait_front(num_tiles_per_cycle);
 #endif
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
         // Copy predicate to destination register 0
-        copy_tile_init(predicate_cb.get_cb_id());
-        copy_tile(predicate_cb.get_cb_id(), 0, 0);
+        copy_tile_init(predicate_dfb.get_id());
+        copy_tile(predicate_dfb.get_id(), 0, 0);
 
         // Fill scalar and copy tensor based on variant
         fill_tile_init();
-        copy_tile_init(tensor_cb.get_cb_id());
+        copy_tile_init(tensor_dfb.get_id());
 
         // TTS: scalar=false (reg 2), tensor=true (reg 1)
         // TST: scalar=true (reg 1), tensor=false (reg 2)
         if constexpr (get_compile_time_arg_val(1) == 0) {  // TTS: scalar is false
             // Copy true tensor to reg 1
-            copy_tile(tensor_cb.get_cb_id(), 0, 1);
+            copy_tile(tensor_dfb.get_id(), 0, 1);
             // Fill false scalar to reg 2
 #ifdef FILL_WITH_VALUE_FLOAT
             const auto scalar_val = reinterpret_cast<const float*>(&scalar);
@@ -79,7 +80,7 @@ ALWI void process_tile(
             FILL_LLK(1, scalar);
 #endif
             // Copy false tensor to reg 2
-            copy_tile(tensor_cb.get_cb_id(), 0, 2);
+            copy_tile(tensor_dfb.get_id(), 0, 2);
         }
 
         // Perform the ternary operation
@@ -90,29 +91,29 @@ ALWI void process_tile(
 
         tile_regs_wait();
 
-        pack_tile(0, cb_out.get_cb_id());  // result is stored in predicate register
+        pack_tile(0, dfb_out.get_id());  // result is stored in predicate register
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
 
         // Pop non-broadcast CBs inside loop
 #if !BCAST_A
-        predicate_cb.pop_front(num_tiles_per_cycle);
+        predicate_dfb.pop_front(num_tiles_per_cycle);
 #endif
 #if !(BCAST_B && !BCAST_C) && !(BCAST_C && !BCAST_B)  // Neither or both broadcast
-        tensor_cb.pop_front(num_tiles_per_cycle);
+        tensor_dfb.pop_front(num_tiles_per_cycle);
 #endif
     }
 
     // Pop broadcast CBs outside loop
 #if BCAST_A
-    predicate_cb.pop_front(num_tiles_per_cycle);
+    predicate_dfb.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_B && !BCAST_C  // TTS case: true tensor is broadcast
-    tensor_cb.pop_front(num_tiles_per_cycle);
+    tensor_dfb.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_C && !BCAST_B  // TST case: false tensor is broadcast
-    tensor_cb.pop_front(num_tiles_per_cycle);
+    tensor_dfb.pop_front(num_tiles_per_cycle);
 #endif
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_unary/lerp.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI void process_tile(
     uint32_t predicate_cb_id,
@@ -20,47 +21,47 @@ ALWI void process_tile(
     uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
 
-    CircularBuffer predicate_cb(predicate_cb_id);
-    CircularBuffer true_cb(true_cb_id);
-    CircularBuffer false_cb(false_cb_id);
-    CircularBuffer cb_out(cb_out_id);
+    DataflowBuffer predicate_dfb(predicate_cb_id);
+    DataflowBuffer true_dfb(true_cb_id);
+    DataflowBuffer false_dfb(false_cb_id);
+    DataflowBuffer dfb_out(cb_out_id);
 
     // 3-tensor broadcast-aware synchronization - wait for broadcast CBs outside loop
 #if BCAST_A
-    predicate_cb.wait_front(num_tiles_per_cycle);  // predicate_cb is broadcast
+    predicate_dfb.wait_front(num_tiles_per_cycle);  // predicate_dfb is broadcast
 #endif
 #if BCAST_B
-    true_cb.wait_front(num_tiles_per_cycle);  // true_cb is broadcast
+    true_dfb.wait_front(num_tiles_per_cycle);  // true_dfb is broadcast
 #endif
 #if BCAST_C
-    false_cb.wait_front(num_tiles_per_cycle);  // false_cb is broadcast
+    false_dfb.wait_front(num_tiles_per_cycle);  // false_dfb is broadcast
 #endif
 
     for (uint32_t j = tile_start; j < freq; ++j) {
         // Wait for non-broadcast CBs inside loop
 #if !BCAST_A
-        predicate_cb.wait_front(num_tiles_per_cycle);
+        predicate_dfb.wait_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_B
-        true_cb.wait_front(num_tiles_per_cycle);
+        true_dfb.wait_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        false_cb.wait_front(num_tiles_per_cycle);
+        false_dfb.wait_front(num_tiles_per_cycle);
 #endif
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
         // Copy all 3 inputs to destination registers
-        copy_tile_init(predicate_cb.get_cb_id());
-        copy_tile(predicate_cb.get_cb_id(), 0, 0);  // predicate to reg 0, 3, 6, ...
+        copy_tile_init(predicate_dfb.get_id());
+        copy_tile(predicate_dfb.get_id(), 0, 0);  // predicate to reg 0, 3, 6, ...
 
-        copy_tile_init(true_cb.get_cb_id());
-        copy_tile(true_cb.get_cb_id(), 0, 1);  // true to reg 1, 4, 7, ...
+        copy_tile_init(true_dfb.get_id());
+        copy_tile(true_dfb.get_id(), 0, 1);  // true to reg 1, 4, 7, ...
 
-        copy_tile_init(false_cb.get_cb_id());
-        copy_tile(false_cb.get_cb_id(), 0, 2);  // false to reg 2, 5, 8, ...
+        copy_tile_init(false_dfb.get_id());
+        copy_tile(false_dfb.get_id(), 0, 2);  // false to reg 2, 5, 8, ...
 
         // Perform the ternary operation
         TERNARY_SFPU_OP_INIT();
@@ -70,32 +71,32 @@ ALWI void process_tile(
 
         tile_regs_wait();
 
-        pack_tile(0, cb_out.get_cb_id());  // result is stored in predicate register
+        pack_tile(0, dfb_out.get_id());  // result is stored in predicate register
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
 
         // Pop non-broadcast CBs inside loop
 #if !BCAST_A
-        predicate_cb.pop_front(num_tiles_per_cycle);
+        predicate_dfb.pop_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_B
-        true_cb.pop_front(num_tiles_per_cycle);
+        true_dfb.pop_front(num_tiles_per_cycle);
 #endif
 #if !BCAST_C
-        false_cb.pop_front(num_tiles_per_cycle);
+        false_dfb.pop_front(num_tiles_per_cycle);
 #endif
     }
 
     // Pop broadcast CBs outside loop
 #if BCAST_A
-    predicate_cb.pop_front(num_tiles_per_cycle);
+    predicate_dfb.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_B
-    true_cb.pop_front(num_tiles_per_cycle);
+    true_dfb.pop_front(num_tiles_per_cycle);
 #endif
 #if BCAST_C
-    false_cb.pop_front(num_tiles_per_cycle);
+    false_dfb.pop_front(num_tiles_per_cycle);
 #endif
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/eltwise_unary/lerp.h"
 #include "api/compute/eltwise_unary/fill.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -18,31 +19,31 @@ void kernel_main() {
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
     constexpr bool scalar_is_true = get_compile_time_arg_val(1);           // 1=TST (scalar=true), 0=TTS (scalar=false)
 
-    CircularBuffer cb_pre_in1(tt::CBIndex::c_0);
-    CircularBuffer cb_pre_in2(tt::CBIndex::c_1);
-    CircularBuffer cb_out(tt::CBIndex::c_3);
+    DataflowBuffer dfb_pre_in1(tt::CBIndex::c_0);
+    DataflowBuffer dfb_pre_in2(tt::CBIndex::c_1);
+    DataflowBuffer dfb_out(tt::CBIndex::c_3);
 
-    unary_op_init_common(cb_pre_in1.get_cb_id(), cb_out.get_cb_id());
+    unary_op_init_common(dfb_pre_in1.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_pre_in1.wait_front(num_tiles_per_cycle);
-        cb_pre_in2.wait_front(num_tiles_per_cycle);
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_pre_in1.wait_front(num_tiles_per_cycle);
+        dfb_pre_in2.wait_front(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
         // Always copy condition to dst reg 0
-        copy_tile_to_dst_init_short(cb_pre_in1.get_cb_id());
-        copy_tile(cb_pre_in1.get_cb_id(), 0, 0);  // Copy condition to dst reg 0
+        copy_tile_to_dst_init_short(dfb_pre_in1.get_id());
+        copy_tile(dfb_pre_in1.get_id(), 0, 0);  // Copy condition to dst reg 0
 
         // Copy tensor to appropriate dst register based on variant
-        copy_tile_to_dst_init_short(cb_pre_in2.get_cb_id());
+        copy_tile_to_dst_init_short(dfb_pre_in2.get_id());
         if constexpr (scalar_is_true) {
             // TST: tensor is false value, goes to dst reg 2
-            copy_tile(cb_pre_in2.get_cb_id(), 0, 2);  // Copy false tensor to dst reg 2
+            copy_tile(dfb_pre_in2.get_id(), 0, 2);  // Copy false tensor to dst reg 2
         } else {
             // TTS: tensor is true value, goes to dst reg 1
-            copy_tile(cb_pre_in2.get_cb_id(), 0, 1);  // Copy true tensor to dst reg 1
+            copy_tile(dfb_pre_in2.get_id(), 0, 1);  // Copy true tensor to dst reg 1
         }
 
         // Fill scalar value to appropriate dst register
@@ -72,12 +73,12 @@ void kernel_main() {
         tile_regs_commit();
         tile_regs_wait();
 
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_pre_in1.pop_front(num_tiles_per_cycle);
-        cb_pre_in2.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_pre_in1.pop_front(num_tiles_per_cycle);
+        dfb_pre_in2.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
@@ -10,36 +10,37 @@
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/eltwise_unary/lerp.h"
 #include "api/compute/eltwise_unary/snake_beta.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
 
-    CircularBuffer cb_pre_in1(tt::CBIndex::c_0);
-    CircularBuffer cb_pre_in2(tt::CBIndex::c_1);
-    CircularBuffer cb_pre_in3(tt::CBIndex::c_2);
-    CircularBuffer cb_out(tt::CBIndex::c_3);
+    DataflowBuffer dfb_pre_in1(tt::CBIndex::c_0);
+    DataflowBuffer dfb_pre_in2(tt::CBIndex::c_1);
+    DataflowBuffer dfb_pre_in3(tt::CBIndex::c_2);
+    DataflowBuffer dfb_out(tt::CBIndex::c_3);
 
-    unary_op_init_common(cb_pre_in1.get_cb_id(), cb_out.get_cb_id());
+    unary_op_init_common(dfb_pre_in1.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_pre_in1.wait_front(num_tiles_per_cycle);
-        cb_pre_in2.wait_front(num_tiles_per_cycle);
-        cb_pre_in3.wait_front(num_tiles_per_cycle);
+        dfb_pre_in1.wait_front(num_tiles_per_cycle);
+        dfb_pre_in2.wait_front(num_tiles_per_cycle);
+        dfb_pre_in3.wait_front(num_tiles_per_cycle);
 
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
-        copy_tile_to_dst_init_short(cb_pre_in1.get_cb_id());
-        copy_tile(cb_pre_in1.get_cb_id(), 0, 0);  // Copy to dst reg 0
+        copy_tile_to_dst_init_short(dfb_pre_in1.get_id());
+        copy_tile(dfb_pre_in1.get_id(), 0, 0);  // Copy to dst reg 0
 
-        copy_tile_to_dst_init_short(cb_pre_in2.get_cb_id());
-        copy_tile(cb_pre_in2.get_cb_id(), 0, 1);  // Copy to dst reg 1
+        copy_tile_to_dst_init_short(dfb_pre_in2.get_id());
+        copy_tile(dfb_pre_in2.get_id(), 0, 1);  // Copy to dst reg 1
 
-        copy_tile_to_dst_init_short(cb_pre_in3.get_cb_id());
-        copy_tile(cb_pre_in3.get_cb_id(), 0, 2);  // Copy to dst reg 2
+        copy_tile_to_dst_init_short(dfb_pre_in3.get_id());
+        copy_tile(dfb_pre_in3.get_id(), 0, 2);  // Copy to dst reg 2
 
         TERNARY_SFPU_OP_INIT();
         TERNARY_SFPU_OP_FUNC(0, 1, 2, 0);
@@ -47,13 +48,13 @@ void kernel_main() {
         tile_regs_commit();
         tile_regs_wait();
 
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
 
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
-        cb_pre_in1.pop_front(num_tiles_per_cycle);
-        cb_pre_in2.pop_front(num_tiles_per_cycle);
-        cb_pre_in3.pop_front(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
+        dfb_pre_in1.pop_front(num_tiles_per_cycle);
+        dfb_pre_in2.pop_front(num_tiles_per_cycle);
+        dfb_pre_in3.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
@@ -21,6 +21,7 @@
 #include "api/compute/eltwise_unary/snake_beta.h"
 #include "api/compute/bcast.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -28,110 +29,110 @@ void kernel_main() {
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // typically 1
 
     // Pre-CBs for inputs A, B, C and output CB
-    CircularBuffer cb_out(tt::CBIndex::c_3);
+    DataflowBuffer dfb_out(tt::CBIndex::c_3);
 #if BCAST_A
-    CircularBuffer cb_pre_a(tt::CBIndex::c_0);
-    CircularBuffer cb_bcast_a(tt::CBIndex::c_4);
-    CircularBuffer cb_eff_a = cb_bcast_a;
+    DataflowBuffer dfb_pre_a(tt::CBIndex::c_0);
+    DataflowBuffer dfb_bcast_a(tt::CBIndex::c_4);
+    DataflowBuffer dfb_eff_a = dfb_bcast_a;
 #else
-    CircularBuffer cb_eff_a(tt::CBIndex::c_0);
+    DataflowBuffer dfb_eff_a(tt::CBIndex::c_0);
 #endif
 #if BCAST_B
-    CircularBuffer cb_pre_b(tt::CBIndex::c_1);
-    CircularBuffer cb_bcast_b(tt::CBIndex::c_5);
-    CircularBuffer cb_eff_b = cb_bcast_b;
+    DataflowBuffer dfb_pre_b(tt::CBIndex::c_1);
+    DataflowBuffer dfb_bcast_b(tt::CBIndex::c_5);
+    DataflowBuffer dfb_eff_b = dfb_bcast_b;
 #else
-    CircularBuffer cb_eff_b(tt::CBIndex::c_1);
+    DataflowBuffer dfb_eff_b(tt::CBIndex::c_1);
 #endif
 #if BCAST_C
-    CircularBuffer cb_pre_c(tt::CBIndex::c_2);
-    CircularBuffer cb_bcast_c(tt::CBIndex::c_6);
-    CircularBuffer cb_eff_c = cb_bcast_c;
+    DataflowBuffer dfb_pre_c(tt::CBIndex::c_2);
+    DataflowBuffer dfb_bcast_c(tt::CBIndex::c_6);
+    DataflowBuffer dfb_eff_c = dfb_bcast_c;
 #else
-    CircularBuffer cb_eff_c(tt::CBIndex::c_2);
+    DataflowBuffer dfb_eff_c(tt::CBIndex::c_2);
 #endif
 
     // Initialize pack/format for SFPU-style ternary kernels (matches existing ternary SFPU kernels)
-    unary_op_init_common(cb_eff_a.get_cb_id(), cb_out.get_cb_id());
+    unary_op_init_common(dfb_eff_a.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
 #if BCAST_A
         {
-            cb_pre_a.wait_front(num_tiles_per_cycle);
-            cb_bcast_a.reserve_back(num_tiles_per_cycle);
-            unary_bcast_init<BroadcastType::ROW>(cb_pre_a.get_cb_id(), cb_bcast_a.get_cb_id());
+            dfb_pre_a.wait_front(num_tiles_per_cycle);
+            dfb_bcast_a.reserve_back(num_tiles_per_cycle);
+            unary_bcast_init<BroadcastType::ROW>(dfb_pre_a.get_id(), dfb_bcast_a.get_id());
 
             tile_regs_acquire();
-            unary_bcast<BroadcastType::ROW>(cb_pre_a.get_cb_id(), 0, 0);
+            unary_bcast<BroadcastType::ROW>(dfb_pre_a.get_id(), 0, 0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile(0, cb_bcast_a.get_cb_id());
-            cb_bcast_a.push_back(num_tiles_per_cycle);
+            pack_tile(0, dfb_bcast_a.get_id());
+            dfb_bcast_a.push_back(num_tiles_per_cycle);
             tile_regs_release();
 
-            cb_pre_a.pop_front(num_tiles_per_cycle);
+            dfb_pre_a.pop_front(num_tiles_per_cycle);
         }
 #endif
 
 #if BCAST_B
         {
-            cb_pre_b.wait_front(num_tiles_per_cycle);
-            cb_bcast_b.reserve_back(num_tiles_per_cycle);
-            unary_bcast_init<BroadcastType::ROW>(cb_pre_b.get_cb_id(), cb_bcast_b.get_cb_id());
+            dfb_pre_b.wait_front(num_tiles_per_cycle);
+            dfb_bcast_b.reserve_back(num_tiles_per_cycle);
+            unary_bcast_init<BroadcastType::ROW>(dfb_pre_b.get_id(), dfb_bcast_b.get_id());
 
             tile_regs_acquire();
-            unary_bcast<BroadcastType::ROW>(cb_pre_b.get_cb_id(), 0, 0);
+            unary_bcast<BroadcastType::ROW>(dfb_pre_b.get_id(), 0, 0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile(0, cb_bcast_b.get_cb_id());
-            cb_bcast_b.push_back(num_tiles_per_cycle);
+            pack_tile(0, dfb_bcast_b.get_id());
+            dfb_bcast_b.push_back(num_tiles_per_cycle);
             tile_regs_release();
 
-            cb_pre_b.pop_front(num_tiles_per_cycle);
+            dfb_pre_b.pop_front(num_tiles_per_cycle);
         }
 #endif
 
 #if BCAST_C
         {
-            cb_pre_c.wait_front(num_tiles_per_cycle);
-            cb_bcast_c.reserve_back(num_tiles_per_cycle);
-            unary_bcast_init<BroadcastType::ROW>(cb_pre_c.get_cb_id(), cb_bcast_c.get_cb_id());
+            dfb_pre_c.wait_front(num_tiles_per_cycle);
+            dfb_bcast_c.reserve_back(num_tiles_per_cycle);
+            unary_bcast_init<BroadcastType::ROW>(dfb_pre_c.get_id(), dfb_bcast_c.get_id());
 
             tile_regs_acquire();
-            unary_bcast<BroadcastType::ROW>(cb_pre_c.get_cb_id(), 0, 0);
+            unary_bcast<BroadcastType::ROW>(dfb_pre_c.get_id(), 0, 0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile(0, cb_bcast_c.get_cb_id());
-            cb_bcast_c.push_back(num_tiles_per_cycle);
+            pack_tile(0, dfb_bcast_c.get_id());
+            dfb_bcast_c.push_back(num_tiles_per_cycle);
             tile_regs_release();
 
-            cb_pre_c.pop_front(num_tiles_per_cycle);
+            dfb_pre_c.pop_front(num_tiles_per_cycle);
         }
 #endif
 
         // Now execute the ternary SFPU operation on the effective inputs.
         // Reserve output when ready to write.
-        cb_out.reserve_back(num_tiles_per_cycle);
+        dfb_out.reserve_back(num_tiles_per_cycle);
 
         // Ensure fronts are ready for whichever CBs we will read from
-        cb_eff_a.wait_front(num_tiles_per_cycle);
-        cb_eff_b.wait_front(num_tiles_per_cycle);
-        cb_eff_c.wait_front(num_tiles_per_cycle);
+        dfb_eff_a.wait_front(num_tiles_per_cycle);
+        dfb_eff_b.wait_front(num_tiles_per_cycle);
+        dfb_eff_c.wait_front(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
         // Load A -> DST[0], B -> DST[1], C -> DST[2]
-        copy_tile_to_dst_init_short(cb_eff_a.get_cb_id());
-        copy_tile(cb_eff_a.get_cb_id(), 0, 0);
+        copy_tile_to_dst_init_short(dfb_eff_a.get_id());
+        copy_tile(dfb_eff_a.get_id(), 0, 0);
 
-        copy_tile_to_dst_init_short(cb_eff_b.get_cb_id());
-        copy_tile(cb_eff_b.get_cb_id(), 0, 1);
+        copy_tile_to_dst_init_short(dfb_eff_b.get_id());
+        copy_tile(dfb_eff_b.get_id(), 0, 1);
 
-        copy_tile_to_dst_init_short(cb_eff_c.get_cb_id());
-        copy_tile(cb_eff_c.get_cb_id(), 0, 2);
+        copy_tile_to_dst_init_short(dfb_eff_c.get_id());
+        copy_tile(dfb_eff_c.get_id(), 0, 2);
 
         // Execute configured ternary SFPU op
         TERNARY_SFPU_OP_INIT();
@@ -141,14 +142,14 @@ void kernel_main() {
         tile_regs_wait();
 
         // Write out result
-        pack_tile(0, cb_out.get_cb_id());
+        pack_tile(0, dfb_out.get_id());
         tile_regs_release();
 
-        cb_out.push_back(num_tiles_per_cycle);
+        dfb_out.push_back(num_tiles_per_cycle);
 
         // Pop fronts for the consumed inputs.
-        cb_eff_a.pop_front(num_tiles_per_cycle);
-        cb_eff_b.pop_front(num_tiles_per_cycle);
-        cb_eff_c.pop_front(num_tiles_per_cycle);
+        dfb_eff_a.pop_front(num_tiles_per_cycle);
+        dfb_eff_b.pop_front(num_tiles_per_cycle);
+        dfb_eff_c.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -19,27 +19,27 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
 
     Noc noc;
-    CircularBuffer cb0(cb_id_in0);
-    CircularBuffer cb1(cb_id_in1);
+    DataflowBuffer dfb0(cb_id_in0);
+    DataflowBuffer dfb1(cb_id_in1);
 
 #if SRC_SHARDED_A
-    cb0.reserve_back(num_tiles);
-    cb0.push_back(num_tiles);
+    dfb0.reserve_back(num_tiles);
+    dfb0.push_back(num_tiles);
 #endif
 #if SRC_SHARDED_B
-    cb1.reserve_back(num_tiles);
-    cb1.push_back(num_tiles);
+    dfb1.reserve_back(num_tiles);
+    dfb1.push_back(num_tiles);
 #endif
 #if !SRC_SHARDED_A || !SRC_SHARDED_B
     constexpr auto src0_args = TensorAccessorArgs<2, 0>();
     constexpr auto src1_args =
         TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
 #if !SRC_SHARDED_A
-    const uint32_t tile_bytes_0 = cb0.get_tile_size();
+    const uint32_t tile_bytes_0 = dfb0.get_entry_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 #endif
 #if !SRC_SHARDED_B
-    const uint32_t tile_bytes_1 = cb1.get_tile_size();
+    const uint32_t tile_bytes_1 = dfb1.get_entry_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 #endif
 
@@ -47,21 +47,21 @@ void kernel_main() {
 
     for (uint32_t tile_id = start_id; tile_id < start_id + num_tiles; tile_id++) {
 #if !SRC_SHARDED_A
-        cb0.reserve_back(onetile);
-        noc.async_read(s0, cb0, tile_bytes_0, {.page_id = tile_id}, {.offset_bytes = 0});
+        dfb0.reserve_back(onetile);
+        noc.async_read(s0, dfb0, tile_bytes_0, {.page_id = tile_id}, {.offset_bytes = 0});
 #endif
 #if !SRC_SHARDED_B
-        cb1.reserve_back(onetile);
-        noc.async_read(s1, cb1, tile_bytes_1, {.page_id = tile_id}, {.offset_bytes = 0});
+        dfb1.reserve_back(onetile);
+        noc.async_read(s1, dfb1, tile_bytes_1, {.page_id = tile_id}, {.offset_bytes = 0});
 #endif
 
         noc.async_read_barrier();
 
 #if !SRC_SHARDED_A
-        cb0.push_back(onetile);
+        dfb0.push_back(onetile);
 #endif
 #if !SRC_SHARDED_B
-        cb1.push_back(onetile);
+        dfb1.push_back(onetile);
 #endif
     }
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_ttt.cpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,32 +26,32 @@ void kernel_main() {
         TensorAccessorArgs<src1_args.next_compile_time_args_offset(), src1_args.next_common_runtime_args_offset()>();
 
     Noc noc;
-    CircularBuffer cb0(cb_id_in0);
-    CircularBuffer cb1(cb_id_in1);
-    CircularBuffer cb2(cb_id_in2);
+    DataflowBuffer dfb0(cb_id_in0);
+    DataflowBuffer dfb1(cb_id_in1);
+    DataflowBuffer dfb2(cb_id_in2);
 
-    const uint32_t tile_bytes_0 = cb0.get_tile_size();
-    const uint32_t tile_bytes_1 = cb1.get_tile_size();
-    const uint32_t tile_bytes_2 = cb2.get_tile_size();
+    const uint32_t tile_bytes_0 = dfb0.get_entry_size();
+    const uint32_t tile_bytes_1 = dfb1.get_entry_size();
+    const uint32_t tile_bytes_2 = dfb2.get_entry_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
     const auto s1 = TensorAccessor(src1_args, src1_addr);
     const auto s2 = TensorAccessor(src2_args, src2_addr);
     constexpr uint32_t onetile = 1;
 
     for (uint32_t tile_id = start_id; tile_id < start_id + num_tiles; tile_id++) {
-        cb0.reserve_back(onetile);
-        noc.async_read(s0, cb0, tile_bytes_0, {.page_id = tile_id}, {.offset_bytes = 0});
+        dfb0.reserve_back(onetile);
+        noc.async_read(s0, dfb0, tile_bytes_0, {.page_id = tile_id}, {.offset_bytes = 0});
 
-        cb1.reserve_back(onetile);
-        noc.async_read(s1, cb1, tile_bytes_1, {.page_id = tile_id}, {.offset_bytes = 0});
+        dfb1.reserve_back(onetile);
+        noc.async_read(s1, dfb1, tile_bytes_1, {.page_id = tile_id}, {.offset_bytes = 0});
 
-        cb2.reserve_back(onetile);
-        noc.async_read(s2, cb2, tile_bytes_2, {.page_id = tile_id}, {.offset_bytes = 0});
+        dfb2.reserve_back(onetile);
+        noc.async_read(s2, dfb2, tile_bytes_2, {.page_id = tile_id}, {.offset_bytes = 0});
 
         noc.async_read_barrier();
 
-        cb0.push_back(onetile);
-        cb1.push_back(onetile);
-        cb2.push_back(onetile);
+        dfb0.push_back(onetile);
+        dfb1.push_back(onetile);
+        dfb2.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -52,29 +52,29 @@ void kernel_main() {
         TensorAccessorArgs<src1_args.next_compile_time_args_offset(), src1_args.next_common_runtime_args_offset()>();
 
     Noc noc;
-    CircularBuffer cb0(cb_id_src0);
-    CircularBuffer cb1(cb_id_src1);
-    CircularBuffer cb2(cb_id_src2);
+    DataflowBuffer dfb0(cb_id_src0);
+    DataflowBuffer dfb1(cb_id_src1);
+    DataflowBuffer dfb2(cb_id_src2);
 
 #if SRC_SHARDED_A
-    cb0.reserve_back(src0_num_tiles);
-    cb0.push_back(src0_num_tiles);
+    dfb0.reserve_back(src0_num_tiles);
+    dfb0.push_back(src0_num_tiles);
 #else
-    const uint32_t src0_tile_bytes = cb0.get_tile_size();
+    const uint32_t src0_tile_bytes = dfb0.get_entry_size();
     const auto src0 = TensorAccessor(src0_args, src0_addr);
 #endif
 #if SRC_SHARDED_B
-    cb1.reserve_back(src1_num_tiles);
-    cb1.push_back(src1_num_tiles);
+    dfb1.reserve_back(src1_num_tiles);
+    dfb1.push_back(src1_num_tiles);
 #else
-    const uint32_t src1_tile_bytes = cb1.get_tile_size();
+    const uint32_t src1_tile_bytes = dfb1.get_entry_size();
     const auto src1 = TensorAccessor(src1_args, src1_addr);
 #endif
 #if SRC_SHARDED_C
-    cb2.reserve_back(src2_num_tiles);
-    cb2.push_back(src2_num_tiles);
+    dfb2.reserve_back(src2_num_tiles);
+    dfb2.push_back(src2_num_tiles);
 #else
-    const uint32_t src2_tile_bytes = cb2.get_tile_size();
+    const uint32_t src2_tile_bytes = dfb2.get_entry_size();
     const auto src2 = TensorAccessor(src2_args, src2_addr);
 #endif
 #if !SRC_SHARDED_A || !SRC_SHARDED_B || !SRC_SHARDED_C
@@ -129,31 +129,31 @@ void kernel_main() {
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
                              ++tw, ++num_tiles_read) {
 #if !SRC_SHARDED_A
-                            cb0.reserve_back(onetile);
+                            dfb0.reserve_back(onetile);
                             noc.async_read(
-                                src0, cb0, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                                src0, dfb0, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
 #endif
 #if !SRC_SHARDED_B
-                            cb1.reserve_back(onetile);
+                            dfb1.reserve_back(onetile);
                             noc.async_read(
-                                src1, cb1, src1_tile_bytes, {.page_id = tile_offset_b + tw}, {.offset_bytes = 0});
+                                src1, dfb1, src1_tile_bytes, {.page_id = tile_offset_b + tw}, {.offset_bytes = 0});
 #endif
 #if !SRC_SHARDED_C
-                            cb2.reserve_back(onetile);
+                            dfb2.reserve_back(onetile);
                             noc.async_read(
-                                src2, cb2, src2_tile_bytes, {.page_id = tile_offset_c + tw}, {.offset_bytes = 0});
+                                src2, dfb2, src2_tile_bytes, {.page_id = tile_offset_c + tw}, {.offset_bytes = 0});
 #endif
 #if !SRC_SHARDED_A || !SRC_SHARDED_B || !SRC_SHARDED_C
                             noc.async_read_barrier();
 #endif
 #if !SRC_SHARDED_A
-                            cb0.push_back(onetile);
+                            dfb0.push_back(onetile);
 #endif
 #if !SRC_SHARDED_B
-                            cb1.push_back(onetile);
+                            dfb1.push_back(onetile);
 #endif
 #if !SRC_SHARDED_C
-                            cb2.push_back(onetile);
+                            dfb2.push_back(onetile);
 #endif
                         }
                         if constexpr (!has_sharding) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_writer_nobcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_writer_nobcast.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,11 +26,11 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<1, 0>();
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
 
 #if !DST_SHARDED
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes = cb_out.get_tile_size();
+    const uint32_t tile_bytes = dfb_out.get_entry_size();
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     constexpr bool has_sharding = get_compile_time_arg_val(dst_args.next_compile_time_args_offset()) == 1;
@@ -61,11 +61,11 @@ void kernel_main() {
                     for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
                              ++tw, ++num_tiles_written) {
-                            cb_out.wait_front(onetile);
+                            dfb_out.wait_front(onetile);
                             noc.async_write(
-                                cb_out, s, tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
+                                dfb_out, s, tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
                             noc.async_write_barrier();
-                            cb_out.pop_front(onetile);
+                            dfb_out.pop_front(onetile);
                         }
                         if constexpr (has_sharding) {
                             // adjust the output tile offset since we had to skip parts of the row

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -45,15 +45,15 @@ void kernel_main() {
         TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
 
     Noc noc;
-    CircularBuffer cb_pred(predicate_cb);
-    CircularBuffer cb_b(src_b_cb);
+    DataflowBuffer dfb_pred(predicate_cb);
+    DataflowBuffer dfb_b(src_b_cb);
 
 #if !SRC_SHARDED_A
-    const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
+    const uint32_t src0_tile_bytes = dfb_pred.get_entry_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 #endif
 #if !SRC_SHARDED_B
-    const uint32_t src1_tile_bytes = cb_b.get_tile_size();
+    const uint32_t src1_tile_bytes = dfb_b.get_entry_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 #endif
 
@@ -101,23 +101,23 @@ void kernel_main() {
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
                              ++tw, ++num_tiles_read) {
 #if !SRC_SHARDED_A
-                            cb_pred.reserve_back(onetile);
+                            dfb_pred.reserve_back(onetile);
                             noc.async_read(
-                                s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                                s0, dfb_pred, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
 #endif
 #if !SRC_SHARDED_B
-                            cb_b.reserve_back(onetile);
+                            dfb_b.reserve_back(onetile);
                             noc.async_read(
-                                s1, cb_b, src1_tile_bytes, {.page_id = tile_offset_b + tw}, {.offset_bytes = 0});
+                                s1, dfb_b, src1_tile_bytes, {.page_id = tile_offset_b + tw}, {.offset_bytes = 0});
 #endif
 #if !SRC_SHARDED_A || !SRC_SHARDED_B
                             noc.async_read_barrier();
 #endif
 #if !SRC_SHARDED_A
-                            cb_pred.push_back(onetile);
+                            dfb_pred.push_back(onetile);
 #endif
 #if !SRC_SHARDED_B
-                            cb_b.push_back(onetile);
+                            dfb_b.push_back(onetile);
 #endif
                         }
                         if constexpr (!has_sharding) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
@@ -6,7 +6,7 @@
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -14,8 +14,8 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
 
     init_sfpu(cb_input, cb_output);
     copy_tile_init(cb_input);
@@ -23,8 +23,8 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
 
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
 
         copy_tile(cb_input, 0, 0);
 
@@ -33,8 +33,8 @@ void kernel_main() {
 
         pack_tile(0, cb_output);
 
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
 
         tile_regs_release();
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
@@ -12,7 +12,7 @@
 #include "api/compute/eltwise_unary/rpow.h"
 #include "api/compute/eltwise_unary/rdiv.h"
 #include "api/compute/eltwise_unary/fill.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -20,15 +20,15 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
 
     init_sfpu(cb_input, cb_output);
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
 
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
 
         copy_tile(cb_input, 0, 0);
 
@@ -41,8 +41,8 @@ void kernel_main() {
 
         pack_tile(0, cb_output);
 
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
 
         tile_regs_release();
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel.cpp
@@ -11,7 +11,7 @@
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/activations.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -19,16 +19,16 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
 
     init_sfpu(cb_input, cb_output);
 
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
 
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
 
         copy_tile_to_dst_init_short(cb_input);
         copy_tile(cb_input, 0, 0);
@@ -51,8 +51,8 @@ void kernel_main() {
 
         pack_tile(0, cb_output);
 
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
 
         tile_regs_release();
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_fast_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_fast_kernel.cpp
@@ -15,7 +15,7 @@
 #include "api/compute/eltwise_unary/trigonometry.h"
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -25,15 +25,15 @@ void kernel_main() {
 
     constexpr float M_PI = 3.14159265358979323846f;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
 
     init_sfpu(cb_input, cb_output);
 
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
 
         // copy input to dst 0 and 1
         copy_tile_to_dst_init_short(cb_input);
@@ -100,8 +100,8 @@ void kernel_main() {
 
         pack_tile(0, cb_output);
 
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
 
         tile_regs_release();
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_kernel.cpp
@@ -16,7 +16,7 @@
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/eltwise_unary/comp.h"
 #include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -26,15 +26,15 @@ void kernel_main() {
 
     constexpr float M_PI = 3.14159265358979323846f;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
 
     init_sfpu(cb_input, cb_output);
 
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
 
         // copy input to dst 0 and 1
         copy_tile_to_dst_init_short(cb_input);
@@ -130,8 +130,8 @@ void kernel_main() {
 
         pack_tile(0, cb_output);
 
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
 
         tile_regs_release();
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logit_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logit_kernel.cpp
@@ -11,7 +11,7 @@
 #include "api/compute/eltwise_unary/clamp.h"
 #include "api/compute/eltwise_unary/rsub.h"
 #include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 // Formula: logit(x) = log(x/(1-x)) -- calls clamp, rsub, div, and log tiles.
 
@@ -24,15 +24,15 @@ void kernel_main() {
     constexpr auto cb_output = tt::CBIndex::c_2;
     constexpr auto cb_tmp0 = tt::CBIndex::c_1;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
-    CircularBuffer cb_tmp(cb_tmp0);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
+    DataflowBuffer dfb_tmp(cb_tmp0);
 
     init_sfpu(cb_input, cb_output);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
-        cb_tmp.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
+        dfb_tmp.reserve_back(1);
 
         tile_regs_acquire();
 
@@ -48,8 +48,8 @@ void kernel_main() {
         pack_tile(0, cb_tmp0);
         tile_regs_release();
 
-        cb_tmp.push_back(1);
-        cb_tmp.wait_front(1);
+        dfb_tmp.push_back(1);
+        dfb_tmp.wait_front(1);
 
         tile_regs_acquire();
 
@@ -72,8 +72,8 @@ void kernel_main() {
         pack_tile(0, cb_output);
         tile_regs_release();
 
-        cb_tmp.pop_front(1);
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_tmp.pop_front(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
@@ -10,7 +10,7 @@
 #include "api/compute/eltwise_unary/exp.h"
 #include "api/compute/logsigmoid.h"
 #include "api/compute/eltwise_unary/negative.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -18,14 +18,14 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
 
     init_sfpu(cb_input, cb_output);
 
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
 
         tile_regs_acquire();
 
@@ -48,7 +48,7 @@ void kernel_main() {
         pack_tile(0, cb_output);
         tile_regs_release();
 
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
@@ -10,7 +10,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/fill.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -22,13 +22,13 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
 
-    CircularBuffer cb_in(cb_input);
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_in(cb_input);
+    DataflowBuffer dfb_out(cb_output);
 
     init_sfpu(cb_input, cb_output);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_in.wait_front(1);
-        cb_out.reserve_back(1);
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
         tile_regs_acquire();
         copy_tile_to_dst_init_short(cb_input);
         copy_tile(cb_input, 0, 0);
@@ -56,7 +56,7 @@ void kernel_main() {
         pack_tile(0, cb_output);
         tile_regs_release();
 
-        cb_in.pop_front(1);
-        cb_out.push_back(1);
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -15,11 +15,11 @@ void kernel_main() {
     constexpr auto cb_id_src = tt::CBIndex::c_0;
 
     Noc noc;
-    CircularBuffer cb_src(cb_id_src);
+    DataflowBuffer dfb_src(cb_id_src);
 
 #if SRC_SHARDED
-    cb_src.reserve_back(num_pages);
-    cb_src.push_back(num_pages);
+    dfb_src.reserve_back(num_pages);
+    dfb_src.push_back(num_pages);
 #else
     constexpr uint32_t onepage = 1;
     constexpr auto src_args = TensorAccessorArgs<0, 0>();
@@ -40,26 +40,26 @@ void kernel_main() {
 
         for (uint32_t j = 0; j < chunks_per_row; ++j) {
             uint32_t bytes = (j == chunks_per_row - 1) ? last_chunk_size : chunk_size;
-            cb_src.reserve_back(onepage);
+            dfb_src.reserve_back(onepage);
             for (uint32_t r = 0; r < actual_rows; ++r) {
                 noc.async_read(
                     src,
-                    cb_src,
+                    dfb_src,
                     bytes,
                     {.page_id = base_page + r, .offset_bytes = j * chunk_size},
                     {.offset_bytes = r * bytes});
             }
             noc.async_read_barrier();
-            cb_src.push_back(onepage);
+            dfb_src.push_back(onepage);
         }
     }
 #else
     const uint32_t page_bytes = get_local_cb_interface(cb_id_src).fifo_page_size;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_src.reserve_back(onepage);
-        noc.async_read(src, cb_src, page_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_src.reserve_back(onepage);
+        noc.async_read(src, dfb_src, page_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_src.push_back(onepage);
+        dfb_src.push_back(onepage);
     }
 #endif
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp
@@ -5,7 +5,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,10 +23,10 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb(cb_id_in0);
+    DataflowBuffer dfb(cb_id_in0);
 
 #ifdef OUT_SHARDED
-    cb.wait_front(onetile);
+    dfb.wait_front(onetile);
 #else
 
     // single-tile ublocks
@@ -49,11 +49,11 @@ void kernel_main() {
                  i < end_id + num_tiles_per_2d * dim;
                  i = i + tiles_per_row) {
 #endif
-                cb.reserve_back(onetile);
-                noc.async_read(s, cb, tile_bytes, {.page_id = static_cast<uint32_t>(i + k)}, {.offset_bytes = 0});
+                dfb.reserve_back(onetile);
+                noc.async_read(s, dfb, tile_bytes, {.page_id = static_cast<uint32_t>(i + k)}, {.offset_bytes = 0});
 
                 noc.async_read_barrier();
-                cb.push_back(onetile);
+                dfb.push_back(onetile);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -25,7 +25,7 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb(cb_id_in0);
+    DataflowBuffer dfb(cb_id_in0);
 
 // read a ublock of pages from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS
@@ -35,9 +35,9 @@ void kernel_main() {
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb.reserve_back(onepage);
-        noc.async_read(s, cb, page_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb.reserve_back(onepage);
+        noc.async_read(s, dfb, page_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb.push_back(onepage);
+        dfb.push_back(onepage);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp
@@ -5,7 +5,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -27,7 +27,7 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb(cb_id_in0);
+    DataflowBuffer dfb(cb_id_in0);
 
 #ifdef BACKWARDS
     for (uint32_t dim = 0; dim > -third_dim; dim--) {
@@ -40,11 +40,11 @@ void kernel_main() {
             for (uint32_t r = 0; r < single_block_size_row_arg; r++) {
                 uint32_t tile = start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
 #endif
-                cb.reserve_back(onetile);
-                noc.async_read(s, cb, tile_bytes, {.page_id = tile}, {.offset_bytes = 0});
+                dfb.reserve_back(onetile);
+                noc.async_read(s, dfb, tile_bytes, {.page_id = tile}, {.offset_bytes = 0});
 
                 noc.async_read_barrier();
-                cb.push_back(onetile);
+                dfb.push_back(onetile);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 #include "api/debug/dprint.h"
 
@@ -12,6 +12,6 @@ void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
 
-    CircularBuffer cb(cb_id_in0);
-    cb.push_back(num_tiles_per_core);
+    DataflowBuffer dfb(cb_id_in0);
+    dfb.push_back(num_tiles_per_core);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -15,13 +15,13 @@ void kernel_main() {
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
 
     Noc noc;
-    CircularBuffer cb_dst(cb_id_dst);
+    DataflowBuffer dfb_dst(cb_id_dst);
 
 #if DST_SHARDED
     // Output is sharded in place; the wait is only a readiness handshake. Pop to
     // leave the CB balanced.
-    cb_dst.wait_front(num_pages);
-    cb_dst.pop_front(num_pages);
+    dfb_dst.wait_front(num_pages);
+    dfb_dst.pop_front(num_pages);
 #else
     constexpr uint32_t onepage = 1;
     constexpr auto dst_args = TensorAccessorArgs<0, 0>();
@@ -42,27 +42,27 @@ void kernel_main() {
 
         for (uint32_t j = 0; j < chunks_per_row; ++j) {
             uint32_t bytes = (j == chunks_per_row - 1) ? last_chunk_size : chunk_size;
-            cb_dst.wait_front(onepage);
+            dfb_dst.wait_front(onepage);
             for (uint32_t r = 0; r < actual_rows; ++r) {
                 noc.async_write(
-                    cb_dst,
+                    dfb_dst,
                     dst,
                     bytes,
                     {.offset_bytes = r * bytes},
                     {.page_id = base_page + r, .offset_bytes = j * chunk_size});
             }
             noc.async_writes_flushed();
-            cb_dst.pop_front(onepage);
+            dfb_dst.pop_front(onepage);
         }
     }
     noc.async_write_barrier();
 #else
     const uint32_t page_bytes = get_local_cb_interface(cb_id_dst).fifo_page_size;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_dst.wait_front(onepage);
-        noc.async_write(cb_dst, dst, page_bytes, {}, {.page_id = i});
+        dfb_dst.wait_front(onepage);
+        noc.async_write(dfb_dst, dst, page_bytes, {}, {.page_id = i});
         noc.async_writes_flushed();
-        cb_dst.pop_front(onepage);
+        dfb_dst.pop_front(onepage);
     }
     noc.async_write_barrier();
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -19,10 +19,10 @@ void kernel_main() {
     const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
 
     Noc noc;
-    CircularBuffer cb(cb_id_out);
+    DataflowBuffer dfb(cb_id_out);
 
 #ifdef OUT_SHARDED
-    cb.wait_front(num_pages);
+    dfb.wait_front(num_pages);
 #else
 
     // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
@@ -37,10 +37,10 @@ void kernel_main() {
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb.wait_front(onepage);
-        noc.async_write(cb, s, page_bytes, {}, {.page_id = i});
+        dfb.wait_front(onepage);
+        noc.async_write(dfb, s, page_bytes, {}, {.page_id = i});
         noc.async_writes_flushed();
-        cb.pop_front(onepage);
+        dfb.pop_front(onepage);
     }
     noc.async_write_barrier();
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,7 +26,7 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb(cb_id_out);
+    DataflowBuffer dfb(cb_id_out);
 
 #ifdef BACKWARDS
     for (uint32_t dim = 0; dim > -third_dim; dim--) {
@@ -39,10 +39,10 @@ void kernel_main() {
             for (uint32_t r = 0; r < single_block_size_row_arg; r++) {
                 uint32_t tile = start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
 #endif
-                cb.wait_front(onetile);
-                noc.async_write(cb, s, tile_bytes, {}, {.page_id = tile});
+                dfb.wait_front(onetile);
+                noc.async_write(dfb, s, tile_bytes, {}, {.page_id = tile});
                 noc.async_writes_flushed();
-                cb.pop_front(onetile);
+                dfb.pop_front(onetile);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/kernels/compute/eltwise_bw_tanh_deriv.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/kernels/compute/eltwise_bw_tanh_deriv.cpp
@@ -14,7 +14,7 @@
 #include "api/compute/eltwise_unary/tanh_derivative.h"
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
@@ -24,18 +24,18 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_1;
     constexpr auto cb_grad_in = tt::CBIndex::c_2;
 
-    CircularBuffer exp_cb_grad_out(cb_grad_out);
-    CircularBuffer exp_cb_input(cb_input);
-    CircularBuffer exp_cb_grad_in(cb_grad_in);
+    DataflowBuffer exp_dfb_grad_out(cb_grad_out);
+    DataflowBuffer exp_dfb_input(cb_input);
+    DataflowBuffer exp_dfb_grad_in(cb_grad_in);
 
     unary_op_init_common(cb_grad_out, cb_grad_in);
     tanh_derivative_tile_init<false>();
     mul_binary_tile_init();
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
-        exp_cb_grad_in.reserve_back(per_core_block_size);
-        exp_cb_grad_out.wait_front(per_core_block_size);
-        exp_cb_input.wait_front(per_core_block_size);
+        exp_dfb_grad_in.reserve_back(per_core_block_size);
+        exp_dfb_grad_out.wait_front(per_core_block_size);
+        exp_dfb_input.wait_front(per_core_block_size);
 
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
             tile_regs_acquire();
@@ -53,8 +53,8 @@ void kernel_main() {
             tile_regs_release();
         }
 
-        exp_cb_grad_out.pop_front(per_core_block_size);
-        exp_cb_input.pop_front(per_core_block_size);
-        exp_cb_grad_in.push_back(per_core_block_size);
+        exp_dfb_grad_out.pop_front(per_core_block_size);
+        exp_dfb_input.pop_front(per_core_block_size);
+        exp_dfb_grad_in.push_back(per_core_block_size);
     }
 }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/45010 - first cut at changing eltwise ops from using CBs to using DFBs

DFBs use CBs under the hood for WH/BH, but this helps prepare for Quasar and Metal 2.0.

```
class DataflowBuffer {
public:
#ifdef ARCH_QUASAR
    using DFBInterface = LocalDFBInterface;
#else
    using DFBInterface = LocalCBInterface;
#endif
```

This only focuses on what can be currently converted over cleanly/mechanically. A second pass will be needed for any blocked CB usage patterns (see https://github.com/tenstorrent/tt-metal/issues/49368)

Single card model perf [passes](https://github.com/tenstorrent/tt-metal/actions/runs/29020813828) 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/45010/DFB_Eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/45010/DFB_Eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/45010/DFB_Eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/45010/DFB_Eltwise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/45010/DFB_Eltwise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/45010/DFB_Eltwise)