### PR TITLE
Fix std::terminate/use-after-free on watcher thread join ti…

### DIFF
--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -169,11 +169,20 @@ void WatcherServer::Impl::detach_devices() {
         stop_server_ = true;
         stop_server_cv_.notify_all();
 
-        // Wait for the thread to end, with a timeout
+        // Wait for the thread to end. The timeout is used only to emit a diagnostic if the
+        // thread is slow to return (e.g. wedged inside a device read in dump()); we must not
+        // delete a still-joinable std::thread (that calls std::terminate()), nor delete it
+        // while the async join task below is still executing on it (use-after-free). The poll
+        // loop is guaranteed to observe stop_server_ and return once any in-flight dump()
+        // completes, so we block until the join genuinely finishes before deleting.
         auto future = std::async(std::launch::async, &std::thread::join, server_thread_);
         if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
-            log_fatal(tt::LogMetal, "Timed out waiting on watcher server thread to terminate.");
+            log_warning(
+                tt::LogMetal,
+                "Watcher server thread is taking longer than 2s to terminate (likely blocked in a device read); "
+                "continuing to wait for it to finish.");
         }
+        future.wait();
         delete server_thread_;
         server_thread_ = nullptr;
     }


### PR DESCRIPTION
## Summary

Fixes a `std::terminate` / use-after-free in `WatcherServer::detach_devices()` during device teardown. Also tracked as finding #2 in the host-side race audit #48579.
Fixes #44454

`detach_devices()` ran `delete server_thread_` even when the 2s join timed out. `log_fatal` only logs (it expands to `SPDLOG_LOGGER_CRITICAL`, which does **not** abort), so on timeout execution fell through to the `delete`, which:
- destroyed a still-joinable `std::thread` → `std::terminate()`, and
- freed the object while the `std::async` join task was still executing on it → use-after-free.

This is reachable on the normal teardown path (`MetalContext::teardown()` → `WatcherServer::detach_devices()`) whenever the poll thread is slow to return (e.g. wedged in a device read inside `dump()`).

## Fix

Never delete a joinable thread:
- The 2s timeout is now diagnostic-only (`log_fatal` → `log_warning`).
- Block on `future.wait()` before `delete server_thread_`, so the thread is guaranteed joined (and no longer touching the object) before it is freed.

The poll loop already shuts down cooperatively via `stop_server_` + the condition variable, so it returns once any in-flight `dump()` completes.

Note: detaching the thread (the remedy originally suggested in #44454) is **not** safe here - the poll thread dereferences `this` (`watch_mutex_`, `logfile_`, `device_id_to_reader_`), which is torn down immediately after this block, so a detached-but-running thread would UAF. This matches #48579's own guidance.

## Test plan

- [x] Incremental build of `libtt_metal.so` + `unit_tests_debug_tools` (clean).
- [x] `unit_tests_debug_tools --gtest_filter='MeshWatcherFixture.TestWatcherWaypoints:MeshWatcherFixture.TestWatcherRingBufferBrisc'` pass on hardware; logs confirm the modified teardown path executes (`Watcher thread stopped watching...` → `Watcher detached device 0`) with no crash.
- The timeout branch itself (a device read exceeding 2s) is not triggerable without artificially hanging a device read; its safety is structural (delete only after `future.wait()` returns).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-48579-watcher-thread-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-48579-watcher-thread-race)