### PR TITLE
Fix namespace collision in functions.hpp in Unity builds

### DIFF
--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -89,7 +89,7 @@ static Tensor index_trilu(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -130,7 +130,7 @@ static Tensor index_width(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -171,7 +171,7 @@ static Tensor index_height(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -211,7 +211,7 @@ static Tensor index_all(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -275,7 +275,7 @@ static Tensor fill_first_val_into_tensor(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           input_tensor.logical_shape(),
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type,
                               PageConfig(Layout::ROW_MAJOR),
                               MemoryConfig{},
@@ -310,7 +310,7 @@ static Tensor prod_result_computation_WH_B0(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           ttnn::Shape({}),
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type,
                               PageConfig(Layout::ROW_MAJOR),
                               MemoryConfig{},
@@ -356,7 +356,7 @@ static Tensor index_channel(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -396,7 +396,7 @@ static Tensor index_batch(
                       tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {
@@ -423,7 +423,7 @@ static Tensor manual_insertion(
                       tt::tt_metal::host_buffer::get_host_buffer(input_cpu_tensor),
                       TensorSpec(
                           logical_shape,
-                          detail::legacy_tensor_layout_from_padded_shape(
+                          ttnn::detail::legacy_tensor_layout_from_padded_shape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
                       .to_layout(layout);
     if (device != nullptr) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix `detail::` -> `ttnn::detail::` in functions.hpp.

**Root cause:** `ttnn/cpp/ttnn/operations/functions.hpp` (inside `namespace ttnn`) called its helper
`detail::legacy_tensor_layout_from_padded_shape` unqualified. In a Unity build this header can
share a translation unit with a CCL source that defines `ttnn::operations::ccl::detail` while a
`using namespace ttnn::operations::ccl;` is in scope. Bare `detail::` then resolves to both
`ttnn::detail` and `ttnn::operations::ccl::detail`:

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:scardoza/fix-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-namespace)