### PR TITLE
[Bug fix] Cover Quasar in runtime arch branches that gate on Blackhole

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -127,16 +127,6 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithMeshBuffer) {
     EXPECT_EQ(tensor.logical_shape(), Shape({1, 32}));
 }
 
-// ============================================================================
-// Quasar arch-enablement: FP8_E4M3 tensors must be allocatable on Quasar (and
-// Blackhole), not just Blackhole. Exercises the arch guard in
-// MeshTensor::allocate_on_device. On Wormhole it must still FATAL (no regression).
-// ============================================================================
-// Uses MeshDeviceSingleCardFixture rather than GenericMeshDeviceFixture so it can run on the
-// single-card Quasar emulator (which cannot host fast-dispatch cores). NOTE: this fixture GTEST_SKIPs
-// unless TT_METAL_SLOW_DISPATCH_MODE is set, so this device-level check only executes on slow-dispatch
-// runners (e.g. the Quasar emu). The arch-guard logic itself is covered on every runner by the host-side
-// DataFormatFp8ArchGuard.Fp8E4m3PackSrcFormatPerArch test.
 TEST_F(MeshDeviceSingleCardFixture, AllocateFp8E4m3OnDevice) {
     auto& mesh_device = *devices_[0];
     const auto arch = mesh_device.arch();
@@ -148,11 +138,10 @@ TEST_F(MeshDeviceSingleCardFixture, AllocateFp8E4m3OnDevice) {
     auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
 
     if (arch == tt::ARCH::BLACKHOLE || arch == tt::ARCH::QUASAR) {
-        MeshTensor tensor = MeshTensor::allocate_on_device(mesh_device, spec, TensorTopology());
+        MeshTensor tensor = MeshTensor::allocate_on_device(mesh_device, spec);
         EXPECT_EQ(tensor.dtype(), DataType::FP8_E4M3);
     } else {
-        EXPECT_ANY_THROW(
-            { [[maybe_unused]] auto tensor = MeshTensor::allocate_on_device(mesh_device, spec, TensorTopology()); });
+        EXPECT_ANY_THROW({ [[maybe_unused]] auto tensor = MeshTensor::allocate_on_device(mesh_device, spec); });
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -49,6 +49,7 @@
 #include <tt_stl/aligned_allocator.hpp>
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "tt_metal/tt_metal/common/device_fixture.hpp"
 
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "impl/context/metal_context.hpp"
@@ -124,6 +125,35 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithMeshBuffer) {
     EXPECT_EQ(tensor.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(tensor.logical_shape(), Shape({1, 32}));
+}
+
+// ============================================================================
+// Quasar arch-enablement: FP8_E4M3 tensors must be allocatable on Quasar (and
+// Blackhole), not just Blackhole. Exercises the arch guard in
+// MeshTensor::allocate_on_device. On Wormhole it must still FATAL (no regression).
+// ============================================================================
+// Uses MeshDeviceSingleCardFixture rather than GenericMeshDeviceFixture so it can run on the
+// single-card Quasar emulator (which cannot host fast-dispatch cores). NOTE: this fixture GTEST_SKIPs
+// unless TT_METAL_SLOW_DISPATCH_MODE is set, so this device-level check only executes on slow-dispatch
+// runners (e.g. the Quasar emu). The arch-guard logic itself is covered on every runner by the host-side
+// DataFormatFp8ArchGuard.Fp8E4m3PackSrcFormatPerArch test.
+TEST_F(MeshDeviceSingleCardFixture, AllocateFp8E4m3OnDevice) {
+    auto& mesh_device = *devices_[0];
+    const auto arch = mesh_device.arch();
+    // FP8_E4M3 requires ROW_MAJOR layout (enforced by TensorSpec).
+    auto tensor_layout = TensorLayout(
+        DataType::FP8_E4M3,
+        PageConfig(Layout::ROW_MAJOR),
+        MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM});
+    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
+
+    if (arch == tt::ARCH::BLACKHOLE || arch == tt::ARCH::QUASAR) {
+        MeshTensor tensor = MeshTensor::allocate_on_device(mesh_device, spec, TensorTopology());
+        EXPECT_EQ(tensor.dtype(), DataType::FP8_E4M3);
+    } else {
+        EXPECT_ANY_THROW(
+            { [[maybe_unused]] auto tensor = MeshTensor::allocate_on_device(mesh_device, spec, TensorTopology()); });
+    }
 }
 
 TEST_F(MeshTensorDeviceTest, MoveConstructionTransfersOwnership) {

--- a/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
@@ -5,10 +5,13 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include "impl/data_format/blockfloat_common.hpp"
+#include <array>
 #include <bit>
 #include <memory>
 
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <umd/device/types/arch.hpp>
+#include "jit_build/data_format.hpp"
 
 namespace {
 
@@ -87,3 +90,30 @@ INSTANTIATE_TEST_SUITE_P(
     )  // Values
     // clang-format on
 );
+
+// ============================================================================
+// Quasar arch-enablement: the Fp8_e4m3 pack-src-format guard must admit QUASAR.
+// get_single_pack_src_format() previously FATAL'd unless arch == BLACKHOLE; it now
+// gates on is_data_format_supported(Fp8_e4m3, arch) (true for BLACKHOLE and QUASAR,
+// false for WORMHOLE_B0). Host-only: exercises the guard directly via the public
+// get_pack_src_formats() wrapper, no device required.
+// ============================================================================
+TEST(DataFormatFp8ArchGuard, Fp8E4m3PackSrcFormatPerArch) {
+    const std::array<tt::DataFormat, 1> fp8_formats{tt::DataFormat::Fp8_e4m3};
+    constexpr auto unpack_dst = tt::DataFormat::Float16_b;
+
+    // QUASAR supports Fp8_e4m3 -> must NOT throw the "only available in Blackhole" guard.
+    EXPECT_NO_THROW(tt::get_pack_src_formats(
+        fp8_formats,
+        unpack_dst,
+        /*fp32_dest_acc_en=*/true,
+        /*bfp8_pack_precise=*/false,
+        /*int_fpu_en=*/false,
+        tt::ARCH::QUASAR));
+
+    // BLACKHOLE: baseline, still allowed (no regression).
+    EXPECT_NO_THROW(tt::get_pack_src_formats(fp8_formats, unpack_dst, true, false, false, tt::ARCH::BLACKHOLE));
+
+    // WORMHOLE_B0: still rejected (is_data_format_supported(Fp8_e4m3, WORMHOLE_B0) == false) -> no regression.
+    EXPECT_ANY_THROW(tt::get_pack_src_formats(fp8_formats, unpack_dst, true, false, false, tt::ARCH::WORMHOLE_B0));
+}

--- a/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
@@ -91,18 +91,13 @@ INSTANTIATE_TEST_SUITE_P(
     // clang-format on
 );
 
-// ============================================================================
-// Quasar arch-enablement: the Fp8_e4m3 pack-src-format guard must admit QUASAR.
-// get_single_pack_src_format() previously FATAL'd unless arch == BLACKHOLE; it now
-// gates on is_data_format_supported(Fp8_e4m3, arch) (true for BLACKHOLE and QUASAR,
-// false for WORMHOLE_B0). Host-only: exercises the guard directly via the public
-// get_pack_src_formats() wrapper, no device required.
-// ============================================================================
+// FP8_E4M3 is supported on Blackhole and Quasar but not Wormhole. Verify the arch guard in
+// get_single_pack_src_format() matches that: QUASAR and BLACKHOLE pass, WORMHOLE_B0 throws.
+// Host-only: calls the public get_pack_src_formats() wrapper, no device required.
 TEST(DataFormatFp8ArchGuard, Fp8E4m3PackSrcFormatPerArch) {
     const std::array<tt::DataFormat, 1> fp8_formats{tt::DataFormat::Fp8_e4m3};
     constexpr auto unpack_dst = tt::DataFormat::Float16_b;
 
-    // QUASAR supports Fp8_e4m3 -> must NOT throw the "only available in Blackhole" guard.
     EXPECT_NO_THROW(tt::get_pack_src_formats(
         fp8_formats,
         unpack_dst,
@@ -111,9 +106,7 @@ TEST(DataFormatFp8ArchGuard, Fp8E4m3PackSrcFormatPerArch) {
         /*int_fpu_en=*/false,
         tt::ARCH::QUASAR));
 
-    // BLACKHOLE: baseline, still allowed (no regression).
     EXPECT_NO_THROW(tt::get_pack_src_formats(fp8_formats, unpack_dst, true, false, false, tt::ARCH::BLACKHOLE));
 
-    // WORMHOLE_B0: still rejected (is_data_format_supported(Fp8_e4m3, WORMHOLE_B0) == false) -> no regression.
     EXPECT_ANY_THROW(tt::get_pack_src_formats(fp8_formats, unpack_dst, true, false, false, tt::ARCH::WORMHOLE_B0));
 }

--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -54,6 +54,14 @@ uint32_t get_l1_alignment();
 uint32_t get_pcie_alignment();
 
 /**
+ * @brief Uses the hardware abstraction layer to inform client of the architecture specific maximum
+ * NoC burst size (NOC_MAX_BURST_SIZE from the architecture's noc_parameters.h).
+ *
+ * @return Maximum NoC burst size in bytes
+ */
+uint32_t get_noc_max_burst_size_bytes();
+
+/**
  * @brief Uses the hardware abstraction layer to inform client of architecture specific address.
  * this address corresponds to the beginning of free space in the ERISC's L1 SRAM
  *

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -38,6 +38,10 @@ uint32_t get_l1_alignment() { return tt::tt_metal::MetalContext::instance().hal(
 
 uint32_t get_pcie_alignment() { return tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST); }
 
+uint32_t get_noc_max_burst_size_bytes() {
+    return tt::tt_metal::MetalContext::instance().hal().get_noc_max_burst_size_bytes();
+}
+
 uint32_t get_erisc_l1_unreserved_base() {
     const auto& hal_ref = tt::tt_metal::MetalContext::instance().hal();
     return hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -374,9 +374,15 @@ struct addressable_core_t {
 // TODO: This can move into the hal eventually.
 // This is the max number of non tensix cores between WH and BH that can be queried through Virtual Coordinates.
 // All other Non Worker Cores are not accessible through virtual coordinates. Subject to change, depending on the arch.
-// Currently sized for BH (first term is DRAM, second term is PCIe and last term is eth). On WH only Eth and Tensix
-// cores are virtualized BH = DRAM(8*2) + 1 PCIe + Eth(12) vs. WH = Eth(16)
-constexpr std::uint32_t MAX_VIRTUAL_NON_WORKER_CORES = 29;
+// Sized for the largest supported configuration: UNHARVESTED Blackhole (the ttsim CI target) =
+// DRAM(8*2) + Eth(14) = 30. Harvested BH silicon (P150) is DRAM(8*2) + 1 PCIe + Eth(12) = 29; WH
+// virtualizes only Eth(16) and Tensix; Quasar (quasar_32) is DRAM only today. The previous value of
+// 29 fit only harvested parts, and the unharvested simulator silently overran this array by one
+// entry into harvested_coords on every device init (masked because harvested_coords is written
+// afterwards); populate_core_info_msg now bounds-checks against this capacity, so it must cover
+// the unharvested case (30). Kept at the exact requirement: the mailbox L1 budgets
+// (MEM_MAILBOX_SIZE) on WH/BH have no headroom, so every extra entry here costs kernel L1.
+constexpr std::uint32_t MAX_VIRTUAL_NON_WORKER_CORES = 30;
 // This is the max number of Non Worker Cores across BH and WH.
 // BH = DRAM(8) + 1 PCIe + Eth(12) vs. WH = DRAM(18) + 1 PCIe + Eth(16)
 constexpr std::uint32_t MAX_PHYSICAL_NON_WORKER_CORES = 35;

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -374,14 +374,11 @@ struct addressable_core_t {
 // TODO: This can move into the hal eventually.
 // This is the max number of non tensix cores between WH and BH that can be queried through Virtual Coordinates.
 // All other Non Worker Cores are not accessible through virtual coordinates. Subject to change, depending on the arch.
-// Sized for the largest supported configuration: UNHARVESTED Blackhole (the ttsim CI target) =
+// Sized for the largest supported configuration: unharvested Blackhole (the ttsim CI target) =
 // DRAM(8*2) + Eth(14) = 30. Harvested BH silicon (P150) is DRAM(8*2) + 1 PCIe + Eth(12) = 29; WH
-// virtualizes only Eth(16) and Tensix; Quasar (quasar_32) is DRAM only today. The previous value of
-// 29 fit only harvested parts, and the unharvested simulator silently overran this array by one
-// entry into harvested_coords on every device init (masked because harvested_coords is written
-// afterwards); populate_core_info_msg now bounds-checks against this capacity, so it must cover
-// the unharvested case (30). Kept at the exact requirement: the mailbox L1 budgets
-// (MEM_MAILBOX_SIZE) on WH/BH have no headroom, so every extra entry here costs kernel L1.
+// virtualizes only Eth(16) and Tensix; Quasar (quasar_32) is DRAM only today.
+// populate_core_info_msg bounds-checks against this capacity. Kept at the exact requirement:
+// the mailbox L1 budgets (MEM_MAILBOX_SIZE) have no headroom, so every extra entry costs kernel L1.
 constexpr std::uint32_t MAX_VIRTUAL_NON_WORKER_CORES = 30;
 // This is the max number of Non Worker Cores across BH and WH.
 // BH = DRAM(8) + 1 PCIe + Eth(12) vs. WH = DRAM(18) + 1 PCIe + Eth(16)

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -369,9 +369,15 @@ struct addressable_core_t {
 // TODO: This can move into the hal eventually.
 // This is the max number of non tensix cores between WH and BH that can be queried through Virtual Coordinates.
 // All other Non Worker Cores are not accessible through virtual coordinates. Subject to change, depending on the arch.
-// Currently sized for BH (first term is DRAM, second term is PCIe and last term is eth). On WH only Eth and Tensix
-// cores are virtualized BH = DRAM(8*2) + 1 PCIe + Eth(12) vs. WH = Eth(16)
-constexpr std::uint32_t MAX_VIRTUAL_NON_WORKER_CORES = 29;
+// Sized for the largest supported configuration: UNHARVESTED Blackhole (the ttsim CI target) =
+// DRAM(8*2) + Eth(14) = 30. Harvested BH silicon (P150) is DRAM(8*2) + 1 PCIe + Eth(12) = 29; WH
+// virtualizes only Eth(16) and Tensix; Quasar (quasar_32) is DRAM only today. The previous value of
+// 29 fit only harvested parts, and the unharvested simulator silently overran this array by one
+// entry into harvested_coords on every device init (masked because harvested_coords is written
+// afterwards); populate_core_info_msg now bounds-checks against this capacity, so it must cover
+// the unharvested case (30). Kept at the exact requirement: the mailbox L1 budgets
+// (MEM_MAILBOX_SIZE) on WH/BH have no headroom, so every extra entry here costs kernel L1.
+constexpr std::uint32_t MAX_VIRTUAL_NON_WORKER_CORES = 30;
 // This is the max number of Non Worker Cores across BH and WH.
 // BH = DRAM(8) + 1 PCIe + Eth(12) vs. WH = DRAM(18) + 1 PCIe + Eth(16)
 constexpr std::uint32_t MAX_PHYSICAL_NON_WORKER_CORES = 35;

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -110,7 +110,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 13424
+#define MEM_MAILBOX_SIZE 13440
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -334,7 +334,7 @@
 // mailboxes_t is unconditional: every debug/profiling feature that lives in the mailbox reserves its space
 // whether or not it is enabled at runtime, so this number must cover the watcher, DPRINT and the kernel
 // profiler simultaneously.
-#define MEM_DRISC_MAILBOX_SIZE 4416
+#define MEM_DRISC_MAILBOX_SIZE 4432
 #define MEM_DRISC_MAILBOX_END (MEM_DRISC_MAILBOX_BASE + MEM_DRISC_MAILBOX_SIZE)
 #define MEM_DRISC_L1_INLINE_BASE MEM_DRISC_MAILBOX_END
 #define MEM_DRISC_L1_INLINE_END (MEM_DRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -110,7 +110,8 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 13296
+// (was 13296; +16 when MAX_VIRTUAL_NON_WORKER_CORES grew 29 -> 30 to fit unharvested Blackhole)
+#define MEM_MAILBOX_SIZE 13312
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -86,7 +86,8 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 13296
+// (was 13296; +16 when MAX_VIRTUAL_NON_WORKER_CORES grew 29 -> 30 to fit unharvested Blackhole)
+#define MEM_MAILBOX_SIZE 13312
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 4)
 #define MEM_SUBORDINATE_RUN_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 8)

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -86,7 +86,6 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-// (was 13296; +16 when MAX_VIRTUAL_NON_WORKER_CORES grew 29 -> 30 to fit unharvested Blackhole)
 #define MEM_MAILBOX_SIZE 13312
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 4)

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -960,8 +960,6 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             dev_msgs::AddressableCoreType::UNKNOWN);
     }
     int non_worker_cores_idx = 0;
-    // Whether PCIE/DRAM non-worker cores are addressed virtually (Blackhole, Quasar) or physically
-    // (Wormhole) is a per-arch HAL capability; ETH is virtualized on every arch.
     const bool virtualizes_non_worker_cores = hal_.virtualizes_non_worker_cores();
     bool skip_physical = hal_.is_coordinate_virtualization_enabled() and virtualizes_non_worker_cores;
     if (not skip_physical) {
@@ -978,24 +976,13 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
                 core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::ETH);
         }
     }
-    // DISPATCH cores are never written into virtual_non_worker_cores below, so register them in the
-    // physical list unconditionally. This restores the mailbox content produced for Quasar before
-    // skip_physical became true for it; without it these cores appear in neither mailbox array and fall
-    // through to the permissive physical-Tensix range check in debug/sanitize.h, which returns TENSIX for
-    // any in-grid coordinate -- so the watcher mislabels them and a multicast covering a dispatch core is
-    // no longer flagged as touching a non-worker. Only Quasar registers a DISPATCH programmable core type,
-    // so dispatch_cores is empty on Wormhole and Blackhole and this loop is a no-op there. Bounded by the
-    // pcie+dram+eth+dispatch TT_ASSERT above (debug-only; capacity is MAX_PHYSICAL_NON_WORKER_CORES).
+    // DISPATCH cores (Quasar-only) are never virtualized, so always register them in the physical list.
     for (tt::umd::CoreCoord core : dispatch_cores) {
         set_addressable_core(
             core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::DISPATCH);
     }
 
     if (hal_.is_coordinate_virtualization_enabled()) {
-        // Guard the fixed-size virtual_non_worker_cores mailbox array (MAX_VIRTUAL_NON_WORKER_CORES,
-        // hand-sized for Blackhole's topology). ETH is always written; PCIE/DRAM are written when this
-        // arch virtualizes its non-worker cores. Fail loudly at config time rather than silently overrunning
-        // the array into adjacent mailbox fields on an arch whose core count exceeds the constant.
         const size_t num_virtual_non_worker_cores =
             eth_cores.size() + (virtualizes_non_worker_cores ? pcie_cores.size() + dram_cores.size() : 0);
         TT_FATAL(
@@ -1012,8 +999,6 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
                 dev_msgs::AddressableCoreType::ETH);
         }
 
-        // Set virtual PCIE/DRAM cores for arches that virtualize them (Blackhole, Quasar). ETH is handled
-        // for all virtualized arches above; Wormhole addresses PCIE/DRAM physically instead.
         if (virtualizes_non_worker_cores) {
             for (const CoreCoord& core : pcie_cores) {
                 auto virtual_core =
@@ -1059,10 +1044,6 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             if (hal_.get_tensix_harvest_axis() == HalTensixHarvestAxis::ROW) {
                 end_virtual_grid = hal_.get_virtual_worker_start_y() + logical_grid_size.y;
             } else if (cluster_.arch() != ARCH::WORMHOLE_B0) {
-                // COL-harvest arches (Blackhole, Quasar, and future arches) place a harvested column at
-                // this virtual coordinate. Wormhole is ROW-harvest and never reaches this COL branch, but
-                // keeping the guard as "not Wormhole" future-proofs new COL-harvest arches (GRAYSKULL is
-                // retired). The x-based fallback below remains for any arch that opts out.
                 end_virtual_grid = max_along_axis - 1;
             } else {
                 end_virtual_grid = hal_.get_virtual_worker_start_x() + logical_grid_size.x;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -960,12 +960,12 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             dev_msgs::AddressableCoreType::UNKNOWN);
     }
     int non_worker_cores_idx = 0;
-    // Skip the physical PCIE/DRAM/ETH addressable cores when this arch virtualizes them (they are set as
-    // virtual cores below). Gate on the HAL capability instead of a hard-coded arch: BLACKHOLE and QUASAR
-    // virtualize DRAM/PCIE, WORMHOLE_B0 does not. This mirrors the dram_is_virtualized check above and
-    // covers future arches automatically.
-    bool skip_physical = hal_.is_coordinate_virtualization_enabled() and
-                         hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
+    // Wormhole addresses its PCIE/DRAM non-worker cores physically; Blackhole and Quasar (and future
+    // arches) virtualize them and write them as virtual cores below. ETH is virtualized on every arch.
+    // GRAYSKULL is retired, so "not Wormhole" cleanly covers the virtualizing arches without enumerating
+    // each one, and picks up future arches automatically.
+    const bool virtualizes_non_worker_cores = cluster_.arch() != ARCH::WORMHOLE_B0;
+    bool skip_physical = hal_.is_coordinate_virtualization_enabled() and virtualizes_non_worker_cores;
     if (not skip_physical) {
         for (tt::umd::CoreCoord core : pcie_cores) {
             set_addressable_core(
@@ -988,12 +988,10 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
     if (hal_.is_coordinate_virtualization_enabled()) {
         // Guard the fixed-size virtual_non_worker_cores mailbox array (MAX_VIRTUAL_NON_WORKER_CORES,
         // hand-sized for Blackhole's topology). ETH is always written; PCIE/DRAM are written when this
-        // arch virtualizes DRAM. Fail loudly at config time rather than silently overrunning the array
-        // into adjacent mailbox fields on an arch whose core count exceeds the constant.
-        const bool dram_virtualized =
-            hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
+        // arch virtualizes its non-worker cores. Fail loudly at config time rather than silently overrunning
+        // the array into adjacent mailbox fields on an arch whose core count exceeds the constant.
         const size_t num_virtual_non_worker_cores =
-            eth_cores.size() + (dram_virtualized ? pcie_cores.size() + dram_cores.size() : 0);
+            eth_cores.size() + (virtualizes_non_worker_cores ? pcie_cores.size() + dram_cores.size() : 0);
         TT_FATAL(
             num_virtual_non_worker_cores <= core_info.virtual_non_worker_cores().size(),
             "Virtual non-worker cores ({}) exceed the mailbox capacity ({}) for this architecture",
@@ -1008,9 +1006,9 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
                 dev_msgs::AddressableCoreType::ETH);
         }
 
-        // Set virtual PCIE/DRAM cores for arches that virtualize them (BLACKHOLE, QUASAR). ETH is handled
-        // for all virtualized arches above; WORMHOLE_B0 does not virtualize PCIE/DRAM.
-        if (dram_virtualized) {
+        // Set virtual PCIE/DRAM cores for arches that virtualize them (Blackhole, Quasar). ETH is handled
+        // for all virtualized arches above; Wormhole addresses PCIE/DRAM physically instead.
+        if (virtualizes_non_worker_cores) {
             for (const CoreCoord& core : pcie_cores) {
                 auto virtual_core =
                     cluster_.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y});
@@ -1054,10 +1052,11 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             uint32_t end_virtual_grid;
             if (hal_.get_tensix_harvest_axis() == HalTensixHarvestAxis::ROW) {
                 end_virtual_grid = hal_.get_virtual_worker_start_y() + logical_grid_size.y;
-            } else if (cluster_.arch() == ARCH::BLACKHOLE || cluster_.arch() == ARCH::QUASAR) {
-                // Quasar shares Blackhole's COL harvest axis and virtual-grid layout
-                // (VIRTUAL_TENSIX_START_X/Y are identical), so a harvested column takes the same
-                // virtual coordinate as on Blackhole rather than the Wormhole-shaped fallback below.
+            } else if (cluster_.arch() != ARCH::WORMHOLE_B0) {
+                // COL-harvest arches (Blackhole, Quasar, and future arches) place a harvested column at
+                // this virtual coordinate. Wormhole is ROW-harvest and never reaches this COL branch, but
+                // keeping the guard as "not Wormhole" future-proofs new COL-harvest arches (GRAYSKULL is
+                // retired). The x-based fallback below remains for any arch that opts out.
                 end_virtual_grid = max_along_axis - 1;
             } else {
                 end_virtual_grid = hal_.get_virtual_worker_start_x() + logical_grid_size.x;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -960,7 +960,12 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             dev_msgs::AddressableCoreType::UNKNOWN);
     }
     int non_worker_cores_idx = 0;
-    bool skip_physical = cluster_.arch() == ARCH::BLACKHOLE and hal_.is_coordinate_virtualization_enabled();
+    // Skip the physical PCIE/DRAM/ETH addressable cores when this arch virtualizes them (they are set as
+    // virtual cores below). Gate on the HAL capability instead of a hard-coded arch: BLACKHOLE and QUASAR
+    // virtualize DRAM/PCIE, WORMHOLE_B0 does not. This mirrors the dram_is_virtualized check above and
+    // covers future arches automatically.
+    bool skip_physical = hal_.is_coordinate_virtualization_enabled() and
+                         hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
     if (not skip_physical) {
         for (tt::umd::CoreCoord core : pcie_cores) {
             set_addressable_core(
@@ -981,6 +986,19 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
     }
 
     if (hal_.is_coordinate_virtualization_enabled()) {
+        // Guard the fixed-size virtual_non_worker_cores mailbox array (MAX_VIRTUAL_NON_WORKER_CORES,
+        // hand-sized for Blackhole's topology). ETH is always written; PCIE/DRAM are written when this
+        // arch virtualizes DRAM. Fail loudly at config time rather than silently overrunning the array
+        // into adjacent mailbox fields on an arch whose core count exceeds the constant.
+        const bool dram_virtualized =
+            hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
+        const size_t num_virtual_non_worker_cores =
+            eth_cores.size() + (dram_virtualized ? pcie_cores.size() + dram_cores.size() : 0);
+        TT_FATAL(
+            num_virtual_non_worker_cores <= core_info.virtual_non_worker_cores().size(),
+            "Virtual non-worker cores ({}) exceed the mailbox capacity ({}) for this architecture",
+            num_virtual_non_worker_cores,
+            core_info.virtual_non_worker_cores().size());
         uint32_t virtual_non_worker_cores_idx = 0;
         for (tt::umd::CoreCoord core : eth_cores) {
             auto virtual_core = cluster_.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y});
@@ -990,7 +1008,9 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
                 dev_msgs::AddressableCoreType::ETH);
         }
 
-        if (cluster_.arch() == ARCH::BLACKHOLE) {
+        // Set virtual PCIE/DRAM cores for arches that virtualize them (BLACKHOLE, QUASAR). ETH is handled
+        // for all virtualized arches above; WORMHOLE_B0 does not virtualize PCIE/DRAM.
+        if (dram_virtualized) {
             for (const CoreCoord& core : pcie_cores) {
                 auto virtual_core =
                     cluster_.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y});

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -1054,7 +1054,10 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             uint32_t end_virtual_grid;
             if (hal_.get_tensix_harvest_axis() == HalTensixHarvestAxis::ROW) {
                 end_virtual_grid = hal_.get_virtual_worker_start_y() + logical_grid_size.y;
-            } else if (cluster_.arch() == ARCH::BLACKHOLE) {
+            } else if (cluster_.arch() == ARCH::BLACKHOLE || cluster_.arch() == ARCH::QUASAR) {
+                // Quasar shares Blackhole's COL harvest axis and virtual-grid layout
+                // (VIRTUAL_TENSIX_START_X/Y are identical), so a harvested column takes the same
+                // virtual coordinate as on Blackhole rather than the Wormhole-shaped fallback below.
                 end_virtual_grid = max_along_axis - 1;
             } else {
                 end_virtual_grid = hal_.get_virtual_worker_start_x() + logical_grid_size.x;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -960,11 +960,9 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             dev_msgs::AddressableCoreType::UNKNOWN);
     }
     int non_worker_cores_idx = 0;
-    // Wormhole addresses its PCIE/DRAM non-worker cores physically; Blackhole and Quasar (and future
-    // arches) virtualize them and write them as virtual cores below. ETH is virtualized on every arch.
-    // GRAYSKULL is retired, so "not Wormhole" cleanly covers the virtualizing arches without enumerating
-    // each one, and picks up future arches automatically.
-    const bool virtualizes_non_worker_cores = cluster_.arch() != ARCH::WORMHOLE_B0;
+    // Whether PCIE/DRAM non-worker cores are addressed virtually (Blackhole, Quasar) or physically
+    // (Wormhole) is a per-arch HAL capability; ETH is virtualized on every arch.
+    const bool virtualizes_non_worker_cores = hal_.virtualizes_non_worker_cores();
     bool skip_physical = hal_.is_coordinate_virtualization_enabled() and virtualizes_non_worker_cores;
     if (not skip_physical) {
         for (tt::umd::CoreCoord core : pcie_cores) {
@@ -979,10 +977,18 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             set_addressable_core(
                 core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::ETH);
         }
-        for (tt::umd::CoreCoord core : dispatch_cores) {
-            set_addressable_core(
-                core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::DISPATCH);
-        }
+    }
+    // DISPATCH cores are never written into virtual_non_worker_cores below, so register them in the
+    // physical list unconditionally. This restores the mailbox content produced for Quasar before
+    // skip_physical became true for it; without it these cores appear in neither mailbox array and fall
+    // through to the permissive physical-Tensix range check in debug/sanitize.h, which returns TENSIX for
+    // any in-grid coordinate -- so the watcher mislabels them and a multicast covering a dispatch core is
+    // no longer flagged as touching a non-worker. Only Quasar registers a DISPATCH programmable core type,
+    // so dispatch_cores is empty on Wormhole and Blackhole and this loop is a no-op there. Bounded by the
+    // pcie+dram+eth+dispatch TT_ASSERT above (debug-only; capacity is MAX_PHYSICAL_NON_WORKER_CORES).
+    for (tt::umd::CoreCoord core : dispatch_cores) {
+        set_addressable_core(
+            core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::DISPATCH);
     }
 
     if (hal_.is_coordinate_virtualization_enabled()) {

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -957,7 +957,12 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             dev_msgs::AddressableCoreType::UNKNOWN);
     }
     int non_worker_cores_idx = 0;
-    bool skip_physical = cluster_.arch() == ARCH::BLACKHOLE and hal_.is_coordinate_virtualization_enabled();
+    // Skip the physical PCIE/DRAM/ETH addressable cores when this arch virtualizes them (they are set as
+    // virtual cores below). Gate on the HAL capability instead of a hard-coded arch: BLACKHOLE and QUASAR
+    // virtualize DRAM/PCIE, WORMHOLE_B0 does not. This mirrors the dram_is_virtualized check above and
+    // covers future arches automatically.
+    bool skip_physical = hal_.is_coordinate_virtualization_enabled() and
+                         hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
     if (not skip_physical) {
         for (tt::umd::CoreCoord core : pcie_cores) {
             set_addressable_core(
@@ -978,6 +983,19 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
     }
 
     if (hal_.is_coordinate_virtualization_enabled()) {
+        // Guard the fixed-size virtual_non_worker_cores mailbox array (MAX_VIRTUAL_NON_WORKER_CORES,
+        // hand-sized for Blackhole's topology). ETH is always written; PCIE/DRAM are written when this
+        // arch virtualizes DRAM. Fail loudly at config time rather than silently overrunning the array
+        // into adjacent mailbox fields on an arch whose core count exceeds the constant.
+        const bool dram_virtualized =
+            hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
+        const size_t num_virtual_non_worker_cores =
+            eth_cores.size() + (dram_virtualized ? pcie_cores.size() + dram_cores.size() : 0);
+        TT_FATAL(
+            num_virtual_non_worker_cores <= core_info.virtual_non_worker_cores().size(),
+            "Virtual non-worker cores ({}) exceed the mailbox capacity ({}) for this architecture",
+            num_virtual_non_worker_cores,
+            core_info.virtual_non_worker_cores().size());
         uint32_t virtual_non_worker_cores_idx = 0;
         for (tt::umd::CoreCoord core : eth_cores) {
             auto virtual_core = cluster_.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y});
@@ -987,7 +1005,9 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
                 dev_msgs::AddressableCoreType::ETH);
         }
 
-        if (cluster_.arch() == ARCH::BLACKHOLE) {
+        // Set virtual PCIE/DRAM cores for arches that virtualize them (BLACKHOLE, QUASAR). ETH is handled
+        // for all virtualized arches above; WORMHOLE_B0 does not virtualize PCIE/DRAM.
+        if (dram_virtualized) {
             for (const CoreCoord& core : pcie_cores) {
                 auto virtual_core =
                     cluster_.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y});

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -957,11 +957,9 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             dev_msgs::AddressableCoreType::UNKNOWN);
     }
     int non_worker_cores_idx = 0;
-    // Wormhole addresses its PCIE/DRAM non-worker cores physically; Blackhole and Quasar (and future
-    // arches) virtualize them and write them as virtual cores below. ETH is virtualized on every arch.
-    // GRAYSKULL is retired, so "not Wormhole" cleanly covers the virtualizing arches without enumerating
-    // each one, and picks up future arches automatically.
-    const bool virtualizes_non_worker_cores = cluster_.arch() != ARCH::WORMHOLE_B0;
+    // Whether PCIE/DRAM non-worker cores are addressed virtually (Blackhole, Quasar) or physically
+    // (Wormhole) is a per-arch HAL capability; ETH is virtualized on every arch.
+    const bool virtualizes_non_worker_cores = hal_.virtualizes_non_worker_cores();
     bool skip_physical = hal_.is_coordinate_virtualization_enabled() and virtualizes_non_worker_cores;
     if (not skip_physical) {
         for (tt::umd::CoreCoord core : pcie_cores) {
@@ -976,10 +974,18 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             set_addressable_core(
                 core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::ETH);
         }
-        for (tt::umd::CoreCoord core : dispatch_cores) {
-            set_addressable_core(
-                core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::DISPATCH);
-        }
+    }
+    // DISPATCH cores are never written into virtual_non_worker_cores below, so register them in the
+    // physical list unconditionally. This restores the mailbox content produced for Quasar before
+    // skip_physical became true for it; without it these cores appear in neither mailbox array and fall
+    // through to the permissive physical-Tensix range check in debug/sanitize.h, which returns TENSIX for
+    // any in-grid coordinate -- so the watcher mislabels them and a multicast covering a dispatch core is
+    // no longer flagged as touching a non-worker. Only Quasar registers a DISPATCH programmable core type,
+    // so dispatch_cores is empty on Wormhole and Blackhole and this loop is a no-op there. Bounded by the
+    // pcie+dram+eth+dispatch TT_ASSERT above (debug-only; capacity is MAX_PHYSICAL_NON_WORKER_CORES).
+    for (tt::umd::CoreCoord core : dispatch_cores) {
+        set_addressable_core(
+            core_info.non_worker_cores()[non_worker_cores_idx++], core, dev_msgs::AddressableCoreType::DISPATCH);
     }
 
     if (hal_.is_coordinate_virtualization_enabled()) {

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -1051,7 +1051,10 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             uint32_t end_virtual_grid;
             if (hal_.get_tensix_harvest_axis() == HalTensixHarvestAxis::ROW) {
                 end_virtual_grid = hal_.get_virtual_worker_start_y() + logical_grid_size.y;
-            } else if (cluster_.arch() == ARCH::BLACKHOLE) {
+            } else if (cluster_.arch() == ARCH::BLACKHOLE || cluster_.arch() == ARCH::QUASAR) {
+                // Quasar shares Blackhole's COL harvest axis and virtual-grid layout
+                // (VIRTUAL_TENSIX_START_X/Y are identical), so a harvested column takes the same
+                // virtual coordinate as on Blackhole rather than the Wormhole-shaped fallback below.
                 end_virtual_grid = max_along_axis - 1;
             } else {
                 end_virtual_grid = hal_.get_virtual_worker_start_x() + logical_grid_size.x;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -957,12 +957,12 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             dev_msgs::AddressableCoreType::UNKNOWN);
     }
     int non_worker_cores_idx = 0;
-    // Skip the physical PCIE/DRAM/ETH addressable cores when this arch virtualizes them (they are set as
-    // virtual cores below). Gate on the HAL capability instead of a hard-coded arch: BLACKHOLE and QUASAR
-    // virtualize DRAM/PCIE, WORMHOLE_B0 does not. This mirrors the dram_is_virtualized check above and
-    // covers future arches automatically.
-    bool skip_physical = hal_.is_coordinate_virtualization_enabled() and
-                         hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
+    // Wormhole addresses its PCIE/DRAM non-worker cores physically; Blackhole and Quasar (and future
+    // arches) virtualize them and write them as virtual cores below. ETH is virtualized on every arch.
+    // GRAYSKULL is retired, so "not Wormhole" cleanly covers the virtualizing arches without enumerating
+    // each one, and picks up future arches automatically.
+    const bool virtualizes_non_worker_cores = cluster_.arch() != ARCH::WORMHOLE_B0;
+    bool skip_physical = hal_.is_coordinate_virtualization_enabled() and virtualizes_non_worker_cores;
     if (not skip_physical) {
         for (tt::umd::CoreCoord core : pcie_cores) {
             set_addressable_core(
@@ -985,12 +985,10 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
     if (hal_.is_coordinate_virtualization_enabled()) {
         // Guard the fixed-size virtual_non_worker_cores mailbox array (MAX_VIRTUAL_NON_WORKER_CORES,
         // hand-sized for Blackhole's topology). ETH is always written; PCIE/DRAM are written when this
-        // arch virtualizes DRAM. Fail loudly at config time rather than silently overrunning the array
-        // into adjacent mailbox fields on an arch whose core count exceeds the constant.
-        const bool dram_virtualized =
-            hal_.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM);
+        // arch virtualizes its non-worker cores. Fail loudly at config time rather than silently overrunning
+        // the array into adjacent mailbox fields on an arch whose core count exceeds the constant.
         const size_t num_virtual_non_worker_cores =
-            eth_cores.size() + (dram_virtualized ? pcie_cores.size() + dram_cores.size() : 0);
+            eth_cores.size() + (virtualizes_non_worker_cores ? pcie_cores.size() + dram_cores.size() : 0);
         TT_FATAL(
             num_virtual_non_worker_cores <= core_info.virtual_non_worker_cores().size(),
             "Virtual non-worker cores ({}) exceed the mailbox capacity ({}) for this architecture",
@@ -1005,9 +1003,9 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
                 dev_msgs::AddressableCoreType::ETH);
         }
 
-        // Set virtual PCIE/DRAM cores for arches that virtualize them (BLACKHOLE, QUASAR). ETH is handled
-        // for all virtualized arches above; WORMHOLE_B0 does not virtualize PCIE/DRAM.
-        if (dram_virtualized) {
+        // Set virtual PCIE/DRAM cores for arches that virtualize them (Blackhole, Quasar). ETH is handled
+        // for all virtualized arches above; Wormhole addresses PCIE/DRAM physically instead.
+        if (virtualizes_non_worker_cores) {
             for (const CoreCoord& core : pcie_cores) {
                 auto virtual_core =
                     cluster_.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y});
@@ -1051,10 +1049,11 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
             uint32_t end_virtual_grid;
             if (hal_.get_tensix_harvest_axis() == HalTensixHarvestAxis::ROW) {
                 end_virtual_grid = hal_.get_virtual_worker_start_y() + logical_grid_size.y;
-            } else if (cluster_.arch() == ARCH::BLACKHOLE || cluster_.arch() == ARCH::QUASAR) {
-                // Quasar shares Blackhole's COL harvest axis and virtual-grid layout
-                // (VIRTUAL_TENSIX_START_X/Y are identical), so a harvested column takes the same
-                // virtual coordinate as on Blackhole rather than the Wormhole-shaped fallback below.
+            } else if (cluster_.arch() != ARCH::WORMHOLE_B0) {
+                // COL-harvest arches (Blackhole, Quasar, and future arches) place a harvested column at
+                // this virtual coordinate. Wormhole is ROW-harvest and never reaches this COL branch, but
+                // keeping the guard as "not Wormhole" future-proofs new COL-harvest arches (GRAYSKULL is
+                // retired). The x-based fallback below remains for any arch that opts out.
                 end_virtual_grid = max_along_axis - 1;
             } else {
                 end_virtual_grid = hal_.get_virtual_worker_start_x() + logical_grid_size.x;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2566,7 +2566,6 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         // width formats that are supported mostly in tt-metal. This conservative check fires whenever a
         // compute kernel shares a core with any FP8 CB — the old Program API has no way to know which CB
         // a given kernel actually reads, so we err on the side of catching the misconfiguration.
-        // (Wormhole has no FP8 support at all; get_single_pack_src_format rejects it earlier.)
         if ((build_options.build_env.get_arch() == tt::ARCH::BLACKHOLE ||
              build_options.build_env.get_arch() == tt::ARCH::QUASAR) &&
             kernel->get_kernel_processor_class() == HalProcessorClassType::COMPUTE &&

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2561,12 +2561,14 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         this->set_cb_data_fmt_and_tile(kernel->logical_coreranges(), build_options);
         this->set_dfb_data_fmt_and_tile(kernel->logical_coreranges(), build_options);
 
-        // Blackhole-only: Fp8_e4m3 / Lf8 dataformats require fp32_dest_acc_en=true in the associated compute
-        // kernel. This is due to FP8/LF8 being considered "A" exp width formats, instead of "B" exp width
-        // formats that are supported mostly in tt-metal. This conservative check fires whenever a compute
-        // kernel shares a core with any FP8 CB — the old Program API has no way to know which CB
+        // Blackhole and Quasar: Fp8_e4m3 / Lf8 dataformats require fp32_dest_acc_en=true in the associated
+        // compute kernel. This is due to FP8/LF8 being considered "A" exp width formats, instead of "B" exp
+        // width formats that are supported mostly in tt-metal. This conservative check fires whenever a
+        // compute kernel shares a core with any FP8 CB — the old Program API has no way to know which CB
         // a given kernel actually reads, so we err on the side of catching the misconfiguration.
-        if (build_options.build_env.get_arch() == tt::ARCH::BLACKHOLE &&
+        // (Wormhole has no FP8 support at all; get_single_pack_src_format rejects it earlier.)
+        if ((build_options.build_env.get_arch() == tt::ARCH::BLACKHOLE ||
+             build_options.build_env.get_arch() == tt::ARCH::QUASAR) &&
             kernel->get_kernel_processor_class() == HalProcessorClassType::COMPUTE &&
             std::any_of(
                 build_options.hlk_desc.buf_dataformat_arr.begin(),
@@ -2574,7 +2576,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                 is_fp8_format)) {
             TT_FATAL(
                 build_options.fp32_dest_acc_en,
-                "Blackhole: Fp8_e4m3 / Lf8 require fp32_dest_acc_en=true in ComputeConfig. The DEST "
+                "Fp8_e4m3 / Lf8 require fp32_dest_acc_en=true in ComputeConfig. The DEST "
                 "register must be in 32-bit (family-agnostic) mode when any CB on the same core uses "
                 "an 8-bit float format. Kernel: {}",
                 kernel->name());

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2389,12 +2389,14 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         this->set_cb_data_fmt_and_tile(kernel->logical_coreranges(), build_options);
         this->set_dfb_data_fmt_and_tile(kernel->logical_coreranges(), build_options);
 
-        // Blackhole-only: Fp8_e4m3 / Lf8 dataformats require fp32_dest_acc_en=true in the associated compute
-        // kernel. This is due to FP8/LF8 being considered "A" exp width formats, instead of "B" exp width
-        // formats that are supported mostly in tt-metal. This conservative check fires whenever a compute
-        // kernel shares a core with any FP8 CB — the old Program API has no way to know which CB
+        // Blackhole and Quasar: Fp8_e4m3 / Lf8 dataformats require fp32_dest_acc_en=true in the associated
+        // compute kernel. This is due to FP8/LF8 being considered "A" exp width formats, instead of "B" exp
+        // width formats that are supported mostly in tt-metal. This conservative check fires whenever a
+        // compute kernel shares a core with any FP8 CB — the old Program API has no way to know which CB
         // a given kernel actually reads, so we err on the side of catching the misconfiguration.
-        if (build_options.build_env.get_arch() == tt::ARCH::BLACKHOLE &&
+        // (Wormhole has no FP8 support at all; get_single_pack_src_format rejects it earlier.)
+        if ((build_options.build_env.get_arch() == tt::ARCH::BLACKHOLE ||
+             build_options.build_env.get_arch() == tt::ARCH::QUASAR) &&
             kernel->get_kernel_processor_class() == HalProcessorClassType::COMPUTE &&
             std::any_of(
                 build_options.hlk_desc.buf_dataformat_arr.begin(),
@@ -2402,7 +2404,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                 is_fp8_format)) {
             TT_FATAL(
                 build_options.fp32_dest_acc_en,
-                "Blackhole: Fp8_e4m3 / Lf8 require fp32_dest_acc_en=true in ComputeConfig. The DEST "
+                "Fp8_e4m3 / Lf8 require fp32_dest_acc_en=true in ComputeConfig. The DEST "
                 "register must be in 32-bit (family-agnostic) mode when any CB on the same core uses "
                 "an 8-bit float format. Kernel: {}",
                 kernel->name());

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -36,14 +36,14 @@ MeshTensor mesh_tensor_from_buffer_with_topology(
 
 MeshTensor allocate_mesh_tensor_on_device_with_topology(
     distributed::MeshDevice& mesh_device, TensorSpec spec, TensorTopology topology) {
-    // Catch-all guard: FP8_E4M3 is only supported on Blackhole. Op-level validators may also
+    // Catch-all guard: FP8_E4M3 is only supported on Blackhole and Quasar. Op-level validators may also
     // check this, but we enforce it here at the device-binding boundary so any path that
     // produces an FP8 tensor on unsupported hardware fails loudly rather than silently
     // generating programs that misbehave later.
     if (spec.data_type() == DataType::FP8_E4M3) {
         TT_FATAL(
-            mesh_device.arch() == tt::ARCH::BLACKHOLE,
-            "FP8_E4M3 is only supported on Blackhole hardware (got arch {})",
+            mesh_device.arch() == tt::ARCH::BLACKHOLE || mesh_device.arch() == tt::ARCH::QUASAR,
+            "FP8_E4M3 is only supported on Blackhole/Quasar hardware (got arch {})",
             mesh_device.arch());
     }
     auto mesh_buffer = tensor_impl::allocate_device_buffer(&mesh_device, spec);

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_view_impl.hpp"
 
@@ -36,14 +37,14 @@ MeshTensor mesh_tensor_from_buffer_with_topology(
 
 MeshTensor allocate_mesh_tensor_on_device_with_topology(
     distributed::MeshDevice& mesh_device, TensorSpec spec, TensorTopology topology) {
-    // Catch-all guard: FP8_E4M3 is only supported on Blackhole and Quasar. Op-level validators may also
-    // check this, but we enforce it here at the device-binding boundary so any path that
-    // produces an FP8 tensor on unsupported hardware fails loudly rather than silently
-    // generating programs that misbehave later.
+    // Catch-all guard enforced at the device-binding boundary so any path that produces an FP8 tensor on
+    // unsupported hardware fails loudly rather than silently generating programs that misbehave later.
+    // Gate on the data-format capability (the same predicate used in data_format.cpp / program_spec.cpp)
+    // rather than an arch list, so this stays correct as arches are added or drop FP8 support.
     if (spec.data_type() == DataType::FP8_E4M3) {
         TT_FATAL(
-            mesh_device.arch() == tt::ARCH::BLACKHOLE || mesh_device.arch() == tt::ARCH::QUASAR,
-            "FP8_E4M3 is only supported on Blackhole/Quasar hardware (got arch {})",
+            tt::is_data_format_supported(tt::DataFormat::Fp8_e4m3, mesh_device.arch()),
+            "FP8_E4M3 is not supported on arch {}",
             mesh_device.arch());
     }
     auto mesh_buffer = tensor_impl::allocate_device_buffer(&mesh_device, spec);

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -242,7 +242,10 @@ DataFormat get_single_pack_src_format(
     bool int_fpu_en,
     tt::ARCH arch) {
     if (data_format == DataFormat::Fp8_e4m3) {
-        TT_FATAL(arch == tt::ARCH::BLACKHOLE, "Fp8 E4M3 mode only available in Blackhole");
+        TT_FATAL(
+            tt::is_data_format_supported(DataFormat::Fp8_e4m3, arch),
+            "Fp8 E4M3 mode not supported on arch {}",
+            arch);
     }
 
     DataFormat pack_src_format;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -380,6 +380,9 @@ private:
     uint32_t virtual_worker_start_y_{};
     bool eth_fw_is_cooperative_ = false;  // set when eth riscs have to context switch
     std::unordered_set<dev_msgs::AddressableCoreType> virtualized_core_types_;
+    // Whether this arch addresses its PCIE/DRAM non-worker cores through virtual coordinates
+    // (Blackhole, Quasar) rather than physical ones (Wormhole). ETH is virtualized on every arch.
+    bool virtualizes_non_worker_cores_{};
     HalTensixHarvestAxis tensix_harvest_axis_{HalTensixHarvestAxis::ROW};
     size_t max_pinned_memory_count_{};
     size_t total_pinned_memory_size_{};
@@ -542,6 +545,7 @@ public:
     const std::unordered_set<dev_msgs::AddressableCoreType>& get_virtualized_core_types() const {
         return this->virtualized_core_types_;
     }
+    bool virtualizes_non_worker_cores() const { return this->virtualizes_non_worker_cores_; }
 
     bool get_supports_eth_fw_mailbox() const;
     bool get_supports_eth_debug_regs() const;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -374,6 +374,9 @@ private:
     uint32_t virtual_worker_start_y_{};
     bool eth_fw_is_cooperative_ = false;  // set when eth riscs have to context switch
     std::unordered_set<dev_msgs::AddressableCoreType> virtualized_core_types_;
+    // Whether this arch addresses its PCIE/DRAM non-worker cores through virtual coordinates
+    // (Blackhole, Quasar) rather than physical ones (Wormhole). ETH is virtualized on every arch.
+    bool virtualizes_non_worker_cores_{};
     HalTensixHarvestAxis tensix_harvest_axis_{HalTensixHarvestAxis::ROW};
     size_t max_pinned_memory_count_{};
     size_t total_pinned_memory_size_{};
@@ -527,6 +530,7 @@ public:
     const std::unordered_set<dev_msgs::AddressableCoreType>& get_virtualized_core_types() const {
         return this->virtualized_core_types_;
     }
+    bool virtualizes_non_worker_cores() const { return this->virtualizes_non_worker_cores_; }
 
     bool get_supports_eth_fw_mailbox() const;
     bool get_supports_eth_debug_regs() const;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -492,6 +492,7 @@ void Hal::initialize_bh(
         dev_msgs::AddressableCoreType::ETH,
         dev_msgs::AddressableCoreType::PCIE,
         dev_msgs::AddressableCoreType::DRAM};
+    this->virtualizes_non_worker_cores_ = true;
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
     this->has_tile_counter_registers_ = false;
     this->supports_implicit_dfb_sync_ = false;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -467,6 +467,7 @@ void Hal::initialize_bh(
         dev_msgs::AddressableCoreType::ETH,
         dev_msgs::AddressableCoreType::PCIE,
         dev_msgs::AddressableCoreType::DRAM};
+    this->virtualizes_non_worker_cores_ = true;
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
     this->has_tile_counter_registers_ = false;
     this->supports_implicit_dfb_sync_ = false;

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -381,6 +381,8 @@ void Hal::initialize_wh(
     this->virtual_worker_start_y_ = VIRTUAL_TENSIX_START_Y;
     this->eth_fw_is_cooperative_ = true;
     this->virtualized_core_types_ = {dev_msgs::AddressableCoreType::TENSIX, dev_msgs::AddressableCoreType::ETH};
+    // Wormhole addresses its PCIE/DRAM non-worker cores physically.
+    this->virtualizes_non_worker_cores_ = false;
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
     this->has_tile_counter_registers_ = false;
     this->supports_implicit_dfb_sync_ = false;

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -563,6 +563,7 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes, bo
         dev_msgs::AddressableCoreType::ETH,
         dev_msgs::AddressableCoreType::PCIE,
         dev_msgs::AddressableCoreType::DRAM};
+    this->virtualizes_non_worker_cores_ = true;
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
     this->has_tile_counter_registers_ = true;
     this->supports_implicit_dfb_sync_ = true;

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -553,6 +553,7 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes, bo
         dev_msgs::AddressableCoreType::ETH,
         dev_msgs::AddressableCoreType::PCIE,
         dev_msgs::AddressableCoreType::DRAM};
+    this->virtualizes_non_worker_cores_ = true;
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
     this->has_tile_counter_registers_ = true;
     this->supports_implicit_dfb_sync_ = true;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
@@ -183,8 +183,10 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
     const uint32_t input0_stride = stride_tile_size * num_tiles_for_each_input_shard[0].second / groups;
     const uint32_t input1_stride = stride_tile_size * num_tiles_for_each_input_shard[1].second / groups;
 
-    // NOC_MAX_BURST_SIZE from noc_parameters.h: Wormhole = 8192, Blackhole = 16384
-    const uint32_t noc_max_burst_size = (input_tensors[0].device()->arch() == tt::ARCH::BLACKHOLE) ? 16384 : 8192;
+    // NOC_MAX_BURST_SIZE from noc_parameters.h: Wormhole = 8192, Blackhole = 16384, Quasar = 65536
+    const uint32_t noc_max_burst_size = (input_tensors[0].device()->arch() == tt::ARCH::BLACKHOLE) ? 16384
+                                        : (input_tensors[0].device()->arch() == tt::ARCH::QUASAR)  ? 65536
+                                                                                                   : 8192;
     const bool use_single_packet_read = (input0_stride <= noc_max_burst_size && input1_stride <= noc_max_burst_size);
 
     KernelDescriptor::CompileTimeArgs compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
 
 namespace ttnn::prim {
 
@@ -183,10 +184,9 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
     const uint32_t input0_stride = stride_tile_size * num_tiles_for_each_input_shard[0].second / groups;
     const uint32_t input1_stride = stride_tile_size * num_tiles_for_each_input_shard[1].second / groups;
 
-    // NOC_MAX_BURST_SIZE from noc_parameters.h: Wormhole = 8192, Blackhole = 16384, Quasar = 65536
-    const uint32_t noc_max_burst_size = (input_tensors[0].device()->arch() == tt::ARCH::BLACKHOLE) ? 16384
-                                        : (input_tensors[0].device()->arch() == tt::ARCH::QUASAR)  ? 65536
-                                                                                                   : 8192;
+    // NOC_MAX_BURST_SIZE from the architecture's noc_parameters.h, via the HAL:
+    // Wormhole = 8192, Blackhole = 16384, Quasar = 65536.
+    const uint32_t noc_max_burst_size = tt::tt_metal::hal::get_noc_max_burst_size_bytes();
     const bool use_single_packet_read = (input0_stride <= noc_max_burst_size && input1_stride <= noc_max_burst_size);
 
     KernelDescriptor::CompileTimeArgs compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -92,7 +92,10 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     auto* dst_buffer = output.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    // Quasar shares Blackhole's NoC alignment (DRAM read align 64, L1 16), which differs from Wormhole
+    // (DRAM align 32), so both take the same alignment-adjust path below.
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+    bool is_quasar = (input.device()->arch() == tt::ARCH::QUASAR);
 
     if (input.layout() == Layout::TILE) {
         input_unit_size = tt::tile_size(input_cb_data_format);
@@ -175,7 +178,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     uint32_t dram_alignment = hal::get_dram_alignment();
     uint32_t l1_alignment = hal::get_l1_alignment();
     uint32_t num_trids = 4;
-    if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
+    if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || (is_blackhole || is_quasar) || keep_l1_aligned) {
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
         // This is done to mitigate the alignment issues.
         // See issue #34414.
@@ -355,7 +358,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
             bool aligned = false;
             if (src_is_dram) {
                 aligned = (curr_idx_w % dram_alignment == 0) && (padded_offset_bytes % dram_alignment == 0);
-            } else if (is_blackhole) {
+            } else if (is_blackhole || is_quasar) {
                 aligned = (curr_idx_w % l1_alignment == 0) && (padded_offset_bytes % l1_alignment == 0);
             } else {
                 aligned = true;
@@ -365,7 +368,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
             uint32_t aligned_offset = 0;
             if (!aligned) {
                 // TODO: is this right, leaving non BH case the same for now, should investigate
-                if (!is_blackhole) {
+                if (!(is_blackhole || is_quasar)) {
                     aligned_width_offset = tt::round_down(curr_idx_w, dram_alignment);
                 } else {
                     if (src_is_dram) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -92,8 +92,6 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     auto* dst_buffer = output.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    // Quasar shares Blackhole's NoC alignment (DRAM read align 64, L1 16), which differs from Wormhole
-    // (DRAM align 32), so both take the same alignment-adjust path below.
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
     bool is_quasar = (input.device()->arch() == tt::ARCH::QUASAR);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -83,8 +83,6 @@ ProgramDescriptor InterleavedToShardedPartialProgramFactory::create_descriptor(
     auto* dst_buffer = output.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    // Quasar shares Blackhole's NoC alignment (DRAM read align 64, L1 16), which differs from Wormhole
-    // (DRAM align 32), so both take the same alignment-adjust path below.
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
     bool is_quasar = (input.device()->arch() == tt::ARCH::QUASAR);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -83,7 +83,10 @@ ProgramDescriptor InterleavedToShardedPartialProgramFactory::create_descriptor(
     auto* dst_buffer = output.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    // Quasar shares Blackhole's NoC alignment (DRAM read align 64, L1 16), which differs from Wormhole
+    // (DRAM align 32), so both take the same alignment-adjust path below.
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+    bool is_quasar = (input.device()->arch() == tt::ARCH::QUASAR);
 
     if (input.layout() == Layout::TILE) {
         input_unit_size = tt::tile_size(input_cb_data_format);
@@ -168,7 +171,7 @@ ProgramDescriptor InterleavedToShardedPartialProgramFactory::create_descriptor(
     uint32_t dram_alignment = hal::get_dram_alignment();
     uint32_t l1_alignment = hal::get_l1_alignment();
     uint32_t num_trids = 4;
-    if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
+    if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || (is_blackhole || is_quasar) || keep_l1_aligned) {
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
         // This is done to mitigate the alignment issues.
         // See issue #34414.
@@ -353,13 +356,13 @@ ProgramDescriptor InterleavedToShardedPartialProgramFactory::create_descriptor(
                 (src_is_dram ? (curr_idx_w % dram_alignment == 0) && (padded_offset_bytes % dram_alignment == 0)
                              : true);
             // for blackhole and keep_l1_aligned cases, always enforce unaligned kernel call
-            aligned = aligned and !(is_blackhole);
+            aligned = aligned and !(is_blackhole || is_quasar);
             uint32_t aligned_width_offset = 0;
             uint32_t aligned_shard_width = 0;
             uint32_t aligned_offset = 0;
             if (!aligned) {
                 // TODO: is this right, leaving non BH case the same for now, should investigate
-                if (!is_blackhole) {
+                if (!(is_blackhole || is_quasar)) {
                     aligned_width_offset = tt::round_down(curr_idx_w, dram_alignment);
                 } else {
                     if (src_is_dram) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -353,9 +353,13 @@ void get_max_page_size_and_num_pages(
         noc_max_page_size = 8192;
     } else if (device->arch() == tt::ARCH::BLACKHOLE) {
         noc_max_page_size = 16384;
+    } else if (device->arch() == tt::ARCH::QUASAR) {
+        // Quasar NOC_MAX_BURST_SIZE = NOC_MAX_BURST_WORDS(256) * NOC_WORD_BYTES(256) = 65536.
+        noc_max_page_size = 65536;
     } else {
         TT_THROW(
-            "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported. Got: {}",
+            "Unsupported architecture for DRAM sharded matmul. Only Wormhole, Blackhole and Quasar are supported. "
+            "Got: {}",
             device->arch());
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -363,9 +363,13 @@ void get_max_page_size_and_num_pages(
         noc_max_page_size = 8192;
     } else if (device->arch() == tt::ARCH::BLACKHOLE) {
         noc_max_page_size = 16384;
+    } else if (device->arch() == tt::ARCH::QUASAR) {
+        // Quasar NOC_MAX_BURST_SIZE = NOC_MAX_BURST_WORDS(256) * NOC_WORD_BYTES(256) = 65536.
+        noc_max_page_size = 65536;
     } else {
         TT_THROW(
-            "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported. Got: {}",
+            "Unsupported architecture for DRAM sharded matmul. Only Wormhole, Blackhole and Quasar are supported. "
+            "Got: {}",
             device->arch());
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -11,6 +11,7 @@
 #include "tt-metalium/allocator.hpp"
 #include "tt-metalium/experimental/device.hpp"
 #include "tt-metalium/buffer_types.hpp"
+#include "tt-metalium/hal.hpp"
 #include "tt-metalium/kernel_types.hpp"
 #include "tt-metalium/work_split.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
@@ -354,24 +355,16 @@ tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const tt
 }
 
 void get_max_page_size_and_num_pages(
-    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
+    tt::tt_metal::IDevice* /*device*/,
+    uint32_t num_tiles,
+    uint32_t tile_size,
+    uint32_t& page_size,
+    uint32_t& num_pages) {
     uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
 
-    // TODO(#32477): Remove hardcoding when NOC_MAX_BURST_SIZE is available from HAL
-    uint32_t noc_max_page_size;
-    if (device->arch() == tt::ARCH::WORMHOLE_B0) {
-        noc_max_page_size = 8192;
-    } else if (device->arch() == tt::ARCH::BLACKHOLE) {
-        noc_max_page_size = 16384;
-    } else if (device->arch() == tt::ARCH::QUASAR) {
-        // Quasar NOC_MAX_BURST_SIZE = NOC_MAX_BURST_WORDS(256) * NOC_WORD_BYTES(256) = 65536.
-        noc_max_page_size = 65536;
-    } else {
-        TT_THROW(
-            "Unsupported architecture for DRAM sharded matmul. Only Wormhole, Blackhole and Quasar are supported. "
-            "Got: {}",
-            device->arch());
-    }
+    // NOC_MAX_BURST_SIZE from the architecture's noc_parameters.h, via the HAL (resolves #32477):
+    // Wormhole = 8192, Blackhole = 16384, Quasar = 65536.
+    const uint32_t noc_max_page_size = tt::tt_metal::hal::get_noc_max_burst_size_bytes();
 
     page_size = (noc_max_page_size / tile_size) * tile_size;
     while (total_size % page_size != 0 && page_size >= tile_size) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -9,6 +9,7 @@
 
 #include "tt-metalium/allocator.hpp"
 #include "tt-metalium/buffer_types.hpp"
+#include "tt-metalium/hal.hpp"
 #include "tt-metalium/work_split.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
@@ -344,24 +345,16 @@ tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const tt
 }
 
 void get_max_page_size_and_num_pages(
-    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
+    tt::tt_metal::IDevice* /*device*/,
+    uint32_t num_tiles,
+    uint32_t tile_size,
+    uint32_t& page_size,
+    uint32_t& num_pages) {
     uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
 
-    // TODO(#32477): Remove hardcoding when NOC_MAX_BURST_SIZE is available from HAL
-    uint32_t noc_max_page_size;
-    if (device->arch() == tt::ARCH::WORMHOLE_B0) {
-        noc_max_page_size = 8192;
-    } else if (device->arch() == tt::ARCH::BLACKHOLE) {
-        noc_max_page_size = 16384;
-    } else if (device->arch() == tt::ARCH::QUASAR) {
-        // Quasar NOC_MAX_BURST_SIZE = NOC_MAX_BURST_WORDS(256) * NOC_WORD_BYTES(256) = 65536.
-        noc_max_page_size = 65536;
-    } else {
-        TT_THROW(
-            "Unsupported architecture for DRAM sharded matmul. Only Wormhole, Blackhole and Quasar are supported. "
-            "Got: {}",
-            device->arch());
-    }
+    // NOC_MAX_BURST_SIZE from the architecture's noc_parameters.h, via the HAL (resolves #32477):
+    // Wormhole = 8192, Blackhole = 16384, Quasar = 65536.
+    const uint32_t noc_max_page_size = tt::tt_metal::hal::get_noc_max_burst_size_bytes();
 
     page_size = (noc_max_page_size / tile_size) * tile_size;
     while (total_size % page_size != 0 && page_size >= tile_size) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Quasar arch-enablement. Across the runtime, code branched on `ARCH::BLACKHOLE`
(or `== WORMHOLE_B0`) as a *proxy* for a capability that Quasar actually shares, so a
Quasar device was silently excluded, either crashing (`TT_THROW`/`TT_FATAL`) or getting
Wormhole's (wrong) settings. This is the same class of gap as the missing
`get_string_lowercase` QUASAR case fixed in #48155. Each fix either uses the real
capability predicate or adds `QUASAR` explicitly; none change Wormhole/Blackhole behavior.

Eight gaps fixed (grouped by commit):

**FP8_E4M3 guards** (Quasar supports FP8; only Wormhole doesn't)
- `jit_build/data_format.cpp`: FP8 pack-format selection FATAL'd unless Blackhole; now
  gates on `is_data_format_supported(Fp8_e4m3, arch)` (the support table = source of truth).
- `impl/tensor/mesh_tensor.cpp`: FP8 tensor device-binding guard now allows `BLACKHOLE || QUASAR`.

**Device init**
- `impl/device/firmware/risc_firmware_initializer.cpp`: the virtual PCIE/DRAM
  addressable-core table (feeds the device NoC watcher/sanitizer) was populated only for
  Blackhole; now gated on a new HAL capability, `hal.virtualizes_non_worker_cores()`.
  DISPATCH cores (Quasar-only) are now always registered in the physical list. Also adds
  a bounds guard on the fixed-size `virtual_non_worker_cores` mailbox array to fail
  loudly instead of overrunning.
- `risc_firmware_initializer.cpp`: the harvested-COL-column virtual coordinate used a
  Blackhole-only formula; Quasar is COL-harvest with an identical virtual-grid layout
  (`VIRTUAL_TENSIX_START_X/Y`), so it now uses the same formula.

**ttnn NoC size/alignment** (Quasar uses DRAM align 64 / L1 align 16 like Blackhole, but a larger NOC max burst size (65536))
- `matmul` `get_max_page_size_and_num_pages`: DRAM-sharded matmul `TT_THROW`'d on Quasar;
  now `noc_max_page_size = 65536`.
- `concat_s2s_tiled`: burst size defaulted Quasar to Wormhole's 8192; now 65536.
- `interleaved_to_sharded` / `interleaved_to_sharded_partial`: the Blackhole-only alignment
  path now also covers Quasar.

Tests added:
- `test_blockfloat_common.cpp`: host-side `DataFormatFp8ArchGuard.Fp8E4m3PackSrcFormatPerArch`
  (QUASAR/BLACKHOLE allowed, WORMHOLE_B0 still rejected).
- `test_mesh_tensor.cpp`: `MeshDeviceSingleCardFixture.AllocateFp8E4m3OnDevice`.

### Notes for reviewers

**Verification status:**
- FP8 pack guard: host test **passes**.
- FP8 tensor guard: **passes on the Quasar emulator** (`emu-quasar-1x3`, slow dispatch).
- The device virtualization fix runs on every Quasar boot (exercised by the tensor test).
- The **harvest** fix and the **4 ttnn** fixes are **compile-clean + verified against the Quasar
  HW headers** (`tt-2xx/quasar/noc/noc_parameters.h`, `qa_hal.cpp`) but **not run end-to-end**.

**No Wormhole/Blackhole behavior change**

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ymoussa/fix-quasar-fp8-arch-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ymoussa/fix-quasar-fp8-arch-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ymoussa/fix-quasar-fp8-arch-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ymoussa/fix-quasar-fp8-arch-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ymoussa/fix-quasar-fp8-arch-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ymoussa/fix-quasar-fp8-arch-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ymoussa/fix-quasar-fp8-arch-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ymoussa/fix-quasar-fp8-arch-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ymoussa/fix-quasar-fp8-arch-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ymoussa/fix-quasar-fp8-arch-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ymoussa/fix-quasar-fp8-arch-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ymoussa/fix-quasar-fp8-arch-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ymoussa/fix-quasar-fp8-arch-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ymoussa/fix-quasar-fp8-arch-guards)