### PR TITLE
[Cleanup] Migrate Moreh Kernels from CircularBuffer to DataflowBuffer

### DIFF
--- a/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
@@ -21,108 +21,108 @@
 #include "api/compute/mask.h"
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 namespace ckernel {
 
-ALWI void pack_tile_with_dt(uint32_t ifrom_dst, CircularBuffer icb) {
+ALWI void pack_tile_with_dt(uint32_t ifrom_dst, DataflowBuffer icb) {
 #if defined FP32_DEST_ACC_EN
-    pack_reconfig_data_format(icb.get_cb_id());
+    pack_reconfig_data_format(icb.get_id());
 #endif
-    pack_tile(ifrom_dst, icb.get_cb_id());
+    pack_tile(ifrom_dst, icb.get_id());
 }
 
-ALWI void copy_tile_init_with_dt(CircularBuffer icb, uint32_t transpose = 0) {
+ALWI void copy_tile_init_with_dt(DataflowBuffer icb, uint32_t transpose = 0) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format_srca(icb.get_cb_id());
+    reconfig_data_format_srca(icb.get_id());
 #endif
-    copy_tile_to_dst_init_short(icb.get_cb_id(), transpose);
+    copy_tile_to_dst_init_short(icb.get_id(), transpose);
 }
 
-ALWI void add_tiles_init_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void add_tiles_init_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    add_tiles_init(icb0.get_cb_id(), icb1.get_cb_id());
+    add_tiles_init(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void add_bcast_rows_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void add_bcast_rows_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    add_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    add_bcast_rows_init_short(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void add_bcast_cols_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void add_bcast_cols_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    add_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    add_bcast_cols_init_short(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void add_bcast_scalar_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void add_bcast_scalar_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    add_bcast_scalar_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    add_bcast_scalar_init_short(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void sub_tiles_init_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void sub_tiles_init_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    sub_tiles_init(icb0.get_cb_id(), icb1.get_cb_id());
+    sub_tiles_init(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void sub_bcast_rows_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void sub_bcast_rows_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
     MATH((llk_math_eltwise_binary_init<EltwiseBinaryType::ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>(
-        icb0.get_cb_id(), icb1.get_cb_id())));
-    UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0.get_cb_id(), icb1.get_cb_id())));
+        icb0.get_id(), icb1.get_id())));
+    UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0.get_id(), icb1.get_id())));
 }
 
-ALWI void sub_bcast_cols_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void sub_bcast_cols_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    sub_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    sub_bcast_cols_init_short(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void sub_tiles_bcast_scalar_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void sub_tiles_bcast_scalar_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    sub_tiles_bcast_scalar_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    sub_tiles_bcast_scalar_init_short(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void mul_tiles_init_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void mul_tiles_init_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_tiles_init(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_tiles_init(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void mul_bcast_rows_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void mul_bcast_rows_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_bcast_rows_init_short(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void mul_bcast_cols_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void mul_bcast_cols_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_bcast_cols_init_short(icb0.get_id(), icb1.get_id());
 }
 
-ALWI void mul_tiles_bcast_scalar_init_short_with_dt(CircularBuffer icb0, CircularBuffer icb1) {
+ALWI void mul_tiles_bcast_scalar_init_short_with_dt(DataflowBuffer icb0, DataflowBuffer icb1) {
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_tiles_bcast_scalar_init_short(icb0.get_cb_id(), icb1.get_cb_id());
+    mul_tiles_bcast_scalar_init_short(icb0.get_id(), icb1.get_id());
 }
 
 class ArgFetcher {
@@ -137,9 +137,9 @@ public:
 };
 
 ALWI void mul_tiles_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -153,7 +153,7 @@ ALWI void mul_tiles_to_cb(
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_tiles(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -171,9 +171,9 @@ ALWI void mul_tiles_to_cb(
 }
 
 ALWI void mul_tiles_and_negative_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -187,7 +187,7 @@ ALWI void mul_tiles_and_negative_to_cb(
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_tiles(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
 
     negative_tile_init();
     negative_tile(dst0);
@@ -208,10 +208,10 @@ ALWI void mul_tiles_and_negative_to_cb(
 }
 
 ALWI void mul_tiles_and_mask_tile_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer maskcb,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer maskcb,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t mtile = 0,
@@ -228,11 +228,11 @@ ALWI void mul_tiles_and_mask_tile_to_cb(
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_tiles(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
 
     constexpr int dst_mask = 1;
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
+    copy_tile(maskcb.get_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst0, dst_mask);
@@ -256,9 +256,9 @@ ALWI void mul_tiles_and_mask_tile_to_cb(
 }
 
 ALWI void mul_tiles_log_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -272,7 +272,7 @@ ALWI void mul_tiles_log_to_cb(
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(icb0, icb1);
-    mul_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_tiles(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -293,9 +293,9 @@ ALWI void mul_tiles_log_to_cb(
 }
 
 ALWI void mul_tiles_bcast_rows_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -310,10 +310,10 @@ ALWI void mul_tiles_bcast_rows_to_cb(
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
-    mul_tiles_bcast_rows(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_bcast_rows_init_short(icb0.get_id(), icb1.get_id());
+    mul_tiles_bcast_rows(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -331,9 +331,9 @@ ALWI void mul_tiles_bcast_rows_to_cb(
 }
 
 ALWI void mul_tiles_bcast_rows_log_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -348,10 +348,10 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_bcast_rows_init_short(icb0.get_cb_id(), icb1.get_cb_id());
-    mul_tiles_bcast_rows(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_bcast_rows_init_short(icb0.get_id(), icb1.get_id());
+    mul_tiles_bcast_rows(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -372,9 +372,9 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
 }
 
 ALWI void mul_tiles_bcast_cols_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -389,10 +389,10 @@ ALWI void mul_tiles_bcast_cols_to_cb(
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
-    mul_tiles_bcast_cols(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_bcast_cols_init_short(icb0.get_id(), icb1.get_id());
+    mul_tiles_bcast_cols(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -410,9 +410,9 @@ ALWI void mul_tiles_bcast_cols_to_cb(
 }
 
 ALWI void mul_tiles_bcast_cols_log_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -427,10 +427,10 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    mul_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
-    mul_tiles_bcast_cols(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    mul_bcast_cols_init_short(icb0.get_id(), icb1.get_id());
+    mul_tiles_bcast_cols(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -450,7 +450,7 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
     ocb.push_back(onetile);
 }
 
-ALWI void copy_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void copy_tile_to_cb(DataflowBuffer icb, DataflowBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
@@ -459,7 +459,7 @@ ALWI void copy_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst0);
+    copy_tile(icb.get_id(), itile, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -472,7 +472,7 @@ ALWI void copy_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile
     ocb.push_back(onetile);
 }
 
-ALWI void sign_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void sign_tile_to_cb(DataflowBuffer icb, DataflowBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
@@ -481,7 +481,7 @@ ALWI void sign_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst0);
+    copy_tile(icb.get_id(), itile, dst0);
 
     sign_tile_init();
     sign_tile(dst0);
@@ -498,9 +498,9 @@ ALWI void sign_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile
 }
 
 ALWI void add_tiles_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -514,7 +514,7 @@ ALWI void add_tiles_to_cb(
 
     tile_regs_acquire();
     add_tiles_init_with_dt(icb0, icb1);
-    add_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    add_tiles(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -532,9 +532,9 @@ ALWI void add_tiles_to_cb(
 }
 
 ALWI void mask_tile_to_cb(
-    CircularBuffer icb,
-    CircularBuffer maskcb,
-    CircularBuffer ocb,
+    DataflowBuffer icb,
+    DataflowBuffer maskcb,
+    DataflowBuffer ocb,
     uint32_t itile = 0,
     uint32_t mtile = 0,
     uint32_t pop = 1,
@@ -549,10 +549,10 @@ ALWI void mask_tile_to_cb(
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst0);
+    copy_tile(icb.get_id(), itile, dst0);
 
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
+    copy_tile(maskcb.get_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst0, dst_mask);
@@ -573,9 +573,9 @@ ALWI void mask_tile_to_cb(
 }
 
 ALWI void sub_tiles_bcast_cols_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -590,10 +590,10 @@ ALWI void sub_tiles_bcast_cols_to_cb(
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
-    sub_bcast_cols_init_short(icb0.get_cb_id(), icb1.get_cb_id());
-    sub_tiles_bcast<BroadcastType::COL>(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    sub_bcast_cols_init_short(icb0.get_id(), icb1.get_id());
+    sub_tiles_bcast<BroadcastType::COL>(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -611,9 +611,9 @@ ALWI void sub_tiles_bcast_cols_to_cb(
 }
 
 ALWI void sub_tiles_bcast_rows_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -628,15 +628,15 @@ ALWI void sub_tiles_bcast_rows_to_cb(
 
     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
-    reconfig_data_format(icb0.get_cb_id(), icb1.get_cb_id());
+    reconfig_data_format(icb0.get_id(), icb1.get_id());
 #endif
     // sub_bcast_rows_init_short();
     {
         MATH((llk_math_eltwise_binary_init<EltwiseBinaryType::ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>(
-            icb0.get_cb_id(), icb1.get_cb_id())));
-        UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0.get_cb_id(), icb1.get_cb_id())));
+            icb0.get_id(), icb1.get_id())));
+        UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0.get_id(), icb1.get_id())));
     }
-    sub_tiles_bcast<BroadcastType::ROW>(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    sub_tiles_bcast<BroadcastType::ROW>(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -654,9 +654,9 @@ ALWI void sub_tiles_bcast_rows_to_cb(
 }
 
 ALWI void sub_tiles_to_cb(
-    CircularBuffer icb0,
-    CircularBuffer icb1,
-    CircularBuffer ocb,
+    DataflowBuffer icb0,
+    DataflowBuffer icb1,
+    DataflowBuffer ocb,
     uint32_t itile0 = 0,
     uint32_t itile1 = 0,
     uint32_t pop0 = 1,
@@ -670,7 +670,7 @@ ALWI void sub_tiles_to_cb(
 
     tile_regs_acquire();
     sub_tiles_init_with_dt(icb0, icb1);
-    sub_tiles(icb0.get_cb_id(), icb1.get_cb_id(), itile0, itile1, dst0);
+    sub_tiles(icb0.get_id(), icb1.get_id(), itile0, itile1, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -688,7 +688,7 @@ ALWI void sub_tiles_to_cb(
 }
 
 ALWI void exp_tile_to_cb(
-    CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
+    DataflowBuffer icb, DataflowBuffer ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
 
     ocb.reserve_back(onetile);
@@ -696,7 +696,7 @@ ALWI void exp_tile_to_cb(
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst);
+    copy_tile(icb.get_id(), itile, dst);
 
     exp_tile_init();
     exp_tile(dst);
@@ -713,7 +713,7 @@ ALWI void exp_tile_to_cb(
 }
 
 ALWI void rexp_tile_to_cb(
-    CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
+    DataflowBuffer icb, DataflowBuffer ocb, uint32_t itile = 0, uint32_t dst = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
 
     ocb.reserve_back(onetile);
@@ -721,7 +721,7 @@ ALWI void rexp_tile_to_cb(
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst);
+    copy_tile(icb.get_id(), itile, dst);
 
     negative_tile_init();
     negative_tile(dst);
@@ -741,9 +741,9 @@ ALWI void rexp_tile_to_cb(
 }
 
 ALWI void exp_tile_and_mask_tile_to_cb(
-    CircularBuffer icb,
-    CircularBuffer maskcb,
-    CircularBuffer ocb,
+    DataflowBuffer icb,
+    DataflowBuffer maskcb,
+    DataflowBuffer ocb,
     uint32_t itile = 0,
     uint32_t mtile = 0,
     uint32_t pop = 1,
@@ -758,7 +758,7 @@ ALWI void exp_tile_and_mask_tile_to_cb(
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst);
+    copy_tile(icb.get_id(), itile, dst);
 
     if (pop) {
         icb.pop_front(pop);
@@ -768,7 +768,7 @@ ALWI void exp_tile_and_mask_tile_to_cb(
     exp_tile(dst);
 
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
+    copy_tile(maskcb.get_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst, dst_mask);
@@ -786,9 +786,9 @@ ALWI void exp_tile_and_mask_tile_to_cb(
 }
 
 ALWI void rexp_tile_and_mask_tile_to_cb(
-    CircularBuffer icb,
-    CircularBuffer maskcb,
-    CircularBuffer ocb,
+    DataflowBuffer icb,
+    DataflowBuffer maskcb,
+    DataflowBuffer ocb,
     uint32_t itile = 0,
     uint32_t mtile = 0,
     uint32_t pop = 1,
@@ -803,7 +803,7 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst);
+    copy_tile(icb.get_id(), itile, dst);
 
     if (pop) {
         icb.pop_front(pop);
@@ -816,7 +816,7 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
     exp_tile(dst);
 
     copy_tile_init_with_dt(maskcb);
-    copy_tile(maskcb.get_cb_id(), mtile, dst_mask);
+    copy_tile(maskcb.get_id(), mtile, dst_mask);
 
     mask_tile_init();
     mask_tile(dst, dst_mask);
@@ -833,7 +833,7 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
     ocb.push_back(onetile);
 }
 
-ALWI void recip_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void recip_tile_to_cb(DataflowBuffer icb, DataflowBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
@@ -842,7 +842,7 @@ ALWI void recip_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itil
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst0);
+    copy_tile(icb.get_id(), itile, dst0);
 
     recip_tile_init();
     recip_tile(dst0);
@@ -858,7 +858,7 @@ ALWI void recip_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itil
     ocb.push_back(onetile);
 }
 
-ALWI void log_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
+ALWI void log_tile_to_cb(DataflowBuffer icb, DataflowBuffer ocb, uint32_t itile = 0, uint32_t pop = 1) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
 
@@ -867,7 +867,7 @@ ALWI void log_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile 
 
     tile_regs_acquire();
     copy_tile_init_with_dt(icb);
-    copy_tile(icb.get_cb_id(), itile, dst0);
+    copy_tile(icb.get_id(), itile, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -885,12 +885,12 @@ ALWI void log_tile_to_cb(CircularBuffer icb, CircularBuffer ocb, uint32_t itile 
 
 // TODO(seunghwan100): If p is 2 and decimal is 0, we can use sqrt_tile.
 ALWI void power_tile_to_cb(
-    CircularBuffer cb_x,
-    CircularBuffer cb_xpow,
-    CircularBuffer cb_logx,
-    CircularBuffer cb_decimal,
-    CircularBuffer cb_exp_lxmd,
-    CircularBuffer cb_correct_xpow,
+    DataflowBuffer cb_x,
+    DataflowBuffer cb_xpow,
+    DataflowBuffer cb_logx,
+    DataflowBuffer cb_decimal,
+    DataflowBuffer cb_exp_lxmd,
+    DataflowBuffer cb_correct_xpow,
     uint32_t p,
     bool p_is_negative) {
     constexpr uint32_t onetile = 1;
@@ -902,7 +902,7 @@ ALWI void power_tile_to_cb(
     cb_xpow.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x.get_cb_id(), 0, dst0);
+    copy_tile(cb_x.get_id(), 0, dst0);
 
     power_iterative_tile_init();
     power_iterative_tile(dst0, p);
@@ -925,7 +925,7 @@ ALWI void power_tile_to_cb(
     cb_logx.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x.get_cb_id(), 0, dst0);
+    copy_tile(cb_x.get_id(), 0, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -944,7 +944,7 @@ ALWI void power_tile_to_cb(
     cb_exp_lxmd.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_logx, cb_decimal);
-    mul_tiles(cb_logx.get_cb_id(), cb_decimal.get_cb_id(), 0, 0, dst0);
+    mul_tiles(cb_logx.get_id(), cb_decimal.get_id(), 0, 0, dst0);
 
     exp_tile_init();
     exp_tile(dst0);
@@ -964,7 +964,7 @@ ALWI void power_tile_to_cb(
     cb_correct_xpow.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_xpow, cb_exp_lxmd);
-    mul_tiles(cb_xpow.get_cb_id(), cb_exp_lxmd.get_cb_id(), 0, 0, dst0);
+    mul_tiles(cb_xpow.get_id(), cb_exp_lxmd.get_id(), 0, 0, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -977,12 +977,12 @@ ALWI void power_tile_to_cb(
 }
 
 ALWI void power_tile_with_abs_x_to_cb(
-    CircularBuffer cb_x,
-    CircularBuffer cb_xpow,
-    CircularBuffer cb_logx,
-    CircularBuffer cb_decimal,
-    CircularBuffer cb_exp_lxmd,
-    CircularBuffer cb_correct_xpow,
+    DataflowBuffer cb_x,
+    DataflowBuffer cb_xpow,
+    DataflowBuffer cb_logx,
+    DataflowBuffer cb_decimal,
+    DataflowBuffer cb_exp_lxmd,
+    DataflowBuffer cb_correct_xpow,
     uint32_t p,
     bool p_is_negative) {
     constexpr uint32_t onetile = 1;
@@ -994,7 +994,7 @@ ALWI void power_tile_with_abs_x_to_cb(
     cb_xpow.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x.get_cb_id(), 0, dst0);
+    copy_tile(cb_x.get_id(), 0, dst0);
 
     abs_tile_init();
     abs_tile(dst0);
@@ -1020,7 +1020,7 @@ ALWI void power_tile_with_abs_x_to_cb(
     cb_logx.reserve_back(onetile);
 
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x.get_cb_id(), 0, dst0);
+    copy_tile(cb_x.get_id(), 0, dst0);
 
     abs_tile_init();
     abs_tile(dst0);
@@ -1042,7 +1042,7 @@ ALWI void power_tile_with_abs_x_to_cb(
     cb_exp_lxmd.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_logx, cb_decimal);
-    mul_tiles(cb_logx.get_cb_id(), cb_decimal.get_cb_id(), 0, 0, dst0);
+    mul_tiles(cb_logx.get_id(), cb_decimal.get_id(), 0, 0, dst0);
 
     exp_tile_init();
     exp_tile(dst0);
@@ -1062,7 +1062,7 @@ ALWI void power_tile_with_abs_x_to_cb(
     cb_correct_xpow.reserve_back(onetile);
 
     mul_tiles_init_with_dt(cb_xpow, cb_exp_lxmd);
-    mul_tiles(cb_xpow.get_cb_id(), cb_exp_lxmd.get_cb_id(), 0, 0, dst0);
+    mul_tiles(cb_xpow.get_id(), cb_exp_lxmd.get_id(), 0, 0, dst0);
     tile_regs_commit();
 
     tile_regs_wait();
@@ -1075,12 +1075,12 @@ ALWI void power_tile_with_abs_x_to_cb(
 }
 
 ALWI void power_and_recip_tile_to_cb(
-    CircularBuffer cb_x,
-    CircularBuffer cb_xpow,
-    CircularBuffer cb_logx,
-    CircularBuffer cb_decimal,
-    CircularBuffer cb_exp_lxmd,
-    CircularBuffer cb_recip_xpow,
+    DataflowBuffer cb_x,
+    DataflowBuffer cb_xpow,
+    DataflowBuffer cb_logx,
+    DataflowBuffer cb_decimal,
+    DataflowBuffer cb_exp_lxmd,
+    DataflowBuffer cb_recip_xpow,
     uint32_t p,
     bool p_is_negative) {
     constexpr uint32_t onetile = 1;
@@ -1092,7 +1092,7 @@ ALWI void power_and_recip_tile_to_cb(
 
     tile_regs_acquire();
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x.get_cb_id(), 0, dst0);
+    copy_tile(cb_x.get_id(), 0, dst0);
 
     power_iterative_tile_init();
     power_iterative_tile(dst0, p);
@@ -1115,7 +1115,7 @@ ALWI void power_and_recip_tile_to_cb(
 
     tile_regs_acquire();
     copy_tile_init_with_dt(cb_x);
-    copy_tile(cb_x.get_cb_id(), 0, dst0);
+    copy_tile(cb_x.get_id(), 0, dst0);
 
     log_tile_init();
     log_tile(dst0);
@@ -1134,7 +1134,7 @@ ALWI void power_and_recip_tile_to_cb(
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(cb_logx, cb_decimal);
-    mul_tiles(cb_logx.get_cb_id(), cb_decimal.get_cb_id(), 0, 0, dst0);
+    mul_tiles(cb_logx.get_id(), cb_decimal.get_id(), 0, 0, dst0);
 
     exp_tile_init();
     exp_tile(dst0);
@@ -1154,7 +1154,7 @@ ALWI void power_and_recip_tile_to_cb(
 
     tile_regs_acquire();
     mul_tiles_init_with_dt(cb_xpow, cb_exp_lxmd);
-    mul_tiles(cb_xpow.get_cb_id(), cb_exp_lxmd.get_cb_id(), 0, 0, dst0);
+    mul_tiles(cb_xpow.get_id(), cb_exp_lxmd.get_id(), 0, 0, dst0);
 
     recip_tile_init();
     recip_tile(dst0);
@@ -1169,24 +1169,24 @@ ALWI void power_and_recip_tile_to_cb(
     cb_recip_xpow.push_back(onetile);
 }
 
-ALWI void copy_tile_to_dst(CircularBuffer icb, uint32_t itile = 0, uint32_t dst = 0, bool cb_wait_and_pop = true) {
+ALWI void copy_tile_to_dst(DataflowBuffer icb, uint32_t itile = 0, uint32_t dst = 0, bool cb_wait_and_pop = true) {
     constexpr uint32_t onetile = 1;
     if (cb_wait_and_pop) {
         icb.wait_front(onetile);
     }
-    reconfig_data_format_srca(icb.get_cb_id());
-    copy_tile_to_dst_init_short(icb.get_cb_id());
-    copy_tile(icb.get_cb_id(), itile, dst);
+    reconfig_data_format_srca(icb.get_id());
+    copy_tile_to_dst_init_short(icb.get_id());
+    copy_tile(icb.get_id(), itile, dst);
     if (cb_wait_and_pop) {
         icb.pop_front(onetile);
     }
 }
 
-ALWI void pack_tile_from_dst(CircularBuffer ocb, uint32_t dst = 0) {
+ALWI void pack_tile_from_dst(DataflowBuffer ocb, uint32_t dst = 0) {
     constexpr uint32_t onetile = 1;
     ocb.reserve_back(onetile);
-    pack_reconfig_data_format(ocb.get_cb_id());
-    pack_tile(dst, ocb.get_cb_id());
+    pack_reconfig_data_format(ocb.get_id());
+    pack_tile(dst, ocb.get_id());
     ocb.push_back(onetile);
 }
 

--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_mm_scaler.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_mm_scaler.hpp
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/dataflow_api.h"
 
 // Tile is assumed to have 16-bit elements
 // Scaler is assumed to be a 16-bit value double packed into a u32
-FORCE_INLINE void generate_mm_scaler(CircularBuffer cb, const uint32_t scaler) {
+FORCE_INLINE void generate_mm_scaler(DataflowBuffer cb, const uint32_t scaler) {
     cb.reserve_back(1);
 
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());

--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -12,7 +12,7 @@
 #include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "noc/noc_parameters.h"
 #include "api/numeric/bfloat16.h"
@@ -53,7 +53,7 @@ public:
 };
 
 template <typename T>
-FORCE_INLINE void process_data(CircularBuffer cb, uint32_t value, int32_t num_of_elems) {
+FORCE_INLINE void process_data(DataflowBuffer cb, uint32_t value, int32_t num_of_elems) {
     T* ptr = reinterpret_cast<T*>(cb.get_write_ptr());
     for (int j = 0; j < num_of_elems; j++) {
         ptr[j] = static_cast<T>(value);
@@ -61,7 +61,7 @@ FORCE_INLINE void process_data(CircularBuffer cb, uint32_t value, int32_t num_of
 }
 
 template <>
-FORCE_INLINE void process_data<uint16_t>(CircularBuffer cb, uint32_t value, int32_t num_of_elems) {
+FORCE_INLINE void process_data<uint16_t>(DataflowBuffer cb, uint32_t value, int32_t num_of_elems) {
     uint16_t* ptr = reinterpret_cast<uint16_t*>(cb.get_write_ptr());
     for (int j = 0; j < num_of_elems; j++) {
         ptr[j] = static_cast<uint16_t>(value >> 16);
@@ -69,7 +69,7 @@ FORCE_INLINE void process_data<uint16_t>(CircularBuffer cb, uint32_t value, int3
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_bcast_scaler(CircularBuffer cb_scaler, uint32_t scaler) {
+FORCE_INLINE void generate_bcast_scaler(DataflowBuffer cb_scaler, uint32_t scaler) {
     union {
         float f;
         uint32_t u;
@@ -95,9 +95,9 @@ FORCE_INLINE void generate_bcast_scaler(CircularBuffer cb_scaler, uint32_t scale
     cb_scaler.push_back(1);
 }
 
-FORCE_INLINE void fill_cb_with_value(CircularBuffer cb, uint32_t value, int32_t num_of_elems = 1024) {
+FORCE_INLINE void fill_cb_with_value(DataflowBuffer cb, uint32_t value, int32_t num_of_elems = 1024) {
     cb.reserve_back(1);
-    const DataFormat data_format = get_dataformat(cb.get_cb_id());
+    const DataFormat data_format = get_dataformat(cb.get_id());
     switch ((uint)data_format & 0x1F) {
         case ((uint8_t)DataFormat::Float32):
         case ((uint8_t)DataFormat::Int32):
@@ -180,7 +180,7 @@ FORCE_INLINE void fill_subtile_mask_w(
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_mask_h(CircularBuffer cb_mask, uint32_t mask_h) {
+FORCE_INLINE void generate_mask_h(DataflowBuffer cb_mask, uint32_t mask_h) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -220,7 +220,7 @@ FORCE_INLINE void generate_mask_h(CircularBuffer cb_mask, uint32_t mask_h) {
 }
 
 template <typename T = uint16_t>
-FORCE_INLINE void generate_mask_w(CircularBuffer cb_mask, uint32_t mask_w) {
+FORCE_INLINE void generate_mask_w(DataflowBuffer cb_mask, uint32_t mask_w) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -260,7 +260,7 @@ FORCE_INLINE void generate_mask_w(CircularBuffer cb_mask, uint32_t mask_w) {
 }
 
 FORCE_INLINE void generate_mask_h_w(
-    CircularBuffer cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    DataflowBuffer cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
     Scalar one = {};
     Scalar zero = {};
 
@@ -393,7 +393,7 @@ FORCE_INLINE void generate_mask_h_w(
     cb_mask_h_w.push_back(2);
 }
 
-FORCE_INLINE void generate_mask_h_w_if_needed(CircularBuffer cb_mask_h_w, uint32_t origin_h, uint32_t origin_w) {
+FORCE_INLINE void generate_mask_h_w_if_needed(DataflowBuffer cb_mask_h_w, uint32_t origin_h, uint32_t origin_w) {
     constexpr uint32_t TILE_H = 32;
     constexpr uint32_t TILE_W = 32;
 
@@ -404,7 +404,7 @@ FORCE_INLINE void generate_mask_h_w_if_needed(CircularBuffer cb_mask_h_w, uint32
     const uint32_t mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_h || do_mask_w) {
-        const uint32_t mask_tile_bytes = get_tile_size(cb_mask_h_w.get_cb_id());
+        const uint32_t mask_tile_bytes = get_tile_size(cb_mask_h_w.get_id());
         generate_mask_h_w(cb_mask_h_w, mask_h, mask_w, mask_tile_bytes);
     }
 }
@@ -471,7 +471,7 @@ FORCE_INLINE void mask_tile_if_need(uint32_t l1_addr, uint32_t origin_h, uint32_
 }
 
 FORCE_INLINE void generate_mask_tiles(
-    CircularBuffer cb_mask, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    DataflowBuffer cb_mask, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
     constexpr uint32_t num_mask_tiles = 3;
     Scalar one = {};
     Scalar zero = {};
@@ -664,7 +664,7 @@ void get_noc_offset(uint32_t h, uint32_t w, uint32_t element_size, uint32_t& noc
 // It reads values from one tile.
 template <typename AddrGen>
 void read_tile(
-    CircularBuffer cb,
+    DataflowBuffer cb,
     AddrGen addrgen,
     uint32_t noc_id,
     uint32_t size = 0,
@@ -680,7 +680,7 @@ void read_tile(
 
     // If the size is 0, it reads one tile.
     if (size == 0) {
-        size = get_tile_size(cb.get_cb_id());
+        size = get_tile_size(cb.get_id());
     }
 
     noc.async_read(addrgen, cb, size, {.page_id = noc_id, .offset_bytes = offset}, {.offset_bytes = 0});
@@ -693,7 +693,7 @@ void read_tile(
 
 template <typename AddrGen>
 void read_value(
-    CircularBuffer cb,
+    DataflowBuffer cb,
     AddrGen addrgen,
     uint32_t noc_id,
     uint32_t tilized_idx = 0,
@@ -706,7 +706,7 @@ void read_value(
         cb.reserve_back(onetile);
     }
 
-    const uint32_t element_size = get_tile_size(cb.get_cb_id()) / 1024;
+    const uint32_t element_size = get_tile_size(cb.get_id()) / 1024;
     const uint32_t byte_offset = tilized_idx * element_size;
 
     noc.async_read(
@@ -727,8 +727,8 @@ void read_value(
  *
  * | Argument                     | Description                             | Data type        | Valid range                    | required |
  * |------------------------------|-----------------------------------------|------------------|--------------------------------|----------|
- * | cb                           | Destination CB for the read data        | CircularBuffer   | Any valid CB                   | True     |
- * | cb_scratch                   | CB to use as scratch storage            | CircularBuffer   | Any valid CB                   | True     |
+ * | cb                           | Destination CB for the read data        | DataflowBuffer   | Any valid CB                   | True     |
+ * | cb_scratch                   | CB to use as scratch storage            | DataflowBuffer   | Any valid CB                   | True     |
  * | addrgen                      | Address generator object                | AddrGen          | N/A                            | True     |
  * | num_tiles                    | Number of tiles to read                 | uint32_t         | Any uint32_t number            | True     |
  * | do_reserve                   | Whether to reserve space in the CB      | bool             | true or false                  | False    |
@@ -737,8 +737,8 @@ void read_value(
 // clang-format on
 template <typename AddrGen>
 void read_line(
-    CircularBuffer cb,
-    CircularBuffer cb_scratch,
+    DataflowBuffer cb,
+    DataflowBuffer cb_scratch,
     AddrGen addrgen,
     uint32_t num_tiles,
     bool do_reserve = true,
@@ -750,7 +750,7 @@ void read_line(
         cb.reserve_back(num_tiles);
     }
 
-    const auto tile_bytes = get_tile_size(cb.get_cb_id());
+    const auto tile_bytes = get_tile_size(cb.get_id());
     const auto element_bytes = tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
     const auto valid_elements_bytes = FACE_WIDTH * element_bytes;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "api/debug/dprint.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -39,37 +39,37 @@ void kernel_main() {
 
     binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
-    CircularBuffer cb_x_obj(cb_x);
-    CircularBuffer cb_one_obj(cb_one);
-    CircularBuffer cb_decimal_obj(cb_decimal);
-    CircularBuffer cb_mask_w_obj(cb_mask_w);
-    CircularBuffer cb_y_obj(cb_y);
-    CircularBuffer cb_xabs_obj(cb_xabs);
-    CircularBuffer cb_xpow_obj(cb_xpow);
-    CircularBuffer cb_logx_obj(cb_logx);
-    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
+    DataflowBuffer dfb_x_obj(cb_x);
+    DataflowBuffer dfb_one_obj(cb_one);
+    DataflowBuffer dfb_decimal_obj(cb_decimal);
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);
+    DataflowBuffer dfb_y_obj(cb_y);
+    DataflowBuffer dfb_xabs_obj(cb_xabs);
+    DataflowBuffer dfb_xpow_obj(cb_xpow);
+    DataflowBuffer dfb_logx_obj(cb_logx);
+    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
 
-    cb_one_obj.wait_front(onetile);
-    cb_decimal_obj.wait_front(onetile);
+    dfb_one_obj.wait_front(onetile);
+    dfb_decimal_obj.wait_front(onetile);
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
     const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);
+        dfb_mask_w_obj.wait_front(onetile);
     }
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);
-            cb_xabs_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);
+            dfb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x_obj);
+            copy_tile_init_with_dt(dfb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(cb_mask_w_obj);
+                copy_tile_init_with_dt(dfb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
 
                 mask_tile_init();
@@ -81,20 +81,27 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs_obj);
+            pack_tile_with_dt(dst0, dfb_xabs_obj);
             tile_regs_release();
 
-            cb_x_obj.pop_front(onetile);
-            cb_xabs_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_xabs_obj.push_back(onetile);
 
             power_tile_to_cb(
-                cb_xabs_obj, cb_xpow_obj, cb_logx_obj, cb_decimal_obj, cb_exp_lxmd_obj, cb_y_obj, p, p_is_negative);
+                dfb_xabs_obj,
+                dfb_xpow_obj,
+                dfb_logx_obj,
+                dfb_decimal_obj,
+                dfb_exp_lxmd_obj,
+                dfb_y_obj,
+                p,
+                p_is_negative);
         }
     }
 
-    cb_one_obj.pop_front(onetile);
-    cb_decimal_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
+    dfb_decimal_obj.pop_front(onetile);
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/reader_moreh_abs_pow.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/reader_moreh_abs_pow.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -28,22 +28,22 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    CircularBuffer cb_one(cb_id_one);
-    CircularBuffer cb_decimal(cb_id_decimal);
-    fill_cb_with_value(cb_one, one.u);
-    fill_cb_with_value(cb_decimal, decimal);
+    DataflowBuffer dfb_one(cb_id_one);
+    DataflowBuffer dfb_decimal(cb_id_decimal);
+    fill_cb_with_value(dfb_one, one.u);
+    fill_cb_with_value(dfb_decimal, decimal);
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
     const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
-        CircularBuffer cb_mask_w(cb_id_mask_w);
-        generate_mask_w(cb_mask_w, mask_w);
+        DataflowBuffer dfb_mask_w(cb_id_mask_w);
+        generate_mask_w(dfb_mask_w, mask_w);
     }
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
 
     const auto start_tile_idx = tile_offset;
     const auto input_tile_bytes = get_tile_size(cb_id_input);
@@ -51,10 +51,10 @@ void kernel_main() {
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             const auto tile_idx = start_tile_idx + row_idx * Wt + col_idx;
-            cb_input.reserve_back(1);
-            noc.async_read(s, cb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_input.reserve_back(1);
+            noc.async_read(s, dfb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(1);
+            dfb_input.push_back(1);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/writer_moreh_abs_pow.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/writer_moreh_abs_pow.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -24,7 +24,7 @@ void kernel_main() {
     const auto s = TensorAccessor(output_args, output_addr);
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
 
     const auto start_tile_idx = tile_offset;
     const auto output_tile_bytes = get_tile_size(cb_id_output);
@@ -32,10 +32,10 @@ void kernel_main() {
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             const auto tile_idx = start_tile_idx + row_idx * Wt + col_idx;
-            cb_output.wait_front(1);
-            noc.async_write(cb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+            dfb_output.wait_front(1);
+            noc.async_write(dfb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
             noc.async_write_barrier();
-            cb_output.pop_front(1);
+            dfb_output.pop_front(1);
         }
     }
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
@@ -11,7 +11,7 @@
 #include "api/compute/eltwise_unary/sqrt.h"
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 #ifdef FP32_DEST_ACC_EN
 #define WITH_FP32_DEST_ACC(x) x
@@ -60,81 +60,82 @@ void kernel_main() {
     constexpr uint32_t weight_decay_tile = 4;
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb_param_in_obj(cb_param_in);
-    CircularBuffer cb_grad_in_obj(cb_grad_in);
-    CircularBuffer cb_exp_avg_in_obj(cb_exp_avg_in);
-    CircularBuffer cb_exp_avg_sq_in_obj(cb_exp_avg_sq_in);
+    DataflowBuffer dfb_param_in_obj(cb_param_in);
+    DataflowBuffer dfb_grad_in_obj(cb_grad_in);
+    DataflowBuffer dfb_exp_avg_in_obj(cb_exp_avg_in);
+    DataflowBuffer dfb_exp_avg_sq_in_obj(cb_exp_avg_sq_in);
 #ifdef AMSGRAD
-    CircularBuffer cb_max_exp_avg_sq_in_obj(cb_max_exp_avg_sq_in);
-    CircularBuffer tmp_cb_max_exp_avg_sq_obj(tmp_cb_max_exp_avg_sq);
-    CircularBuffer cb_max_exp_avg_sq_out_obj(cb_max_exp_avg_sq_out);
+    DataflowBuffer dfb_max_exp_avg_sq_in_obj(cb_max_exp_avg_sq_in);
+    DataflowBuffer tmp_dfb_max_exp_avg_sq_obj(tmp_cb_max_exp_avg_sq);
+    DataflowBuffer dfb_max_exp_avg_sq_out_obj(cb_max_exp_avg_sq_out);
 #endif
-    CircularBuffer cb_scalar_args_obj(cb_scalar_args);
-    CircularBuffer cb_one_obj(cb_one);
-    CircularBuffer cb_param_out_obj(cb_param_out);
-    CircularBuffer cb_exp_avg_out_obj(cb_exp_avg_out);
-    CircularBuffer cb_exp_avg_sq_out_obj(cb_exp_avg_sq_out);
-    CircularBuffer tmp_cb_grad_obj(tmp_cb_grad);
-    CircularBuffer tmp_cb_exp_avg_obj(tmp_cb_exp_avg);
-    CircularBuffer cb_tmp1_obj(cb_tmp1);
-    CircularBuffer cb_tmp2_obj(cb_tmp2);
-    CircularBuffer tmp_cb_exp_avg_sq_obj(tmp_cb_exp_avg_sq);
+    DataflowBuffer dfb_scalar_args_obj(cb_scalar_args);
+    DataflowBuffer dfb_one_obj(cb_one);
+    DataflowBuffer dfb_param_out_obj(cb_param_out);
+    DataflowBuffer dfb_exp_avg_out_obj(cb_exp_avg_out);
+    DataflowBuffer dfb_exp_avg_sq_out_obj(cb_exp_avg_sq_out);
+    DataflowBuffer tmp_dfb_grad_obj(tmp_cb_grad);
+    DataflowBuffer tmp_dfb_exp_avg_obj(tmp_cb_exp_avg);
+    DataflowBuffer dfb_tmp1_obj(cb_tmp1);
+    DataflowBuffer dfb_tmp2_obj(cb_tmp2);
+    DataflowBuffer tmp_dfb_exp_avg_sq_obj(tmp_cb_exp_avg_sq);
 
-    cb_scalar_args_obj.wait_front(5);
-    cb_one_obj.wait_front(onetile);
+    dfb_scalar_args_obj.wait_front(5);
+    dfb_one_obj.wait_front(onetile);
 
     binary_op_init_common(cb_param_in, cb_scalar_args, cb_param_out);
 
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         // grad += grad + param * weight_decay;
         // cb_tmp1 : param * weight_decay;
-        cb_param_in_obj.wait_front(onetile);
-        cb_grad_in_obj.wait_front(onetile);
-        cb_exp_avg_in_obj.wait_front(onetile);
-        cb_exp_avg_sq_in_obj.wait_front(onetile);
+        dfb_param_in_obj.wait_front(onetile);
+        dfb_grad_in_obj.wait_front(onetile);
+        dfb_exp_avg_in_obj.wait_front(onetile);
+        dfb_exp_avg_sq_in_obj.wait_front(onetile);
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq_in_obj.wait_front(onetile);
+        dfb_max_exp_avg_sq_in_obj.wait_front(onetile);
 #endif
         // cb_tmp1 : param * weight_decay;
-        mul_tiles_to_cb(cb_param_in_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, weight_decay_tile, 0, 0);
+        mul_tiles_to_cb(dfb_param_in_obj, dfb_scalar_args_obj, dfb_tmp1_obj, first_tile, weight_decay_tile, 0, 0);
 
         // tmp_cb_grad : cb_grad_in + cb_tmp1;
-        add_tiles_to_cb(cb_grad_in_obj, cb_tmp1_obj, tmp_cb_grad_obj, first_tile, first_tile, 0, 1);
+        add_tiles_to_cb(dfb_grad_in_obj, dfb_tmp1_obj, tmp_dfb_grad_obj, first_tile, first_tile, 0, 1);
 
         ////////////////////////////////////////////////////////////////////////
         // exp_avg = exp_avg * beta1 + grad * (1 - beta1);
         // cb_tmp1 = (1 - beta1)
-        sub_tiles_to_cb(cb_one_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, beta1_tile, 0, 0);
-        mul_tiles_to_cb(tmp_cb_grad_obj, cb_tmp1_obj, cb_tmp1_obj, first_tile, first_tile, 0, 1);
+        sub_tiles_to_cb(dfb_one_obj, dfb_scalar_args_obj, dfb_tmp1_obj, first_tile, beta1_tile, 0, 0);
+        mul_tiles_to_cb(tmp_dfb_grad_obj, dfb_tmp1_obj, dfb_tmp1_obj, first_tile, first_tile, 0, 1);
 
         // tmp_cb_exp_avg = cb_exp_avg_in * beta1
-        mul_tiles_to_cb(cb_exp_avg_in_obj, cb_scalar_args_obj, tmp_cb_exp_avg_obj, first_tile, beta1_tile, 0, 0);
+        mul_tiles_to_cb(dfb_exp_avg_in_obj, dfb_scalar_args_obj, tmp_dfb_exp_avg_obj, first_tile, beta1_tile, 0, 0);
 
         // tmp_cb_exp_avg = tmp_cb_exp_avg + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg_obj, cb_tmp1_obj, tmp_cb_exp_avg_obj, first_tile, first_tile, 1, 1);
+        add_tiles_to_cb(tmp_dfb_exp_avg_obj, dfb_tmp1_obj, tmp_dfb_exp_avg_obj, first_tile, first_tile, 1, 1);
 
         // cb_exp_avg_out
-        copy_tile_to_cb(tmp_cb_exp_avg_obj, cb_exp_avg_out_obj, first_tile, 0);
+        copy_tile_to_cb(tmp_dfb_exp_avg_obj, dfb_exp_avg_out_obj, first_tile, 0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
         // exp_avg_sq = exp_avg_sq * beta2 + grad * grad * (1 - beta2);
-        sub_tiles_to_cb(cb_one_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, beta2_tile, 0, 0);
+        sub_tiles_to_cb(dfb_one_obj, dfb_scalar_args_obj, dfb_tmp1_obj, first_tile, beta2_tile, 0, 0);
 
         // cb_tmp2 = grad * grad
-        mul_tiles_to_cb(tmp_cb_grad_obj, tmp_cb_grad_obj, cb_tmp2_obj, first_tile, first_tile, 1, 0);
+        mul_tiles_to_cb(tmp_dfb_grad_obj, tmp_dfb_grad_obj, dfb_tmp2_obj, first_tile, first_tile, 1, 0);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2
-        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile, 1, 1);
+        mul_tiles_to_cb(dfb_tmp1_obj, dfb_tmp2_obj, dfb_tmp1_obj, first_tile, first_tile, 1, 1);
 
         // tmp_cb_exp_avg_sq = cb_exp_avg_sq_in * beta2
-        mul_tiles_to_cb(cb_exp_avg_sq_in_obj, cb_scalar_args_obj, tmp_cb_exp_avg_sq_obj, first_tile, beta2_tile, 0, 0);
+        mul_tiles_to_cb(
+            dfb_exp_avg_sq_in_obj, dfb_scalar_args_obj, tmp_dfb_exp_avg_sq_obj, first_tile, beta2_tile, 0, 0);
 
         // tmp_cb_exp_avg_sq = tmp_cb_exp_avg_sq + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg_sq_obj, cb_tmp1_obj, tmp_cb_exp_avg_sq_obj, first_tile, first_tile, 1, 1);
+        add_tiles_to_cb(tmp_dfb_exp_avg_sq_obj, dfb_tmp1_obj, tmp_dfb_exp_avg_sq_obj, first_tile, first_tile, 1, 1);
 
         // cb_exp_avg_sq_out
-        copy_tile_to_cb(tmp_cb_exp_avg_sq_obj, cb_exp_avg_sq_out_obj, first_tile, 0);
+        copy_tile_to_cb(tmp_dfb_exp_avg_sq_obj, dfb_exp_avg_sq_out_obj, first_tile, 0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -143,22 +144,22 @@ void kernel_main() {
         // bias_correction2 = 1 - pow(beta2, step);
         // cb_tmp1 = pow(beta2, step);
         tile_regs_acquire();
-        copy_tile_init_with_dt(cb_scalar_args_obj);
+        copy_tile_init_with_dt(dfb_scalar_args_obj);
         copy_tile(cb_scalar_args, beta2_tile, dst0);
         power_tile_init();
         power_tile(dst0, step);
         tile_regs_commit();
 
         tile_regs_wait();
-        cb_tmp1_obj.reserve_back(onetile);
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
-        cb_tmp1_obj.push_back(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
+        dfb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp1 = 1 / (1 - cb_tmp1);
         tile_regs_acquire();
-        cb_tmp1_obj.wait_front(onetile);
-        cb_tmp1_obj.reserve_back(onetile);
+        dfb_tmp1_obj.wait_front(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
         WITH_FP32_DEST_ACC(reconfig_data_format(cb_one, cb_tmp1));
         sub_tiles_init(cb_one, cb_tmp1);
         sub_tiles(cb_one, cb_tmp1, first_tile, first_tile, dst0);
@@ -167,46 +168,46 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
-        cb_tmp1_obj.pop_front(onetile);
-        cb_tmp1_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
+        dfb_tmp1_obj.pop_front(onetile);
+        dfb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
 #ifdef AMSGRAD
         // tmp_cb_max_exp_avg_sq = max(cb_max_exp_avg_sq_in, tmp_cb_exp_avg_sq);
         tile_regs_acquire();
-        tmp_cb_max_exp_avg_sq_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(cb_max_exp_avg_sq_in_obj);
+        tmp_dfb_max_exp_avg_sq_obj.reserve_back(onetile);
+        copy_tile_init_with_dt(dfb_max_exp_avg_sq_in_obj);
         copy_tile(cb_max_exp_avg_sq_in, first_tile, dst0);
-        copy_tile_init_with_dt(tmp_cb_exp_avg_sq_obj);
+        copy_tile_init_with_dt(tmp_dfb_exp_avg_sq_obj);
         copy_tile(tmp_cb_exp_avg_sq, first_tile, dst1);
         binary_max_tile_init();
         binary_max_tile(dst0, dst1, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, tmp_cb_max_exp_avg_sq_obj);
-        tmp_cb_max_exp_avg_sq_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, tmp_dfb_max_exp_avg_sq_obj);
+        tmp_dfb_max_exp_avg_sq_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_max_exp_avg_sq_out
         tile_regs_acquire();
-        tmp_cb_max_exp_avg_sq_obj.wait_front(onetile);
-        cb_max_exp_avg_sq_out_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(tmp_cb_max_exp_avg_sq_obj);
+        tmp_dfb_max_exp_avg_sq_obj.wait_front(onetile);
+        dfb_max_exp_avg_sq_out_obj.reserve_back(onetile);
+        copy_tile_init_with_dt(tmp_dfb_max_exp_avg_sq_obj);
         copy_tile(tmp_cb_max_exp_avg_sq, first_tile, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_max_exp_avg_sq_out_obj);
-        cb_max_exp_avg_sq_out_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_max_exp_avg_sq_out_obj);
+        dfb_max_exp_avg_sq_out_obj.push_back(onetile);
         tile_regs_release();
 #endif
 
         // cb_tmp1 = sqrt(exp_avg_sq / cb_tmp1);
         tile_regs_acquire();
-        cb_tmp1_obj.wait_front(onetile);
-        cb_tmp1_obj.reserve_back(onetile);
+        dfb_tmp1_obj.wait_front(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
 
 #ifdef AMSGRAD
         mul_tiles_init(tmp_cb_max_exp_avg_sq, cb_tmp1);
@@ -219,22 +220,22 @@ void kernel_main() {
 #endif
         sqrt_tile_init();
         sqrt_tile(dst0);
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
         tile_regs_commit();
 
         tile_regs_wait();
-        cb_tmp1_obj.pop_front(onetile);
-        cb_tmp1_obj.push_back(onetile);
+        dfb_tmp1_obj.pop_front(onetile);
+        dfb_tmp1_obj.push_back(onetile);
 #ifdef AMSGRAD
-        tmp_cb_max_exp_avg_sq_obj.pop_front(onetile);
+        tmp_dfb_max_exp_avg_sq_obj.pop_front(onetile);
 #endif
-        tmp_cb_exp_avg_sq_obj.pop_front(onetile);
+        tmp_dfb_exp_avg_sq_obj.pop_front(onetile);
         tile_regs_release();
 
         // cb_tmp1 = 1 / (cb_tmp1 + eps)
         tile_regs_acquire();
-        cb_tmp1_obj.wait_front(onetile);
-        cb_tmp1_obj.reserve_back(onetile);
+        dfb_tmp1_obj.wait_front(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
         WITH_FP32_DEST_ACC(reconfig_data_format(cb_tmp1, cb_scalar_args));
         add_tiles_init(cb_tmp1, cb_scalar_args);
         add_tiles(cb_tmp1, cb_scalar_args, first_tile, eps_tile, dst0);
@@ -243,64 +244,64 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
-        cb_tmp1_obj.pop_front(onetile);
-        cb_tmp1_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
+        dfb_tmp1_obj.pop_front(onetile);
+        dfb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
         // bias_correction1 = 1 - pow(beta1, step);
         // cb_tmp2 = pow(beta1, step);
         tile_regs_acquire();
-        cb_tmp2_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(cb_scalar_args_obj);
+        dfb_tmp2_obj.reserve_back(onetile);
+        copy_tile_init_with_dt(dfb_scalar_args_obj);
         copy_tile(cb_scalar_args, beta1_tile, dst0);
         power_tile_init();
         power_tile(dst0, step);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp2_obj);
-        cb_tmp2_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp2_obj);
+        dfb_tmp2_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp2 = 1 / (1 - cb_tmp2);
         tile_regs_acquire();
-        cb_tmp2_obj.wait_front(onetile);
+        dfb_tmp2_obj.wait_front(onetile);
         WITH_FP32_DEST_ACC(reconfig_data_format(cb_one, cb_tmp2));
         sub_tiles_init(cb_one, cb_tmp2);
         sub_tiles(cb_one, cb_tmp2, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
-        cb_tmp2_obj.pop_front(onetile);
+        dfb_tmp2_obj.pop_front(onetile);
         tile_regs_commit();
 
         tile_regs_wait();
-        cb_tmp2_obj.reserve_back(onetile);
-        pack_tile_with_dt(dst0, cb_tmp2_obj);
-        cb_tmp2_obj.push_back(onetile);
+        dfb_tmp2_obj.reserve_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp2_obj);
+        dfb_tmp2_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp2 = lr * cb_tmp2;
-        mul_tiles_to_cb(cb_scalar_args_obj, cb_tmp2_obj, cb_tmp2_obj, lr_tile, first_tile, 0, 1);
+        mul_tiles_to_cb(dfb_scalar_args_obj, dfb_tmp2_obj, dfb_tmp2_obj, lr_tile, first_tile, 0, 1);
 
         // cb_tmp2 = cb_tmp2 * tmp_cb_exp_avg;
-        mul_tiles_to_cb(cb_tmp2_obj, tmp_cb_exp_avg_obj, cb_tmp2_obj, first_tile, first_tile, 1, 1);
+        mul_tiles_to_cb(dfb_tmp2_obj, tmp_dfb_exp_avg_obj, dfb_tmp2_obj, first_tile, first_tile, 1, 1);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2;
-        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile, 1, 1);
+        mul_tiles_to_cb(dfb_tmp1_obj, dfb_tmp2_obj, dfb_tmp1_obj, first_tile, first_tile, 1, 1);
 
         // param = param - cb_tmp1;
-        sub_tiles_to_cb(cb_param_in_obj, cb_tmp1_obj, cb_param_out_obj, first_tile, first_tile, 0, 1);
+        sub_tiles_to_cb(dfb_param_in_obj, dfb_tmp1_obj, dfb_param_out_obj, first_tile, first_tile, 0, 1);
 
-        cb_param_in_obj.pop_front(onetile);
-        cb_grad_in_obj.pop_front(onetile);
-        cb_exp_avg_in_obj.pop_front(onetile);
-        cb_exp_avg_sq_in_obj.pop_front(onetile);
+        dfb_param_in_obj.pop_front(onetile);
+        dfb_grad_in_obj.pop_front(onetile);
+        dfb_exp_avg_in_obj.pop_front(onetile);
+        dfb_exp_avg_sq_in_obj.pop_front(onetile);
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq_in_obj.pop_front(onetile);
+        dfb_max_exp_avg_sq_in_obj.pop_front(onetile);
 #endif
     }
 
-    cb_scalar_args_obj.pop_front(5);
-    cb_one_obj.pop_front(onetile);
+    dfb_scalar_args_obj.pop_front(5);
+    dfb_one_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/reader_moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/reader_moreh_adam.cpp
@@ -6,27 +6,27 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
 void fill_cb_with_value(uint32_t cb_id, uint32_t value) {
-    CircularBuffer cb(cb_id);
-    cb.reserve_back(1);
+    DataflowBuffer dfb(cb_id);
+    dfb.reserve_back(1);
 
 #if defined FP32_DEST_ACC_EN
-    CoreLocalMem<uint32_t> ptr(cb.get_write_ptr());
+    CoreLocalMem<uint32_t> ptr(dfb.get_write_ptr());
     for (int j = 0; j < 1024; j++) {
         ptr[j] = value;
     }
 #else
-    CoreLocalMem<uint16_t> ptr(cb.get_write_ptr());
+    CoreLocalMem<uint16_t> ptr(dfb.get_write_ptr());
     for (int j = 0; j < 1024; j++) {
         ptr[j] = uint16_t(value >> 16);
     }
 #endif
 
-    cb.push_back(1);
+    dfb.push_back(1);
 }
 
 void kernel_main() {
@@ -85,12 +85,12 @@ void kernel_main() {
     fill_cb_with_value(cb_id_one, scaler.u);
 
     Noc noc;
-    CircularBuffer cb_param(cb_id_param);
-    CircularBuffer cb_grad(cb_id_grad);
-    CircularBuffer cb_exp_avg(cb_id_exp_avg);
-    CircularBuffer cb_exp_avg_sq(cb_id_exp_avg_sq);
+    DataflowBuffer dfb_param(cb_id_param);
+    DataflowBuffer dfb_grad(cb_id_grad);
+    DataflowBuffer dfb_exp_avg(cb_id_exp_avg);
+    DataflowBuffer dfb_exp_avg_sq(cb_id_exp_avg_sq);
 #ifdef AMSGRAD
-    CircularBuffer cb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
+    DataflowBuffer dfb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
 #endif
 
     const auto param_tile_bytes = get_tile_size(cb_id_param);
@@ -104,32 +104,32 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_param.reserve_back(onetile);
-        noc.async_read(param_addrg, cb_param, param_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_param.reserve_back(onetile);
+        noc.async_read(param_addrg, dfb_param, param_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_param.push_back(onetile);
+        dfb_param.push_back(onetile);
 
-        cb_grad.reserve_back(onetile);
-        noc.async_read(grad_addrg, cb_grad, grad_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_grad.reserve_back(onetile);
+        noc.async_read(grad_addrg, dfb_grad, grad_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_grad.push_back(onetile);
+        dfb_grad.push_back(onetile);
 
-        cb_exp_avg.reserve_back(onetile);
-        noc.async_read(exp_avg_addrg, cb_exp_avg, exp_avg_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_exp_avg.reserve_back(onetile);
+        noc.async_read(exp_avg_addrg, dfb_exp_avg, exp_avg_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_exp_avg.push_back(onetile);
+        dfb_exp_avg.push_back(onetile);
 
-        cb_exp_avg_sq.reserve_back(onetile);
-        noc.async_read(exp_avg_sq_addrg, cb_exp_avg_sq, exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_exp_avg_sq.reserve_back(onetile);
+        noc.async_read(exp_avg_sq_addrg, dfb_exp_avg_sq, exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_exp_avg_sq.push_back(onetile);
+        dfb_exp_avg_sq.push_back(onetile);
 
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq.reserve_back(onetile);
+        dfb_max_exp_avg_sq.reserve_back(onetile);
         noc.async_read(
-            max_exp_avg_sq_addrg, cb_max_exp_avg_sq, max_exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+            max_exp_avg_sq_addrg, dfb_max_exp_avg_sq, max_exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_max_exp_avg_sq.push_back(onetile);
+        dfb_max_exp_avg_sq.push_back(onetile);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/writer_moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/writer_moreh_adam.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -35,11 +35,11 @@ void kernel_main() {
 #endif
 
     Noc noc;
-    CircularBuffer cb_param(cb_id_param);
-    CircularBuffer cb_exp_avg(cb_id_exp_avg);
-    CircularBuffer cb_exp_avg_sq(cb_id_exp_avg_sq);
+    DataflowBuffer dfb_param(cb_id_param);
+    DataflowBuffer dfb_exp_avg(cb_id_exp_avg);
+    DataflowBuffer dfb_exp_avg_sq(cb_id_exp_avg_sq);
 #ifdef AMSGRAD
-    CircularBuffer cb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
+    DataflowBuffer dfb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
 #endif
 
     const auto param_tile_bytes = get_tile_size(cb_id_param);
@@ -52,27 +52,27 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_param.wait_front(onetile);
-        noc.async_write(cb_param, param_addrg, param_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_param.wait_front(onetile);
+        noc.async_write(dfb_param, param_addrg, param_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_param.pop_front(onetile);
+        dfb_param.pop_front(onetile);
 
-        cb_exp_avg.wait_front(onetile);
-        noc.async_write(cb_exp_avg, exp_avg_addrg, exp_avg_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_exp_avg.wait_front(onetile);
+        noc.async_write(dfb_exp_avg, exp_avg_addrg, exp_avg_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_exp_avg.pop_front(onetile);
+        dfb_exp_avg.pop_front(onetile);
 
-        cb_exp_avg_sq.wait_front(onetile);
-        noc.async_write(cb_exp_avg_sq, exp_avg_sq_addrg, exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_exp_avg_sq.wait_front(onetile);
+        noc.async_write(dfb_exp_avg_sq, exp_avg_sq_addrg, exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_exp_avg_sq.pop_front(onetile);
+        dfb_exp_avg_sq.pop_front(onetile);
 
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq.wait_front(onetile);
+        dfb_max_exp_avg_sq.wait_front(onetile);
         noc.async_write(
-            cb_max_exp_avg_sq, max_exp_avg_sq_addrg, max_exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+            dfb_max_exp_avg_sq, max_exp_avg_sq_addrg, max_exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_max_exp_avg_sq.pop_front(onetile);
+        dfb_max_exp_avg_sq.pop_front(onetile);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
@@ -11,58 +11,58 @@
 #include "api/compute/eltwise_unary/sqrt.h"
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t step = get_arg_val<uint32_t>(0);
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
 
     constexpr auto cb_param_in = tt::CBIndex::c_0;
-    CircularBuffer cb_param_in_obj(cb_param_in);
+    DataflowBuffer dfb_param_in_obj(cb_param_in);
     constexpr auto cb_grad_in = tt::CBIndex::c_1;
-    CircularBuffer cb_grad_in_obj(cb_grad_in);
+    DataflowBuffer dfb_grad_in_obj(cb_grad_in);
     constexpr auto cb_exp_avg_in = tt::CBIndex::c_2;
-    CircularBuffer cb_exp_avg_in_obj(cb_exp_avg_in);
+    DataflowBuffer dfb_exp_avg_in_obj(cb_exp_avg_in);
     constexpr auto cb_exp_avg_sq_in = tt::CBIndex::c_3;
-    CircularBuffer cb_exp_avg_sq_in_obj(cb_exp_avg_sq_in);
+    DataflowBuffer dfb_exp_avg_sq_in_obj(cb_exp_avg_sq_in);
 #ifdef AMSGRAD
     constexpr auto cb_max_exp_avg_sq_in = tt::CBIndex::c_4;
-    CircularBuffer cb_max_exp_avg_sq_in_obj(cb_max_exp_avg_sq_in);
+    DataflowBuffer dfb_max_exp_avg_sq_in_obj(cb_max_exp_avg_sq_in);
 #endif
     // lr, beta1, beta2, eps, weight_decay
     constexpr auto cb_scalar_args = tt::CBIndex::c_5;
-    CircularBuffer cb_scalar_args_obj(cb_scalar_args);
+    DataflowBuffer dfb_scalar_args_obj(cb_scalar_args);
     constexpr auto cb_one = tt::CBIndex::c_6;
-    CircularBuffer cb_one_obj(cb_one);
+    DataflowBuffer dfb_one_obj(cb_one);
     constexpr auto cb_param_out = tt::CBIndex::c_16;
-    CircularBuffer cb_param_out_obj(cb_param_out);
+    DataflowBuffer dfb_param_out_obj(cb_param_out);
     constexpr auto cb_exp_avg_out = tt::CBIndex::c_17;
-    CircularBuffer cb_exp_avg_out_obj(cb_exp_avg_out);
+    DataflowBuffer dfb_exp_avg_out_obj(cb_exp_avg_out);
     constexpr auto cb_exp_avg_sq_out = tt::CBIndex::c_18;
-    CircularBuffer cb_exp_avg_sq_out_obj(cb_exp_avg_sq_out);
+    DataflowBuffer dfb_exp_avg_sq_out_obj(cb_exp_avg_sq_out);
 #ifdef AMSGRAD
     constexpr auto cb_max_exp_avg_sq_out = tt::CBIndex::c_19;
-    CircularBuffer cb_max_exp_avg_sq_out_obj(cb_max_exp_avg_sq_out);
+    DataflowBuffer dfb_max_exp_avg_sq_out_obj(cb_max_exp_avg_sq_out);
 #endif
 
     constexpr auto tmp_cb_param = tt::CBIndex::c_24;
-    CircularBuffer tmp_cb_param_obj(tmp_cb_param);
+    DataflowBuffer tmp_dfb_param_obj(tmp_cb_param);
     constexpr auto tmp_cb_exp_avg = tt::CBIndex::c_25;
-    CircularBuffer tmp_cb_exp_avg_obj(tmp_cb_exp_avg);
+    DataflowBuffer tmp_dfb_exp_avg_obj(tmp_cb_exp_avg);
     constexpr auto tmp_cb_exp_avg_sq = tt::CBIndex::c_26;
-    CircularBuffer tmp_cb_exp_avg_sq_obj(tmp_cb_exp_avg_sq);
+    DataflowBuffer tmp_dfb_exp_avg_sq_obj(tmp_cb_exp_avg_sq);
 #ifdef AMSGRAD
     constexpr auto tmp_cb_max_exp_avg_sq = tt::CBIndex::c_27;
-    CircularBuffer tmp_cb_max_exp_avg_sq_obj(tmp_cb_max_exp_avg_sq);
+    DataflowBuffer tmp_dfb_max_exp_avg_sq_obj(tmp_cb_max_exp_avg_sq);
 #endif
     constexpr auto cb_beta1_exponent = tt::CBIndex::c_28;
-    CircularBuffer cb_beta1_exponent_obj(cb_beta1_exponent);
+    DataflowBuffer dfb_beta1_exponent_obj(cb_beta1_exponent);
     constexpr auto cb_beta2_exponent = tt::CBIndex::c_29;
-    CircularBuffer cb_beta2_exponent_obj(cb_beta2_exponent);
+    DataflowBuffer dfb_beta2_exponent_obj(cb_beta2_exponent);
     constexpr auto cb_tmp1 = tt::CBIndex::c_30;
-    CircularBuffer cb_tmp1_obj(cb_tmp1);
+    DataflowBuffer dfb_tmp1_obj(cb_tmp1);
     constexpr auto cb_tmp2 = tt::CBIndex::c_31;
-    CircularBuffer cb_tmp2_obj(cb_tmp2);
+    DataflowBuffer dfb_tmp2_obj(cb_tmp2);
 
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
@@ -75,86 +75,93 @@ void kernel_main() {
     constexpr uint32_t weight_decay_tile = 4;
     constexpr uint32_t onetile = 1;
 
-    cb_scalar_args_obj.wait_front(5);
-    cb_one_obj.wait_front(onetile);
-    cb_beta1_exponent_obj.wait_front(onetile);
-    cb_beta2_exponent_obj.wait_front(onetile);
+    dfb_scalar_args_obj.wait_front(5);
+    dfb_one_obj.wait_front(onetile);
+    dfb_beta1_exponent_obj.wait_front(onetile);
+    dfb_beta2_exponent_obj.wait_front(onetile);
 
     binary_op_init_common(cb_param_in, cb_scalar_args, cb_param_out);
 
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
-        cb_param_in_obj.wait_front(onetile);
-        cb_grad_in_obj.wait_front(onetile);
-        cb_exp_avg_in_obj.wait_front(onetile);
-        cb_exp_avg_sq_in_obj.wait_front(onetile);
+        dfb_param_in_obj.wait_front(onetile);
+        dfb_grad_in_obj.wait_front(onetile);
+        dfb_exp_avg_in_obj.wait_front(onetile);
+        dfb_exp_avg_sq_in_obj.wait_front(onetile);
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq_in_obj.wait_front(onetile);
+        dfb_max_exp_avg_sq_in_obj.wait_front(onetile);
 #endif
         // param = param - lr * weight_decay * param.
         // cb_tmp1 : weight_decay * cb_param_in
         mul_tiles_to_cb(
-            cb_scalar_args_obj, cb_param_in_obj, cb_tmp1_obj, weight_decay_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
+            dfb_scalar_args_obj, dfb_param_in_obj, dfb_tmp1_obj, weight_decay_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
 
         // cb_tmp1 : lr * cb_tmp1
-        mul_tiles_to_cb(cb_scalar_args_obj, cb_tmp1_obj, cb_tmp1_obj, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        mul_tiles_to_cb(dfb_scalar_args_obj, dfb_tmp1_obj, dfb_tmp1_obj, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         // tmp_cb_param : cb_param_in - cb_tmp1
-        sub_tiles_to_cb(cb_param_in_obj, cb_tmp1_obj, tmp_cb_param_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        sub_tiles_to_cb(
+            dfb_param_in_obj, dfb_tmp1_obj, tmp_dfb_param_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         ////////////////////////////////////////////////////////////////////////
         // exp_avg = exp_avg * beta1 + grad * (1 - beta1);
         // cb_tmp1 = (1 - beta1)
-        sub_tiles_to_cb(cb_one_obj, cb_scalar_args_obj, cb_tmp1_obj, first_tile, beta1_tile, /*pop0=*/0, /*pop1=*/0);
+        sub_tiles_to_cb(dfb_one_obj, dfb_scalar_args_obj, dfb_tmp1_obj, first_tile, beta1_tile, /*pop0=*/0, /*pop1=*/0);
 
         // cb_tmp1 = cb_grad_in * cb_tmp1
-        mul_tiles_to_cb(cb_grad_in_obj, cb_tmp1_obj, cb_tmp1_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        mul_tiles_to_cb(dfb_grad_in_obj, dfb_tmp1_obj, dfb_tmp1_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         // tmp_cb_exp_avg = cb_exp_avg_in * beta1
         mul_tiles_to_cb(
-            cb_exp_avg_in_obj, cb_scalar_args_obj, tmp_cb_exp_avg_obj, first_tile, beta1_tile, /*pop0=*/0, /*pop1=*/0);
+            dfb_exp_avg_in_obj,
+            dfb_scalar_args_obj,
+            tmp_dfb_exp_avg_obj,
+            first_tile,
+            beta1_tile,
+            /*pop0=*/0,
+            /*pop1=*/0);
 
         // tmp_cb_exp_avg = tmp_cb_exp_avg + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg_obj, cb_tmp1_obj, tmp_cb_exp_avg_obj, first_tile, first_tile);
+        add_tiles_to_cb(tmp_dfb_exp_avg_obj, dfb_tmp1_obj, tmp_dfb_exp_avg_obj, first_tile, first_tile);
 
         // cb_exp_avg_out
-        copy_tile_to_cb(tmp_cb_exp_avg_obj, cb_exp_avg_out_obj, first_tile, /*pop=*/0);
+        copy_tile_to_cb(tmp_dfb_exp_avg_obj, dfb_exp_avg_out_obj, first_tile, /*pop=*/0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
         // exp_avg_sq = exp_avg_sq * beta2 + grad * grad * (1 - beta2);
         // cb_tmp1 = (1 - beta2)
         tile_regs_acquire();
-        cb_tmp1_obj.reserve_back(onetile);
-        sub_tiles_init_with_dt(cb_one_obj, cb_scalar_args_obj);
+        dfb_tmp1_obj.reserve_back(onetile);
+        sub_tiles_init_with_dt(dfb_one_obj, dfb_scalar_args_obj);
         sub_tiles(cb_one, cb_scalar_args, first_tile, beta2_tile, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
-        cb_tmp1_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
+        dfb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp2 = grad * grad
-        mul_tiles_to_cb(cb_grad_in_obj, cb_grad_in_obj, cb_tmp2_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
+        mul_tiles_to_cb(dfb_grad_in_obj, dfb_grad_in_obj, dfb_tmp2_obj, first_tile, first_tile, /*pop0=*/0, /*pop1=*/0);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2
-        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile);
+        mul_tiles_to_cb(dfb_tmp1_obj, dfb_tmp2_obj, dfb_tmp1_obj, first_tile, first_tile);
 
         // tmp_cb_exp_avg_sq = cb_exp_avg_sq_in * beta2
         mul_tiles_to_cb(
-            cb_exp_avg_sq_in_obj,
-            cb_scalar_args_obj,
-            tmp_cb_exp_avg_sq_obj,
+            dfb_exp_avg_sq_in_obj,
+            dfb_scalar_args_obj,
+            tmp_dfb_exp_avg_sq_obj,
             first_tile,
             beta2_tile,
             /*pop0=*/0,
             /*pop1=*/0);
 
         // tmp_cb_exp_avg_sq = tmp_cb_exp_avg_sq + cb_tmp1
-        add_tiles_to_cb(tmp_cb_exp_avg_sq_obj, cb_tmp1_obj, tmp_cb_exp_avg_sq_obj, first_tile, first_tile);
+        add_tiles_to_cb(tmp_dfb_exp_avg_sq_obj, dfb_tmp1_obj, tmp_dfb_exp_avg_sq_obj, first_tile, first_tile);
 
         // cb_exp_avg_sq_out
-        copy_tile_to_cb(tmp_cb_exp_avg_sq_obj, cb_exp_avg_sq_out_obj, first_tile, /*pop=*/0);
+        copy_tile_to_cb(tmp_dfb_exp_avg_sq_obj, dfb_exp_avg_sq_out_obj, first_tile, /*pop=*/0);
         //////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -165,48 +172,48 @@ void kernel_main() {
 
         // cb_tmp1 = 1 / (1 - cb_beta2_exponent);
         tile_regs_acquire();
-        cb_tmp1_obj.reserve_back(onetile);
-        sub_tiles_init_with_dt(cb_one_obj, cb_beta2_exponent_obj);
+        dfb_tmp1_obj.reserve_back(onetile);
+        sub_tiles_init_with_dt(dfb_one_obj, dfb_beta2_exponent_obj);
         sub_tiles(cb_one, cb_beta2_exponent, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
-        cb_tmp1_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
+        dfb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
 #ifdef AMSGRAD
         // tmp_cb_max_exp_avg_sq = max(cb_max_exp_avg_sq_in, tmp_cb_exp_avg_sq);
         tile_regs_acquire();
-        tmp_cb_max_exp_avg_sq_obj.reserve_back(onetile);
-        copy_tile_init_with_dt(cb_max_exp_avg_sq_in_obj);
+        tmp_dfb_max_exp_avg_sq_obj.reserve_back(onetile);
+        copy_tile_init_with_dt(dfb_max_exp_avg_sq_in_obj);
         copy_tile(cb_max_exp_avg_sq_in, first_tile, dst0);
-        copy_tile_init_with_dt(tmp_cb_exp_avg_sq_obj);
+        copy_tile_init_with_dt(tmp_dfb_exp_avg_sq_obj);
         copy_tile(tmp_cb_exp_avg_sq, first_tile, dst1);
         binary_max_tile_init();
         binary_max_tile(dst0, dst1, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, tmp_cb_max_exp_avg_sq_obj);
-        tmp_cb_max_exp_avg_sq_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, tmp_dfb_max_exp_avg_sq_obj);
+        tmp_dfb_max_exp_avg_sq_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_max_exp_avg_sq_out
-        copy_tile_to_cb(tmp_cb_max_exp_avg_sq_obj, cb_max_exp_avg_sq_out_obj, first_tile, /*pop=*/0);
+        copy_tile_to_cb(tmp_dfb_max_exp_avg_sq_obj, dfb_max_exp_avg_sq_out_obj, first_tile, /*pop=*/0);
 #endif
 
         // cb_tmp1 = sqrt(exp_avg_sq / cb_tmp1);
         tile_regs_acquire();
-        cb_tmp1_obj.wait_front(onetile);
-        cb_tmp1_obj.reserve_back(onetile);
+        dfb_tmp1_obj.wait_front(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
 #ifdef AMSGRAD
-        mul_tiles_init_with_dt(tmp_cb_max_exp_avg_sq_obj, cb_tmp1_obj);
+        mul_tiles_init_with_dt(tmp_dfb_max_exp_avg_sq_obj, dfb_tmp1_obj);
         mul_tiles(tmp_cb_max_exp_avg_sq, cb_tmp1, first_tile, first_tile, dst0);
 #else
-        mul_tiles_init_with_dt(tmp_cb_exp_avg_sq_obj, cb_tmp1_obj);
+        mul_tiles_init_with_dt(tmp_dfb_exp_avg_sq_obj, dfb_tmp1_obj);
         mul_tiles(tmp_cb_exp_avg_sq, cb_tmp1, first_tile, first_tile, dst0);
 #endif
         sqrt_tile_init();
@@ -214,29 +221,29 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
-        cb_tmp1_obj.pop_front(onetile);
-        cb_tmp1_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
+        dfb_tmp1_obj.pop_front(onetile);
+        dfb_tmp1_obj.push_back(onetile);
 #ifdef AMSGRAD
-        tmp_cb_max_exp_avg_sq_obj.pop_front(onetile);
+        tmp_dfb_max_exp_avg_sq_obj.pop_front(onetile);
 #endif
-        tmp_cb_exp_avg_sq_obj.pop_front(onetile);
+        tmp_dfb_exp_avg_sq_obj.pop_front(onetile);
         tile_regs_release();
 
         // cb_tmp1 = 1 / (cb_tmp1 + eps)
         tile_regs_acquire();
-        cb_tmp1_obj.wait_front(onetile);
-        cb_tmp1_obj.reserve_back(onetile);
-        add_tiles_init_with_dt(cb_tmp1_obj, cb_scalar_args_obj);
+        dfb_tmp1_obj.wait_front(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
+        add_tiles_init_with_dt(dfb_tmp1_obj, dfb_scalar_args_obj);
         add_tiles(cb_tmp1, cb_scalar_args, first_tile, eps_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
-        cb_tmp1_obj.pop_front(onetile);
-        cb_tmp1_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
+        dfb_tmp1_obj.pop_front(onetile);
+        dfb_tmp1_obj.push_back(onetile);
         tile_regs_release();
 
         // bias_correction1 = 1 - pow(beta1, step);
@@ -244,41 +251,41 @@ void kernel_main() {
 
         // cb_tmp2 = 1 / (1 - cb_beta1_exponent);
         tile_regs_acquire();
-        cb_tmp2_obj.reserve_back(onetile);
-        sub_tiles_init_with_dt(cb_one_obj, cb_beta1_exponent_obj);
+        dfb_tmp2_obj.reserve_back(onetile);
+        sub_tiles_init_with_dt(dfb_one_obj, dfb_beta1_exponent_obj);
         sub_tiles(cb_one, cb_beta1_exponent, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp2_obj);
-        cb_tmp2_obj.push_back(onetile);
+        pack_tile_with_dt(dst0, dfb_tmp2_obj);
+        dfb_tmp2_obj.push_back(onetile);
         tile_regs_release();
 
         // cb_tmp2 = lr * cb_tmp2;
-        mul_tiles_to_cb(cb_scalar_args_obj, cb_tmp2_obj, cb_tmp2_obj, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
+        mul_tiles_to_cb(dfb_scalar_args_obj, dfb_tmp2_obj, dfb_tmp2_obj, lr_tile, first_tile, /*pop0=*/0, /*pop1=*/1);
 
         // cb_tmp2 = cb_tmp2 * tmp_cb_exp_avg;
-        mul_tiles_to_cb(cb_tmp2_obj, tmp_cb_exp_avg_obj, cb_tmp2_obj, first_tile, first_tile);
+        mul_tiles_to_cb(dfb_tmp2_obj, tmp_dfb_exp_avg_obj, dfb_tmp2_obj, first_tile, first_tile);
 
         // cb_tmp1 = cb_tmp1 * cb_tmp2;
-        mul_tiles_to_cb(cb_tmp1_obj, cb_tmp2_obj, cb_tmp1_obj, first_tile, first_tile);
+        mul_tiles_to_cb(dfb_tmp1_obj, dfb_tmp2_obj, dfb_tmp1_obj, first_tile, first_tile);
 
         // param = tmp_cb_param - cb_tmp1;
-        sub_tiles_to_cb(tmp_cb_param_obj, cb_tmp1_obj, cb_param_out_obj, first_tile, first_tile);
+        sub_tiles_to_cb(tmp_dfb_param_obj, dfb_tmp1_obj, dfb_param_out_obj, first_tile, first_tile);
 
-        cb_param_in_obj.pop_front(onetile);
-        cb_grad_in_obj.pop_front(onetile);
-        cb_exp_avg_in_obj.pop_front(onetile);
-        cb_exp_avg_sq_in_obj.pop_front(onetile);
+        dfb_param_in_obj.pop_front(onetile);
+        dfb_grad_in_obj.pop_front(onetile);
+        dfb_exp_avg_in_obj.pop_front(onetile);
+        dfb_exp_avg_sq_in_obj.pop_front(onetile);
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq_in_obj.pop_front(onetile);
+        dfb_max_exp_avg_sq_in_obj.pop_front(onetile);
 #endif
     }
 
-    cb_scalar_args_obj.pop_front(5);
-    cb_one_obj.pop_front(onetile);
-    cb_beta1_exponent_obj.pop_front(onetile);
-    cb_beta2_exponent_obj.pop_front(onetile);
+    dfb_scalar_args_obj.pop_front(5);
+    dfb_one_obj.pop_front(onetile);
+    dfb_beta1_exponent_obj.pop_front(onetile);
+    dfb_beta2_exponent_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
@@ -7,7 +7,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -59,31 +59,31 @@ void kernel_main() {
     const auto max_exp_avg_sq_addrg = TensorAccessor(max_exp_avg_sq_args, max_exp_avg_sq_addr);
 #endif
 
-    CircularBuffer cb_scalar(cb_scalar_args);
-    CircularBuffer cb_beta1_exp(cb_beta1_exponent);
-    CircularBuffer cb_beta2_exp(cb_beta2_exponent);
-    CircularBuffer cb_one(cb_id_one);
-    fill_cb_with_value(cb_scalar, lr);
-    fill_cb_with_value(cb_scalar, beta1);
-    fill_cb_with_value(cb_scalar, beta2);
-    fill_cb_with_value(cb_scalar, eps);
-    fill_cb_with_value(cb_scalar, weight_decay);
-    fill_cb_with_value(cb_beta1_exp, beta1_exponent);
-    fill_cb_with_value(cb_beta2_exp, beta2_exponent);
+    DataflowBuffer dfb_scalar(cb_scalar_args);
+    DataflowBuffer dfb_beta1_exp(cb_beta1_exponent);
+    DataflowBuffer dfb_beta2_exp(cb_beta2_exponent);
+    DataflowBuffer dfb_one(cb_id_one);
+    fill_cb_with_value(dfb_scalar, lr);
+    fill_cb_with_value(dfb_scalar, beta1);
+    fill_cb_with_value(dfb_scalar, beta2);
+    fill_cb_with_value(dfb_scalar, eps);
+    fill_cb_with_value(dfb_scalar, weight_decay);
+    fill_cb_with_value(dfb_beta1_exp, beta1_exponent);
+    fill_cb_with_value(dfb_beta2_exp, beta2_exponent);
     union {
         float f;
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    fill_cb_with_value(cb_one, scaler.u);
+    fill_cb_with_value(dfb_one, scaler.u);
 
     Noc noc;
-    CircularBuffer cb_param(cb_id_param);
-    CircularBuffer cb_grad(cb_id_grad);
-    CircularBuffer cb_exp_avg(cb_id_exp_avg);
-    CircularBuffer cb_exp_avg_sq(cb_id_exp_avg_sq);
+    DataflowBuffer dfb_param(cb_id_param);
+    DataflowBuffer dfb_grad(cb_id_grad);
+    DataflowBuffer dfb_exp_avg(cb_id_exp_avg);
+    DataflowBuffer dfb_exp_avg_sq(cb_id_exp_avg_sq);
 #ifdef AMSGRAD
-    CircularBuffer cb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
+    DataflowBuffer dfb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
 #endif
 
     const auto param_tile_bytes = get_tile_size(cb_id_param);
@@ -97,32 +97,32 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_param.reserve_back(onetile);
-        noc.async_read(param_addrg, cb_param, param_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_param.reserve_back(onetile);
+        noc.async_read(param_addrg, dfb_param, param_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_param.push_back(onetile);
+        dfb_param.push_back(onetile);
 
-        cb_grad.reserve_back(onetile);
-        noc.async_read(grad_addrg, cb_grad, grad_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_grad.reserve_back(onetile);
+        noc.async_read(grad_addrg, dfb_grad, grad_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_grad.push_back(onetile);
+        dfb_grad.push_back(onetile);
 
-        cb_exp_avg.reserve_back(onetile);
-        noc.async_read(exp_avg_addrg, cb_exp_avg, exp_avg_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_exp_avg.reserve_back(onetile);
+        noc.async_read(exp_avg_addrg, dfb_exp_avg, exp_avg_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_exp_avg.push_back(onetile);
+        dfb_exp_avg.push_back(onetile);
 
-        cb_exp_avg_sq.reserve_back(onetile);
-        noc.async_read(exp_avg_sq_addrg, cb_exp_avg_sq, exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_exp_avg_sq.reserve_back(onetile);
+        noc.async_read(exp_avg_sq_addrg, dfb_exp_avg_sq, exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_exp_avg_sq.push_back(onetile);
+        dfb_exp_avg_sq.push_back(onetile);
 
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq.reserve_back(onetile);
+        dfb_max_exp_avg_sq.reserve_back(onetile);
         noc.async_read(
-            max_exp_avg_sq_addrg, cb_max_exp_avg_sq, max_exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+            max_exp_avg_sq_addrg, dfb_max_exp_avg_sq, max_exp_avg_sq_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_max_exp_avg_sq.push_back(onetile);
+        dfb_max_exp_avg_sq.push_back(onetile);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/writer_moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/writer_moreh_adamw.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -36,11 +36,11 @@ void kernel_main() {
 #endif
 
     Noc noc;
-    CircularBuffer cb_param(cb_id_param);
-    CircularBuffer cb_exp_avg(cb_id_exp_avg);
-    CircularBuffer cb_exp_avg_sq(cb_id_exp_avg_sq);
+    DataflowBuffer dfb_param(cb_id_param);
+    DataflowBuffer dfb_exp_avg(cb_id_exp_avg);
+    DataflowBuffer dfb_exp_avg_sq(cb_id_exp_avg_sq);
 #ifdef AMSGRAD
-    CircularBuffer cb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
+    DataflowBuffer dfb_max_exp_avg_sq(cb_id_max_exp_avg_sq);
 #endif
 
     const auto param_tile_bytes = get_tile_size(cb_id_param);
@@ -53,27 +53,27 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_param.wait_front(onetile);
-        noc.async_write(cb_param, param_addrg, param_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_param.wait_front(onetile);
+        noc.async_write(dfb_param, param_addrg, param_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_param.pop_front(onetile);
+        dfb_param.pop_front(onetile);
 
-        cb_exp_avg.wait_front(onetile);
-        noc.async_write(cb_exp_avg, exp_avg_addrg, exp_avg_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_exp_avg.wait_front(onetile);
+        noc.async_write(dfb_exp_avg, exp_avg_addrg, exp_avg_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_exp_avg.pop_front(onetile);
+        dfb_exp_avg.pop_front(onetile);
 
-        cb_exp_avg_sq.wait_front(onetile);
-        noc.async_write(cb_exp_avg_sq, exp_avg_sq_addrg, exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_exp_avg_sq.wait_front(onetile);
+        noc.async_write(dfb_exp_avg_sq, exp_avg_sq_addrg, exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_exp_avg_sq.pop_front(onetile);
+        dfb_exp_avg_sq.pop_front(onetile);
 
 #ifdef AMSGRAD
-        cb_max_exp_avg_sq.wait_front(onetile);
+        dfb_max_exp_avg_sq.wait_front(onetile);
         noc.async_write(
-            cb_max_exp_avg_sq, max_exp_avg_sq_addrg, max_exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+            dfb_max_exp_avg_sq, max_exp_avg_sq_addrg, max_exp_avg_sq_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_max_exp_avg_sq.pop_front(onetile);
+        dfb_max_exp_avg_sq.pop_front(onetile);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI bool need_to_do_mask_h(uint32_t tile_idx, uint32_t ht, uint32_t wt) { return (((tile_idx / wt) + 1) % ht) == 0; }
 
@@ -18,30 +18,30 @@ void kernel_main() {
 
     constexpr std::uint8_t input_id = 0;
     constexpr auto cb_x = input_id + 0;
-    CircularBuffer cb_x_obj(cb_x);  // input(==x)
+    DataflowBuffer dfb_x_obj(cb_x);  // input(==x)
     constexpr auto cb_one = input_id + 1;
-    CircularBuffer cb_one_obj(cb_one);  // one
+    DataflowBuffer dfb_one_obj(cb_one);  // one
     constexpr auto cb_decimal = input_id + 2;
-    CircularBuffer cb_decimal_obj(cb_decimal);  // decimal
+    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
     constexpr auto cb_mask_h_w = input_id + 3;
-    CircularBuffer cb_mask_h_w_obj(cb_mask_h_w);  // mask_h_w
+    DataflowBuffer dfb_mask_h_w_obj(cb_mask_h_w);  // mask_h_w
 
     constexpr std::uint8_t output_id = 16;
     constexpr auto cb_y = output_id;  // output(==y)
 
     constexpr std::uint8_t intermed_id = 24;
     constexpr auto cb_xabs = intermed_id + 0;
-    CircularBuffer cb_xabs_obj(cb_xabs);         // |x|
+    DataflowBuffer dfb_xabs_obj(cb_xabs);        // |x|
     constexpr auto cb_xpow = intermed_id + 1;    // |x|^p
-    CircularBuffer cb_xpow_obj(cb_xpow);
+    DataflowBuffer dfb_xpow_obj(cb_xpow);
     constexpr auto cb_xpowadd = intermed_id + 2;
-    CircularBuffer cb_xpowadd_obj(cb_xpowadd);   // Add[|x|^p * exp(log(|x|) * decimal)]
+    DataflowBuffer dfb_xpowadd_obj(cb_xpowadd);  // Add[|x|^p * exp(log(|x|) * decimal)]
     constexpr auto cb_logx = intermed_id + 3;    // log(|x|)
-    CircularBuffer cb_logx_obj(cb_logx);
+    DataflowBuffer dfb_logx_obj(cb_logx);
     constexpr auto cb_exp_lxmd = intermed_id + 4;  // exp(log(|x|) * decimal)
-    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
+    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
     constexpr auto cb_correct_xpow = intermed_id + 5;
-    CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)
+    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -58,11 +58,11 @@ void kernel_main() {
 
     binary_op_init_common(cb_logx, cb_decimal, cb_y);
 
-    cb_decimal_obj.wait_front(onetile);  // comes from the reader
-    cb_one_obj.wait_front(onetile);      // comes from the reader
+    dfb_decimal_obj.wait_front(onetile);  // comes from the reader
+    dfb_one_obj.wait_front(onetile);      // comes from the reader
 
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.wait_front(2);  // comes from the reader
+        dfb_mask_h_w_obj.wait_front(2);  // comes from the reader
     }
 
     // Compute cb_xpowadd
@@ -70,8 +70,8 @@ void kernel_main() {
         // Comput cb_xabs and mask(optional)
         // |x|
         tile_regs_acquire();
-        cb_x_obj.wait_front(onetile);  // comes from the reader
-        cb_xabs_obj.reserve_back(onetile);
+        dfb_x_obj.wait_front(onetile);  // comes from the reader
+        dfb_xabs_obj.reserve_back(onetile);
 
         copy_tile_init(cb_x);
         copy_tile(cb_x, 0, dst0);
@@ -94,29 +94,29 @@ void kernel_main() {
 
         abs_tile_init();
         abs_tile(dst0);
-        cb_x_obj.pop_front(onetile);
+        dfb_x_obj.pop_front(onetile);
         tile_regs_commit();
 
         tile_regs_wait();
         pack_tile(dst0, cb_xabs);
-        cb_xabs_obj.push_back(onetile);
+        dfb_xabs_obj.push_back(onetile);
         tile_regs_release();
 
         // |x + decimal|^p
         power_tile_to_cb(
-            cb_xabs_obj,
-            cb_xpow_obj,
-            cb_logx_obj,
-            cb_decimal_obj,
-            cb_exp_lxmd_obj,
-            cb_correct_xpow_obj,
+            dfb_xabs_obj,
+            dfb_xpow_obj,
+            dfb_logx_obj,
+            dfb_decimal_obj,
+            dfb_exp_lxmd_obj,
+            dfb_correct_xpow_obj,
             p,
             p_is_negative);
 
         if (tile_idx == 0) {
             tile_regs_acquire();
-            cb_correct_xpow_obj.wait_front(onetile);
-            cb_xpowadd_obj.reserve_back(onetile);
+            dfb_correct_xpow_obj.wait_front(onetile);
+            dfb_xpowadd_obj.reserve_back(onetile);
 
             copy_tile_init(cb_correct_xpow);
             copy_tile(cb_correct_xpow, 0, dst0);
@@ -125,14 +125,14 @@ void kernel_main() {
             tile_regs_wait();
             pack_tile(dst0, cb_xpowadd);
 
-            cb_correct_xpow_obj.pop_front(onetile);
-            cb_xpowadd_obj.push_back(onetile);
+            dfb_correct_xpow_obj.pop_front(onetile);
+            dfb_xpowadd_obj.push_back(onetile);
             tile_regs_release();
         } else {
             tile_regs_acquire();
-            cb_correct_xpow_obj.wait_front(onetile);
-            cb_xpowadd_obj.wait_front(onetile);
-            cb_xpowadd_obj.reserve_back(onetile);
+            dfb_correct_xpow_obj.wait_front(onetile);
+            dfb_xpowadd_obj.wait_front(onetile);
+            dfb_xpowadd_obj.reserve_back(onetile);
 
             add_tiles_init(cb_correct_xpow, cb_xpowadd);
             add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
@@ -141,9 +141,9 @@ void kernel_main() {
             tile_regs_wait();
             pack_tile(dst0, cb_xpowadd);
 
-            cb_correct_xpow_obj.pop_front(onetile);
-            cb_xpowadd_obj.pop_front(onetile);
-            cb_xpowadd_obj.push_back(onetile);
+            dfb_correct_xpow_obj.pop_front(onetile);
+            dfb_xpowadd_obj.pop_front(onetile);
+            dfb_xpowadd_obj.push_back(onetile);
             tile_regs_release();
         }
     }
@@ -152,9 +152,9 @@ void kernel_main() {
     compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_y>(
         compute_kernel_lib::ReduceInputBlockShape::single());
 
-    cb_decimal_obj.pop_front(onetile);
-    cb_one_obj.pop_front(onetile);
+    dfb_decimal_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.pop_front(2);
+        dfb_mask_h_w_obj.pop_front(2);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/reader_moreh_clip_grad_norm_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/reader_moreh_clip_grad_norm_step1.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -29,24 +29,24 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    CircularBuffer cb_decimal(cb_id_decimal);
-    CircularBuffer cb_one(cb_id_one);
-    CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
-    fill_cb_with_value(cb_decimal, decimal);
-    fill_cb_with_value(cb_one, scaler.u);
-    generate_mask_h_w_if_needed(cb_mask_h_w, origin_h, origin_w);
+    DataflowBuffer dfb_decimal(cb_id_decimal);
+    DataflowBuffer dfb_one(cb_id_one);
+    DataflowBuffer dfb_mask_h_w(cb_id_mask_h_w);
+    fill_cb_with_value(dfb_decimal, decimal);
+    fill_cb_with_value(dfb_one, scaler.u);
+    generate_mask_h_w_if_needed(dfb_mask_h_w, origin_h, origin_w);
 
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
 
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
-        cb_input.reserve_back(onetile);
-        noc.async_read(s, cb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+        dfb_input.reserve_back(onetile);
+        noc.async_read(s, dfb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_input.push_back(onetile);
+        dfb_input.push_back(onetile);
     }
 
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/writer_moreh_clip_grad_norm_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/writer_moreh_clip_grad_norm_step1.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -20,12 +20,12 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
     const auto output_tile_bytes = get_tile_size(cb_id_output);
 
-    cb_output.wait_front(onetile);
-    noc.async_write(cb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_offset});
+    dfb_output.wait_front(onetile);
+    noc.async_write(dfb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_offset});
     noc.async_write_barrier();
-    cb_output.pop_front(onetile);
+    dfb_output.pop_front(onetile);
 
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -13,24 +13,24 @@ void kernel_main() {
 
     std::uint8_t input_id{0};
     const auto cb_input = input_id++;
-    CircularBuffer cb_input_obj(cb_input);  // input(==tmp_pow_sum)
+    DataflowBuffer dfb_input_obj(cb_input);  // input(==tmp_pow_sum)
     const auto cb_decimal = input_id++;
-    CircularBuffer cb_decimal_obj(cb_decimal);  // decimal
+    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
 
     std::uint8_t output_id{16};
     // x^p * exp(log(x) * decimal)
     const auto cb_y = output_id++;  // output(==total_norm)
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
 
     std::uint8_t intermed_id{24};
     const auto cb_x = intermed_id++;
-    CircularBuffer cb_x_obj(cb_x);           // Sum[tmp_pow_sum](==x)
+    DataflowBuffer dfb_x_obj(cb_x);          // Sum[tmp_pow_sum](==x)
     const auto cb_xpow = intermed_id++;      // x^p
-    CircularBuffer cb_xpow_obj(cb_xpow);
+    DataflowBuffer dfb_xpow_obj(cb_xpow);
     const auto cb_logx = intermed_id++;      // log(x)
-    CircularBuffer cb_logx_obj(cb_logx);
+    DataflowBuffer dfb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = intermed_id++;  // exp(log(x) * decimal)
-    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
+    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -41,42 +41,43 @@ void kernel_main() {
         binary_op_init_common(cb_logx, cb_decimal, cb_y);
     }
 
-    cb_decimal_obj.wait_front(onetile);  // comes from the reader
+    dfb_decimal_obj.wait_front(onetile);  // comes from the reader
 
     // Compute cb_x
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
         if (tile_idx == 0) {
             tile_regs_acquire();
-            cb_input_obj.wait_front(onetile);  // comes from the reader
-            cb_x_obj.reserve_back(onetile);
+            dfb_input_obj.wait_front(onetile);  // comes from the reader
+            dfb_x_obj.reserve_back(onetile);
 
             copy_tile_init(cb_input);
             copy_tile(cb_input, 0, dst0);
-            cb_input_obj.pop_front(onetile);
+            dfb_input_obj.pop_front(onetile);
             tile_regs_commit();
 
             tile_regs_wait();
             pack_tile(dst0, cb_x);
-            cb_x_obj.push_back(onetile);
+            dfb_x_obj.push_back(onetile);
             tile_regs_release();
         } else {
             tile_regs_acquire();
-            cb_input_obj.wait_front(onetile);  // comes from the reader
-            cb_x_obj.wait_front(onetile);
-            cb_x_obj.reserve_back(onetile);
+            dfb_input_obj.wait_front(onetile);  // comes from the reader
+            dfb_x_obj.wait_front(onetile);
+            dfb_x_obj.reserve_back(onetile);
 
             add_tiles_init(cb_input, cb_x);
             add_tiles(cb_input, cb_x, 0, 0, dst0);
-            cb_x_obj.pop_front(onetile);
-            cb_input_obj.pop_front(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_input_obj.pop_front(onetile);
             tile_regs_commit();
 
             tile_regs_wait();
             pack_tile(dst0, cb_x);
-            cb_x_obj.push_back(onetile);
+            dfb_x_obj.push_back(onetile);
             tile_regs_release();
         }
     }
     // x^p
-    power_tile_to_cb(cb_x_obj, cb_xpow_obj, cb_logx_obj, cb_decimal_obj, cb_exp_lxmd_obj, cb_y_obj, p, p_is_negative);
+    power_tile_to_cb(
+        dfb_x_obj, dfb_xpow_obj, dfb_logx_obj, dfb_decimal_obj, dfb_exp_lxmd_obj, dfb_y_obj, p, p_is_negative);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/reader_moreh_clip_grad_norm_step2.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/reader_moreh_clip_grad_norm_step2.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -20,20 +20,20 @@ void kernel_main() {
     constexpr auto input_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(input_args, input_addr);
 
-    CircularBuffer cb_decimal(cb_id_decimal);
-    fill_cb_with_value(cb_decimal, decimal);
+    DataflowBuffer dfb_decimal(cb_id_decimal);
+    fill_cb_with_value(dfb_decimal, decimal);
 
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
 
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
-        cb_input.reserve_back(onetile);
-        noc.async_read(s, cb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+        dfb_input.reserve_back(onetile);
+        noc.async_read(s, dfb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_input.push_back(onetile);
+        dfb_input.push_back(onetile);
     }
 
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/writer_moreh_clip_grad_norm_step2.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/writer_moreh_clip_grad_norm_step2.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -19,12 +19,12 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
     const auto output_tile_bytes = get_tile_size(cb_id_output);
 
-    cb_output.wait_front(onetile);
-    noc.async_write(cb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = 0});
+    dfb_output.wait_front(onetile);
+    noc.async_write(dfb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = 0});
     noc.async_write_barrier();
-    cb_output.pop_front(onetile);
+    dfb_output.pop_front(onetile);
 
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/moreh_clip_grad_norm_step3_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/moreh_clip_grad_norm_step3_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -11,37 +11,37 @@ void kernel_main() {
 
     std::uint8_t input_id{0};
     const auto cb_x = input_id++;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     const auto cb_clip_coef_clamped = input_id++;
-    CircularBuffer cb_clip_coef_clamped_obj(cb_clip_coef_clamped);  // clip_coef_clamped
+    DataflowBuffer dfb_clip_coef_clamped_obj(cb_clip_coef_clamped);  // clip_coef_clamped
 
     std::uint8_t output_id{16};
     const auto cb_y = output_id++;
-    CircularBuffer cb_y_obj(cb_y);  // output
+    DataflowBuffer dfb_y_obj(cb_y);  // output
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
     binary_op_init_common(cb_x, cb_clip_coef_clamped, cb_y);
 
-    cb_clip_coef_clamped_obj.wait_front(onetile);  // comes from the reader
+    dfb_clip_coef_clamped_obj.wait_front(onetile);  // comes from the reader
 
     // Compute cb_y
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
         tile_regs_acquire();
-        cb_x_obj.wait_front(onetile);  // comes from the reader
-        cb_y_obj.reserve_back(onetile);
+        dfb_x_obj.wait_front(onetile);  // comes from the reader
+        dfb_y_obj.reserve_back(onetile);
 
         mul_tiles_bcast_scalar_init_short(cb_x, cb_clip_coef_clamped);
         mul_tiles_bcast_scalar(cb_x, cb_clip_coef_clamped, 0, 0, dst0);
-        cb_x_obj.pop_front(onetile);
+        dfb_x_obj.pop_front(onetile);
         tile_regs_commit();
 
         tile_regs_wait();
         pack_tile(dst0, cb_y);
-        cb_y_obj.push_back(onetile);
+        dfb_y_obj.push_back(onetile);
         tile_regs_release();
     }
 
-    cb_clip_coef_clamped_obj.pop_front(onetile);
+    dfb_clip_coef_clamped_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/reader_moreh_clip_grad_norm_step3.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/reader_moreh_clip_grad_norm_step3.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -28,23 +28,23 @@ void kernel_main() {
     const auto coef_addrg = TensorAccessor(coef_args, clip_coef_clamped_addr);
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_clip_coef(cb_id_clip_coef_clamped);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_clip_coef(cb_id_clip_coef_clamped);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
     const auto clip_coef_tile_bytes = get_tile_size(cb_id_clip_coef_clamped);
 
     // clip_coef_clamped
-    cb_clip_coef.reserve_back(onetile);
-    noc.async_read(coef_addrg, cb_clip_coef, clip_coef_tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
+    dfb_clip_coef.reserve_back(onetile);
+    noc.async_read(coef_addrg, dfb_clip_coef, clip_coef_tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
     noc.async_read_barrier();
-    cb_clip_coef.push_back(onetile);
+    dfb_clip_coef.push_back(onetile);
 
     // input
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
-        cb_input.reserve_back(onetile);
-        noc.async_read(input_addrg, cb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+        dfb_input.reserve_back(onetile);
+        noc.async_read(input_addrg, dfb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_input.push_back(onetile);
+        dfb_input.push_back(onetile);
     }
 
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/writer_moreh_clip_grad_norm_step3.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/writer_moreh_clip_grad_norm_step3.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -22,15 +22,15 @@ void kernel_main() {
     const auto s = TensorAccessor(output_args, output_addr);
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
     const auto output_tile_bytes = get_tile_size(cb_id_output);
 
     // output
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
-        cb_output.wait_front(onetile);
-        noc.async_write(cb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+        dfb_output.wait_front(onetile);
+        noc.async_write(dfb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
         noc.async_write_barrier();
-        cb_output.pop_front(onetile);
+        dfb_output.pop_front(onetile);
     }
 
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -6,39 +6,39 @@
 
 #include "api/compute/eltwise_binary.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr int onetile = 1;
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
-    CircularBuffer cb_c0(tt::CBIndex::c_0);
-    CircularBuffer cb_c1(tt::CBIndex::c_1);
-    CircularBuffer cb_c2(tt::CBIndex::c_2);
-    CircularBuffer cb_c24(tt::CBIndex::c_24);
+    DataflowBuffer dfb_c0(tt::CBIndex::c_0);
+    DataflowBuffer dfb_c1(tt::CBIndex::c_1);
+    DataflowBuffer dfb_c2(tt::CBIndex::c_2);
+    DataflowBuffer dfb_c24(tt::CBIndex::c_24);
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         bool last_out = block == (per_core_block_cnt - 1);
 
-        cb_c0.wait_front(onetile);
-        cb_c1.wait_front(onetile);
+        dfb_c0.wait_front(onetile);
+        dfb_c1.wait_front(onetile);
 
         tile_regs_acquire();
         mul_tiles_init(tt::CBIndex::c_0, tt::CBIndex::c_1);
         mul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_1, 0, 0, 0);
         tile_regs_commit();
 
-        cb_c0.pop_front(onetile);
-        cb_c1.pop_front(onetile);
+        dfb_c0.pop_front(onetile);
+        dfb_c1.pop_front(onetile);
 
-        cb_c24.reserve_back(onetile);
+        dfb_c24.reserve_back(onetile);
 
         tile_regs_wait();
         pack_tile(0, tt::CBIndex::c_24);
         tile_regs_release();
 
-        cb_c24.push_back(onetile);
+        dfb_c24.push_back(onetile);
 
         // reduce-w
         if (last_out) {
@@ -69,5 +69,5 @@ void kernel_main() {
     }
     // The reduce helper waits on the scaler CB (c_2) each block but never pops it; the single
     // scaler tile is reused across all blocks. Pop it once at the end to balance the CB.
-    cb_c2.pop_front(onetile);
+    dfb_c2.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/reader_moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/reader_moreh_dot.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -82,21 +82,21 @@ void kernel_main() {
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
-    CircularBuffer cb_in1(cb_id_in1);
+    DataflowBuffer dfb_in0(cb_id_in0);
+    DataflowBuffer dfb_in1(cb_id_in1);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
     const auto in1_tile_bytes = get_tile_size(cb_id_in1);
 
     constexpr uint32_t onetile = 1;
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         bool last_tile = i == (start_id + num_tiles - 1);
-        cb_in0.reserve_back(onetile);
-        l1_write_addr_in0 = cb_in0.get_write_ptr();
-        noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_in0.reserve_back(onetile);
+        l1_write_addr_in0 = dfb_in0.get_write_ptr();
+        noc.async_read(s0, dfb_in0, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
 
-        cb_in1.reserve_back(onetile);
-        l1_write_addr_in1 = cb_in1.get_write_ptr();
-        noc.async_read(s1, cb_in1, in1_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_in1.reserve_back(onetile);
+        l1_write_addr_in1 = dfb_in1.get_write_ptr();
+        noc.async_read(s1, dfb_in1, in1_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
 
         noc.async_read_barrier();
 
@@ -105,7 +105,7 @@ void kernel_main() {
             mask_tile_in_reader(l1_write_addr_in1, mask_w, mask_h);
         }
 
-        cb_in0.push_back(onetile);
-        cb_in1.push_back(onetile);
+        dfb_in0.push_back(onetile);
+        dfb_in1.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/writer_moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/writer_moreh_dot.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,14 +21,14 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; i++) {
-        cb_out.wait_front(onetile);
-        noc.async_write(cb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out.wait_front(onetile);
+        noc.async_write(dfb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/compute/bcast.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr int onetile = 1;
@@ -11,45 +11,45 @@ void kernel_main() {
     uint32_t has_other_grad = get_arg_val<uint32_t>(1);
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(2);
 
-    CircularBuffer cb_c0(tt::CBIndex::c_0);
-    CircularBuffer cb_c1(tt::CBIndex::c_1);
-    CircularBuffer cb_c2(tt::CBIndex::c_2);
-    CircularBuffer cb_c16(tt::CBIndex::c_16);
-    CircularBuffer cb_c17(tt::CBIndex::c_17);
+    DataflowBuffer dfb_c0(tt::CBIndex::c_0);
+    DataflowBuffer dfb_c1(tt::CBIndex::c_1);
+    DataflowBuffer dfb_c2(tt::CBIndex::c_2);
+    DataflowBuffer dfb_c16(tt::CBIndex::c_16);
+    DataflowBuffer dfb_c17(tt::CBIndex::c_17);
 
     init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, tt::CBIndex::c_16);
-    cb_c0.wait_front(onetile);
+    dfb_c0.wait_front(onetile);
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         if (has_input_grad) {
-            cb_c2.wait_front(onetile);
+            dfb_c2.wait_front(onetile);
 
             tile_regs_acquire();
             mul_tiles_bcast<BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, 0, 0, 0);
             tile_regs_commit();
 
-            cb_c2.pop_front(onetile);
+            dfb_c2.pop_front(onetile);
 
             tile_regs_wait();
             pack_tile(0, tt::CBIndex::c_16);
             tile_regs_release();
 
-            cb_c16.push_back(onetile);
+            dfb_c16.push_back(onetile);
         }
 
         if (has_other_grad) {
-            cb_c1.wait_front(onetile);
+            dfb_c1.wait_front(onetile);
 
             tile_regs_acquire();
             mul_tiles_bcast<BroadcastType::SCALAR>(tt::CBIndex::c_1, tt::CBIndex::c_0, 0, 0, 0);
             tile_regs_commit();
 
-            cb_c1.pop_front(onetile);
+            dfb_c1.pop_front(onetile);
 
             tile_regs_wait();
             pack_tile(0, tt::CBIndex::c_17);
             tile_regs_release();
 
-            cb_c17.push_back(onetile);
+            dfb_c17.push_back(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/reader_moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/reader_moreh_dot_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -30,31 +30,31 @@ void kernel_main() {
     const auto s2 = TensorAccessor(src2_args, src2_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
-    CircularBuffer cb_in1(cb_id_in1);
-    CircularBuffer cb_in2(cb_id_in2);
+    DataflowBuffer dfb_in0(cb_id_in0);
+    DataflowBuffer dfb_in1(cb_id_in1);
+    DataflowBuffer dfb_in2(cb_id_in2);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
     const auto in1_tile_bytes = get_tile_size(cb_id_in1);
     const auto in2_tile_bytes = get_tile_size(cb_id_in2);
 
-    cb_in0.reserve_back(onetile);
-    noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
+    dfb_in0.reserve_back(onetile);
+    noc.async_read(s0, dfb_in0, in0_tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
     noc.async_read_barrier();
-    cb_in0.push_back(onetile);
+    dfb_in0.push_back(onetile);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         if (has_input_grad) {
-            cb_in2.reserve_back(onetile);
-            noc.async_read(s2, cb_in2, in2_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+            dfb_in2.reserve_back(onetile);
+            noc.async_read(s2, dfb_in2, in2_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in2.push_back(onetile);
+            dfb_in2.push_back(onetile);
         }
 
         if (has_other_grad) {
-            cb_in1.reserve_back(onetile);
-            noc.async_read(s1, cb_in1, in1_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+            dfb_in1.reserve_back(onetile);
+            noc.async_read(s1, dfb_in1, in1_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in1.push_back(onetile);
+            dfb_in1.push_back(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/writer_moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/writer_moreh_dot_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -28,25 +28,25 @@ void kernel_main() {
     const auto s1 = TensorAccessor(dst1_args, dst1_addr);
 
     Noc noc;
-    CircularBuffer cb_out0(cb_id_out0);
-    CircularBuffer cb_out1(cb_id_out1);
+    DataflowBuffer dfb_out0(cb_id_out0);
+    DataflowBuffer dfb_out1(cb_id_out1);
     const auto out0_tile_bytes = get_tile_size(cb_id_out0);
     const auto out1_tile_bytes = get_tile_size(cb_id_out1);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; i++) {
         if (has_input_grad) {
-            cb_out0.wait_front(onetile);
-            noc.async_write(cb_out0, s0, out0_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+            dfb_out0.wait_front(onetile);
+            noc.async_write(dfb_out0, s0, out0_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
             noc.async_write_barrier();
-            cb_out0.pop_front(onetile);
+            dfb_out0.pop_front(onetile);
         }
 
         if (has_other_grad) {
-            cb_out1.wait_front(onetile);
-            noc.async_write(cb_out1, s1, out1_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+            dfb_out1.wait_front(onetile);
+            noc.async_write(dfb_out1, s1, out1_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
             noc.async_write_barrier();
-            cb_out1.pop_front(onetile);
+            dfb_out1.pop_front(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/reader_fold_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/reader_fold_rm.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -49,12 +49,12 @@ void kernel_main() {
     const auto s0 = TensorAccessor(input_args, input_addr, input_cb_page_size);
 
     Noc noc;
-    CircularBuffer input_cb(input_cb_id);
-    CircularBuffer output_cb(output_cb_id);
-    CircularBuffer scratch_cb(scratch_cb_id);
+    DataflowBuffer input_dfb(input_cb_id);
+    DataflowBuffer output_dfb(output_cb_id);
+    DataflowBuffer scratch_dfb(scratch_cb_id);
 
     for (uint32_t row_id = start_id; row_id < start_id + num_units_per_core; row_id++) {
-        output_cb.reserve_back(onetile);
+        output_dfb.reserve_back(onetile);
         for (uint32_t elem_id = 0; elem_id < W; elem_id++) {
             uint32_t gid = row_id * W + elem_id;
             uint32_t nch = gid / W;
@@ -87,20 +87,20 @@ void kernel_main() {
                     // kernel_size_w, LH * LW}
                     uint32_t input_row_id = n * C * P + (c * P + ph * kernel_size_w + pw);
                     // Read entire row into input_cb
-                    input_cb.reserve_back(onetile);
-                    uint32_t l1_write_addr = input_cb.get_write_ptr();
+                    input_dfb.reserve_back(onetile);
+                    uint32_t l1_write_addr = input_dfb.get_write_ptr();
 
                     if (aligned) {
                         // Direct read when aligned (L1 sources or non-BH DRAM with aligned size)
                         noc.async_read(
-                            s0, input_cb, input_cb_page_size, {.page_id = input_row_id}, {.offset_bytes = 0});
+                            s0, input_dfb, input_cb_page_size, {.page_id = input_row_id}, {.offset_bytes = 0});
                         noc.async_read_barrier();
                     } else {
                         // Two-step read via scratch buffer for DRAM alignment
                         // Read DRAM-aligned size to scratch buffer first
                         noc.async_read(
                             s0,
-                            scratch_cb,
+                            scratch_dfb,
                             dram_aligned_input_cb_page_size,
                             {.page_id = input_row_id},
                             {.offset_bytes = 0});
@@ -109,20 +109,20 @@ void kernel_main() {
                         UnicastEndpoint scratch_src{};
                         noc.async_read(
                             scratch_src,
-                            input_cb,
+                            input_dfb,
                             input_cb_page_size,
                             {.noc_x = static_cast<uint32_t>(my_x[noc.get_noc_id()]),
                              .noc_y = static_cast<uint32_t>(my_y[noc.get_noc_id()]),
-                             .addr = scratch_cb.get_write_ptr()},
+                             .addr = scratch_dfb.get_write_ptr()},
                             {.offset_bytes = 0});
                         noc.async_read_barrier();
                     }
 
-                    input_cb.push_back(onetile);
+                    input_dfb.push_back(onetile);
 
-                    input_cb.wait_front(onetile);
+                    input_dfb.wait_front(onetile);
 #ifdef DTYPE_BFLOAT16
-                    CoreLocalMem<uint16_t> input_cb_ptr_uint16(input_cb.get_read_ptr());
+                    CoreLocalMem<uint16_t> input_cb_ptr_uint16(input_dfb.get_read_ptr());
                     uint16_t bfloat16_value = input_cb_ptr_uint16[lh * LW + lw];
                     uint32_t float_value_as_int = static_cast<uint32_t>(bfloat16_value) << 16;
                     auto tmp = reinterpret_cast<float*>(&float_value_as_int);
@@ -130,22 +130,22 @@ void kernel_main() {
                     sum += value_as_float;
 #endif
 #ifdef DTYPE_FLOAT32
-                    CoreLocalMem<float> input_cb_ptr_float(input_cb.get_read_ptr());
+                    CoreLocalMem<float> input_cb_ptr_float(input_dfb.get_read_ptr());
                     sum += input_cb_ptr_float[lh * LW + lw];
 #endif
-                    input_cb.pop_front(onetile);
+                    input_dfb.pop_front(onetile);
                 }
             }
 #ifdef DTYPE_BFLOAT16
-            CoreLocalMem<uint16_t> output_cb_write_ptr(output_cb.get_write_ptr());
+            CoreLocalMem<uint16_t> output_cb_write_ptr(output_dfb.get_write_ptr());
             auto sum_ptr = reinterpret_cast<uint16_t*>(&sum) + 1;
             output_cb_write_ptr[w] = *sum_ptr;
 #endif
 #ifdef DTYPE_FLOAT32
-            CoreLocalMem<float> output_cb_write_ptr(output_cb.get_write_ptr());
+            CoreLocalMem<float> output_cb_write_ptr(output_dfb.get_write_ptr());
             output_cb_write_ptr[w] = sum;
 #endif
         }
-        output_cb.push_back(onetile);
+        output_dfb.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/writer_fold_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/writer_fold_rm.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -24,12 +24,12 @@ void kernel_main() {
     const auto s = TensorAccessor(output_args, output_addr, output_cb_page_size);
 
     Noc noc;
-    CircularBuffer output_cb(output_cb_id);
+    DataflowBuffer output_dfb(output_cb_id);
 
     for (uint32_t i = start_id; i < start_id + num_units_per_core; i++) {
-        output_cb.wait_front(onetile);
-        noc.async_write(output_cb, s, output_cb_page_size, {.offset_bytes = 0}, {.page_id = i});
+        output_dfb.wait_front(onetile);
+        noc.async_write(output_dfb, s, output_cb_page_size, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        output_cb.pop_front(onetile);
+        output_dfb.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/reader_moreh_getitem.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/reader_moreh_getitem.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -130,11 +130,11 @@ void kernel_main() {
     };
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_in0);
-    CircularBuffer cb_in1_obj(cb_in1);
-    CircularBuffer cb_in2_obj(cb_in2);
-    CircularBuffer cb_in3_obj(cb_in3);
-    CircularBuffer cb_in4_obj(cb_in4);
+    DataflowBuffer dfb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in1_obj(cb_in1);
+    DataflowBuffer dfb_in2_obj(cb_in2);
+    DataflowBuffer dfb_in3_obj(cb_in3);
+    DataflowBuffer dfb_in4_obj(cb_in4);
 
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -155,39 +155,39 @@ void kernel_main() {
                 }
 
                 uint32_t index_l1_addr = 0;
-                CircularBuffer* index_cb_obj = nullptr;
+                DataflowBuffer* index_dfb_obj = nullptr;
                 if (dim == 0) {
-                    index_cb_obj = &cb_in1_obj;
-                    cb_in1_obj.reserve_back(1);
-                    index_l1_addr = cb_in1_obj.get_write_ptr();
-                    noc.async_read(index0, cb_in1_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
+                    index_dfb_obj = &dfb_in1_obj;
+                    dfb_in1_obj.reserve_back(1);
+                    index_l1_addr = dfb_in1_obj.get_write_ptr();
+                    noc.async_read(index0, dfb_in1_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
                 }
                 if (dim == 1) {
-                    index_cb_obj = &cb_in2_obj;
-                    cb_in2_obj.reserve_back(1);
-                    index_l1_addr = cb_in2_obj.get_write_ptr();
-                    noc.async_read(index1, cb_in2_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
+                    index_dfb_obj = &dfb_in2_obj;
+                    dfb_in2_obj.reserve_back(1);
+                    index_l1_addr = dfb_in2_obj.get_write_ptr();
+                    noc.async_read(index1, dfb_in2_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
                 }
                 if (dim == 2) {
-                    index_cb_obj = &cb_in3_obj;
-                    cb_in3_obj.reserve_back(1);
-                    index_l1_addr = cb_in3_obj.get_write_ptr();
-                    noc.async_read(index2, cb_in3_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
+                    index_dfb_obj = &dfb_in3_obj;
+                    dfb_in3_obj.reserve_back(1);
+                    index_l1_addr = dfb_in3_obj.get_write_ptr();
+                    noc.async_read(index2, dfb_in3_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
                 }
                 if (dim == 3) {
-                    index_cb_obj = &cb_in4_obj;
-                    cb_in4_obj.reserve_back(1);
-                    index_l1_addr = cb_in4_obj.get_write_ptr();
-                    noc.async_read(index3, cb_in4_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
+                    index_dfb_obj = &dfb_in4_obj;
+                    dfb_in4_obj.reserve_back(1);
+                    index_l1_addr = dfb_in4_obj.get_write_ptr();
+                    noc.async_read(index3, dfb_in4_obj, index_stick_sizes[dim], {.page_id = 0}, {.offset_bytes = 0});
                 }
                 noc.async_read_barrier();
-                index_cb_obj->push_back(1);
+                index_dfb_obj->push_back(1);
 
                 volatile tt_l1_ptr int32_t* index_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(index_l1_addr);
                 int32_t noc_idx = index_l1_ptr[index_index];
 
-                index_cb_obj->wait_front(1);
-                index_cb_obj->pop_front(1);
+                index_dfb_obj->wait_front(1);
+                index_dfb_obj->pop_front(1);
 
                 if (noc_idx < 0) {
                     noc_idx += input_size_list[dim];
@@ -208,9 +208,9 @@ void kernel_main() {
             }
         }
 
-        cb_in0_obj.reserve_back(1);
-        noc.async_read(s0, cb_in0_obj, stick_size, {.page_id = noc_id}, {.offset_bytes = 0});
+        dfb_in0_obj.reserve_back(1);
+        noc.async_read(s0, dfb_in0_obj, stick_size, {.page_id = noc_id}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0_obj.push_back(1);
+        dfb_in0_obj.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/writer_moreh_getitem.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/writer_moreh_getitem.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -27,13 +27,13 @@ void kernel_main() {
     const auto s0 = TensorAccessor(dst_args, dst_addr, output_stick_size);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
 
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out_obj.wait_front(1);
-        noc.async_write(cb_out_obj, s0, output_stick_size, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out_obj.wait_front(1);
+        noc.async_write(dfb_out_obj, s0, output_stick_size, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(1);
+        dfb_out_obj.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/reader_moreh_getitem_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/reader_moreh_getitem_tilize.cpp
@@ -5,7 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -133,11 +133,11 @@ void kernel_main() {
 #define INDEX_SIZE (4)
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_in0);
-    CircularBuffer cb_in1_obj(cb_in1);
-    CircularBuffer cb_in2_obj(cb_in2);
-    CircularBuffer cb_in3_obj(cb_in3);
-    CircularBuffer cb_in4_obj(cb_in4);
+    DataflowBuffer dfb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in1_obj(cb_in1);
+    DataflowBuffer dfb_in2_obj(cb_in2);
+    DataflowBuffer dfb_in3_obj(cb_in3);
+    DataflowBuffer dfb_in4_obj(cb_in4);
 
     uint32_t end_id = start_id + num_sticks;
 
@@ -160,24 +160,28 @@ void kernel_main() {
 #ifdef TILIZE_INDEX
                 uint32_t index_noc_id = index_index / TILE_HEIGHT;
                 if (dim == 0) {
-                    cb_in1_obj.reserve_back(1);
-                    index_l1_addr = cb_in1_obj.get_write_ptr();
-                    noc.async_read(index0, cb_in1_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                    dfb_in1_obj.reserve_back(1);
+                    index_l1_addr = dfb_in1_obj.get_write_ptr();
+                    noc.async_read(
+                        index0, dfb_in1_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                 }
                 if (dim == 1) {
-                    cb_in2_obj.reserve_back(1);
-                    index_l1_addr = cb_in2_obj.get_write_ptr();
-                    noc.async_read(index1, cb_in2_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                    dfb_in2_obj.reserve_back(1);
+                    index_l1_addr = dfb_in2_obj.get_write_ptr();
+                    noc.async_read(
+                        index1, dfb_in2_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                 }
                 if (dim == 2) {
-                    cb_in3_obj.reserve_back(1);
-                    index_l1_addr = cb_in3_obj.get_write_ptr();
-                    noc.async_read(index2, cb_in3_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                    dfb_in3_obj.reserve_back(1);
+                    index_l1_addr = dfb_in3_obj.get_write_ptr();
+                    noc.async_read(
+                        index2, dfb_in3_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                 }
                 if (dim == 3) {
-                    cb_in4_obj.reserve_back(1);
-                    index_l1_addr = cb_in4_obj.get_write_ptr();
-                    noc.async_read(index3, cb_in4_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                    dfb_in4_obj.reserve_back(1);
+                    index_l1_addr = dfb_in4_obj.get_write_ptr();
+                    noc.async_read(
+                        index3, dfb_in4_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                 }
                 noc.async_read_barrier();
 
@@ -196,41 +200,41 @@ void kernel_main() {
                 uint32_t noc_offset =
                     ((uint32_t)((index_index * INDEX_SIZE) / NOC_MINIMUM_READ_SIZE)) * NOC_MINIMUM_READ_SIZE;
                 if (dim == 0) {
-                    cb_in1_obj.reserve_back(1);
-                    index_l1_addr = cb_in1_obj.get_write_ptr();
+                    dfb_in1_obj.reserve_back(1);
+                    index_l1_addr = dfb_in1_obj.get_write_ptr();
                     noc.async_read(
                         index0,
-                        cb_in1_obj,
+                        dfb_in1_obj,
                         NOC_MINIMUM_READ_SIZE,
                         {.page_id = 0, .offset_bytes = noc_offset},
                         {.offset_bytes = 0});
                 }
                 if (dim == 1) {
-                    cb_in2_obj.reserve_back(1);
-                    index_l1_addr = cb_in2_obj.get_write_ptr();
+                    dfb_in2_obj.reserve_back(1);
+                    index_l1_addr = dfb_in2_obj.get_write_ptr();
                     noc.async_read(
                         index1,
-                        cb_in2_obj,
+                        dfb_in2_obj,
                         NOC_MINIMUM_READ_SIZE,
                         {.page_id = 0, .offset_bytes = noc_offset},
                         {.offset_bytes = 0});
                 }
                 if (dim == 2) {
-                    cb_in3_obj.reserve_back(1);
-                    index_l1_addr = cb_in3_obj.get_write_ptr();
+                    dfb_in3_obj.reserve_back(1);
+                    index_l1_addr = dfb_in3_obj.get_write_ptr();
                     noc.async_read(
                         index2,
-                        cb_in3_obj,
+                        dfb_in3_obj,
                         NOC_MINIMUM_READ_SIZE,
                         {.page_id = 0, .offset_bytes = noc_offset},
                         {.offset_bytes = 0});
                 }
                 if (dim == 3) {
-                    cb_in4_obj.reserve_back(1);
-                    index_l1_addr = cb_in4_obj.get_write_ptr();
+                    dfb_in4_obj.reserve_back(1);
+                    index_l1_addr = dfb_in4_obj.get_write_ptr();
                     noc.async_read(
                         index3,
-                        cb_in4_obj,
+                        dfb_in4_obj,
                         NOC_MINIMUM_READ_SIZE,
                         {.page_id = 0, .offset_bytes = noc_offset},
                         {.offset_bytes = 0});
@@ -269,7 +273,7 @@ void kernel_main() {
             }
         }
 
-        cb_in0_obj.reserve_back(1);
+        dfb_in0_obj.reserve_back(1);
 
         Idx5d stick_index_5d = get_stick_indices(
             input_stick_idx,
@@ -286,8 +290,8 @@ void kernel_main() {
         uint32_t noc_offset = get_noc_offset_in_tile(stick_index_5d.h, stick_index_5d.w, tile_index_5d.h, element_size);
 
         noc.async_read(
-            s0, cb_in0_obj, stick_size, {.page_id = noc_id, .offset_bytes = noc_offset}, {.offset_bytes = 0});
+            s0, dfb_in0_obj, stick_size, {.page_id = noc_id, .offset_bytes = noc_offset}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0_obj.push_back(1);
+        dfb_in0_obj.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/reader_moreh_getitem_tilize_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/reader_moreh_getitem_tilize_w.cpp
@@ -6,7 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -136,12 +136,12 @@ void kernel_main() {
 #define INDEX_SIZE (4)
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_in0);
-    CircularBuffer cb_in1_obj(cb_in1);
-    CircularBuffer cb_in2_obj(cb_in2);
-    CircularBuffer cb_in3_obj(cb_in3);
-    CircularBuffer cb_in4_obj(cb_in4);
-    CircularBuffer cb_in5_obj(cb_in5);
+    DataflowBuffer dfb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in1_obj(cb_in1);
+    DataflowBuffer dfb_in2_obj(cb_in2);
+    DataflowBuffer dfb_in3_obj(cb_in3);
+    DataflowBuffer dfb_in4_obj(cb_in4);
+    DataflowBuffer dfb_in5_obj(cb_in5);
 
     uint32_t end_id = start_id + num_sticks;
     uint32_t index_size_w = output_size_w;
@@ -173,34 +173,34 @@ void kernel_main() {
 
 #ifdef TILIZE_INDEX
                     if (dim == 0) {
-                        cb_in1_obj.reserve_back(1);
-                        index_l1_addr = cb_in1_obj.get_write_ptr();
+                        dfb_in1_obj.reserve_back(1);
+                        index_l1_addr = dfb_in1_obj.get_write_ptr();
                         noc.async_read(
-                            index0, cb_in1_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                            index0, dfb_in1_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                     }
                     if (dim == 1) {
-                        cb_in2_obj.reserve_back(1);
-                        index_l1_addr = cb_in2_obj.get_write_ptr();
+                        dfb_in2_obj.reserve_back(1);
+                        index_l1_addr = dfb_in2_obj.get_write_ptr();
                         noc.async_read(
-                            index1, cb_in2_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                            index1, dfb_in2_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                     }
                     if (dim == 2) {
-                        cb_in3_obj.reserve_back(1);
-                        index_l1_addr = cb_in3_obj.get_write_ptr();
+                        dfb_in3_obj.reserve_back(1);
+                        index_l1_addr = dfb_in3_obj.get_write_ptr();
                         noc.async_read(
-                            index2, cb_in3_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                            index2, dfb_in3_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                     }
                     if (dim == 3) {
-                        cb_in4_obj.reserve_back(1);
-                        index_l1_addr = cb_in4_obj.get_write_ptr();
+                        dfb_in4_obj.reserve_back(1);
+                        index_l1_addr = dfb_in4_obj.get_write_ptr();
                         noc.async_read(
-                            index3, cb_in4_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                            index3, dfb_in4_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                     }
                     if (dim == 4) {
-                        cb_in5_obj.reserve_back(1);
-                        index_l1_addr = cb_in5_obj.get_write_ptr();
+                        dfb_in5_obj.reserve_back(1);
+                        index_l1_addr = dfb_in5_obj.get_write_ptr();
                         noc.async_read(
-                            index4, cb_in5_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
+                            index4, dfb_in5_obj, INDEX_TILE_SIZE, {.page_id = index_noc_id}, {.offset_bytes = 0});
                     }
                     noc.async_read_barrier();
 
@@ -244,51 +244,51 @@ void kernel_main() {
                     uint32_t noc_offset =
                         ((uint32_t)((index_index * INDEX_SIZE) / NOC_MINIMUM_READ_SIZE)) * NOC_MINIMUM_READ_SIZE;
                     if (dim == 0) {
-                        cb_in1_obj.reserve_back(1);
-                        index_l1_addr = cb_in1_obj.get_write_ptr();
+                        dfb_in1_obj.reserve_back(1);
+                        index_l1_addr = dfb_in1_obj.get_write_ptr();
                         noc.async_read(
                             index0,
-                            cb_in1_obj,
+                            dfb_in1_obj,
                             NOC_MINIMUM_READ_SIZE,
                             {.page_id = 0, .offset_bytes = noc_offset},
                             {.offset_bytes = 0});
                     }
                     if (dim == 1) {
-                        cb_in2_obj.reserve_back(1);
-                        index_l1_addr = cb_in2_obj.get_write_ptr();
+                        dfb_in2_obj.reserve_back(1);
+                        index_l1_addr = dfb_in2_obj.get_write_ptr();
                         noc.async_read(
                             index1,
-                            cb_in2_obj,
+                            dfb_in2_obj,
                             NOC_MINIMUM_READ_SIZE,
                             {.page_id = 0, .offset_bytes = noc_offset},
                             {.offset_bytes = 0});
                     }
                     if (dim == 2) {
-                        cb_in3_obj.reserve_back(1);
-                        index_l1_addr = cb_in3_obj.get_write_ptr();
+                        dfb_in3_obj.reserve_back(1);
+                        index_l1_addr = dfb_in3_obj.get_write_ptr();
                         noc.async_read(
                             index2,
-                            cb_in3_obj,
+                            dfb_in3_obj,
                             NOC_MINIMUM_READ_SIZE,
                             {.page_id = 0, .offset_bytes = noc_offset},
                             {.offset_bytes = 0});
                     }
                     if (dim == 3) {
-                        cb_in4_obj.reserve_back(1);
-                        index_l1_addr = cb_in4_obj.get_write_ptr();
+                        dfb_in4_obj.reserve_back(1);
+                        index_l1_addr = dfb_in4_obj.get_write_ptr();
                         noc.async_read(
                             index3,
-                            cb_in4_obj,
+                            dfb_in4_obj,
                             NOC_MINIMUM_READ_SIZE,
                             {.page_id = 0, .offset_bytes = noc_offset},
                             {.offset_bytes = 0});
                     }
                     if (dim == 4) {
-                        cb_in5_obj.reserve_back(1);
-                        index_l1_addr = cb_in5_obj.get_write_ptr();
+                        dfb_in5_obj.reserve_back(1);
+                        index_l1_addr = dfb_in5_obj.get_write_ptr();
                         noc.async_read(
                             index4,
-                            cb_in5_obj,
+                            dfb_in5_obj,
                             NOC_MINIMUM_READ_SIZE,
                             {.page_id = 0, .offset_bytes = noc_offset},
                             {.offset_bytes = 0});
@@ -328,8 +328,8 @@ void kernel_main() {
                 }
             }
 
-            cb_in0_obj.reserve_back(1);
-            uint32_t l1_write_addr = cb_in0_obj.get_write_ptr();
+            dfb_in0_obj.reserve_back(1);
+            uint32_t l1_write_addr = dfb_in0_obj.get_write_ptr();
 
             Idx5d stick_index_5d = get_stick_indices(
                 input_stick_idx,
@@ -352,7 +352,7 @@ void kernel_main() {
 
             noc.async_read(
                 s0,
-                cb_in0_obj,
+                dfb_in0_obj,
                 NOC_MINIMUM_READ_SIZE,
                 {.page_id = noc_id, .offset_bytes = noc_offset},
                 {.offset_bytes = 0});
@@ -368,7 +368,7 @@ void kernel_main() {
                 index_l1_ptr[0] = index_l1_ptr[w_index % num_elements_per_alignment];
             }
 
-            cb_in0_obj.push_back(1);
+            dfb_in0_obj.push_back(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/writer_moreh_getitem_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/writer_moreh_getitem_tilize.cpp
@@ -5,7 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -36,11 +36,11 @@ void kernel_main() {
     const auto s0 = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
 
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out_obj.wait_front(1);
+        dfb_out_obj.wait_front(1);
 
         uint32_t stick_idx = i;
 
@@ -59,8 +59,8 @@ void kernel_main() {
         uint32_t noc_offset = get_noc_offset_in_tile(stick_index_5d.h, stick_index_5d.w, tile_index_5d.h, element_size);
 
         noc.async_write(
-            cb_out_obj, s0, stick_size, {.offset_bytes = 0}, {.page_id = noc_id, .offset_bytes = noc_offset});
+            dfb_out_obj, s0, stick_size, {.offset_bytes = 0}, {.page_id = noc_id, .offset_bytes = noc_offset});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(1);
+        dfb_out_obj.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/writer_moreh_getitem_tilize_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/writer_moreh_getitem_tilize_w.cpp
@@ -6,7 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -43,11 +43,11 @@ void kernel_main() {
 #define NOC_MINIMUM_READ_SIZE 32
 
     Noc noc;
-    CircularBuffer cb_out0_obj(cb_id_out0);
-    CircularBuffer cb_out1_obj(cb_id_out1);
+    DataflowBuffer dfb_out0_obj(cb_id_out0);
+    DataflowBuffer dfb_out1_obj(cb_id_out1);
 
-    uint32_t l1_read_addr0 = cb_out0_obj.get_read_ptr();
-    uint32_t l1_read_addr1 = cb_out1_obj.get_read_ptr();
+    uint32_t l1_read_addr0 = dfb_out0_obj.get_read_ptr();
+    uint32_t l1_read_addr1 = dfb_out1_obj.get_read_ptr();
 
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -80,7 +80,7 @@ void kernel_main() {
 
         uint32_t j = 0;
         for (uint32_t w = w_start; w < w_end; w++, j++) {
-            cb_out0_obj.wait_front(1);
+            dfb_out0_obj.wait_front(1);
 
             if (element_size == 4) {
                 volatile tt_l1_ptr uint32_t* index_l1_ptr0 =
@@ -98,11 +98,11 @@ void kernel_main() {
                 index_l1_ptr1[j] = index_l1_ptr0[0];
             }
 
-            cb_out0_obj.pop_front(1);
+            dfb_out0_obj.pop_front(1);
         }
 
         noc.async_write(
-            cb_out1_obj,
+            dfb_out1_obj,
             s0,
             NOC_MINIMUM_READ_SIZE,
             {.offset_bytes = 0},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_large.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -53,10 +53,10 @@ void kernel_main() {
     const auto cb_id_mask_h = cb_id++;
     const auto cb_id_mask_w = cb_id++;
 
-    CircularBuffer cb_scaler(cb_id_scaler);
-    CircularBuffer cb_eps(cb_id_eps);
-    fill_cb_with_value(cb_scaler, scaler);
-    fill_cb_with_value(cb_eps, eps);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    DataflowBuffer dfb_eps(cb_id_eps);
+    fill_cb_with_value(dfb_scaler, scaler);
+    fill_cb_with_value(dfb_eps, eps);
 
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? origin_h % TILE_H : TILE_H;
@@ -65,12 +65,12 @@ void kernel_main() {
     const auto mask_w = do_mask_w ? origin_w % TILE_W : TILE_W;
 
     if (do_mask_h) {
-        CircularBuffer cb_mask_h(cb_id_mask_h);
-        generate_mask_h(cb_mask_h, mask_h);
+        DataflowBuffer dfb_mask_h(cb_id_mask_h);
+        generate_mask_h(dfb_mask_h, mask_h);
     }
     if (do_mask_w) {
-        CircularBuffer cb_mask_w(cb_id_mask_w);
-        generate_mask_w(cb_mask_w, mask_w);
+        DataflowBuffer dfb_mask_w(cb_id_mask_w);
+        generate_mask_w(dfb_mask_w, mask_w);
     }
 
     // input
@@ -86,58 +86,58 @@ void kernel_main() {
     const auto beta_addrg = TensorAccessor(beta_args, beta_addr);
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_gamma(cb_id_gamma);
-    CircularBuffer cb_beta(cb_id_beta);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_beta(cb_id_beta);
 
     uint32_t input_tile_idx;
     for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; ++outer_idx) {
         // For E[x]
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
-            cb_input.reserve_back(block_size);
+            dfb_input.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                 noc.async_read(
                     input_addrg,
-                    cb_input,
+                    dfb_input,
                     input_tile_bytes,
                     {.page_id = input_tile_idx},
                     {.offset_bytes = r * input_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_input.push_back(block_size);
+            dfb_input.push_back(block_size);
         }  // inner_idx loop
 
         // For Var[x]
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
-            cb_input.reserve_back(block_size);
+            dfb_input.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                 noc.async_read(
                     input_addrg,
-                    cb_input,
+                    dfb_input,
                     input_tile_bytes,
                     {.page_id = input_tile_idx},
                     {.offset_bytes = r * input_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_input.push_back(block_size);
+            dfb_input.push_back(block_size);
         }  // inner_idx loop
 
         // For (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
-            cb_input.reserve_back(block_size);
+            dfb_input.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                 noc.async_read(
                     input_addrg,
-                    cb_input,
+                    dfb_input,
                     input_tile_bytes,
                     {.page_id = input_tile_idx},
                     {.offset_bytes = r * input_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_input.push_back(block_size);
+            dfb_input.push_back(block_size);
 
             // input (N, C, H, W)
             // input_tile_idx = n * C * Ht * Wt + c * Ht * Wt + h * Wt + w
@@ -146,14 +146,14 @@ void kernel_main() {
             // gamma (1, 1, 1, C)
             if (gamma_has_value) {
                 uint32_t gamma_tile_idx;
-                const auto gamma_l1_write_ptr = cb_gamma.get_write_ptr();
-                cb_gamma.reserve_back(block_size);
+                const auto gamma_l1_write_ptr = dfb_gamma.get_write_ptr();
+                dfb_gamma.reserve_back(block_size);
                 for (uint32_t r = 0; r < block_size; r++) {
                     input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                     gamma_tile_idx = get_gamma_beta_tile_idx(input_tile_idx, HtWt, C, TILE_W);
                     noc.async_read(
                         gamma_addrg,
-                        cb_gamma,
+                        dfb_gamma,
                         gamma_tile_bytes,
                         {.page_id = gamma_tile_idx},
                         {.offset_bytes = r * gamma_tile_bytes});
@@ -170,20 +170,20 @@ void kernel_main() {
                         gamma_ptr[0] = gamma_ptr[tilized_gamma_idx_in_tile];
                     }
                 }
-                cb_gamma.push_back(block_size);
+                dfb_gamma.push_back(block_size);
             }
 
             // beta (1, 1, 1, C)
             if (beta_has_value) {
                 uint32_t beta_tile_idx;
-                const auto beta_l1_write_ptr = cb_beta.get_write_ptr();
-                cb_beta.reserve_back(block_size);
+                const auto beta_l1_write_ptr = dfb_beta.get_write_ptr();
+                dfb_beta.reserve_back(block_size);
                 for (uint32_t r = 0; r < block_size; r++) {
                     input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                     beta_tile_idx = get_gamma_beta_tile_idx(input_tile_idx, HtWt, C, TILE_W);
                     noc.async_read(
                         beta_addrg,
-                        cb_beta,
+                        dfb_beta,
                         beta_tile_bytes,
                         {.page_id = beta_tile_idx},
                         {.offset_bytes = r * beta_tile_bytes});
@@ -200,7 +200,7 @@ void kernel_main() {
                         beta_ptr[0] = beta_ptr[tilized_beta_idx_in_tile];
                     }
                 }
-                cb_beta.push_back(block_size);
+                dfb_beta.push_back(block_size);
             }
         }  // inner_idx loop
     }  // outer_idx loop

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/reader_moreh_group_norm_small.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -53,10 +53,10 @@ void kernel_main() {
     const auto cb_id_mask_h = cb_id++;
     const auto cb_id_mask_w = cb_id++;
 
-    CircularBuffer cb_scaler(cb_id_scaler);
-    CircularBuffer cb_eps(cb_id_eps);
-    fill_cb_with_value(cb_scaler, scaler);
-    fill_cb_with_value(cb_eps, eps);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    DataflowBuffer dfb_eps(cb_id_eps);
+    fill_cb_with_value(dfb_scaler, scaler);
+    fill_cb_with_value(dfb_eps, eps);
 
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? origin_h % TILE_H : TILE_H;
@@ -65,12 +65,12 @@ void kernel_main() {
     const auto mask_w = do_mask_w ? origin_w % TILE_W : TILE_W;
 
     if (do_mask_h) {
-        CircularBuffer cb_mask_h(cb_id_mask_h);
-        generate_mask_h(cb_mask_h, mask_h);
+        DataflowBuffer dfb_mask_h(cb_id_mask_h);
+        generate_mask_h(dfb_mask_h, mask_h);
     }
     if (do_mask_w) {
-        CircularBuffer cb_mask_w(cb_id_mask_w);
-        generate_mask_w(cb_mask_w, mask_w);
+        DataflowBuffer dfb_mask_w(cb_id_mask_w);
+        generate_mask_w(dfb_mask_w, mask_w);
     }
 
     // input
@@ -86,25 +86,25 @@ void kernel_main() {
     const auto beta_addrg = TensorAccessor(beta_args, beta_addr);
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_gamma(cb_id_gamma);
-    CircularBuffer cb_beta(cb_id_beta);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_beta(cb_id_beta);
 
     uint32_t input_tile_idx;
     for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; ++outer_idx) {
-        cb_input.reserve_back(num_inner_tiles);
+        dfb_input.reserve_back(num_inner_tiles);
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; ++inner_idx) {
-            cb_input.reserve_back(num_inner_tiles);
+            dfb_input.reserve_back(num_inner_tiles);
             input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx;
             noc.async_read(
                 input_addrg,
-                cb_input,
+                dfb_input,
                 input_tile_bytes,
                 {.page_id = input_tile_idx},
                 {.offset_bytes = inner_idx * input_tile_bytes});
         }  // inner_idx loop
         noc.async_read_barrier();
-        cb_input.push_back(num_inner_tiles);
+        dfb_input.push_back(num_inner_tiles);
 
         // input (N, C, H, W)
         // input_tile_idx = n * C * Ht * Wt + c * Ht * Wt + h * Wt + w
@@ -114,14 +114,14 @@ void kernel_main() {
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
             if (gamma_has_value) {
                 uint32_t gamma_tile_idx;
-                const auto gamma_l1_write_ptr = cb_gamma.get_write_ptr();
-                cb_gamma.reserve_back(block_size);
+                const auto gamma_l1_write_ptr = dfb_gamma.get_write_ptr();
+                dfb_gamma.reserve_back(block_size);
                 for (uint32_t r = 0; r < block_size; r++) {
                     input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                     gamma_tile_idx = get_gamma_beta_tile_idx(input_tile_idx, HtWt, C, TILE_W);
                     noc.async_read(
                         gamma_addrg,
-                        cb_gamma,
+                        dfb_gamma,
                         gamma_tile_bytes,
                         {.page_id = gamma_tile_idx},
                         {.offset_bytes = r * gamma_tile_bytes});
@@ -138,20 +138,20 @@ void kernel_main() {
                         gamma_ptr[0] = gamma_ptr[tilized_gamma_idx_in_tile];
                     }
                 }
-                cb_gamma.push_back(block_size);
+                dfb_gamma.push_back(block_size);
             }
 
             // beta (1, 1, 1, C)
             if (beta_has_value) {
                 uint32_t beta_tile_idx;
-                const auto beta_l1_write_ptr = cb_beta.get_write_ptr();
-                cb_beta.reserve_back(block_size);
+                const auto beta_l1_write_ptr = dfb_beta.get_write_ptr();
+                dfb_beta.reserve_back(block_size);
                 for (uint32_t r = 0; r < block_size; r++) {
                     input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                     beta_tile_idx = get_gamma_beta_tile_idx(input_tile_idx, HtWt, C, TILE_W);
                     noc.async_read(
                         beta_addrg,
-                        cb_beta,
+                        dfb_beta,
                         beta_tile_bytes,
                         {.page_id = beta_tile_idx},
                         {.offset_bytes = r * beta_tile_bytes});
@@ -168,7 +168,7 @@ void kernel_main() {
                         beta_ptr[0] = beta_ptr[tilized_beta_idx_in_tile];
                     }
                 }
-                cb_beta.push_back(block_size);
+                dfb_beta.push_back(block_size);
             }
         }  // inner_idx loop
     }  // outer_idx loop

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/writer_moreh_group_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/dataflow/writer_moreh_group_norm.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -52,11 +52,11 @@ void kernel_main() {
     const auto start_mean_rstd_idx = tile_offset / num_inner_tiles;
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
-    CircularBuffer cb_mean(cb_id_mean);
-    CircularBuffer cb_rstd(cb_id_rstd);
+    DataflowBuffer dfb_output(cb_id_output);
+    DataflowBuffer dfb_mean(cb_id_mean);
+    DataflowBuffer dfb_rstd(cb_id_rstd);
 
-    const auto output_l1_read_ptr = cb_output.get_read_ptr();
+    const auto output_l1_read_ptr = dfb_output.get_read_ptr();
     uint32_t output_tile_idx;
     for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; ++outer_idx) {
         // mean, rstd (1, 1, N, num_groups)
@@ -81,55 +81,55 @@ void kernel_main() {
         // mean (1, 1, N, num_groups)
         if (mean_has_value) {
             const auto mean_dtype_bytes = mean_tile_bytes / (TILE_H * TILE_W);
-            const auto mean_l1_read_ptr = cb_mean.get_read_ptr();
-            cb_mean.wait_front(onetile);
+            const auto mean_l1_read_ptr = dfb_mean.get_read_ptr();
+            dfb_mean.wait_front(onetile);
             if (tilized_mean_rstd_idx_in_tile != 0) {
                 CoreLocalMem<uint16_t> mean_ptr(mean_l1_read_ptr);
                 mean_ptr[tilized_mean_rstd_idx_in_tile] = mean_ptr[0];
             }
             noc.async_write(
-                cb_mean,
+                dfb_mean,
                 mean_addrg,
                 mean_dtype_bytes,
                 {.offset_bytes = tilized_mean_rstd_idx_in_tile * mean_dtype_bytes},
                 {.page_id = mean_rstd_tile_idx, .offset_bytes = tilized_mean_rstd_idx_in_tile * mean_dtype_bytes});
             noc.async_write_barrier();
-            cb_mean.pop_front(onetile);
+            dfb_mean.pop_front(onetile);
         }
 
         // rstd (1, 1, N, num_groups)
         if (rstd_has_value) {
             const auto rstd_dtype_bytes = rstd_tile_bytes / (TILE_H * TILE_W);
-            const auto rstd_l1_read_ptr = cb_rstd.get_read_ptr();
-            cb_rstd.wait_front(onetile);
+            const auto rstd_l1_read_ptr = dfb_rstd.get_read_ptr();
+            dfb_rstd.wait_front(onetile);
             if (tilized_mean_rstd_idx_in_tile != 0) {
                 CoreLocalMem<uint16_t> rstd_ptr(rstd_l1_read_ptr);
                 rstd_ptr[tilized_mean_rstd_idx_in_tile] = rstd_ptr[0];
             }
             noc.async_write(
-                cb_rstd,
+                dfb_rstd,
                 rstd_addrg,
                 rstd_dtype_bytes,
                 {.offset_bytes = tilized_mean_rstd_idx_in_tile * rstd_dtype_bytes},
                 {.page_id = mean_rstd_tile_idx, .offset_bytes = tilized_mean_rstd_idx_in_tile * rstd_dtype_bytes});
             noc.async_write_barrier();
-            cb_rstd.pop_front(onetile);
+            dfb_rstd.pop_front(onetile);
         }
 
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
             // output (N, C, H, W)
-            cb_output.wait_front(block_size);
+            dfb_output.wait_front(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 output_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
                 noc.async_write(
-                    cb_output,
+                    dfb_output,
                     output_addrg,
                     output_tile_bytes,
                     {.offset_bytes = r * output_tile_bytes},
                     {.page_id = output_tile_idx});
             }
             noc.async_write_barrier();
-            cb_output.pop_front(block_size);
+            dfb_output.pop_front(block_size);
         }  // inner_idx loop
     }  // outer_idx loop
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/kernels/dataflow/reader_moreh_group_norm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/kernels/dataflow/reader_moreh_group_norm_backward_gamma_beta_grad.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -65,17 +65,17 @@ void kernel_main() {
         uint32_t u;
     } one;
     one.f = 1.0f;
-    CircularBuffer cb_one(cb_id_one);
-    fill_cb_with_value(cb_one, one.u);
+    DataflowBuffer dfb_one(cb_id_one);
+    fill_cb_with_value(dfb_one, one.u);
 
     if (do_mask_h) {
-        CircularBuffer cb_mask_h(cb_id_mask_h);
-        generate_mask_h(cb_mask_h, mask_h);
+        DataflowBuffer dfb_mask_h(cb_id_mask_h);
+        generate_mask_h(dfb_mask_h, mask_h);
     }
 
     if (do_mask_w) {
-        CircularBuffer cb_mask_w(cb_id_mask_w);
-        generate_mask_w(cb_mask_w, mask_w);
+        DataflowBuffer dfb_mask_w(cb_id_mask_w);
+        generate_mask_w(dfb_mask_w, mask_w);
     }
 
     // output_grad
@@ -91,18 +91,18 @@ void kernel_main() {
     const auto rstd_addrg = TensorAccessor(rstd_args, rstd_addr);
 
     Noc noc;
-    CircularBuffer cb_output_grad(cb_id_output_grad);
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_mean(cb_id_mean);
-    CircularBuffer cb_rstd(cb_id_rstd);
+    DataflowBuffer dfb_output_grad(cb_id_output_grad);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_mean(cb_id_mean);
+    DataflowBuffer dfb_rstd(cb_id_rstd);
 
     const auto output_grad_tile_bytes = get_tile_size(cb_id_output_grad);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
     const auto mean_tile_bytes = get_tile_size(cb_id_mean);
     const auto rstd_tile_bytes = get_tile_size(cb_id_rstd);
 
-    const auto mean_l1_write_ptr = cb_mean.get_write_ptr();
-    const auto rstd_l1_write_ptr = cb_rstd.get_write_ptr();
+    const auto mean_l1_write_ptr = dfb_mean.get_write_ptr();
+    const auto rstd_l1_write_ptr = dfb_rstd.get_write_ptr();
 
     uint32_t mean_rstd_n_idx, mean_rstd_g_idx;
     uint32_t mean_rstd_tile_h_idx, mean_rstd_tile_w_idx;
@@ -119,24 +119,24 @@ void kernel_main() {
 
             // output_grad (N, C, H, W)
             output_grad_tile_idx = n_idx * CHtWt + c_idx * HtWt + htwt_idx + tile_offset;
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = output_grad_tile_idx},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_grad_has_value) {
                 // input (N, C, H, W)
                 input_tile_idx = output_grad_tile_idx;
-                cb_input.reserve_back(onetile);
+                dfb_input.reserve_back(onetile);
                 noc.async_read(
-                    input_addrg, cb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
+                    input_addrg, dfb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_input.push_back(onetile);
+                dfb_input.push_back(onetile);
 
                 // mean, rstd (1, 1, N, num_groups)
                 // mean_rstd_idx = n * num_groups + g
@@ -157,26 +157,26 @@ void kernel_main() {
                     get_tilized_idx(mean_rstd_h_idx_in_tile, mean_rstd_w_idx_in_tile, TILE_H, TILE_W);
 
                 // mean (1, 1, N, num_groups)
-                cb_mean.reserve_back(onetile);
+                dfb_mean.reserve_back(onetile);
                 noc.async_read(
-                    mean_addrg, cb_mean, mean_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
+                    mean_addrg, dfb_mean, mean_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if (tilized_mean_rstd_idx_in_tile != 0) {
                     CoreLocalMem<uint16_t> mean_ptr(mean_l1_write_ptr);
                     mean_ptr[0] = mean_ptr[tilized_mean_rstd_idx_in_tile];
                 }
-                cb_mean.push_back(onetile);
+                dfb_mean.push_back(onetile);
 
                 // rstd (1, 1, N, num_groups)
-                cb_rstd.reserve_back(onetile);
+                dfb_rstd.reserve_back(onetile);
                 noc.async_read(
-                    rstd_addrg, cb_rstd, rstd_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
+                    rstd_addrg, dfb_rstd, rstd_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if (tilized_mean_rstd_idx_in_tile != 0) {
                     CoreLocalMem<uint16_t> rstd_ptr(rstd_l1_write_ptr);
                     rstd_ptr[0] = rstd_ptr[tilized_mean_rstd_idx_in_tile];
                 }
-                cb_rstd.push_back(onetile);
+                dfb_rstd.push_back(onetile);
             }  // gamma_grad_has_value
 
         }  // inner_idx loop

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/kernels/dataflow/writer_moreh_group_norm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/kernels/dataflow/writer_moreh_group_norm_backward_gamma_beta_grad.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -43,11 +43,11 @@ void kernel_main() {
     constexpr uint32_t TILE_W = 32;
 
     Noc noc;
-    CircularBuffer cb_gamma_grad(cb_id_gamma_grad);
-    CircularBuffer cb_beta_grad(cb_id_beta_grad);
+    DataflowBuffer dfb_gamma_grad(cb_id_gamma_grad);
+    DataflowBuffer dfb_beta_grad(cb_id_beta_grad);
 
-    const auto gamma_grad_l1_read_ptr = cb_gamma_grad.get_read_ptr();
-    const auto beta_grad_l1_read_ptr = cb_beta_grad.get_read_ptr();
+    const auto gamma_grad_l1_read_ptr = dfb_gamma_grad.get_read_ptr();
+    const auto beta_grad_l1_read_ptr = dfb_beta_grad.get_read_ptr();
 
     for (uint32_t outer_idx = 0; outer_idx < num_channels_per_core; ++outer_idx) {
         auto c_idx = outer_idx + (tile_offset / HtWt);
@@ -61,39 +61,39 @@ void kernel_main() {
         if (gamma_grad_has_value) {
             // gamma_grad (1, 1, 1, C)
             const auto gamma_grad_dtype_bytes = gamma_grad_tile_bytes / (TILE_H * TILE_W);
-            cb_gamma_grad.wait_front(onetile);
+            dfb_gamma_grad.wait_front(onetile);
             if (tilized_gamma_beta_idx_in_tile != 0) {
                 CoreLocalMem<uint16_t> gamma_grad_ptr(gamma_grad_l1_read_ptr);
                 gamma_grad_ptr[tilized_gamma_beta_idx_in_tile] = gamma_grad_ptr[0];
             }
             noc.async_write(
-                cb_gamma_grad,
+                dfb_gamma_grad,
                 gamma_grad_addrg,
                 gamma_grad_dtype_bytes,
                 {.offset_bytes = tilized_gamma_beta_idx_in_tile * gamma_grad_dtype_bytes},
                 {.page_id = gamma_beta_tile_idx,
                  .offset_bytes = tilized_gamma_beta_idx_in_tile * gamma_grad_dtype_bytes});
             noc.async_write_barrier();
-            cb_gamma_grad.pop_front(onetile);
+            dfb_gamma_grad.pop_front(onetile);
         }
 
         if (beta_grad_has_value) {
             // beta_grad (1, 1, 1, C)
             const auto beta_grad_dtype_bytes = beta_grad_tile_bytes / (TILE_H * TILE_W);
-            cb_beta_grad.wait_front(onetile);
+            dfb_beta_grad.wait_front(onetile);
             if (tilized_gamma_beta_idx_in_tile != 0) {
                 CoreLocalMem<uint16_t> beta_grad_ptr(beta_grad_l1_read_ptr);
                 beta_grad_ptr[tilized_gamma_beta_idx_in_tile] = beta_grad_ptr[0];
             }
             noc.async_write(
-                cb_beta_grad,
+                dfb_beta_grad,
                 beta_grad_addrg,
                 beta_grad_dtype_bytes,
                 {.offset_bytes = tilized_gamma_beta_idx_in_tile * beta_grad_dtype_bytes},
                 {.page_id = gamma_beta_tile_idx,
                  .offset_bytes = tilized_gamma_beta_idx_in_tile * beta_grad_dtype_bytes});
             noc.async_write_barrier();
-            cb_beta_grad.pop_front(onetile);
+            dfb_beta_grad.pop_front(onetile);
         }
 
     }  // outer_idx loop

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_large.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -63,19 +63,19 @@ void kernel_main() {
         uint32_t u;
     } scalar;
     scalar.f = 1.0f;
-    CircularBuffer cb_one(cb_id_one);
-    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
-    fill_cb_with_value(cb_one, scalar.u);
+    DataflowBuffer dfb_one(cb_id_one);
+    DataflowBuffer dfb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(dfb_one, scalar.u);
 
     const auto n = static_cast<float>((num_channels / num_groups) * origin_h * origin_w);
     scalar.f = n;
-    fill_cb_with_value(cb_n_recip_n, scalar.u);
+    fill_cb_with_value(dfb_n_recip_n, scalar.u);
     scalar.f = 1.0f / n;
-    fill_cb_with_value(cb_n_recip_n, scalar.u);
+    fill_cb_with_value(dfb_n_recip_n, scalar.u);
 
     if (do_mask_h || do_mask_w) {
-        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
-        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
+        DataflowBuffer dfb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(dfb_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
     }
 
     // output_grad
@@ -99,20 +99,20 @@ void kernel_main() {
     const auto start_mean_rstd_idx = tile_offset / num_inner_tiles;
 
     Noc noc;
-    CircularBuffer cb_output_grad(cb_id_output_grad);
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_mean(cb_id_mean);
-    CircularBuffer cb_rstd(cb_id_rstd);
-    CircularBuffer cb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_output_grad(cb_id_output_grad);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_mean(cb_id_mean);
+    DataflowBuffer dfb_rstd(cb_id_rstd);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
 
     const auto output_grad_tile_bytes = get_tile_size(cb_id_output_grad);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
     const auto rstd_tile_bytes = get_tile_size(cb_id_rstd);
     const auto gamma_tile_bytes = get_tile_size(cb_id_gamma);
 
-    const auto mean_l1_write_ptr = cb_mean.get_write_ptr();
-    const auto rstd_l1_write_ptr = cb_rstd.get_write_ptr();
-    const auto gamma_l1_write_ptr = cb_gamma.get_write_ptr();
+    const auto mean_l1_write_ptr = dfb_mean.get_write_ptr();
+    const auto rstd_l1_write_ptr = dfb_rstd.get_write_ptr();
+    const auto gamma_l1_write_ptr = dfb_gamma.get_write_ptr();
 
     uint32_t mean_rstd_idx, mean_rstd_n_idx, mean_rstd_g_idx;
     uint32_t mean_rstd_tile_h_idx, mean_rstd_tile_w_idx;
@@ -142,44 +142,44 @@ void kernel_main() {
             get_tilized_idx(mean_rstd_h_idx_in_tile, mean_rstd_w_idx_in_tile, TILE_H, TILE_W);
 
         // mean (1, 1, N, num_groups)
-        cb_mean.reserve_back(onetile);
-        noc.async_read(mean_addrg, cb_mean, mean_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
+        dfb_mean.reserve_back(onetile);
+        noc.async_read(mean_addrg, dfb_mean, mean_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
         noc.async_read_barrier();
         if (tilized_mean_rstd_idx_in_tile != 0) {
             CoreLocalMem<uint16_t> mean_ptr(mean_l1_write_ptr);
             mean_ptr[0] = mean_ptr[tilized_mean_rstd_idx_in_tile];
         }
-        cb_mean.push_back(onetile);
+        dfb_mean.push_back(onetile);
 
         // rstd (1, 1, N, num_groups)
-        cb_rstd.reserve_back(onetile);
-        noc.async_read(rstd_addrg, cb_rstd, rstd_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
+        dfb_rstd.reserve_back(onetile);
+        noc.async_read(rstd_addrg, dfb_rstd, rstd_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
         noc.async_read_barrier();
         if (tilized_mean_rstd_idx_in_tile != 0) {
             CoreLocalMem<uint16_t> rstd_ptr(rstd_l1_write_ptr);
             rstd_ptr[0] = rstd_ptr[tilized_mean_rstd_idx_in_tile];
         }
-        cb_rstd.push_back(onetile);
+        dfb_rstd.push_back(onetile);
 
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; ++inner_idx) {
             // input (N, C, H, W)
             input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx;
-            cb_input.reserve_back(onetile);
-            noc.async_read(input_addrg, cb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
+            dfb_input.reserve_back(onetile);
+            noc.async_read(input_addrg, dfb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(onetile);
+            dfb_input.push_back(onetile);
 
             // output_grad (N, C, H, W)
             output_grad_tile_idx = input_tile_idx;
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = output_grad_tile_idx},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_has_value) {
                 // gamma (1, 1, 1, C)
@@ -187,30 +187,30 @@ void kernel_main() {
                 const auto gamma_tile_idx = gamma_c_idx / TILE_W;
                 const auto gamma_w_idx_in_tile = gamma_c_idx % TILE_W;
                 const auto tilized_gamma_idx_in_tile = get_tilized_idx(0, gamma_w_idx_in_tile, TILE_H, TILE_W);
-                cb_gamma.reserve_back(onetile);
+                dfb_gamma.reserve_back(onetile);
                 noc.async_read(
-                    gamma_addrg, cb_gamma, gamma_tile_bytes, {.page_id = gamma_tile_idx}, {.offset_bytes = 0});
+                    gamma_addrg, dfb_gamma, gamma_tile_bytes, {.page_id = gamma_tile_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if (tilized_gamma_idx_in_tile != 0) {
                     CoreLocalMem<uint16_t> gamma_ptr(gamma_l1_write_ptr);
                     gamma_ptr[0] = gamma_ptr[tilized_gamma_idx_in_tile];
                 }
-                cb_gamma.push_back(onetile);
+                dfb_gamma.push_back(onetile);
             }
         }  // inner_idx loop
 
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; ++inner_idx) {
             // output_grad (N, C, H, W)
             output_grad_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx;
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = output_grad_tile_idx},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_has_value) {
                 // gamma (1, 1, 1, C)
@@ -218,23 +218,23 @@ void kernel_main() {
                 const auto gamma_tile_idx = gamma_c_idx / TILE_W;
                 const auto gamma_w_idx_in_tile = gamma_c_idx % TILE_W;
                 const auto tilized_gamma_idx_in_tile = get_tilized_idx(0, gamma_w_idx_in_tile, TILE_H, TILE_W);
-                cb_gamma.reserve_back(onetile);
+                dfb_gamma.reserve_back(onetile);
                 noc.async_read(
-                    gamma_addrg, cb_gamma, gamma_tile_bytes, {.page_id = gamma_tile_idx}, {.offset_bytes = 0});
+                    gamma_addrg, dfb_gamma, gamma_tile_bytes, {.page_id = gamma_tile_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if (tilized_gamma_idx_in_tile != 0) {
                     CoreLocalMem<uint16_t> gamma_ptr(gamma_l1_write_ptr);
                     gamma_ptr[0] = gamma_ptr[tilized_gamma_idx_in_tile];
                 }
-                cb_gamma.push_back(onetile);
+                dfb_gamma.push_back(onetile);
             }
 
             // input (N, C, H, W)
             input_tile_idx = output_grad_tile_idx;
-            cb_input.reserve_back(onetile);
-            noc.async_read(input_addrg, cb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
+            dfb_input.reserve_back(onetile);
+            noc.async_read(input_addrg, dfb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(onetile);
+            dfb_input.push_back(onetile);
         }  // inner_idx loop
     }  // outer_idx loop
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/reader_moreh_group_norm_backward_input_grad_small.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -63,19 +63,19 @@ void kernel_main() {
         uint32_t u;
     } scalar;
     scalar.f = 1.0f;
-    CircularBuffer cb_one(cb_id_one);
-    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
-    fill_cb_with_value(cb_one, scalar.u);
+    DataflowBuffer dfb_one(cb_id_one);
+    DataflowBuffer dfb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(dfb_one, scalar.u);
 
     const auto n = static_cast<float>((num_channels / num_groups) * origin_h * origin_w);
     scalar.f = n;
-    fill_cb_with_value(cb_n_recip_n, scalar.u);
+    fill_cb_with_value(dfb_n_recip_n, scalar.u);
     scalar.f = 1.0f / n;
-    fill_cb_with_value(cb_n_recip_n, scalar.u);
+    fill_cb_with_value(dfb_n_recip_n, scalar.u);
 
     if (do_mask_h || do_mask_w) {
-        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
-        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
+        DataflowBuffer dfb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(dfb_mask_h_w, mask_h, mask_w, get_tile_size(cb_id_mask_h_w));
     }
 
     // output_grad
@@ -99,20 +99,20 @@ void kernel_main() {
     const auto start_mean_rstd_idx = tile_offset / num_inner_tiles;
 
     Noc noc;
-    CircularBuffer cb_output_grad(cb_id_output_grad);
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_mean(cb_id_mean);
-    CircularBuffer cb_rstd(cb_id_rstd);
-    CircularBuffer cb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_output_grad(cb_id_output_grad);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_mean(cb_id_mean);
+    DataflowBuffer dfb_rstd(cb_id_rstd);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
 
     const auto output_grad_tile_bytes = get_tile_size(cb_id_output_grad);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
     const auto rstd_tile_bytes = get_tile_size(cb_id_rstd);
     const auto gamma_tile_bytes = get_tile_size(cb_id_gamma);
 
-    const auto mean_l1_write_ptr = cb_mean.get_write_ptr();
-    const auto rstd_l1_write_ptr = cb_rstd.get_write_ptr();
-    const auto gamma_l1_write_ptr = cb_gamma.get_write_ptr();
+    const auto mean_l1_write_ptr = dfb_mean.get_write_ptr();
+    const auto rstd_l1_write_ptr = dfb_rstd.get_write_ptr();
+    const auto gamma_l1_write_ptr = dfb_gamma.get_write_ptr();
 
     uint32_t mean_rstd_idx, mean_rstd_n_idx, mean_rstd_g_idx;
     uint32_t mean_rstd_tile_h_idx, mean_rstd_tile_w_idx;
@@ -142,46 +142,46 @@ void kernel_main() {
             get_tilized_idx(mean_rstd_h_idx_in_tile, mean_rstd_w_idx_in_tile, TILE_H, TILE_W);
 
         // mean (1, 1, N, num_groups)
-        cb_mean.reserve_back(onetile);
-        noc.async_read(mean_addrg, cb_mean, mean_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
+        dfb_mean.reserve_back(onetile);
+        noc.async_read(mean_addrg, dfb_mean, mean_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
         noc.async_read_barrier();
         if (tilized_mean_rstd_idx_in_tile != 0) {
             CoreLocalMem<uint16_t> mean_ptr(mean_l1_write_ptr);
             mean_ptr[0] = mean_ptr[tilized_mean_rstd_idx_in_tile];
         }
-        cb_mean.push_back(onetile);
+        dfb_mean.push_back(onetile);
 
         // rstd (1, 1, N, num_groups)
-        cb_rstd.reserve_back(onetile);
-        noc.async_read(rstd_addrg, cb_rstd, rstd_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
+        dfb_rstd.reserve_back(onetile);
+        noc.async_read(rstd_addrg, dfb_rstd, rstd_tile_bytes, {.page_id = mean_rstd_tile_idx}, {.offset_bytes = 0});
         noc.async_read_barrier();
         if (tilized_mean_rstd_idx_in_tile != 0) {
             CoreLocalMem<uint16_t> rstd_ptr(rstd_l1_write_ptr);
             rstd_ptr[0] = rstd_ptr[tilized_mean_rstd_idx_in_tile];
         }
-        cb_rstd.push_back(onetile);
+        dfb_rstd.push_back(onetile);
 
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; ++inner_idx) {
             // input (N, C, H, W)
             input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx;
-            cb_input.reserve_back(onetile);
-            noc.async_read(input_addrg, cb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
+            dfb_input.reserve_back(onetile);
+            noc.async_read(input_addrg, dfb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(onetile);
+            dfb_input.push_back(onetile);
         }  // inner_idx loop
 
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; ++inner_idx) {
             // output_grad (N, C, H, W)
             output_grad_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx;
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = output_grad_tile_idx},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_has_value) {
                 // gamma (1, 1, 1, C)
@@ -189,15 +189,15 @@ void kernel_main() {
                 const auto gamma_tile_idx = gamma_c_idx / TILE_W;
                 const auto gamma_w_idx_in_tile = gamma_c_idx % TILE_W;
                 const auto tilized_gamma_idx_in_tile = get_tilized_idx(0, gamma_w_idx_in_tile, TILE_H, TILE_W);
-                cb_gamma.reserve_back(onetile);
+                dfb_gamma.reserve_back(onetile);
                 noc.async_read(
-                    gamma_addrg, cb_gamma, gamma_tile_bytes, {.page_id = gamma_tile_idx}, {.offset_bytes = 0});
+                    gamma_addrg, dfb_gamma, gamma_tile_bytes, {.page_id = gamma_tile_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if (tilized_gamma_idx_in_tile != 0) {
                     CoreLocalMem<uint16_t> gamma_ptr(gamma_l1_write_ptr);
                     gamma_ptr[0] = gamma_ptr[tilized_gamma_idx_in_tile];
                 }
-                cb_gamma.push_back(onetile);
+                dfb_gamma.push_back(onetile);
             }
         }  // inner_idx loop
     }  // outer_idx loop

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/writer_moreh_group_norm_backward_input_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/writer_moreh_group_norm_backward_input_grad.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,7 +26,7 @@ void kernel_main() {
     const auto input_grad_addrg = TensorAccessor(input_grad_args, input_grad_addr);
 
     Noc noc;
-    CircularBuffer cb_input_grad(cb_id_input_grad);
+    DataflowBuffer dfb_input_grad(cb_id_input_grad);
     const auto input_grad_tile_bytes = get_tile_size(cb_id_input_grad);
 
     uint32_t input_grad_tile_idx;
@@ -34,15 +34,15 @@ void kernel_main() {
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; ++inner_idx) {
             // input_grad (N, C, H, W)
             input_grad_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx;
-            cb_input_grad.wait_front(onetile);
+            dfb_input_grad.wait_front(onetile);
             noc.async_write(
-                cb_input_grad,
+                dfb_input_grad,
                 input_grad_addrg,
                 input_grad_tile_bytes,
                 {.offset_bytes = 0},
                 {.page_id = input_grad_tile_idx});
             noc.async_write_barrier();
-            cb_input_grad.pop_front(onetile);
+            dfb_input_grad.pop_front(onetile);
         }  // inner_idx loop
     }  // outer_idx loop
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI bool need_to_do_mask_h(uint32_t w_idx, uint32_t origin_num_h_tiles, uint32_t origin_num_w_tiles) {
     return ((w_idx / origin_num_w_tiles) + 1) % origin_num_h_tiles == 0;
@@ -26,57 +26,57 @@ void kernel_main() {
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     constexpr auto cb_x = tt::CBIndex::c_0;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     constexpr auto cb_scaler = tt::CBIndex::c_1;
-    CircularBuffer cb_scaler_obj(cb_scaler);  // scaler
+    DataflowBuffer dfb_scaler_obj(cb_scaler);  // scaler
     constexpr auto cb_eps = tt::CBIndex::c_2;
-    CircularBuffer cb_eps_obj(cb_eps);  // epsilon
+    DataflowBuffer dfb_eps_obj(cb_eps);  // epsilon
     constexpr auto cb_gamma = tt::CBIndex::c_3;
-    CircularBuffer cb_gamma_obj(cb_gamma);  // gamma
+    DataflowBuffer dfb_gamma_obj(cb_gamma);  // gamma
     constexpr auto cb_beta = tt::CBIndex::c_4;
-    CircularBuffer cb_beta_obj(cb_beta);  // beta
+    DataflowBuffer dfb_beta_obj(cb_beta);  // beta
     constexpr auto cb_mask_h = tt::CBIndex::c_5;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);  // mask_h
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);  // mask_h
     constexpr auto cb_mask_w = tt::CBIndex::c_6;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);  // mask_w
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);  // mask_w
 
     constexpr auto cb_out = tt::CBIndex::c_16;
-    CircularBuffer cb_out_obj(cb_out);  // output
+    DataflowBuffer dfb_out_obj(cb_out);  // output
     constexpr auto cb_mean = tt::CBIndex::c_17;
-    CircularBuffer cb_mean_obj(cb_mean);  // mean
+    DataflowBuffer dfb_mean_obj(cb_mean);  // mean
     constexpr auto cb_rstd = tt::CBIndex::c_18;
-    CircularBuffer cb_rstd_obj(cb_rstd);  // rstd
+    DataflowBuffer dfb_rstd_obj(cb_rstd);  // rstd
 
     constexpr auto cb_ex = tt::CBIndex::c_24;
-    CircularBuffer cb_ex_obj(cb_ex);  // E[x]
+    DataflowBuffer dfb_ex_obj(cb_ex);  // E[x]
     constexpr auto cb_xmm = tt::CBIndex::c_25;
-    CircularBuffer cb_xmm_obj(cb_xmm);  // x - E[x]
+    DataflowBuffer dfb_xmm_obj(cb_xmm);  // x - E[x]
     constexpr auto cb_xmm2 = tt::CBIndex::c_26;
-    CircularBuffer cb_xmm2_obj(cb_xmm2);  // (x - E[x])^2
+    DataflowBuffer dfb_xmm2_obj(cb_xmm2);  // (x - E[x])^2
     constexpr auto cb_xmm2sum = tt::CBIndex::c_27;
-    CircularBuffer cb_xmm2sum_obj(cb_xmm2sum);  // Sum[(x - E[x])^2]
+    DataflowBuffer dfb_xmm2sum_obj(cb_xmm2sum);  // Sum[(x - E[x])^2]
     constexpr auto cb_var = tt::CBIndex::c_28;
-    CircularBuffer cb_var_obj(cb_var);  // E[(x - E[x])^2] = Var[x]
+    DataflowBuffer dfb_var_obj(cb_var);  // E[(x - E[x])^2] = Var[x]
     constexpr auto cb_recip_std = tt::CBIndex::c_29;
-    CircularBuffer cb_recip_std_obj(cb_recip_std);  // 1.0/(sqrt(Var[x] + eps))
+    DataflowBuffer dfb_recip_std_obj(cb_recip_std);  // 1.0/(sqrt(Var[x] + eps))
     constexpr auto cb_gamma_beta = tt::CBIndex::c_30;
-    CircularBuffer cb_gamma_beta_obj(cb_gamma_beta);  // p * gamm + beta
+    DataflowBuffer dfb_gamma_beta_obj(cb_gamma_beta);  // p * gamm + beta
     constexpr auto cb_xsum = tt::CBIndex::c_31;
-    CircularBuffer cb_xsum_obj(cb_xsum);  // Sum[x]
+    DataflowBuffer dfb_xsum_obj(cb_xsum);  // Sum[x]
 
     constexpr uint32_t onetile = 1;
 
-    cb_scaler_obj.wait_front(onetile);  // comes from the reader
-    cb_eps_obj.wait_front(onetile);     // comes from the reader
+    dfb_scaler_obj.wait_front(onetile);  // comes from the reader
+    dfb_eps_obj.wait_front(onetile);     // comes from the reader
 
     constexpr bool do_mask_h = (origin_H % TILE_HEIGHT) != 0 && !is_lastdim_layernorm;
     constexpr bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
 
     if (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);
+        dfb_mask_h_obj.wait_front(onetile);
     }
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);
+        dfb_mask_w_obj.wait_front(onetile);
     }
 
     constexpr uint32_t dst0 = 0;
@@ -92,25 +92,25 @@ void kernel_main() {
          * cb_xsum
          */
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
-            cb_x_obj.wait_front(block_size);
+            dfb_x_obj.wait_front(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 const uint32_t w_idx = inner_idx + j;
                 if (w_idx == 0) {
                     tile_regs_acquire();
-                    cb_xsum_obj.reserve_back(onetile);
+                    dfb_xsum_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x_obj);
+                    copy_tile_init_with_dt(dfb_x_obj);
                     copy_tile(cb_x, first_tile, dst0);  // input
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h_obj);
+                        copy_tile_init_with_dt(dfb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, dst1);  // mask_h
                         mask_tile_init();
                         mask_tile(dst0, dst1);
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w_obj);
+                        copy_tile_init_with_dt(dfb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, dst1);  // mask_w
                         mask_tile_init();
                         mask_tile(dst0, dst1);
@@ -118,30 +118,30 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum_obj);
-                    cb_xsum_obj.push_back(onetile);
+                    pack_tile_with_dt(dst0, dfb_xsum_obj);
+                    dfb_xsum_obj.push_back(onetile);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
                     // I use cb_ex temporarily.
                     constexpr auto cb_tmp = cb_ex;
-                    CircularBuffer cb_tmp_obj(cb_tmp);
-                    cb_tmp_obj.reserve_back(onetile);
+                    DataflowBuffer dfb_tmp_obj(cb_tmp);
+                    dfb_tmp_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x_obj);
+                    copy_tile_init_with_dt(dfb_x_obj);
                     copy_tile(cb_x, j, j);  // input
 
                     const uint32_t mask_dst = j < 15 ? j + 1 : 0;
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h_obj);
+                        copy_tile_init_with_dt(dfb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
                         mask_tile_init();
                         mask_tile(j, mask_dst);
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w_obj);
+                        copy_tile_init_with_dt(dfb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
                         mask_tile_init();
                         mask_tile(j, mask_dst);
@@ -149,29 +149,29 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_tmp_obj);
-                    cb_tmp_obj.push_back(onetile);
+                    pack_tile_with_dt(j, dfb_tmp_obj);
+                    dfb_tmp_obj.push_back(onetile);
                     tile_regs_release();
 
                     tile_regs_acquire();
-                    cb_tmp_obj.wait_front(onetile);
-                    cb_xsum_obj.wait_front(onetile);
-                    cb_xsum_obj.reserve_back(onetile);
+                    dfb_tmp_obj.wait_front(onetile);
+                    dfb_xsum_obj.wait_front(onetile);
+                    dfb_xsum_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_xsum_obj, cb_tmp_obj);
+                    add_tiles_init_with_dt(dfb_xsum_obj, dfb_tmp_obj);
                     add_tiles(cb_xsum, cb_tmp, first_tile, first_tile, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum_obj);
+                    pack_tile_with_dt(dst0, dfb_xsum_obj);
 
-                    cb_tmp_obj.pop_front(onetile);
-                    cb_xsum_obj.pop_front(onetile);
-                    cb_xsum_obj.push_back(onetile);
+                    dfb_tmp_obj.pop_front(onetile);
+                    dfb_xsum_obj.pop_front(onetile);
+                    dfb_xsum_obj.push_back(onetile);
                     tile_regs_release();
                 }
             }  // block_size loop
-            cb_x_obj.pop_front(block_size);
+            dfb_x_obj.pop_front(block_size);
         }  // num_inner loop
 
         /*
@@ -181,20 +181,20 @@ void kernel_main() {
         compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xsum, cb_scaler, cb_ex>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
-        cb_ex_obj.wait_front(onetile);
+        dfb_ex_obj.wait_front(onetile);
         if (mean_has_value) {
             // Write on cb_mean.
             tile_regs_acquire();
-            cb_mean_obj.reserve_back(onetile);
+            dfb_mean_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_ex_obj, is_lastdim_layernorm);
+            copy_tile_init_with_dt(dfb_ex_obj, is_lastdim_layernorm);
             copy_tile(cb_ex, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_mean_obj);
+            pack_tile_with_dt(dst0, dfb_mean_obj);
 
-            cb_mean_obj.push_back(onetile);
+            dfb_mean_obj.push_back(onetile);
             tile_regs_release();
         }
         // We don't pop cb_ex here.
@@ -204,50 +204,50 @@ void kernel_main() {
          * xmm
          */
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
-            cb_x_obj.wait_front(block_size);
-            cb_xmm_obj.reserve_back(block_size);
+            dfb_x_obj.wait_front(block_size);
+            dfb_xmm_obj.reserve_back(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_ex_obj);
+                    sub_bcast_cols_init_short_with_dt(dfb_x_obj, dfb_ex_obj);
                     sub_tiles_bcast_cols(cb_x, cb_ex, j, first_tile, j);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_ex_obj);
+                    sub_tiles_bcast_scalar_init_short_with_dt(dfb_x_obj, dfb_ex_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_ex, j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_xmm_obj);
+                pack_tile_with_dt(j, dfb_xmm_obj);
                 tile_regs_release();
             }  // block_size loop
-            cb_x_obj.pop_front(block_size);
-            cb_xmm_obj.push_back(block_size);
+            dfb_x_obj.pop_front(block_size);
+            dfb_xmm_obj.push_back(block_size);
 
             /*
              * mask xmm
              */
             if (do_mask_h || do_mask_w) {
-                cb_xmm_obj.wait_front(block_size);
-                cb_xmm_obj.reserve_back(block_size);
+                dfb_xmm_obj.wait_front(block_size);
+                dfb_xmm_obj.reserve_back(block_size);
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
 
-                    copy_tile_init_with_dt(cb_xmm_obj);
+                    copy_tile_init_with_dt(dfb_xmm_obj);
                     copy_tile(cb_xmm, j, j);  // xmm
 
                     const uint32_t mask_dst = j < 15 ? j + 1 : 0;
                     const uint32_t w_idx = inner_idx + j;
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h_obj);
+                        copy_tile_init_with_dt(dfb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
                         mask_tile_init();
                         mask_tile(j, mask_dst);
                     }
 
                     if (do_mask_w && (w_idx + 1) % origin_Wt == 0) {
-                        copy_tile_init_with_dt(cb_mask_w_obj);
+                        copy_tile_init_with_dt(dfb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
                         mask_tile_init();
                         mask_tile(j, mask_dst);
@@ -256,70 +256,70 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_xmm_obj);
+                    pack_tile_with_dt(j, dfb_xmm_obj);
                     tile_regs_release();
                 }  // block_size loop
-                cb_xmm_obj.pop_front(block_size);
-                cb_xmm_obj.push_back(block_size);
+                dfb_xmm_obj.pop_front(block_size);
+                dfb_xmm_obj.push_back(block_size);
             }
 
             /*
              * (x - E[x])^2
              * cb_xmm2
              */
-            cb_xmm_obj.wait_front(block_size);
-            cb_xmm2_obj.reserve_back(block_size);
+            dfb_xmm_obj.wait_front(block_size);
+            dfb_xmm2_obj.reserve_back(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
-                mul_tiles_init_with_dt(cb_xmm_obj, cb_xmm_obj);
+                mul_tiles_init_with_dt(dfb_xmm_obj, dfb_xmm_obj);
                 mul_tiles(cb_xmm, cb_xmm, j, j, j);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_xmm2_obj);
+                pack_tile_with_dt(j, dfb_xmm2_obj);
 
                 tile_regs_release();
             }  // block_size loop
-            cb_xmm_obj.pop_front(block_size);
-            cb_xmm2_obj.push_back(block_size);
+            dfb_xmm_obj.pop_front(block_size);
+            dfb_xmm2_obj.push_back(block_size);
 
             /*
              * Sum[(x-E[x])^2]
              * cb_xmm2sum
              */
-            cb_xmm2_obj.wait_front(block_size);
+            dfb_xmm2_obj.wait_front(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 if (inner_idx == 0 && j == 0) {
                     tile_regs_acquire();
-                    cb_xmm2sum_obj.reserve_back(onetile);
+                    dfb_xmm2sum_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_xmm2_obj);
+                    copy_tile_init_with_dt(dfb_xmm2_obj);
                     copy_tile(cb_xmm2, first_tile, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xmm2sum_obj);
+                    pack_tile_with_dt(dst0, dfb_xmm2sum_obj);
 
-                    cb_xmm2sum_obj.push_back(onetile);
+                    dfb_xmm2sum_obj.push_back(onetile);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
-                    cb_xmm2sum_obj.wait_front(onetile);
-                    cb_xmm2sum_obj.reserve_back(onetile);
+                    dfb_xmm2sum_obj.wait_front(onetile);
+                    dfb_xmm2sum_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_xmm2sum_obj, cb_xmm2_obj);
+                    add_tiles_init_with_dt(dfb_xmm2sum_obj, dfb_xmm2_obj);
                     add_tiles(cb_xmm2sum, cb_xmm2, first_tile, j, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xmm2sum_obj);
+                    pack_tile_with_dt(dst0, dfb_xmm2sum_obj);
 
-                    cb_xmm2sum_obj.pop_front(onetile);
-                    cb_xmm2sum_obj.push_back(onetile);
+                    dfb_xmm2sum_obj.pop_front(onetile);
+                    dfb_xmm2sum_obj.push_back(onetile);
                     tile_regs_release();
                 }
             }  // block_size loop
-            cb_xmm2_obj.pop_front(block_size);
+            dfb_xmm2_obj.pop_front(block_size);
         }  // num_inner loop
         // Do not pop cb_ex here, we need it later.
 
@@ -335,10 +335,10 @@ void kernel_main() {
          * cb_recip_std
          */
         tile_regs_acquire();
-        cb_var_obj.wait_front(onetile);
-        cb_recip_std_obj.reserve_back(onetile);
+        dfb_var_obj.wait_front(onetile);
+        dfb_recip_std_obj.reserve_back(onetile);
 
-        add_tiles_init_with_dt(cb_var_obj, cb_eps_obj);
+        add_tiles_init_with_dt(dfb_var_obj, dfb_eps_obj);
         add_tiles(cb_var, cb_eps, first_tile, first_tile, dst0);
 
         rsqrt_tile_init();
@@ -346,26 +346,26 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_std_obj);
+        pack_tile_with_dt(dst0, dfb_recip_std_obj);
 
-        cb_var_obj.pop_front(onetile);
-        cb_recip_std_obj.push_back(onetile);
+        dfb_var_obj.pop_front(onetile);
+        dfb_recip_std_obj.push_back(onetile);
         tile_regs_release();
 
-        cb_recip_std_obj.wait_front(onetile);
+        dfb_recip_std_obj.wait_front(onetile);
         if (rstd_has_value) {
             // Write on cb_rstd.
             tile_regs_acquire();
-            cb_rstd_obj.reserve_back(onetile);
+            dfb_rstd_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_recip_std_obj, is_lastdim_layernorm);
+            copy_tile_init_with_dt(dfb_recip_std_obj, is_lastdim_layernorm);
             copy_tile(cb_recip_std, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_rstd_obj);
+            pack_tile_with_dt(dst0, dfb_rstd_obj);
 
-            cb_rstd_obj.push_back(onetile);
+            dfb_rstd_obj.push_back(onetile);
             tile_regs_release();
         }
 
@@ -375,130 +375,130 @@ void kernel_main() {
          * cb_out
          */
         constexpr auto cb_reuse = cb_xmm;
-        CircularBuffer cb_reuse_obj(cb_reuse);
+        DataflowBuffer dfb_reuse_obj(cb_reuse);
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
             /*
              * x - E[x]
              * cb_reuse(==cb_xmm)
              */
-            cb_x_obj.wait_front(block_size);
-            cb_reuse_obj.reserve_back(block_size);
+            dfb_x_obj.wait_front(block_size);
+            dfb_reuse_obj.reserve_back(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_ex_obj);
+                    sub_bcast_cols_init_short_with_dt(dfb_x_obj, dfb_ex_obj);
                     sub_tiles_bcast_cols(cb_x, cb_ex, j, first_tile, j);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_ex_obj);
+                    sub_tiles_bcast_scalar_init_short_with_dt(dfb_x_obj, dfb_ex_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_ex, j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_reuse_obj);
+                pack_tile_with_dt(j, dfb_reuse_obj);
                 tile_regs_release();
             }  // block_size loop
-            cb_x_obj.pop_front(block_size);
-            cb_reuse_obj.push_back(block_size);
+            dfb_x_obj.pop_front(block_size);
+            dfb_reuse_obj.push_back(block_size);
 
             /*
              * (x - E[x]) * 1.0/sqrt(Var[x] + eps)
              * cb_gamma_beta_or_out
              */
             constexpr auto cb_gamma_beta_or_out = (gamma_has_value || beta_has_value) ? cb_gamma_beta : cb_out;
-            CircularBuffer cb_gamma_beta_or_out_obj(cb_gamma_beta_or_out);
-            cb_reuse_obj.wait_front(block_size);
-            cb_gamma_beta_or_out_obj.reserve_back(block_size);
+            DataflowBuffer dfb_gamma_beta_or_out_obj(cb_gamma_beta_or_out);
+            dfb_reuse_obj.wait_front(block_size);
+            dfb_gamma_beta_or_out_obj.reserve_back(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    mul_bcast_cols_init_short_with_dt(cb_reuse_obj, cb_recip_std_obj);
+                    mul_bcast_cols_init_short_with_dt(dfb_reuse_obj, dfb_recip_std_obj);
                     mul_tiles_bcast_cols(cb_reuse, cb_recip_std, j, first_tile, j);
                 } else {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_reuse_obj, cb_recip_std_obj);
+                    mul_tiles_bcast_scalar_init_short_with_dt(dfb_reuse_obj, dfb_recip_std_obj);
                     mul_tiles_bcast_scalar(cb_reuse, cb_recip_std, j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_gamma_beta_or_out_obj);
+                pack_tile_with_dt(j, dfb_gamma_beta_or_out_obj);
                 tile_regs_release();
             }  // block_size loop
-            cb_reuse_obj.pop_front(block_size);
-            cb_gamma_beta_or_out_obj.push_back(block_size);
+            dfb_reuse_obj.pop_front(block_size);
+            dfb_gamma_beta_or_out_obj.push_back(block_size);
 
             // * gamma
             if (gamma_has_value) {
                 constexpr auto cb_outg = beta_has_value ? cb_gamma_beta : cb_out;
-                CircularBuffer cb_outg_obj(cb_outg);
-                cb_gamma_beta_or_out_obj.wait_front(block_size);
-                cb_gamma_obj.wait_front(block_size);
-                cb_outg_obj.reserve_back(block_size);
+                DataflowBuffer dfb_outg_obj(cb_outg);
+                dfb_gamma_beta_or_out_obj.wait_front(block_size);
+                dfb_gamma_obj.wait_front(block_size);
+                dfb_outg_obj.reserve_back(block_size);
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
+                        mul_tiles_bcast_scalar_init_short_with_dt(dfb_gamma_beta_or_out_obj, dfb_gamma_obj);
                         mul_tiles_bcast_scalar(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            mul_bcast_rows_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
+                            mul_bcast_rows_init_short_with_dt(dfb_gamma_beta_or_out_obj, dfb_gamma_obj);
                             mul_tiles_bcast_rows(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         } else {
-                            mul_tiles_init_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
+                            mul_tiles_init_with_dt(dfb_gamma_beta_or_out_obj, dfb_gamma_obj);
                             mul_tiles(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_outg_obj);
+                    pack_tile_with_dt(j, dfb_outg_obj);
                     tile_regs_release();
                 }  // block_size loop
-                cb_gamma_beta_or_out_obj.pop_front(block_size);
-                cb_gamma_obj.pop_front(block_size);
-                cb_outg_obj.push_back(block_size);
+                dfb_gamma_beta_or_out_obj.pop_front(block_size);
+                dfb_gamma_obj.pop_front(block_size);
+                dfb_outg_obj.push_back(block_size);
             }
 
             // + beta
             if (beta_has_value) {
-                cb_gamma_beta_obj.wait_front(block_size);
-                cb_beta_obj.wait_front(block_size);
-                cb_out_obj.reserve_back(block_size);
+                dfb_gamma_beta_obj.wait_front(block_size);
+                dfb_beta_obj.wait_front(block_size);
+                dfb_out_obj.reserve_back(block_size);
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        add_bcast_scalar_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
+                        add_bcast_scalar_init_short_with_dt(dfb_gamma_beta_obj, dfb_beta_obj);
                         add_tiles_bcast_scalar(cb_gamma_beta, cb_beta, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            add_bcast_rows_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
+                            add_bcast_rows_init_short_with_dt(dfb_gamma_beta_obj, dfb_beta_obj);
                             add_tiles_bcast_rows(cb_gamma_beta, cb_beta, j, j, j);
                         } else {
-                            add_tiles_init_with_dt(cb_gamma_beta_obj, cb_beta_obj);
+                            add_tiles_init_with_dt(dfb_gamma_beta_obj, dfb_beta_obj);
                             add_tiles(cb_gamma_beta, cb_beta, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_out_obj);
+                    pack_tile_with_dt(j, dfb_out_obj);
                     tile_regs_release();
                 }  // block_size loop
-                cb_gamma_beta_obj.pop_front(block_size);
-                cb_beta_obj.pop_front(block_size);
-                cb_out_obj.push_back(block_size);
+                dfb_gamma_beta_obj.pop_front(block_size);
+                dfb_beta_obj.pop_front(block_size);
+                dfb_out_obj.push_back(block_size);
             }
         }  // num_inner loop
-        cb_recip_std_obj.pop_front(onetile);
-        cb_ex_obj.pop_front(onetile);
+        dfb_recip_std_obj.pop_front(onetile);
+        dfb_ex_obj.pop_front(onetile);
     }  // num_rows_per_core loop
-    cb_scaler_obj.pop_front(onetile);
-    cb_eps_obj.pop_front(onetile);
+    dfb_scaler_obj.pop_front(onetile);
+    dfb_eps_obj.pop_front(onetile);
 
     if (do_mask_h) {
-        cb_mask_h_obj.pop_front(onetile);
+        dfb_mask_h_obj.pop_front(onetile);
     }
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI bool need_to_do_mask_h(uint32_t w_idx, uint32_t origin_num_h_tiles, uint32_t origin_num_w_tiles) {
     return ((w_idx / origin_num_w_tiles) + 1) % origin_num_h_tiles == 0;
@@ -26,48 +26,48 @@ void kernel_main() {
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     constexpr auto cb_x = tt::CBIndex::c_0;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     constexpr auto cb_scaler = tt::CBIndex::c_1;
-    CircularBuffer cb_scaler_obj(cb_scaler);  // scaler
+    DataflowBuffer dfb_scaler_obj(cb_scaler);  // scaler
     constexpr auto cb_eps = tt::CBIndex::c_2;
-    CircularBuffer cb_eps_obj(cb_eps);  // epsilon
+    DataflowBuffer dfb_eps_obj(cb_eps);  // epsilon
     constexpr auto cb_gamma = tt::CBIndex::c_3;
-    CircularBuffer cb_gamma_obj(cb_gamma);  // gamma
+    DataflowBuffer dfb_gamma_obj(cb_gamma);  // gamma
     constexpr auto cb_beta = tt::CBIndex::c_4;
-    CircularBuffer cb_beta_obj(cb_beta);  // beta
+    DataflowBuffer dfb_beta_obj(cb_beta);  // beta
     constexpr auto cb_mask_h = tt::CBIndex::c_5;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);  // mask_h
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);  // mask_h
     constexpr auto cb_mask_w = tt::CBIndex::c_6;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);  // mask_w
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);  // mask_w
 
     constexpr auto cb_out = tt::CBIndex::c_16;
-    CircularBuffer cb_out_obj(cb_out);  // output
+    DataflowBuffer dfb_out_obj(cb_out);  // output
     constexpr auto cb_mean = tt::CBIndex::c_17;
-    CircularBuffer cb_mean_obj(cb_mean);  // mean
+    DataflowBuffer dfb_mean_obj(cb_mean);  // mean
     constexpr auto cb_rstd = tt::CBIndex::c_18;
-    CircularBuffer cb_rstd_obj(cb_rstd);  // rstd
+    DataflowBuffer dfb_rstd_obj(cb_rstd);  // rstd
 
     constexpr auto cb_ex = tt::CBIndex::c_24;
-    CircularBuffer cb_ex_obj(cb_ex);  // E[x]
+    DataflowBuffer dfb_ex_obj(cb_ex);  // E[x]
     constexpr auto cb_xmm = tt::CBIndex::c_25;
-    CircularBuffer cb_xmm_obj(cb_xmm);  // x - E[x]
+    DataflowBuffer dfb_xmm_obj(cb_xmm);  // x - E[x]
     constexpr auto cb_xmm2 = tt::CBIndex::c_26;
-    CircularBuffer cb_xmm2_obj(cb_xmm2);  // (x - E[x])^2
+    DataflowBuffer dfb_xmm2_obj(cb_xmm2);  // (x - E[x])^2
     constexpr auto cb_xmm2sum = tt::CBIndex::c_27;
-    CircularBuffer cb_xmm2sum_obj(cb_xmm2sum);  // Sum[(x - E[x])^2]
+    DataflowBuffer dfb_xmm2sum_obj(cb_xmm2sum);  // Sum[(x - E[x])^2]
     constexpr auto cb_var = tt::CBIndex::c_28;
-    CircularBuffer cb_var_obj(cb_var);  // E[(x - E[x])^2] = Var[x]
+    DataflowBuffer dfb_var_obj(cb_var);  // E[(x - E[x])^2] = Var[x]
     constexpr auto cb_recip_std = tt::CBIndex::c_29;
-    CircularBuffer cb_recip_std_obj(cb_recip_std);  // 1.0/(sqrt(Var[x] + eps))
+    DataflowBuffer dfb_recip_std_obj(cb_recip_std);  // 1.0/(sqrt(Var[x] + eps))
     constexpr auto cb_gamma_beta = tt::CBIndex::c_30;
-    CircularBuffer cb_gamma_beta_obj(cb_gamma_beta);  // p * gamm + beta
+    DataflowBuffer dfb_gamma_beta_obj(cb_gamma_beta);  // p * gamm + beta
     constexpr auto cb_xsum = tt::CBIndex::c_31;
-    CircularBuffer cb_xsum_obj(cb_xsum);  // Sum[x]
+    DataflowBuffer dfb_xsum_obj(cb_xsum);  // Sum[x]
 
     constexpr uint32_t onetile = 1;
 
-    cb_scaler_obj.wait_front(onetile);  // comes from the reader
-    cb_eps_obj.wait_front(onetile);     // comes from the reader
+    dfb_scaler_obj.wait_front(onetile);  // comes from the reader
+    dfb_eps_obj.wait_front(onetile);     // comes from the reader
 
     constexpr uint32_t TILE_H = 32;
     constexpr uint32_t TILE_W = 32;
@@ -76,10 +76,10 @@ void kernel_main() {
     constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
 
     if (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);
+        dfb_mask_h_obj.wait_front(onetile);
     }
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);
+        dfb_mask_w_obj.wait_front(onetile);
     }
 
     constexpr uint32_t dst0 = 0;
@@ -94,19 +94,19 @@ void kernel_main() {
          * Sum[x]
          * cb_xsum
          */
-        cb_x_obj.wait_front(num_inner);
+        dfb_x_obj.wait_front(num_inner);
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
             for (uint32_t j = 0; j < block_size; j++) {
                 const uint32_t w_idx = inner_idx + j;
                 if (w_idx == 0) {
                     tile_regs_acquire();
-                    cb_xsum_obj.reserve_back(onetile);
+                    dfb_xsum_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x_obj);
+                    copy_tile_init_with_dt(dfb_x_obj);
                     copy_tile(cb_x, first_tile, dst0);  // input
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h_obj);
+                        copy_tile_init_with_dt(dfb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, dst1);  // mask_h
 
                         mask_tile_init();
@@ -114,7 +114,7 @@ void kernel_main() {
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w_obj);
+                        copy_tile_init_with_dt(dfb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, dst1);  // mask_w
 
                         mask_tile_init();
@@ -123,23 +123,23 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum_obj);
-                    cb_xsum_obj.push_back(onetile);
+                    pack_tile_with_dt(dst0, dfb_xsum_obj);
+                    dfb_xsum_obj.push_back(onetile);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
                     // I use cb_ex temporarily.
                     constexpr auto cb_tmp = cb_ex;
-                    CircularBuffer cb_tmp_obj(cb_tmp);
-                    cb_tmp_obj.reserve_back(onetile);
+                    DataflowBuffer dfb_tmp_obj(cb_tmp);
+                    dfb_tmp_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_x_obj);
+                    copy_tile_init_with_dt(dfb_x_obj);
                     copy_tile(cb_x, inner_idx + j, dst0);  // input
 
                     const uint32_t mask_dst = dst0 < 15 ? dst0 + 1 : 0;
 
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h_obj);
+                        copy_tile_init_with_dt(dfb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
 
                         mask_tile_init();
@@ -147,7 +147,7 @@ void kernel_main() {
                     }
 
                     if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                        copy_tile_init_with_dt(cb_mask_w_obj);
+                        copy_tile_init_with_dt(dfb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
 
                         mask_tile_init();
@@ -156,25 +156,25 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_tmp_obj);
-                    cb_tmp_obj.push_back(onetile);
+                    pack_tile_with_dt(dst0, dfb_tmp_obj);
+                    dfb_tmp_obj.push_back(onetile);
                     tile_regs_release();
 
                     tile_regs_acquire();
-                    cb_tmp_obj.wait_front(onetile);
-                    cb_xsum_obj.wait_front(onetile);
-                    cb_xsum_obj.reserve_back(onetile);
+                    dfb_tmp_obj.wait_front(onetile);
+                    dfb_xsum_obj.wait_front(onetile);
+                    dfb_xsum_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_xsum_obj, cb_tmp_obj);
+                    add_tiles_init_with_dt(dfb_xsum_obj, dfb_tmp_obj);
                     add_tiles(cb_xsum, cb_tmp, first_tile, first_tile, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_xsum_obj);
+                    pack_tile_with_dt(dst0, dfb_xsum_obj);
 
-                    cb_tmp_obj.pop_front(onetile);
-                    cb_xsum_obj.pop_front(onetile);
-                    cb_xsum_obj.push_back(onetile);
+                    dfb_tmp_obj.pop_front(onetile);
+                    dfb_xsum_obj.pop_front(onetile);
+                    dfb_xsum_obj.push_back(onetile);
                     tile_regs_release();
                 }
             }  // block_size loop
@@ -188,20 +188,20 @@ void kernel_main() {
         compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xsum, cb_scaler, cb_ex>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
-        cb_ex_obj.wait_front(onetile);
+        dfb_ex_obj.wait_front(onetile);
         if (mean_has_value) {
             // Write on cb_mean.
             tile_regs_acquire();
-            cb_mean_obj.reserve_back(onetile);
+            dfb_mean_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_ex_obj, is_lastdim_layernorm);
+            copy_tile_init_with_dt(dfb_ex_obj, is_lastdim_layernorm);
             copy_tile(cb_ex, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_mean_obj);
+            pack_tile_with_dt(dst0, dfb_mean_obj);
 
-            cb_mean_obj.push_back(onetile);
+            dfb_mean_obj.push_back(onetile);
             tile_regs_release();
         }
         // We don't pop cb_ex here.
@@ -210,30 +210,30 @@ void kernel_main() {
          * x - E[x]
          * xmm
          */
-        cb_xmm_obj.reserve_back(num_inner);
+        dfb_xmm_obj.reserve_back(num_inner);
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
             for (uint32_t j = 0; j < block_size; j++) {
                 const uint32_t w_idx = inner_idx + j;
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_ex_obj);
+                    sub_bcast_cols_init_short_with_dt(dfb_x_obj, dfb_ex_obj);
                     sub_tiles_bcast_cols(cb_x, cb_ex, w_idx, first_tile, j);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_ex_obj);
+                    sub_tiles_bcast_scalar_init_short_with_dt(dfb_x_obj, dfb_ex_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_ex, w_idx, first_tile, j);
                 }
                 // mask xmm
                 if (do_mask_h || do_mask_w) {
                     const uint32_t mask_dst = j < 15 ? j + 1 : 0;
                     if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
-                        copy_tile_init_with_dt(cb_mask_h_obj);
+                        copy_tile_init_with_dt(dfb_mask_h_obj);
                         copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
 
                         mask_tile_init();
                         mask_tile(j, mask_dst);
                     }
                     if (do_mask_w && (w_idx + 1) % origin_Wt == 0) {
-                        copy_tile_init_with_dt(cb_mask_w_obj);
+                        copy_tile_init_with_dt(dfb_mask_w_obj);
                         copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
 
                         mask_tile_init();
@@ -243,63 +243,63 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_xmm_obj);
+                pack_tile_with_dt(j, dfb_xmm_obj);
                 tile_regs_release();
             }  // block_size loop
-            cb_xmm_obj.push_back(block_size);
+            dfb_xmm_obj.push_back(block_size);
         }  // num_inner loop
-        cb_ex_obj.pop_front(onetile);
-        cb_x_obj.pop_front(num_inner);
+        dfb_ex_obj.pop_front(onetile);
+        dfb_x_obj.pop_front(num_inner);
 
         /*
          * Sum[(x - E[x])^2]
          * cb_xmm2sum
          */
-        cb_xmm_obj.wait_front(num_inner);
+        dfb_xmm_obj.wait_front(num_inner);
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx++) {
             tile_regs_acquire();
-            cb_xmm2_obj.reserve_back(onetile);
+            dfb_xmm2_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_xmm_obj, cb_xmm_obj);
+            mul_tiles_init_with_dt(dfb_xmm_obj, dfb_xmm_obj);
             mul_tiles(cb_xmm, cb_xmm, inner_idx, inner_idx, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm2_obj);
+            pack_tile_with_dt(dst0, dfb_xmm2_obj);
 
-            cb_xmm2_obj.push_back(onetile);
+            dfb_xmm2_obj.push_back(onetile);
             tile_regs_release();
             if (inner_idx == 0) {
                 tile_regs_acquire();
-                cb_xmm2_obj.wait_front(onetile);
-                cb_xmm2sum_obj.reserve_back(onetile);
+                dfb_xmm2_obj.wait_front(onetile);
+                dfb_xmm2sum_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_xmm2_obj);
+                copy_tile_init_with_dt(dfb_xmm2_obj);
                 copy_tile(cb_xmm2, first_tile, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xmm2sum_obj);
+                pack_tile_with_dt(dst0, dfb_xmm2sum_obj);
 
-                cb_xmm2_obj.pop_front(onetile);
-                cb_xmm2sum_obj.push_back(onetile);
+                dfb_xmm2_obj.pop_front(onetile);
+                dfb_xmm2sum_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 tile_regs_acquire();
-                cb_xmm2sum_obj.wait_front(onetile);
-                cb_xmm2_obj.wait_front(onetile);
-                cb_xmm2sum_obj.reserve_back(onetile);
+                dfb_xmm2sum_obj.wait_front(onetile);
+                dfb_xmm2_obj.wait_front(onetile);
+                dfb_xmm2sum_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_xmm2sum_obj, cb_xmm2_obj);
+                add_tiles_init_with_dt(dfb_xmm2sum_obj, dfb_xmm2_obj);
                 add_tiles(cb_xmm2sum, cb_xmm2, first_tile, first_tile, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xmm2sum_obj);
+                pack_tile_with_dt(dst0, dfb_xmm2sum_obj);
 
-                cb_xmm2sum_obj.pop_front(onetile);
-                cb_xmm2_obj.pop_front(onetile);
-                cb_xmm2sum_obj.push_back(onetile);
+                dfb_xmm2sum_obj.pop_front(onetile);
+                dfb_xmm2_obj.pop_front(onetile);
+                dfb_xmm2sum_obj.push_back(onetile);
                 tile_regs_release();
             }
         }  // num_inner loop
@@ -316,11 +316,11 @@ void kernel_main() {
          * 1.0/(sqrt(E[(x-E[x])^2] + eps))
          * cb_recip_std
          */
-        cb_var_obj.wait_front(onetile);
-        cb_recip_std_obj.reserve_back(onetile);
+        dfb_var_obj.wait_front(onetile);
+        dfb_recip_std_obj.reserve_back(onetile);
 
         tile_regs_acquire();
-        add_tiles_init_with_dt(cb_var_obj, cb_eps_obj);
+        add_tiles_init_with_dt(dfb_var_obj, dfb_eps_obj);
         add_tiles(cb_var, cb_eps, first_tile, first_tile, dst0);
 
         rsqrt_tile_init();
@@ -328,26 +328,26 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_std_obj);
+        pack_tile_with_dt(dst0, dfb_recip_std_obj);
 
-        cb_var_obj.pop_front(onetile);
-        cb_recip_std_obj.push_back(onetile);
+        dfb_var_obj.pop_front(onetile);
+        dfb_recip_std_obj.push_back(onetile);
         tile_regs_release();
 
-        cb_recip_std_obj.wait_front(onetile);
+        dfb_recip_std_obj.wait_front(onetile);
         if (rstd_has_value) {
             // Write on cb_rstd.
             tile_regs_acquire();
-            cb_rstd_obj.reserve_back(onetile);
+            dfb_rstd_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_recip_std_obj, is_lastdim_layernorm);
+            copy_tile_init_with_dt(dfb_recip_std_obj, is_lastdim_layernorm);
             copy_tile(cb_recip_std, first_tile, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_rstd_obj);
+            pack_tile_with_dt(dst0, dfb_rstd_obj);
 
-            cb_rstd_obj.push_back(onetile);
+            dfb_rstd_obj.push_back(onetile);
             tile_regs_release();
         }
 
@@ -357,98 +357,98 @@ void kernel_main() {
          * cb_out
          */
         constexpr auto cb_gamma_beta_or_out = (gamma_has_value || beta_has_value) ? cb_gamma_beta : cb_out;
-        CircularBuffer cb_gamma_beta_or_out_obj(cb_gamma_beta_or_out);
+        DataflowBuffer dfb_gamma_beta_or_out_obj(cb_gamma_beta_or_out);
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
-            cb_gamma_beta_or_out_obj.reserve_back(block_size);
+            dfb_gamma_beta_or_out_obj.reserve_back(block_size);
             for (uint32_t j = 0; j < block_size; j++) {
                 tile_regs_acquire();
                 if (is_lastdim_layernorm) {
-                    mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_recip_std_obj);
+                    mul_bcast_cols_init_short_with_dt(dfb_xmm_obj, dfb_recip_std_obj);
                     mul_tiles_bcast_cols(cb_xmm, cb_recip_std, inner_idx + j, first_tile, j);
                 } else {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_recip_std_obj);
+                    mul_tiles_bcast_scalar_init_short_with_dt(dfb_xmm_obj, dfb_recip_std_obj);
                     mul_tiles_bcast_scalar(cb_xmm, cb_recip_std, inner_idx + j, first_tile, j);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(j, cb_gamma_beta_or_out_obj);
+                pack_tile_with_dt(j, dfb_gamma_beta_or_out_obj);
                 tile_regs_release();
             }  // block_size loop
-            cb_gamma_beta_or_out_obj.push_back(block_size);
+            dfb_gamma_beta_or_out_obj.push_back(block_size);
 
             // * gamma
             if (gamma_has_value) {
                 constexpr auto cb_outg = beta_has_value ? cb_gamma_beta : cb_out;
-                CircularBuffer cb_outg_obj(cb_outg);
-                cb_gamma_beta_or_out_obj.wait_front(block_size);
-                cb_gamma_obj.wait_front(block_size);
-                cb_outg_obj.reserve_back(block_size);
+                DataflowBuffer dfb_outg_obj(cb_outg);
+                dfb_gamma_beta_or_out_obj.wait_front(block_size);
+                dfb_gamma_obj.wait_front(block_size);
+                dfb_outg_obj.reserve_back(block_size);
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
+                        mul_tiles_bcast_scalar_init_short_with_dt(dfb_gamma_beta_or_out_obj, dfb_gamma_obj);
                         mul_tiles_bcast_scalar(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            mul_bcast_rows_init_short_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
+                            mul_bcast_rows_init_short_with_dt(dfb_gamma_beta_or_out_obj, dfb_gamma_obj);
                             mul_tiles_bcast_rows(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         } else {
-                            mul_tiles_init_with_dt(cb_gamma_beta_or_out_obj, cb_gamma_obj);
+                            mul_tiles_init_with_dt(dfb_gamma_beta_or_out_obj, dfb_gamma_obj);
                             mul_tiles(cb_gamma_beta_or_out, cb_gamma, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_outg_obj);
+                    pack_tile_with_dt(j, dfb_outg_obj);
                     tile_regs_release();
                 }  // block_size loop
-                cb_gamma_beta_or_out_obj.pop_front(block_size);
-                cb_gamma_obj.pop_front(block_size);
-                cb_outg_obj.push_back(block_size);
+                dfb_gamma_beta_or_out_obj.pop_front(block_size);
+                dfb_gamma_obj.pop_front(block_size);
+                dfb_outg_obj.push_back(block_size);
             }  // if (gamma_has_value)
 
             // + beta
             if (beta_has_value) {
-                cb_gamma_beta_obj.wait_front(block_size);
-                cb_beta_obj.wait_front(block_size);
-                cb_out_obj.reserve_back(block_size);
+                dfb_gamma_beta_obj.wait_front(block_size);
+                dfb_beta_obj.wait_front(block_size);
+                dfb_out_obj.reserve_back(block_size);
                 for (uint32_t j = 0; j < block_size; j++) {
                     tile_regs_acquire();
                     if (is_groupnorm) {
-                        add_bcast_scalar_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
+                        add_bcast_scalar_init_short_with_dt(dfb_gamma_beta_obj, dfb_beta_obj);
                         add_tiles_bcast_scalar(cb_gamma_beta, cb_beta, j, j, j);
                     } else {
                         if (is_lastdim_layernorm) {
-                            add_bcast_rows_init_short_with_dt(cb_gamma_beta_obj, cb_beta_obj);
+                            add_bcast_rows_init_short_with_dt(dfb_gamma_beta_obj, dfb_beta_obj);
                             add_tiles_bcast_rows(cb_gamma_beta, cb_beta, j, j, j);
                         } else {
-                            add_tiles_init_with_dt(cb_gamma_beta_obj, cb_beta_obj);
+                            add_tiles_init_with_dt(dfb_gamma_beta_obj, dfb_beta_obj);
                             add_tiles(cb_gamma_beta, cb_beta, j, j, j);
                         }
                     }
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(j, cb_out_obj);
+                    pack_tile_with_dt(j, dfb_out_obj);
                     tile_regs_release();
                 }  // block_size loop
-                cb_gamma_beta_obj.pop_front(block_size);
-                cb_beta_obj.pop_front(block_size);
-                cb_out_obj.push_back(block_size);
+                dfb_gamma_beta_obj.pop_front(block_size);
+                dfb_beta_obj.pop_front(block_size);
+                dfb_out_obj.push_back(block_size);
             }  // if (beta_has_value)
         }  // num_inner loop
-        cb_recip_std_obj.pop_front(onetile);
-        cb_xmm_obj.pop_front(num_inner);
+        dfb_recip_std_obj.pop_front(onetile);
+        dfb_xmm_obj.pop_front(num_inner);
     }  // num_rows_per_core loop
-    cb_scaler_obj.pop_front(onetile);
-    cb_eps_obj.pop_front(onetile);
+    dfb_scaler_obj.pop_front(onetile);
+    dfb_eps_obj.pop_front(onetile);
 
     if (do_mask_h) {
-        cb_mask_h_obj.pop_front(onetile);
+        dfb_mask_h_obj.pop_front(onetile);
     }
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_large.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -48,22 +48,22 @@ void kernel_main() {
     const auto beta_addrg = TensorAccessor(beta_args, beta_addr);
 #endif
 
-    CircularBuffer cb_scaler(cb_id_scaler);
-    CircularBuffer cb_eps(cb_id_eps);
-    fill_cb_with_value(cb_scaler, scaler);
-    fill_cb_with_value(cb_eps, eps);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    DataflowBuffer dfb_eps(cb_id_eps);
+    fill_cb_with_value(dfb_scaler, scaler);
+    fill_cb_with_value(dfb_eps, eps);
 
 #ifdef DO_MASK_H
     {
-        CircularBuffer cb_mask_h(cb_id_mask_h);
-        generate_mask_h(cb_mask_h, mask_h);
+        DataflowBuffer dfb_mask_h(cb_id_mask_h);
+        generate_mask_h(dfb_mask_h, mask_h);
     }
 #endif
 
 #ifdef DO_MASK_W
     {
-        CircularBuffer cb_mask_w(cb_id_mask_w);
-        generate_mask_w(cb_mask_w, mask_w);
+        DataflowBuffer dfb_mask_w(cb_id_mask_w);
+        generate_mask_w(dfb_mask_w, mask_w);
     }
 #endif
 
@@ -71,85 +71,85 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
 #ifdef GAMMA_HAS_VALUE
-    CircularBuffer cb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
 #endif
 #ifdef BETA_HAS_VALUE
-    CircularBuffer cb_beta(cb_id_beta);
+    DataflowBuffer dfb_beta(cb_id_beta);
 #endif
 
     for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; outer_idx++) {
         // For E[x]
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
-            cb_input.reserve_back(block_size);
+            dfb_input.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_read(
                     input_addrg,
-                    cb_input,
+                    dfb_input,
                     input_tile_bytes,
                     {.page_id = offs + inner_idx + r + tile_offset},
                     {.offset_bytes = r * input_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_input.push_back(block_size);
+            dfb_input.push_back(block_size);
         }  // num_inner loop
 
         // For x - E[x]
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
-            cb_input.reserve_back(block_size);
+            dfb_input.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_read(
                     input_addrg,
-                    cb_input,
+                    dfb_input,
                     input_tile_bytes,
                     {.page_id = offs + inner_idx + r + tile_offset},
                     {.offset_bytes = r * input_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_input.push_back(block_size);
+            dfb_input.push_back(block_size);
         }  // num_inner loop
 
         // For (x - E[x]) * (1.0/(sqrt(Var[x] + eps)))
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
-            cb_input.reserve_back(block_size);
+            dfb_input.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_read(
                     input_addrg,
-                    cb_input,
+                    dfb_input,
                     input_tile_bytes,
                     {.page_id = offs + inner_idx + r + tile_offset},
                     {.offset_bytes = r * input_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_input.push_back(block_size);
+            dfb_input.push_back(block_size);
 
 #ifdef GAMMA_HAS_VALUE
-            cb_gamma.reserve_back(block_size);
+            dfb_gamma.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_read(
                     gamm_addrg,
-                    cb_gamma,
+                    dfb_gamma,
                     gamma_tile_bytes,
                     {.page_id = inner_idx + r},
                     {.offset_bytes = r * gamma_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_gamma.push_back(block_size);
+            dfb_gamma.push_back(block_size);
 #endif
 
 #ifdef BETA_HAS_VALUE
-            cb_beta.reserve_back(block_size);
+            dfb_beta.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_read(
                     beta_addrg,
-                    cb_beta,
+                    dfb_beta,
                     beta_tile_bytes,
                     {.page_id = inner_idx + r},
                     {.offset_bytes = r * beta_tile_bytes});
             }
             noc.async_read_barrier();
-            cb_beta.push_back(block_size);
+            dfb_beta.push_back(block_size);
 #endif
         }  // num_inner loop
         offs += num_inner;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/reader_moreh_layer_norm_small.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -48,22 +48,22 @@ void kernel_main() {
     const auto beta_addrg = TensorAccessor(beta_args, beta_addr);
 #endif
 
-    CircularBuffer cb_scaler(cb_id_scaler);
-    CircularBuffer cb_eps(cb_id_eps);
-    fill_cb_with_value(cb_scaler, scaler);
-    fill_cb_with_value(cb_eps, eps);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    DataflowBuffer dfb_eps(cb_id_eps);
+    fill_cb_with_value(dfb_scaler, scaler);
+    fill_cb_with_value(dfb_eps, eps);
 
 #ifdef DO_MASK_H
     {
-        CircularBuffer cb_mask_h(cb_id_mask_h);
-        generate_mask_h(cb_mask_h, mask_h);
+        DataflowBuffer dfb_mask_h(cb_id_mask_h);
+        generate_mask_h(dfb_mask_h, mask_h);
     }
 #endif
 
 #ifdef DO_MASK_W
     {
-        CircularBuffer cb_mask_w(cb_id_mask_w);
-        generate_mask_w(cb_mask_w, mask_w);
+        DataflowBuffer dfb_mask_w(cb_id_mask_w);
+        generate_mask_w(dfb_mask_w, mask_w);
     }
 #endif
 
@@ -71,56 +71,56 @@ void kernel_main() {
     uint32_t offs = 0;
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
 #ifdef GAMMA_HAS_VALUE
-    CircularBuffer cb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
 #endif
 #ifdef BETA_HAS_VALUE
-    CircularBuffer cb_beta(cb_id_beta);
+    DataflowBuffer dfb_beta(cb_id_beta);
 #endif
 
     uint32_t input_tile_idx;
     for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; outer_idx++) {
-        cb_input.reserve_back(num_inner);
+        dfb_input.reserve_back(num_inner);
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx++) {
             input_tile_idx = tile_offset + outer_idx * num_inner + inner_idx;
             noc.async_read(
                 input_addrg,
-                cb_input,
+                dfb_input,
                 input_tile_bytes,
                 {.page_id = input_tile_idx},
                 {.offset_bytes = inner_idx * input_tile_bytes});
         }  // num_inner loop
         noc.async_read_barrier();
-        cb_input.push_back(num_inner);
+        dfb_input.push_back(num_inner);
 
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
 #ifdef GAMMA_HAS_VALUE
-            cb_gamma.reserve_back(block_size);
+            dfb_gamma.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_read(
                     gamm_addrg,
-                    cb_gamma,
+                    dfb_gamma,
                     gamma_tile_bytes,
                     {.page_id = inner_idx + r},
                     {.offset_bytes = r * gamma_tile_bytes});
             }  // block_size loop
             noc.async_read_barrier();
-            cb_gamma.push_back(block_size);
+            dfb_gamma.push_back(block_size);
 #endif
 
 #ifdef BETA_HAS_VALUE
-            cb_beta.reserve_back(block_size);
+            dfb_beta.reserve_back(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_read(
                     beta_addrg,
-                    cb_beta,
+                    dfb_beta,
                     beta_tile_bytes,
                     {.page_id = inner_idx + r},
                     {.offset_bytes = r * beta_tile_bytes});
             }  // block_size loop
             noc.async_read_barrier();
-            cb_beta.push_back(block_size);
+            dfb_beta.push_back(block_size);
 #endif
         }  // num_inner loop
         offs += num_inner;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/writer_moreh_layer_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/writer_moreh_layer_norm.cpp
@@ -5,7 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -25,13 +25,13 @@ void write_mean_rstd(
     using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb(cb_id);
+    DataflowBuffer dfb(cb_id);
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
     const auto cb_dtype_bytes = cb_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
 
-    cb.wait_front(onetile);
+    dfb.wait_front(onetile);
 
-    uint32_t output_l1_write_addr = cb.get_read_ptr();
+    uint32_t output_l1_write_addr = dfb.get_read_ptr();
     CoreLocalMem<volatile uint16_t> l1_ptr(output_l1_write_addr);
 
     uint32_t output_tile_offset = tile_offset / num_inner;
@@ -55,7 +55,7 @@ void write_mean_rstd(
             auto src_idx = get_tilized_idx(0, src_h * FACE_WIDTH);
 
             noc.async_write(
-                cb,
+                dfb,
                 addrg,
                 cb_dtype_bytes * FACE_HEIGHT,
                 {.offset_bytes = src_idx * cb_dtype_bytes},
@@ -82,7 +82,7 @@ void write_mean_rstd(
         }
 
         noc.async_write(
-            cb,
+            dfb,
             addrg,
             cb_dtype_bytes,
             {.offset_bytes = tilized_idx * cb_dtype_bytes},
@@ -90,7 +90,7 @@ void write_mean_rstd(
         noc.async_write_barrier();
     }
 
-    cb.pop_front(onetile);
+    dfb.pop_front(onetile);
 }
 
 void kernel_main() {
@@ -133,7 +133,7 @@ void kernel_main() {
     uint32_t Ht = (mean_rstd_height + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
 
     for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; outer_idx++) {
         if (mean_has_value) {
@@ -168,17 +168,17 @@ void kernel_main() {
 
         // output
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
-            cb_output.wait_front(block_size);
+            dfb_output.wait_front(block_size);
             for (uint32_t r = 0; r < block_size; r++) {
                 noc.async_write(
-                    cb_output,
+                    dfb_output,
                     output_addrg,
                     output_tile_bytes,
                     {.offset_bytes = r * output_tile_bytes},
                     {.page_id = offs + inner_idx + r + tile_offset});
             }
             noc.async_write_barrier();
-            cb_output.pop_front(block_size);
+            dfb_output.pop_front(block_size);
         }  // num_inner loop
 
         offs += num_inner;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t num_cols_per_core = get_compile_time_arg_val(0);
@@ -18,40 +18,40 @@ void kernel_main() {
     constexpr bool is_groupnorm = get_compile_time_arg_val(8) == 1;
 
     constexpr auto cb_dy = tt::CBIndex::c_0;
-    CircularBuffer cb_dy_obj(cb_dy);  // output_grad(==dy)
+    DataflowBuffer dfb_dy_obj(cb_dy);  // output_grad(==dy)
     constexpr auto cb_x = tt::CBIndex::c_1;
-    CircularBuffer cb_x_obj(cb_x);  // input(==x)
+    DataflowBuffer dfb_x_obj(cb_x);  // input(==x)
     constexpr auto cb_mean = tt::CBIndex::c_2;
-    CircularBuffer cb_mean_obj(cb_mean);  // mean
+    DataflowBuffer dfb_mean_obj(cb_mean);  // mean
     constexpr auto cb_rstd = tt::CBIndex::c_3;
-    CircularBuffer cb_rstd_obj(cb_rstd);  // rstd
+    DataflowBuffer dfb_rstd_obj(cb_rstd);  // rstd
     constexpr auto cb_scaler = tt::CBIndex::c_4;
-    CircularBuffer cb_scaler_obj(cb_scaler);  // scaler
+    DataflowBuffer dfb_scaler_obj(cb_scaler);  // scaler
     constexpr auto cb_mask_h = tt::CBIndex::c_5;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);  // mask_h
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);  // mask_h
     constexpr auto cb_mask_w = tt::CBIndex::c_6;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);  // mask_w
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);  // mask_w
 
     // Sum[y * dy]
     constexpr auto cb_dgamma = tt::CBIndex::c_16;
-    CircularBuffer cb_dgamma_obj(cb_dgamma);  // gamma_grad(==dgamma)
+    DataflowBuffer dfb_dgamma_obj(cb_dgamma);  // gamma_grad(==dgamma)
     // Sum[dy]
     constexpr auto cb_dbeta = tt::CBIndex::c_17;
-    CircularBuffer cb_dbeta_obj(cb_dbeta);  // beta_grad(==dbeta)
+    DataflowBuffer dfb_dbeta_obj(cb_dbeta);  // beta_grad(==dbeta)
 
     // y = (x - mean) * rstd
     constexpr auto cb_y = tt::CBIndex::c_24;
-    CircularBuffer cb_y_obj(cb_y);  // output(==y)
+    DataflowBuffer dfb_y_obj(cb_y);  // output(==y)
     constexpr auto cb_ydy = tt::CBIndex::c_25;
-    CircularBuffer cb_ydy_obj(cb_ydy);  // y * dy
+    DataflowBuffer dfb_ydy_obj(cb_ydy);  // y * dy
     constexpr auto cb_dyadd = tt::CBIndex::c_26;
-    CircularBuffer cb_dyadd_obj(cb_dyadd);  // Add[dy]
+    DataflowBuffer dfb_dyadd_obj(cb_dyadd);  // Add[dy]
     constexpr auto cb_ydyadd = tt::CBIndex::c_27;
-    CircularBuffer cb_ydyadd_obj(cb_ydyadd);  // Add[y * dy]
+    DataflowBuffer dfb_ydyadd_obj(cb_ydyadd);  // Add[y * dy]
     constexpr auto cb_xmm = tt::CBIndex::c_28;
-    CircularBuffer cb_xmm_obj(cb_xmm);  // x - mean
+    DataflowBuffer dfb_xmm_obj(cb_xmm);  // x - mean
     constexpr auto cb_dycopy = tt::CBIndex::c_29;
-    CircularBuffer cb_dycopy_obj(cb_dycopy);  // dycopy
+    DataflowBuffer dfb_dycopy_obj(cb_dycopy);  // dycopy
 
     constexpr uint32_t onetile = 1;
 
@@ -73,13 +73,13 @@ void kernel_main() {
     constexpr auto cb_out_init = gamma_grad_has_value ? cb_dgamma : cb_dbeta;
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, cb_out_init);
 
-    cb_scaler_obj.wait_front(onetile);  // comes from the reader
+    dfb_scaler_obj.wait_front(onetile);  // comes from the reader
 
     if (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);
+        dfb_mask_h_obj.wait_front(onetile);
     }
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);
+        dfb_mask_w_obj.wait_front(onetile);
     }
 
     uint32_t h_idx;
@@ -97,14 +97,14 @@ void kernel_main() {
             // Compute cb_dycopy
             // deepcopy and mask(optional)
             tile_regs_acquire();
-            cb_dy_obj.wait_front(onetile);  // comes from the reader
-            cb_dycopy_obj.reserve_back(onetile);
+            dfb_dy_obj.wait_front(onetile);  // comes from the reader
+            dfb_dycopy_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_dy_obj);
+            copy_tile_init_with_dt(dfb_dy_obj);
             copy_tile(cb_dy, 0, dst0);
 
             if (do_mask_h && ((h_idx + 1) % origin_Ht == 0)) {
-                copy_tile_init_with_dt(cb_mask_h_obj);
+                copy_tile_init_with_dt(dfb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, dst1);
 
                 mask_tile_init();
@@ -112,7 +112,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_w_obj);
+                copy_tile_init_with_dt(dfb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
 
                 mask_tile_init();
@@ -121,42 +121,42 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_dycopy_obj);
+            pack_tile_with_dt(dst0, dfb_dycopy_obj);
 
-            cb_dy_obj.pop_front(onetile);
-            cb_dycopy_obj.push_back(onetile);
+            dfb_dy_obj.pop_front(onetile);
+            dfb_dycopy_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_dyadd
-            cb_dycopy_obj.wait_front(onetile);
+            dfb_dycopy_obj.wait_front(onetile);
             if (beta_grad_has_value) {
                 if (inner_idx == 0) {
                     tile_regs_acquire();
-                    cb_dyadd_obj.reserve_back(onetile);
+                    dfb_dyadd_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_dycopy_obj);
+                    copy_tile_init_with_dt(dfb_dycopy_obj);
                     copy_tile(cb_dycopy, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_dyadd_obj);
+                    pack_tile_with_dt(dst0, dfb_dyadd_obj);
 
-                    cb_dyadd_obj.push_back(onetile);
+                    dfb_dyadd_obj.push_back(onetile);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
-                    cb_dyadd_obj.wait_front(onetile);
-                    cb_dyadd_obj.reserve_back(onetile);
+                    dfb_dyadd_obj.wait_front(onetile);
+                    dfb_dyadd_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_dyadd_obj, cb_dycopy_obj);
+                    add_tiles_init_with_dt(dfb_dyadd_obj, dfb_dycopy_obj);
                     add_tiles(cb_dyadd, cb_dycopy, 0, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_dyadd_obj);
+                    pack_tile_with_dt(dst0, dfb_dyadd_obj);
 
-                    cb_dyadd_obj.pop_front(onetile);
-                    cb_dyadd_obj.push_back(onetile);
+                    dfb_dyadd_obj.pop_front(onetile);
+                    dfb_dyadd_obj.push_back(onetile);
                     tile_regs_release();
                 }
             }  // beta_grad_has_value
@@ -166,20 +166,20 @@ void kernel_main() {
                 // Compute cb_xmm
                 // x - mean and mask(optional)
                 tile_regs_acquire();
-                cb_x_obj.wait_front(onetile);     // comes from the reader
-                cb_mean_obj.wait_front(onetile);  // comes from the reader
-                cb_xmm_obj.reserve_back(onetile);
+                dfb_x_obj.wait_front(onetile);     // comes from the reader
+                dfb_mean_obj.wait_front(onetile);  // comes from the reader
+                dfb_xmm_obj.reserve_back(onetile);
 
                 if (is_lastdim_layernorm) {
-                    sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                    sub_bcast_cols_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                     sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
                 } else {
-                    sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                    sub_tiles_bcast_scalar_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                     sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
                 }
 
                 if (do_mask_h && ((h_idx + 1) % origin_Ht == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_obj);
                     copy_tile(cb_mask_h, 0, dst1);
 
                     mask_tile_init();
@@ -187,7 +187,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_w_obj);
                     copy_tile(cb_mask_w, 0, dst1);
 
                     mask_tile_init();
@@ -196,90 +196,90 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xmm_obj);
+                pack_tile_with_dt(dst0, dfb_xmm_obj);
 
-                cb_x_obj.pop_front(onetile);
-                cb_mean_obj.pop_front(onetile);
-                cb_xmm_obj.push_back(onetile);
+                dfb_x_obj.pop_front(onetile);
+                dfb_mean_obj.pop_front(onetile);
+                dfb_xmm_obj.push_back(onetile);
                 tile_regs_release();
 
                 // Compute cb_y
                 // (x - mean) * rstd
                 tile_regs_acquire();
-                cb_xmm_obj.wait_front(onetile);
-                cb_rstd_obj.wait_front(onetile);  // comes from the reader
-                cb_y_obj.reserve_back(onetile);
+                dfb_xmm_obj.wait_front(onetile);
+                dfb_rstd_obj.wait_front(onetile);  // comes from the reader
+                dfb_y_obj.reserve_back(onetile);
 
                 if (is_lastdim_layernorm) {
-                    mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                    mul_bcast_cols_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                     mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
                 } else {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                    mul_tiles_bcast_scalar_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                     mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_y_obj);
+                pack_tile_with_dt(dst0, dfb_y_obj);
 
-                cb_xmm_obj.pop_front(onetile);
-                cb_rstd_obj.pop_front(onetile);
-                cb_y_obj.push_back(onetile);
+                dfb_xmm_obj.pop_front(onetile);
+                dfb_rstd_obj.pop_front(onetile);
+                dfb_y_obj.push_back(onetile);
                 tile_regs_release();
 
                 // Compute cb_ydy
                 tile_regs_acquire();
-                cb_y_obj.wait_front(onetile);
-                cb_ydy_obj.reserve_back(onetile);
+                dfb_y_obj.wait_front(onetile);
+                dfb_ydy_obj.reserve_back(onetile);
 
-                mul_tiles_init_with_dt(cb_y_obj, cb_dycopy_obj);
+                mul_tiles_init_with_dt(dfb_y_obj, dfb_dycopy_obj);
                 mul_tiles(cb_y, cb_dycopy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydy_obj);
+                pack_tile_with_dt(dst0, dfb_ydy_obj);
 
-                cb_y_obj.pop_front(onetile);
-                cb_ydy_obj.push_back(onetile);
+                dfb_y_obj.pop_front(onetile);
+                dfb_ydy_obj.push_back(onetile);
                 tile_regs_release();
 
                 // Compute cb_ydyadd
                 if (inner_idx == 0) {
                     tile_regs_acquire();
-                    cb_ydy_obj.wait_front(onetile);
-                    cb_ydyadd_obj.reserve_back(onetile);
+                    dfb_ydy_obj.wait_front(onetile);
+                    dfb_ydyadd_obj.reserve_back(onetile);
 
-                    copy_tile_init_with_dt(cb_ydy_obj);
+                    copy_tile_init_with_dt(dfb_ydy_obj);
                     copy_tile(cb_ydy, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_ydyadd_obj);
+                    pack_tile_with_dt(dst0, dfb_ydyadd_obj);
 
-                    cb_ydy_obj.pop_front(onetile);
-                    cb_ydyadd_obj.push_back(onetile);
+                    dfb_ydy_obj.pop_front(onetile);
+                    dfb_ydyadd_obj.push_back(onetile);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
-                    cb_ydy_obj.wait_front(onetile);
-                    cb_ydyadd_obj.wait_front(onetile);
-                    cb_ydyadd_obj.reserve_back(onetile);
+                    dfb_ydy_obj.wait_front(onetile);
+                    dfb_ydyadd_obj.wait_front(onetile);
+                    dfb_ydyadd_obj.reserve_back(onetile);
 
-                    add_tiles_init_with_dt(cb_ydyadd_obj, cb_ydy_obj);
+                    add_tiles_init_with_dt(dfb_ydyadd_obj, dfb_ydy_obj);
                     add_tiles(cb_ydyadd, cb_ydy, 0, 0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_with_dt(dst0, cb_ydyadd_obj);
+                    pack_tile_with_dt(dst0, dfb_ydyadd_obj);
 
-                    cb_ydy_obj.pop_front(onetile);
-                    cb_ydyadd_obj.pop_front(onetile);
-                    cb_ydyadd_obj.push_back(onetile);
+                    dfb_ydy_obj.pop_front(onetile);
+                    dfb_ydyadd_obj.pop_front(onetile);
+                    dfb_ydyadd_obj.push_back(onetile);
                     tile_regs_release();
                 }
             }  // gamma_grad_has_value
 
-            cb_dycopy_obj.pop_front(onetile);
+            dfb_dycopy_obj.pop_front(onetile);
         }  // inner_idx loop
 
         if (gamma_grad_has_value) {
@@ -291,18 +291,18 @@ void kernel_main() {
             } else {
                 // Just copy
                 tile_regs_acquire();
-                cb_ydyadd_obj.wait_front(onetile);
-                cb_dgamma_obj.reserve_back(onetile);
+                dfb_ydyadd_obj.wait_front(onetile);
+                dfb_dgamma_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_ydyadd_obj);
+                copy_tile_init_with_dt(dfb_ydyadd_obj);
                 copy_tile(cb_ydyadd, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dgamma_obj);
+                pack_tile_with_dt(dst0, dfb_dgamma_obj);
 
-                cb_ydyadd_obj.pop_front(onetile);
-                cb_dgamma_obj.push_back(onetile);
+                dfb_ydyadd_obj.pop_front(onetile);
+                dfb_dgamma_obj.push_back(onetile);
                 tile_regs_release();
             }
         }  // gamma_grad_has_value
@@ -316,29 +316,29 @@ void kernel_main() {
             } else {
                 // Just copy
                 tile_regs_acquire();
-                cb_dyadd_obj.wait_front(onetile);
-                cb_dbeta_obj.reserve_back(onetile);
+                dfb_dyadd_obj.wait_front(onetile);
+                dfb_dbeta_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_dyadd_obj);
+                copy_tile_init_with_dt(dfb_dyadd_obj);
                 copy_tile(cb_dyadd, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dbeta_obj);
+                pack_tile_with_dt(dst0, dfb_dbeta_obj);
 
-                cb_dyadd_obj.pop_front(onetile);
-                cb_dbeta_obj.push_back(onetile);
+                dfb_dyadd_obj.pop_front(onetile);
+                dfb_dbeta_obj.push_back(onetile);
                 tile_regs_release();
             }
         }  // beta_grad_has_value
 
     }  // outer_idx loop
-    cb_scaler_obj.pop_front(onetile);
+    dfb_scaler_obj.pop_front(onetile);
 
     if (do_mask_h) {
-        cb_mask_h_obj.pop_front(onetile);
+        dfb_mask_h_obj.pop_front(onetile);
     }
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI bool need_to_do_mask_h(uint32_t w_idx, uint32_t origin_num_h_tiles, uint32_t origin_num_w_tiles) {
     return ((w_idx / origin_num_w_tiles) + 1) % origin_num_h_tiles == 0;
@@ -22,35 +22,35 @@ void kernel_main() {
     binary_op_init_common(tt::CBIndex::c_1, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     constexpr auto cb_dy = tt::CBIndex::c_0;
-    CircularBuffer cb_dy_obj(cb_dy);  // output_grad(==dy)
+    DataflowBuffer dfb_dy_obj(cb_dy);  // output_grad(==dy)
     constexpr auto cb_x = tt::CBIndex::c_1;
-    CircularBuffer cb_x_obj(cb_x);  // input(==x)
+    DataflowBuffer dfb_x_obj(cb_x);  // input(==x)
     constexpr auto cb_mean = tt::CBIndex::c_2;
-    CircularBuffer cb_mean_obj(cb_mean);  // mean
+    DataflowBuffer dfb_mean_obj(cb_mean);  // mean
     constexpr auto cb_rstd = tt::CBIndex::c_3;
-    CircularBuffer cb_rstd_obj(cb_rstd);  // rstd
+    DataflowBuffer dfb_rstd_obj(cb_rstd);  // rstd
     constexpr auto cb_scaler = tt::CBIndex::c_4;
-    CircularBuffer cb_scaler_obj(cb_scaler);  // scaler
+    DataflowBuffer dfb_scaler_obj(cb_scaler);  // scaler
     constexpr auto cb_n_recip_n = tt::CBIndex::c_5;
-    CircularBuffer cb_n_recip_n_obj(cb_n_recip_n);  // n_recip_n
+    DataflowBuffer dfb_n_recip_n_obj(cb_n_recip_n);  // n_recip_n
     constexpr auto cb_gamma = tt::CBIndex::c_6;
-    CircularBuffer cb_gamma_obj(cb_gamma);  // gamma
+    DataflowBuffer dfb_gamma_obj(cb_gamma);  // gamma
     constexpr auto cb_mask_h_w = tt::CBIndex::c_7;
-    CircularBuffer cb_mask_h_w_obj(cb_mask_h_w);  // mask_h_w
+    DataflowBuffer dfb_mask_h_w_obj(cb_mask_h_w);  // mask_h_w
 
     // ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)
     constexpr auto cb_dx = tt::CBIndex::c_16;
-    CircularBuffer cb_dx_obj(cb_dx);  // input_grad(==dx)
+    DataflowBuffer dfb_dx_obj(cb_dx);  // input_grad(==dx)
 
     // y = (x - mean) * rstd
     constexpr auto cb_dycopy = tt::CBIndex::c_24;
-    CircularBuffer cb_dycopy_obj(cb_dycopy);  // copy output_grad(==dycopy)
+    DataflowBuffer dfb_dycopy_obj(cb_dycopy);  // copy output_grad(==dycopy)
     constexpr auto cb_y = tt::CBIndex::c_25;
-    CircularBuffer cb_y_obj(cb_y);  // output(==y)
+    DataflowBuffer dfb_y_obj(cb_y);  // output(==y)
     constexpr auto cb_dysum = tt::CBIndex::c_26;
-    CircularBuffer cb_dysum_obj(cb_dysum);  // Sum[dy]
+    DataflowBuffer dfb_dysum_obj(cb_dysum);  // Sum[dy]
     constexpr auto cb_ydysum = tt::CBIndex::c_27;
-    CircularBuffer cb_ydysum_obj(cb_ydysum);  // Sum[y * dy]
+    DataflowBuffer dfb_ydysum_obj(cb_ydysum);  // Sum[y * dy]
 
     constexpr auto cb_tmp1 = tt::CBIndex::c_28;  // tmp1
     constexpr auto cb_tmp2 = tt::CBIndex::c_29;  // tmp2
@@ -58,8 +58,8 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    cb_scaler_obj.wait_front(onetile);  // comes from the reader
-    cb_n_recip_n_obj.wait_front(2);     // comes from the reader
+    dfb_scaler_obj.wait_front(onetile);  // comes from the reader
+    dfb_n_recip_n_obj.wait_front(2);     // comes from the reader
 
     constexpr uint32_t TILE_H = 32;
     constexpr uint32_t TILE_W = 32;
@@ -71,7 +71,7 @@ void kernel_main() {
     constexpr uint32_t origin_Wt = (origin_W + TILE_W - 1) / TILE_W;
 
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.wait_front(2);  // comes from the reader
+        dfb_mask_h_w_obj.wait_front(2);  // comes from the reader
     }
 
     constexpr uint32_t NCHt = num_rows_per_core;
@@ -79,56 +79,56 @@ void kernel_main() {
     constexpr uint32_t dst1 = 1;
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
-        cb_mean_obj.wait_front(onetile);  // comes from the reader
-        cb_rstd_obj.wait_front(onetile);  // comes from the reader
+        dfb_mean_obj.wait_front(onetile);  // comes from the reader
+        dfb_rstd_obj.wait_front(onetile);  // comes from the reader
 
         // Compute cb_y
         // y = (x - mean) * rstd
         constexpr auto cb_dyadd = cb_tmp1;
-        CircularBuffer cb_dyadd_obj(cb_dyadd);
+        DataflowBuffer dfb_dyadd_obj(cb_dyadd);
         constexpr auto cb_ydyadd = cb_tmp2;
-        CircularBuffer cb_ydyadd_obj(cb_ydyadd);
+        DataflowBuffer dfb_ydyadd_obj(cb_ydyadd);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             // Compute cb_xmm
             // x - mean
             constexpr auto cb_xmm = cb_tmp3;
-            CircularBuffer cb_xmm_obj(cb_xmm);
+            DataflowBuffer dfb_xmm_obj(cb_xmm);
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_xmm_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_xmm_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                sub_bcast_cols_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                 sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                sub_tiles_bcast_scalar_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                 sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm_obj);
+            pack_tile_with_dt(dst0, dfb_xmm_obj);
 
-            cb_x_obj.pop_front(onetile);
-            cb_xmm_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_xmm_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_y
             // (x - mean) * rstd and mask(optional)
             tile_regs_acquire();
-            cb_xmm_obj.wait_front(onetile);
-            cb_y_obj.reserve_back(onetile);
+            dfb_xmm_obj.wait_front(onetile);
+            dfb_y_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                mul_bcast_cols_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                 mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                mul_tiles_bcast_scalar_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                 mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
             }
 
             if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                copy_tile_init_with_dt(cb_mask_h_w_obj);
+                copy_tile_init_with_dt(dfb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 0, dst1);
 
                 mask_tile_init();
@@ -136,7 +136,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_h_w_obj);
+                copy_tile_init_with_dt(dfb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 1, dst1);
 
                 mask_tile_init();
@@ -145,36 +145,36 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_y_obj);
+            pack_tile_with_dt(dst0, dfb_y_obj);
 
-            cb_xmm_obj.pop_front(onetile);
-            cb_y_obj.push_back(onetile);
+            dfb_xmm_obj.pop_front(onetile);
+            dfb_y_obj.push_back(onetile);
             tile_regs_release();
 
             // Copy cb_dy to cb_dycopy
-            cb_dycopy_obj.reserve_back(onetile);
+            dfb_dycopy_obj.reserve_back(onetile);
             if (gamma_has_value) {
                 // Compute cb_dycopy
                 // dycopy = dy * gamma and mask(optional)
                 tile_regs_acquire();
-                cb_dy_obj.wait_front(onetile);     // comes from the reader
-                cb_gamma_obj.wait_front(onetile);  // comes from the reader
+                dfb_dy_obj.wait_front(onetile);     // comes from the reader
+                dfb_gamma_obj.wait_front(onetile);  // comes from the reader
 
                 if (is_groupnorm) {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
+                    mul_tiles_bcast_scalar_init_short_with_dt(dfb_dy_obj, dfb_gamma_obj);
                     mul_tiles_bcast_scalar(cb_dy, cb_gamma, 0, 0, dst0);
                 } else {
                     if (is_lastdim_layernorm) {
-                        mul_bcast_rows_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
+                        mul_bcast_rows_init_short_with_dt(dfb_dy_obj, dfb_gamma_obj);
                         mul_tiles_bcast_rows(cb_dy, cb_gamma, 0, 0, dst0);
                     } else {
-                        mul_tiles_init_with_dt(cb_dy_obj, cb_gamma_obj);
+                        mul_tiles_init_with_dt(dfb_dy_obj, dfb_gamma_obj);
                         mul_tiles(cb_dy, cb_gamma, 0, 0, dst0);
                     }
                 }
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -182,7 +182,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -191,23 +191,23 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy_obj);
+                pack_tile_with_dt(dst0, dfb_dycopy_obj);
 
-                cb_dy_obj.pop_front(onetile);
-                cb_gamma_obj.pop_front(onetile);
-                cb_dycopy_obj.push_back(onetile);
+                dfb_dy_obj.pop_front(onetile);
+                dfb_gamma_obj.pop_front(onetile);
+                dfb_dycopy_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 // Compute cb_dycopy
                 // dycopy = dy and mask(optional)
                 tile_regs_acquire();
-                cb_dy_obj.wait_front(onetile);  // comes from the reader
+                dfb_dy_obj.wait_front(onetile);  // comes from the reader
 
-                copy_tile_init_with_dt(cb_dy_obj);
+                copy_tile_init_with_dt(dfb_dy_obj);
                 copy_tile(cb_dy, 0, dst0);
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -215,7 +215,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -224,98 +224,98 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy_obj);
+                pack_tile_with_dt(dst0, dfb_dycopy_obj);
 
-                cb_dy_obj.pop_front(onetile);
-                cb_dycopy_obj.push_back(onetile);
+                dfb_dy_obj.pop_front(onetile);
+                dfb_dycopy_obj.push_back(onetile);
                 tile_regs_release();
             }
 
             // Compute cb_dyadd
-            cb_dycopy_obj.wait_front(onetile);
+            dfb_dycopy_obj.wait_front(onetile);
             if (wt == 0) {
                 tile_regs_acquire();
-                cb_dyadd_obj.reserve_back(onetile);
+                dfb_dyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_dycopy_obj);
+                copy_tile_init_with_dt(dfb_dycopy_obj);
                 copy_tile(cb_dycopy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd_obj);
+                pack_tile_with_dt(dst0, dfb_dyadd_obj);
 
-                cb_dyadd_obj.push_back(onetile);
+                dfb_dyadd_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 tile_regs_acquire();
-                cb_dyadd_obj.wait_front(onetile);
-                cb_dyadd_obj.reserve_back(onetile);
+                dfb_dyadd_obj.wait_front(onetile);
+                dfb_dyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_dyadd_obj, cb_dycopy_obj);
+                add_tiles_init_with_dt(dfb_dyadd_obj, dfb_dycopy_obj);
                 add_tiles(cb_dyadd, cb_dycopy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd_obj);
+                pack_tile_with_dt(dst0, dfb_dyadd_obj);
 
-                cb_dyadd_obj.pop_front(onetile);
-                cb_dyadd_obj.push_back(onetile);
+                dfb_dyadd_obj.pop_front(onetile);
+                dfb_dyadd_obj.push_back(onetile);
                 tile_regs_release();
             }
             // We don't pop cb_dycopy here.
 
             // Compute cb_ydy and cb_ydyadd
             constexpr auto cb_ydy = cb_tmp3;
-            CircularBuffer cb_ydy_obj(cb_ydy);
+            DataflowBuffer dfb_ydy_obj(cb_ydy);
             // Compute cb_ydy
             tile_regs_acquire();
-            cb_y_obj.wait_front(onetile);
-            cb_ydy_obj.reserve_back(onetile);
+            dfb_y_obj.wait_front(onetile);
+            dfb_ydy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_y_obj, cb_dycopy_obj);
+            mul_tiles_init_with_dt(dfb_y_obj, dfb_dycopy_obj);
             mul_tiles(cb_y, cb_dycopy, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ydy_obj);
+            pack_tile_with_dt(dst0, dfb_ydy_obj);
 
-            cb_y_obj.pop_front(onetile);
-            cb_dycopy_obj.pop_front(onetile);
-            cb_ydy_obj.push_back(onetile);
+            dfb_y_obj.pop_front(onetile);
+            dfb_dycopy_obj.pop_front(onetile);
+            dfb_ydy_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_ydyadd
             if (wt == 0) {
                 tile_regs_acquire();
-                cb_ydy_obj.wait_front(onetile);
-                cb_ydyadd_obj.reserve_back(onetile);
+                dfb_ydy_obj.wait_front(onetile);
+                dfb_ydyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_ydy_obj);
+                copy_tile_init_with_dt(dfb_ydy_obj);
                 copy_tile(cb_ydy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd_obj);
+                pack_tile_with_dt(dst0, dfb_ydyadd_obj);
 
-                cb_ydy_obj.pop_front(onetile);
-                cb_ydyadd_obj.push_back(onetile);
+                dfb_ydy_obj.pop_front(onetile);
+                dfb_ydyadd_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 tile_regs_acquire();
-                cb_ydy_obj.wait_front(onetile);
-                cb_ydyadd_obj.wait_front(onetile);
-                cb_ydyadd_obj.reserve_back(onetile);
+                dfb_ydy_obj.wait_front(onetile);
+                dfb_ydyadd_obj.wait_front(onetile);
+                dfb_ydyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_ydyadd_obj, cb_ydy_obj);
+                add_tiles_init_with_dt(dfb_ydyadd_obj, dfb_ydy_obj);
                 add_tiles(cb_ydyadd, cb_ydy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd_obj);
+                pack_tile_with_dt(dst0, dfb_ydyadd_obj);
 
-                cb_ydy_obj.pop_front(onetile);
-                cb_ydyadd_obj.pop_front(onetile);
-                cb_ydyadd_obj.push_back(onetile);
+                dfb_ydy_obj.pop_front(onetile);
+                dfb_ydyadd_obj.pop_front(onetile);
+                dfb_ydyadd_obj.push_back(onetile);
                 tile_regs_release();
             }
         }  // Wt loop
@@ -333,55 +333,55 @@ void kernel_main() {
         // Compute cb_recip_nrstd
         // rstd / n -> cb_tmp3
         constexpr auto cb_recip_nrstd = cb_tmp3;
-        CircularBuffer cb_recip_nrstd_obj(cb_recip_nrstd);
+        DataflowBuffer dfb_recip_nrstd_obj(cb_recip_nrstd);
         tile_regs_acquire();
-        cb_recip_nrstd_obj.reserve_back(onetile);
+        dfb_recip_nrstd_obj.reserve_back(onetile);
 
         if (is_lastdim_layernorm) {
-            mul_bcast_cols_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
+            mul_bcast_cols_init_short_with_dt(dfb_n_recip_n_obj, dfb_rstd_obj);
             mul_tiles_bcast_cols(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         } else {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
+            mul_tiles_bcast_scalar_init_short_with_dt(dfb_n_recip_n_obj, dfb_rstd_obj);
             mul_tiles_bcast_scalar(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_nrstd_obj);
+        pack_tile_with_dt(dst0, dfb_recip_nrstd_obj);
 
-        cb_recip_nrstd_obj.push_back(onetile);
+        dfb_recip_nrstd_obj.push_back(onetile);
         tile_regs_release();
 
         // Compute cb_dx
         // ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)
-        cb_dysum_obj.wait_front(onetile);
-        cb_ydysum_obj.wait_front(onetile);
-        cb_recip_nrstd_obj.wait_front(onetile);
+        dfb_dysum_obj.wait_front(onetile);
+        dfb_ydysum_obj.wait_front(onetile);
+        dfb_recip_nrstd_obj.wait_front(onetile);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             // Copy cb_dy to cb_dycopy
-            cb_dycopy_obj.reserve_back(onetile);
+            dfb_dycopy_obj.reserve_back(onetile);
             if (gamma_has_value) {
                 // Compute cb_dycopy
                 // dycopy = dy * gamma and mask(optional)
                 tile_regs_acquire();
-                cb_dy_obj.wait_front(onetile);     // comes from the reader
-                cb_gamma_obj.wait_front(onetile);  // comes from the reader
+                dfb_dy_obj.wait_front(onetile);     // comes from the reader
+                dfb_gamma_obj.wait_front(onetile);  // comes from the reader
 
                 if (is_groupnorm) {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
+                    mul_tiles_bcast_scalar_init_short_with_dt(dfb_dy_obj, dfb_gamma_obj);
                     mul_tiles_bcast_scalar(cb_dy, cb_gamma, 0, 0, dst0);
                 } else {
                     if (is_lastdim_layernorm) {
-                        mul_bcast_rows_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
+                        mul_bcast_rows_init_short_with_dt(dfb_dy_obj, dfb_gamma_obj);
                         mul_tiles_bcast_rows(cb_dy, cb_gamma, 0, 0, dst0);
                     } else {
-                        mul_tiles_init_with_dt(cb_dy_obj, cb_gamma_obj);
+                        mul_tiles_init_with_dt(dfb_dy_obj, dfb_gamma_obj);
                         mul_tiles(cb_dy, cb_gamma, 0, 0, dst0);
                     }
                 }
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -389,7 +389,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -398,23 +398,23 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy_obj);
+                pack_tile_with_dt(dst0, dfb_dycopy_obj);
 
-                cb_dy_obj.pop_front(onetile);
-                cb_gamma_obj.pop_front(onetile);
-                cb_dycopy_obj.push_back(onetile);
+                dfb_dy_obj.pop_front(onetile);
+                dfb_gamma_obj.pop_front(onetile);
+                dfb_dycopy_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 // Compute cb_dycopy
                 // dycopy = dy and mask(optional)
                 tile_regs_acquire();
-                cb_dy_obj.wait_front(onetile);  // comes from the reader
+                dfb_dy_obj.wait_front(onetile);  // comes from the reader
 
-                copy_tile_init_with_dt(cb_dy_obj);
+                copy_tile_init_with_dt(dfb_dy_obj);
                 copy_tile(cb_dy, 0, dst0);
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -422,7 +422,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -431,74 +431,74 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy_obj);
+                pack_tile_with_dt(dst0, dfb_dycopy_obj);
 
-                cb_dy_obj.pop_front(onetile);
-                cb_dycopy_obj.push_back(onetile);
+                dfb_dy_obj.pop_front(onetile);
+                dfb_dycopy_obj.push_back(onetile);
                 tile_regs_release();
             }
 
             // Compute cb_ndy
             // n * dy
             constexpr auto cb_ndy = cb_tmp1;
-            CircularBuffer cb_ndy_obj(cb_ndy);
+            DataflowBuffer dfb_ndy_obj(cb_ndy);
             tile_regs_acquire();
-            cb_dycopy_obj.wait_front(onetile);
-            cb_ndy_obj.reserve_back(onetile);
+            dfb_dycopy_obj.wait_front(onetile);
+            dfb_ndy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_n_recip_n_obj, cb_dycopy_obj);
+            mul_tiles_init_with_dt(dfb_n_recip_n_obj, dfb_dycopy_obj);
             mul_tiles(cb_n_recip_n, cb_dycopy, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndy_obj);
+            pack_tile_with_dt(dst0, dfb_ndy_obj);
 
-            cb_dycopy_obj.pop_front(onetile);
-            cb_ndy_obj.push_back(onetile);
+            dfb_dycopy_obj.pop_front(onetile);
+            dfb_ndy_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_ndymdysum
             // n * dy - Sum[dy]
             constexpr auto cb_ndymdysum = cb_tmp2;
-            CircularBuffer cb_ndymdysum_obj(cb_ndymdysum);
+            DataflowBuffer dfb_ndymdysum_obj(cb_ndymdysum);
             tile_regs_acquire();
-            cb_ndy_obj.wait_front(onetile);
-            cb_ndymdysum_obj.reserve_back(onetile);
+            dfb_ndy_obj.wait_front(onetile);
+            dfb_ndymdysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
+                sub_bcast_cols_init_short_with_dt(dfb_ndy_obj, dfb_dysum_obj);
                 sub_tiles_bcast_cols(cb_ndy, cb_dysum, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
+                sub_tiles_bcast_scalar_init_short_with_dt(dfb_ndy_obj, dfb_dysum_obj);
                 sub_tiles_bcast_scalar(cb_ndy, cb_dysum, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndymdysum_obj);
+            pack_tile_with_dt(dst0, dfb_ndymdysum_obj);
 
-            cb_ndy_obj.pop_front(onetile);
-            cb_ndymdysum_obj.push_back(onetile);
+            dfb_ndy_obj.pop_front(onetile);
+            dfb_ndymdysum_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_xmm
             // x - mean and mask(optional)
             constexpr auto cb_xmm = cb_tmp1;
-            CircularBuffer cb_xmm_obj(cb_xmm);
+            DataflowBuffer dfb_xmm_obj(cb_xmm);
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_xmm_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_xmm_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                sub_bcast_cols_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                 sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                sub_tiles_bcast_scalar_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                 sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
             }
 
             if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                copy_tile_init_with_dt(cb_mask_h_w_obj);
+                copy_tile_init_with_dt(dfb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 0, dst1);
 
                 mask_tile_init();
@@ -506,7 +506,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_h_w_obj);
+                copy_tile_init_with_dt(dfb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 1, dst1);
 
                 mask_tile_init();
@@ -515,107 +515,107 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm_obj);
+            pack_tile_with_dt(dst0, dfb_xmm_obj);
 
-            cb_x_obj.pop_front(onetile);
-            cb_xmm_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_xmm_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_y
             // (x - mean) * rstd
             tile_regs_acquire();
-            cb_xmm_obj.wait_front(onetile);
-            cb_y_obj.reserve_back(onetile);
+            dfb_xmm_obj.wait_front(onetile);
+            dfb_y_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                mul_bcast_cols_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                 mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                mul_tiles_bcast_scalar_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                 mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_y_obj);
+            pack_tile_with_dt(dst0, dfb_y_obj);
 
-            cb_xmm_obj.pop_front(onetile);
-            cb_y_obj.push_back(onetile);
+            dfb_xmm_obj.pop_front(onetile);
+            dfb_y_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_yydysum
             // y * Sum[y * dy]
             constexpr auto cb_yydysum = cb_tmp1;
-            CircularBuffer cb_yydysum_obj(cb_yydysum);
+            DataflowBuffer dfb_yydysum_obj(cb_yydysum);
             tile_regs_acquire();
-            cb_y_obj.wait_front(onetile);
-            cb_yydysum_obj.reserve_back(onetile);
+            dfb_y_obj.wait_front(onetile);
+            dfb_yydysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
+                mul_bcast_cols_init_short_with_dt(dfb_y_obj, dfb_ydysum_obj);
                 mul_tiles_bcast_cols(cb_y, cb_ydysum, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
+                mul_tiles_bcast_scalar_init_short_with_dt(dfb_y_obj, dfb_ydysum_obj);
                 mul_tiles_bcast_scalar(cb_y, cb_ydysum, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_yydysum_obj);
+            pack_tile_with_dt(dst0, dfb_yydysum_obj);
 
-            cb_y_obj.pop_front(onetile);
-            cb_yydysum_obj.push_back(onetile);
+            dfb_y_obj.pop_front(onetile);
+            dfb_yydysum_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_tmp4
             // (n * dy - Sum[dy]) - (y * Sum[y * dy])
             constexpr auto cb_tmp4 = cb_y;
-            CircularBuffer cb_tmp4_obj(cb_tmp4);
+            DataflowBuffer dfb_tmp4_obj(cb_tmp4);
             tile_regs_acquire();
-            cb_ndymdysum_obj.wait_front(onetile);
-            cb_yydysum_obj.wait_front(onetile);
-            cb_tmp4_obj.reserve_back(onetile);
+            dfb_ndymdysum_obj.wait_front(onetile);
+            dfb_yydysum_obj.wait_front(onetile);
+            dfb_tmp4_obj.reserve_back(onetile);
 
-            sub_tiles_init_with_dt(cb_ndymdysum_obj, cb_yydysum_obj);
+            sub_tiles_init_with_dt(dfb_ndymdysum_obj, dfb_yydysum_obj);
             sub_tiles(cb_ndymdysum, cb_yydysum, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_tmp4_obj);
+            pack_tile_with_dt(dst0, dfb_tmp4_obj);
 
-            cb_ndymdysum_obj.pop_front(onetile);
-            cb_yydysum_obj.pop_front(onetile);
-            cb_tmp4_obj.push_back(onetile);
+            dfb_ndymdysum_obj.pop_front(onetile);
+            dfb_yydysum_obj.pop_front(onetile);
+            dfb_tmp4_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_dx
             // ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)
             tile_regs_acquire();
-            cb_tmp4_obj.wait_front(onetile);
-            cb_dx_obj.reserve_back(onetile);
+            dfb_tmp4_obj.wait_front(onetile);
+            dfb_dx_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_tmp4_obj, cb_recip_nrstd_obj);
+            mul_tiles_init_with_dt(dfb_tmp4_obj, dfb_recip_nrstd_obj);
             mul_tiles(cb_tmp4, cb_recip_nrstd, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_dx_obj);
+            pack_tile_with_dt(dst0, dfb_dx_obj);
 
-            cb_tmp4_obj.pop_front(onetile);
-            cb_dx_obj.push_back(onetile);
+            dfb_tmp4_obj.pop_front(onetile);
+            dfb_dx_obj.push_back(onetile);
             tile_regs_release();
         }  // Wt loop
-        cb_recip_nrstd_obj.pop_front(onetile);
-        cb_dysum_obj.pop_front(onetile);
-        cb_ydysum_obj.pop_front(onetile);
+        dfb_recip_nrstd_obj.pop_front(onetile);
+        dfb_dysum_obj.pop_front(onetile);
+        dfb_ydysum_obj.pop_front(onetile);
 
-        cb_mean_obj.pop_front(onetile);
-        cb_rstd_obj.pop_front(onetile);
+        dfb_mean_obj.pop_front(onetile);
+        dfb_rstd_obj.pop_front(onetile);
     }  // NCHt loop
-    cb_scaler_obj.pop_front(onetile);
-    cb_n_recip_n_obj.pop_front(2);
+    dfb_scaler_obj.pop_front(onetile);
+    dfb_n_recip_n_obj.pop_front(2);
 
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.pop_front(2);
+        dfb_mask_h_w_obj.pop_front(2);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ALWI bool need_to_do_mask_h(uint32_t w_idx, uint32_t origin_num_h_tiles, uint32_t origin_num_w_tiles) {
     return ((w_idx / origin_num_w_tiles) + 1) % origin_num_h_tiles == 0;
@@ -22,47 +22,47 @@ void kernel_main() {
     binary_op_init_common(tt::CBIndex::c_1, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     constexpr auto cb_dy = tt::CBIndex::c_0;
-    CircularBuffer cb_dy_obj(cb_dy);  // output_grad(==dy)
+    DataflowBuffer dfb_dy_obj(cb_dy);  // output_grad(==dy)
     constexpr auto cb_x = tt::CBIndex::c_1;
-    CircularBuffer cb_x_obj(cb_x);  // input(==x)
+    DataflowBuffer dfb_x_obj(cb_x);  // input(==x)
     constexpr auto cb_mean = tt::CBIndex::c_2;
-    CircularBuffer cb_mean_obj(cb_mean);  // mean
+    DataflowBuffer dfb_mean_obj(cb_mean);  // mean
     constexpr auto cb_rstd = tt::CBIndex::c_3;
-    CircularBuffer cb_rstd_obj(cb_rstd);  // rstd
+    DataflowBuffer dfb_rstd_obj(cb_rstd);  // rstd
     constexpr auto cb_scaler = tt::CBIndex::c_4;
-    CircularBuffer cb_scaler_obj(cb_scaler);  // scaler
+    DataflowBuffer dfb_scaler_obj(cb_scaler);  // scaler
     constexpr auto cb_n_recip_n = tt::CBIndex::c_5;
-    CircularBuffer cb_n_recip_n_obj(cb_n_recip_n);  // n_recip_n
+    DataflowBuffer dfb_n_recip_n_obj(cb_n_recip_n);  // n_recip_n
     constexpr auto cb_gamma = tt::CBIndex::c_6;
-    CircularBuffer cb_gamma_obj(cb_gamma);  // gamma
+    DataflowBuffer dfb_gamma_obj(cb_gamma);  // gamma
     constexpr auto cb_mask_h_w = tt::CBIndex::c_7;
-    CircularBuffer cb_mask_h_w_obj(cb_mask_h_w);  // mask_h_w
+    DataflowBuffer dfb_mask_h_w_obj(cb_mask_h_w);  // mask_h_w
 
     // dx = ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)
     constexpr auto cb_dx = tt::CBIndex::c_16;
-    CircularBuffer cb_dx_obj(cb_dx);  // input_grad(==dx)
+    DataflowBuffer dfb_dx_obj(cb_dx);  // input_grad(==dx)
 
     // y = (x - mean) * rstd
     constexpr auto cb_dycopy = tt::CBIndex::c_24;
-    CircularBuffer cb_dycopy_obj(cb_dycopy);  // copy output_grad(==dycopy)
+    DataflowBuffer dfb_dycopy_obj(cb_dycopy);  // copy output_grad(==dycopy)
     constexpr auto cb_y = tt::CBIndex::c_25;
-    CircularBuffer cb_y_obj(cb_y);  // output(==y)
+    DataflowBuffer dfb_y_obj(cb_y);  // output(==y)
     constexpr auto cb_dysum = tt::CBIndex::c_26;
-    CircularBuffer cb_dysum_obj(cb_dysum);  // Sum[dy]
+    DataflowBuffer dfb_dysum_obj(cb_dysum);  // Sum[dy]
     constexpr auto cb_ydysum = tt::CBIndex::c_27;
-    CircularBuffer cb_ydysum_obj(cb_ydysum);  // Sum[y * dy]
+    DataflowBuffer dfb_ydysum_obj(cb_ydysum);  // Sum[y * dy]
     constexpr auto cb_recip_nrstd = tt::CBIndex::c_28;
-    CircularBuffer cb_recip_nrstd_obj(cb_recip_nrstd);  // rstd / n
+    DataflowBuffer dfb_recip_nrstd_obj(cb_recip_nrstd);  // rstd / n
 
     constexpr auto cb_tmp1 = tt::CBIndex::c_29;
-    CircularBuffer cb_tmp1_obj(cb_tmp1);         // tmp1
+    DataflowBuffer dfb_tmp1_obj(cb_tmp1);        // tmp1
     constexpr auto cb_tmp2 = tt::CBIndex::c_30;  // tmp2
     constexpr auto cb_tmp3 = tt::CBIndex::c_31;  // tmp3
 
     constexpr uint32_t onetile = 1;
 
-    cb_scaler_obj.wait_front(onetile);  // comes from the reader
-    cb_n_recip_n_obj.wait_front(2);     // comes from the reader
+    dfb_scaler_obj.wait_front(onetile);  // comes from the reader
+    dfb_n_recip_n_obj.wait_front(2);     // comes from the reader
 
     constexpr uint32_t TILE_H = 32;
     constexpr uint32_t TILE_W = 32;
@@ -74,7 +74,7 @@ void kernel_main() {
     constexpr uint32_t origin_Wt = (origin_W + TILE_W - 1) / TILE_W;
 
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.wait_front(2);  // comes from the reader
+        dfb_mask_h_w_obj.wait_front(2);  // comes from the reader
     }
 
     constexpr uint32_t NCHt = num_rows_per_core;
@@ -82,50 +82,50 @@ void kernel_main() {
     constexpr uint32_t dst1 = 1;
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
-        cb_mean_obj.wait_front(onetile);  // comes from the reader
-        cb_rstd_obj.wait_front(onetile);  // comes from the reader
+        dfb_mean_obj.wait_front(onetile);  // comes from the reader
+        dfb_rstd_obj.wait_front(onetile);  // comes from the reader
 
         // Compute cb_recip_nrstd
         // rstd / n
         tile_regs_acquire();
-        cb_recip_nrstd_obj.reserve_back(onetile);
+        dfb_recip_nrstd_obj.reserve_back(onetile);
 
         if (is_lastdim_layernorm) {
-            mul_bcast_cols_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
+            mul_bcast_cols_init_short_with_dt(dfb_n_recip_n_obj, dfb_rstd_obj);
             mul_tiles_bcast_cols(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         } else {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_n_recip_n_obj, cb_rstd_obj);
+            mul_tiles_bcast_scalar_init_short_with_dt(dfb_n_recip_n_obj, dfb_rstd_obj);
             mul_tiles_bcast_scalar(cb_n_recip_n, cb_rstd, 1, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_recip_nrstd_obj);
+        pack_tile_with_dt(dst0, dfb_recip_nrstd_obj);
 
-        cb_recip_nrstd_obj.push_back(onetile);
+        dfb_recip_nrstd_obj.push_back(onetile);
         tile_regs_release();
 
         // y = (x - mean) * rstd
-        cb_y_obj.reserve_back(Wt);
+        dfb_y_obj.reserve_back(Wt);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             // Compute cb_xmm
             // x - mean and mask(optional)
             constexpr auto cb_xmm = cb_tmp2;
-            CircularBuffer cb_xmm_obj(cb_xmm);
+            DataflowBuffer dfb_xmm_obj(cb_xmm);
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_xmm_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_xmm_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                sub_bcast_cols_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                 sub_tiles_bcast_cols(cb_x, cb_mean, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_x_obj, cb_mean_obj);
+                sub_tiles_bcast_scalar_init_short_with_dt(dfb_x_obj, dfb_mean_obj);
                 sub_tiles_bcast_scalar(cb_x, cb_mean, 0, 0, dst0);
             }
 
             if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                copy_tile_init_with_dt(cb_mask_h_w_obj);
+                copy_tile_init_with_dt(dfb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 0, dst1);
 
                 mask_tile_init();
@@ -133,7 +133,7 @@ void kernel_main() {
             }
 
             if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                copy_tile_init_with_dt(cb_mask_h_w_obj);
+                copy_tile_init_with_dt(dfb_mask_h_w_obj);
                 copy_tile(cb_mask_h_w, 1, dst1);
 
                 mask_tile_init();
@@ -142,59 +142,59 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xmm_obj);
+            pack_tile_with_dt(dst0, dfb_xmm_obj);
 
-            cb_x_obj.pop_front(onetile);
-            cb_xmm_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_xmm_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_y
             // (x - mean) * rstd
             tile_regs_acquire();
-            cb_xmm_obj.wait_front(onetile);
+            dfb_xmm_obj.wait_front(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                mul_bcast_cols_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                 mul_tiles_bcast_cols(cb_xmm, cb_rstd, 0, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm_obj, cb_rstd_obj);
+                mul_tiles_bcast_scalar_init_short_with_dt(dfb_xmm_obj, dfb_rstd_obj);
                 mul_tiles_bcast_scalar(cb_xmm, cb_rstd, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_y_obj);
+            pack_tile_with_dt(dst0, dfb_y_obj);
 
-            cb_xmm_obj.pop_front(onetile);
-            cb_y_obj.push_back(onetile);
+            dfb_xmm_obj.pop_front(onetile);
+            dfb_y_obj.push_back(onetile);
             tile_regs_release();
         }  // Wt loop
 
         // Copy cb_dy to cb_dycopy
-        cb_dycopy_obj.reserve_back(Wt);
+        dfb_dycopy_obj.reserve_back(Wt);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             if (gamma_has_value) {
                 // Compute cb_dycopy
                 // dycopy = dy * gamma and mask(optional)
                 tile_regs_acquire();
-                cb_dy_obj.wait_front(onetile);     // comes from the reader
-                cb_gamma_obj.wait_front(onetile);  // comes from the reader
+                dfb_dy_obj.wait_front(onetile);     // comes from the reader
+                dfb_gamma_obj.wait_front(onetile);  // comes from the reader
 
                 if (is_groupnorm) {
-                    mul_tiles_bcast_scalar_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
+                    mul_tiles_bcast_scalar_init_short_with_dt(dfb_dy_obj, dfb_gamma_obj);
                     mul_tiles_bcast_scalar(cb_dy, cb_gamma, 0, 0, dst0);
                 } else {
                     if (is_lastdim_layernorm) {
-                        mul_bcast_rows_init_short_with_dt(cb_dy_obj, cb_gamma_obj);
+                        mul_bcast_rows_init_short_with_dt(dfb_dy_obj, dfb_gamma_obj);
                         mul_tiles_bcast_rows(cb_dy, cb_gamma, 0, 0, dst0);
                     } else {
-                        mul_tiles_init_with_dt(cb_dy_obj, cb_gamma_obj);
+                        mul_tiles_init_with_dt(dfb_dy_obj, dfb_gamma_obj);
                         mul_tiles(cb_dy, cb_gamma, 0, 0, dst0);
                     }
                 }
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -202,7 +202,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -211,23 +211,23 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy_obj);
+                pack_tile_with_dt(dst0, dfb_dycopy_obj);
 
-                cb_dy_obj.pop_front(onetile);
-                cb_gamma_obj.pop_front(onetile);
-                cb_dycopy_obj.push_back(onetile);
+                dfb_dy_obj.pop_front(onetile);
+                dfb_gamma_obj.pop_front(onetile);
+                dfb_dycopy_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 // Compute cb_dycopy
                 // dycopy = dy and mask(optional)
                 tile_regs_acquire();
-                cb_dy_obj.wait_front(onetile);  // comes from the reader
+                dfb_dy_obj.wait_front(onetile);  // comes from the reader
 
-                copy_tile_init_with_dt(cb_dy_obj);
+                copy_tile_init_with_dt(dfb_dy_obj);
                 copy_tile(cb_dy, 0, dst0);
 
                 if (do_mask_h && need_to_do_mask_h(wt, origin_Ht, origin_Wt)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 0, dst1);
 
                     mask_tile_init();
@@ -235,7 +235,7 @@ void kernel_main() {
                 }
 
                 if (do_mask_w && ((wt + 1) % origin_Wt == 0)) {
-                    copy_tile_init_with_dt(cb_mask_h_w_obj);
+                    copy_tile_init_with_dt(dfb_mask_h_w_obj);
                     copy_tile(cb_mask_h_w, 1, dst1);
 
                     mask_tile_init();
@@ -244,46 +244,46 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dycopy_obj);
+                pack_tile_with_dt(dst0, dfb_dycopy_obj);
 
-                cb_dy_obj.pop_front(onetile);
-                cb_dycopy_obj.push_back(onetile);
+                dfb_dy_obj.pop_front(onetile);
+                dfb_dycopy_obj.push_back(onetile);
                 tile_regs_release();
             }
         }  // Wt loop
 
         // Compute cb_dyadd
         constexpr auto cb_dyadd = cb_tmp1;
-        CircularBuffer cb_dyadd_obj(cb_dyadd);
-        cb_dycopy_obj.wait_front(Wt);
+        DataflowBuffer dfb_dyadd_obj(cb_dyadd);
+        dfb_dycopy_obj.wait_front(Wt);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             if (wt == 0) {
                 tile_regs_acquire();
-                cb_dyadd_obj.reserve_back(onetile);
+                dfb_dyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_dycopy_obj);
+                copy_tile_init_with_dt(dfb_dycopy_obj);
                 copy_tile(cb_dycopy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd_obj);
+                pack_tile_with_dt(dst0, dfb_dyadd_obj);
 
-                cb_dyadd_obj.push_back(onetile);
+                dfb_dyadd_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 tile_regs_acquire();
-                cb_dyadd_obj.wait_front(onetile);
-                cb_dyadd_obj.reserve_back(onetile);
+                dfb_dyadd_obj.wait_front(onetile);
+                dfb_dyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_dyadd_obj, cb_dycopy_obj);
+                add_tiles_init_with_dt(dfb_dyadd_obj, dfb_dycopy_obj);
                 add_tiles(cb_dyadd, cb_dycopy, 0, wt, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_dyadd_obj);
+                pack_tile_with_dt(dst0, dfb_dyadd_obj);
 
-                cb_dyadd_obj.pop_front(onetile);
-                cb_dyadd_obj.push_back(onetile);
+                dfb_dyadd_obj.pop_front(onetile);
+                dfb_dyadd_obj.push_back(onetile);
                 tile_regs_release();
             }
         }  // Wt loop
@@ -296,57 +296,57 @@ void kernel_main() {
 
         // Compute cb_ydy and cb_ydyadd
         constexpr auto cb_ydy = cb_tmp2;
-        CircularBuffer cb_ydy_obj(cb_ydy);
+        DataflowBuffer dfb_ydy_obj(cb_ydy);
         constexpr auto cb_ydyadd = cb_tmp3;
-        CircularBuffer cb_ydyadd_obj(cb_ydyadd);
-        cb_y_obj.wait_front(Wt);
+        DataflowBuffer dfb_ydyadd_obj(cb_ydyadd);
+        dfb_y_obj.wait_front(Wt);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             // Compute cb_ydy
             tile_regs_acquire();
-            cb_ydy_obj.reserve_back(onetile);
+            dfb_ydy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_y_obj, cb_dycopy_obj);
+            mul_tiles_init_with_dt(dfb_y_obj, dfb_dycopy_obj);
             mul_tiles(cb_y, cb_dycopy, wt, wt, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ydy_obj);
+            pack_tile_with_dt(dst0, dfb_ydy_obj);
 
-            cb_ydy_obj.push_back(onetile);
+            dfb_ydy_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_ydyadd
             if (wt == 0) {
                 tile_regs_acquire();
-                cb_ydy_obj.wait_front(onetile);
-                cb_ydyadd_obj.reserve_back(onetile);
+                dfb_ydy_obj.wait_front(onetile);
+                dfb_ydyadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_ydy_obj);
+                copy_tile_init_with_dt(dfb_ydy_obj);
                 copy_tile(cb_ydy, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd_obj);
+                pack_tile_with_dt(dst0, dfb_ydyadd_obj);
 
-                cb_ydy_obj.pop_front(onetile);
-                cb_ydyadd_obj.push_back(onetile);
+                dfb_ydy_obj.pop_front(onetile);
+                dfb_ydyadd_obj.push_back(onetile);
                 tile_regs_release();
             } else {
                 tile_regs_acquire();
-                cb_ydy_obj.wait_front(onetile);
-                cb_ydyadd_obj.wait_front(onetile);
-                cb_ydyadd_obj.reserve_back(onetile);
+                dfb_ydy_obj.wait_front(onetile);
+                dfb_ydyadd_obj.wait_front(onetile);
+                dfb_ydyadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_ydyadd_obj, cb_ydy_obj);
+                add_tiles_init_with_dt(dfb_ydyadd_obj, dfb_ydy_obj);
                 add_tiles(cb_ydyadd, cb_ydy, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_ydyadd_obj);
+                pack_tile_with_dt(dst0, dfb_ydyadd_obj);
 
-                cb_ydy_obj.pop_front(onetile);
-                cb_ydyadd_obj.pop_front(onetile);
-                cb_ydyadd_obj.push_back(onetile);
+                dfb_ydy_obj.pop_front(onetile);
+                dfb_ydyadd_obj.pop_front(onetile);
+                dfb_ydyadd_obj.push_back(onetile);
                 tile_regs_release();
             }
         }  // Wt loop
@@ -359,123 +359,123 @@ void kernel_main() {
 
         // Compute cb_dx
         // ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)
-        cb_dysum_obj.wait_front(onetile);
-        cb_ydysum_obj.wait_front(onetile);
-        cb_recip_nrstd_obj.wait_front(onetile);
+        dfb_dysum_obj.wait_front(onetile);
+        dfb_ydysum_obj.wait_front(onetile);
+        dfb_recip_nrstd_obj.wait_front(onetile);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             // Compute cb_ndy
             // n * dy
             constexpr auto cb_ndy = cb_tmp1;
-            CircularBuffer cb_ndy_obj(cb_ndy);
+            DataflowBuffer dfb_ndy_obj(cb_ndy);
             tile_regs_acquire();
-            cb_ndy_obj.reserve_back(onetile);
+            dfb_ndy_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_n_recip_n_obj, cb_dycopy_obj);
+            mul_tiles_init_with_dt(dfb_n_recip_n_obj, dfb_dycopy_obj);
             mul_tiles(cb_n_recip_n, cb_dycopy, 0, wt, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndy_obj);
+            pack_tile_with_dt(dst0, dfb_ndy_obj);
 
-            cb_ndy_obj.push_back(onetile);
+            dfb_ndy_obj.push_back(onetile);
             tile_regs_release();
 
             // cb_ndymdysum
             // n * dy - Sum[dy]
             constexpr auto cb_ndymdysum = cb_tmp2;
-            CircularBuffer cb_ndymdysum_obj(cb_ndymdysum);
+            DataflowBuffer dfb_ndymdysum_obj(cb_ndymdysum);
             tile_regs_acquire();
-            cb_ndy_obj.wait_front(onetile);
-            cb_ndymdysum_obj.reserve_back(onetile);
+            dfb_ndy_obj.wait_front(onetile);
+            dfb_ndymdysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                sub_bcast_cols_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
+                sub_bcast_cols_init_short_with_dt(dfb_ndy_obj, dfb_dysum_obj);
                 sub_tiles_bcast_cols(cb_ndy, cb_dysum, 0, 0, dst0);
             } else {
-                sub_tiles_bcast_scalar_init_short_with_dt(cb_ndy_obj, cb_dysum_obj);
+                sub_tiles_bcast_scalar_init_short_with_dt(dfb_ndy_obj, dfb_dysum_obj);
                 sub_tiles_bcast_scalar(cb_ndy, cb_dysum, 0, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_ndymdysum_obj);
+            pack_tile_with_dt(dst0, dfb_ndymdysum_obj);
 
-            cb_ndy_obj.pop_front(onetile);
-            cb_ndymdysum_obj.push_back(onetile);
+            dfb_ndy_obj.pop_front(onetile);
+            dfb_ndymdysum_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_yydysum
             // y * Sum[y * dy]
             constexpr auto cb_yydysum = cb_tmp3;
-            CircularBuffer cb_yydysum_obj(cb_yydysum);
+            DataflowBuffer dfb_yydysum_obj(cb_yydysum);
             tile_regs_acquire();
-            cb_yydysum_obj.reserve_back(onetile);
+            dfb_yydysum_obj.reserve_back(onetile);
 
             if (is_lastdim_layernorm) {
-                mul_bcast_cols_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
+                mul_bcast_cols_init_short_with_dt(dfb_y_obj, dfb_ydysum_obj);
                 mul_tiles_bcast_cols(cb_y, cb_ydysum, wt, 0, dst0);
             } else {
-                mul_tiles_bcast_scalar_init_short_with_dt(cb_y_obj, cb_ydysum_obj);
+                mul_tiles_bcast_scalar_init_short_with_dt(dfb_y_obj, dfb_ydysum_obj);
                 mul_tiles_bcast_scalar(cb_y, cb_ydysum, wt, 0, dst0);
             }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_yydysum_obj);
+            pack_tile_with_dt(dst0, dfb_yydysum_obj);
 
-            cb_yydysum_obj.push_back(onetile);
+            dfb_yydysum_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_tmp1
             // (n * dy - Sum[dy]) - (y * Sum[y * dy])
             tile_regs_acquire();
-            cb_ndymdysum_obj.wait_front(onetile);
-            cb_yydysum_obj.wait_front(onetile);
-            cb_tmp1_obj.reserve_back(onetile);
+            dfb_ndymdysum_obj.wait_front(onetile);
+            dfb_yydysum_obj.wait_front(onetile);
+            dfb_tmp1_obj.reserve_back(onetile);
 
-            sub_tiles_init_with_dt(cb_ndymdysum_obj, cb_yydysum_obj);
+            sub_tiles_init_with_dt(dfb_ndymdysum_obj, dfb_yydysum_obj);
             sub_tiles(cb_ndymdysum, cb_yydysum, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_tmp1_obj);
+            pack_tile_with_dt(dst0, dfb_tmp1_obj);
 
-            cb_ndymdysum_obj.pop_front(onetile);
-            cb_yydysum_obj.pop_front(onetile);
-            cb_tmp1_obj.push_back(onetile);
+            dfb_ndymdysum_obj.pop_front(onetile);
+            dfb_yydysum_obj.pop_front(onetile);
+            dfb_tmp1_obj.push_back(onetile);
             tile_regs_release();
 
             // Compute cb_dx
             // ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)
             tile_regs_acquire();
-            cb_tmp1_obj.wait_front(onetile);
-            cb_dx_obj.reserve_back(onetile);
+            dfb_tmp1_obj.wait_front(onetile);
+            dfb_dx_obj.reserve_back(onetile);
 
-            mul_tiles_init_with_dt(cb_tmp1_obj, cb_recip_nrstd_obj);
+            mul_tiles_init_with_dt(dfb_tmp1_obj, dfb_recip_nrstd_obj);
             mul_tiles(cb_tmp1, cb_recip_nrstd, 0, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_dx_obj);
+            pack_tile_with_dt(dst0, dfb_dx_obj);
 
-            cb_tmp1_obj.pop_front(onetile);
-            cb_dx_obj.push_back(onetile);
+            dfb_tmp1_obj.pop_front(onetile);
+            dfb_dx_obj.push_back(onetile);
             tile_regs_release();
         }  // Wt loop
-        cb_dycopy_obj.pop_front(Wt);
-        cb_y_obj.pop_front(Wt);
+        dfb_dycopy_obj.pop_front(Wt);
+        dfb_y_obj.pop_front(Wt);
 
-        cb_recip_nrstd_obj.pop_front(onetile);
-        cb_dysum_obj.pop_front(onetile);
-        cb_ydysum_obj.pop_front(onetile);
+        dfb_recip_nrstd_obj.pop_front(onetile);
+        dfb_dysum_obj.pop_front(onetile);
+        dfb_ydysum_obj.pop_front(onetile);
 
-        cb_mean_obj.pop_front(onetile);
-        cb_rstd_obj.pop_front(onetile);
+        dfb_mean_obj.pop_front(onetile);
+        dfb_rstd_obj.pop_front(onetile);
     }  // NCHt loop
-    cb_scaler_obj.pop_front(onetile);
-    cb_n_recip_n_obj.pop_front(2);
+    dfb_scaler_obj.pop_front(onetile);
+    dfb_n_recip_n_obj.pop_front(2);
 
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.wait_front(2);
+        dfb_mask_h_w_obj.wait_front(2);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_gamma_beta_grad.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -23,13 +23,13 @@ void read_mean_rstd(
     using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb(cb_id);
+    DataflowBuffer dfb(cb_id);
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
     const auto cb_dtype_bytes = cb_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
 
-    cb.reserve_back(onetile);
+    dfb.reserve_back(onetile);
 
-    uint32_t l1_write_addr = cb.get_write_ptr();
+    uint32_t l1_write_addr = dfb.get_write_ptr();
     CoreLocalMem<volatile uint16_t> l1_ptr(l1_write_addr);
     if (normalized_dims == 1) {
         for (uint32_t src_h = 0; src_h < 2; src_h++) {
@@ -51,7 +51,7 @@ void read_mean_rstd(
 
             noc.async_read(
                 addrg,
-                cb,
+                dfb,
                 cb_dtype_bytes * FACE_HEIGHT,
                 {.page_id = noc_id, .offset_bytes = tilized_idx * cb_dtype_bytes},
                 {.offset_bytes = src_idx * cb_dtype_bytes});
@@ -81,7 +81,7 @@ void read_mean_rstd(
 
         noc.async_read(
             addrg,
-            cb,
+            dfb,
             cb_dtype_bytes,
             {.page_id = noc_id, .offset_bytes = tilized_idx * cb_dtype_bytes},
             {.offset_bytes = tilized_idx * cb_dtype_bytes});
@@ -92,7 +92,7 @@ void read_mean_rstd(
         }
     }
 
-    cb.push_back(onetile);
+    dfb.push_back(onetile);
 }
 
 void kernel_main() {
@@ -139,12 +139,12 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    CircularBuffer cb_scaler(cb_id_scaler);
-    fill_cb_with_value(cb_scaler, scaler.u);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    fill_cb_with_value(dfb_scaler, scaler.u);
 
     if (do_mask_h) {
-        CircularBuffer cb_mask_h(cb_id_mask_h);
-        generate_mask_h(cb_mask_h, mask_h);
+        DataflowBuffer dfb_mask_h(cb_id_mask_h);
+        generate_mask_h(dfb_mask_h, mask_h);
     }
 
     auto mean_rstd_Ht = (mean_rstd_height + TILE_HEIGHT - 1) / TILE_HEIGHT;
@@ -153,8 +153,8 @@ void kernel_main() {
     const uint32_t start_tile_idx = tile_offset;
 
     Noc noc;
-    CircularBuffer cb_output_grad(cb_id_output_grad);
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_output_grad(cb_id_output_grad);
+    DataflowBuffer dfb_input(cb_id_input);
     const auto output_grad_tile_bytes = get_tile_size(cb_id_output_grad);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
 
@@ -162,23 +162,23 @@ void kernel_main() {
         for (uint32_t outer_idx = 0; outer_idx < num_outer; outer_idx++) {
             // output_grad (N, C, H, W)
             const uint32_t dy_tile_idx = num_inner * outer_idx + w_idx + start_tile_idx;
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = dy_tile_idx},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_grad_has_value) {
                 // input (N, C, H, W)
                 const uint32_t x_tile_idx = num_inner * outer_idx + w_idx + start_tile_idx;
-                cb_input.reserve_back(onetile);
-                noc.async_read(input_addrg, cb_input, input_tile_bytes, {.page_id = x_tile_idx}, {.offset_bytes = 0});
+                dfb_input.reserve_back(onetile);
+                noc.async_read(input_addrg, dfb_input, input_tile_bytes, {.page_id = x_tile_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_input.push_back(onetile);
+                dfb_input.push_back(onetile);
 
                 uint32_t mean_rstd_tile_offset = tile_offset / num_inner;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_large.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -23,13 +23,13 @@ void read_mean_rstd(
     using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb(cb_id);
+    DataflowBuffer dfb(cb_id);
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
     const auto cb_dtype_bytes = cb_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
 
-    cb.reserve_back(onetile);
+    dfb.reserve_back(onetile);
 
-    uint32_t l1_write_addr = cb.get_write_ptr();
+    uint32_t l1_write_addr = dfb.get_write_ptr();
     CoreLocalMem<volatile uint16_t> l1_ptr(l1_write_addr);
     if (normalized_dims == 1) {
         for (uint32_t src_h = 0; src_h < 2; src_h++) {
@@ -51,7 +51,7 @@ void read_mean_rstd(
 
             noc.async_read(
                 addrg,
-                cb,
+                dfb,
                 cb_dtype_bytes * FACE_HEIGHT,
                 {.page_id = noc_id, .offset_bytes = tilized_idx * cb_dtype_bytes},
                 {.offset_bytes = src_idx * cb_dtype_bytes});
@@ -81,7 +81,7 @@ void read_mean_rstd(
 
         noc.async_read(
             addrg,
-            cb,
+            dfb,
             cb_dtype_bytes,
             {.page_id = noc_id, .offset_bytes = tilized_idx * cb_dtype_bytes},
             {.offset_bytes = tilized_idx * cb_dtype_bytes});
@@ -92,7 +92,7 @@ void read_mean_rstd(
         }
     }
 
-    cb.push_back(onetile);
+    dfb.push_back(onetile);
 }
 
 void kernel_main() {
@@ -144,15 +144,15 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    CircularBuffer cb_scaler(cb_id_scaler);
-    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
-    fill_cb_with_value(cb_scaler, scaler.u);
-    fill_cb_with_value(cb_n_recip_n, n);
-    fill_cb_with_value(cb_n_recip_n, recip_n);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    DataflowBuffer dfb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(dfb_scaler, scaler.u);
+    fill_cb_with_value(dfb_n_recip_n, n);
+    fill_cb_with_value(dfb_n_recip_n, recip_n);
 
     if (do_mask_h || do_mask_w) {
-        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
-        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
+        DataflowBuffer dfb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(dfb_mask_h_w, mask_h, mask_w);
     }
 
     uint32_t offs = 0;
@@ -162,9 +162,9 @@ void kernel_main() {
     auto mean_rstd_Wt = (mean_rstd_width + TILE_WIDTH - 1) / TILE_WIDTH;
 
     Noc noc;
-    CircularBuffer cb_output_grad(cb_id_output_grad);
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_output_grad(cb_id_output_grad);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
     const auto output_grad_tile_bytes = get_tile_size(cb_id_output_grad);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
     const auto gamma_tile_bytes = get_tile_size(cb_id_gamma);
@@ -201,67 +201,67 @@ void kernel_main() {
         // For Sum[dy] and Sum[y * dy]
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx++) {
             // input (N, C, H, W)
-            cb_input.reserve_back(onetile);
+            dfb_input.reserve_back(onetile);
             noc.async_read(
                 input_addrg,
-                cb_input,
+                dfb_input,
                 input_tile_bytes,
                 {.page_id = offs + inner_idx + tile_offset},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(onetile);
+            dfb_input.push_back(onetile);
 
             // output_grad (N, C, H, W)
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = offs + inner_idx + tile_offset},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_has_value) {
                 // gamma (1, 1, 1, W)
-                cb_gamma.reserve_back(onetile);
-                noc.async_read(gamma_addrg, cb_gamma, gamma_tile_bytes, {.page_id = inner_idx}, {.offset_bytes = 0});
+                dfb_gamma.reserve_back(onetile);
+                noc.async_read(gamma_addrg, dfb_gamma, gamma_tile_bytes, {.page_id = inner_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_gamma.push_back(onetile);
+                dfb_gamma.push_back(onetile);
             }  // gamma_has_value
         }  // num_inner loop
 
         // For ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx++) {
             // output_grad (N, C, H, W)
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = offs + inner_idx + tile_offset},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_has_value) {
                 // gamma (1, 1, 1, W)
-                cb_gamma.reserve_back(onetile);
-                noc.async_read(gamma_addrg, cb_gamma, gamma_tile_bytes, {.page_id = inner_idx}, {.offset_bytes = 0});
+                dfb_gamma.reserve_back(onetile);
+                noc.async_read(gamma_addrg, dfb_gamma, gamma_tile_bytes, {.page_id = inner_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_gamma.push_back(onetile);
+                dfb_gamma.push_back(onetile);
             }  // gamma_has_value
 
             // input (N, C, H, W)
-            cb_input.reserve_back(onetile);
+            dfb_input.reserve_back(onetile);
             noc.async_read(
                 input_addrg,
-                cb_input,
+                dfb_input,
                 input_tile_bytes,
                 {.page_id = offs + inner_idx + tile_offset},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(onetile);
+            dfb_input.push_back(onetile);
         }  // num_inner loop
 
         offs += num_inner;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_small.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -23,13 +23,13 @@ void read_mean_rstd(
     using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb(cb_id);
+    DataflowBuffer dfb(cb_id);
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
     const auto cb_dtype_bytes = cb_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
 
-    cb.reserve_back(onetile);
+    dfb.reserve_back(onetile);
 
-    uint32_t l1_write_addr = cb.get_write_ptr();
+    uint32_t l1_write_addr = dfb.get_write_ptr();
     CoreLocalMem<volatile uint16_t> l1_ptr(l1_write_addr);
     if (normalized_dims == 1) {
         for (uint32_t src_h = 0; src_h < 2; src_h++) {
@@ -51,7 +51,7 @@ void read_mean_rstd(
 
             noc.async_read(
                 addrg,
-                cb,
+                dfb,
                 cb_dtype_bytes * FACE_HEIGHT,
                 {.page_id = noc_id, .offset_bytes = tilized_idx * cb_dtype_bytes},
                 {.offset_bytes = src_idx * cb_dtype_bytes});
@@ -81,7 +81,7 @@ void read_mean_rstd(
 
         noc.async_read(
             addrg,
-            cb,
+            dfb,
             cb_dtype_bytes,
             {.page_id = noc_id, .offset_bytes = tilized_idx * cb_dtype_bytes},
             {.offset_bytes = tilized_idx * cb_dtype_bytes});
@@ -92,7 +92,7 @@ void read_mean_rstd(
         }
     }
 
-    cb.push_back(onetile);
+    dfb.push_back(onetile);
 }
 
 void kernel_main() {
@@ -143,15 +143,15 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    CircularBuffer cb_scaler(cb_id_scaler);
-    CircularBuffer cb_n_recip_n(cb_id_n_recip_n);
-    fill_cb_with_value(cb_scaler, scaler.u);
-    fill_cb_with_value(cb_n_recip_n, n);
-    fill_cb_with_value(cb_n_recip_n, recip_n);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    DataflowBuffer dfb_n_recip_n(cb_id_n_recip_n);
+    fill_cb_with_value(dfb_scaler, scaler.u);
+    fill_cb_with_value(dfb_n_recip_n, n);
+    fill_cb_with_value(dfb_n_recip_n, recip_n);
 
     if (do_mask_h || do_mask_w) {
-        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
-        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
+        DataflowBuffer dfb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(dfb_mask_h_w, mask_h, mask_w);
     }
 
     uint32_t offs = 0;
@@ -161,9 +161,9 @@ void kernel_main() {
     auto mean_rstd_Wt = (mean_rstd_width + TILE_WIDTH - 1) / TILE_WIDTH;
 
     Noc noc;
-    CircularBuffer cb_output_grad(cb_id_output_grad);
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_gamma(cb_id_gamma);
+    DataflowBuffer dfb_output_grad(cb_id_output_grad);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_gamma(cb_id_gamma);
     const auto output_grad_tile_bytes = get_tile_size(cb_id_output_grad);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
     const auto gamma_tile_bytes = get_tile_size(cb_id_gamma);
@@ -199,35 +199,35 @@ void kernel_main() {
 
         // input (N, C, H, W)
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx++) {
-            cb_input.reserve_back(onetile);
+            dfb_input.reserve_back(onetile);
             noc.async_read(
                 input_addrg,
-                cb_input,
+                dfb_input,
                 input_tile_bytes,
                 {.page_id = offs + inner_idx + tile_offset},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(onetile);
+            dfb_input.push_back(onetile);
         }  // inner_idx loop
 
         // output_grad (N, C, H, W)
         for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx++) {
-            cb_output_grad.reserve_back(onetile);
+            dfb_output_grad.reserve_back(onetile);
             noc.async_read(
                 output_grad_addrg,
-                cb_output_grad,
+                dfb_output_grad,
                 output_grad_tile_bytes,
                 {.page_id = offs + inner_idx + tile_offset},
                 {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_output_grad.push_back(onetile);
+            dfb_output_grad.push_back(onetile);
 
             if (gamma_has_value) {
                 // gamma (1, 1, 1, W)
-                cb_gamma.reserve_back(onetile);
-                noc.async_read(gamma_addrg, cb_gamma, gamma_tile_bytes, {.page_id = inner_idx}, {.offset_bytes = 0});
+                dfb_gamma.reserve_back(onetile);
+                noc.async_read(gamma_addrg, dfb_gamma, gamma_tile_bytes, {.page_id = inner_idx}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_gamma.push_back(onetile);
+                dfb_gamma.push_back(onetile);
             }  // gamma_has_value
 
         }  // num_inner loop

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/writer_moreh_layer_norm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/writer_moreh_layer_norm_backward_gamma_beta_grad.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -30,36 +30,36 @@ void kernel_main() {
     const auto start_tile_idx = tile_offset;
 
     Noc noc;
-    CircularBuffer cb_gamma_grad(cb_id_gamma_grad);
-    CircularBuffer cb_beta_grad(cb_id_beta_grad);
+    DataflowBuffer dfb_gamma_grad(cb_id_gamma_grad);
+    DataflowBuffer dfb_beta_grad(cb_id_beta_grad);
     const auto gamma_grad_tile_bytes = get_tile_size(cb_id_gamma_grad);
     const auto beta_grad_tile_bytes = get_tile_size(cb_id_beta_grad);
 
     for (uint32_t w_idx = 0; w_idx < num_cols_per_core; w_idx++) {
         if (gamma_grad_has_value) {
             // gamma_grad (1, 1, 1, W)
-            cb_gamma_grad.wait_front(onetile);
+            dfb_gamma_grad.wait_front(onetile);
             noc.async_write(
-                cb_gamma_grad,
+                dfb_gamma_grad,
                 gamma_grad_addrg,
                 gamma_grad_tile_bytes,
                 {.offset_bytes = 0},
                 {.page_id = w_idx + start_tile_idx});
             noc.async_write_barrier();
-            cb_gamma_grad.pop_front(onetile);
+            dfb_gamma_grad.pop_front(onetile);
         }  // gamma_grad_has_value
 
         if (beta_grad_has_value) {
             // beta_grad (1, 1, 1, W)
-            cb_beta_grad.wait_front(onetile);
+            dfb_beta_grad.wait_front(onetile);
             noc.async_write(
-                cb_beta_grad,
+                dfb_beta_grad,
                 beta_grad_addrg,
                 beta_grad_tile_bytes,
                 {.offset_bytes = 0},
                 {.page_id = w_idx + start_tile_idx});
             noc.async_write_barrier();
-            cb_beta_grad.pop_front(onetile);
+            dfb_beta_grad.pop_front(onetile);
         }  // beta_grad_has_value
 
     }  // num_cols_per_core loop

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/writer_moreh_layer_norm_backward_input_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/writer_moreh_layer_norm_backward_input_grad.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -24,21 +24,21 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_input_grad(cb_id_input_grad);
+    DataflowBuffer dfb_input_grad(cb_id_input_grad);
     const auto input_grad_tile_bytes = get_tile_size(cb_id_input_grad);
 
     for (uint32_t ncht = 0; ncht < num_rows_per_core; ncht++) {
         // input_grad (N, C, H, W)
         for (uint32_t wt = 0; wt < Wt; wt++) {
-            cb_input_grad.wait_front(onetile);
+            dfb_input_grad.wait_front(onetile);
             noc.async_write(
-                cb_input_grad,
+                dfb_input_grad,
                 input_grad_addrg,
                 input_grad_tile_bytes,
                 {.offset_bytes = 0},
                 {.page_id = offs + wt + tile_offset});
             noc.async_write_barrier();
-            cb_input_grad.pop_front(onetile);
+            dfb_input_grad.pop_front(onetile);
         }  // wt loop
         offs += Wt;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr int onetile = 1;
@@ -16,23 +16,23 @@ void kernel_main() {
     const bool do_mask_w = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_scaler = tt::CBIndex::c_1;
-    CircularBuffer cb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
     constexpr auto cb_mask_h_w = tt::CBIndex::c_2;
-    CircularBuffer cb_mask_h_w_obj(cb_mask_h_w);
+    DataflowBuffer dfb_mask_h_w_obj(cb_mask_h_w);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     constexpr auto cb_intermed1 = tt::CBIndex::c_25;
     constexpr auto cb_out0 = tt::CBIndex::c_16;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
     binary_op_init_common(cb_in0, cb_in0, cb_out0);
-    cb_scaler_obj.wait_front(onetile);
+    dfb_scaler_obj.wait_front(onetile);
 
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.wait_front(onetile * 2);
+        dfb_mask_h_w_obj.wait_front(onetile * 2);
     }
 
     uint32_t num_tiles = batch_num * Ht;
@@ -47,7 +47,7 @@ void kernel_main() {
 
                 if (do_mask) {
                     // get tile from reader and apply mask
-                    cb_in0_obj.wait_front(onetile);
+                    dfb_in0_obj.wait_front(onetile);
                     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
                     reconfig_data_format_srca(cb_in0);
@@ -77,15 +77,15 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    cb_intermed0_obj.reserve_back(onetile);
+                    dfb_intermed0_obj.reserve_back(onetile);
 #if defined FP32_DEST_ACC_EN
                     pack_reconfig_data_format(cb_intermed0);
 #endif
                     pack_tile(dst0, cb_intermed0);
-                    cb_intermed0_obj.push_back(onetile);
+                    dfb_intermed0_obj.push_back(onetile);
                     tile_regs_release();
 
-                    cb_in0_obj.pop_front(onetile);
+                    dfb_in0_obj.pop_front(onetile);
                 }
 
                 const auto reduce_block = compute_kernel_lib::ReduceInputBlockShape::single();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 void kernel_main() {
     constexpr int onetile = 1;
     ArgFetcher arg_fetcher;
@@ -15,23 +15,23 @@ void kernel_main() {
     const bool do_mask_w = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_scaler = tt::CBIndex::c_1;
-    CircularBuffer cb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
     constexpr auto cb_mask_h_w = tt::CBIndex::c_2;
-    CircularBuffer cb_mask_h_w_obj(cb_mask_h_w);
+    DataflowBuffer dfb_mask_h_w_obj(cb_mask_h_w);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     constexpr auto cb_intermed1 = tt::CBIndex::c_25;
     constexpr auto cb_out0 = tt::CBIndex::c_16;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
     binary_op_init_common(cb_in0, cb_in0, cb_out0);
-    cb_scaler_obj.wait_front(onetile);
+    dfb_scaler_obj.wait_front(onetile);
 
     if (do_mask_h || do_mask_w) {
-        cb_mask_h_w_obj.wait_front(onetile * 2);
+        dfb_mask_h_w_obj.wait_front(onetile * 2);
     }
 
     uint32_t num_tiles = batch_num * Ht * Wt;
@@ -46,7 +46,7 @@ void kernel_main() {
 
                 if (do_mask) {
                     // get tile from reader and apply mask
-                    cb_in0_obj.wait_front(onetile);
+                    dfb_in0_obj.wait_front(onetile);
                     tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
                     reconfig_data_format_srca(cb_in0);
@@ -76,15 +76,15 @@ void kernel_main() {
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    cb_intermed0_obj.reserve_back(onetile);
+                    dfb_intermed0_obj.reserve_back(onetile);
 #if defined FP32_DEST_ACC_EN
                     pack_reconfig_data_format(cb_intermed0);
 #endif
                     pack_tile(dst0, cb_intermed0);
-                    cb_intermed0_obj.push_back(onetile);
+                    dfb_intermed0_obj.push_back(onetile);
                     tile_regs_release();
 
-                    cb_in0_obj.pop_front(onetile);
+                    dfb_in0_obj.pop_front(onetile);
                 }
 
                 const auto reduce_block = compute_kernel_lib::ReduceInputBlockShape::single();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_h.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 void kernel_main() {
     ArgFetcher arg_fetcher;
@@ -28,24 +28,24 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_id_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_COL>();
 
     if (do_mask_h || do_mask_w) {
-        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
-        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
+        DataflowBuffer dfb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(dfb_mask_h_w, mask_h, mask_w);
     }
 
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer dfb_in0(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     constexpr uint32_t onetile = 1;
     for (uint32_t wt = 0; wt < Wt_per_core; ++wt) {
         uint32_t read_tile_id = start_id + wt;
         for (uint32_t b = 0; b < batch_num; ++b) {
-            cb_in0.reserve_back(onetile);
-            noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+            dfb_in0.reserve_back(onetile);
+            noc.async_read(s0, dfb_in0, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in0.push_back(onetile);
+            dfb_in0.push_back(onetile);
             read_tile_id += Wt;
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_hw.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -28,25 +28,25 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 1.0f;
-    CircularBuffer cb_scaler(cb_id_scaler);
-    fill_cb_with_value(cb_scaler, scaler.u);
+    DataflowBuffer dfb_scaler(cb_id_scaler);
+    fill_cb_with_value(dfb_scaler, scaler.u);
 
     if (do_mask_h || do_mask_w) {
-        CircularBuffer cb_mask_h_w(cb_id_mask_h_w);
-        generate_mask_h_w(cb_mask_h_w, mask_h, mask_w);
+        DataflowBuffer dfb_mask_h_w(cb_id_mask_h_w);
+        generate_mask_h_w(dfb_mask_h_w, mask_h, mask_w);
     }
 
     const auto s0 = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer dfb_in0(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     constexpr uint32_t onetile = 1;
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
-        cb_in0.reserve_back(onetile);
-        noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_in0.reserve_back(onetile);
+        noc.async_read(s0, dfb_in0, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0.push_back(onetile);
+        dfb_in0.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/writer_moreh_bias_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/writer_moreh_bias_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -20,14 +20,14 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; i++) {
-        cb_out.wait_front(onetile);
-        noc.async_write(cb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out.wait_front(onetile);
+        noc.async_write(dfb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/moreh_matmul.cpp
@@ -7,7 +7,7 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/transpose.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 ////////////////////
 // global variables
@@ -42,7 +42,7 @@ FORCE_INLINE void unravel_output_tidx(uint32_t output_tidx, uint32_t* output_idx
 
 // TODO: move it to moreh_common.hpp if more use cases.
 FORCE_INLINE void transpose_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_t idst = 0) {
-    CircularBuffer ocb_obj(ocb);
+    DataflowBuffer ocb_obj(ocb);
 #if defined FP32_DEST_ACC_EN
     reconfig_data_format_srca(icb);
 #endif
@@ -66,7 +66,7 @@ FORCE_INLINE void transpose_src_tile(uint32_t& mm_src, bool transpose, bool need
     }
 
     if (need_mask) {
-        CircularBuffer mm_src_obj(mm_src);
+        DataflowBuffer mm_src_obj(mm_src);
         mm_src_obj.wait_front(onetile);
         transpose_tile_to_cb(mm_src, mm_src);
         mm_src_obj.pop_front(onetile);
@@ -78,7 +78,7 @@ FORCE_INLINE void transpose_src_tile(uint32_t& mm_src, bool transpose, bool need
 }
 
 FORCE_INLINE void pack_onetile_to_cb(uint32_t ocb = 16, uint32_t idst = 0) {
-    CircularBuffer ocb_obj(ocb);
+    DataflowBuffer ocb_obj(ocb);
     ocb_obj.reserve_back(onetile);
     tile_regs_wait();
 #if defined FP32_DEST_ACC_EN
@@ -153,10 +153,10 @@ FORCE_INLINE void mask_tile_to_cb(
 #ifdef FUSE_BIAS
 template <bool is_scalar_bias>
 FORCE_INLINE void bias_add() {
-    CircularBuffer cb_intermed3_obj(cb_intermed3);
-    CircularBuffer bias_cb_id_obj(bias_cb_id);
+    DataflowBuffer dfb_intermed3_obj(cb_intermed3);
+    DataflowBuffer bias_cb_id_obj(bias_cb_id);
     pack_onetile_to_cb(cb_intermed3);
-    cb_intermed3_obj.wait_front(onetile);
+    dfb_intermed3_obj.wait_front(onetile);
     bias_cb_id_obj.wait_front(onetile);
     tile_regs_acquire();
     if (is_scalar_bias) {
@@ -174,7 +174,7 @@ FORCE_INLINE void bias_add() {
     }
     tile_regs_commit();
 
-    cb_intermed3_obj.pop_front(onetile);
+    dfb_intermed3_obj.pop_front(onetile);
     if constexpr (!is_scalar_bias) {
         bias_cb_id_obj.pop_front(onetile);
     }
@@ -195,11 +195,11 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
     uint32_t Nt,
     bool need_other_mask_h,
     bool need_other_mask_w) {
-    CircularBuffer cb_in0_obj(cb_in0);
-    CircularBuffer cb_in1_obj(cb_in1);
-    CircularBuffer cb_in2_obj(cb_in2);
-    CircularBuffer cb_in3_obj(cb_in3);
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in1_obj(cb_in1);
+    DataflowBuffer dfb_in2_obj(cb_in2);
+    DataflowBuffer dfb_in3_obj(cb_in3);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     // TODO: checking required when the input cb format and intermediate cb format are different.
     matmul_init(cb_in0, cb_in1);
     if (transpose_input || transpose_other) {
@@ -207,11 +207,11 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
     }
 
     if (need_input_mask_h || need_input_mask_w) {
-        cb_in2_obj.wait_front(num_mask_tiles);
+        dfb_in2_obj.wait_front(num_mask_tiles);
     }
 
     if (need_other_mask_h || need_other_mask_w) {
-        cb_in3_obj.wait_front(num_mask_tiles);
+        dfb_in3_obj.wait_front(num_mask_tiles);
     }
 
 #pragma GCC unroll 0
@@ -234,8 +234,8 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
             uint32_t mm_src0 = cb_in0;
             uint32_t mm_src1 = cb_in0;
 
-            cb_in0_obj.wait_front(onetile);
-            cb_in1_obj.wait_front(onetile);
+            dfb_in0_obj.wait_front(onetile);
+            dfb_in1_obj.wait_front(onetile);
 
             mm_src0 = cb_in0;
             mm_src1 = cb_in1;
@@ -271,17 +271,17 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
             ////////////////////
             tile_regs_acquire();
             if (enable_reload) {
-                cb_intermed0_obj.wait_front(onetile);
+                dfb_intermed0_obj.wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format_srca(cb_intermed0);
 #endif
                 copy_tile_to_dst_init_short(cb_intermed0);
                 copy_tile(cb_intermed0, 0, 0);
-                cb_intermed0_obj.pop_front(onetile);
+                dfb_intermed0_obj.pop_front(onetile);
             }
 
-            CircularBuffer mm_src0_obj(mm_src0);
-            CircularBuffer mm_src1_obj(mm_src1);
+            DataflowBuffer mm_src0_obj(mm_src0);
+            DataflowBuffer mm_src1_obj(mm_src1);
             if (transpose_input || need_input_mask) {
                 mm_src0_obj.wait_front(onetile);
             }
@@ -297,8 +297,8 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
             matmul_tiles(mm_src0, mm_src1, 0, 0, 0);
             tile_regs_commit();
 
-            cb_in0_obj.pop_front(onetile);
-            cb_in1_obj.pop_front(onetile);
+            dfb_in0_obj.pop_front(onetile);
+            dfb_in1_obj.pop_front(onetile);
 
             if (transpose_input || need_input_mask) {
                 mm_src0_obj.pop_front(onetile);
@@ -328,17 +328,17 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
 }
 
 FORCE_INLINE void matmul(uint32_t num_output_tiles, uint32_t Kt) {
-    CircularBuffer cb_in0_obj(cb_in0);
-    CircularBuffer cb_in1_obj(cb_in1);
+    DataflowBuffer dfb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in1_obj(cb_in1);
     matmul_init(cb_in0, cb_in1);
     for (uint32_t i = 0; i < num_output_tiles; ++i) {
         tile_regs_acquire();
         for (uint32_t kt = 0; kt < Kt; kt++) {
-            cb_in0_obj.wait_front(onetile);
-            cb_in1_obj.wait_front(onetile);
+            dfb_in0_obj.wait_front(onetile);
+            dfb_in1_obj.wait_front(onetile);
             matmul_tiles(cb_in0, cb_in1, 0, 0, 0);
-            cb_in0_obj.pop_front(onetile);
-            cb_in1_obj.pop_front(onetile);
+            dfb_in0_obj.pop_front(onetile);
+            dfb_in1_obj.pop_front(onetile);
         }
         tile_regs_commit();
         pack_onetile_to_cb(cb_out0);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/reader_moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/reader_moreh_matmul.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 static constexpr int32_t MAX_NUM_DIMENSIONS = 8;
@@ -99,15 +99,15 @@ void kernel_main() {
     bool need_input_mask_w = (input_mask_w != 32);
 
     if (need_input_mask_h || need_input_mask_w) {
-        CircularBuffer cb_in2(cb_id_in2);
-        generate_mask_tiles(cb_in2, input_mask_h, input_mask_w);
+        DataflowBuffer dfb_in2(cb_id_in2);
+        generate_mask_tiles(dfb_in2, input_mask_h, input_mask_w);
     }
 
     bool need_other_mask_h = (other_mask_h != 32);
     bool need_other_mask_w = (other_mask_w != 32);
     if (need_other_mask_h || need_other_mask_w) {
-        CircularBuffer cb_in3(cb_id_in3);
-        generate_mask_tiles(cb_in3, other_mask_h, other_mask_w);
+        DataflowBuffer dfb_in3(cb_id_in3);
+        generate_mask_tiles(dfb_in3, other_mask_h, other_mask_w);
     }
 
     uint32_t output_tidx = output_tile_start_idx;
@@ -115,21 +115,21 @@ void kernel_main() {
     uint32_t other_step_count = (transpose_other) ? (other_stride[0]) : (other_stride[1]);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
-    CircularBuffer cb_in1(cb_id_in1);
+    DataflowBuffer dfb_in0(cb_id_in0);
+    DataflowBuffer dfb_in1(cb_id_in1);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
     const auto in1_tile_bytes = get_tile_size(cb_id_in1);
 #ifdef FUSE_BIAS
-    CircularBuffer cb_in4(cb_id_in4);
+    DataflowBuffer dfb_in4(cb_id_in4);
     const auto in4_tile_bytes = get_tile_size(cb_id_in4);
 #endif
 
 #ifdef FUSE_BIAS
     if (is_scalar_bias && num_output_tiles > 0) {
-        cb_in4.reserve_back(onetile);
-        noc.async_read(s_bias, cb_in4, in4_tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
+        dfb_in4.reserve_back(onetile);
+        noc.async_read(s_bias, dfb_in4, in4_tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in4.push_back(onetile);
+        dfb_in4.push_back(onetile);
     }
 #endif
 
@@ -140,15 +140,15 @@ void kernel_main() {
         uint32_t other_tidx = get_tidx(output_idxes, other_stride, other_not_bcast, transpose_other, false);
 
         for (uint32_t kt = 0; kt < Kt; kt++) {
-            cb_in0.reserve_back(onetile);
-            cb_in1.reserve_back(onetile);
+            dfb_in0.reserve_back(onetile);
+            dfb_in1.reserve_back(onetile);
 
-            noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = input_tidx}, {.offset_bytes = 0});
-            noc.async_read(s1, cb_in1, in1_tile_bytes, {.page_id = other_tidx}, {.offset_bytes = 0});
+            noc.async_read(s0, dfb_in0, in0_tile_bytes, {.page_id = input_tidx}, {.offset_bytes = 0});
+            noc.async_read(s1, dfb_in1, in1_tile_bytes, {.page_id = other_tidx}, {.offset_bytes = 0});
             noc.async_read_barrier();
 
-            cb_in0.push_back(onetile);
-            cb_in1.push_back(onetile);
+            dfb_in0.push_back(onetile);
+            dfb_in1.push_back(onetile);
 
             input_tidx += input_step_count;
             other_tidx += other_step_count;
@@ -156,10 +156,10 @@ void kernel_main() {
 #ifdef FUSE_BIAS
         if constexpr (!is_scalar_bias) {
             uint32_t bias_tidx = output_idxes[0];
-            cb_in4.reserve_back(onetile);
-            noc.async_read(s_bias, cb_in4, in4_tile_bytes, {.page_id = bias_tidx}, {.offset_bytes = 0});
+            dfb_in4.reserve_back(onetile);
+            noc.async_read(s_bias, dfb_in4, in4_tile_bytes, {.page_id = bias_tidx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in4.push_back(onetile);
+            dfb_in4.push_back(onetile);
         }
 #endif
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/writer_moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/writer_moreh_matmul.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,14 +21,14 @@ void kernel_main() {
     const auto s = TensorAccessor(output_args, output_addr);
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_output_tiles;
     for (uint32_t i = start_id; i < end_id; i++) {
-        cb_out.wait_front(onetile);
-        noc.async_write(cb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out.wait_front(onetile);
+        noc.async_write(dfb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
@@ -10,7 +10,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -19,27 +19,27 @@ void kernel_main() {
     constexpr uint32_t origin_H = get_compile_time_arg_val(3);
 
     constexpr auto cb_input = tt::CBIndex::c_0;
-    CircularBuffer cb_input_obj(cb_input);
+    DataflowBuffer dfb_input_obj(cb_input);
     constexpr auto cb_scaler = tt::CBIndex::c_2;
-    CircularBuffer cb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
     constexpr auto cb_mask_h = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);
     constexpr auto cb_accum_dst = tt::CBIndex::c_24;
     constexpr auto cb_masked_input = tt::CBIndex::c_25;
-    CircularBuffer cb_masked_input_obj(cb_masked_input);
+    DataflowBuffer dfb_masked_input_obj(cb_masked_input);
     constexpr auto cb_out = tt::CBIndex::c_16;
     constexpr bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
 
     binary_op_init_common(cb_input, cb_input, cb_out);
 
-    cb_scaler_obj.wait_front(1);  // scaler tile from the reader
+    dfb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
     int reduce_dst_idx = 0;
     const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
     if constexpr (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);
+        dfb_mask_h_obj.wait_front(onetile);
     }
 
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -58,24 +58,24 @@ void kernel_main() {
             // Optional masking of last H tile
             if constexpr (do_mask_h) {
                 tile_regs_acquire();
-                cb_input_obj.wait_front(onetile);
-                copy_tile_init_with_dt(cb_input_obj);
+                dfb_input_obj.wait_front(onetile);
+                copy_tile_init_with_dt(dfb_input_obj);
                 copy_tile(cb_input, 0, reduce_dst_idx);
 
-                copy_tile_init_with_dt(cb_mask_h_obj);
+                copy_tile_init_with_dt(dfb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, mask_dst_idx);
 
                 mask_tile_init();
                 mask_tile(reduce_dst_idx, mask_dst_idx);
                 tile_regs_commit();
 
-                cb_masked_input_obj.reserve_back(onetile);
+                dfb_masked_input_obj.reserve_back(onetile);
                 tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, cb_masked_input_obj);
+                pack_tile_with_dt(reduce_dst_idx, dfb_masked_input_obj);
                 tile_regs_release();
-                cb_masked_input_obj.push_back(onetile);
+                dfb_masked_input_obj.push_back(onetile);
 
-                cb_input_obj.pop_front(onetile);
+                dfb_input_obj.pop_front(onetile);
 
                 // Phase 2 with masked input: Reduce final masked tile with accumulation
                 compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_masked_input, cb_scaler, cb_out>(
@@ -95,7 +95,7 @@ void kernel_main() {
     }
 
     if constexpr (do_mask_h) {
-        cb_mask_h_obj.pop_front(onetile);
+        dfb_mask_h_obj.pop_front(onetile);
     }
-    cb_scaler_obj.pop_front(onetile);
+    dfb_scaler_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
@@ -8,22 +8,22 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     const auto num_input_tiles = get_arg_val<uint32_t>(0);
     const auto num_output_tiles = get_arg_val<uint32_t>(1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_in1 = tt::CBIndex::c_1;
-    CircularBuffer cb_in1_obj(cb_in1);
+    DataflowBuffer dfb_in1_obj(cb_in1);
     constexpr auto cb_scalar = tt::CBIndex::c_2;
-    CircularBuffer cb_scalar_obj(cb_scalar);
+    DataflowBuffer dfb_scalar_obj(cb_scalar);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
@@ -31,8 +31,8 @@ void kernel_main() {
 
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
-    cb_in1_obj.wait_front(onetile);
-    cb_scalar_obj.wait_front(1);  // scalar tile from the reader
+    dfb_in1_obj.wait_front(onetile);
+    dfb_scalar_obj.wait_front(1);  // scalar tile from the reader
 
     for (uint32_t i = 0; i < num_output_tiles; i++) {
         bool enable_reload = false;
@@ -40,42 +40,42 @@ void kernel_main() {
             bool last_out = (j == num_input_tiles - 1);
 
             tile_regs_acquire();
-            cb_in0_obj.wait_front(onetile);
+            dfb_in0_obj.wait_front(onetile);
             if (enable_reload) {
-                cb_intermed0_obj.wait_front(onetile);
+                dfb_intermed0_obj.wait_front(onetile);
             }
 
             uint32_t cb_add = (enable_reload) ? (cb_intermed0) : (cb_in1);
-            add_tiles_init_with_dt(cb_in0_obj, CircularBuffer(cb_add));
+            add_tiles_init_with_dt(dfb_in0_obj, DataflowBuffer(cb_add));
             add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
 
-            cb_in0_obj.pop_front(onetile);
+            dfb_in0_obj.pop_front(onetile);
             if (enable_reload) {
-                cb_intermed0_obj.pop_front(onetile);
+                dfb_intermed0_obj.pop_front(onetile);
             }
             tile_regs_commit();
 
-            cb_intermed0_obj.reserve_back(onetile);
+            dfb_intermed0_obj.reserve_back(onetile);
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_intermed0_obj);
+            pack_tile_with_dt(dst0, dfb_intermed0_obj);
             tile_regs_release();
-            cb_intermed0_obj.push_back(onetile);
+            dfb_intermed0_obj.push_back(onetile);
 
             enable_reload = true;
         }
 
         // output * (1 / number_of_elements)
         tile_regs_acquire();
-        cb_intermed0_obj.wait_front(onetile);
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_intermed0_obj, cb_scalar_obj);
+        dfb_intermed0_obj.wait_front(onetile);
+        mul_tiles_bcast_scalar_init_short_with_dt(dfb_intermed0_obj, dfb_scalar_obj);
         mul_tiles_bcast<BroadcastType::SCALAR>(cb_intermed0, cb_scalar, 0, 0, 0);
         tile_regs_commit();
 
-        cb_out0_obj.reserve_back(onetile);
+        dfb_out0_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_out0_obj);
+        pack_tile_with_dt(dst0, dfb_out0_obj);
         tile_regs_release();
-        cb_out0_obj.push_back(onetile);
-        cb_intermed0_obj.pop_front(onetile);
+        dfb_out0_obj.push_back(onetile);
+        dfb_intermed0_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
@@ -10,7 +10,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -20,27 +20,27 @@ void kernel_main() {
 
     auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_scaler = tt::CBIndex::c_2;
-    CircularBuffer cb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
     constexpr auto cb_mask_w = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);
     constexpr auto cb_accum_dst = tt::CBIndex::c_24;
-    CircularBuffer cb_accum_dst_obj(cb_accum_dst);
+    DataflowBuffer dfb_accum_dst_obj(cb_accum_dst);
     constexpr auto cb_masked_input = tt::CBIndex::c_25;
-    CircularBuffer cb_masked_input_obj(cb_masked_input);
+    DataflowBuffer dfb_masked_input_obj(cb_masked_input);
     constexpr auto cb_out = tt::CBIndex::c_16;
-    CircularBuffer cb_out_obj(cb_out);
+    DataflowBuffer dfb_out_obj(cb_out);
     constexpr bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
 
     binary_op_init_common(cb_input, cb_input, cb_out);
 
-    cb_scaler_obj.wait_front(1);  // scaler tile from the reader
+    dfb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
     int reduce_dst_idx = 0;
     const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);
+        dfb_mask_w_obj.wait_front(onetile);
     }
 
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -54,53 +54,53 @@ void kernel_main() {
                 tile_regs_acquire();
 
                 for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
-                    CircularBuffer(cb_input).wait_front(onetile);
+                    DataflowBuffer(cb_input).wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
                     reconfig_data_format(cb_input, cb_scaler);
 #endif
                     matmul_init(cb_input, cb_scaler, false);
                     matmul_tiles(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-                    CircularBuffer(cb_input).pop_front(onetile);
+                    DataflowBuffer(cb_input).pop_front(onetile);
                 }
                 tile_regs_commit();
 
-                cb_accum_dst_obj.reserve_back(onetile);
+                dfb_accum_dst_obj.reserve_back(onetile);
                 tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, cb_accum_dst_obj);
+                pack_tile_with_dt(reduce_dst_idx, dfb_accum_dst_obj);
                 tile_regs_release();
-                cb_accum_dst_obj.push_back(onetile);
+                dfb_accum_dst_obj.push_back(onetile);
             }
 
             if (do_mask_w) {
                 tile_regs_acquire();
-                CircularBuffer(cb_input).wait_front(onetile);
+                DataflowBuffer(cb_input).wait_front(onetile);
 
-                copy_tile_init_with_dt(CircularBuffer(cb_input));
+                copy_tile_init_with_dt(DataflowBuffer(cb_input));
                 copy_tile(cb_input, 0, reduce_dst_idx);
 
-                copy_tile_init_with_dt(cb_mask_w_obj);
+                copy_tile_init_with_dt(dfb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, mask_dst_idx);
 
                 mask_tile_init();
                 mask_tile(reduce_dst_idx, mask_dst_idx);
                 tile_regs_commit();
 
-                cb_masked_input_obj.reserve_back(onetile);
+                dfb_masked_input_obj.reserve_back(onetile);
                 tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, cb_masked_input_obj);
+                pack_tile_with_dt(reduce_dst_idx, dfb_masked_input_obj);
                 tile_regs_release();
-                cb_masked_input_obj.push_back(onetile);
+                dfb_masked_input_obj.push_back(onetile);
 
-                CircularBuffer(cb_input).pop_front(onetile);
+                DataflowBuffer(cb_input).pop_front(onetile);
                 cb_input = cb_masked_input;
             }
 
             tile_regs_acquire();
-            CircularBuffer(cb_input).wait_front(onetile);
+            DataflowBuffer(cb_input).wait_front(onetile);
             if (!is_w_single_tile) {
-                cb_accum_dst_obj.wait_front(onetile);
+                dfb_accum_dst_obj.wait_front(onetile);
 
-                copy_tile_init_with_dt(cb_accum_dst_obj);
+                copy_tile_init_with_dt(dfb_accum_dst_obj);
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
 
@@ -111,21 +111,21 @@ void kernel_main() {
             matmul_tiles(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
             tile_regs_commit();
 
-            cb_out_obj.reserve_back(onetile);
+            dfb_out_obj.reserve_back(onetile);
             tile_regs_wait();
-            pack_tile_with_dt(reduce_dst_idx, cb_out_obj);
+            pack_tile_with_dt(reduce_dst_idx, dfb_out_obj);
             tile_regs_release();
-            cb_out_obj.push_back(onetile);
+            dfb_out_obj.push_back(onetile);
 
-            CircularBuffer(cb_input).pop_front(onetile);
+            DataflowBuffer(cb_input).pop_front(onetile);
             if (!is_w_single_tile) {
-                cb_accum_dst_obj.pop_front(onetile);
+                dfb_accum_dst_obj.pop_front(onetile);
             }
         }
     }
 
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
-    cb_scaler_obj.pop_front(onetile);
+    dfb_scaler_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -39,14 +39,14 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_mask_h = tt::CBIndex::c_3;
 #ifdef DO_MASK_H
-    CircularBuffer cb_mask_h(cb_id_mask_h);
-    generate_mask_h(cb_mask_h, mask_h);
+    DataflowBuffer dfb_mask_h(cb_id_mask_h);
+    generate_mask_h(dfb_mask_h, mask_h);
 #endif
 
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer dfb_in0(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     uint32_t w = curr_col_in_batch;
@@ -54,10 +54,10 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_cols; i++) {
         uint32_t curr_id = col_start_tile_id;
         for (uint32_t j = 0; j < Ht; j++) {
-            cb_in0.reserve_back(onetile);
-            noc.async_read(s, cb_in0, in0_tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
+            dfb_in0.reserve_back(onetile);
+            noc.async_read(s, dfb_in0, in0_tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in0.push_back(onetile);
+            dfb_in0.push_back(onetile);
             curr_id += Wt;  // stride in H
         }
         w++;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
@@ -5,7 +5,7 @@
 #include "api/debug/dprint.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -28,18 +28,18 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 0.0f;
-    CircularBuffer cb_in1(cb_id_in1);
-    fill_cb_with_value(cb_in1, scaler.u);
+    DataflowBuffer dfb_in1(cb_id_in1);
+    fill_cb_with_value(dfb_in1, scaler.u);
 
     scaler.f = 1.0f / num_input_tiles;
-    CircularBuffer cb_in2(cb_id_in2);
-    fill_cb_with_value(cb_in2, scaler.u, 1);
+    DataflowBuffer dfb_in2(cb_id_in2);
+    fill_cb_with_value(dfb_in2, scaler.u, 1);
 
     constexpr auto input_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(input_args, input_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer dfb_in0(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
@@ -49,10 +49,10 @@ void kernel_main() {
 
         auto read_tile_id = outer_id + inner_id + hw_tile_id;
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
-            cb_in0.reserve_back(onetile);
-            noc.async_read(s, cb_in0, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+            dfb_in0.reserve_back(onetile);
+            noc.async_read(s, dfb_in0, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in0.push_back(onetile);
+            dfb_in0.push_back(onetile);
             read_tile_id += input_tile_stride;
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/generate_mm_scaler.hpp"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -17,13 +17,13 @@ void kernel_main() {
     constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
 
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_2;
-    CircularBuffer cb_in2(cb_id_in2);
-    generate_mm_scaler(cb_in2, scaler);
+    DataflowBuffer dfb_in2(cb_id_in2);
+    generate_mm_scaler(dfb_in2, scaler);
 
     constexpr uint32_t cb_id_mask_w = tt::CBIndex::c_3;
 #ifdef DO_MASK_W
-    CircularBuffer cb_mask_w(cb_id_mask_w);
-    generate_mask_w(cb_mask_w, mask_w);
+    DataflowBuffer dfb_mask_w(cb_id_mask_w);
+    generate_mask_w(dfb_mask_w, mask_w);
 #endif
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
@@ -34,13 +34,13 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer dfb_in0(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
-        cb_in0.reserve_back(onetile);
-        noc.async_read(s, cb_in0, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_in0.reserve_back(onetile);
+        noc.async_read(s, dfb_in0, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0.push_back(onetile);
+        dfb_in0.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,15 +21,15 @@ void kernel_main() {
     const auto s = TensorAccessor(output_args, output_addr);
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         uint32_t write_tile_id = i;
-        cb_out.wait_front(onetile);
+        dfb_out.wait_front(onetile);
 
-        noc.async_write(cb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
+        noc.async_write(dfb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -20,14 +20,14 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out.wait_front(onetile);
-        noc.async_write(cb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out.wait_front(onetile);
+        noc.async_write(dfb_out, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
@@ -8,7 +8,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     // compile-time args
@@ -17,62 +17,62 @@ void kernel_main() {
     constexpr bool ht_need_bcast = (get_compile_time_arg_val(2) == 1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);  // input
+    DataflowBuffer dfb_in0_obj(cb_in0);  // input
     constexpr auto cb_in1 = tt::CBIndex::c_1;
-    CircularBuffer cb_in1_obj(cb_in1);  // zero tile
+    DataflowBuffer dfb_in1_obj(cb_in1);  // zero tile
     constexpr auto cb_scalar = tt::CBIndex::c_2;
-    CircularBuffer cb_scalar_obj(cb_scalar);
+    DataflowBuffer dfb_scalar_obj(cb_scalar);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
-    cb_in1_obj.wait_front(onetile);
+    dfb_in1_obj.wait_front(onetile);
     for (uint32_t i = 0; i < num_output_tiles; i++) {
         tile_regs_acquire();
-        cb_in0_obj.wait_front(onetile);
+        dfb_in0_obj.wait_front(onetile);
         if (ht_need_bcast && wt_need_bcast) {
-            add_bcast_scalar_init_short_with_dt(cb_in1_obj, cb_in0_obj);
+            add_bcast_scalar_init_short_with_dt(dfb_in1_obj, dfb_in0_obj);
             add_tiles_bcast_scalar(cb_in1, cb_in0, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            add_bcast_rows_init_short_with_dt(cb_in1_obj, cb_in0_obj);
+            add_bcast_rows_init_short_with_dt(dfb_in1_obj, dfb_in0_obj);
             add_tiles_bcast_rows(cb_in1, cb_in0, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            add_bcast_cols_init_short_with_dt(cb_in1_obj, cb_in0_obj);
+            add_bcast_cols_init_short_with_dt(dfb_in1_obj, dfb_in0_obj);
             add_tiles_bcast_cols(cb_in1, cb_in0, 0, 0, dst0);
         } else {
-            copy_tile_init_with_dt(cb_in0_obj);
+            copy_tile_init_with_dt(dfb_in0_obj);
             copy_tile(cb_in0, 0, dst0);
         }
         tile_regs_commit();
 
-        cb_intermed0_obj.reserve_back(onetile);
+        dfb_intermed0_obj.reserve_back(onetile);
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_intermed0_obj);
+        pack_tile_with_dt(dst0, dfb_intermed0_obj);
         tile_regs_release();
 
-        cb_intermed0_obj.push_back(onetile);
-        cb_in0_obj.pop_front(onetile);
+        dfb_intermed0_obj.push_back(onetile);
+        dfb_in0_obj.pop_front(onetile);
 
         // output * (1 / number_of_elements)
         tile_regs_acquire();
-        cb_intermed0_obj.wait_front(onetile);
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_intermed0_obj, cb_scalar_obj);
+        dfb_intermed0_obj.wait_front(onetile);
+        mul_tiles_bcast_scalar_init_short_with_dt(dfb_intermed0_obj, dfb_scalar_obj);
         mul_tiles_bcast<BroadcastType::SCALAR>(cb_intermed0, cb_scalar, 0, 0, 0);
         tile_regs_commit();
 
-        cb_out0_obj.reserve_back(onetile);
+        dfb_out0_obj.reserve_back(onetile);
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_out0_obj);
+        pack_tile_with_dt(dst0, dfb_out0_obj);
         tile_regs_release();
 
-        cb_out0_obj.push_back(onetile);
-        cb_intermed0_obj.pop_front(onetile);
+        dfb_out0_obj.push_back(onetile);
+        dfb_intermed0_obj.pop_front(onetile);
     }
-    cb_in1_obj.pop_front(onetile);
+    dfb_in1_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/reader_moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/reader_moreh_mean_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 static constexpr int32_t MAX_NUM_DIMENSIONS = 8;
@@ -82,26 +82,26 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 0.0f;
-    CircularBuffer cb_in1(cb_id_in1);
-    fill_cb_with_value(cb_in1, scaler.u);
+    DataflowBuffer dfb_in1(cb_id_in1);
+    fill_cb_with_value(dfb_in1, scaler.u);
 
     scaler.f = 1.0f / num_dim;
-    CircularBuffer cb_in2(cb_id_in2);
-    fill_cb_with_value(cb_in2, scaler.u, 1);
+    DataflowBuffer dfb_in2(cb_id_in2);
+    fill_cb_with_value(dfb_in2, scaler.u, 1);
 
     const auto output_grad_addrg = TensorAccessor(output_grad_args, output_grad_addr);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer dfb_in0(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
         auto read_tile_id = get_output_grad_tile(
             i, input_grad_rank, output_grad_dim, output_grad_stride, input_grad_dim, input_grad_stride, need_bcast_dim);
 
-        cb_in0.reserve_back(onetile);
-        noc.async_read(output_grad_addrg, cb_in0, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+        dfb_in0.reserve_back(onetile);
+        noc.async_read(output_grad_addrg, dfb_in0, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0.push_back(onetile);
+        dfb_in0.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/writer_moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/writer_moreh_mean_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,15 +21,15 @@ void kernel_main() {
     const auto input_grad_addrg = TensorAccessor(input_grad_args, input_grad_addr);
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer dfb_out(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         uint32_t write_tile_id = i;
-        cb_out.wait_front(onetile);
+        dfb_out.wait_front(onetile);
 
-        noc.async_write(cb_out, input_grad_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
+        noc.async_write(dfb_out, input_grad_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -46,31 +46,31 @@ void kernel_main() {
     const auto u16_one = uint16_t(one.u >> 16);
     const auto u16_zero = uint16_t(zero.u >> 16);
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_output_obj(cb_output);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_output_obj(cb_output);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
 #endif
 
 #if defined(WEIGHT)
     // weight: (1, C)
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
-    cb_weight_obj.wait_front(weight_num_tile);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(weight_num_tile);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
     uint32_t end_id = start_id + num_units_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
         uint32_t target_noc_id = i;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
-        cb_output_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_output_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile uint16_t> output_l1_ptr(cb_output_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> output_l1_ptr(dfb_output_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -92,8 +92,8 @@ void kernel_main() {
                 }
             }
         }
-        cb_output_obj.push_back(onetile);
+        dfb_output_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1_large.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -48,22 +48,22 @@ void kernel_main() {
     const auto u16_one = uint16_t(one.u >> 16);
     const auto u16_zero = uint16_t(zero.u >> 16);
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_output_obj(cb_output);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_output_obj(cb_output);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
 #endif
 
     uint32_t end_id = start_id + num_units_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
         uint32_t target_noc_id = i;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
-        cb_output_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_output_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile uint16_t> output_l1_ptr(cb_output_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> output_l1_ptr(dfb_output_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -76,14 +76,14 @@ void kernel_main() {
 
                         uint32_t noc_id = target_idx / TILE_WIDTH;
                         uint32_t weight_tilized_idx = get_tilized_idx(0, target_idx);
-                        read_value(cb_weight_obj, addrg_weight, noc_id, weight_tilized_idx);
+                        read_value(dfb_weight_obj, addrg_weight, noc_id, weight_tilized_idx);
 
-                        cb_weight_obj.wait_front(onetile);
-                        CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+                        dfb_weight_obj.wait_front(onetile);
+                        CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 
                         output_l1_ptr[inout_idx] = weight_l1_ptr[weight_tilized_idx];
 
-                        cb_weight_obj.pop_front(onetile);
+                        dfb_weight_obj.pop_front(onetile);
 #else
                         output_l1_ptr[inout_idx] = u16_one;
 #endif
@@ -95,8 +95,8 @@ void kernel_main() {
                 }
             }
         }
-        cb_output_obj.push_back(onetile);
+        dfb_output_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/writer_moreh_nll_loss_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/writer_moreh_nll_loss_step1.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,14 +21,14 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_out(cb_output);
     const auto out_tile_bytes = get_tile_size(cb_output);
 
     uint32_t end_id = start_id + num_units_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out.wait_front(onetile);
-        noc.async_write(cb_out, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out.wait_front(onetile);
+        noc.async_write(dfb_out, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
@@ -5,28 +5,28 @@
 #include <cstdint>
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
 
     constexpr uint32_t cb_weight = tt::CBIndex::c_2;
     constexpr uint32_t cb_divisor = tt::CBIndex::c_3;
-    CircularBuffer cb_divisor_obj(cb_divisor);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
 
     constexpr uint32_t cb_tmp_weight = tt::CBIndex::c_24;
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
     constexpr uint32_t cb_tmp_input = tt::CBIndex::c_25;
-    CircularBuffer cb_tmp_input_obj(cb_tmp_input);
+    DataflowBuffer dfb_tmp_input_obj(cb_tmp_input);
     constexpr uint32_t cb_tmp1 = tt::CBIndex::c_26;
-    CircularBuffer cb_tmp1_obj(cb_tmp1);
+    DataflowBuffer dfb_tmp1_obj(cb_tmp1);
     constexpr uint32_t cb_divisor_recip = tt::CBIndex::c_27;
-    CircularBuffer cb_divisor_recip_obj(cb_divisor_recip);  // 1/divisor
+    DataflowBuffer dfb_divisor_recip_obj(cb_divisor_recip);  // 1/divisor
     constexpr uint32_t cb_tmp3 = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp3_obj(cb_tmp3);
+    DataflowBuffer dfb_tmp3_obj(cb_tmp3);
 
     constexpr uint32_t cb_output = tt::CBIndex::c_16;
-    CircularBuffer cb_output_obj(cb_output);
+    DataflowBuffer dfb_output_obj(cb_output);
 
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t onetile = 1;
@@ -34,64 +34,64 @@ void kernel_main() {
     binary_op_init_common(cb_tmp_weight, cb_tmp_input, cb_output);
 
 #if defined(DIVISOR)
-    cb_divisor_obj.wait_front(onetile);
+    dfb_divisor_obj.wait_front(onetile);
 
     tile_regs_acquire();
-    copy_tile_init_with_dt(cb_divisor_obj);
+    copy_tile_init_with_dt(dfb_divisor_obj);
     copy_tile(cb_divisor, 0, dst0);
     recip_tile_init();
     recip_tile(dst0);
     tile_regs_commit();
 
-    cb_divisor_obj.pop_front(onetile);
-    cb_divisor_recip_obj.reserve_back(onetile);
+    dfb_divisor_obj.pop_front(onetile);
+    dfb_divisor_recip_obj.reserve_back(onetile);
     tile_regs_wait();
-    pack_tile_with_dt(dst0, cb_divisor_recip_obj);
+    pack_tile_with_dt(dst0, dfb_divisor_recip_obj);
     tile_regs_release();
-    cb_divisor_recip_obj.push_back(onetile);
+    dfb_divisor_recip_obj.push_back(onetile);
 #endif
 
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
-        cb_tmp_input_obj.wait_front(onetile);
+        dfb_tmp_input_obj.wait_front(onetile);
 
         tile_regs_acquire();
-        copy_tile_init_with_dt(cb_tmp_input_obj);
+        copy_tile_init_with_dt(dfb_tmp_input_obj);
         copy_tile(cb_tmp_input, 0, dst0);
 
         negative_tile_init();
         negative_tile(dst0);
         tile_regs_commit();
 
-        cb_tmp_input_obj.pop_front(onetile);
+        dfb_tmp_input_obj.pop_front(onetile);
 
 #if defined(WEIGHT)
-        cb_tmp1_obj.reserve_back(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
         tile_regs_release();
-        cb_tmp1_obj.push_back(onetile);
+        dfb_tmp1_obj.push_back(onetile);
 
         // multiply weight
-        cb_tmp1_obj.wait_front(onetile);
-        cb_tmp_weight_obj.wait_front(onetile);
+        dfb_tmp1_obj.wait_front(onetile);
+        dfb_tmp_weight_obj.wait_front(onetile);
 
         tile_regs_acquire();
-        mul_tiles_init_with_dt(cb_tmp1_obj, cb_tmp_weight_obj);
+        mul_tiles_init_with_dt(dfb_tmp1_obj, dfb_tmp_weight_obj);
         mul_tiles(cb_tmp1, cb_tmp_weight, 0, 0, dst0);
         tile_regs_commit();
 
-        cb_tmp_weight_obj.pop_front(onetile);
-        cb_tmp1_obj.pop_front(onetile);
+        dfb_tmp_weight_obj.pop_front(onetile);
+        dfb_tmp1_obj.pop_front(onetile);
 
 #if defined(DIVISOR)
-        cb_tmp3_obj.reserve_back(onetile);
+        dfb_tmp3_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp3_obj);
+        pack_tile_with_dt(dst0, dfb_tmp3_obj);
         tile_regs_release();
-        cb_tmp3_obj.push_back(onetile);
+        dfb_tmp3_obj.push_back(onetile);
 
-        cb_tmp3_obj.wait_front(onetile);
-        cb_divisor_recip_obj.wait_front(onetile);
+        dfb_tmp3_obj.wait_front(onetile);
+        dfb_divisor_recip_obj.wait_front(onetile);
         tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
         reconfig_data_format(cb_tmp3, cb_divisor_recip);
@@ -99,30 +99,30 @@ void kernel_main() {
         mul_tiles_bcast_scalar_init_short(cb_tmp3, cb_divisor_recip);
         mul_tiles_bcast_scalar(cb_tmp3, cb_divisor_recip, 0, 0, dst0);
         tile_regs_commit();
-        cb_tmp3_obj.pop_front(onetile);
+        dfb_tmp3_obj.pop_front(onetile);
 
-        cb_output_obj.reserve_back(onetile);
+        dfb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output_obj);
+        pack_tile_with_dt(dst0, dfb_output_obj);
         tile_regs_release();
-        cb_output_obj.push_back(onetile);
+        dfb_output_obj.push_back(onetile);
 #else
-        cb_output_obj.reserve_back(onetile);
+        dfb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output_obj);
+        pack_tile_with_dt(dst0, dfb_output_obj);
         tile_regs_release();
-        cb_output_obj.push_back(onetile);
+        dfb_output_obj.push_back(onetile);
 #endif
 #else
 #if defined(DIVISOR)
-        cb_tmp1_obj.reserve_back(onetile);
+        dfb_tmp1_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1_obj);
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
         tile_regs_release();
-        cb_tmp1_obj.push_back(onetile);
+        dfb_tmp1_obj.push_back(onetile);
 
-        cb_divisor_recip_obj.wait_front(onetile);
-        cb_tmp1_obj.wait_front(onetile);
+        dfb_divisor_recip_obj.wait_front(onetile);
+        dfb_tmp1_obj.wait_front(onetile);
 
         tile_regs_acquire();
 #if defined FP32_DEST_ACC_EN
@@ -132,24 +132,24 @@ void kernel_main() {
         mul_tiles_bcast_scalar(cb_tmp1, cb_divisor_recip, 0, 0, dst0);
         tile_regs_commit();
 
-        cb_tmp1_obj.pop_front(onetile);
+        dfb_tmp1_obj.pop_front(onetile);
 
-        cb_output_obj.reserve_back(onetile);
+        dfb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output_obj);
+        pack_tile_with_dt(dst0, dfb_output_obj);
         tile_regs_release();
-        cb_output_obj.push_back(onetile);
+        dfb_output_obj.push_back(onetile);
 #else
-        cb_output_obj.reserve_back(onetile);
+        dfb_output_obj.reserve_back(onetile);
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_output_obj);
+        pack_tile_with_dt(dst0, dfb_output_obj);
         tile_regs_release();
-        cb_output_obj.push_back(onetile);
+        dfb_output_obj.push_back(onetile);
 #endif
 #endif
     }
 
 #if defined(DIVISOR)
-    cb_divisor_recip_obj.pop_front(onetile);
+    dfb_divisor_recip_obj.pop_front(onetile);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_2d.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -53,18 +53,18 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    CircularBuffer cb_divisor_obj(cb_divisor);
-    read_tile(cb_divisor_obj, addrg_divisor, 0);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
+    read_tile(dfb_divisor_obj, addrg_divisor, 0);
 #endif
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
-    CircularBuffer cb_input_obj(cb_input);
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_tmp_input_obj(cb_tmp_input);
+    DataflowBuffer dfb_input_obj(cb_input);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_tmp_input_obj(cb_tmp_input);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
 #endif
 
     uint32_t end_id = start_id + num_tiles_per_core;
@@ -74,18 +74,18 @@ void kernel_main() {
         uint32_t nt = i;
 
         auto target_noc_id = nt;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
 #if defined(WEIGHT)
-        cb_tmp_weight_obj.reserve_back(onetile);
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(cb_tmp_weight_obj.get_write_ptr());
+        dfb_tmp_weight_obj.reserve_back(onetile);
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(dfb_tmp_weight_obj.get_write_ptr());
 #endif
 
-        cb_tmp_input_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_tmp_input_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_input_l1_ptr(cb_tmp_input_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_input_l1_ptr(dfb_tmp_input_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
         uint32_t w = 0;
         for (uint32_t n = n_start; n < n_end; n++, w++) {
@@ -95,13 +95,13 @@ void kernel_main() {
             if (target_val != ignore_index && (0 <= target_val && target_val < static_cast<int32_t>(C))) {
                 uint32_t noc_id = (nt * Ct) + (target_val / TILE_WIDTH);
                 uint32_t input_tilized_idx = get_tilized_idx(n, target_val);
-                read_value(cb_input_obj, addrg_input, noc_id, input_tilized_idx);
+                read_value(dfb_input_obj, addrg_input, noc_id, input_tilized_idx);
 
-                cb_input_obj.wait_front(onetile);
-                CoreLocalMem<volatile uint16_t> input_l1_ptr(cb_input_obj.get_read_ptr());
+                dfb_input_obj.wait_front(onetile);
+                CoreLocalMem<volatile uint16_t> input_l1_ptr(dfb_input_obj.get_read_ptr());
                 tmp_input_l1_ptr[tilized_idx] = fp32_dest_acc_cast(input_l1_ptr[input_tilized_idx]);
 
-                cb_input_obj.pop_front(onetile);
+                dfb_input_obj.pop_front(onetile);
             } else {
                 tmp_input_l1_ptr[tilized_idx] = fp32_dest_acc_cast(0.0f);
             }
@@ -109,18 +109,18 @@ void kernel_main() {
 #if defined(WEIGHT)
             uint32_t noc_id = target_val / TILE_WIDTH;
             uint32_t weight_tilized_idx = get_tilized_idx(0, target_val);
-            read_value(cb_weight_obj, addrg_weight, noc_id, weight_tilized_idx);
+            read_value(dfb_weight_obj, addrg_weight, noc_id, weight_tilized_idx);
 
-            cb_weight_obj.wait_front(onetile);
-            CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+            dfb_weight_obj.wait_front(onetile);
+            CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
             tmp_weight_l1_ptr[tilized_idx] = fp32_dest_acc_cast(weight_l1_ptr[weight_tilized_idx]);
-            cb_weight_obj.pop_front(onetile);
+            dfb_weight_obj.pop_front(onetile);
 #endif
         }
-        cb_tmp_input_obj.push_back(onetile);
+        dfb_tmp_input_obj.push_back(onetile);
 #if defined(WEIGHT)
-        cb_tmp_weight_obj.push_back(onetile);
+        dfb_tmp_weight_obj.push_back(onetile);
 #endif
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_3d.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -56,20 +56,20 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    CircularBuffer cb_divisor_obj(cb_divisor);
-    read_tile(cb_divisor_obj, addrg_divisor, 0);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
+    read_tile(dfb_divisor_obj, addrg_divisor, 0);
 #endif
 
     uint32_t Wf = (W + FACE_WIDTH - 1) / FACE_WIDTH;
     uint32_t Wt = (W + TILE_WIDTH - 1) / TILE_WIDTH;
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
-    CircularBuffer cb_input_obj(cb_input);
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_tmp_input_obj(cb_tmp_input);
+    DataflowBuffer dfb_input_obj(cb_input);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_tmp_input_obj(cb_tmp_input);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
 #endif
 
     uint32_t end_id = start_id + num_tiles_per_core;
@@ -83,22 +83,22 @@ void kernel_main() {
         uint32_t target_offset;
         get_noc_offset(n, w, target_element_size, target_offset);
         read_tile(
-            cb_target_obj,
+            dfb_target_obj,
             addrg_target,
             traget_noc_id,
             NOC_MINIMUM_READ_SIZE / element_size * target_element_size,
             target_offset);
 
 #if defined(WEIGHT)
-        cb_tmp_weight_obj.reserve_back(onetile);
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(cb_tmp_weight_obj.get_write_ptr());
+        dfb_tmp_weight_obj.reserve_back(onetile);
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(dfb_tmp_weight_obj.get_write_ptr());
 #endif
 
-        cb_tmp_input_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_tmp_input_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_input_l1_ptr(cb_tmp_input_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_input_l1_ptr(dfb_tmp_input_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
         uint32_t idx_max = std::min(w + FACE_WIDTH, W);
         for (uint32_t idx = 0; idx < idx_max; idx++) {
@@ -107,35 +107,35 @@ void kernel_main() {
             if (target_val != ignore_index && (0 <= target_val && target_val < static_cast<int32_t>(C))) {
                 uint32_t noc_id = (n * Ct * Wt) + (target_val / TILE_HEIGHT) * Wt + (w / TILE_WIDTH);
                 uint32_t tilized_idx = get_tilized_idx(target_val, w + idx);
-                read_value(cb_input_obj, addrg_input, noc_id, tilized_idx);
+                read_value(dfb_input_obj, addrg_input, noc_id, tilized_idx);
 
-                cb_input_obj.wait_front(onetile);
-                CoreLocalMem<volatile uint16_t> input_l1_ptr(cb_input_obj.get_read_ptr());
+                dfb_input_obj.wait_front(onetile);
+                CoreLocalMem<volatile uint16_t> input_l1_ptr(dfb_input_obj.get_read_ptr());
 
                 tmp_input_l1_ptr[idx] = fp32_dest_acc_cast(input_l1_ptr[tilized_idx]);
 
-                cb_input_obj.pop_front(onetile);
+                dfb_input_obj.pop_front(onetile);
 #if defined(WEIGHT)
                 {
                     uint32_t noc_id = target_val / TILE_WIDTH;
                     uint32_t tilized_idx = get_tilized_idx(0, target_val);
-                    read_value(cb_weight_obj, addrg_weight, noc_id, tilized_idx);
+                    read_value(dfb_weight_obj, addrg_weight, noc_id, tilized_idx);
 
-                    cb_weight_obj.wait_front(onetile);
-                    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+                    dfb_weight_obj.wait_front(onetile);
+                    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 
                     tmp_weight_l1_ptr[idx] = fp32_dest_acc_cast(weight_l1_ptr[tilized_idx]);
-                    cb_weight_obj.pop_front(onetile);
+                    dfb_weight_obj.pop_front(onetile);
                 }
 #endif
             } else {
                 tmp_input_l1_ptr[idx] = fp32_dest_acc_cast(0.0f);
             }
         }
-        cb_tmp_input_obj.push_back(onetile);
+        dfb_tmp_input_obj.push_back(onetile);
 #if defined(WEIGHT)
-        cb_tmp_weight_obj.push_back(onetile);
+        dfb_tmp_weight_obj.push_back(onetile);
 #endif
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_4d.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -57,37 +57,37 @@ void kernel_main() {
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    CircularBuffer cb_divisor_obj(cb_divisor);
-    read_tile(cb_divisor_obj, addrg_divisor, 0);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
+    read_tile(dfb_divisor_obj, addrg_divisor, 0);
 #endif
 
-    CircularBuffer cb_input_obj(cb_input);
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_tmp_input_obj(cb_tmp_input);
+    DataflowBuffer dfb_input_obj(cb_input);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_tmp_input_obj(cb_tmp_input);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
 
-    cb_weight_obj.reserve_back(weight_num_tile);
+    dfb_weight_obj.reserve_back(weight_num_tile);
 
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
-    cb_weight_obj.wait_front(weight_num_tile);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(weight_num_tile);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
         uint32_t target_noc_id = i;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
-        cb_target_obj.wait_front(onetile);
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        dfb_target_obj.wait_front(onetile);
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
 #if defined(WEIGHT)
-        cb_tmp_weight_obj.reserve_back(onetile);
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(cb_tmp_weight_obj.get_write_ptr());
+        dfb_tmp_weight_obj.reserve_back(onetile);
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(dfb_tmp_weight_obj.get_write_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -102,11 +102,11 @@ void kernel_main() {
                 tmp_weight_l1_ptr[tilized_idx] = fp32_dest_acc_cast(0.0f);
             }
         }
-        cb_tmp_weight_obj.push_back(onetile);
+        dfb_tmp_weight_obj.push_back(onetile);
 #endif
 
-        cb_tmp_input_obj.reserve_back(onetile);
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_input_l1_ptr(cb_tmp_input_obj.get_write_ptr());
+        dfb_tmp_input_obj.reserve_back(onetile);
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_input_l1_ptr(dfb_tmp_input_obj.get_write_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -120,14 +120,14 @@ void kernel_main() {
 
                         uint32_t noc_id = (n * C * num_inner_tile) + target_val * num_inner_tile + inner;
                         uint32_t tilized_idx = get_tilized_idx(h, w);
-                        read_value(cb_input_obj, addrg_input, noc_id, tilized_idx);
+                        read_value(dfb_input_obj, addrg_input, noc_id, tilized_idx);
 
-                        cb_input_obj.wait_front(onetile);
-                        CoreLocalMem<volatile uint16_t> input_l1_ptr(cb_input_obj.get_read_ptr());
+                        dfb_input_obj.wait_front(onetile);
+                        CoreLocalMem<volatile uint16_t> input_l1_ptr(dfb_input_obj.get_read_ptr());
 
                         tmp_input_l1_ptr[tilized_idx] = fp32_dest_acc_cast(input_l1_ptr[tilized_idx]);
 
-                        cb_input_obj.pop_front(onetile);
+                        dfb_input_obj.pop_front(onetile);
                         continue;
                     }
                 }
@@ -136,10 +136,10 @@ void kernel_main() {
             }
         }
 
-        cb_tmp_input_obj.push_back(onetile);
-        cb_target_obj.pop_front(onetile);
+        dfb_tmp_input_obj.push_back(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 #if defined(WEIGHT)
-    cb_weight_obj.pop_front(weight_num_tile);
+    dfb_weight_obj.pop_front(weight_num_tile);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/writer_moreh_nll_loss_step2_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/writer_moreh_nll_loss_step2_2d.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,14 +21,14 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_out(cb_output);
     const auto out_tile_bytes = get_tile_size(cb_output);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out.wait_front(onetile);
-        noc.async_write(cb_out, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out.wait_front(onetile);
+        noc.async_write(dfb_out, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/writer_moreh_nll_loss_step2_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/writer_moreh_nll_loss_step2_3d.cpp
@@ -5,7 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -29,11 +29,11 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_out(cb_output);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out.wait_front(onetile);
+        dfb_out.wait_front(onetile);
         uint32_t n = i / Wf;
         uint32_t w = (i % Wf) * FACE_WIDTH;
         uint32_t nt = n / TILE_HEIGHT;
@@ -44,13 +44,13 @@ void kernel_main() {
         get_noc_offset(n, w, element_size, noc_offset);
 
         noc.async_write(
-            cb_out,
+            dfb_out,
             output_addrg,
             NOC_MINIMUM_READ_SIZE,
             {.offset_bytes = 0},
             {.page_id = noc_id, .offset_bytes = noc_offset});
         noc.async_write_barrier();
 
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/writer_moreh_nll_loss_step2_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/writer_moreh_nll_loss_step2_4d.cpp
@@ -5,7 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,14 +23,14 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_out(cb_output);
+    DataflowBuffer dfb_out(cb_output);
     const auto out_tile_bytes = get_tile_size(cb_output);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out.wait_front(onetile);
-        noc.async_write(cb_out, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out.wait_front(onetile);
+        noc.async_write(dfb_out, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out.pop_front(onetile);
+        dfb_out.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/moreh_nll_loss_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/moreh_nll_loss_backward_kernel.cpp
@@ -6,7 +6,7 @@
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
@@ -14,17 +14,17 @@ void kernel_main() {
     const uint32_t tile_offset = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t cb_divisor = tt::CBIndex::c_3;
-    CircularBuffer cb_divisor_obj(cb_divisor);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
     constexpr uint32_t cb_output_grad = tt::CBIndex::c_0;
-    CircularBuffer cb_output_grad_obj(cb_output_grad);
+    DataflowBuffer dfb_output_grad_obj(cb_output_grad);
     constexpr uint32_t cb_tmp_weight = tt::CBIndex::c_24;
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
     constexpr uint32_t cb_tmp1 = tt::CBIndex::c_25;
-    CircularBuffer cb_tmp1_obj(cb_tmp1);
+    DataflowBuffer dfb_tmp1_obj(cb_tmp1);
     constexpr uint32_t cb_tmp2 = tt::CBIndex::c_26;
-    CircularBuffer cb_tmp2_obj(cb_tmp2);
+    DataflowBuffer dfb_tmp2_obj(cb_tmp2);
     constexpr uint32_t cb_input_grad = tt::CBIndex::c_16;
-    CircularBuffer cb_input_grad_obj(cb_input_grad);
+    DataflowBuffer dfb_input_grad_obj(cb_input_grad);
 
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t onetile = 1;
@@ -32,67 +32,67 @@ void kernel_main() {
     init_sfpu(cb_output_grad, tt::CBIndex::c_16);
 
 #if defined(DIVISOR)
-    cb_divisor_obj.wait_front(onetile);
-    cb_tmp1_obj.reserve_back(onetile);
+    dfb_divisor_obj.wait_front(onetile);
+    dfb_tmp1_obj.reserve_back(onetile);
 
     tile_regs_acquire();
-    copy_tile_init_with_dt(cb_divisor_obj);
+    copy_tile_init_with_dt(dfb_divisor_obj);
     copy_tile(cb_divisor, 0, dst0);
     recip_tile_init();
     recip_tile(dst0);
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_tile_with_dt(dst0, cb_tmp1_obj);
+    pack_tile_with_dt(dst0, dfb_tmp1_obj);
     tile_regs_release();
 
-    cb_tmp1_obj.push_back(onetile);
+    dfb_tmp1_obj.push_back(onetile);
 #endif
 
-    cb_output_grad_obj.wait_front(onetile);
+    dfb_output_grad_obj.wait_front(onetile);
 
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
 #if defined(DIVISOR)
-        cb_tmp_weight_obj.wait_front(onetile);
-        cb_tmp2_obj.reserve_back(onetile);
+        dfb_tmp_weight_obj.wait_front(onetile);
+        dfb_tmp2_obj.reserve_back(onetile);
 
         tile_regs_acquire();
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp_weight_obj, cb_output_grad_obj);
+        mul_tiles_bcast_scalar_init_short_with_dt(dfb_tmp_weight_obj, dfb_output_grad_obj);
         mul_tiles_bcast_scalar(cb_tmp_weight, cb_output_grad, 0, 0, dst0);
         negative_tile_init();
         negative_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp2_obj);
+        pack_tile_with_dt(dst0, dfb_tmp2_obj);
         tile_regs_release();
 
-        cb_tmp2_obj.push_back(onetile);
-        cb_tmp_weight_obj.pop_front(onetile);
+        dfb_tmp2_obj.push_back(onetile);
+        dfb_tmp_weight_obj.pop_front(onetile);
 
-        cb_input_grad_obj.reserve_back(onetile);
-        cb_tmp2_obj.wait_front(onetile);
-        cb_tmp1_obj.wait_front(onetile);
+        dfb_input_grad_obj.reserve_back(onetile);
+        dfb_tmp2_obj.wait_front(onetile);
+        dfb_tmp1_obj.wait_front(onetile);
 
         tile_regs_acquire();
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp2_obj, cb_tmp1_obj);
+        mul_tiles_bcast_scalar_init_short_with_dt(dfb_tmp2_obj, dfb_tmp1_obj);
         mul_tiles_bcast_scalar(cb_tmp2, cb_tmp1, 0, 0, dst0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_input_grad_obj);
+        pack_tile_with_dt(dst0, dfb_input_grad_obj);
         tile_regs_release();
 
-        cb_input_grad_obj.push_back(onetile);
-        cb_tmp2_obj.pop_front(onetile);
+        dfb_input_grad_obj.push_back(onetile);
+        dfb_tmp2_obj.pop_front(onetile);
 
 #else
-        cb_tmp_weight_obj.wait_front(onetile);
+        dfb_tmp_weight_obj.wait_front(onetile);
 
-        cb_input_grad_obj.reserve_back(onetile);
+        dfb_input_grad_obj.reserve_back(onetile);
 
         tile_regs_acquire();
-        mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp_weight_obj, cb_output_grad_obj);
+        mul_tiles_bcast_scalar_init_short_with_dt(dfb_tmp_weight_obj, dfb_output_grad_obj);
         mul_tiles_bcast_scalar(cb_tmp_weight, cb_output_grad, 0, 0, dst0);
         negative_tile_init();
         negative_tile(dst0);
@@ -100,16 +100,16 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_input_grad_obj);
+        pack_tile_with_dt(dst0, dfb_input_grad_obj);
         tile_regs_release();
 
-        cb_input_grad_obj.push_back(onetile);
+        dfb_input_grad_obj.push_back(onetile);
 
-        cb_tmp_weight_obj.pop_front(onetile);
+        dfb_tmp_weight_obj.pop_front(onetile);
 #endif
     }
 
 #if defined(DIVISOR)
-    cb_divisor_obj.pop_front(onetile);
+    dfb_divisor_obj.pop_front(onetile);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_2d.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -46,28 +46,28 @@ void kernel_main() {
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
-    cb_weight_obj.wait_front(weight_num_tile);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(weight_num_tile);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    CircularBuffer cb_divisor_obj(cb_divisor);
-    read_tile(cb_divisor_obj, addrg_divisor, 0);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
+    read_tile(dfb_divisor_obj, addrg_divisor, 0);
 #endif
 
-    CircularBuffer cb_output_grad_obj(cb_output_grad);
-    read_tile(cb_output_grad_obj, addrg_output_grad, 0);
+    DataflowBuffer dfb_output_grad_obj(cb_output_grad);
+    read_tile(dfb_output_grad_obj, addrg_output_grad, 0);
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
@@ -77,13 +77,13 @@ void kernel_main() {
         uint32_t ct = i % Ct;
 
         uint32_t target_noc_id = nt;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
-        cb_tmp_weight_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_tmp_weight_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(cb_tmp_weight_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(dfb_tmp_weight_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -107,8 +107,8 @@ void kernel_main() {
             }
         }
 
-        cb_tmp_weight_obj.push_back(onetile);
+        dfb_tmp_weight_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_3d.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -47,28 +47,28 @@ void kernel_main() {
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
-    cb_weight_obj.wait_front(weight_num_tile);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(weight_num_tile);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    CircularBuffer cb_divisor_obj(cb_divisor);
-    read_tile(cb_divisor_obj, addrg_divisor, 0);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
+    read_tile(dfb_divisor_obj, addrg_divisor, 0);
 #endif
 
-    CircularBuffer cb_output_grad_obj(cb_output_grad);
-    read_tile(cb_output_grad_obj, addrg_output_grad, 0);
+    DataflowBuffer dfb_output_grad_obj(cb_output_grad);
+    read_tile(dfb_output_grad_obj, addrg_output_grad, 0);
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
@@ -83,13 +83,13 @@ void kernel_main() {
         uint32_t Wt = num_inner_tile;
         uint32_t nt = n / TILE_HEIGHT;
         uint32_t target_noc_id = nt * Wt + wt;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
-        cb_tmp_weight_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_tmp_weight_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(cb_tmp_weight_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(dfb_tmp_weight_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -111,8 +111,8 @@ void kernel_main() {
             }
         }
 
-        cb_tmp_weight_obj.push_back(onetile);
+        dfb_tmp_weight_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/reader_moreh_nll_loss_backward_4d.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -47,28 +47,28 @@ void kernel_main() {
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_tmp_weight_obj(cb_tmp_weight);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_tmp_weight_obj(cb_tmp_weight);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, weight_num_tile);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, weight_num_tile);
 
-    cb_weight_obj.wait_front(weight_num_tile);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(weight_num_tile);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
 #if defined(DIVISOR)
     const auto addrg_divisor = TensorAccessor(divisor_args, divisor_addr);
 
-    CircularBuffer cb_divisor_obj(cb_divisor);
-    read_tile(cb_divisor_obj, addrg_divisor, 0);
+    DataflowBuffer dfb_divisor_obj(cb_divisor);
+    read_tile(dfb_divisor_obj, addrg_divisor, 0);
 #endif
 
-    CircularBuffer cb_output_grad_obj(cb_output_grad);
-    read_tile(cb_output_grad_obj, addrg_output_grad, 0);
+    DataflowBuffer dfb_output_grad_obj(cb_output_grad);
+    read_tile(dfb_output_grad_obj, addrg_output_grad, 0);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -78,13 +78,13 @@ void kernel_main() {
         uint32_t c = nc % C;
 
         uint32_t target_noc_id = n * num_inner_tile + inner;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
-        cb_tmp_weight_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_tmp_weight_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(cb_tmp_weight_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile FP32_DEST_ACC_FTYPE> tmp_weight_l1_ptr(dfb_tmp_weight_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -106,8 +106,8 @@ void kernel_main() {
             }
         }
 
-        cb_tmp_weight_obj.push_back(onetile);
+        dfb_tmp_weight_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/writer_moreh_nll_loss_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/writer_moreh_nll_loss_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -22,15 +22,15 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_input_grad_obj(cb_input_grad);
+    DataflowBuffer dfb_input_grad_obj(cb_input_grad);
     const auto input_grad_tile_bytes = get_tile_size(cb_input_grad);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_input_grad_obj.wait_front(onetile);
+        dfb_input_grad_obj.wait_front(onetile);
         noc.async_write(
-            cb_input_grad_obj, input_grad_addrg, input_grad_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+            dfb_input_grad_obj, input_grad_addrg, input_grad_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_input_grad_obj.pop_front(onetile);
+        dfb_input_grad_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_2d.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -42,26 +42,26 @@ void kernel_main() {
     const auto addrg_target = TensorAccessor(target_args, target_addr);
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_output_grad_obj(cb_output_grad);
-    CircularBuffer cb_input_grad_obj(cb_input_grad);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_output_grad_obj(cb_output_grad);
+    DataflowBuffer dfb_input_grad_obj(cb_input_grad);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, Ct);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, Ct);
 
-    cb_weight_obj.wait_front(Ct);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(Ct);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
 
-    CircularBuffer cb_output_grad_scratch_obj(cb_output_grad_scratch);
-    read_line(cb_output_grad_obj, cb_output_grad_scratch_obj, addrg_output_grad, Nt);
+    DataflowBuffer dfb_output_grad_scratch_obj(cb_output_grad_scratch);
+    read_line(dfb_output_grad_obj, dfb_output_grad_scratch_obj, addrg_output_grad, Nt);
 
-    cb_output_grad_obj.wait_front(Nt);
+    dfb_output_grad_obj.wait_front(Nt);
 
     auto zero = fp32_to_bf16_truncate(0.0f);
 
@@ -71,14 +71,14 @@ void kernel_main() {
         uint32_t ct = i % Ct;
 
         auto target_noc_id = nt;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
-        cb_input_grad_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
+        dfb_input_grad_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile uint16_t> input_grad_l1_ptr(cb_input_grad_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
-        CoreLocalMem<volatile uint16_t> output_grad_l1_ptr(cb_output_grad_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> input_grad_l1_ptr(dfb_input_grad_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> output_grad_l1_ptr(dfb_output_grad_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -108,8 +108,8 @@ void kernel_main() {
             }
         }
 
-        cb_input_grad_obj.push_back(onetile);
+        dfb_input_grad_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_3d.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -41,18 +41,18 @@ void kernel_main() {
     const auto addrg_target = TensorAccessor(target_args, target_addr);
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_output_grad_obj(cb_output_grad);
-    CircularBuffer cb_input_grad_obj(cb_input_grad);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_output_grad_obj(cb_output_grad);
+    DataflowBuffer dfb_input_grad_obj(cb_input_grad);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, Ct);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, Ct);
 
-    cb_weight_obj.wait_front(Ct);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(Ct);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
@@ -68,18 +68,18 @@ void kernel_main() {
         uint32_t ct = nct % Ct;
 
         auto target_noc_id = nt * Wt + wt;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
         auto output_grad_noc_id = nt * Wt + wt;
-        read_tile(cb_output_grad_obj, addrg_output_grad, output_grad_noc_id);
+        read_tile(dfb_output_grad_obj, addrg_output_grad, output_grad_noc_id);
 
-        cb_input_grad_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
-        cb_output_grad_obj.wait_front(onetile);
+        dfb_input_grad_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
+        dfb_output_grad_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile uint16_t> input_grad_l1_ptr(cb_input_grad_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
-        CoreLocalMem<volatile uint16_t> output_grad_l1_ptr(cb_output_grad_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> input_grad_l1_ptr(dfb_input_grad_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> output_grad_l1_ptr(dfb_output_grad_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -108,10 +108,10 @@ void kernel_main() {
             }
         }
 
-        cb_input_grad_obj.push_back(onetile);
+        dfb_input_grad_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
 
-        cb_output_grad_obj.pop_front(onetile);
+        dfb_output_grad_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_4d.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
@@ -42,18 +42,18 @@ void kernel_main() {
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
     constexpr uint32_t onetile = 1;
 
-    CircularBuffer cb_target_obj(cb_target);
-    CircularBuffer cb_output_grad_obj(cb_output_grad);
-    CircularBuffer cb_input_grad_obj(cb_input_grad);
+    DataflowBuffer dfb_target_obj(cb_target);
+    DataflowBuffer dfb_output_grad_obj(cb_output_grad);
+    DataflowBuffer dfb_input_grad_obj(cb_input_grad);
 #if defined(WEIGHT)
-    CircularBuffer cb_weight_obj(cb_weight);
+    DataflowBuffer dfb_weight_obj(cb_weight);
     const auto addrg_weight = TensorAccessor(weight_args, weight_addr);
 
-    CircularBuffer cb_weight_scratch_obj(cb_weight_scratch);
-    read_line(cb_weight_obj, cb_weight_scratch_obj, addrg_weight, Ct);
+    DataflowBuffer dfb_weight_scratch_obj(cb_weight_scratch);
+    read_line(dfb_weight_obj, dfb_weight_scratch_obj, addrg_weight, Ct);
 
-    cb_weight_obj.wait_front(Ct);
-    CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
+    dfb_weight_obj.wait_front(Ct);
+    CoreLocalMem<volatile uint16_t> weight_l1_ptr(dfb_weight_obj.get_read_ptr());
 #endif
 
     auto zero = fp32_to_bf16_truncate(0.0f);
@@ -66,18 +66,18 @@ void kernel_main() {
         uint32_t c = nc % C;
 
         auto target_noc_id = n * num_inner_tile + inner;
-        read_tile(cb_target_obj, addrg_target, target_noc_id);
+        read_tile(dfb_target_obj, addrg_target, target_noc_id);
 
         auto output_grad_noc_id = n * num_inner_tile + inner;
-        read_tile(cb_output_grad_obj, addrg_output_grad, output_grad_noc_id);
+        read_tile(dfb_output_grad_obj, addrg_output_grad, output_grad_noc_id);
 
-        cb_input_grad_obj.reserve_back(onetile);
-        cb_target_obj.wait_front(onetile);
-        cb_output_grad_obj.wait_front(onetile);
+        dfb_input_grad_obj.reserve_back(onetile);
+        dfb_target_obj.wait_front(onetile);
+        dfb_output_grad_obj.wait_front(onetile);
 
-        CoreLocalMem<volatile uint16_t> input_grad_l1_ptr(cb_input_grad_obj.get_write_ptr());
-        CoreLocalMem<volatile int32_t> target_l1_ptr(cb_target_obj.get_read_ptr());
-        CoreLocalMem<volatile uint16_t> output_grad_l1_ptr(cb_output_grad_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> input_grad_l1_ptr(dfb_input_grad_obj.get_write_ptr());
+        CoreLocalMem<volatile int32_t> target_l1_ptr(dfb_target_obj.get_read_ptr());
+        CoreLocalMem<volatile uint16_t> output_grad_l1_ptr(dfb_output_grad_obj.get_read_ptr());
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -105,9 +105,9 @@ void kernel_main() {
             }
         }
 
-        cb_input_grad_obj.push_back(onetile);
+        dfb_input_grad_obj.push_back(onetile);
 
-        cb_target_obj.pop_front(onetile);
-        cb_output_grad_obj.pop_front(onetile);
+        dfb_target_obj.pop_front(onetile);
+        dfb_output_grad_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/writer_moreh_nll_loss_unreduced_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/writer_moreh_nll_loss_unreduced_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -22,15 +22,15 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     Noc noc;
-    CircularBuffer cb_input_grad_obj(cb_input_grad);
+    DataflowBuffer dfb_input_grad_obj(cb_input_grad);
     const auto input_grad_tile_bytes = get_tile_size(cb_input_grad);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_input_grad_obj.wait_front(onetile);
+        dfb_input_grad_obj.wait_front(onetile);
         noc.async_write(
-            cb_input_grad_obj, input_grad_addrg, input_grad_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+            dfb_input_grad_obj, input_grad_addrg, input_grad_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_input_grad_obj.pop_front(onetile);
+        dfb_input_grad_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -18,19 +18,19 @@ void kernel_main() {
 
     std::uint8_t input_id{tt::CBIndex::c_0};
     const auto cb_x = input_id++;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     const auto cb_one = input_id++;
-    CircularBuffer cb_one_obj(cb_one);  // one
+    DataflowBuffer dfb_one_obj(cb_one);  // one
     const auto cb_decimal = input_id++;
-    CircularBuffer cb_decimal_obj(cb_decimal);  // decimal
+    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
     const auto cb_recip_p_decimal = input_id++;
-    CircularBuffer cb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
+    DataflowBuffer dfb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
     const auto cb_mask_h = input_id++;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);  // mask_h
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);  // mask_h
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_y = output_id++;  // output
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -42,19 +42,19 @@ void kernel_main() {
     const auto cb_tmp6 = intermed_id++;
 
     const auto cb_xabs = cb_tmp0;
-    CircularBuffer cb_xabs_obj(cb_xabs);   // |x|
+    DataflowBuffer dfb_xabs_obj(cb_xabs);  // |x|
     const auto cb_xpow = cb_tmp1;          // |x|^p
-    CircularBuffer cb_xpow_obj(cb_xpow);
+    DataflowBuffer dfb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp2;          // log(|x|)
-    CircularBuffer cb_logx_obj(cb_logx);
+    DataflowBuffer dfb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
-    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
+    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp4;
-    CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
+    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
     const auto cb_xpowadd = cb_tmp5;
-    CircularBuffer cb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
+    DataflowBuffer dfb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
     const auto cb_xpowsum = cb_tmp6;       // Sum(|x + decimal|^p)
-    CircularBuffer cb_xpowsum_obj(cb_xpowsum);
+    DataflowBuffer dfb_xpowsum_obj(cb_xpowsum);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -62,30 +62,30 @@ void kernel_main() {
 
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
-    cb_one_obj.wait_front(onetile);              // comes from the reader
-    cb_decimal_obj.wait_front(onetile);          // comes from the reader
-    cb_recip_p_decimal_obj.wait_front(onetile);  // comes from the reader
+    dfb_one_obj.wait_front(onetile);              // comes from the reader
+    dfb_decimal_obj.wait_front(onetile);          // comes from the reader
+    dfb_recip_p_decimal_obj.wait_front(onetile);  // comes from the reader
 
     constexpr uint32_t TILE_H = 32;
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? (origin_h % TILE_H) : TILE_H;
 
     if (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);  // comes from the reader
+        dfb_mask_h_obj.wait_front(onetile);  // comes from the reader
     }
 
     for (uint32_t col_idx = 0; col_idx < num_cols_per_core; ++col_idx) {
         for (uint32_t row_idx = 0; row_idx < Ht; ++row_idx) {
             // |x|
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_xabs_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x_obj);
+            copy_tile_init_with_dt(dfb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_h && (row_idx == Ht - 1)) {
-                copy_tile_init_with_dt(cb_mask_h_obj);
+                copy_tile_init_with_dt(dfb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, dst1);
 
                 mask_tile_init();
@@ -97,55 +97,55 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs_obj);
+            pack_tile_with_dt(dst0, dfb_xabs_obj);
             tile_regs_release();
 
-            cb_x_obj.pop_front(onetile);
-            cb_xabs_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_xabs_obj.push_back(onetile);
 
             power_tile_to_cb(
-                cb_xabs_obj,
-                cb_xpow_obj,
-                cb_logx_obj,
-                cb_decimal_obj,
-                cb_exp_lxmd_obj,
-                cb_correct_xpow_obj,
+                dfb_xabs_obj,
+                dfb_xpow_obj,
+                dfb_logx_obj,
+                dfb_decimal_obj,
+                dfb_exp_lxmd_obj,
+                dfb_correct_xpow_obj,
                 p,
                 p_is_negative);
 
             // Add(|x|^p)
             if (row_idx == 0) {
                 tile_regs_acquire();
-                cb_correct_xpow_obj.wait_front(onetile);
-                cb_xpowadd_obj.reserve_back(onetile);
+                dfb_correct_xpow_obj.wait_front(onetile);
+                dfb_xpowadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_correct_xpow_obj);
+                copy_tile_init_with_dt(dfb_correct_xpow_obj);
                 copy_tile(cb_correct_xpow, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd_obj);
+                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
                 tile_regs_release();
 
-                cb_correct_xpow_obj.pop_front(onetile);
-                cb_xpowadd_obj.push_back(onetile);
+                dfb_correct_xpow_obj.pop_front(onetile);
+                dfb_xpowadd_obj.push_back(onetile);
             } else {
                 tile_regs_acquire();
-                cb_correct_xpow_obj.wait_front(onetile);
-                cb_xpowadd_obj.wait_front(onetile);
-                cb_xpowadd_obj.reserve_back(onetile);
+                dfb_correct_xpow_obj.wait_front(onetile);
+                dfb_xpowadd_obj.wait_front(onetile);
+                dfb_xpowadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_correct_xpow_obj, cb_xpowadd_obj);
+                add_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_xpowadd_obj);
                 add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd_obj);
+                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
                 tile_regs_release();
 
-                cb_correct_xpow_obj.pop_front(onetile);
-                cb_xpowadd_obj.pop_front(onetile);
-                cb_xpowadd_obj.push_back(onetile);
+                dfb_correct_xpow_obj.pop_front(onetile);
+                dfb_xpowadd_obj.pop_front(onetile);
+                dfb_xpowadd_obj.push_back(onetile);
             }
         }
         // Sum(|x|^p) - reduce single pre-accumulated tile
@@ -153,20 +153,20 @@ void kernel_main() {
             compute_kernel_lib::ReduceInputBlockShape::single());
 
         power_tile_to_cb(
-            cb_xpowsum_obj,
-            cb_xabs_obj,
-            cb_xpow_obj,
-            cb_recip_p_decimal_obj,
-            cb_logx_obj,
-            cb_y_obj,
+            dfb_xpowsum_obj,
+            dfb_xabs_obj,
+            dfb_xpow_obj,
+            dfb_recip_p_decimal_obj,
+            dfb_logx_obj,
+            dfb_y_obj,
             recip_p,
             recip_p_is_negative);
     }
 
-    cb_one_obj.pop_front(onetile);
-    cb_decimal_obj.pop_front(onetile);
-    cb_recip_p_decimal_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
+    dfb_decimal_obj.pop_front(onetile);
+    dfb_recip_p_decimal_obj.pop_front(onetile);
     if (do_mask_h) {
-        cb_mask_h_obj.pop_front(onetile);
+        dfb_mask_h_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -16,17 +16,17 @@ void kernel_main() {
 
     std::uint8_t input_id{tt::CBIndex::c_0};
     const auto cb_x = input_id++;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     const auto cb_one = input_id++;
-    CircularBuffer cb_one_obj(cb_one);  // one
+    DataflowBuffer dfb_one_obj(cb_one);  // one
     const auto cb_decimal = input_id++;
-    CircularBuffer cb_decimal_obj(cb_decimal);  // decimal
+    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
     const auto cb_recip_p_decimal = input_id++;
-    CircularBuffer cb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
+    DataflowBuffer dfb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_y = output_id++;  // output
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -37,17 +37,17 @@ void kernel_main() {
     const auto cb_tmp5 = intermed_id++;
 
     const auto cb_xabs = cb_tmp0;
-    CircularBuffer cb_xabs_obj(cb_xabs);   // |x|
+    DataflowBuffer dfb_xabs_obj(cb_xabs);  // |x|
     const auto cb_xpow = cb_tmp1;          // |x|^p
-    CircularBuffer cb_xpow_obj(cb_xpow);
+    DataflowBuffer dfb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp2;          // log(|x|)
-    CircularBuffer cb_logx_obj(cb_logx);
+    DataflowBuffer dfb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
-    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
+    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp4;
-    CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
+    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
     const auto cb_xpowadd = cb_tmp5;
-    CircularBuffer cb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
+    DataflowBuffer dfb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -55,18 +55,18 @@ void kernel_main() {
 
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
-    cb_one_obj.wait_front(onetile);              // comes from the reader
-    cb_decimal_obj.wait_front(onetile);          // comes from the reader
-    cb_recip_p_decimal_obj.wait_front(onetile);  // comes from the reader
+    dfb_one_obj.wait_front(onetile);              // comes from the reader
+    dfb_decimal_obj.wait_front(onetile);          // comes from the reader
+    dfb_recip_p_decimal_obj.wait_front(onetile);  // comes from the reader
 
     for (uint32_t outer_idx = 0; outer_idx < num_output_tiles_per_core; ++outer_idx) {
         for (uint32_t inner_idx = 0; inner_idx < num_reduced_tiles_along_dim; ++inner_idx) {
             // |x|
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_xabs_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x_obj);
+            copy_tile_init_with_dt(dfb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             abs_tile_init();
@@ -74,70 +74,70 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs_obj);
+            pack_tile_with_dt(dst0, dfb_xabs_obj);
             tile_regs_release();
 
-            cb_x_obj.pop_front(onetile);
-            cb_xabs_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_xabs_obj.push_back(onetile);
 
             power_tile_to_cb(
-                cb_xabs_obj,
-                cb_xpow_obj,
-                cb_logx_obj,
-                cb_decimal_obj,
-                cb_exp_lxmd_obj,
-                cb_correct_xpow_obj,
+                dfb_xabs_obj,
+                dfb_xpow_obj,
+                dfb_logx_obj,
+                dfb_decimal_obj,
+                dfb_exp_lxmd_obj,
+                dfb_correct_xpow_obj,
                 p,
                 p_is_negative);
 
             // Add(|x|^p)
             if (inner_idx == 0) {
                 tile_regs_acquire();
-                cb_correct_xpow_obj.wait_front(onetile);
-                cb_xpowadd_obj.reserve_back(onetile);
+                dfb_correct_xpow_obj.wait_front(onetile);
+                dfb_xpowadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_correct_xpow_obj);
+                copy_tile_init_with_dt(dfb_correct_xpow_obj);
                 copy_tile(cb_correct_xpow, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd_obj);
+                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
                 tile_regs_release();
 
-                cb_correct_xpow_obj.pop_front(onetile);
-                cb_xpowadd_obj.push_back(onetile);
+                dfb_correct_xpow_obj.pop_front(onetile);
+                dfb_xpowadd_obj.push_back(onetile);
             } else {
                 tile_regs_acquire();
-                cb_correct_xpow_obj.wait_front(onetile);
-                cb_xpowadd_obj.wait_front(onetile);
-                cb_xpowadd_obj.reserve_back(onetile);
+                dfb_correct_xpow_obj.wait_front(onetile);
+                dfb_xpowadd_obj.wait_front(onetile);
+                dfb_xpowadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_correct_xpow_obj, cb_xpowadd_obj);
+                add_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_xpowadd_obj);
                 add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd_obj);
+                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
                 tile_regs_release();
 
-                cb_correct_xpow_obj.pop_front(onetile);
-                cb_xpowadd_obj.pop_front(onetile);
-                cb_xpowadd_obj.push_back(onetile);
+                dfb_correct_xpow_obj.pop_front(onetile);
+                dfb_xpowadd_obj.pop_front(onetile);
+                dfb_xpowadd_obj.push_back(onetile);
             }
         }
 
         // Compute cb_y
         power_tile_to_cb(
-            cb_xpowadd_obj,
-            cb_xabs_obj,
-            cb_xpow_obj,
-            cb_recip_p_decimal_obj,
-            cb_logx_obj,
-            cb_y_obj,
+            dfb_xpowadd_obj,
+            dfb_xabs_obj,
+            dfb_xpow_obj,
+            dfb_recip_p_decimal_obj,
+            dfb_logx_obj,
+            dfb_y_obj,
             recip_p,
             recip_p_is_negative);
     }
-    cb_one_obj.pop_front(onetile);
-    cb_decimal_obj.pop_front(onetile);
-    cb_recip_p_decimal_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
+    dfb_decimal_obj.pop_front(onetile);
+    dfb_recip_p_decimal_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -18,19 +18,19 @@ void kernel_main() {
 
     std::uint8_t input_id{tt::CBIndex::c_0};
     const auto cb_x = input_id++;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     const auto cb_one = input_id++;
-    CircularBuffer cb_one_obj(cb_one);  // one
+    DataflowBuffer dfb_one_obj(cb_one);  // one
     const auto cb_decimal = input_id++;
-    CircularBuffer cb_decimal_obj(cb_decimal);  // decimal
+    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
     const auto cb_recip_p_decimal = input_id++;
-    CircularBuffer cb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
+    DataflowBuffer dfb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
     const auto cb_mask_w = input_id++;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);  // mask_w
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);  // mask_w
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_y = output_id++;  // output
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -42,19 +42,19 @@ void kernel_main() {
     const auto cb_tmp6 = intermed_id++;
 
     const auto cb_xabs = cb_tmp0;
-    CircularBuffer cb_xabs_obj(cb_xabs);   // |x|
+    DataflowBuffer dfb_xabs_obj(cb_xabs);  // |x|
     const auto cb_xpow = cb_tmp1;          // |x|^p
-    CircularBuffer cb_xpow_obj(cb_xpow);
+    DataflowBuffer dfb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp2;          // log(|x|)
-    CircularBuffer cb_logx_obj(cb_logx);
+    DataflowBuffer dfb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
-    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
+    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp4;
-    CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
+    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
     const auto cb_xpowadd = cb_tmp5;
-    CircularBuffer cb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
+    DataflowBuffer dfb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
     const auto cb_xpowsum = cb_tmp6;       // Sum(|x + decimal|^p)
-    CircularBuffer cb_xpowsum_obj(cb_xpowsum);
+    DataflowBuffer dfb_xpowsum_obj(cb_xpowsum);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -62,30 +62,30 @@ void kernel_main() {
 
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
-    cb_one_obj.wait_front(onetile);              // comes from the reader
-    cb_decimal_obj.wait_front(onetile);          // comes from the reader
-    cb_recip_p_decimal_obj.wait_front(onetile);  // comes from the reader
+    dfb_one_obj.wait_front(onetile);              // comes from the reader
+    dfb_decimal_obj.wait_front(onetile);          // comes from the reader
+    dfb_recip_p_decimal_obj.wait_front(onetile);  // comes from the reader
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
     const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);  // comes from the reader
+        dfb_mask_w_obj.wait_front(onetile);  // comes from the reader
     }
 
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             // |x|
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_xabs_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_xabs_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x_obj);
+            copy_tile_init_with_dt(dfb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(cb_mask_w_obj);
+                copy_tile_init_with_dt(dfb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
 
                 mask_tile_init();
@@ -97,55 +97,55 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_xabs_obj);
+            pack_tile_with_dt(dst0, dfb_xabs_obj);
             tile_regs_release();
 
-            cb_x_obj.pop_front(onetile);
-            cb_xabs_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_xabs_obj.push_back(onetile);
 
             power_tile_to_cb(
-                cb_xabs_obj,
-                cb_xpow_obj,
-                cb_logx_obj,
-                cb_decimal_obj,
-                cb_exp_lxmd_obj,
-                cb_correct_xpow_obj,
+                dfb_xabs_obj,
+                dfb_xpow_obj,
+                dfb_logx_obj,
+                dfb_decimal_obj,
+                dfb_exp_lxmd_obj,
+                dfb_correct_xpow_obj,
                 p,
                 p_is_negative);
 
             // Add(|x|^p)
             if (col_idx == 0) {
                 tile_regs_acquire();
-                cb_correct_xpow_obj.wait_front(onetile);
-                cb_xpowadd_obj.reserve_back(onetile);
+                dfb_correct_xpow_obj.wait_front(onetile);
+                dfb_xpowadd_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_correct_xpow_obj);
+                copy_tile_init_with_dt(dfb_correct_xpow_obj);
                 copy_tile(cb_correct_xpow, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd_obj);
+                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
                 tile_regs_release();
 
-                cb_correct_xpow_obj.pop_front(onetile);
-                cb_xpowadd_obj.push_back(onetile);
+                dfb_correct_xpow_obj.pop_front(onetile);
+                dfb_xpowadd_obj.push_back(onetile);
             } else {
                 tile_regs_acquire();
-                cb_correct_xpow_obj.wait_front(onetile);
-                cb_xpowadd_obj.wait_front(onetile);
-                cb_xpowadd_obj.reserve_back(onetile);
+                dfb_correct_xpow_obj.wait_front(onetile);
+                dfb_xpowadd_obj.wait_front(onetile);
+                dfb_xpowadd_obj.reserve_back(onetile);
 
-                add_tiles_init_with_dt(cb_correct_xpow_obj, cb_xpowadd_obj);
+                add_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_xpowadd_obj);
                 add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_xpowadd_obj);
+                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
                 tile_regs_release();
 
-                cb_correct_xpow_obj.pop_front(onetile);
-                cb_xpowadd_obj.pop_front(onetile);
-                cb_xpowadd_obj.push_back(onetile);
+                dfb_correct_xpow_obj.pop_front(onetile);
+                dfb_xpowadd_obj.pop_front(onetile);
+                dfb_xpowadd_obj.push_back(onetile);
             }
         }
         // Sum(|x|^p)
@@ -153,20 +153,20 @@ void kernel_main() {
             compute_kernel_lib::ReduceInputBlockShape::single());
 
         power_tile_to_cb(
-            cb_xpowsum_obj,
-            cb_xabs_obj,
-            cb_xpow_obj,
-            cb_recip_p_decimal_obj,
-            cb_logx_obj,
-            cb_y_obj,
+            dfb_xpowsum_obj,
+            dfb_xabs_obj,
+            dfb_xpow_obj,
+            dfb_recip_p_decimal_obj,
+            dfb_logx_obj,
+            dfb_y_obj,
             recip_p,
             recip_p_is_negative);
     }
 
-    cb_one_obj.pop_front(onetile);
-    cb_decimal_obj.pop_front(onetile);
-    cb_recip_p_decimal_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
+    dfb_decimal_obj.pop_front(onetile);
+    dfb_recip_p_decimal_obj.pop_front(onetile);
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -13,14 +13,14 @@ void kernel_main() {
 
     constexpr std::uint8_t input_id = tt::CB::c_in0;
     constexpr auto cb_x = input_id + 0;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     constexpr auto cb_one = input_id + 1;
-    CircularBuffer cb_one_obj(cb_one);  // one
+    DataflowBuffer dfb_one_obj(cb_one);  // one
     constexpr auto cb_mask_h = input_id + 2;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);  // mask_h
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);  // mask_h
 
     constexpr auto cb_y = tt::CB::c_out0;
-    CircularBuffer cb_y_obj(cb_y);  // output
+    DataflowBuffer dfb_y_obj(cb_y);  // output
 
     constexpr std::uint8_t intermed_id = tt::CB::c_intermed0;
     constexpr auto cb_tmp0 = intermed_id + 0;
@@ -28,11 +28,11 @@ void kernel_main() {
     constexpr auto cb_tmp2 = intermed_id + 2;
 
     constexpr auto cb_val = cb_tmp0;
-    CircularBuffer cb_val_obj(cb_val);  // f(x)
+    DataflowBuffer dfb_val_obj(cb_val);  // f(x)
     constexpr auto cb_cal = cb_tmp1;
-    CircularBuffer cb_cal_obj(cb_cal);  // calculate f(x) over dimension
+    DataflowBuffer dfb_cal_obj(cb_cal);  // calculate f(x) over dimension
     constexpr auto cb_reduce = cb_tmp2;
-    CircularBuffer cb_reduce_obj(cb_reduce);  // reduce f(x)
+    DataflowBuffer dfb_reduce_obj(cb_reduce);  // reduce f(x)
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -40,27 +40,27 @@ void kernel_main() {
 
     binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
-    cb_one_obj.wait_front(onetile);  // comes from the reader
+    dfb_one_obj.wait_front(onetile);  // comes from the reader
 
     constexpr uint32_t TILE_H = 32;
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? (origin_h % TILE_H) : TILE_H;
 
     if (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);  // comes from the reader
+        dfb_mask_h_obj.wait_front(onetile);  // comes from the reader
     }
     for (uint32_t col_idx = 0; col_idx < num_cols_per_core; ++col_idx) {
         for (uint32_t row_idx = 0; row_idx < Ht; ++row_idx) {
             // f(x)
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_val_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_val_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x_obj);
+            copy_tile_init_with_dt(dfb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_h && (row_idx == Ht - 1)) {
-                copy_tile_init_with_dt(cb_mask_h_obj);
+                copy_tile_init_with_dt(dfb_mask_h_obj);
                 copy_tile(cb_mask_h, 0, dst1);
 
                 mask_tile_init();
@@ -85,42 +85,42 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_val_obj);
+            pack_tile_with_dt(dst0, dfb_val_obj);
             tile_regs_release();
 
-            cb_x_obj.pop_front(onetile);
-            cb_val_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_val_obj.push_back(onetile);
 
             // calculate f(x) over dimension
             if (row_idx == 0) {
                 tile_regs_acquire();
-                cb_val_obj.wait_front(onetile);
-                cb_cal_obj.reserve_back(onetile);
+                dfb_val_obj.wait_front(onetile);
+                dfb_cal_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_val_obj);
+                copy_tile_init_with_dt(dfb_val_obj);
                 copy_tile(cb_val, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal_obj);
+                pack_tile_with_dt(dst0, dfb_cal_obj);
                 tile_regs_release();
 
-                cb_val_obj.pop_front(onetile);
-                cb_cal_obj.push_back(onetile);
+                dfb_val_obj.pop_front(onetile);
+                dfb_cal_obj.push_back(onetile);
 
             } else {
                 tile_regs_acquire();
-                cb_val_obj.wait_front(onetile);
-                cb_cal_obj.wait_front(onetile);
-                cb_cal_obj.reserve_back(onetile);
+                dfb_val_obj.wait_front(onetile);
+                dfb_cal_obj.wait_front(onetile);
+                dfb_cal_obj.reserve_back(onetile);
 #ifdef IS_ZERO
-                add_tiles_init_with_dt(cb_val_obj, cb_cal_obj);
+                add_tiles_init_with_dt(dfb_val_obj, dfb_cal_obj);
                 add_tiles(cb_val, cb_cal, 0, 0, dst0);
 #else
-                copy_tile_init_with_dt(cb_val_obj);
+                copy_tile_init_with_dt(dfb_val_obj);
                 copy_tile(cb_val, 0, dst0);
 
-                copy_tile_init_with_dt(cb_cal_obj);
+                copy_tile_init_with_dt(dfb_cal_obj);
                 copy_tile(cb_cal, 0, dst1);
 
                 binary_max_tile_init();
@@ -129,12 +129,12 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal_obj);
+                pack_tile_with_dt(dst0, dfb_cal_obj);
                 tile_regs_release();
 
-                cb_val_obj.pop_front(onetile);
-                cb_cal_obj.pop_front(onetile);
-                cb_cal_obj.push_back(onetile);
+                dfb_val_obj.pop_front(onetile);
+                dfb_cal_obj.pop_front(onetile);
+                dfb_cal_obj.push_back(onetile);
             }
         }
         // reduce f(x)
@@ -143,10 +143,10 @@ void kernel_main() {
 
         tile_regs_acquire();
 
-        cb_reduce_obj.wait_front(onetile);
-        cb_y_obj.reserve_back(onetile);
+        dfb_reduce_obj.wait_front(onetile);
+        dfb_y_obj.reserve_back(onetile);
 
-        copy_tile_init_with_dt(cb_reduce_obj);
+        copy_tile_init_with_dt(dfb_reduce_obj);
         copy_tile(cb_reduce, 0, dst0);
 #ifdef MINUS_INF
         negative_tile_init();
@@ -155,15 +155,15 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_y_obj);
+        pack_tile_with_dt(dst0, dfb_y_obj);
         tile_regs_release();
 
-        cb_reduce_obj.pop_front(onetile);
-        cb_y_obj.push_back(onetile);
+        dfb_reduce_obj.pop_front(onetile);
+        dfb_y_obj.push_back(onetile);
     }
 
-    cb_one_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
     if (do_mask_h) {
-        cb_mask_h_obj.pop_front(onetile);
+        dfb_mask_h_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/reader_moreh_norm_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/reader_moreh_norm_h.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -27,20 +27,20 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    CircularBuffer cb_one(cb_id_one);
-    fill_cb_with_value(cb_one, one.u);
+    DataflowBuffer dfb_one(cb_id_one);
+    fill_cb_with_value(dfb_one, one.u);
 
     constexpr uint32_t TILE_H = 32;
     const bool do_mask_h = (origin_h % TILE_H) != 0;
     const auto mask_h = do_mask_h ? (origin_h % TILE_H) : TILE_H;
 
     if (do_mask_h) {
-        CircularBuffer cb_mask_h(cb_id_mask_h);
-        generate_mask_h(cb_mask_h, mask_h);
+        DataflowBuffer dfb_mask_h(cb_id_mask_h);
+        generate_mask_h(dfb_mask_h, mask_h);
     }
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
 
     auto start_output_tile_idx = tile_offset;
@@ -50,10 +50,10 @@ void kernel_main() {
 
         auto input_tile_idx = outer_idx * Ht * Wt + inner_idx;
         for (uint32_t row_idx = 0; row_idx < Ht; ++row_idx) {
-            cb_input.reserve_back(1);
-            noc.async_read(s, cb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
+            dfb_input.reserve_back(1);
+            noc.async_read(s, dfb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(1);
+            dfb_input.push_back(1);
             input_tile_idx += Wt;
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/writer_moreh_norm_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/writer_moreh_norm_h.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,15 +23,15 @@ void kernel_main() {
     const auto s = TensorAccessor(output_args, output_addr);
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
     const auto output_tile_bytes = get_tile_size(cb_id_output);
 
     auto output_tile_idx = tile_offset;
     for (uint32_t idx = 0; idx < num_cols_per_core; ++idx) {
-        cb_output.wait_front(1);
-        noc.async_write(cb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = output_tile_idx});
+        dfb_output.wait_front(1);
+        noc.async_write(dfb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = output_tile_idx});
         noc.async_write_barrier();
-        cb_output.pop_front(1);
+        dfb_output.pop_front(1);
         output_tile_idx++;
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -11,22 +11,22 @@ void kernel_main() {
 
     std::uint8_t input_id{tt::CB::c_in0};
     const auto cb_x = input_id++;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     const auto cb_one = input_id++;
-    CircularBuffer cb_one_obj(cb_one);  // one
+    DataflowBuffer dfb_one_obj(cb_one);  // one
 
     std::uint8_t output_id{tt::CB::c_out0};
     const auto cb_y = output_id++;
-    CircularBuffer cb_y_obj(cb_y);  // output
+    DataflowBuffer dfb_y_obj(cb_y);  // output
 
     std::uint8_t intermed_id{tt::CB::c_intermed0};
     const auto cb_tmp0 = intermed_id++;
     const auto cb_tmp1 = intermed_id++;
 
     const auto cb_val = cb_tmp0;
-    CircularBuffer cb_val_obj(cb_val);  // f(x)
+    DataflowBuffer dfb_val_obj(cb_val);  // f(x)
     const auto cb_cal = cb_tmp1;
-    CircularBuffer cb_cal_obj(cb_cal);  // calculate f(x) over dimensions
+    DataflowBuffer dfb_cal_obj(cb_cal);  // calculate f(x) over dimensions
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -34,16 +34,16 @@ void kernel_main() {
 
     binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
-    cb_one_obj.wait_front(onetile);  // comes from the reader
+    dfb_one_obj.wait_front(onetile);  // comes from the reader
 
     for (uint32_t outer_idx = 0; outer_idx < num_output_tiles_per_core; ++outer_idx) {
         for (uint32_t inner_idx = 0; inner_idx < num_reduced_tiles_along_dim; ++inner_idx) {
             // x != 0
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_val_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_val_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x_obj);
+            copy_tile_init_with_dt(dfb_x_obj);
             copy_tile(cb_x, 0, dst0);
 #ifdef IS_ZERO
             unary_ne_tile_init();
@@ -60,42 +60,42 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_val_obj);
+            pack_tile_with_dt(dst0, dfb_val_obj);
             tile_regs_release();
 
-            cb_x_obj.pop_front(onetile);
-            cb_val_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_val_obj.push_back(onetile);
 
             // Add(x != 0)
             if (inner_idx == 0) {
                 tile_regs_acquire();
-                cb_val_obj.wait_front(onetile);
-                cb_cal_obj.reserve_back(onetile);
+                dfb_val_obj.wait_front(onetile);
+                dfb_cal_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_val_obj);
+                copy_tile_init_with_dt(dfb_val_obj);
                 copy_tile(cb_val, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal_obj);
+                pack_tile_with_dt(dst0, dfb_cal_obj);
                 tile_regs_release();
 
-                cb_val_obj.pop_front(onetile);
-                cb_cal_obj.push_back(onetile);
+                dfb_val_obj.pop_front(onetile);
+                dfb_cal_obj.push_back(onetile);
 
             } else {
                 tile_regs_acquire();
-                cb_val_obj.wait_front(onetile);
-                cb_cal_obj.wait_front(onetile);
-                cb_cal_obj.reserve_back(onetile);
+                dfb_val_obj.wait_front(onetile);
+                dfb_cal_obj.wait_front(onetile);
+                dfb_cal_obj.reserve_back(onetile);
 #ifdef IS_ZERO
-                add_tiles_init_with_dt(cb_val_obj, cb_cal_obj);
+                add_tiles_init_with_dt(dfb_val_obj, dfb_cal_obj);
                 add_tiles(cb_val, cb_cal, 0, 0, dst0);
 #else
-                copy_tile_init_with_dt(cb_val_obj);
+                copy_tile_init_with_dt(dfb_val_obj);
                 copy_tile(cb_val, 0, dst0);
 
-                copy_tile_init_with_dt(cb_cal_obj);
+                copy_tile_init_with_dt(dfb_cal_obj);
                 copy_tile(cb_cal, 0, dst1);
 
                 binary_max_tile_init();
@@ -104,22 +104,22 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal_obj);
+                pack_tile_with_dt(dst0, dfb_cal_obj);
                 tile_regs_release();
 
-                cb_val_obj.pop_front(onetile);
-                cb_cal_obj.pop_front(onetile);
-                cb_cal_obj.push_back(onetile);
+                dfb_val_obj.pop_front(onetile);
+                dfb_cal_obj.pop_front(onetile);
+                dfb_cal_obj.push_back(onetile);
             }
         }
 
         // Compute cb_y
         tile_regs_acquire();
 
-        cb_cal_obj.wait_front(onetile);
-        cb_y_obj.reserve_back(onetile);
+        dfb_cal_obj.wait_front(onetile);
+        dfb_y_obj.reserve_back(onetile);
 
-        copy_tile_init_with_dt(cb_cal_obj);
+        copy_tile_init_with_dt(dfb_cal_obj);
         copy_tile(cb_cal, 0, dst0);
 #ifdef MINUS_INF
         negative_tile_init();
@@ -128,11 +128,11 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_y_obj);
+        pack_tile_with_dt(dst0, dfb_y_obj);
         tile_regs_release();
 
-        cb_cal_obj.pop_front(onetile);
-        cb_y_obj.push_back(onetile);
+        dfb_cal_obj.pop_front(onetile);
+        dfb_y_obj.push_back(onetile);
     }
-    cb_one_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/reader_moreh_norm_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/reader_moreh_norm_nc.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,11 +26,11 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    CircularBuffer cb_one(cb_id_one);
-    fill_cb_with_value(cb_one, one.u);
+    DataflowBuffer dfb_one(cb_id_one);
+    fill_cb_with_value(dfb_one, one.u);
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
 
     auto start_output_tile_idx = tile_offset;
@@ -41,10 +41,10 @@ void kernel_main() {
 
         auto input_tile_idx = outer_idx * outer_stride + inner_idx;
         for (uint32_t d = 0; d < num_reduced_tiles_along_dim; ++d) {
-            cb_input.reserve_back(1);
-            noc.async_read(s, cb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
+            dfb_input.reserve_back(1);
+            noc.async_read(s, dfb_input, input_tile_bytes, {.page_id = input_tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(1);
+            dfb_input.push_back(1);
             input_tile_idx += inner_stride;
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/writer_moreh_norm_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/writer_moreh_norm_nc.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,15 +23,15 @@ void kernel_main() {
     const auto s = TensorAccessor(output_args, output_addr);
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
     const auto output_tile_bytes = get_tile_size(cb_id_output);
 
     auto output_tile_idx = tile_offset;
     for (uint32_t idx = 0; idx < num_output_tiles_per_core; ++idx) {
-        cb_output.wait_front(1);
-        noc.async_write(cb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = output_tile_idx});
+        dfb_output.wait_front(1);
+        noc.async_write(dfb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = output_tile_idx});
         noc.async_write_barrier();
-        cb_output.pop_front(1);
+        dfb_output.pop_front(1);
         output_tile_idx++;
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     int i{0};
@@ -13,14 +13,14 @@ void kernel_main() {
 
     constexpr std::uint8_t input_id = tt::CB::c_in0;
     constexpr auto cb_x = input_id + 0;
-    CircularBuffer cb_x_obj(cb_x);  // input
+    DataflowBuffer dfb_x_obj(cb_x);  // input
     constexpr auto cb_one = input_id + 1;
-    CircularBuffer cb_one_obj(cb_one);  // one
+    DataflowBuffer dfb_one_obj(cb_one);  // one
     constexpr auto cb_mask_w = input_id + 2;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);  // mask_w
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);  // mask_w
 
     constexpr auto cb_y = tt::CB::c_out0;
-    CircularBuffer cb_y_obj(cb_y);  // output
+    DataflowBuffer dfb_y_obj(cb_y);  // output
 
     constexpr std::uint8_t intermed_id = tt::CB::c_intermed0;
     constexpr auto cb_tmp0 = intermed_id + 0;
@@ -28,11 +28,11 @@ void kernel_main() {
     constexpr auto cb_tmp2 = intermed_id + 2;
 
     constexpr auto cb_val = cb_tmp0;
-    CircularBuffer cb_val_obj(cb_val);  // f(x)
+    DataflowBuffer dfb_val_obj(cb_val);  // f(x)
     constexpr auto cb_cal = cb_tmp1;
-    CircularBuffer cb_cal_obj(cb_cal);  // calculate f(x) over dimension
+    DataflowBuffer dfb_cal_obj(cb_cal);  // calculate f(x) over dimension
     constexpr auto cb_reduce = cb_tmp2;
-    CircularBuffer cb_reduce_obj(cb_reduce);  // reduce f(x)
+    DataflowBuffer dfb_reduce_obj(cb_reduce);  // reduce f(x)
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -40,28 +40,28 @@ void kernel_main() {
 
     binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
-    cb_one_obj.wait_front(onetile);  // comes from the reader
+    dfb_one_obj.wait_front(onetile);  // comes from the reader
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
     const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);  // comes from the reader
+        dfb_mask_w_obj.wait_front(onetile);  // comes from the reader
     }
 
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             // f(x)
             tile_regs_acquire();
-            cb_x_obj.wait_front(onetile);  // comes from the reader
-            cb_val_obj.reserve_back(onetile);
+            dfb_x_obj.wait_front(onetile);  // comes from the reader
+            dfb_val_obj.reserve_back(onetile);
 
-            copy_tile_init_with_dt(cb_x_obj);
+            copy_tile_init_with_dt(dfb_x_obj);
             copy_tile(cb_x, 0, dst0);
 
             if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(cb_mask_w_obj);
+                copy_tile_init_with_dt(dfb_mask_w_obj);
                 copy_tile(cb_mask_w, 0, dst1);
                 mask_tile_init();
 #ifdef MINUS_INF
@@ -85,41 +85,41 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_val_obj);
+            pack_tile_with_dt(dst0, dfb_val_obj);
             tile_regs_release();
 
-            cb_x_obj.pop_front(onetile);
-            cb_val_obj.push_back(onetile);
+            dfb_x_obj.pop_front(onetile);
+            dfb_val_obj.push_back(onetile);
 
             // calculate f(x) over dimension
             if (col_idx == 0) {
                 tile_regs_acquire();
-                cb_val_obj.wait_front(onetile);
-                cb_cal_obj.reserve_back(onetile);
+                dfb_val_obj.wait_front(onetile);
+                dfb_cal_obj.reserve_back(onetile);
 
-                copy_tile_init_with_dt(cb_val_obj);
+                copy_tile_init_with_dt(dfb_val_obj);
                 copy_tile(cb_val, 0, dst0);
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal_obj);
+                pack_tile_with_dt(dst0, dfb_cal_obj);
                 tile_regs_release();
 
-                cb_val_obj.pop_front(onetile);
-                cb_cal_obj.push_back(onetile);
+                dfb_val_obj.pop_front(onetile);
+                dfb_cal_obj.push_back(onetile);
             } else {
                 tile_regs_acquire();
-                cb_val_obj.wait_front(onetile);
-                cb_cal_obj.wait_front(onetile);
-                cb_cal_obj.reserve_back(onetile);
+                dfb_val_obj.wait_front(onetile);
+                dfb_cal_obj.wait_front(onetile);
+                dfb_cal_obj.reserve_back(onetile);
 #ifdef IS_ZERO
-                add_tiles_init_with_dt(cb_val_obj, cb_cal_obj);
+                add_tiles_init_with_dt(dfb_val_obj, dfb_cal_obj);
                 add_tiles(cb_val, cb_cal, 0, 0, dst0);
 #else
-                copy_tile_init_with_dt(cb_val_obj);
+                copy_tile_init_with_dt(dfb_val_obj);
                 copy_tile(cb_val, 0, dst0);
 
-                copy_tile_init_with_dt(cb_cal_obj);
+                copy_tile_init_with_dt(dfb_cal_obj);
                 copy_tile(cb_cal, 0, dst1);
 
                 binary_max_tile_init();
@@ -128,12 +128,12 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_cal_obj);
+                pack_tile_with_dt(dst0, dfb_cal_obj);
                 tile_regs_release();
 
-                cb_val_obj.pop_front(onetile);
-                cb_cal_obj.pop_front(onetile);
-                cb_cal_obj.push_back(onetile);
+                dfb_val_obj.pop_front(onetile);
+                dfb_cal_obj.pop_front(onetile);
+                dfb_cal_obj.push_back(onetile);
             }
         }
         // reduce f(x)
@@ -142,10 +142,10 @@ void kernel_main() {
 
         tile_regs_acquire();
 
-        cb_reduce_obj.wait_front(onetile);
-        cb_y_obj.reserve_back(onetile);
+        dfb_reduce_obj.wait_front(onetile);
+        dfb_y_obj.reserve_back(onetile);
 
-        copy_tile_init_with_dt(cb_reduce_obj);
+        copy_tile_init_with_dt(dfb_reduce_obj);
         copy_tile(cb_reduce, 0, dst0);
 #ifdef MINUS_INF
         negative_tile_init();
@@ -154,15 +154,15 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_y_obj);
+        pack_tile_with_dt(dst0, dfb_y_obj);
         tile_regs_release();
 
-        cb_reduce_obj.pop_front(onetile);
-        cb_y_obj.push_back(onetile);
+        dfb_reduce_obj.pop_front(onetile);
+        dfb_y_obj.push_back(onetile);
     }
 
-    cb_one_obj.pop_front(onetile);
+    dfb_one_obj.pop_front(onetile);
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/reader_moreh_norm_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/reader_moreh_norm_w.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,31 +26,31 @@ void kernel_main() {
 
     Scalar one;
     one.f = 1.0f;
-    CircularBuffer cb_one(cb_id_one);
-    fill_cb_with_value(cb_one, one.u);
+    DataflowBuffer dfb_one(cb_id_one);
+    fill_cb_with_value(dfb_one, one.u);
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
     const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
-        CircularBuffer cb_mask_w(cb_id_mask_w);
-        generate_mask_w(cb_mask_w, mask_w);
+        DataflowBuffer dfb_mask_w(cb_id_mask_w);
+        generate_mask_w(dfb_mask_w, mask_w);
     }
 
     const auto start_tile_idx = tile_offset;
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
+    DataflowBuffer dfb_input(cb_id_input);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
 
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             const auto tile_idx = start_tile_idx + row_idx * Wt + col_idx;
-            cb_input.reserve_back(1);
-            noc.async_read(s, cb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_input.reserve_back(1);
+            noc.async_read(s, dfb_input, input_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_input.push_back(1);
+            dfb_input.push_back(1);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/writer_moreh_norm_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/writer_moreh_norm_w.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,14 +26,14 @@ void kernel_main() {
     const auto start_tile_idx = tile_offset / Wt;
 
     Noc noc;
-    CircularBuffer cb_output(cb_id_output);
+    DataflowBuffer dfb_output(cb_id_output);
     const auto output_tile_bytes = get_tile_size(cb_id_output);
 
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         const auto tile_idx = start_tile_idx + row_idx;
-        cb_output.wait_front(1);
-        noc.async_write(cb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+        dfb_output.wait_front(1);
+        noc.async_write(dfb_output, s, output_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
         noc.async_write_barrier();
-        cb_output.pop_front(1);
+        dfb_output.pop_front(1);
     }
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     // compile-time args
@@ -21,17 +21,17 @@ void kernel_main() {
 
     std::uint8_t input_id{tt::CBIndex::c_0};
     const auto cb_x = input_id++;
-    CircularBuffer cb_x_obj(cb_x);  // input(==x)
+    DataflowBuffer dfb_x_obj(cb_x);  // input(==x)
     const auto cb_y = input_id++;
-    CircularBuffer cb_y_obj(cb_y);  // output(==y)
+    DataflowBuffer dfb_y_obj(cb_y);  // output(==y)
     const auto cb_dy = input_id++;
-    CircularBuffer cb_dy_obj(cb_dy);  // output_grad(==dy)
+    DataflowBuffer dfb_dy_obj(cb_dy);  // output_grad(==dy)
     const auto cb_decimal = input_id++;
-    CircularBuffer cb_decimal_obj(cb_decimal);  // decimal
+    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
 
     std::uint8_t output_id{tt::CBIndex::c_16};
     const auto cb_dx = output_id++;  // input_grad(==dx)
-    CircularBuffer cb_dx_obj(cb_dx);
+    DataflowBuffer dfb_dx_obj(cb_dx);
 
     std::uint8_t intermed_id{tt::CBIndex::c_24};
     const auto cb_tmp0 = intermed_id++;
@@ -39,141 +39,148 @@ void kernel_main() {
     const auto cb_tmp2 = intermed_id++;
     const auto cb_tmp3 = intermed_id++;
     const auto cb_tmp4 = intermed_id++;
-    CircularBuffer cb_tmp4_obj(cb_tmp4);
+    DataflowBuffer dfb_tmp4_obj(cb_tmp4);
     const auto cb_tmp5 = intermed_id++;
-    CircularBuffer cb_tmp5_obj(cb_tmp5);
+    DataflowBuffer dfb_tmp5_obj(cb_tmp5);
     const auto cb_tmp6 = intermed_id++;
     const auto cb_tmp7 = intermed_id++;
 
     const auto cb_xpow = cb_tmp0;
-    CircularBuffer cb_xpow_obj(cb_xpow);
+    DataflowBuffer dfb_xpow_obj(cb_xpow);
     const auto cb_logx = cb_tmp1;
-    CircularBuffer cb_logx_obj(cb_logx);
+    DataflowBuffer dfb_logx_obj(cb_logx);
     const auto cb_exp_lxmd = cb_tmp2;
-    CircularBuffer cb_exp_lxmd_obj(cb_exp_lxmd);
+    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
     const auto cb_correct_xpow = cb_tmp3;
-    CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);
+    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);
     const auto cb_recip_ypow = cb_tmp6;
-    CircularBuffer cb_recip_ypow_obj(cb_recip_ypow);
+    DataflowBuffer dfb_recip_ypow_obj(cb_recip_ypow);
     const auto cb_sign = cb_tmp7;
-    CircularBuffer cb_sign_obj(cb_sign);
+    DataflowBuffer dfb_sign_obj(cb_sign);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
-    cb_decimal_obj.wait_front(onetile);  // comes from the reader
+    dfb_decimal_obj.wait_front(onetile);  // comes from the reader
 
     for (uint32_t idx = 0; idx < num_input_tiles_per_core; ++idx) {
-        cb_x_obj.wait_front(onetile);   // comes from the reader
-        cb_y_obj.wait_front(onetile);   // comes from the reader
-        cb_dy_obj.wait_front(onetile);  // comes from the reader
+        dfb_x_obj.wait_front(onetile);   // comes from the reader
+        dfb_y_obj.wait_front(onetile);   // comes from the reader
+        dfb_dy_obj.wait_front(onetile);  // comes from the reader
 
-        sign_tile_to_cb(cb_x_obj, cb_sign_obj, 0, /*pop=*/0);
+        sign_tile_to_cb(dfb_x_obj, dfb_sign_obj, 0, /*pop=*/0);
 
         // x^(p - 1)
         power_tile_with_abs_x_to_cb(
-            cb_x_obj,
-            cb_xpow_obj,
-            cb_logx_obj,
-            cb_decimal_obj,
-            cb_exp_lxmd_obj,
-            cb_correct_xpow_obj,
+            dfb_x_obj,
+            dfb_xpow_obj,
+            dfb_logx_obj,
+            dfb_decimal_obj,
+            dfb_exp_lxmd_obj,
+            dfb_correct_xpow_obj,
             p_minus_one,
             p_minus_one_is_negative);
 
         // x^(p - 1) * y -> cb_tmp4
-        cb_correct_xpow_obj.wait_front(onetile);
-        cb_tmp4_obj.reserve_back(onetile);
+        dfb_correct_xpow_obj.wait_front(onetile);
+        dfb_tmp4_obj.reserve_back(onetile);
 
         tile_regs_acquire();
         if (ht_need_bcast && wt_need_bcast) {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_correct_xpow_obj, cb_y_obj);
+            mul_tiles_bcast_scalar_init_short_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
             mul_tiles_bcast_scalar(cb_correct_xpow, cb_y, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            mul_bcast_rows_init_short_with_dt(cb_correct_xpow_obj, cb_y_obj);
+            mul_bcast_rows_init_short_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
             mul_tiles_bcast_rows(cb_correct_xpow, cb_y, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            mul_bcast_cols_init_short_with_dt(cb_correct_xpow_obj, cb_y_obj);
+            mul_bcast_cols_init_short_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
             mul_tiles_bcast_cols(cb_correct_xpow, cb_y, 0, 0, dst0);
         } else {
-            mul_tiles_init_with_dt(cb_correct_xpow_obj, cb_y_obj);
+            mul_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
             mul_tiles(cb_correct_xpow, cb_y, 0, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp4_obj);
+        pack_tile_with_dt(dst0, dfb_tmp4_obj);
         tile_regs_release();
 
-        cb_correct_xpow_obj.pop_front(onetile);
-        cb_tmp4_obj.push_back(onetile);
+        dfb_correct_xpow_obj.pop_front(onetile);
+        dfb_tmp4_obj.push_back(onetile);
 
         // x^(p - 1) * y * dy -> cb_tmp5
-        cb_tmp4_obj.wait_front(onetile);
-        cb_tmp5_obj.reserve_back(onetile);
+        dfb_tmp4_obj.wait_front(onetile);
+        dfb_tmp5_obj.reserve_back(onetile);
 
         tile_regs_acquire();
         if (ht_need_bcast && wt_need_bcast) {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp4_obj, cb_dy_obj);
+            mul_tiles_bcast_scalar_init_short_with_dt(dfb_tmp4_obj, dfb_dy_obj);
             mul_tiles_bcast_scalar(cb_tmp4, cb_dy, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            mul_bcast_rows_init_short_with_dt(cb_tmp4_obj, cb_dy_obj);
+            mul_bcast_rows_init_short_with_dt(dfb_tmp4_obj, dfb_dy_obj);
             mul_tiles_bcast_rows(cb_tmp4, cb_dy, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            mul_bcast_cols_init_short_with_dt(cb_tmp4_obj, cb_dy_obj);
+            mul_bcast_cols_init_short_with_dt(dfb_tmp4_obj, dfb_dy_obj);
             mul_tiles_bcast_cols(cb_tmp4, cb_dy, 0, 0, dst0);
         } else {
-            mul_tiles_init_with_dt(cb_tmp4_obj, cb_dy_obj);
+            mul_tiles_init_with_dt(dfb_tmp4_obj, dfb_dy_obj);
             mul_tiles(cb_tmp4, cb_dy, 0, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp5_obj);
+        pack_tile_with_dt(dst0, dfb_tmp5_obj);
         tile_regs_release();
 
-        cb_tmp4_obj.pop_front(onetile);
-        cb_tmp5_obj.push_back(onetile);
+        dfb_tmp4_obj.pop_front(onetile);
+        dfb_tmp5_obj.push_back(onetile);
 
         // 1 / y^p
         power_and_recip_tile_to_cb(
-            cb_y_obj, cb_xpow_obj, cb_logx_obj, cb_decimal_obj, cb_exp_lxmd_obj, cb_recip_ypow_obj, p, p_is_negative);
+            dfb_y_obj,
+            dfb_xpow_obj,
+            dfb_logx_obj,
+            dfb_decimal_obj,
+            dfb_exp_lxmd_obj,
+            dfb_recip_ypow_obj,
+            p,
+            p_is_negative);
 
         // (x^(p - 1) * y * dy) / y^p -> cb_dx
-        cb_tmp5_obj.wait_front(onetile);
-        cb_recip_ypow_obj.wait_front(onetile);
-        cb_tmp4_obj.reserve_back(onetile);
+        dfb_tmp5_obj.wait_front(onetile);
+        dfb_recip_ypow_obj.wait_front(onetile);
+        dfb_tmp4_obj.reserve_back(onetile);
 
         tile_regs_acquire();
         if (ht_need_bcast && wt_need_bcast) {
-            mul_tiles_bcast_scalar_init_short_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
+            mul_tiles_bcast_scalar_init_short_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
             mul_tiles_bcast_scalar(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         } else if (ht_need_bcast) {
-            mul_bcast_rows_init_short_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
+            mul_bcast_rows_init_short_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
             mul_tiles_bcast_rows(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         } else if (wt_need_bcast) {
-            mul_bcast_cols_init_short_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
+            mul_bcast_cols_init_short_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
             mul_tiles_bcast_cols(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         } else {
-            mul_tiles_init_with_dt(cb_tmp5_obj, cb_recip_ypow_obj);
+            mul_tiles_init_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
             mul_tiles(cb_tmp5, cb_recip_ypow, 0, 0, dst0);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp4_obj);
+        pack_tile_with_dt(dst0, dfb_tmp4_obj);
         tile_regs_release();
 
-        cb_tmp5_obj.pop_front(onetile);
-        cb_recip_ypow_obj.pop_front(onetile);
-        cb_tmp4_obj.push_back(onetile);
+        dfb_tmp5_obj.pop_front(onetile);
+        dfb_recip_ypow_obj.pop_front(onetile);
+        dfb_tmp4_obj.push_back(onetile);
 
-        cb_dy_obj.pop_front(onetile);
+        dfb_dy_obj.pop_front(onetile);
 
         // multiply abs sign
-        mul_tiles_to_cb(cb_sign_obj, cb_tmp4_obj, cb_dx_obj, 0, 0);
+        mul_tiles_to_cb(dfb_sign_obj, dfb_tmp4_obj, dfb_dx_obj, 0, 0);
     }
 
-    cb_decimal_obj.pop_front(onetile);
+    dfb_decimal_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/reader_moreh_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/reader_moreh_norm_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 static constexpr int32_t MAX_NUM_DIMENSIONS = 8;
@@ -91,13 +91,13 @@ void kernel_main() {
     // output_grad
     const auto output_grad_addrg = TensorAccessor(output_grad_args, output_grad_addr);
 
-    CircularBuffer cb_decimal(cb_id_decimal);
-    fill_cb_with_value(cb_decimal, decimal);
+    DataflowBuffer dfb_decimal(cb_id_decimal);
+    fill_cb_with_value(dfb_decimal, decimal);
 
     Noc noc;
-    CircularBuffer cb_input(cb_id_input);
-    CircularBuffer cb_output(cb_id_output);
-    CircularBuffer cb_output_grad(cb_id_output_grad);
+    DataflowBuffer dfb_input(cb_id_input);
+    DataflowBuffer dfb_output(cb_id_output);
+    DataflowBuffer dfb_output_grad(cb_id_output_grad);
     const auto input_tile_bytes = get_tile_size(cb_id_input);
     const auto output_tile_bytes = get_tile_size(cb_id_output);
     const auto output_grad_tile_bytes = get_tile_size(cb_id_output_grad);
@@ -107,21 +107,21 @@ void kernel_main() {
         auto read_tile_id = get_output_grad_tile(
             i, input_grad_rank, output_grad_dim, output_grad_stride, input_grad_dim, input_grad_stride, need_bcast_dim);
 
-        cb_input.reserve_back(1);
-        noc.async_read(input_addrg, cb_input, input_tile_bytes, {.page_id = input_tile_id}, {.offset_bytes = 0});
+        dfb_input.reserve_back(1);
+        noc.async_read(input_addrg, dfb_input, input_tile_bytes, {.page_id = input_tile_id}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_input.push_back(1);
+        dfb_input.push_back(1);
 
-        cb_output.reserve_back(1);
-        noc.async_read(output_addrg, cb_output, output_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+        dfb_output.reserve_back(1);
+        noc.async_read(output_addrg, dfb_output, output_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_output.push_back(1);
+        dfb_output.push_back(1);
 
-        cb_output_grad.reserve_back(1);
+        dfb_output_grad.reserve_back(1);
         noc.async_read(
-            output_grad_addrg, cb_output_grad, output_grad_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+            output_grad_addrg, dfb_output_grad, output_grad_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_output_grad.push_back(1);
+        dfb_output_grad.push_back(1);
     }
 
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/writer_moreh_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/writer_moreh_norm_backward.cpp
@@ -6,7 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -25,20 +25,20 @@ void kernel_main() {
     const auto input_grad_addrg = TensorAccessor(input_grad_args, input_grad_addr);
 
     Noc noc;
-    CircularBuffer cb_input_grad(cb_id_input_grad);
+    DataflowBuffer dfb_input_grad(cb_id_input_grad);
     const auto input_grad_tile_bytes = get_tile_size(cb_id_input_grad);
 
     auto input_grad_tile_idx = tile_offset;
     for (uint32_t idx = 0; idx < num_input_tiles_per_core; ++idx) {
-        cb_input_grad.wait_front(1);
+        dfb_input_grad.wait_front(1);
         noc.async_write(
-            cb_input_grad,
+            dfb_input_grad,
             input_grad_addrg,
             input_grad_tile_bytes,
             {.offset_bytes = 0},
             {.page_id = input_grad_tile_idx});
         noc.async_write_barrier();
-        cb_input_grad.pop_front(1);
+        dfb_input_grad.pop_front(1);
         input_grad_tile_idx++;
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/moreh_sgd.cpp
@@ -3,31 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr auto cb_param_in = tt::CBIndex::c_0;
-    CircularBuffer cb_param_in_obj(cb_param_in);
+    DataflowBuffer dfb_param_in_obj(cb_param_in);
     constexpr auto cb_grad = tt::CBIndex::c_1;
-    CircularBuffer cb_grad_obj(cb_grad);
+    DataflowBuffer dfb_grad_obj(cb_grad);
     constexpr auto cb_momentum_in = tt::CBIndex::c_2;
-    CircularBuffer cb_momentum_in_obj(cb_momentum_in);
+    DataflowBuffer dfb_momentum_in_obj(cb_momentum_in);
 
     constexpr auto cb_param_out = tt::CBIndex::c_16;
-    CircularBuffer cb_param_out_obj(cb_param_out);
+    DataflowBuffer dfb_param_out_obj(cb_param_out);
     constexpr auto cb_momentum_out = tt::CBIndex::c_17;
-    CircularBuffer cb_momentum_out_obj(cb_momentum_out);
+    DataflowBuffer dfb_momentum_out_obj(cb_momentum_out);
 
     constexpr auto cb_scalar_args = tt::CBIndex::c_24;
-    CircularBuffer cb_scalar_args_obj(cb_scalar_args);
+    DataflowBuffer dfb_scalar_args_obj(cb_scalar_args);
     constexpr auto cb_tmp1 = tt::CBIndex::c_25;
-    CircularBuffer cb_tmp1_obj(cb_tmp1);
+    DataflowBuffer dfb_tmp1_obj(cb_tmp1);
     constexpr auto cb_tmp2 = tt::CBIndex::c_26;
-    CircularBuffer cb_tmp2_obj(cb_tmp2);
+    DataflowBuffer dfb_tmp2_obj(cb_tmp2);
     constexpr auto cb_tmp3 = tt::CBIndex::c_27;
-    CircularBuffer cb_tmp3_obj(cb_tmp3);
+    DataflowBuffer dfb_tmp3_obj(cb_tmp3);
     constexpr auto cb_tmp4 = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp4_obj(cb_tmp4);
+    DataflowBuffer dfb_tmp4_obj(cb_tmp4);
 
     constexpr uint32_t lr_tile = 0;
     constexpr uint32_t momentum_tile = 1;
@@ -40,15 +40,16 @@ void kernel_main() {
     uint32_t num_tiles = get_compile_time_arg_val(0);
 
     // from reader
-    cb_scalar_args_obj.wait_front(5);
+    dfb_scalar_args_obj.wait_front(5);
 
     for (uint32_t n = 0; n < num_tiles; ++n) {
         uint32_t cb_grad_tmp = cb_grad;
 #if defined(WEIGHT_DECAY)
         // grad += param * weight_decay
-        mul_tiles_to_cb(cb_param_in_obj, cb_scalar_args_obj, cb_tmp1_obj, 0, weight_decay_tile, /*pop0=*/0, /*pop1=*/0);
+        mul_tiles_to_cb(
+            dfb_param_in_obj, dfb_scalar_args_obj, dfb_tmp1_obj, 0, weight_decay_tile, /*pop0=*/0, /*pop1=*/0);
 
-        add_tiles_to_cb(cb_grad_obj, cb_tmp1_obj, cb_tmp2_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        add_tiles_to_cb(dfb_grad_obj, dfb_tmp1_obj, dfb_tmp2_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
 
         cb_grad_tmp = cb_tmp2;
 #endif  // WEIGHT_DECAY
@@ -58,35 +59,36 @@ void kernel_main() {
 #if defined(MOMENTUM_INITIALIZED)
         // grad * (1 - dampening)
         sub_tiles_to_cb(
-            cb_scalar_args_obj, cb_scalar_args_obj, cb_tmp1_obj, one_tile, dampening_tile, /*pop0=*/0, /*pop0=*/0);
+            dfb_scalar_args_obj, dfb_scalar_args_obj, dfb_tmp1_obj, one_tile, dampening_tile, /*pop0=*/0, /*pop0=*/0);
 
         {
-            CircularBuffer cb_grad_tmp_obj(cb_grad_tmp);
-            mul_tiles_to_cb(cb_grad_tmp_obj, cb_tmp1_obj, cb_tmp3_obj, 0, 0, /*pop0=*/0, /*pop0=*/1);
+            DataflowBuffer dfb_grad_tmp_obj(cb_grad_tmp);
+            mul_tiles_to_cb(dfb_grad_tmp_obj, dfb_tmp1_obj, dfb_tmp3_obj, 0, 0, /*pop0=*/0, /*pop0=*/1);
         }
 
         // momentum_v * momentum
-        mul_tiles_to_cb(cb_momentum_in_obj, cb_scalar_args_obj, cb_tmp4_obj, 0, momentum_tile, /*pop0=*/1, /*pop0=*/0);
+        mul_tiles_to_cb(
+            dfb_momentum_in_obj, dfb_scalar_args_obj, dfb_tmp4_obj, 0, momentum_tile, /*pop0=*/1, /*pop0=*/0);
 
-        add_tiles_to_cb(cb_tmp3_obj, cb_tmp4_obj, cb_tmp1_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        add_tiles_to_cb(dfb_tmp3_obj, dfb_tmp4_obj, dfb_tmp1_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
 
         cb_momentum_tmp = cb_tmp1;
 #endif
 
         {
-            CircularBuffer cb_momentum_tmp_obj(cb_momentum_tmp);
-            copy_tile_to_cb(cb_momentum_tmp_obj, cb_momentum_out_obj, 0, /*pop=*/0);
+            DataflowBuffer dfb_momentum_tmp_obj(cb_momentum_tmp);
+            copy_tile_to_cb(dfb_momentum_tmp_obj, dfb_momentum_out_obj, 0, /*pop=*/0);
         }
 
 #if defined(NESTEROV)
         // grad = grad + momentum_v * momentum
         uint32_t pop_momentum = (cb_grad_tmp != cb_momentum_tmp);
         {
-            CircularBuffer cb_momentum_tmp_obj(cb_momentum_tmp);
+            DataflowBuffer dfb_momentum_tmp_obj(cb_momentum_tmp);
             mul_tiles_to_cb(
-                cb_momentum_tmp_obj,
-                cb_scalar_args_obj,
-                cb_tmp3_obj,
+                dfb_momentum_tmp_obj,
+                dfb_scalar_args_obj,
+                dfb_tmp3_obj,
                 0,
                 momentum_tile,
                 /*pop0=*/pop_momentum,
@@ -94,16 +96,16 @@ void kernel_main() {
         }
 
         {
-            CircularBuffer cb_grad_tmp_obj(cb_grad_tmp);
-            add_tiles_to_cb(cb_tmp3_obj, cb_grad_tmp_obj, cb_tmp4_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
+            DataflowBuffer dfb_grad_tmp_obj(cb_grad_tmp);
+            add_tiles_to_cb(dfb_tmp3_obj, dfb_grad_tmp_obj, dfb_tmp4_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
         }
 
         cb_grad_tmp = cb_tmp4;
 #else
 // have to pop cb_grad_tmp
 #if defined(MOMENTUM_INITIALIZED)
-        CircularBuffer cb_grad_tmp_obj(cb_grad_tmp);
-        cb_grad_tmp_obj.pop_front(1);
+        DataflowBuffer dfb_grad_tmp_obj(cb_grad_tmp);
+        dfb_grad_tmp_obj.pop_front(1);
 #else
 // not pop this case because `cb_momentum_tmp == cb_grad_tmp`
 #endif
@@ -115,10 +117,10 @@ void kernel_main() {
 
         // param_out = param_in - lr * grad
         {
-            CircularBuffer cb_grad_tmp_obj(cb_grad_tmp);
-            mul_tiles_to_cb(cb_scalar_args_obj, cb_grad_tmp_obj, cb_tmp3_obj, lr_tile, 0, /*pop0=*/0, /*pop1=*/1);
+            DataflowBuffer dfb_grad_tmp_obj(cb_grad_tmp);
+            mul_tiles_to_cb(dfb_scalar_args_obj, dfb_grad_tmp_obj, dfb_tmp3_obj, lr_tile, 0, /*pop0=*/0, /*pop1=*/1);
         }
 
-        sub_tiles_to_cb(cb_param_in_obj, cb_tmp3_obj, cb_param_out_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
+        sub_tiles_to_cb(dfb_param_in_obj, dfb_tmp3_obj, dfb_param_out_obj, 0, 0, /*pop0=*/1, /*pop1=*/1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/reader_moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/reader_moreh_sgd.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -49,42 +49,42 @@ void kernel_main() {
     auto momentum_in = TensorAccessor(momentum_in_args, momentum_in_addr);
 #endif
 
-    CircularBuffer cb_scalar_args_obj(cb_scalar_args);
-    fill_cb_with_value(cb_scalar_args_obj, lr);
-    fill_cb_with_value(cb_scalar_args_obj, momentum);
-    fill_cb_with_value(cb_scalar_args_obj, dampening);
-    fill_cb_with_value(cb_scalar_args_obj, weight_decay);
-    fill_cb_with_value(cb_scalar_args_obj, one);
+    DataflowBuffer dfb_scalar_args_obj(cb_scalar_args);
+    fill_cb_with_value(dfb_scalar_args_obj, lr);
+    fill_cb_with_value(dfb_scalar_args_obj, momentum);
+    fill_cb_with_value(dfb_scalar_args_obj, dampening);
+    fill_cb_with_value(dfb_scalar_args_obj, weight_decay);
+    fill_cb_with_value(dfb_scalar_args_obj, one);
 
     Noc noc;
-    CircularBuffer cb_param_in_obj(cb_param_in);
-    CircularBuffer cb_grad_obj(cb_grad);
+    DataflowBuffer dfb_param_in_obj(cb_param_in);
+    DataflowBuffer dfb_grad_obj(cb_grad);
     const auto param_in_tile_bytes = get_tile_size(cb_param_in);
     const auto grad_tile_bytes = get_tile_size(cb_grad);
 #if defined(MOMENTUM) && defined(MOMENTUM_INITIALIZED)
-    CircularBuffer cb_momentum_in_obj(cb_momentum_in);
+    DataflowBuffer dfb_momentum_in_obj(cb_momentum_in);
     const auto momentum_in_tile_bytes = get_tile_size(cb_momentum_in);
 #endif
 
     uint32_t curr_tile = tile_offset;
 
     for (uint32_t i = 0; i < num_tiles; i += onetile) {
-        cb_param_in_obj.reserve_back(onetile);
-        noc.async_read(param_in, cb_param_in_obj, param_in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+        dfb_param_in_obj.reserve_back(onetile);
+        noc.async_read(param_in, dfb_param_in_obj, param_in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_param_in_obj.push_back(onetile);
+        dfb_param_in_obj.push_back(onetile);
 
-        cb_grad_obj.reserve_back(onetile);
-        noc.async_read(grad, cb_grad_obj, grad_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+        dfb_grad_obj.reserve_back(onetile);
+        noc.async_read(grad, dfb_grad_obj, grad_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_grad_obj.push_back(onetile);
+        dfb_grad_obj.push_back(onetile);
 
 #if defined(MOMENTUM) && defined(MOMENTUM_INITIALIZED)
-        cb_momentum_in_obj.reserve_back(onetile);
+        dfb_momentum_in_obj.reserve_back(onetile);
         noc.async_read(
-            momentum_in, cb_momentum_in_obj, momentum_in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            momentum_in, dfb_momentum_in_obj, momentum_in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_momentum_in_obj.push_back(onetile);
+        dfb_momentum_in_obj.push_back(onetile);
 #endif
         curr_tile++;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/writer_moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/writer_moreh_sgd.cpp
@@ -5,7 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -35,27 +35,27 @@ void kernel_main() {
 #endif
 
     Noc noc;
-    CircularBuffer cb_param_out_obj(cb_param_out);
+    DataflowBuffer dfb_param_out_obj(cb_param_out);
     const auto param_out_tile_bytes = get_tile_size(cb_param_out);
 #if defined(MOMENTUM)
-    CircularBuffer cb_momentum_out_obj(cb_momentum_out);
+    DataflowBuffer dfb_momentum_out_obj(cb_momentum_out);
     const auto momentum_out_tile_bytes = get_tile_size(cb_momentum_out);
 #endif
 
     uint32_t tile_idx = tile_offset;
     for (uint32_t i = 0; i < num_tiles; i++) {
 #if defined(MOMENTUM)
-        cb_momentum_out_obj.wait_front(onetile);
+        dfb_momentum_out_obj.wait_front(onetile);
         noc.async_write(
-            cb_momentum_out_obj, momentum_out, momentum_out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+            dfb_momentum_out_obj, momentum_out, momentum_out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
         noc.async_write_barrier();
-        cb_momentum_out_obj.pop_front(onetile);
+        dfb_momentum_out_obj.pop_front(onetile);
 #endif
 
-        cb_param_out_obj.wait_front(onetile);
-        noc.async_write(cb_param_out_obj, param_out, param_out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+        dfb_param_out_obj.wait_front(onetile);
+        noc.async_write(dfb_param_out_obj, param_out, param_out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
         noc.async_write_barrier();
-        cb_param_out_obj.pop_front(onetile);
+        dfb_param_out_obj.pop_front(onetile);
 
         tile_idx++;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
@@ -5,23 +5,23 @@
 #include <cstdint>
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
-    CircularBuffer cb_exps_obj(cb_exps);
+    DataflowBuffer dfb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
-    CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
+    DataflowBuffer dfb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_add = tt::CBIndex::c_26;
-    CircularBuffer cb_add_obj(cb_add);
+    DataflowBuffer dfb_add_obj(cb_add);
     constexpr auto cb_max = tt::CBIndex::c_27;
-    CircularBuffer cb_max_obj(cb_max);
+    DataflowBuffer dfb_max_obj(cb_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp_obj(cb_tmp);
+    DataflowBuffer dfb_tmp_obj(cb_tmp);
 
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
@@ -36,97 +36,97 @@ void kernel_main() {
         // find max
         for (uint32_t i = 0; i < dim_size; ++i) {
             if (i == 0) {
-                copy_tile_to_cb(cb_in0_obj, cb_max_obj);
+                copy_tile_to_cb(dfb_in0_obj, dfb_max_obj);
             } else {
-                cb_in0_obj.wait_front(onetile);
-                cb_max_obj.wait_front(onetile);
+                dfb_in0_obj.wait_front(onetile);
+                dfb_max_obj.wait_front(onetile);
 
                 tile_regs_acquire();
 
-                copy_tile_init_with_dt(cb_in0_obj);
+                copy_tile_init_with_dt(dfb_in0_obj);
                 copy_tile(cb_in0, 0, dst0);
 
-                copy_tile_init_with_dt(cb_max_obj);
+                copy_tile_init_with_dt(dfb_max_obj);
                 copy_tile(cb_max, 0, dst1);
 
                 binary_max_tile_init();
                 binary_max_tile(dst0, dst1, dst0);
                 tile_regs_commit();
 
-                cb_max_obj.pop_front(onetile);
-                cb_max_obj.reserve_back(onetile);
+                dfb_max_obj.pop_front(onetile);
+                dfb_max_obj.reserve_back(onetile);
 
                 tile_regs_wait();
-                pack_tile_with_dt(dst0, cb_max_obj);
+                pack_tile_with_dt(dst0, dfb_max_obj);
                 tile_regs_release();
 
-                cb_max_obj.push_back(onetile);
-                cb_in0_obj.pop_front(onetile);
+                dfb_max_obj.push_back(onetile);
+                dfb_in0_obj.pop_front(onetile);
             }
         }
 
         // compute exp(x - max(x))
         for (uint32_t i = 0; i < dim_size; ++i) {
 #ifdef SOFTMAX
-            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 #else
-            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 #endif
 
             if (i == 0) {
-                copy_tile_to_cb(cb_exps_obj, cb_add_obj);
+                copy_tile_to_cb(dfb_exps_obj, dfb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add_obj, cb_exps_obj, cb_add_obj);
+                add_tiles_to_cb(dfb_add_obj, dfb_exps_obj, dfb_add_obj);
             }
         }
 
 #ifdef LOG
         // compute log(sum)
-        log_tile_to_cb(cb_add_obj, cb_recipsumexps_obj);
+        log_tile_to_cb(dfb_add_obj, dfb_recipsumexps_obj);
 #else
         // compute 1/sum(exp(x))
-        recip_tile_to_cb(cb_add_obj, cb_recipsumexps_obj);
+        recip_tile_to_cb(dfb_add_obj, dfb_recipsumexps_obj);
 #endif
 
         // step 3, compute final result
-        cb_recipsumexps_obj.wait_front(onetile);
+        dfb_recipsumexps_obj.wait_front(onetile);
         for (uint32_t i = 0; i < dim_size; ++i) {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // -x + max - log(sum)
-            sub_tiles_to_cb(cb_max_obj, cb_in0_obj, cb_tmp_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_cb(dfb_max_obj, dfb_in0_obj, dfb_tmp_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
 
-            sub_tiles_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 
-            mul_tiles_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 
-            mul_tiles_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }
 
-        cb_recipsumexps_obj.pop_front(onetile);
-        cb_max_obj.pop_front(onetile);
+        dfb_recipsumexps_obj.pop_front(onetile);
+        dfb_max_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
@@ -6,29 +6,29 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_mask = tt::CBIndex::c_1;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_max_scaler = tt::CBIndex::c_2;
-    CircularBuffer cb_max_scaler_obj(cb_max_scaler);
+    DataflowBuffer dfb_max_scaler_obj(cb_max_scaler);
     constexpr auto cb_sum_scaler = tt::CBIndex::c_3;
-    CircularBuffer cb_sum_scaler_obj(cb_sum_scaler);
+    DataflowBuffer dfb_sum_scaler_obj(cb_sum_scaler);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
-    CircularBuffer cb_exps_obj(cb_exps);
+    DataflowBuffer dfb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
-    CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
+    DataflowBuffer dfb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_max = tt::CBIndex::c_26;
-    CircularBuffer cb_max_obj(cb_max);
+    DataflowBuffer dfb_max_obj(cb_max);
     constexpr auto cb_x_m_max = tt::CBIndex::c_27;
-    CircularBuffer cb_x_m_max_obj(cb_x_m_max);
+    DataflowBuffer dfb_x_m_max_obj(cb_x_m_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp_obj(cb_tmp);
+    DataflowBuffer dfb_tmp_obj(cb_tmp);
 
     constexpr int dst0 = 0;
     constexpr int dst1 = 1;
@@ -39,14 +39,14 @@ void kernel_main() {
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Ht = get_compile_time_arg_val(1);
 
-    cb_mask_obj.wait_front(onetile);
-    cb_max_scaler_obj.wait_front(onetile);
-    cb_sum_scaler_obj.wait_front(onetile);
+    dfb_mask_obj.wait_front(onetile);
+    dfb_max_scaler_obj.wait_front(onetile);
+    dfb_sum_scaler_obj.wait_front(onetile);
 
     for (uint32_t n = 0; n < N; ++n) {
         // find max value
         if (Ht == 1) {
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -60,7 +60,7 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single(),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
@@ -68,30 +68,30 @@ void kernel_main() {
         }
 
         // compute x - max(x)
-        cb_x_m_max_obj.reserve_back(Ht);
-        cb_in0_obj.wait_front(Ht);
-        cb_max_obj.wait_front(1);
+        dfb_x_m_max_obj.reserve_back(Ht);
+        dfb_in0_obj.wait_front(Ht);
+        dfb_max_obj.wait_front(1);
 
         for (uint32_t h = 0; h < Ht; ++h) {
             tile_regs_acquire();
-            sub_bcast_rows_init_short_with_dt(cb_in0_obj, cb_max_obj);
+            sub_bcast_rows_init_short_with_dt(dfb_in0_obj, dfb_max_obj);
             sub_tiles_bcast<BroadcastType::ROW>(cb_in0, cb_max, h, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_x_m_max_obj);
+            pack_tile_with_dt(dst0, dfb_x_m_max_obj);
             tile_regs_release();
         }
-        cb_max_obj.pop_front(1);
-        cb_in0_obj.pop_front(Ht);
-        cb_x_m_max_obj.push_back(Ht);
+        dfb_max_obj.pop_front(1);
+        dfb_in0_obj.pop_front(Ht);
+        dfb_x_m_max_obj.push_back(Ht);
 
         // compute exp(x - max(x))
-        cb_exps_obj.reserve_back(Ht);
-        cb_x_m_max_obj.wait_front(Ht);
+        dfb_exps_obj.reserve_back(Ht);
+        dfb_x_m_max_obj.wait_front(Ht);
         for (uint32_t h = 0; h < Ht; ++h) {
             tile_regs_acquire();
-            copy_tile_init_with_dt(cb_x_m_max_obj);
+            copy_tile_init_with_dt(dfb_x_m_max_obj);
             copy_tile(cb_x_m_max, h, dst0);
 
 #ifndef SOFTMAX
@@ -103,7 +103,7 @@ void kernel_main() {
             exp_tile(dst0);
 
             if (h == Ht - 1) {
-                copy_tile_init_with_dt(cb_mask_obj);
+                copy_tile_init_with_dt(dfb_mask_obj);
                 copy_tile(cb_mask, 0, dst1);
 
                 mask_tile_init();
@@ -112,10 +112,10 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_exps_obj);
+            pack_tile_with_dt(dst0, dfb_exps_obj);
             tile_regs_release();
         }
-        cb_exps_obj.push_back(Ht);
+        dfb_exps_obj.push_back(Ht);
 
 #ifdef LOG
         // log(sum) - pop tiles after reduce
@@ -152,42 +152,42 @@ void kernel_main() {
 #endif
 
         // compute final result
-        cb_out0_obj.reserve_back(Ht);
-        cb_x_m_max_obj.wait_front(Ht);
-        cb_recipsumexps_obj.wait_front(1);
+        dfb_out0_obj.reserve_back(Ht);
+        dfb_x_m_max_obj.wait_front(Ht);
+        dfb_recipsumexps_obj.wait_front(1);
 #ifndef LOG
-        cb_exps_obj.wait_front(Ht);
+        dfb_exps_obj.wait_front(Ht);
 #endif
 
         for (uint32_t h = 0; h < Ht; h += onetile) {
 #ifdef LOG
             // x - max - log(sum)
             tile_regs_acquire();
-            sub_bcast_rows_init_short_with_dt(cb_x_m_max_obj, cb_recipsumexps_obj);
+            sub_bcast_rows_init_short_with_dt(dfb_x_m_max_obj, dfb_recipsumexps_obj);
             sub_tiles_bcast<BroadcastType::ROW>(cb_x_m_max, cb_recipsumexps, h, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0_obj);
+            pack_tile_with_dt(dst0, dfb_out0_obj);
             tile_regs_release();
 #else
             // exp(x - max) / psum
             tile_regs_acquire();
-            mul_bcast_rows_init_short_with_dt(cb_exps_obj, cb_recipsumexps_obj);
+            mul_bcast_rows_init_short_with_dt(dfb_exps_obj, dfb_recipsumexps_obj);
             mul_tiles_bcast_rows(cb_exps, cb_recipsumexps, h, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0_obj);
+            pack_tile_with_dt(dst0, dfb_out0_obj);
             tile_regs_release();
 #endif
         }
 
-        cb_recipsumexps_obj.pop_front(1);
-        cb_x_m_max_obj.pop_front(Ht);
-        cb_out0_obj.push_back(Ht);
+        dfb_recipsumexps_obj.pop_front(1);
+        dfb_x_m_max_obj.pop_front(Ht);
+        dfb_out0_obj.push_back(Ht);
 #ifndef LOG
-        cb_exps_obj.pop_front(Ht);
+        dfb_exps_obj.pop_front(Ht);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
@@ -6,27 +6,27 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_mask = tt::CBIndex::c_1;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_max_scaler = tt::CBIndex::c_2;
     constexpr auto cb_sum_scaler = tt::CBIndex::c_3;
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
-    CircularBuffer cb_exps_obj(cb_exps);
+    DataflowBuffer dfb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
-    CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
+    DataflowBuffer dfb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_add = tt::CBIndex::c_26;
-    CircularBuffer cb_add_obj(cb_add);
+    DataflowBuffer dfb_add_obj(cb_add);
     constexpr auto cb_max = tt::CBIndex::c_27;
-    CircularBuffer cb_max_obj(cb_max);
+    DataflowBuffer dfb_max_obj(cb_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp_obj(cb_tmp);
+    DataflowBuffer dfb_tmp_obj(cb_tmp);
 
     binary_op_init_common(cb_in0, cb_max_scaler, cb_out0);
 
@@ -39,7 +39,7 @@ void kernel_main() {
     for (uint32_t n = 0; n < N; ++n) {
         // find max
         if (Ht == 1) {
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -48,7 +48,7 @@ void kernel_main() {
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_in0, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
 
             // Phase 2: Reduce final masked tile with accumulation
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
@@ -61,21 +61,21 @@ void kernel_main() {
             // compute exp(x - max(x))
             if (h == Ht - 1) {
 #ifdef SOFTMAX
-                sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
                 exp_tile_and_mask_tile_to_cb(
-                    cb_tmp_obj,
-                    cb_mask_obj,
-                    cb_exps_obj,
+                    dfb_tmp_obj,
+                    dfb_mask_obj,
+                    dfb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
                     /*popm=*/0);
 #else
                 rexp_tile_and_mask_tile_to_cb(
-                    cb_in0_obj,
-                    cb_mask_obj,
-                    cb_exps_obj,
+                    dfb_in0_obj,
+                    dfb_mask_obj,
+                    dfb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
@@ -83,20 +83,20 @@ void kernel_main() {
 #endif
             } else {
 #ifdef SOFTMAX
-                sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+                exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 #else
-                sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+                rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 #endif
             }
 
             if (h == 0) {
-                copy_tile_to_cb(cb_exps_obj, cb_add_obj);
+                copy_tile_to_cb(dfb_exps_obj, dfb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add_obj, cb_exps_obj, cb_add_obj);
+                add_tiles_to_cb(dfb_add_obj, dfb_exps_obj, dfb_add_obj);
             }
         }
 
@@ -139,9 +139,9 @@ void kernel_main() {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_bcast_rows_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // -x + max - log(sum)
             // logsoftmin not implemented
@@ -149,23 +149,23 @@ void kernel_main() {
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 
-            mul_tiles_bcast_rows_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_bcast_rows_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 
-            mul_tiles_bcast_rows_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }
 
-        cb_recipsumexps_obj.pop_front(onetile);
-        cb_max_obj.pop_front(onetile);
+        dfb_recipsumexps_obj.pop_front(onetile);
+        dfb_max_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -6,29 +6,29 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_mask = tt::CBIndex::c_1;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_max_scaler = tt::CBIndex::c_2;
-    CircularBuffer cb_max_scaler_obj(cb_max_scaler);
+    DataflowBuffer dfb_max_scaler_obj(cb_max_scaler);
     constexpr auto cb_sum_scaler = tt::CBIndex::c_3;
-    CircularBuffer cb_sum_scaler_obj(cb_sum_scaler);
+    DataflowBuffer dfb_sum_scaler_obj(cb_sum_scaler);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
-    CircularBuffer cb_exps_obj(cb_exps);
+    DataflowBuffer dfb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
-    CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
+    DataflowBuffer dfb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_max = tt::CBIndex::c_26;
-    CircularBuffer cb_max_obj(cb_max);
+    DataflowBuffer dfb_max_obj(cb_max);
     constexpr auto cb_x_m_max = tt::CBIndex::c_27;
-    CircularBuffer cb_x_m_max_obj(cb_x_m_max);
+    DataflowBuffer dfb_x_m_max_obj(cb_x_m_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp_obj(cb_tmp);
+    DataflowBuffer dfb_tmp_obj(cb_tmp);
 
     binary_op_init_common(cb_in0, cb_max_scaler, cb_out0);
 
@@ -39,14 +39,14 @@ void kernel_main() {
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
 
-    cb_mask_obj.wait_front(onetile);
-    cb_max_scaler_obj.wait_front(onetile);
-    cb_sum_scaler_obj.wait_front(onetile);
+    dfb_mask_obj.wait_front(onetile);
+    dfb_max_scaler_obj.wait_front(onetile);
+    dfb_sum_scaler_obj.wait_front(onetile);
 
     for (uint32_t n = 0; n < N; ++n) {
         // find max value
         if (Wt == 1) {
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -66,7 +66,7 @@ void kernel_main() {
             // Phase 2: mask the last tile (index Wt-1, no pop) and continue reducing
             // into cb_max via Accumulate. The accumulator and output are both cb_max:
             // the helper waits+pops the previous tile, then packs+pushes the new one.
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
@@ -74,30 +74,30 @@ void kernel_main() {
         }
 
         // compute x - max(x)
-        cb_x_m_max_obj.reserve_back(Wt);
-        cb_in0_obj.wait_front(Wt);
-        cb_max_obj.wait_front(1);
+        dfb_x_m_max_obj.reserve_back(Wt);
+        dfb_in0_obj.wait_front(Wt);
+        dfb_max_obj.wait_front(1);
 
         for (uint32_t w = 0; w < Wt; ++w) {
             tile_regs_acquire();
-            sub_bcast_cols_init_short_with_dt(cb_in0_obj, cb_max_obj);
+            sub_bcast_cols_init_short_with_dt(dfb_in0_obj, dfb_max_obj);
             sub_tiles_bcast<BroadcastType::COL>(cb_in0, cb_max, w, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_x_m_max_obj);
+            pack_tile_with_dt(dst0, dfb_x_m_max_obj);
             tile_regs_release();
         }
-        cb_max_obj.pop_front(1);
-        cb_in0_obj.pop_front(Wt);
-        cb_x_m_max_obj.push_back(Wt);
+        dfb_max_obj.pop_front(1);
+        dfb_in0_obj.pop_front(Wt);
+        dfb_x_m_max_obj.push_back(Wt);
 
         // compute exp(x - max(x))
-        cb_exps_obj.reserve_back(Wt);
-        cb_x_m_max_obj.wait_front(Wt);
+        dfb_exps_obj.reserve_back(Wt);
+        dfb_x_m_max_obj.wait_front(Wt);
         for (uint32_t w = 0; w < Wt; ++w) {
             tile_regs_acquire();
-            copy_tile_init_with_dt(cb_x_m_max_obj);
+            copy_tile_init_with_dt(dfb_x_m_max_obj);
             copy_tile(cb_x_m_max, w, dst0);
 
 #ifndef SOFTMAX
@@ -109,7 +109,7 @@ void kernel_main() {
             exp_tile(dst0);
 
             if (w == Wt - 1) {
-                copy_tile_init_with_dt(cb_mask_obj);
+                copy_tile_init_with_dt(dfb_mask_obj);
                 copy_tile(cb_mask, 0, dst1);
 
                 mask_tile_init();
@@ -118,10 +118,10 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_exps_obj);
+            pack_tile_with_dt(dst0, dfb_exps_obj);
             tile_regs_release();
         }
-        cb_exps_obj.push_back(Wt);
+        dfb_exps_obj.push_back(Wt);
 
 #ifdef LOG
         // log(sum) - pop tiles after reduce
@@ -158,43 +158,43 @@ void kernel_main() {
 #endif
 
         // compute final result
-        cb_out0_obj.reserve_back(Wt);
-        cb_x_m_max_obj.wait_front(Wt);
-        cb_recipsumexps_obj.wait_front(1);
+        dfb_out0_obj.reserve_back(Wt);
+        dfb_x_m_max_obj.wait_front(Wt);
+        dfb_recipsumexps_obj.wait_front(1);
 
 #ifndef LOG
-        cb_exps_obj.wait_front(Wt);
+        dfb_exps_obj.wait_front(Wt);
 #endif
 
         for (uint32_t w = 0; w < Wt; w += onetile) {
 #ifdef LOG
             // x - max - log(sum)
             tile_regs_acquire();
-            sub_bcast_cols_init_short_with_dt(cb_x_m_max_obj, cb_recipsumexps_obj);
+            sub_bcast_cols_init_short_with_dt(dfb_x_m_max_obj, dfb_recipsumexps_obj);
             sub_tiles_bcast<BroadcastType::COL>(cb_x_m_max, cb_recipsumexps, w, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0_obj);
+            pack_tile_with_dt(dst0, dfb_out0_obj);
             tile_regs_release();
 #else
             // exp(x - max) / psum
             tile_regs_acquire();
-            mul_bcast_cols_init_short_with_dt(cb_exps_obj, cb_recipsumexps_obj);
+            mul_bcast_cols_init_short_with_dt(dfb_exps_obj, dfb_recipsumexps_obj);
             mul_tiles_bcast_cols(cb_exps, cb_recipsumexps, w, 0, dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_out0_obj);
+            pack_tile_with_dt(dst0, dfb_out0_obj);
             tile_regs_release();
 #endif
         }
 
-        cb_recipsumexps_obj.pop_front(1);
-        cb_x_m_max_obj.pop_front(Wt);
-        cb_out0_obj.push_back(Wt);
+        dfb_recipsumexps_obj.pop_front(1);
+        dfb_x_m_max_obj.pop_front(Wt);
+        dfb_out0_obj.push_back(Wt);
 #ifndef LOG
-        cb_exps_obj.pop_front(Wt);
+        dfb_exps_obj.pop_front(Wt);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -6,27 +6,27 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_mask = tt::CBIndex::c_1;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_max_scaler = tt::CBIndex::c_2;
     constexpr auto cb_sum_scaler = tt::CBIndex::c_3;
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_exps = tt::CBIndex::c_24;
-    CircularBuffer cb_exps_obj(cb_exps);
+    DataflowBuffer dfb_exps_obj(cb_exps);
     constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
-    CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
+    DataflowBuffer dfb_recipsumexps_obj(cb_recipsumexps);
     constexpr auto cb_add = tt::CBIndex::c_26;
-    CircularBuffer cb_add_obj(cb_add);
+    DataflowBuffer dfb_add_obj(cb_add);
     constexpr auto cb_max = tt::CBIndex::c_27;
-    CircularBuffer cb_max_obj(cb_max);
+    DataflowBuffer dfb_max_obj(cb_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp_obj(cb_tmp);
+    DataflowBuffer dfb_tmp_obj(cb_tmp);
 
     binary_op_init_common(cb_in0, cb_max_scaler, cb_out0);
 
@@ -38,7 +38,7 @@ void kernel_main() {
     for (uint32_t n = 0; n < N; ++n) {
         // find max
         if (Wt == 1) {
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -48,7 +48,7 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
             // Phase 2: mask the last tile and continue reducing into cb_max via Accumulate.
-            mask_tile_to_cb(cb_in0_obj, cb_mask_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
@@ -60,21 +60,21 @@ void kernel_main() {
             // compute exp(x)
             if (w == Wt - 1) {
 #ifdef SOFTMAX
-                sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
                 exp_tile_and_mask_tile_to_cb(
-                    cb_tmp_obj,
-                    cb_mask_obj,
-                    cb_exps_obj,
+                    dfb_tmp_obj,
+                    dfb_mask_obj,
+                    dfb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
                     /*popm=*/0);
 #else
                 rexp_tile_and_mask_tile_to_cb(
-                    cb_in0_obj,
-                    cb_mask_obj,
-                    cb_exps_obj,
+                    dfb_in0_obj,
+                    dfb_mask_obj,
+                    dfb_exps_obj,
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
@@ -82,20 +82,20 @@ void kernel_main() {
 #endif
             } else {
 #ifdef SOFTMAX
-                sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+                exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 #else
-                sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+                rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 #endif
             }
 
             if (w == 0) {
-                copy_tile_to_cb(cb_exps_obj, cb_add_obj);
+                copy_tile_to_cb(dfb_exps_obj, dfb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add_obj, cb_exps_obj, cb_add_obj);
+                add_tiles_to_cb(dfb_add_obj, dfb_exps_obj, dfb_add_obj);
             }
         }
 
@@ -138,9 +138,9 @@ void kernel_main() {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_bcast_cols_to_cb(cb_tmp_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // -x + max - log(sum)
             // logsoftmin not implemented
@@ -148,23 +148,23 @@ void kernel_main() {
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 
-            mul_tiles_bcast_cols_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_bcast_cols_to_cb(cb_in0_obj, cb_max_obj, cb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(cb_tmp_obj, cb_exps_obj);
+            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
 
-            mul_tiles_bcast_cols_to_cb(cb_exps_obj, cb_recipsumexps_obj, cb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }
 
-        cb_recipsumexps_obj.pop_front(onetile);
-        cb_max_obj.pop_front(onetile);
+        dfb_recipsumexps_obj.pop_front(onetile);
+        dfb_max_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_c_large.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,7 +23,7 @@ void kernel_main() {
     const auto src_in = TensorAccessor(in_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in_obj(cb_in);
+    DataflowBuffer dfb_in_obj(cb_in);
     const auto in_tile_bytes = get_tile_size(cb_in);
 
     uint32_t curr_tile = tile_offset;
@@ -34,28 +34,28 @@ void kernel_main() {
 
         uint32_t dim_stride = inner_size;
         for (uint32_t d = 0; d < dim_size; d++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             tile_idx += dim_stride;
         }
 
         tile_idx = outer_idx * outer_stride + inner_idx;
         for (uint32_t d = 0; d < dim_size; d++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             tile_idx += dim_stride;
         }
 
         tile_idx = outer_idx * outer_stride + inner_idx;
         for (uint32_t d = 0; d < dim_size; d++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             tile_idx += dim_stride;
         }
         curr_tile += 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -39,29 +39,29 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_COL>();
 
     // Generate mask tile
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_h<uint32_t>(cb_mask_obj, mask_h);
+        generate_mask_h<uint32_t>(dfb_mask_obj, mask_h);
     } else {
-        generate_mask_h<uint16_t>(cb_mask_obj, mask_h);
+        generate_mask_h<uint16_t>(dfb_mask_obj, mask_h);
     }
 
     Noc noc;
-    CircularBuffer cb_in_obj(cb_in);
+    DataflowBuffer dfb_in_obj(cb_in);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
         uint32_t w_idx = curr_tile % Wt;
         uint32_t nc_idx = curr_tile / Wt;
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
-        cb_in_obj.reserve_back(Ht);
+        dfb_in_obj.reserve_back(Ht);
         for (uint32_t h = 0; h < Ht; h++) {
             noc.async_read(
-                src_in, cb_in_obj, src_in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = h * src_in_tile_bytes});
+                src_in, dfb_in_obj, src_in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = h * src_in_tile_bytes});
             tile_idx += Wt;
         }
         noc.async_read_barrier();
-        cb_in_obj.push_back(Ht);
+        dfb_in_obj.push_back(Ht);
         curr_tile += 1;
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -38,15 +38,15 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_COL>();
 
     // Generate mask tile
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_h<uint32_t>(cb_mask_obj, mask_h);
+        generate_mask_h<uint32_t>(dfb_mask_obj, mask_h);
     } else {
-        generate_mask_h<uint16_t>(cb_mask_obj, mask_h);
+        generate_mask_h<uint16_t>(dfb_mask_obj, mask_h);
     }
 
     Noc noc;
-    CircularBuffer cb_in_obj(cb_in);
+    DataflowBuffer dfb_in_obj(cb_in);
     const auto in_tile_bytes = get_tile_size(cb_in);
 
     uint32_t curr_tile = tile_offset;
@@ -55,10 +55,10 @@ void kernel_main() {
         uint32_t nc_idx = curr_tile / Wt;
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             tile_idx += Wt;
         }
 
@@ -66,10 +66,10 @@ void kernel_main() {
         nc_idx = curr_tile / Wt;
         tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             tile_idx += Wt;
         }
 
@@ -77,10 +77,10 @@ void kernel_main() {
         nc_idx = curr_tile / Wt;
         tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             tile_idx += Wt;
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 #include <cstdint>
@@ -40,25 +40,25 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
 
     // Generate mask tile
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_w<uint32_t>(cb_mask_obj, mask_w);
+        generate_mask_w<uint32_t>(dfb_mask_obj, mask_w);
     } else {
-        generate_mask_w<uint16_t>(cb_mask_obj, mask_w);
+        generate_mask_w<uint16_t>(dfb_mask_obj, mask_w);
     }
 
     Noc noc;
-    CircularBuffer cb_in_obj(cb_in);
+    DataflowBuffer dfb_in_obj(cb_in);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
-        cb_in_obj.reserve_back(Wt);
+        dfb_in_obj.reserve_back(Wt);
         for (uint32_t w = 0; w < Wt; w++) {
             noc.async_read(
-                src_in, cb_in_obj, src_in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = w * src_in_tile_bytes});
+                src_in, dfb_in_obj, src_in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = w * src_in_tile_bytes});
             curr_tile++;
         }
         noc.async_read_barrier();
-        cb_in_obj.push_back(Wt);
+        dfb_in_obj.push_back(Wt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 #include <cstdint>
@@ -39,43 +39,43 @@ void kernel_main() {
         calculate_and_prepare_reduce_scaler<cb_sum_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
 
     // Generate mask tile
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     if (is_fp32) {
-        generate_mask_w<uint32_t>(cb_mask_obj, mask_w);
+        generate_mask_w<uint32_t>(dfb_mask_obj, mask_w);
     } else {
-        generate_mask_w<uint16_t>(cb_mask_obj, mask_w);
+        generate_mask_w<uint16_t>(dfb_mask_obj, mask_w);
     }
 
     Noc noc;
-    CircularBuffer cb_in_obj(cb_in);
+    DataflowBuffer dfb_in_obj(cb_in);
     const auto in_tile_bytes = get_tile_size(cb_in);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
         uint32_t curr_offset_i = curr_tile;
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             curr_tile++;
         }
 
         curr_tile = curr_offset_i;
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             curr_tile++;
         }
 
         curr_tile = curr_offset_i;
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_in_obj.reserve_back(onetile);
-            noc.async_read(src_in, cb_in_obj, in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_in_obj.reserve_back(onetile);
+            noc.async_read(src_in, dfb_in_obj, in_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in_obj.push_back(onetile);
+            dfb_in_obj.push_back(onetile);
             curr_tile++;
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_c_large.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,7 +23,7 @@ void kernel_main() {
     const auto dst_out = TensorAccessor(out_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_out);
+    DataflowBuffer dfb_out_obj(cb_out);
     const auto out_tile_bytes = get_tile_size(cb_out);
 
     uint32_t curr_tile = tile_offset;
@@ -34,10 +34,10 @@ void kernel_main() {
 
         uint32_t dim_stride = inner_size;
         for (uint32_t d = 0; d < dim_size; d++) {
-            cb_out_obj.wait_front(onetile);
-            noc.async_write(cb_out_obj, dst_out, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+            dfb_out_obj.wait_front(onetile);
+            noc.async_write(dfb_out_obj, dst_out, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(onetile);
+            dfb_out_obj.pop_front(onetile);
             tile_idx += dim_stride;
         }
         curr_tile += 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -25,7 +25,7 @@ void kernel_main() {
     const auto s = TensorAccessor(out_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i++) {
@@ -33,13 +33,13 @@ void kernel_main() {
         uint32_t nc_idx = curr_tile / Wt;
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
 
-        cb_out_obj.wait_front(Ht);
+        dfb_out_obj.wait_front(Ht);
         for (uint32_t h = 0; h < Ht; h++) {
-            noc.async_write(cb_out_obj, s, tile_bytes, {.offset_bytes = h * tile_bytes}, {.page_id = tile_idx});
+            noc.async_write(dfb_out_obj, s, tile_bytes, {.offset_bytes = h * tile_bytes}, {.page_id = tile_idx});
             tile_idx += Wt;
         }
         noc.async_write_barrier();
-        cb_out_obj.pop_front(Ht);
+        dfb_out_obj.pop_front(Ht);
         curr_tile += 1;
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h_large.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,7 +21,7 @@ void kernel_main() {
     const auto s = TensorAccessor(out_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t blk = 1;
@@ -32,10 +32,10 @@ void kernel_main() {
         uint32_t nc_idx = curr_tile / Wt;
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_out_obj.wait_front(blk);
-            noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+            dfb_out_obj.wait_front(blk);
+            noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(blk);
+            dfb_out_obj.pop_front(blk);
             tile_idx += Wt;
         }
         curr_tile += 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,16 +21,16 @@ void kernel_main() {
     const auto s = TensorAccessor(out_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
 
     uint32_t tile_id = tile_offset;
     for (uint32_t i = 0; i < N; i++) {
-        cb_out_obj.wait_front(Wt);
+        dfb_out_obj.wait_front(Wt);
         for (uint32_t w = 0; w < Wt; w++) {
-            noc.async_write(cb_out_obj, s, tile_bytes, {.offset_bytes = w * tile_bytes}, {.page_id = tile_id});
+            noc.async_write(dfb_out_obj, s, tile_bytes, {.offset_bytes = w * tile_bytes}, {.page_id = tile_id});
             tile_id++;
         }
         noc.async_write_barrier();
-        cb_out_obj.pop_front(Wt);
+        dfb_out_obj.pop_front(Wt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w_large.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -20,7 +20,7 @@ void kernel_main() {
     const auto s = TensorAccessor(out_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t blk = 1;
@@ -28,10 +28,10 @@ void kernel_main() {
     uint32_t tile_id = tile_offset;
     for (uint32_t i = 0; i < N; i++) {
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_out_obj.wait_front(blk);
-            noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
+            dfb_out_obj.wait_front(blk);
+            noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(blk);
+            dfb_out_obj.pop_front(blk);
             tile_id++;
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
@@ -5,24 +5,24 @@
 #include <cstdint>
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     constexpr auto cb_dx = tt::CBIndex::c_16;
-    CircularBuffer cb_dx_obj(cb_dx);
+    DataflowBuffer dfb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
-    CircularBuffer cb_ydy_obj(cb_ydy);
+    DataflowBuffer dfb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
-    CircularBuffer cb_sum_obj(cb_sum);
+    DataflowBuffer dfb_sum_obj(cb_sum);
     constexpr auto cb_dy_m_sum = tt::CBIndex::c_26;  // dy - sum
-    CircularBuffer cb_dy_m_sum_obj(cb_dy_m_sum);
+    DataflowBuffer dfb_dy_m_sum_obj(cb_dy_m_sum);
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t dim_size = get_compile_time_arg_val(1);
@@ -34,36 +34,36 @@ void kernel_main() {
 #ifdef LOG
         for (uint32_t i = 0; i < dim_size; ++i) {
             if (i == 0) {
-                copy_tile_to_cb(cb_dy_obj, cb_sum_obj);
+                copy_tile_to_cb(dfb_dy_obj, dfb_sum_obj);
             } else {
-                add_tiles_to_cb(cb_sum_obj, cb_dy_obj, cb_sum_obj);
+                add_tiles_to_cb(dfb_sum_obj, dfb_dy_obj, dfb_sum_obj);
             }
         }
 
         for (uint32_t i = 0; i < dim_size; ++i) {
             // exp(y)
             constexpr auto cb_exp = tt::CBIndex::c_24;
-            CircularBuffer cb_exp_obj(cb_exp);
-            exp_tile_to_cb(cb_y_obj, cb_exp_obj);
+            DataflowBuffer dfb_exp_obj(cb_exp);
+            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj);
 
             // sum * exp(y)
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
-            CircularBuffer cb_inter2_obj(cb_inter2);
-            mul_tiles_to_cb(cb_sum_obj, cb_exp_obj, cb_inter2_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
+            DataflowBuffer dfb_inter2_obj(cb_inter2);
+            mul_tiles_to_cb(dfb_sum_obj, dfb_exp_obj, dfb_inter2_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj);
+            sub_tiles_to_cb(dfb_dy_obj, dfb_inter2_obj, dfb_dx_obj);
         }
-        cb_sum_obj.pop_front(onetile);
+        dfb_sum_obj.pop_front(onetile);
 #else
         // compute sum(y * dy)
         for (uint32_t i = 0; i < dim_size; ++i) {
-            mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj);
+            mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj);
 
             if (i == 0) {
-                copy_tile_to_cb(cb_ydy_obj, cb_sum_obj);
+                copy_tile_to_cb(dfb_ydy_obj, dfb_sum_obj);
             } else {
-                add_tiles_to_cb(cb_sum_obj, cb_ydy_obj, cb_sum_obj);
+                add_tiles_to_cb(dfb_sum_obj, dfb_ydy_obj, dfb_sum_obj);
             }
         }
 
@@ -71,9 +71,9 @@ void kernel_main() {
         for (uint32_t i = 0; i < dim_size; ++i) {
             // dy - sum
             sub_tiles_to_cb(
-                cb_dy_obj,
-                cb_sum_obj,
-                cb_dy_m_sum_obj,
+                dfb_dy_obj,
+                dfb_sum_obj,
+                dfb_dy_m_sum_obj,
                 /*itile0=*/0,
                 /*itile1=*/0,
                 /*pop0=*/1,
@@ -81,13 +81,13 @@ void kernel_main() {
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_dy_m_sum_obj, cb_y_obj, cb_dx_obj);
+            mul_tiles_to_cb(dfb_dy_m_sum_obj, dfb_y_obj, dfb_dx_obj);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_dy_m_sum_obj, cb_y_obj, cb_dx_obj);
+            mul_tiles_and_negative_to_cb(dfb_dy_m_sum_obj, dfb_y_obj, dfb_dx_obj);
 #endif
         }
-        cb_sum_obj.pop_front(onetile);
+        dfb_sum_obj.pop_front(onetile);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
@@ -6,27 +6,27 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
-    CircularBuffer cb_dx_obj(cb_dx);
+    DataflowBuffer dfb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
-    CircularBuffer cb_ydy_obj(cb_ydy);
+    DataflowBuffer dfb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
-    CircularBuffer cb_sum_obj(cb_sum);
+    DataflowBuffer dfb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
-    CircularBuffer cb_inter2_obj(cb_inter2);
+    DataflowBuffer dfb_inter2_obj(cb_inter2);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -38,7 +38,7 @@ void kernel_main() {
         // sum(dy)
         if (Ht == 1) {
             // apply mask
-            mask_tile_to_cb(cb_dy_obj, cb_mask_obj, cb_inter2_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            mask_tile_to_cb(dfb_dy_obj, dfb_mask_obj, dfb_inter2_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_inter2, cb_bcast_scaler, cb_sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -54,44 +54,44 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
-            CircularBuffer cb_inter1_obj(cb_inter1);
+            DataflowBuffer dfb_inter1_obj(cb_inter1);
             mask_tile_to_cb(
-                cb_dy_obj, cb_mask_obj, cb_inter1_obj, /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+                dfb_dy_obj, dfb_mask_obj, dfb_inter1_obj, /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_inter1, cb_bcast_scaler, cb_inter2>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
 
-            CircularBuffer cb_inter0_obj(cb_inter0);
-            add_tiles_to_cb(cb_inter0_obj, cb_inter2_obj, cb_sum_obj);
+            DataflowBuffer dfb_inter0_obj(cb_inter0);
+            add_tiles_to_cb(dfb_inter0_obj, dfb_inter2_obj, dfb_sum_obj);
         }
 
         // dy - sum * exp(y)
         constexpr auto cb_exp = tt::CBIndex::c_24;  // y * dy
-        CircularBuffer cb_exp_obj(cb_exp);
+        DataflowBuffer dfb_exp_obj(cb_exp);
 
         for (uint32_t w = 0; w < Ht; w += onetile) {
             // exp(y)
-            exp_tile_to_cb(cb_y_obj, cb_exp_obj, w, /*dst=*/0, /*pop=*/0);
+            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, w, /*dst=*/0, /*pop=*/0);
 
             // sum * exp(y)
-            mul_tiles_bcast_rows_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_cb(dfb_dy_obj, dfb_inter2_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
         }
 
-        cb_sum_obj.pop_front(onetile);
-        cb_y_obj.pop_front(Ht);
-        cb_dy_obj.pop_front(Ht);
+        dfb_sum_obj.pop_front(onetile);
+        dfb_y_obj.pop_front(Ht);
+        dfb_dy_obj.pop_front(Ht);
 #else
         // step 1, compute y * dy
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, h, h, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
+                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, h, h, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj, h, h, /*pop0=*/0, /*pop1=*/0);
+                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj, h, h, /*pop0=*/0, /*pop1=*/0);
             }
         }
 
@@ -107,20 +107,20 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {
             // dy - sum
-            sub_tiles_bcast_rows_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, h, 0, /*pop0=*/0, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_inter2_obj, h, 0, /*pop0=*/0, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
 #endif
         }
 
-        cb_sum_obj.pop_front(onetile);
-        cb_dy_obj.pop_front(Ht);
-        cb_y_obj.pop_front(Ht);
+        dfb_sum_obj.pop_front(onetile);
+        dfb_dy_obj.pop_front(Ht);
+        dfb_y_obj.pop_front(Ht);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
@@ -6,29 +6,29 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
-    CircularBuffer cb_dx_obj(cb_dx);
+    DataflowBuffer dfb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
-    CircularBuffer cb_ydy_obj(cb_ydy);
+    DataflowBuffer dfb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
-    CircularBuffer cb_sum_obj(cb_sum);
+    DataflowBuffer dfb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
-    CircularBuffer cb_inter2_obj(cb_inter2);
+    DataflowBuffer dfb_inter2_obj(cb_inter2);
     constexpr auto cb_add = tt::CBIndex::c_27;
-    CircularBuffer cb_add_obj(cb_add);
+    DataflowBuffer dfb_add_obj(cb_add);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -42,20 +42,20 @@ void kernel_main() {
             if (h == Ht - 1) {
                 if (h == 0) {
                     mask_tile_to_cb(
-                        cb_dy_obj, cb_mask_obj, cb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                        dfb_dy_obj, dfb_mask_obj, dfb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
                 } else {
                     constexpr auto cb_inter0 = tt::CBIndex::c_24;
-                    CircularBuffer cb_inter0_obj(cb_inter0);
+                    DataflowBuffer dfb_inter0_obj(cb_inter0);
                     mask_tile_to_cb(
-                        cb_dy_obj, cb_mask_obj, cb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                        dfb_dy_obj, dfb_mask_obj, dfb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
 
-                    add_tiles_to_cb(cb_add_obj, cb_inter0_obj, cb_add_obj);
+                    add_tiles_to_cb(dfb_add_obj, dfb_inter0_obj, dfb_add_obj);
                 }
             } else {
                 if (h == 0) {
-                    copy_tile_to_cb(cb_dy_obj, cb_add_obj);
+                    copy_tile_to_cb(dfb_dy_obj, dfb_add_obj);
                 } else {
-                    add_tiles_to_cb(cb_add_obj, cb_dy_obj, cb_add_obj);
+                    add_tiles_to_cb(dfb_add_obj, dfb_dy_obj, dfb_add_obj);
                 }
             }
         }
@@ -66,32 +66,32 @@ void kernel_main() {
         for (uint32_t h = 0; h < Ht; ++h) {
             // exp(y)
             constexpr auto cb_exp = tt::CBIndex::c_24;
-            CircularBuffer cb_exp_obj(cb_exp);
-            exp_tile_to_cb(cb_y_obj, cb_exp_obj, 0);
+            DataflowBuffer dfb_exp_obj(cb_exp);
+            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, 0);
 
             // sum * exp(y)
-            mul_tiles_bcast_rows_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj);
+            sub_tiles_to_cb(dfb_dy_obj, dfb_inter2_obj, dfb_dx_obj);
         }
 
-        cb_sum_obj.pop_front(onetile);
+        dfb_sum_obj.pop_front(onetile);
 #else
 
         // step 1, compute y * dy
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
+                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj);
+                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj);
             }
 
             if (h == 0) {
-                copy_tile_to_cb(cb_ydy_obj, cb_add_obj);
+                copy_tile_to_cb(dfb_ydy_obj, dfb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add_obj, cb_ydy_obj, cb_add_obj);
+                add_tiles_to_cb(dfb_add_obj, dfb_ydy_obj, dfb_add_obj);
             }
         }
 
@@ -102,18 +102,18 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {
             // dy - sum
-            sub_tiles_bcast_rows_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
+            mul_tiles_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
+            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj);
 #endif
         }
 
-        cb_sum_obj.pop_front(onetile);
+        dfb_sum_obj.pop_front(onetile);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
@@ -6,27 +6,27 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
-    CircularBuffer cb_dx_obj(cb_dx);
+    DataflowBuffer dfb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
-    CircularBuffer cb_ydy_obj(cb_ydy);
+    DataflowBuffer dfb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
-    CircularBuffer cb_sum_obj(cb_sum);
+    DataflowBuffer dfb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
-    CircularBuffer cb_inter2_obj(cb_inter2);
+    DataflowBuffer dfb_inter2_obj(cb_inter2);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -38,7 +38,7 @@ void kernel_main() {
         // sum(dy)
         if (Wt == 1) {
             // apply mask
-            mask_tile_to_cb(cb_dy_obj, cb_mask_obj, cb_inter2_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            mask_tile_to_cb(dfb_dy_obj, dfb_mask_obj, dfb_inter2_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_inter2, cb_bcast_scaler, cb_sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
@@ -54,44 +54,44 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
-            CircularBuffer cb_inter1_obj(cb_inter1);
+            DataflowBuffer dfb_inter1_obj(cb_inter1);
             mask_tile_to_cb(
-                cb_dy_obj, cb_mask_obj, cb_inter1_obj, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+                dfb_dy_obj, dfb_mask_obj, dfb_inter1_obj, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_inter1, cb_bcast_scaler, cb_inter2>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
 
-            CircularBuffer cb_inter0_obj(cb_inter0);
-            add_tiles_to_cb(cb_inter0_obj, cb_inter2_obj, cb_sum_obj);
+            DataflowBuffer dfb_inter0_obj(cb_inter0);
+            add_tiles_to_cb(dfb_inter0_obj, dfb_inter2_obj, dfb_sum_obj);
         }
 
         // dy - sum * exp(y)
         constexpr auto cb_exp = tt::CBIndex::c_24;  // y * dy
-        CircularBuffer cb_exp_obj(cb_exp);
+        DataflowBuffer dfb_exp_obj(cb_exp);
 
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // exp(y)
-            exp_tile_to_cb(cb_y_obj, cb_exp_obj, w, /*dst=*/0, /*pop=*/0);
+            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, w, /*dst=*/0, /*pop=*/0);
 
             // sum * exp(y)
-            mul_tiles_bcast_cols_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_cb(dfb_dy_obj, dfb_inter2_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
         }
 
-        cb_sum_obj.pop_front(onetile);
-        cb_y_obj.pop_front(Wt);
-        cb_dy_obj.pop_front(Wt);
+        dfb_sum_obj.pop_front(onetile);
+        dfb_y_obj.pop_front(Wt);
+        dfb_dy_obj.pop_front(Wt);
 #else
         // step 1, compute y * dy
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, w, w, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
+                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, w, w, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj, w, w, /*pop0=*/0, /*pop1=*/0);
+                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj, w, w, /*pop0=*/0, /*pop1=*/0);
             }
         }
 
@@ -107,20 +107,20 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // dy - sum
-            sub_tiles_bcast_cols_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, w, 0, /*pop0=*/0, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_inter2_obj, w, 0, /*pop0=*/0, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
 #endif
         }
 
-        cb_sum_obj.pop_front(onetile);
-        cb_dy_obj.pop_front(Wt);
-        cb_y_obj.pop_front(Wt);
+        dfb_sum_obj.pop_front(onetile);
+        dfb_dy_obj.pop_front(Wt);
+        dfb_y_obj.pop_front(Wt);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
@@ -6,29 +6,29 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_y = tt::CBIndex::c_0;
-    CircularBuffer cb_y_obj(cb_y);
+    DataflowBuffer dfb_y_obj(cb_y);
     constexpr auto cb_dy = tt::CBIndex::c_1;
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_2;
     constexpr auto cb_mask = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_obj(cb_mask);
+    DataflowBuffer dfb_mask_obj(cb_mask);
     constexpr auto cb_dx = tt::CBIndex::c_16;
-    CircularBuffer cb_dx_obj(cb_dx);
+    DataflowBuffer dfb_dx_obj(cb_dx);
 
     constexpr auto cb_ydy = tt::CBIndex::c_24;  // y * dy
-    CircularBuffer cb_ydy_obj(cb_ydy);
+    DataflowBuffer dfb_ydy_obj(cb_ydy);
     constexpr auto cb_sum = tt::CBIndex::c_25;
-    CircularBuffer cb_sum_obj(cb_sum);
+    DataflowBuffer dfb_sum_obj(cb_sum);
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
-    CircularBuffer cb_inter2_obj(cb_inter2);
+    DataflowBuffer dfb_inter2_obj(cb_inter2);
     constexpr auto cb_add = tt::CBIndex::c_27;
-    CircularBuffer cb_add_obj(cb_add);
+    DataflowBuffer dfb_add_obj(cb_add);
 
     binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
@@ -42,20 +42,20 @@ void kernel_main() {
             if (w == Wt - 1) {
                 if (w == 0) {
                     mask_tile_to_cb(
-                        cb_dy_obj, cb_mask_obj, cb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                        dfb_dy_obj, dfb_mask_obj, dfb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
                 } else {
                     constexpr auto cb_inter0 = tt::CBIndex::c_24;
-                    CircularBuffer cb_inter0_obj(cb_inter0);
+                    DataflowBuffer dfb_inter0_obj(cb_inter0);
                     mask_tile_to_cb(
-                        cb_dy_obj, cb_mask_obj, cb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                        dfb_dy_obj, dfb_mask_obj, dfb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
 
-                    add_tiles_to_cb(cb_add_obj, cb_inter0_obj, cb_add_obj);
+                    add_tiles_to_cb(dfb_add_obj, dfb_inter0_obj, dfb_add_obj);
                 }
             } else {
                 if (w == 0) {
-                    copy_tile_to_cb(cb_dy_obj, cb_add_obj);
+                    copy_tile_to_cb(dfb_dy_obj, dfb_add_obj);
                 } else {
-                    add_tiles_to_cb(cb_add_obj, cb_dy_obj, cb_add_obj);
+                    add_tiles_to_cb(dfb_add_obj, dfb_dy_obj, dfb_add_obj);
                 }
             }
         }
@@ -66,30 +66,30 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // exp(y)
             constexpr auto cb_exp = tt::CBIndex::c_24;
-            CircularBuffer cb_exp_obj(cb_exp);
-            exp_tile_to_cb(cb_y_obj, cb_exp_obj, 0);
+            DataflowBuffer dfb_exp_obj(cb_exp);
+            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, 0);
             // sum * exp(y)
-            mul_tiles_bcast_cols_to_cb(cb_exp_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(cb_dy_obj, cb_inter2_obj, cb_dx_obj);
+            sub_tiles_to_cb(dfb_dy_obj, dfb_inter2_obj, dfb_dx_obj);
         }
 
-        cb_sum_obj.pop_front(onetile);
+        dfb_sum_obj.pop_front(onetile);
 #else
         // step 1, compute y * dy
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
                 mul_tiles_and_mask_tile_to_cb(
-                    cb_y_obj, cb_dy_obj, cb_mask_obj, cb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
+                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(cb_y_obj, cb_dy_obj, cb_ydy_obj);
+                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj);
             }
 
             if (w == 0) {
-                copy_tile_to_cb(cb_ydy_obj, cb_add_obj);
+                copy_tile_to_cb(dfb_ydy_obj, dfb_add_obj);
             } else {
-                add_tiles_to_cb(cb_add_obj, cb_ydy_obj, cb_add_obj);
+                add_tiles_to_cb(dfb_add_obj, dfb_ydy_obj, dfb_add_obj);
             }
         }
 
@@ -100,18 +100,18 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // dy - sum
-            sub_tiles_bcast_cols_to_cb(cb_dy_obj, cb_sum_obj, cb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_inter2_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
+            mul_tiles_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(cb_y_obj, cb_inter2_obj, cb_dx_obj);
+            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_inter2_obj, dfb_dx_obj);
 #endif
         }
 
-        cb_sum_obj.pop_front(onetile);
+        dfb_sum_obj.pop_front(onetile);
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_c.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_c.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -28,8 +28,8 @@ void kernel_main() {
     const auto dy_in = TensorAccessor(dy_args, dy_addr);
 
     Noc noc;
-    CircularBuffer cb_y_obj(cb_y);
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_y_obj(cb_y);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     const auto y_tile_bytes = get_tile_size(cb_y);
     const auto dy_tile_bytes = get_tile_size(cb_dy);
 
@@ -42,30 +42,30 @@ void kernel_main() {
         uint32_t dim_stride = inner_size;
         for (uint32_t d = 0; d < dim_size; d++) {
 #ifndef LOG
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 #endif
 
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
             tile_idx += dim_stride;
         }
 
         tile_idx = outer_idx * outer_stride + inner_idx;
         for (uint32_t d = 0; d < dim_size; d++) {
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
 
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 
             tile_idx += dim_stride;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -34,14 +34,14 @@ void kernel_main() {
     const auto y_in = TensorAccessor(y_args, y_addr);
     const auto dy_in = TensorAccessor(dy_args, dy_addr);
 
-    CircularBuffer cb_scaler_obj(cb_scaler);
-    CircularBuffer cb_mask_obj(cb_mask);
-    generate_bcast_scaler(cb_scaler_obj, scaler);
-    generate_mask_h(cb_mask_obj, mask_h);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_mask_obj(cb_mask);
+    generate_bcast_scaler(dfb_scaler_obj, scaler);
+    generate_mask_h(dfb_mask_obj, mask_h);
 
     Noc noc;
-    CircularBuffer cb_y_obj(cb_y);
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_y_obj(cb_y);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     const auto y_tile_bytes = get_tile_size(cb_y);
     const auto dy_tile_bytes = get_tile_size(cb_dy);
 
@@ -51,15 +51,15 @@ void kernel_main() {
         uint32_t nc_idx = curr_tile / Wt;
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
 
             tile_idx += Wt;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h_large.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -34,14 +34,14 @@ void kernel_main() {
     const auto y_in = TensorAccessor(y_args, y_addr);
     const auto dy_in = TensorAccessor(dy_args, dy_addr);
 
-    CircularBuffer cb_scaler_obj(cb_scaler);
-    CircularBuffer cb_mask_obj(cb_mask);
-    generate_bcast_scaler(cb_scaler_obj, scaler);
-    generate_mask_h(cb_mask_obj, mask_h);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_mask_obj(cb_mask);
+    generate_bcast_scaler(dfb_scaler_obj, scaler);
+    generate_mask_h(dfb_mask_obj, mask_h);
 
     Noc noc;
-    CircularBuffer cb_y_obj(cb_y);
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_y_obj(cb_y);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     const auto y_tile_bytes = get_tile_size(cb_y);
     const auto dy_tile_bytes = get_tile_size(cb_dy);
 
@@ -52,16 +52,16 @@ void kernel_main() {
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
 #ifndef LOG
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 #endif
 
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
 
             tile_idx += Wt;
         }
@@ -70,15 +70,15 @@ void kernel_main() {
         nc_idx = curr_tile / Wt;
         tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = tile_idx}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
 
             tile_idx += Wt;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -35,27 +35,27 @@ void kernel_main() {
 
     dataflow_kernel_lib::
         calculate_and_prepare_reduce_scaler<cb_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
-    CircularBuffer cb_mask_obj(cb_mask);
-    generate_mask_w(cb_mask_obj, mask_w);
+    DataflowBuffer dfb_mask_obj(cb_mask);
+    generate_mask_w(dfb_mask_obj, mask_w);
 
     Noc noc;
-    CircularBuffer cb_y_obj(cb_y);
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_y_obj(cb_y);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     const auto y_tile_bytes = get_tile_size(cb_y);
     const auto dy_tile_bytes = get_tile_size(cb_dy);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
 
             curr_tile++;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w_large.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -35,12 +35,12 @@ void kernel_main() {
 
     dataflow_kernel_lib::
         calculate_and_prepare_reduce_scaler<cb_scaler, ckernel::PoolType::SUM, ckernel::ReduceDim::REDUCE_ROW>();
-    CircularBuffer cb_mask_obj(cb_mask);
-    generate_mask_w(cb_mask_obj, mask_w);
+    DataflowBuffer dfb_mask_obj(cb_mask);
+    generate_mask_w(dfb_mask_obj, mask_w);
 
     Noc noc;
-    CircularBuffer cb_y_obj(cb_y);
-    CircularBuffer cb_dy_obj(cb_dy);
+    DataflowBuffer dfb_y_obj(cb_y);
+    DataflowBuffer dfb_dy_obj(cb_dy);
     const auto y_tile_bytes = get_tile_size(cb_y);
     const auto dy_tile_bytes = get_tile_size(cb_dy);
 
@@ -49,31 +49,31 @@ void kernel_main() {
         uint32_t curr_offset_i = curr_tile;
         for (uint32_t w = 0; w < Wt; w++) {
 #ifndef LOG
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 #endif
 
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
 
             curr_tile++;
         }
 
         curr_tile = curr_offset_i;
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_y_obj.reserve_back(onetile);
-            noc.async_read(y_in, cb_y_obj, y_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_y_obj.reserve_back(onetile);
+            noc.async_read(y_in, dfb_y_obj, y_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_y_obj.push_back(onetile);
+            dfb_y_obj.push_back(onetile);
 
-            cb_dy_obj.reserve_back(onetile);
-            noc.async_read(dy_in, cb_dy_obj, dy_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
+            dfb_dy_obj.reserve_back(onetile);
+            noc.async_read(dy_in, dfb_dy_obj, dy_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_dy_obj.push_back(onetile);
+            dfb_dy_obj.push_back(onetile);
 
             curr_tile++;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_c.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_c.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -24,7 +24,7 @@ void kernel_main() {
     const auto dst_out = TensorAccessor(out_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_out);
+    DataflowBuffer dfb_out_obj(cb_out);
     const auto out_tile_bytes = get_tile_size(cb_out);
 
     uint32_t curr_tile = tile_offset;
@@ -35,10 +35,10 @@ void kernel_main() {
 
         uint32_t dim_stride = inner_size;
         for (uint32_t d = 0; d < dim_size; d++) {
-            cb_out_obj.wait_front(onetile);
-            noc.async_write(cb_out_obj, dst_out, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+            dfb_out_obj.wait_front(onetile);
+            noc.async_write(dfb_out_obj, dst_out, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(onetile);
+            dfb_out_obj.pop_front(onetile);
             tile_idx += dim_stride;
         }
         curr_tile += 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_h.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,7 +23,7 @@ void kernel_main() {
     uint32_t blk = 1;
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t curr_tile = tile_offset;
@@ -32,10 +32,10 @@ void kernel_main() {
         uint32_t nc_idx = curr_tile / Wt;
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_out_obj.wait_front(blk);
-            noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+            dfb_out_obj.wait_front(blk);
+            noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(blk);
+            dfb_out_obj.pop_front(blk);
             tile_idx += Wt;
         }
         curr_tile += 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_w.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -22,16 +22,16 @@ void kernel_main() {
     uint32_t blk = 1;
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t tile_id = tile_offset;
     for (uint32_t i = 0; i < N; i++) {
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_out_obj.wait_front(blk);
-            noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
+            dfb_out_obj.wait_front(blk);
+            noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(blk);
+            dfb_out_obj.pop_front(blk);
             tile_id++;
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,7 +23,7 @@ void kernel_main() {
     uint32_t blk = 1;
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t curr_tile = tile_offset;
@@ -32,10 +32,10 @@ void kernel_main() {
         uint32_t nc_idx = curr_tile / Wt;
         uint32_t tile_idx = nc_idx * Ht * Wt + w_idx;
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_out_obj.wait_front(blk);
-            noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
+            dfb_out_obj.wait_front(blk);
+            noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_idx});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(blk);
+            dfb_out_obj.pop_front(blk);
             tile_idx += Wt;
         }
         curr_tile += 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -22,16 +22,16 @@ void kernel_main() {
     uint32_t blk = 1;
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t tile_id = tile_offset;
     for (uint32_t i = 0; i < N; i++) {
         for (uint32_t w = 0; w < Wt; w++) {
-            cb_out_obj.wait_front(blk);
-            noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
+            dfb_out_obj.wait_front(blk);
+            noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
             noc.async_write_barrier();
-            cb_out_obj.pop_front(blk);
+            dfb_out_obj.pop_front(blk);
             tile_id++;
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp
@@ -4,7 +4,7 @@
 
 #include "api/compute/eltwise_unary/sfpu_int_sum.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t num_cols = get_compile_time_arg_val(0);
@@ -12,13 +12,13 @@ void kernel_main() {
     constexpr uint32_t origin_H = get_compile_time_arg_val(2);
 
     auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_mask_h = tt::CBIndex::c_1;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     constexpr uint32_t TILE_H = 32;
     constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
 
@@ -30,17 +30,17 @@ void kernel_main() {
     constexpr int dst1 = 1;
 
     if (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);
+        dfb_mask_h_obj.wait_front(onetile);
     }
 
     for (uint32_t col = 0; col < num_cols; ++col) {
         constexpr bool is_single_ht = (Ht == 1);
         if (is_single_ht) {
             tile_regs_acquire();
-            copy_tile_to_dst(cb_in0_obj, idx0, dst0);
+            copy_tile_to_dst(dfb_in0_obj, idx0, dst0);
 
             if (do_mask_h) {
-                copy_tile_to_dst(cb_mask_h_obj, idx0, dst1, false);
+                copy_tile_to_dst(dfb_mask_h_obj, idx0, dst1, false);
                 mask_tile_init();
                 mask_tile(dst0, dst1, DataFormat::Int32);
             }
@@ -50,47 +50,47 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0_obj, dst0);
+            pack_tile_from_dst(dfb_out0_obj, dst0);
             tile_regs_release();
         } else {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 if (ht == 0) {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
+                    copy_tile_to_dst(dfb_in0_obj, idx0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0_obj, dst0);
+                    pack_tile_from_dst(dfb_intermed0_obj, dst0);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
+                    copy_tile_to_dst(dfb_in0_obj, idx0, dst0);
 
                     if (ht == Ht - 1 && do_mask_h) {
-                        copy_tile_to_dst(cb_mask_h_obj, idx0, dst1, false);
+                        copy_tile_to_dst(dfb_mask_h_obj, idx0, dst1, false);
                         mask_tile_init();
                         mask_tile(dst0, dst1, DataFormat::Int32);
                     }
 
-                    copy_tile_to_dst(cb_intermed0_obj, idx0, dst1);
+                    copy_tile_to_dst(dfb_intermed0_obj, idx0, dst1);
                     sfpu_sum_int_init();
                     sfpu_add_int(dst0, dst1);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0_obj, dst0);
+                    pack_tile_from_dst(dfb_intermed0_obj, dst0);
                     tile_regs_release();
                 }
             }
 
             tile_regs_acquire();
-            copy_tile_to_dst(cb_intermed0_obj, idx0, dst0);
+            copy_tile_to_dst(dfb_intermed0_obj, idx0, dst0);
             sfpu_sum_int_init();
             sfpu_sum_int_col(dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0_obj, dst0);
+            pack_tile_from_dst(dfb_out0_obj, dst0);
             tile_regs_release();
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -13,28 +13,28 @@ void kernel_main() {
     constexpr uint32_t origin_H = get_compile_time_arg_val(3);
 
     constexpr auto cb_input = tt::CBIndex::c_0;
-    CircularBuffer cb_input_obj(cb_input);
+    DataflowBuffer dfb_input_obj(cb_input);
     constexpr auto cb_scaler = tt::CBIndex::c_2;
-    CircularBuffer cb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
     constexpr auto cb_mask_h = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_h_obj(cb_mask_h);
+    DataflowBuffer dfb_mask_h_obj(cb_mask_h);
     constexpr auto cb_accum_dst = tt::CBIndex::c_24;
     constexpr auto cb_masked_input = tt::CBIndex::c_25;
-    CircularBuffer cb_masked_input_obj(cb_masked_input);
+    DataflowBuffer dfb_masked_input_obj(cb_masked_input);
     constexpr auto cb_out = tt::CBIndex::c_16;
     constexpr uint32_t TILE_H = 32;
     constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
 
     binary_op_init_common(cb_input, cb_input, cb_out);
 
-    cb_scaler_obj.wait_front(1);  // scaler tile from the reader
+    dfb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
     int reduce_dst_idx = 0;
     const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
     if (do_mask_h) {
-        cb_mask_h_obj.wait_front(onetile);
+        dfb_mask_h_obj.wait_front(onetile);
     }
 
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -53,7 +53,7 @@ void kernel_main() {
             // Optional masking of last H tile
             if constexpr (do_mask_h) {
                 tile_regs_acquire();
-                cb_input_obj.wait_front(onetile);
+                dfb_input_obj.wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format_srca(cb_input);
 #endif
@@ -64,16 +64,16 @@ void kernel_main() {
                 mask_tile(reduce_dst_idx, mask_dst_idx);
                 tile_regs_commit();
 
-                cb_masked_input_obj.reserve_back(onetile);
+                dfb_masked_input_obj.reserve_back(onetile);
                 tile_regs_wait();
 #if defined FP32_DEST_ACC_EN
                 pack_reconfig_data_format(cb_masked_input);
 #endif
                 pack_tile(reduce_dst_idx, cb_masked_input);
                 tile_regs_release();
-                cb_masked_input_obj.push_back(onetile);
+                dfb_masked_input_obj.push_back(onetile);
 
-                cb_input_obj.pop_front(onetile);
+                dfb_input_obj.pop_front(onetile);
 
                 // Phase 2 with masked input: Reduce final masked tile with accumulation
                 compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_masked_input, cb_scaler, cb_out>(
@@ -93,7 +93,7 @@ void kernel_main() {
     }
 
     if (do_mask_h) {
-        cb_mask_h_obj.pop_front(onetile);
+        dfb_mask_h_obj.pop_front(onetile);
     }
-    cb_scaler_obj.pop_front(onetile);
+    dfb_scaler_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -26,14 +26,14 @@ void kernel_main() {
 
 #ifdef DO_MASK_H
     constexpr uint32_t cb_id_mask_h = 1;
-    CircularBuffer cb_mask_h_obj(cb_id_mask_h);
-    generate_mask_h<int32_t>(cb_mask_h_obj, mask_h);
+    DataflowBuffer dfb_mask_h_obj(cb_id_mask_h);
+    generate_mask_h<int32_t>(dfb_mask_h_obj, mask_h);
 #endif
 
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_id_in0);
+    DataflowBuffer dfb_in0_obj(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     uint32_t w = curr_col_in_batch;
@@ -41,10 +41,10 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_cols; i++) {
         uint32_t curr_id = col_start_tile_id;
         for (uint32_t j = 0; j < Ht; j++) {
-            cb_in0_obj.reserve_back(onetile);
-            noc.async_read(s, cb_in0_obj, in0_tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
+            dfb_in0_obj.reserve_back(onetile);
+            noc.async_read(s, dfb_in0_obj, in0_tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in0_obj.push_back(onetile);
+            dfb_in0_obj.push_back(onetile);
             curr_id += Wt;
         }
         w++;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -34,14 +34,14 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_mask_h = 3;
 #ifdef DO_MASK_H
-    CircularBuffer cb_mask_h_obj(cb_id_mask_h);
-    generate_mask_h(cb_mask_h_obj, mask_h);
+    DataflowBuffer dfb_mask_h_obj(cb_id_mask_h);
+    generate_mask_h(dfb_mask_h_obj, mask_h);
 #endif
 
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_id_in0);
+    DataflowBuffer dfb_in0_obj(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     uint32_t w = curr_col_in_batch;
@@ -49,10 +49,10 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_cols; i++) {
         uint32_t curr_id = col_start_tile_id;
         for (uint32_t j = 0; j < Ht; j++) {
-            cb_in0_obj.reserve_back(onetile);
-            noc.async_read(s, cb_in0_obj, in0_tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
+            dfb_in0_obj.reserve_back(onetile);
+            noc.async_read(s, dfb_in0_obj, in0_tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in0_obj.push_back(onetile);
+            dfb_in0_obj.push_back(onetile);
             curr_id += Wt;
         }
         w++;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_int_sum_h.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -22,14 +22,14 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out_obj.wait_front(onetile);
+        dfb_out_obj.wait_front(onetile);
 
-        uint32_t l1_read_addr = cb_out_obj.get_read_ptr();
+        uint32_t l1_read_addr = dfb_out_obj.get_read_ptr();
         volatile tt_l1_ptr int32_t* out_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(l1_read_addr);
 
         for (uint32_t w = 0; w < 16; w++) {
@@ -39,8 +39,8 @@ void kernel_main() {
             }
         }
 
-        noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(onetile);
+        dfb_out_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,14 +21,14 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out_obj.wait_front(onetile);
-        noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out_obj.wait_front(onetile);
+        noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(onetile);
+        dfb_out_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp
@@ -11,11 +11,11 @@ void kernel_main() {
     constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     constexpr int onetile = 1;
     constexpr int idx0 = 0;
     constexpr int dst0 = 0;
@@ -27,9 +27,9 @@ void kernel_main() {
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
             bool last_out = (j == num_input_tiles - 1);
             tile_regs_acquire();
-            copy_tile_to_dst(cb_in0_obj, idx0, dst0);
+            copy_tile_to_dst(dfb_in0_obj, idx0, dst0);
             if (enable_reload) {
-                copy_tile_to_dst(cb_intermed0_obj, idx0, dst1);
+                copy_tile_to_dst(dfb_intermed0_obj, idx0, dst1);
                 sfpu_sum_int_init();
                 sfpu_add_int(dst0, dst1);
             }
@@ -37,7 +37,7 @@ void kernel_main() {
 
             tile_regs_wait();
             uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
-            pack_tile_from_dst(CircularBuffer(cb_out), dst0);
+            pack_tile_from_dst(DataflowBuffer(cb_out), dst0);
             tile_regs_release();
             enable_reload = true;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     // compile-time args
@@ -11,11 +11,11 @@ void kernel_main() {
     constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_in1 = tt::CBIndex::c_1;
-    CircularBuffer cb_in1_obj(cb_in1);
+    DataflowBuffer dfb_in1_obj(cb_in1);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
@@ -23,28 +23,28 @@ void kernel_main() {
     constexpr bool acc_to_dest = true;
 
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    cb_in1_obj.wait_front(onetile);
+    dfb_in1_obj.wait_front(onetile);
 
     for (uint32_t i = 0; i < num_output_tiles; i++) {
         tile_regs_acquire();
         add_tiles_init(cb_in0, cb_in1, acc_to_dest);
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
-            cb_in0_obj.wait_front(onetile);
+            dfb_in0_obj.wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
             reconfig_data_format(cb_in0, cb_in1);
 #endif
             add_tiles(cb_in0, cb_in1, idx0, idx0, dst0);
-            cb_in0_obj.pop_front(onetile);
+            dfb_in0_obj.pop_front(onetile);
         }
         tile_regs_commit();
 
-        cb_out0_obj.reserve_back(onetile);
+        dfb_out0_obj.reserve_back(onetile);
         tile_regs_wait();
 #if defined FP32_DEST_ACC_EN
         pack_reconfig_data_format(cb_out0);
 #endif
         pack_tile(dst0, cb_out0);
         tile_regs_release();
-        cb_out0_obj.push_back(onetile);
+        dfb_out0_obj.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 inline uint32_t get_read_tile_id(uint32_t output_tile_id, uint32_t reduce_tile_size, uint32_t inner_tile_size) {
@@ -37,16 +37,16 @@ void kernel_main() {
     const auto input_addrg = TensorAccessor(input_args, input_addr);
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_id_in0);
+    DataflowBuffer dfb_in0_obj(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
         auto read_tile_id = (dim == 0) ? (i) : (get_read_tile_id(i, reduce_tile_size, inner_tile_size));
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
-            cb_in0_obj.reserve_back(onetile);
-            noc.async_read(input_addrg, cb_in0_obj, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+            dfb_in0_obj.reserve_back(onetile);
+            noc.async_read(input_addrg, dfb_in0_obj, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            cb_in0_obj.push_back(onetile);
+            dfb_in0_obj.push_back(onetile);
             read_tile_id += inner_tile_size;
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,15 +23,15 @@ void kernel_main() {
     const auto output_addrg = TensorAccessor(output_args, output_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         uint32_t write_tile_id = i;
-        cb_out_obj.wait_front(onetile);
+        dfb_out_obj.wait_front(onetile);
 
-        noc.async_write(cb_out_obj, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
+        noc.async_write(dfb_out_obj, output_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(onetile);
+        dfb_out_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp
@@ -4,7 +4,7 @@
 
 #include "api/compute/eltwise_unary/sfpu_int_sum.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t num_rows = get_compile_time_arg_val(0);
@@ -12,13 +12,13 @@ void kernel_main() {
     constexpr uint32_t origin_W = get_compile_time_arg_val(2);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
+    DataflowBuffer dfb_in0_obj(cb_in0);
     constexpr auto cb_mask_w = tt::CBIndex::c_1;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);
     constexpr auto cb_intermed0 = tt::CBIndex::c_24;
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
+    DataflowBuffer dfb_intermed0_obj(cb_intermed0);
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr uint32_t TILE_W = 32;
     constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
     constexpr int onetile = 1;
@@ -29,17 +29,17 @@ void kernel_main() {
     unary_op_init_common(cb_in0, cb_out0);
 
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);
+        dfb_mask_w_obj.wait_front(onetile);
     }
 
     for (uint32_t row = 0; row < num_rows; ++row) {
         constexpr bool is_single_wt = (Wt == 1);
         if (is_single_wt) {
             tile_regs_acquire();
-            copy_tile_to_dst(cb_in0_obj, idx0, dst0);
+            copy_tile_to_dst(dfb_in0_obj, idx0, dst0);
 
             if (do_mask_w) {
-                copy_tile_to_dst(cb_mask_w_obj, idx0, dst1, false);
+                copy_tile_to_dst(dfb_mask_w_obj, idx0, dst1, false);
                 mask_tile_init();
                 mask_tile(dst0, dst1, DataFormat::Int32);
             }
@@ -49,46 +49,46 @@ void kernel_main() {
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0_obj, dst0);
+            pack_tile_from_dst(dfb_out0_obj, dst0);
             tile_regs_release();
         } else {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 if (wt == 0) {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
+                    copy_tile_to_dst(dfb_in0_obj, idx0, dst0);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0_obj, dst0);
+                    pack_tile_from_dst(dfb_intermed0_obj, dst0);
                     tile_regs_release();
                 } else {
                     tile_regs_acquire();
-                    copy_tile_to_dst(cb_in0_obj, idx0, dst0);
+                    copy_tile_to_dst(dfb_in0_obj, idx0, dst0);
                     if (wt == Wt - 1 && do_mask_w) {
-                        copy_tile_to_dst(cb_mask_w_obj, idx0, dst1, false);
+                        copy_tile_to_dst(dfb_mask_w_obj, idx0, dst1, false);
                         mask_tile_init();
                         mask_tile(dst0, dst1, DataFormat::Int32);
                     }
 
-                    copy_tile_to_dst(cb_intermed0_obj, idx0, dst1);
+                    copy_tile_to_dst(dfb_intermed0_obj, idx0, dst1);
                     sfpu_sum_int_init();
                     sfpu_add_int(dst0, dst1);
                     tile_regs_commit();
 
                     tile_regs_wait();
-                    pack_tile_from_dst(cb_intermed0_obj, dst0);
+                    pack_tile_from_dst(dfb_intermed0_obj, dst0);
                     tile_regs_release();
                 }
             }
 
             tile_regs_acquire();
-            copy_tile_to_dst(cb_intermed0_obj, idx0, dst0);
+            copy_tile_to_dst(dfb_intermed0_obj, idx0, dst0);
             sfpu_sum_int_init();
             sfpu_sum_int_row(dst0);
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile_from_dst(cb_out0_obj, dst0);
+            pack_tile_from_dst(dfb_out0_obj, dst0);
             tile_regs_release();
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
@@ -4,7 +4,7 @@
 
 #include "api/compute/matmul.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -14,28 +14,28 @@ void kernel_main() {
 
     auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_scaler = tt::CBIndex::c_2;
-    CircularBuffer cb_scaler_obj(cb_scaler);
+    DataflowBuffer dfb_scaler_obj(cb_scaler);
     constexpr auto cb_mask_w = tt::CBIndex::c_3;
-    CircularBuffer cb_mask_w_obj(cb_mask_w);
+    DataflowBuffer dfb_mask_w_obj(cb_mask_w);
     constexpr auto cb_accum_dst = tt::CBIndex::c_24;
-    CircularBuffer cb_accum_dst_obj(cb_accum_dst);
+    DataflowBuffer dfb_accum_dst_obj(cb_accum_dst);
     constexpr auto cb_masked_input = tt::CBIndex::c_25;
-    CircularBuffer cb_masked_input_obj(cb_masked_input);
+    DataflowBuffer dfb_masked_input_obj(cb_masked_input);
     constexpr auto cb_out = tt::CBIndex::c_16;
-    CircularBuffer cb_out_obj(cb_out);
+    DataflowBuffer dfb_out_obj(cb_out);
     constexpr uint32_t TILE_W = 32;
     constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
 
     binary_op_init_common(cb_input, cb_scaler, cb_out);
 
-    cb_scaler_obj.wait_front(1);  // scaler tile from the reader
+    dfb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
     int reduce_dst_idx = 0;
     const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
     if (do_mask_w) {
-        cb_mask_w_obj.wait_front(onetile);
+        dfb_mask_w_obj.wait_front(onetile);
     }
 
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -48,29 +48,29 @@ void kernel_main() {
             if (!is_w_single_tile) {
                 tile_regs_acquire();
                 for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
-                    CircularBuffer(cb_input).wait_front(onetile);
+                    DataflowBuffer(cb_input).wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
                     reconfig_data_format(cb_input, cb_scaler);
 #endif
                     matmul_init(cb_input, cb_scaler, false);
                     matmul_tiles(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
 
-                    CircularBuffer(cb_input).pop_front(onetile);
+                    DataflowBuffer(cb_input).pop_front(onetile);
                 }
                 tile_regs_commit();
-                cb_accum_dst_obj.reserve_back(onetile);
+                dfb_accum_dst_obj.reserve_back(onetile);
                 tile_regs_wait();
 #if defined FP32_DEST_ACC_EN
                 pack_reconfig_data_format(cb_accum_dst);
 #endif
                 pack_tile(reduce_dst_idx, cb_accum_dst);
                 tile_regs_release();
-                cb_accum_dst_obj.push_back(onetile);
+                dfb_accum_dst_obj.push_back(onetile);
             }
 
             if (do_mask_w) {
                 tile_regs_acquire();
-                CircularBuffer(cb_input).wait_front(onetile);
+                DataflowBuffer(cb_input).wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format_srca(cb_input);
 #endif
@@ -81,26 +81,26 @@ void kernel_main() {
                 mask_tile(reduce_dst_idx, mask_dst_idx);
                 tile_regs_commit();
 
-                cb_masked_input_obj.reserve_back(onetile);
+                dfb_masked_input_obj.reserve_back(onetile);
                 tile_regs_wait();
 #if defined FP32_DEST_ACC_EN
                 pack_reconfig_data_format(cb_masked_input);
 #endif
                 pack_tile(reduce_dst_idx, cb_masked_input);
                 tile_regs_release();
-                cb_masked_input_obj.push_back(onetile);
+                dfb_masked_input_obj.push_back(onetile);
 
-                CircularBuffer(cb_input).pop_front(onetile);
+                DataflowBuffer(cb_input).pop_front(onetile);
                 cb_input = cb_masked_input;
             }
 
             tile_regs_acquire();
-            CircularBuffer(cb_input).wait_front(onetile);
+            DataflowBuffer(cb_input).wait_front(onetile);
             if (!is_w_single_tile) {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format_srca(cb_accum_dst);
 #endif
-                cb_accum_dst_obj.wait_front(onetile);
+                dfb_accum_dst_obj.wait_front(onetile);
                 copy_tile_to_dst_init_short(cb_accum_dst);
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
@@ -112,24 +112,24 @@ void kernel_main() {
             matmul_tiles(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
             tile_regs_commit();
 
-            cb_out_obj.reserve_back(onetile);
+            dfb_out_obj.reserve_back(onetile);
             tile_regs_wait();
 #if defined FP32_DEST_ACC_EN
             pack_reconfig_data_format(cb_out);
 #endif
             pack_tile(reduce_dst_idx, cb_out);
             tile_regs_release();
-            cb_out_obj.push_back(onetile);
+            dfb_out_obj.push_back(onetile);
 
-            CircularBuffer(cb_input).pop_front(onetile);
+            DataflowBuffer(cb_input).pop_front(onetile);
             if (!is_w_single_tile) {
-                cb_accum_dst_obj.pop_front(onetile);
+                dfb_accum_dst_obj.pop_front(onetile);
             }
         }
     }
 
     if (do_mask_w) {
-        cb_mask_w_obj.pop_front(onetile);
+        dfb_mask_w_obj.pop_front(onetile);
     }
-    cb_scaler_obj.pop_front(onetile);
+    dfb_scaler_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -18,21 +18,21 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_mask_w = 1;
 #ifdef DO_MASK_W
-    CircularBuffer cb_mask_w_obj(cb_id_mask_w);
-    generate_mask_w<int32_t>(cb_mask_w_obj, mask_w);
+    DataflowBuffer dfb_mask_w_obj(cb_id_mask_w);
+    generate_mask_w<int32_t>(dfb_mask_w_obj, mask_w);
 #endif
 
     constexpr uint32_t onetile = 1;
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_id_in0);
+    DataflowBuffer dfb_in0_obj(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
-        cb_in0_obj.reserve_back(onetile);
-        noc.async_read(s, cb_in0_obj, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_in0_obj.reserve_back(onetile);
+        noc.async_read(s, dfb_in0_obj, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0_obj.push_back(onetile);
+        dfb_in0_obj.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/kernel/dataflow/generate_mm_scaler.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -17,13 +17,13 @@ void kernel_main() {
     constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
 
     constexpr uint32_t cb_id_in2 = 2;
-    CircularBuffer cb_in2_obj(cb_id_in2);
-    generate_mm_scaler(cb_in2_obj, scaler);
+    DataflowBuffer dfb_in2_obj(cb_id_in2);
+    generate_mm_scaler(dfb_in2_obj, scaler);
 
     constexpr uint32_t cb_id_mask_w = 3;
 #ifdef DO_MASK_W
-    CircularBuffer cb_mask_w_obj(cb_id_mask_w);
-    generate_mask_w(cb_mask_w_obj, mask_w);
+    DataflowBuffer dfb_mask_w_obj(cb_id_mask_w);
+    generate_mask_w(dfb_mask_w_obj, mask_w);
 #endif
 
     constexpr uint32_t cb_id_in0 = 0;
@@ -34,13 +34,13 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_id_in0);
+    DataflowBuffer dfb_in0_obj(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
-        cb_in0_obj.reserve_back(onetile);
-        noc.async_read(s, cb_in0_obj, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        dfb_in0_obj.reserve_back(onetile);
+        noc.async_read(s, dfb_in0_obj, in0_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0_obj.push_back(onetile);
+        dfb_in0_obj.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_int_sum_w.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -22,13 +22,13 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out_obj.wait_front(onetile);
-        uint32_t l1_read_addr = cb_out_obj.get_read_ptr();
+        dfb_out_obj.wait_front(onetile);
+        uint32_t l1_read_addr = dfb_out_obj.get_read_ptr();
 
         volatile tt_l1_ptr int32_t* out_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(l1_read_addr);
         for (uint32_t h = 0; h < 16; h++) {
@@ -38,8 +38,8 @@ void kernel_main() {
             }
         }
 
-        noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(onetile);
+        dfb_out_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -21,14 +21,14 @@ void kernel_main() {
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_out_obj.wait_front(onetile);
-        noc.async_write(cb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
+        dfb_out_obj.wait_front(onetile);
+        noc.async_write(dfb_out_obj, s, out_tile_bytes, {.offset_bytes = 0}, {.page_id = i});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(onetile);
+        dfb_out_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/moreh_sum_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/moreh_sum_backward.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 void kernel_main() {
     // compile-time args
     constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
@@ -11,19 +11,19 @@ void kernel_main() {
     constexpr bool ht_need_bcast = (get_compile_time_arg_val(2) == 1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);  // input
+    DataflowBuffer dfb_in0_obj(cb_in0);  // input
     constexpr auto cb_in1 = tt::CBIndex::c_1;
-    CircularBuffer cb_in1_obj(cb_in1);  // zero tile
+    DataflowBuffer dfb_in1_obj(cb_in1);  // zero tile
     constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_out0_obj(cb_out0);
+    DataflowBuffer dfb_out0_obj(cb_out0);
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
     binary_op_init_common(cb_in1, cb_in0, cb_out0);
-    cb_in1_obj.wait_front(onetile);
+    dfb_in1_obj.wait_front(onetile);
     for (uint32_t i = 0; i < num_output_tiles; i++) {
         tile_regs_acquire();
-        cb_in0_obj.wait_front(onetile);
+        dfb_in0_obj.wait_front(onetile);
         if (ht_need_bcast && wt_need_bcast) {
             add_bcast_scalar_init_short(cb_in1, cb_in0);
             add_tiles_bcast_scalar(cb_in1, cb_in0, 0, 0, dst0);
@@ -38,12 +38,12 @@ void kernel_main() {
             copy_tile(cb_in0, 0, dst0);
         }
         tile_regs_commit();
-        cb_out0_obj.reserve_back(onetile);
+        dfb_out0_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_tile(dst0, cb_out0);
         tile_regs_release();
-        cb_out0_obj.push_back(onetile);
-        cb_in0_obj.pop_front(onetile);
+        dfb_out0_obj.push_back(onetile);
+        dfb_in0_obj.pop_front(onetile);
     }
-    cb_in1_obj.pop_front(onetile);
+    dfb_in1_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/reader_moreh_sum_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/reader_moreh_sum_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 static constexpr int32_t MAX_NUM_DIMENSIONS = 8;
 
@@ -78,22 +78,22 @@ void kernel_main() {
         uint32_t u;
     } scaler;
     scaler.f = 0.0f;
-    CircularBuffer cb_in1_obj(cb_id_in1);
-    fill_cb_with_value(cb_in1_obj, scaler.u);
+    DataflowBuffer dfb_in1_obj(cb_id_in1);
+    fill_cb_with_value(dfb_in1_obj, scaler.u);
 
     const auto output_grad_addrg = TensorAccessor(output_grad_args, output_grad_addr);
 
     Noc noc;
-    CircularBuffer cb_in0_obj(cb_id_in0);
+    DataflowBuffer dfb_in0_obj(cb_id_in0);
     const auto in0_tile_bytes = get_tile_size(cb_id_in0);
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
         auto read_tile_id = get_output_grad_tile(
             i, input_grad_rank, output_grad_dim, output_grad_stride, input_grad_dim, input_grad_stride, need_bcast_dim);
 
-        cb_in0_obj.reserve_back(onetile);
-        noc.async_read(output_grad_addrg, cb_in0_obj, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+        dfb_in0_obj.reserve_back(onetile);
+        noc.async_read(output_grad_addrg, dfb_in0_obj, in0_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_in0_obj.push_back(onetile);
+        dfb_in0_obj.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/writer_moreh_sum_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/writer_moreh_sum_backward.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -23,15 +23,15 @@ void kernel_main() {
     const auto input_grad_addrg = TensorAccessor(input_grad_args, input_grad_addr);
 
     Noc noc;
-    CircularBuffer cb_out_obj(cb_id_out);
+    DataflowBuffer dfb_out_obj(cb_id_out);
     const auto out_tile_bytes = get_tile_size(cb_id_out);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         uint32_t write_tile_id = i;
-        cb_out_obj.wait_front(onetile);
+        dfb_out_obj.wait_front(onetile);
 
-        noc.async_write(cb_out_obj, input_grad_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
+        noc.async_write(dfb_out_obj, input_grad_addrg, out_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
         noc.async_write_barrier();
-        cb_out_obj.pop_front(onetile);
+        dfb_out_obj.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/col_mask_dataflow.h
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/col_mask_dataflow.h
@@ -19,7 +19,7 @@
 FORCE_INLINE void generate_col_mask(
     uint32_t cb_col_mask, uint32_t block_w, uint32_t logical_K, uint32_t width_shard_tile_start_id) {
     constexpr uint32_t tile_w = 32;
-    CircularBuffer cb_col_mask_obj(cb_col_mask);
+    DataflowBuffer dfb_col_mask_obj(cb_col_mask);
     // A width shard always starts on a block boundary, so this offset is an exact multiple of block_w.
     ASSERT(width_shard_tile_start_id % block_w == 0);
     const uint32_t core_start_col = width_shard_tile_start_id * tile_w;
@@ -35,6 +35,6 @@ FORCE_INLINE void generate_col_mask(
         }
         // The mask holds only 1.0 or 0.0 (exact in bfloat16) and is always generated as bfloat16;
         // each masking multiply reconfigures the unpacker so SrcB reads it in this format.
-        generate_mask_w<uint16_t>(cb_col_mask_obj, mask_w);
+        generate_mask_w<uint16_t>(dfb_col_mask_obj, mask_w);
     }
 }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/45010 - first cut at changing Moreh kernels from using CBs to using DFBs

DFBs use CBs under the hood for WH/BH, but this helps prepare for Quasar and Metal 2.0.

```
class DataflowBuffer {
public:
#ifdef ARCH_QUASAR
    using DFBInterface = LocalDFBInterface;
#else
    using DFBInterface = LocalCBInterface;
#endif
```

This only focuses on what can be currently converted over cleanly/mechanically. A second pass will be needed for the remaining blocked CB usage patterns (see https://github.com/tenstorrent/tt-metal/issues/49368)

For nightly L2, one of the groups times out after 45 min - this matches [main](https://github.com/tenstorrent/tt-metal/actions/runs/29019875004/job/86127489704)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/45010/DFB_Moreh) 
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/45010/DFB_Moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/45010/DFB_Moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/45010/DFB_Moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/45010/DFB_Moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/45010/DFB_Moreh)


Single card model perf [pass](https://github.com/tenstorrent/tt-metal/actions/runs/29021176972)