### PR TITLE
[LLK][WH,BH] Name packer config words in non-MMIO writes instead of Row_start offsets

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -510,7 +510,7 @@ __attribute__((noinline)) inline void reconfig_packer_data_format(
     config.f.in_data_format  = pack_hw_src_format;
     TT_SETDMAREG(0, LOWER_HALFWORD(config.val[2]), 0, LO_16(p_gpr_pack::TMP_LO));
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
-    TTI_WRCFG(p_gpr_pack::TMP_LO, p_cfg::WRCFG_32b, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 2);
+    TTI_WRCFG(p_gpr_pack::TMP_LO, p_cfg::WRCFG_32b, THCON_SEC0_REG1_Out_data_format_ADDR32);
 
     LLK_ASSERT(
         is_pack_reads_per_xy_plane(1),

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -604,10 +604,10 @@ __attribute__((noinline)) inline void reconfig_packer_data_format(
     // Wait till packer is done before changing config registers
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);
     TT_SETDMAREG(0, LOWER_HALFWORD(config.val[2]), 0, LO_16(p_gpr_pack::TMP_LO));
-    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 2 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO); // 16-bit write
-    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 2 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
-    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 2 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
-    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 2 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
+    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC0_REG1_Out_data_format_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO); // 16-bit write
+    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC0_REG8_Out_data_format_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
+    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC1_REG1_Out_data_format_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
+    TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC1_REG8_Out_data_format_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
 
     LLK_ASSERT(
         is_pack_reads_per_xy_plane(1),
@@ -647,32 +647,32 @@ __attribute__((noinline)) inline void reconfig_packer_data_format(
 
         // Override exp section size for packers 1,2,3
         // Tile header + exp size + datum size
-        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP0_SEC_SIZE_BFP);
+        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP0_SEC_SIZE_BFP);
         if ((pack_dst_format & 0x1F) == to_underlying(DataFormat::Bfp8) || (pack_dst_format & 0x1F) == to_underlying(DataFormat::Bfp8_b))
         {
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP8);
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP8);
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP8);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP8);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP8);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP8);
         }
         else if ((pack_dst_format & 0x1F) == to_underlying(DataFormat::Bfp4) || (pack_dst_format & 0x1F) == to_underlying(DataFormat::Bfp4_b))
         {
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP4);
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP4);
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP4);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP4);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP4);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP4);
         }
         else if ((pack_dst_format & 0x1F) == to_underlying(DataFormat::Bfp2) || (pack_dst_format & 0x1F) == to_underlying(DataFormat::Bfp2_b))
         {
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP2);
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP2);
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP2);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP1_SEC_SIZE_BFP2);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP2_SEC_SIZE_BFP2);
+            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::EXP3_SEC_SIZE_BFP2);
         }
     }
     else if ((pack_dst_format == to_underlying(DataFormat::Lf8)) || (masked_data_format(pack_dst_format) == to_underlying(DataFormat::Int8)))
     {
-        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
-        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
-        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
-        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
+        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
+        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
+        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
+        TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr::ZERO);
     }
 
     // Set l1 address offset
@@ -1049,10 +1049,10 @@ __attribute__((noinline)) void are_packers_configured_correctly(
 
     // Only read config word 2 per packer (contains in_data_format and out_data_format)
     static constexpr std::uint32_t config_word2_addrs[NUM_PACKERS] = {
-        THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 2,
-        THCON_SEC0_REG8_Row_start_section_size_ADDR32 + 2,
-        THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 2,
-        THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 2,
+        THCON_SEC0_REG1_Out_data_format_ADDR32,
+        THCON_SEC0_REG8_Out_data_format_ADDR32,
+        THCON_SEC1_REG1_Out_data_format_ADDR32,
+        THCON_SEC1_REG8_Out_data_format_ADDR32,
     };
 
     const std::uint32_t expected_src = masked_data_format(pack_src_format);


### PR DESCRIPTION
## What

In `cpack_common.h` (Wormhole B0 + Blackhole), some packer config words were addressed by adding a literal offset to `THCON_SEC{0,1}_REG{1,8}_Row_start_section_size_ADDR32`, landing on words owned by *differently-named* field macros in `cfg_defines.h`. This points the **non-MMIO** ones at the target word's own macro:

```
reconfig data-format update (TTI_REG2FLOP on WH, TTI_WRCFG on BH):
    Row_start_section_size_ADDR32 + 2  ->  Out_data_format_ADDR32
reconfig exp-section-size writes (TTI_REG2FLOP):
    Row_start_section_size_ADDR32 + 0  ->  Row_start_section_size_ADDR32   (drop redundant + 0)
are_packers_configured_correctly read-back table:
    Row_start_section_size_ADDR32 + 2  ->  Out_data_format_ADDR32
```

## Deliberately left unchanged (per review feedback)

The `set_packer_config` writes of the form:

```cpp
cfg[THCON_SEC0_REG1_Row_start_section_size_ADDR32 + i] = config.val[i];
```

copy a `pack_config_u` union into consecutive register words one word at a time via MMIO (the unrolled `for i` loop). There the offset `i` **mirrors the union layout** (`val[i]` -> word `i`), so the offset is the natural, correct expression and is kept as-is.

## Correctness

Every replacement resolves to the **identical `ADDR32`** on both architectures, verified against `cfg_defines.h` (base+2 = `Out_data_format`, base+0 = `Row_start_section_size` for all four `SEC0/SEC1 x REG1/REG8` banks). No behavioral effect. clang-format applied; pre-commit clean.

## Scope

- Quasar is unaffected — its LLK never uses the `ADDR32 + offset` idiom.
- Intra-register indexing (`TileDescriptor_ADDR32 + i`, `Out_data_format_ADDR32 + i` loops) is left alone — those walk one wide register with a single macro.

## Status

Draft — opened for CI / hardware regression validation. Tracking issue: tenstorrent/tt-llk#1666

> Upstream note: `tt_metal/tt-llk/` is a vendored copy; the change should also be upstreamed to `tenstorrent/tt-llk` (see the linked issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)