### PR TITLE
NO MERGE (qwen3.6 test)

### DIFF
--- a/models/demos/blackhole/qwen36/tt/attention/tp.py
+++ b/models/demos/blackhole/qwen36/tt/attention/tp.py
@@ -47,7 +47,7 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
         dim=-1,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         cache_path=c("wqkv"),
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16,
     )
     tw["wk"] = tpc.shard_w(
         state_dict["k_proj.weight"],
@@ -55,7 +55,7 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
         dim=-1,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         cache_path=c("wk"),
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16,
     )
     tw["wv"] = tpc.shard_w(
         state_dict["v_proj.weight"],
@@ -63,7 +63,7 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
         dim=-1,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         cache_path=c("wv"),
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16,
     )
     # Row-parallel: shard input dim → reduce-scatter after
     tw["wo"] = tpc.shard_w(
@@ -72,7 +72,7 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
         dim=0,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         cache_path=c("wo"),
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16,
     )
     # Per-head QK norms, replicated. HF Qwen3_5RMSNorm computes output*(1+weight) and the ckpts
     # store raw zero-centered weights (means ~0.32-0.58), so +1 is the correct scale. Without it

--- a/models/demos/blackhole/qwen36/tt/attention/weights.py
+++ b/models/demos/blackhole/qwen36/tt/attention/weights.py
@@ -20,7 +20,7 @@ def load_attention_weights(mesh_device, state_dict, tensor_cache_path=None) -> A
         t = state_dict[f"{name}.weight"].T.contiguous()
         return ttnn.as_tensor(
             t,
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -82,7 +82,7 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
     )
     tw = {}
     tw["qkvz"] = tpc.shard_w(
-        fused, mesh, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG, cache_path=c("qkvz"), dtype=ttnn.bfloat8_b
+        fused, mesh, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG, cache_path=c("qkvz"), dtype=ttnn.bfloat16
     )
     # ---- fused A+B (column-parallel), per-device [a(nv_per), b(nv_per)] ----
     a_w, b_w = sd[P + "in_proj_a.weight"], sd[P + "in_proj_b.weight"]
@@ -91,7 +91,7 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
         dim=0,
     )
     tw["ab"] = tpc.shard_w(
-        ab, mesh, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG, cache_path=c("ab"), dtype=ttnn.bfloat8_b
+        ab, mesh, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG, cache_path=c("ab"), dtype=ttnn.bfloat16
     )
     # ---- out projection (row-parallel) ----
     tw["out"] = tpc.shard_w(
@@ -100,7 +100,7 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
         dim=0,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         cache_path=c("out"),
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16,
     )
     # ---- per-head params ----
     tw["dt_bias"] = tpc.shard_small(sd[P + "dt_bias"].float(), mesh, c("dt_bias"))

--- a/models/demos/blackhole/qwen36/tt/gdn/weights.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/weights.py
@@ -81,7 +81,7 @@ def load_gdn_weights(mesh_device, config: GDNConfig, state_dict, tensor_cache_pa
         t = state_dict[name].T.contiguous()
         return ttnn.as_tensor(
             t,
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -115,7 +115,7 @@ def load_gdn_weights(mesh_device, config: GDNConfig, state_dict, tensor_cache_pa
     t = state_dict[qkv_key].T.contiguous()  # [4096, 8192]
     qkv_proj_weight = ttnn.as_tensor(
         t,
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=mesh_device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -210,7 +210,7 @@ def load_gdn_weights(mesh_device, config: GDNConfig, state_dict, tensor_cache_pa
         a_w = ttnn.to_torch(a_proj_weight)  # [4096, 32]
         b_w = ttnn.to_torch(b_proj_weight)  # [4096, 32]
         fused = torch.cat([a_w, b_w], dim=1).contiguous()  # [4096, 64]
-        return ttnn.from_torch(fused, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=mesh_device)
+        return ttnn.from_torch(fused, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
 
     def _precompute_mega_fused_weight():
         """Fuse QKV + a + b + g projections into one [4096, D_total] weight.
@@ -225,7 +225,7 @@ def load_gdn_weights(mesh_device, config: GDNConfig, state_dict, tensor_cache_pa
         b_w = ttnn.to_torch(b_proj_weight)  # [4096, 32]
         g_w = ttnn.to_torch(g_proj_weight)  # [4096, 4096]
         fused = torch.cat([qkv_w, a_w, b_w, g_w], dim=1).contiguous()
-        return ttnn.from_torch(fused, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=mesh_device)
+        return ttnn.from_torch(fused, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
 
     # Precompute conv weight taps and bias on device to avoid CPU round-trips during decode
     q_weight_taps = _precompute_weight_taps(q_conv_weight)

--- a/models/demos/blackhole/qwen36/tt/mlp.py
+++ b/models/demos/blackhole/qwen36/tt/mlp.py
@@ -15,9 +15,9 @@ import ttnn
 
 @dataclass(frozen=True)
 class MLPWeights:
-    w1: ttnn.Tensor  # gate_proj  [in, out], bfloat4_b
-    w2: ttnn.Tensor  # down_proj  [in, out], bfloat8_b
-    w3: ttnn.Tensor  # up_proj    [in, out], bfloat4_b
+    w1: ttnn.Tensor  # gate_proj  [in, out], bfloat16
+    w2: ttnn.Tensor  # down_proj  [in, out], bfloat16
+    w3: ttnn.Tensor  # up_proj    [in, out], bfloat16
 
 
 def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None) -> MLPWeights:
@@ -43,7 +43,7 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
                 dim=-1,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 cache_path=cache("gate_proj"),
-                dtype=ttnn.bfloat4_b,
+                dtype=ttnn.bfloat16,
             ),
             w3=tpc.shard_w(
                 state_dict["up_proj.weight"],
@@ -51,7 +51,7 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
                 dim=-1,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 cache_path=cache("up_proj"),
-                dtype=ttnn.bfloat4_b,
+                dtype=ttnn.bfloat16,
             ),
             w2=tpc.shard_w(
                 state_dict["down_proj.weight"],
@@ -59,7 +59,7 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
                 dim=0,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 cache_path=cache("down_proj"),
-                dtype=ttnn.bfloat8_b,
+                dtype=ttnn.bfloat16,
             ),
         )
 
@@ -74,12 +74,13 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
             cache_file_name=(tensor_cache_path / f"mlp.{name}.weight") if tensor_cache_path else None,
         )
 
-    # Gate and up projections use bfloat4_b (halves memory bandwidth for these large matmuls).
-    # Down projection stays at bfloat8_b (on the critical accuracy path).
+    # All three projections use bfloat16 for maximum precision (previously gate/up
+    # were bfloat4_b and down was bfloat8_b to save memory bandwidth). This roughly
+    # doubles/quadruples the MLP weight footprint but keeps full bf16 precision.
     return MLPWeights(
-        w1=load("gate_proj", ttnn.bfloat4_b),
-        w2=load("down_proj", ttnn.bfloat8_b),
-        w3=load("up_proj", ttnn.bfloat4_b),
+        w1=load("gate_proj", ttnn.bfloat16),
+        w2=load("down_proj", ttnn.bfloat16),
+        w3=load("up_proj", ttnn.bfloat16),
     )
 
 
@@ -92,11 +93,15 @@ class Qwen36MLP:
         self.tt_ccl = tt_ccl
         self.num_devices = getattr(args, "num_devices", 1) if args is not None else 1
         self.weights = load_mlp_weights(mesh_device, state_dict, tensor_cache_path, args=args)
+        # HiFi2 (was LoFi): LoFi only consumes the top mantissa bits of the inputs,
+        # which is fine for bf4/bf8 weights but discards most of the precision of the
+        # bf16 weights now used above. HiFi2 processes more mantissa bits so the bf16
+        # upgrade is not wasted (at some throughput cost).
         self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi, fp32_dest_acc_en=True, packer_l1_acc=False
+            math_fidelity=ttnn.MathFidelity.HiFi2, fp32_dest_acc_en=True, packer_l1_acc=False
         )
         self.compute_kernel_config_decode = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi, fp32_dest_acc_en=True, packer_l1_acc=True
+            math_fidelity=ttnn.MathFidelity.HiFi2, fp32_dest_acc_en=True, packer_l1_acc=True
         )
 
     def forward(self, x):

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -104,7 +104,7 @@ class Qwen36Model:
         lm_head_weight = state_dict["output.weight"].T.contiguous()  # [dim, vocab_size]
         self.lm_head_weight = ttnn.as_tensor(
             lm_head_weight,
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/models/demos/blackhole/qwen36/tt/model_config.py
+++ b/models/demos/blackhole/qwen36/tt/model_config.py
@@ -101,7 +101,7 @@ class Qwen36ModelArgs(ModelArgs):
         if mesh_device is not None:
             import ttnn
 
-            self.weight_dtype = ttnn.bfloat8_b
+            self.weight_dtype = ttnn.bfloat16
             self.act_dtype = ttnn.bfloat16
         else:
             self.weight_dtype = None

--- a/models/demos/blackhole/qwen36/tt/tp_common.py
+++ b/models/demos/blackhole/qwen36/tt/tp_common.py
@@ -159,7 +159,7 @@ def create_prefill_matmul_program_config(m, k, n, grid_size=None):
 
 
 # ── Mesh tensor helpers ─────────────────────────────────────────────────────
-def shard_w(torch_tensor, mesh, dim, memory_config, cache_path, dtype=ttnn.bfloat8_b):
+def shard_w(torch_tensor, mesh, dim, memory_config, cache_path, dtype=ttnn.bfloat16):
     """Convert a torch weight [out, in] to a sharded mesh tensor.
 
     Transposes to [in, out] (ttnn.linear convention) and shards along ``dim``


### PR DESCRIPTION
Upgrade every reduced-precision weight in the active paths (single-device and TP) to bfloat16 for higher numerical precision:
  - MLP gate/up (was bfloat4_b) and down (was bfloat8_b)
  - Full-attention q/k/v/o projections (was bfloat8_b)
  - Gated DeltaNet qkv/ab/out shards + fused ab/mega weights (was bfloat8_b)
  - LM head (was bfloat8_b)
  - Central weight_dtype + shard_w default (was bfloat8_b)

Also raise the MLP matmul math fidelity from LoFi to HiFi2 so the added bf16 mantissa bits are actually consumed (LoFi is tuned for bf4/bf8).

Left intentionally unchanged: the QWEN_SDPA_BF8_Q=1 opt-in comparison cast in attention/tp.py (defaults off; default path is already bf16) and the GDN fp32 recurrent-state/decode default (already highest precision).

Flipping weight_dtype to bf16 moves the weight cache dir suffix from tensor_cache_bfp8 to tensor_cache_bf16, so caches regenerate at bf16 instead of silently reusing the old low-precision tensors. Expect higher DRAM usage (~2x for former bf8, ~4x for former bf4 MLP gate/up).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lingjunw/support-qwen35-27b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lingjunw/support-qwen35-27b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:lingjunw/support-qwen35-27b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lingjunw/support-qwen35-27b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lingjunw/support-qwen35-27b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lingjunw/support-qwen35-27b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lingjunw/support-qwen35-27b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lingjunw/support-qwen35-27b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lingjunw/support-qwen35-27b)