### PR TITLE
[Feature] Metal 2.0 MakeMeshWorkloadFromSpecs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -136,7 +136,7 @@ void SetScratchpadArgs(Program& program) {
     ProgramRunArgs params;
     params.kernel_run_args = {ProgramRunArgs::KernelRunArgs{
         .kernel = KernelSpecName{kScratchKernel},
-        .runtime_arg_values = {{NodeCoord{0, 0}, {{"report_addr", kReportAddr}}}},
+        .runtime_arg_values = MakeRuntimeArgsForSingleNode(NodeCoord{0, 0}, {{"report_addr", kReportAddr}}),
     }};
     SetProgramRunArgs(program, params);
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -11,7 +11,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -25,34 +24,25 @@
 
 #include "command_queue_fixture.hpp"
 #include "device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "test_helpers.hpp"
 
-namespace tt::tt_metal {
+namespace tt::tt_metal::experimental {
 namespace {
 
 constexpr uint32_t kNumLaunches = 3;
-constexpr uint32_t kScratchpadBytes = 64;  // 16 x uint32_t
-constexpr uint32_t kNumScratchpadElems = kScratchpadBytes / sizeof(uint32_t);
+constexpr uint32_t kScratchpadBytes = 64;       // 16 x uint32_t
 constexpr uint32_t kReportAddr = 100 * 1024;    // host-known fixed L1 addr
 constexpr uint32_t kPatternBase = 0xC0DE0000u;  // must match the kernel
 constexpr uint32_t kDfbEntrySize = 1024;
-constexpr uint32_t kDfbNumTransfers = 8;
-constexpr uint32_t kDfbTotalBytes = kDfbEntrySize * kDfbNumTransfers;
+constexpr uint32_t kTransfers = 8;
+constexpr uint32_t kBufferBytes = kDfbEntrySize * kTransfers;
+constexpr auto kScratchKernel = "writer";
+constexpr auto kLoopbackDfb = "loopback_dfb";
 
-using experimental::test_helpers::MakeMinimalDFB;
-using experimental::test_helpers::MakeMinimalGen1DMKernel;
-using experimental::test_helpers::MakeMinimalWorkUnit;
-
-std::vector<distributed::MeshCoordinate> GetLocalMeshCoordinates(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    std::vector<distributed::MeshCoordinate> coords;
-    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-        if (!mesh_device->get_view().get_devices(distributed::MeshCoordinateRange(coord)).empty()) {
-            coords.push_back(coord);
-        }
-    }
-    return coords;
-}
+using test_helpers::MakeMinimalDFB;
+using test_helpers::MakeMinimalGen1DMKernel;
+using test_helpers::MakeMinimalWorkUnit;
 
 class MeshWorkloadFactoryHWTest : public UnitMeshCQSingleCardFixture {
 protected:
@@ -84,39 +74,42 @@ protected:
     }
 };
 
-experimental::ProgramSpec MakeScratchpadSpec(const std::string& spec_name, const std::string& kernel_name) {
-    const experimental::KernelSpecName kernel_id{kernel_name};
-    experimental::KernelSpec dm_kernel{
-        .unique_id = kernel_id,
-        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/scratchpad_write_pattern.cpp",
-        .num_threads = 1,
-        .runtime_arg_schema = {.runtime_arg_names = {"report_addr"}},
-        .hw_config =
-            experimental::DataMovementHardwareConfig{
-                .gen1_config =
-                    experimental::DataMovementHardwareConfig::Gen1Config{
-                        .processor = DataMovementProcessor::RISCV_0,
-                    },
-            },
-    };
-    dm_kernel.scratchpad_bindings.push_back(experimental::KernelSpec::ScratchpadBinding{
-        .scratchpad_spec_name = experimental::ScratchpadSpecName{"pad"}, .accessor_name = "pad"});
+class MeshWorkloadFactory1x2HWTest : public MeshDevice1x2Fixture {
+protected:
+    void SetUp() override {
+        MeshDevice1x2Fixture::SetUp();
+        if (this->IsSkipped()) {
+            return;
+        }
+        IDevice* device = mesh_device_->get_devices().at(0);
+        if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
+        }
+    }
+};
 
-    return experimental::ProgramSpec{
-        .name = spec_name,
+ProgramSpec MakeScratchpadSpec(uint32_t scratchpad_bytes = kScratchpadBytes) {
+    const KernelSpecName kernel_id{kScratchKernel};
+    auto dm_kernel = MakeMinimalGen1DMKernel(kScratchKernel, DataMovementProcessor::RISCV_0);
+    dm_kernel.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/scratchpad_write_pattern.cpp";
+    dm_kernel.runtime_arg_schema = {.runtime_arg_names = {"report_addr"}};
+    dm_kernel.scratchpad_bindings.push_back(
+        KernelSpec::ScratchpadBinding{.scratchpad_spec_name = ScratchpadSpecName{"pad"}, .accessor_name = "pad"});
+
+    return ProgramSpec{
+        .name = "scratch",
         .kernels = {dm_kernel},
-        .scratchpads = {experimental::ScratchpadSpec{
-            .unique_id = experimental::ScratchpadSpecName{"pad"}, .size_per_node = kScratchpadBytes}},
-        .work_units = {experimental::WorkUnitSpec{
+        .scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"pad"}, .size_per_node = scratchpad_bytes}},
+        .work_units = {WorkUnitSpec{
             .name = "main",
             .kernels = {kernel_id},
-            .target_nodes = experimental::NodeCoord{0, 0},
+            .target_nodes = NodeCoord{0, 0},
         }},
     };
 }
 
-experimental::ProgramSpec MakeDfbLoopbackSpec() {
-    const experimental::NodeCoord node{0, 0};
+ProgramSpec MakeLoopbackSpec() {
+    const NodeCoord node{0, 0};
 
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
@@ -126,305 +119,222 @@ experimental::ProgramSpec MakeDfbLoopbackSpec() {
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
     consumer.advanced_options.num_runtime_varargs = 3;
 
-    auto dfb = MakeMinimalDFB("loopback_dfb", kDfbEntrySize, /*num_entries=*/2);
+    auto dfb = MakeMinimalDFB(kLoopbackDfb, kDfbEntrySize, /*num_entries=*/2);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    producer.dfb_bindings.push_back(
-        experimental::ProducerOf(experimental::DFBSpecName{"loopback_dfb"}, "my_local_dfb_name"));
-    consumer.dfb_bindings.push_back(
-        experimental::ConsumerOf(experimental::DFBSpecName{"loopback_dfb"}, "a_dfb_named_bob"));
+    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{kLoopbackDfb}, "my_local_dfb_name"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{kLoopbackDfb}, "a_dfb_named_bob"));
 
-    return experimental::ProgramSpec{
-        .name = "factory_dfb_resize_loopback",
+    return ProgramSpec{
+        .name = "loopback",
         .kernels = {producer, consumer},
         .dataflow_buffers = {dfb},
-        .work_units =
-            std::vector<experimental::WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})},
+        .work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("main", node, {"producer", "consumer"})},
     };
 }
 
-void SetScratchpadArgs(Program& program, const std::string& kernel_name) {
-    experimental::ProgramRunArgs params;
-    params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
-        .kernel = experimental::KernelSpecName{kernel_name},
-        .runtime_arg_values = {{experimental::NodeCoord{0, 0}, {{"report_addr", kReportAddr}}}},
+void SetScratchpadArgs(Program& program) {
+    ProgramRunArgs params;
+    params.kernel_run_args = {ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{kScratchKernel},
+        .runtime_arg_values = {{NodeCoord{0, 0}, {{"report_addr", kReportAddr}}}},
     }};
-    experimental::SetProgramRunArgs(program, params);
+    SetProgramRunArgs(program, params);
 }
 
-void SetScratchpadArgs(distributed::MeshWorkload& workload, const std::string& kernel_name) {
-    Program& program = workload.get_programs().begin()->second;
-    SetScratchpadArgs(program, kernel_name);
+void SetScratchpadArgs(distributed::MeshWorkload& workload) {
+    SetScratchpadArgs(workload.get_programs().begin()->second);
 }
 
-void EnqueueAndVerifyScratchpadResult(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    distributed::MeshWorkload& workload,
-    const std::vector<distributed::MeshCoordinate>& coords) {
-    const experimental::NodeCoord node{0, 0};
-    for (const auto& coord : coords) {
-        IDevice* device = mesh_device->get_view().get_devices(distributed::MeshCoordinateRange(coord)).at(0);
-        std::vector<uint32_t> zero_report(1, 0u);
-        detail::WriteToDeviceL1(device, node, kReportAddr, zero_report);
+std::vector<uint32_t> ExpectedScratchpadContents(uint32_t scratchpad_bytes) {
+    std::vector<uint32_t> expected(scratchpad_bytes / sizeof(uint32_t));
+    for (size_t i = 0; i < expected.size(); i++) {
+        expected[i] = kPatternBase + static_cast<uint32_t>(i);
     }
+    return expected;
+}
+
+IDevice* DeviceAt(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const distributed::MeshCoordinate& coordinate) {
+    return mesh_device->get_view().get_devices(distributed::MeshCoordinateRange(coordinate)).at(0);
+}
+
+void ClearScratchpadReport(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const distributed::MeshCoordinate& coordinate) {
+    std::vector<uint32_t> report(1, 0u);
+    detail::WriteToDeviceL1(DeviceAt(mesh_device, coordinate), NodeCoord{0, 0}, kReportAddr, report);
+}
+
+void CheckScratchpad(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const distributed::MeshCoordinate& coordinate,
+    uint32_t scratchpad_bytes) {
+    const NodeCoord node{0, 0};
+    IDevice* device = DeviceAt(mesh_device, coordinate);
+
+    std::vector<uint32_t> reported;
+    detail::ReadFromDeviceL1(device, node, kReportAddr, sizeof(uint32_t), reported);
+    ASSERT_EQ(reported.size(), 1u);
+    const uint32_t scratch_base = reported[0];
+    EXPECT_NE(scratch_base, 0u) << "Kernel reported a 0 scratchpad base address";
+
+    std::vector<uint32_t> scratch_contents;
+    detail::ReadFromDeviceL1(device, node, scratch_base, scratchpad_bytes, scratch_contents);
+    EXPECT_EQ(scratch_contents, ExpectedScratchpadContents(scratchpad_bytes));
+}
+
+void EnqueueAndCheckScratchpad(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, distributed::MeshWorkload& workload) {
+    const auto coordinate = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
+    ClearScratchpadReport(mesh_device, coordinate);
 
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
-    for (const auto& coord : coords) {
-        IDevice* device = mesh_device->get_view().get_devices(distributed::MeshCoordinateRange(coord)).at(0);
-        std::vector<uint32_t> reported;
-        detail::ReadFromDeviceL1(device, node, kReportAddr, sizeof(uint32_t), reported);
-        ASSERT_EQ(reported.size(), 1u);
-        const uint32_t scratch_base = reported[0];
-        EXPECT_NE(scratch_base, 0u) << "Kernel reported a 0 scratchpad base address";
-
-        std::vector<uint32_t> scratch_contents;
-        detail::ReadFromDeviceL1(device, node, scratch_base, kScratchpadBytes, scratch_contents);
-        ASSERT_EQ(scratch_contents.size(), kNumScratchpadElems);
-
-        std::vector<uint32_t> expected(kNumScratchpadElems);
-        for (uint32_t i = 0; i < kNumScratchpadElems; i++) {
-            expected[i] = kPatternBase + i;
-        }
-        EXPECT_EQ(scratch_contents, expected);
-    }
+    CheckScratchpad(mesh_device, coordinate, kScratchpadBytes);
 }
 
-void VerifyScratchpadResult(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, distributed::MeshWorkload& workload) {
-    EnqueueAndVerifyScratchpadResult(mesh_device, workload, {distributed::MeshCoordinate(0, 0)});
-}
-
-void SetDfbLoopbackArgs(
+void SetLoopbackArgs(
     distributed::MeshWorkload& workload,
     const std::shared_ptr<Buffer>& input_buffer,
     const std::shared_ptr<Buffer>& output_buffer,
     uint32_t dfb_num_entries) {
-    const experimental::NodeCoord node{0, 0};
+    const NodeCoord node{0, 0};
     Program& program = workload.get_programs().begin()->second;
 
-    experimental::ProgramRunArgs params;
+    ProgramRunArgs params;
     params.kernel_run_args = {
-        experimental::ProgramRunArgs::KernelRunArgs{
-            .kernel = experimental::KernelSpecName{"producer"},
+        ProgramRunArgs::KernelRunArgs{
+            .kernel = KernelSpecName{"producer"},
             .advanced_options =
-                experimental::AdvancedKernelRunArgs{
+                AdvancedKernelRunArgs{
                     .runtime_varargs =
                         {{node,
                           {
                               input_buffer->address(),
                               0u,  // bank_id (single-page buffer -> bank 0)
-                              kDfbNumTransfers,
+                              kTransfers,
                           }}},
                 },
         },
-        experimental::ProgramRunArgs::KernelRunArgs{
-            .kernel = experimental::KernelSpecName{"consumer"},
+        ProgramRunArgs::KernelRunArgs{
+            .kernel = KernelSpecName{"consumer"},
             .advanced_options =
-                experimental::AdvancedKernelRunArgs{
+                AdvancedKernelRunArgs{
                     .runtime_varargs =
                         {{node,
                           {
                               output_buffer->address(),
                               0u,  // bank_id
-                              kDfbNumTransfers,
+                              kTransfers,
                           }}},
                 },
         },
     };
-    params.dfb_run_overrides.push_back(
-        {.dfb = experimental::DFBSpecName{"loopback_dfb"}, .num_entries = dfb_num_entries});
-    experimental::SetProgramRunArgs(program, params);
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{kLoopbackDfb}, .num_entries = dfb_num_entries});
+    SetProgramRunArgs(program, params);
 }
 
-TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecUsesScratchpad) {
+TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecSupportsRepeatedEnqueue) {
     auto mesh_device = devices_.at(0);
 
-    // -------------------------------------------------------
-    // Build one scratchpad ProgramSpec and create a mesh-wide workload.
-    // -------------------------------------------------------
-    constexpr auto kernel_name = "factory_single_kernel";
+    // Build a mesh-wide workload from one ProgramSpec.
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device, MakeScratchpadSpec());
 
-    distributed::MeshWorkload workload =
-        experimental::MakeMeshWorkloadFromSpec(*mesh_device, MakeScratchpadSpec("factory_single", kernel_name));
-    ASSERT_EQ(workload.get_programs().size(), 1u);
-
-    // -------------------------------------------------------
-    // Repeatedly set runtime args, dispatch, and verify scratchpad access.
-    // -------------------------------------------------------
+    // Set runtime args once, then repeatedly enqueue and verify scratchpad access.
+    SetScratchpadArgs(workload);
     for (uint32_t launch = 0; launch < kNumLaunches; launch++) {
-        SetScratchpadArgs(workload, kernel_name);
-        VerifyScratchpadResult(mesh_device, workload);
+        EnqueueAndCheckScratchpad(mesh_device, workload);
     }
 }
 
-TEST_F(MeshWorkloadFactorySlowDispatchHWTest, FactoryMethodsUseScratchpad) {
+TEST_F(MeshWorkloadFactorySlowDispatchHWTest, FactoryMethodsSupportSlowDispatch) {
     auto mesh_device = devices_.at(0);
 
-    // -------------------------------------------------------
-    // Build one workload with MakeMeshWorkloadFromSpec.
-    // -------------------------------------------------------
-    constexpr auto single_kernel_name = "factory_slow_single_kernel";
-    distributed::MeshWorkload single_workload = experimental::MakeMeshWorkloadFromSpec(
-        *mesh_device, MakeScratchpadSpec("factory_slow_single", single_kernel_name));
-    ASSERT_EQ(single_workload.get_programs().size(), 1u);
+    // Exercise the single-spec factory through slow dispatch.
+    distributed::MeshWorkload single_workload = MakeMeshWorkloadFromSpec(*mesh_device, MakeScratchpadSpec());
+    SetScratchpadArgs(single_workload);
+    EnqueueAndCheckScratchpad(mesh_device, single_workload);
 
-    // -------------------------------------------------------
-    // Set runtime args, dispatch, and verify scratchpad access.
-    // -------------------------------------------------------
-    SetScratchpadArgs(single_workload, single_kernel_name);
-    VerifyScratchpadResult(mesh_device, single_workload);
-
-    // -------------------------------------------------------
-    // Build one workload with MakeMeshWorkloadFromSpecs.
-    // -------------------------------------------------------
-    constexpr auto map_kernel_name = "factory_slow_map_kernel";
-    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
-    program_specs.emplace(
-        distributed::MeshCoordinateRange(mesh_device->shape()),
-        MakeScratchpadSpec("factory_slow_map", map_kernel_name));
-    distributed::MeshWorkload map_workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
-    ASSERT_EQ(map_workload.get_programs().size(), 1u);
-
-    // -------------------------------------------------------
-    // Set runtime args, dispatch, and verify scratchpad access.
-    // -------------------------------------------------------
-    SetScratchpadArgs(map_workload, map_kernel_name);
-    VerifyScratchpadResult(mesh_device, map_workload);
+    // Exercise the mapped-spec factory through slow dispatch.
+    std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec> specs;
+    specs.emplace(distributed::MeshCoordinateRange(mesh_device->shape()), MakeScratchpadSpec());
+    distributed::MeshWorkload mapped_workload = MakeMeshWorkloadFromSpecs(*mesh_device, specs);
+    SetScratchpadArgs(mapped_workload);
+    EnqueueAndCheckScratchpad(mesh_device, mapped_workload);
 }
 
-TEST_F(MeshWorkloadFactoryHWTest, AddProgramAndCompileAfterInitialProgramBeforeEnqueue) {
-    auto mesh_device = devices_.at(0);
-    const std::vector<distributed::MeshCoordinate> coords = GetLocalMeshCoordinates(mesh_device);
-    if (coords.size() < 2) {
-        GTEST_SKIP() << "Skipping: test requires at least two local mesh devices";
-    }
-
-    // -------------------------------------------------------
-    // Create an initial factory workload on the first device.
-    // -------------------------------------------------------
-    constexpr auto first_kernel_name = "manual_first_compile_kernel";
-    const distributed::MeshCoordinateRange first_range(coords[0]);
-    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
-    program_specs.emplace(first_range, MakeScratchpadSpec("manual_first_compile", first_kernel_name));
-    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
-
-    // -------------------------------------------------------
-    // Add a second eagerly compiled program before first enqueue.
-    // -------------------------------------------------------
-    constexpr auto second_kernel_name = "manual_second_compile_kernel";
-    const distributed::MeshCoordinateRange second_range(coords[1]);
-    workload.add_program_and_compile(
-        second_range,
-        experimental::MakeProgramFromSpec(
-            *mesh_device, MakeScratchpadSpec("manual_second_compile", second_kernel_name)),
-        *mesh_device);
-    ASSERT_EQ(workload.get_programs().size(), 2u);
-
-    // -------------------------------------------------------
-    // Set runtime args for both programs, dispatch, and verify both devices.
-    // -------------------------------------------------------
-    SetScratchpadArgs(workload.get_programs().at(first_range), first_kernel_name);
-    SetScratchpadArgs(workload.get_programs().at(second_range), second_kernel_name);
-    EnqueueAndVerifyScratchpadResult(mesh_device, workload, {coords[0], coords[1]});
-}
-
-TEST_F(MeshWorkloadFactoryHWTest, AddProgramAfterInitialProgramBeforeEnqueue) {
-    auto mesh_device = devices_.at(0);
-    const std::vector<distributed::MeshCoordinate> coords = GetLocalMeshCoordinates(mesh_device);
-    if (coords.size() < 2) {
-        GTEST_SKIP() << "Skipping: test requires at least two local mesh devices";
-    }
-
-    // -------------------------------------------------------
-    // Create an initial factory workload on the first device.
-    // -------------------------------------------------------
-    constexpr auto first_kernel_name = "manual_first_plain_kernel";
-    const distributed::MeshCoordinateRange first_range(coords[0]);
-    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
-    program_specs.emplace(first_range, MakeScratchpadSpec("manual_first_plain", first_kernel_name));
-    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
-
-    // -------------------------------------------------------
-    // Add a second plain program before first enqueue.
-    // -------------------------------------------------------
-    constexpr auto second_kernel_name = "manual_second_plain_kernel";
-    const distributed::MeshCoordinateRange second_range(coords[1]);
-    workload.add_program(
-        second_range,
-        experimental::MakeProgramFromSpec(*mesh_device, MakeScratchpadSpec("manual_second_plain", second_kernel_name)));
-    ASSERT_EQ(workload.get_programs().size(), 2u);
-
-    // -------------------------------------------------------
-    // Set runtime args for both programs, dispatch, and verify both devices.
-    // -------------------------------------------------------
-    SetScratchpadArgs(workload.get_programs().at(first_range), first_kernel_name);
-    SetScratchpadArgs(workload.get_programs().at(second_range), second_kernel_name);
-    EnqueueAndVerifyScratchpadResult(mesh_device, workload, {coords[0], coords[1]});
-}
-
-TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecHandlesRepeatedDfbSizeOverrides) {
+TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecSupportsDfbResizeBetweenEnqueues) {
     auto mesh_device = devices_.at(0);
     IDevice* device = mesh_device->get_devices()[0];
 
-    // -------------------------------------------------------
-    // Build one DFB loopback ProgramSpec and create the workload.
-    // -------------------------------------------------------
-    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpec(*mesh_device, MakeDfbLoopbackSpec());
-    ASSERT_EQ(workload.get_programs().size(), 1u);
+    // Build a workload with a producer-consumer DFB loopback.
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device, MakeLoopbackSpec());
 
     InterleavedBufferConfig dram_config{
-        .device = device, .size = kDfbTotalBytes, .page_size = kDfbTotalBytes, .buffer_type = BufferType::DRAM};
+        .device = device, .size = kBufferBytes, .page_size = kBufferBytes, .buffer_type = BufferType::DRAM};
     auto input_buffer = CreateBuffer(dram_config);
     auto output_buffer = CreateBuffer(dram_config);
 
-    // -------------------------------------------------------
-    // Repeatedly resize the DFB at runtime, dispatch, and verify loopback.
-    // -------------------------------------------------------
+    // Resize the DFB between enqueues and verify each loopback result.
     for (uint32_t dfb_num_entries : {2u, 4u, 6u}) {
-        std::vector<uint32_t> input_data(kDfbTotalBytes / sizeof(uint32_t));
+        std::vector<uint32_t> input_data(kBufferBytes / sizeof(uint32_t));
         for (size_t i = 0; i < input_data.size(); i++) {
             input_data[i] = (dfb_num_entries << 16) + static_cast<uint32_t>(i);
         }
-        std::vector<uint32_t> zero_output(input_data.size(), 0u);
+        std::vector<uint32_t> output_data(input_data.size());
 
         detail::WriteToBuffer(input_buffer, input_data);
-        detail::WriteToBuffer(output_buffer, zero_output);
-        SetDfbLoopbackArgs(workload, input_buffer, output_buffer, dfb_num_entries);
+        detail::WriteToBuffer(output_buffer, output_data);
+        SetLoopbackArgs(workload, input_buffer, output_buffer, dfb_num_entries);
 
         distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
         distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
-        std::vector<uint32_t> output_data;
+        output_data.clear();
         detail::ReadFromBuffer(output_buffer, output_data);
-        ASSERT_EQ(output_data.size(), input_data.size());
         EXPECT_EQ(output_data, input_data);
     }
 }
 
-TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecsUsesScratchpad) {
+TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecsMapOverloadSupportsRepeatedEnqueue) {
     auto mesh_device = devices_.at(0);
 
-    // -------------------------------------------------------
-    // Build a region-mapped scratchpad ProgramSpec and create the workload.
-    // -------------------------------------------------------
-    constexpr auto kernel_name = "factory_map_kernel";
-
-    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
-    program_specs.emplace(
-        distributed::MeshCoordinateRange(mesh_device->shape()), MakeScratchpadSpec("factory_map", kernel_name));
-    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
-
+    // Build a region-mapped workload through the ProgramSpec map overload.
+    std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec> specs;
+    specs.emplace(distributed::MeshCoordinateRange(mesh_device->shape()), MakeScratchpadSpec());
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpecs(*mesh_device, specs);
     ASSERT_EQ(workload.get_programs().size(), 1u);
 
-    // -------------------------------------------------------
-    // Repeatedly set runtime args, dispatch, and verify scratchpad access.
-    // -------------------------------------------------------
+    // Set runtime args once, then repeatedly enqueue and verify scratchpad access.
+    SetScratchpadArgs(workload);
     for (uint32_t launch = 0; launch < kNumLaunches; launch++) {
-        SetScratchpadArgs(workload, kernel_name);
-        VerifyScratchpadResult(mesh_device, workload);
+        EnqueueAndCheckScratchpad(mesh_device, workload);
     }
 }
 
+TEST_F(MeshWorkloadFactory1x2HWTest, MakeMeshWorkloadFromSpecsRunsDistinctSpecsOnMappedDevices) {
+    constexpr uint32_t kLargeScratchpadBytes = 2 * kScratchpadBytes;
+    const distributed::MeshCoordinate first{0, 0};
+    const distributed::MeshCoordinate second{0, 1};
+
+    // Map ProgramSpecs with observably different scratchpad sizes to separate devices.
+    std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec> specs;
+    specs.emplace(distributed::MeshCoordinateRange(first), MakeScratchpadSpec(kScratchpadBytes));
+    specs.emplace(distributed::MeshCoordinateRange(second), MakeScratchpadSpec(kLargeScratchpadBytes));
+    distributed::MeshWorkload workload = MakeMeshWorkloadFromSpecs(*mesh_device_, specs);
+    ASSERT_EQ(workload.get_programs().size(), 2u);
+
+    // Configure both programs, enqueue once, then verify each device ran its mapped spec.
+    for (auto& [_, program] : workload.get_programs()) {
+        SetScratchpadArgs(program);
+    }
+    ClearScratchpadReport(mesh_device_, first);
+    ClearScratchpadReport(mesh_device_, second);
+    distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, /*blocking=*/true);
+
+    CheckScratchpad(mesh_device_, first, kScratchpadBytes);
+    CheckScratchpad(mesh_device_, second, kLargeScratchpadBytes);
+}
+
 }  // namespace
-}  // namespace tt::tt_metal
+}  // namespace tt::tt_metal::experimental

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -1,0 +1,430 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Real-hardware tests for Metal 2.0 MeshWorkload factory APIs (WH/BH).
+//
+// These tests prove the ProgramSpec -> MakeMeshWorkloadFromSpec(s) -> MeshWorkload enqueue -> verify
+// pipeline end-to-end on real Wormhole B0 and Blackhole hardware.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+
+#include "command_queue_fixture.hpp"
+#include "device_fixture.hpp"
+#include "test_helpers.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+constexpr uint32_t kNumLaunches = 3;
+constexpr uint32_t kScratchpadBytes = 64;  // 16 x uint32_t
+constexpr uint32_t kNumScratchpadElems = kScratchpadBytes / sizeof(uint32_t);
+constexpr uint32_t kReportAddr = 100 * 1024;    // host-known fixed L1 addr
+constexpr uint32_t kPatternBase = 0xC0DE0000u;  // must match the kernel
+constexpr uint32_t kDfbEntrySize = 1024;
+constexpr uint32_t kDfbNumTransfers = 8;
+constexpr uint32_t kDfbTotalBytes = kDfbEntrySize * kDfbNumTransfers;
+
+using experimental::test_helpers::MakeMinimalDFB;
+using experimental::test_helpers::MakeMinimalGen1DMKernel;
+using experimental::test_helpers::MakeMinimalWorkUnit;
+
+std::vector<distributed::MeshCoordinate> GetLocalMeshCoordinates(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    std::vector<distributed::MeshCoordinate> coords;
+    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+        if (!mesh_device->get_view().get_devices(distributed::MeshCoordinateRange(coord)).empty()) {
+            coords.push_back(coord);
+        }
+    }
+    return coords;
+}
+
+class MeshWorkloadFactoryHWTest : public UnitMeshCQSingleCardFixture {
+protected:
+    void SetUp() override {
+        UnitMeshCQSingleCardFixture::SetUp();
+        if (this->IsSkipped()) {
+            return;
+        }
+        auto mesh_device = devices_.at(0);
+        IDevice* device = mesh_device->get_devices()[0];
+        if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
+        }
+    }
+};
+
+class MeshWorkloadFactorySlowDispatchHWTest : public MeshDeviceFixture {
+protected:
+    void SetUp() override {
+        MeshDeviceFixture::SetUp();
+        if (this->IsSkipped()) {
+            return;
+        }
+        auto mesh_device = devices_.at(0);
+        IDevice* device = mesh_device->get_devices()[0];
+        if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
+        }
+    }
+};
+
+experimental::ProgramSpec MakeScratchpadSpec(const std::string& spec_name, const std::string& kernel_name) {
+    const experimental::KernelSpecName kernel_id{kernel_name};
+    experimental::KernelSpec dm_kernel{
+        .unique_id = kernel_id,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/scratchpad_write_pattern.cpp",
+        .num_threads = 1,
+        .runtime_arg_schema = {.runtime_arg_names = {"report_addr"}},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .gen1_config =
+                    experimental::DataMovementHardwareConfig::Gen1Config{
+                        .processor = DataMovementProcessor::RISCV_0,
+                    },
+            },
+    };
+    dm_kernel.scratchpad_bindings.push_back(experimental::KernelSpec::ScratchpadBinding{
+        .scratchpad_spec_name = experimental::ScratchpadSpecName{"pad"}, .accessor_name = "pad"});
+
+    return experimental::ProgramSpec{
+        .name = spec_name,
+        .kernels = {dm_kernel},
+        .scratchpads = {experimental::ScratchpadSpec{
+            .unique_id = experimental::ScratchpadSpecName{"pad"}, .size_per_node = kScratchpadBytes}},
+        .work_units = {experimental::WorkUnitSpec{
+            .name = "main",
+            .kernels = {kernel_id},
+            .target_nodes = experimental::NodeCoord{0, 0},
+        }},
+    };
+}
+
+experimental::ProgramSpec MakeDfbLoopbackSpec() {
+    const experimental::NodeCoord node{0, 0};
+
+    auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
+    producer.advanced_options.num_runtime_varargs = 3;
+
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
+    consumer.advanced_options.num_runtime_varargs = 3;
+
+    auto dfb = MakeMinimalDFB("loopback_dfb", kDfbEntrySize, /*num_entries=*/2);
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    producer.dfb_bindings.push_back(
+        experimental::ProducerOf(experimental::DFBSpecName{"loopback_dfb"}, "my_local_dfb_name"));
+    consumer.dfb_bindings.push_back(
+        experimental::ConsumerOf(experimental::DFBSpecName{"loopback_dfb"}, "a_dfb_named_bob"));
+
+    return experimental::ProgramSpec{
+        .name = "factory_dfb_resize_loopback",
+        .kernels = {producer, consumer},
+        .dataflow_buffers = {dfb},
+        .work_units =
+            std::vector<experimental::WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})},
+    };
+}
+
+void SetScratchpadArgs(Program& program, const std::string& kernel_name) {
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = experimental::KernelSpecName{kernel_name},
+        .runtime_arg_values = {{experimental::NodeCoord{0, 0}, {{"report_addr", kReportAddr}}}},
+    }};
+    experimental::SetProgramRunArgs(program, params);
+}
+
+void SetScratchpadArgs(distributed::MeshWorkload& workload, const std::string& kernel_name) {
+    Program& program = workload.get_programs().begin()->second;
+    SetScratchpadArgs(program, kernel_name);
+}
+
+void EnqueueAndVerifyScratchpadResult(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshWorkload& workload,
+    const std::vector<distributed::MeshCoordinate>& coords) {
+    const experimental::NodeCoord node{0, 0};
+    for (const auto& coord : coords) {
+        IDevice* device = mesh_device->get_view().get_devices(distributed::MeshCoordinateRange(coord)).at(0);
+        std::vector<uint32_t> zero_report(1, 0u);
+        detail::WriteToDeviceL1(device, node, kReportAddr, zero_report);
+    }
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+
+    for (const auto& coord : coords) {
+        IDevice* device = mesh_device->get_view().get_devices(distributed::MeshCoordinateRange(coord)).at(0);
+        std::vector<uint32_t> reported;
+        detail::ReadFromDeviceL1(device, node, kReportAddr, sizeof(uint32_t), reported);
+        ASSERT_EQ(reported.size(), 1u);
+        const uint32_t scratch_base = reported[0];
+        EXPECT_NE(scratch_base, 0u) << "Kernel reported a 0 scratchpad base address";
+
+        std::vector<uint32_t> scratch_contents;
+        detail::ReadFromDeviceL1(device, node, scratch_base, kScratchpadBytes, scratch_contents);
+        ASSERT_EQ(scratch_contents.size(), kNumScratchpadElems);
+
+        std::vector<uint32_t> expected(kNumScratchpadElems);
+        for (uint32_t i = 0; i < kNumScratchpadElems; i++) {
+            expected[i] = kPatternBase + i;
+        }
+        EXPECT_EQ(scratch_contents, expected);
+    }
+}
+
+void VerifyScratchpadResult(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, distributed::MeshWorkload& workload) {
+    EnqueueAndVerifyScratchpadResult(mesh_device, workload, {distributed::MeshCoordinate(0, 0)});
+}
+
+void SetDfbLoopbackArgs(
+    distributed::MeshWorkload& workload,
+    const std::shared_ptr<Buffer>& input_buffer,
+    const std::shared_ptr<Buffer>& output_buffer,
+    uint32_t dfb_num_entries) {
+    const experimental::NodeCoord node{0, 0};
+    Program& program = workload.get_programs().begin()->second;
+
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {
+        experimental::ProgramRunArgs::KernelRunArgs{
+            .kernel = experimental::KernelSpecName{"producer"},
+            .advanced_options =
+                experimental::AdvancedKernelRunArgs{
+                    .runtime_varargs =
+                        {{node,
+                          {
+                              input_buffer->address(),
+                              0u,  // bank_id (single-page buffer -> bank 0)
+                              kDfbNumTransfers,
+                          }}},
+                },
+        },
+        experimental::ProgramRunArgs::KernelRunArgs{
+            .kernel = experimental::KernelSpecName{"consumer"},
+            .advanced_options =
+                experimental::AdvancedKernelRunArgs{
+                    .runtime_varargs =
+                        {{node,
+                          {
+                              output_buffer->address(),
+                              0u,  // bank_id
+                              kDfbNumTransfers,
+                          }}},
+                },
+        },
+    };
+    params.dfb_run_overrides.push_back(
+        {.dfb = experimental::DFBSpecName{"loopback_dfb"}, .num_entries = dfb_num_entries});
+    experimental::SetProgramRunArgs(program, params);
+}
+
+TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecUsesScratchpad) {
+    auto mesh_device = devices_.at(0);
+
+    // -------------------------------------------------------
+    // Build one scratchpad ProgramSpec and create a mesh-wide workload.
+    // -------------------------------------------------------
+    constexpr auto kernel_name = "factory_single_kernel";
+
+    distributed::MeshWorkload workload =
+        experimental::MakeMeshWorkloadFromSpec(*mesh_device, MakeScratchpadSpec("factory_single", kernel_name));
+    ASSERT_EQ(workload.get_programs().size(), 1u);
+
+    // -------------------------------------------------------
+    // Repeatedly set runtime args, dispatch, and verify scratchpad access.
+    // -------------------------------------------------------
+    for (uint32_t launch = 0; launch < kNumLaunches; launch++) {
+        SetScratchpadArgs(workload, kernel_name);
+        VerifyScratchpadResult(mesh_device, workload);
+    }
+}
+
+TEST_F(MeshWorkloadFactorySlowDispatchHWTest, FactoryMethodsUseScratchpad) {
+    auto mesh_device = devices_.at(0);
+
+    // -------------------------------------------------------
+    // Build one workload with MakeMeshWorkloadFromSpec.
+    // -------------------------------------------------------
+    constexpr auto single_kernel_name = "factory_slow_single_kernel";
+    distributed::MeshWorkload single_workload = experimental::MakeMeshWorkloadFromSpec(
+        *mesh_device, MakeScratchpadSpec("factory_slow_single", single_kernel_name));
+    ASSERT_EQ(single_workload.get_programs().size(), 1u);
+
+    // -------------------------------------------------------
+    // Set runtime args, dispatch, and verify scratchpad access.
+    // -------------------------------------------------------
+    SetScratchpadArgs(single_workload, single_kernel_name);
+    VerifyScratchpadResult(mesh_device, single_workload);
+
+    // -------------------------------------------------------
+    // Build one workload with MakeMeshWorkloadFromSpecs.
+    // -------------------------------------------------------
+    constexpr auto map_kernel_name = "factory_slow_map_kernel";
+    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
+    program_specs.emplace(
+        distributed::MeshCoordinateRange(mesh_device->shape()),
+        MakeScratchpadSpec("factory_slow_map", map_kernel_name));
+    distributed::MeshWorkload map_workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
+    ASSERT_EQ(map_workload.get_programs().size(), 1u);
+
+    // -------------------------------------------------------
+    // Set runtime args, dispatch, and verify scratchpad access.
+    // -------------------------------------------------------
+    SetScratchpadArgs(map_workload, map_kernel_name);
+    VerifyScratchpadResult(mesh_device, map_workload);
+}
+
+TEST_F(MeshWorkloadFactoryHWTest, AddProgramAndCompileAfterInitialProgramBeforeEnqueue) {
+    auto mesh_device = devices_.at(0);
+    const std::vector<distributed::MeshCoordinate> coords = GetLocalMeshCoordinates(mesh_device);
+    if (coords.size() < 2) {
+        GTEST_SKIP() << "Skipping: test requires at least two local mesh devices";
+    }
+
+    // -------------------------------------------------------
+    // Create an initial factory workload on the first device.
+    // -------------------------------------------------------
+    constexpr auto first_kernel_name = "manual_first_compile_kernel";
+    const distributed::MeshCoordinateRange first_range(coords[0]);
+    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
+    program_specs.emplace(first_range, MakeScratchpadSpec("manual_first_compile", first_kernel_name));
+    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
+
+    // -------------------------------------------------------
+    // Add a second eagerly compiled program before first enqueue.
+    // -------------------------------------------------------
+    constexpr auto second_kernel_name = "manual_second_compile_kernel";
+    const distributed::MeshCoordinateRange second_range(coords[1]);
+    workload.add_program_and_compile(
+        second_range,
+        experimental::MakeProgramFromSpec(
+            *mesh_device, MakeScratchpadSpec("manual_second_compile", second_kernel_name)),
+        *mesh_device);
+    ASSERT_EQ(workload.get_programs().size(), 2u);
+
+    // -------------------------------------------------------
+    // Set runtime args for both programs, dispatch, and verify both devices.
+    // -------------------------------------------------------
+    SetScratchpadArgs(workload.get_programs().at(first_range), first_kernel_name);
+    SetScratchpadArgs(workload.get_programs().at(second_range), second_kernel_name);
+    EnqueueAndVerifyScratchpadResult(mesh_device, workload, {coords[0], coords[1]});
+}
+
+TEST_F(MeshWorkloadFactoryHWTest, AddProgramAfterInitialProgramBeforeEnqueue) {
+    auto mesh_device = devices_.at(0);
+    const std::vector<distributed::MeshCoordinate> coords = GetLocalMeshCoordinates(mesh_device);
+    if (coords.size() < 2) {
+        GTEST_SKIP() << "Skipping: test requires at least two local mesh devices";
+    }
+
+    // -------------------------------------------------------
+    // Create an initial factory workload on the first device.
+    // -------------------------------------------------------
+    constexpr auto first_kernel_name = "manual_first_plain_kernel";
+    const distributed::MeshCoordinateRange first_range(coords[0]);
+    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
+    program_specs.emplace(first_range, MakeScratchpadSpec("manual_first_plain", first_kernel_name));
+    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
+
+    // -------------------------------------------------------
+    // Add a second plain program before first enqueue.
+    // -------------------------------------------------------
+    constexpr auto second_kernel_name = "manual_second_plain_kernel";
+    const distributed::MeshCoordinateRange second_range(coords[1]);
+    workload.add_program(
+        second_range,
+        experimental::MakeProgramFromSpec(*mesh_device, MakeScratchpadSpec("manual_second_plain", second_kernel_name)));
+    ASSERT_EQ(workload.get_programs().size(), 2u);
+
+    // -------------------------------------------------------
+    // Set runtime args for both programs, dispatch, and verify both devices.
+    // -------------------------------------------------------
+    SetScratchpadArgs(workload.get_programs().at(first_range), first_kernel_name);
+    SetScratchpadArgs(workload.get_programs().at(second_range), second_kernel_name);
+    EnqueueAndVerifyScratchpadResult(mesh_device, workload, {coords[0], coords[1]});
+}
+
+TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecHandlesRepeatedDfbSizeOverrides) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+
+    // -------------------------------------------------------
+    // Build one DFB loopback ProgramSpec and create the workload.
+    // -------------------------------------------------------
+    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpec(*mesh_device, MakeDfbLoopbackSpec());
+    ASSERT_EQ(workload.get_programs().size(), 1u);
+
+    InterleavedBufferConfig dram_config{
+        .device = device, .size = kDfbTotalBytes, .page_size = kDfbTotalBytes, .buffer_type = BufferType::DRAM};
+    auto input_buffer = CreateBuffer(dram_config);
+    auto output_buffer = CreateBuffer(dram_config);
+
+    // -------------------------------------------------------
+    // Repeatedly resize the DFB at runtime, dispatch, and verify loopback.
+    // -------------------------------------------------------
+    for (uint32_t dfb_num_entries : {2u, 4u, 6u}) {
+        std::vector<uint32_t> input_data(kDfbTotalBytes / sizeof(uint32_t));
+        for (size_t i = 0; i < input_data.size(); i++) {
+            input_data[i] = (dfb_num_entries << 16) + static_cast<uint32_t>(i);
+        }
+        std::vector<uint32_t> zero_output(input_data.size(), 0u);
+
+        detail::WriteToBuffer(input_buffer, input_data);
+        detail::WriteToBuffer(output_buffer, zero_output);
+        SetDfbLoopbackArgs(workload, input_buffer, output_buffer, dfb_num_entries);
+
+        distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+
+        std::vector<uint32_t> output_data;
+        detail::ReadFromBuffer(output_buffer, output_data);
+        ASSERT_EQ(output_data.size(), input_data.size());
+        EXPECT_EQ(output_data, input_data);
+    }
+}
+
+TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecsUsesScratchpad) {
+    auto mesh_device = devices_.at(0);
+
+    // -------------------------------------------------------
+    // Build a region-mapped scratchpad ProgramSpec and create the workload.
+    // -------------------------------------------------------
+    constexpr auto kernel_name = "factory_map_kernel";
+
+    std::unordered_map<distributed::MeshCoordinateRange, experimental::ProgramSpec> program_specs;
+    program_specs.emplace(
+        distributed::MeshCoordinateRange(mesh_device->shape()), MakeScratchpadSpec("factory_map", kernel_name));
+    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
+
+    ASSERT_EQ(workload.get_programs().size(), 1u);
+
+    // -------------------------------------------------------
+    // Repeatedly set runtime args, dispatch, and verify scratchpad access.
+    // -------------------------------------------------------
+    for (uint32_t launch = 0; launch < kNumLaunches; launch++) {
+        SetScratchpadArgs(workload, kernel_name);
+        VerifyScratchpadResult(mesh_device, workload);
+    }
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -29,6 +29,7 @@ set(UNIT_TESTS_API_SOURCES
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
+    metal2_host_api/test_mesh_workload_factories_hw.cpp
     metal2_host_api/test_program_spec.cpp
     metal2_host_api/test_program_spec_hw.cpp
     metal2_host_api/test_scratchpad_hw.cpp

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -45,7 +45,7 @@ using tt::test_utils::pack_as_mx_tiles;
 // For Quasar, data is moved via DataflowBuffers (DFBs) and the hardware
 // unpacker/packer performs the format conversion implicitly.
 static vector<uint32_t> run_mxfp4_typecast(
-    const distributed::MeshDevice& mesh_device,
+    distributed::MeshDevice& mesh_device,
     tt::DataFormat input_fmt,
     tt::DataFormat output_fmt,
     const vector<uint32_t>& src_vec,
@@ -323,7 +323,7 @@ namespace mxfp4_tc = unit_tests::llk::mxfp4_typecast;
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16b) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
@@ -338,7 +338,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16bFp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
@@ -359,7 +359,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
@@ -374,7 +374,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4Fp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
@@ -394,7 +394,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4Fp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
@@ -409,7 +409,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4Fp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
@@ -444,7 +444,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4Fp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToBf16SpecialCases) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     auto layout = mxfp4_tc::get_mxfp4_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN (rule 1).

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -46,7 +46,7 @@ using tt::test_utils::pack_as_mx_tiles;
 // (DFBs) and the hardware unpacker/packer performs the format conversion
 // implicitly.
 static vector<uint32_t> run_mxfp6_typecast(
-    const distributed::MeshDevice& mesh_device,
+    distributed::MeshDevice& mesh_device,
     tt::DataFormat input_fmt,
     tt::DataFormat output_fmt,
     const vector<uint32_t>& src_vec,
@@ -260,7 +260,7 @@ static vector<float> unpack_to_floats(tt::DataFormat fmt, const vector<uint32_t>
 // the device, unpack both sides to floats, and check element-wise tolerance
 // + PCC. Used by all random-input TEST_F bodies below.
 static void run_random_typecast_test(
-    const distributed::MeshDevice& mesh_device,
+    distributed::MeshDevice& mesh_device,
     tt::DataFormat input_fmt,
     tt::DataFormat output_fmt,
     float rtol,
@@ -455,7 +455,7 @@ namespace mxfp6_tc = unit_tests::llk::mxfp6_typecast;
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16b) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6R,
@@ -467,7 +467,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16bFp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6R,
@@ -486,7 +486,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6R) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::Float16_b,
@@ -498,7 +498,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6R) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RFp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::Float16_b,
@@ -514,7 +514,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6R) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6R,
@@ -526,7 +526,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6R) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6RFp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6R,
@@ -543,7 +543,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6RFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16b) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6P,
@@ -555,7 +555,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16bFp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6P,
@@ -574,7 +574,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6P) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::Float16_b,
@@ -586,7 +586,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6P) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6PFp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::Float16_b,
@@ -602,7 +602,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6PFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6P) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6P,
@@ -614,7 +614,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6P) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6PFp32Dest) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
         mesh_device,
         tt::DataFormat::MxFp6P,
@@ -646,7 +646,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6PFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToBf16SpecialCases) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     auto layout = mxfp6_tc::get_mxfp6_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN.
@@ -714,7 +714,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToBf16SpecialCases) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToBf16SpecialCases) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
     auto layout = mxfp6_tc::get_mxfp6_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN.
@@ -770,7 +770,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToBf16SpecialCases) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RSpecialCases) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
 
     // Block layout (32 BF16 elements per block):
     //   0: all +NaN  → block must read as NaN (NaN propagation).
@@ -837,7 +837,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RSpecialCases) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6PSpecialCases) {
-    const auto& mesh_device = *devices_[0];
+    auto& mesh_device = *devices_[0];
 
     constexpr uint16_t kBf16PosNaN = 0x7FC0;
     constexpr uint16_t kBf16PosInf = 0x7F80;

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -39,7 +39,7 @@ namespace unit_tests::llk::mxint_typecast {
 // unpacker/packer performs the format conversion implicitly. Identical to the
 // MXFP4/MXFP8 typecast drivers — only the format(s) under test differ.
 static vector<uint32_t> run_mxint_typecast(
-    const distributed::MeshDevice& mesh_device,
+    distributed::MeshDevice& mesh_device,
     tt::DataFormat input_fmt,
     tt::DataFormat output_fmt,
     const vector<uint32_t>& src_vec,
@@ -233,7 +233,7 @@ constexpr float kOffset = -10.0f;  // U(0, 20) + (-10) = U(-10, 10)
 // power-of-two block scale), so the conversion is lossless. We compare the
 // device output against the host-decoded source — both must be bit-identical.
 static void run_widening_or_identity_test(
-    const distributed::MeshDevice& mesh_device,
+    distributed::MeshDevice& mesh_device,
     tt::DataFormat input_fmt,   // an MxInt format
     tt::DataFormat output_fmt,  // Float16_b or the same MxInt format
     bool fp32_dest_acc_en) {
@@ -258,7 +258,7 @@ static void run_widening_or_identity_test(
 // validates that the hardware quantizer matches the OCP MX golden bit-for-bit
 // (modulo rare rounding ties absorbed by `atol`).
 static void run_narrowing_test(
-    const distributed::MeshDevice& mesh_device,
+    distributed::MeshDevice& mesh_device,
     tt::DataFormat output_fmt,  // an MxInt format
     float atol,
     bool fp32_dest_acc_en) {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -27,7 +27,7 @@ namespace tt::tt_metal::experimental {
 // INVARIANT: A successfully constructed Program is always valid.
 //
 Program MakeProgramFromSpec(
-    const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
+    distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
 
 // Create a MeshWorkload object from a set of region-mapped ProgramSpecs
 // (This will become a constructor for the MeshWorkload class)

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -24,7 +24,13 @@ namespace tt::tt_metal::experimental {
 // Create a Program object from a ProgramSpec
 // (This will become a constructor for the Program class)
 //
-// INVARIANT: A successfully constructed Program is always valid.
+// INVARIANT: A successfully constructed Program is semantically valid
+// and compiled, but has not yet been finalized for dispatch.
+// Kernel config layout and capacity are validated when the Program is
+// finalized as part of a MeshWorkload.
+//
+// PRE-CONDITION: If skip_validation is true, the caller guarantees that
+// the ProgramSpec satisfies all semantic validation requirements.
 //
 Program MakeProgramFromSpec(
     distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
@@ -33,6 +39,9 @@ Program MakeProgramFromSpec(
 // (This will become a constructor for the MeshWorkload class)
 //
 // INVARIANT: A successfully constructed MeshWorkload is always valid.
+//
+// PRE-CONDITION: If skip_validation is true, the caller guarantees that
+// the ProgramSpecs satisfy all semantic validation requirements.
 //
 distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
     distributed::MeshDevice& mesh_device,
@@ -44,6 +53,9 @@ distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
 // (This will become a constructor for the MeshWorkload class)
 //
 // INVARIANT: A successfully constructed MeshWorkload is always valid.
+//
+// PRE-CONDITION: If skip_validation is true, the caller guarantees that
+// the ProgramSpec satisfies all semantic validation requirements.
 //
 distributed::MeshWorkload MakeMeshWorkloadFromSpec(
     distributed::MeshDevice& mesh_device, const ProgramSpec& program_spec, bool skip_validation = false);

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -8,8 +8,11 @@
 
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <unordered_map>
 
 namespace tt::tt_metal::experimental {
 
@@ -20,8 +23,30 @@ namespace tt::tt_metal::experimental {
 
 // Create a Program object from a ProgramSpec
 // (This will become a constructor for the Program class)
+//
+// INVARIANT: A successfully constructed Program is always valid.
+//
 Program MakeProgramFromSpec(
     const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
+
+// Create a MeshWorkload object from a set of region-mapped ProgramSpecs
+// (This will become a constructor for the MeshWorkload class)
+//
+// INVARIANT: A successfully constructed MeshWorkload is always valid.
+//
+distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
+    distributed::MeshDevice& mesh_device,
+    const std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec>& program_specs,
+    bool skip_validation = false);
+
+// Create a MeshWorkload object from single ProgramSpec,
+// to be applied mesh-wide (SPMD)
+// (This will become a constructor for the MeshWorkload class)
+//
+// INVARIANT: A successfully constructed MeshWorkload is always valid.
+//
+distributed::MeshWorkload MakeMeshWorkloadFromSpec(
+    distributed::MeshDevice& mesh_device, const ProgramSpec& program_spec, bool skip_validation = false);
 
 // Configure the arguments (mutable parameters) of an existing Program
 // (This will become a member function for the Program class)

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -33,6 +33,7 @@ public:
     // Requirement: In one MeshWorkload, device ranges for different programs must not share devices; each device can
     // belong to only one program. Not all devices need a program—leaving some devices unassigned is allowed.
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
+    void add_program_and_compile(const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device);
     std::unordered_map<MeshCoordinateRange, Program>& get_programs();
     const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const;
 

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -33,7 +33,6 @@ public:
     // Requirement: In one MeshWorkload, device ranges for different programs must not share devices; each device can
     // belong to only one program. Not all devices need a program—leaving some devices unassigned is allowed.
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
-    void add_program_and_compile(const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device);
     std::unordered_map<MeshCoordinateRange, Program>& get_programs();
     const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const;
 

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -85,7 +85,7 @@ MeshWorkloadImpl::MeshWorkloadImpl() : id(get_next_counter()) {
 
 MeshWorkloadImpl::~MeshWorkloadImpl() { Inspector::mesh_workload_destroyed(this); }
 
-Program& MeshWorkloadImpl::add_program_impl(const MeshCoordinateRange& device_range, Program&& program) {
+void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Program&& program) {
     TT_FATAL(!is_finalized(), "Cannot add programs to a MeshWorkload after it has been finalized.");
     auto potential_intersection = find_intersection(programs_, device_range);
     TT_FATAL(
@@ -95,11 +95,6 @@ Program& MeshWorkloadImpl::add_program_impl(const MeshCoordinateRange& device_ra
         *potential_intersection);
     Inspector::mesh_workload_add_program(this, device_range, program.impl().get_id());
     programs_[device_range] = std::move(program);
-    return programs_.at(device_range);
-}
-
-void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Program&& program) {
-    add_program_impl(device_range, std::move(program));
 }
 
 void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device) {

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -85,7 +85,8 @@ MeshWorkloadImpl::MeshWorkloadImpl() : id(get_next_counter()) {
 
 MeshWorkloadImpl::~MeshWorkloadImpl() { Inspector::mesh_workload_destroyed(this); }
 
-void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Program&& program) {
+Program& MeshWorkloadImpl::add_program_impl(const MeshCoordinateRange& device_range, Program&& program) {
+    TT_FATAL(!is_finalized(), "Cannot add programs to a MeshWorkload after it has been finalized.");
     auto potential_intersection = find_intersection(programs_, device_range);
     TT_FATAL(
         !potential_intersection,
@@ -94,6 +95,11 @@ void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Prog
         *potential_intersection);
     Inspector::mesh_workload_add_program(this, device_range, program.impl().get_id());
     programs_[device_range] = std::move(program);
+    return programs_.at(device_range);
+}
+
+void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Program&& program) {
+    add_program_impl(device_range, std::move(program));
 }
 
 void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device) {
@@ -110,7 +116,37 @@ void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, 
     program.impl().validate_dataflow_buffer_region(mesh_device);
 }
 
+void MeshWorkloadImpl::add_program_and_compile(
+    const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device) {
+    if (!program_binary_status_.empty()) {
+        TT_FATAL(
+            program_binary_status_.contains(mesh_device.id()),
+            "Reusing MeshWorkloads across MeshDevices is currently not supported.");
+    }
+    auto& added_program = add_program_impl(device_range, std::move(program));
+
+    // Compile and validate ahead of time as much as possible
+    added_program.impl().compile(&mesh_device);
+    added_program.impl().allocate_circular_buffers(&mesh_device);
+    added_program.impl().validate_circular_buffer_core_ranges(&mesh_device);
+    added_program.impl().validate_circular_buffer_region(&mesh_device);
+    added_program.impl().finalize_dataflow_buffer_configs();
+    added_program.impl().allocate_dataflow_buffers(&mesh_device);
+    // Validates only the DFB without considering the scratchpad region, as that requires runtime
+    // args to be set and must be validated at enqueue time.
+    added_program.impl().validate_dataflow_buffer_region(&mesh_device);
+
+    // Bind the workload to this MeshDevice ahead of any binary load. NotSent is accurate: the
+    // binaries have not been written yet.
+    set_program_binary_status(mesh_device.id(), ProgramBinaryStatus::NotSent);
+}
+
 void MeshWorkloadImpl::compile(MeshDevice* mesh_device) {
+    if (!program_binary_status_.empty()) {
+        TT_FATAL(
+            program_binary_status_.contains(mesh_device->id()),
+            "Reusing MeshWorkloads across MeshDevices is currently not supported.");
+    }
     // Multi-Step Compile:
     // 1. Compile Kernel Binaries
     // 2. Allocate and Validate CBs
@@ -138,9 +174,11 @@ void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
         TT_FATAL(
             program_binary_status_.contains(mesh_device->id()),
             "Reusing MeshWorkloads across MeshDevices is currently not supported.");
+    }
+    if (get_program_binary_status(mesh_device->id()) != ProgramBinaryStatus::NotSent) {
         TT_FATAL(
-            program_binary_status_.at(mesh_device->id()) == ProgramBinaryStatus::Committed,
-            "Expected Program Biinaries to be committed to DRAM.");
+            get_program_binary_status(mesh_device->id()) == ProgramBinaryStatus::Committed,
+            "Expected Program Binaries to be committed to DRAM.");
     } else {
         // Allocate kernel binary buffers of max size across all devices, to ensure we have lock step allocation.
         uint32_t max_kernel_bin_buf_size = 0;
@@ -445,6 +483,11 @@ std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() {
 
 const std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() const {
     return pimpl_->get_programs();
+}
+
+void MeshWorkload::add_program_and_compile(
+    const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device) {
+    pimpl_->add_program_and_compile(device_range, std::move(program), mesh_device);
 }
 
 // For testing purposes only

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -104,49 +104,10 @@ void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Prog
 
 void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device) {
     auto& program = programs_.at(device_range);
-    program.impl().compile(mesh_device);
-    program.impl().allocate_circular_buffers(mesh_device);
-    program.impl().validate_circular_buffer_core_ranges(mesh_device);
-    program.impl().validate_circular_buffer_region(mesh_device);
-    program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(mesh_device);
-    // Metal 2.0 scratchpads stack on the DFB allocations, so must allocate them AFTER the DFBs are placed.
-    // Their locations are passed as implicit CRTAs, so allocate them BEFORE generate_dispatch_commands snapshots.
-    program.impl().allocate_scratchpads(mesh_device);
-    program.impl().validate_dataflow_buffer_region(mesh_device);
-}
-
-void MeshWorkloadImpl::add_program_and_compile(
-    const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device) {
-    if (!program_binary_status_.empty()) {
-        TT_FATAL(
-            program_binary_status_.contains(mesh_device.id()),
-            "Reusing MeshWorkloads across MeshDevices is currently not supported.");
-    }
-    auto& added_program = add_program_impl(device_range, std::move(program));
-
-    // Compile and validate ahead of time as much as possible
-    added_program.impl().compile(&mesh_device);
-    added_program.impl().allocate_circular_buffers(&mesh_device);
-    added_program.impl().validate_circular_buffer_core_ranges(&mesh_device);
-    added_program.impl().validate_circular_buffer_region(&mesh_device);
-    added_program.impl().finalize_dataflow_buffer_configs();
-    added_program.impl().allocate_dataflow_buffers(&mesh_device);
-    // Validates only the DFB without considering the scratchpad region, as that requires runtime
-    // args to be set and must be validated at enqueue time.
-    added_program.impl().validate_dataflow_buffer_region(&mesh_device);
-
-    // Bind the workload to this MeshDevice ahead of any binary load. NotSent is accurate: the
-    // binaries have not been written yet.
-    set_program_binary_status(mesh_device.id(), ProgramBinaryStatus::NotSent);
+    program.impl().compile_and_allocate(mesh_device, false);
 }
 
 void MeshWorkloadImpl::compile(MeshDevice* mesh_device) {
-    if (!program_binary_status_.empty()) {
-        TT_FATAL(
-            program_binary_status_.contains(mesh_device->id()),
-            "Reusing MeshWorkloads across MeshDevices is currently not supported.");
-    }
     // Multi-Step Compile:
     // 1. Compile Kernel Binaries
     // 2. Allocate and Validate CBs
@@ -174,10 +135,8 @@ void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
         TT_FATAL(
             program_binary_status_.contains(mesh_device->id()),
             "Reusing MeshWorkloads across MeshDevices is currently not supported.");
-    }
-    if (get_program_binary_status(mesh_device->id()) != ProgramBinaryStatus::NotSent) {
         TT_FATAL(
-            get_program_binary_status(mesh_device->id()) == ProgramBinaryStatus::Committed,
+            program_binary_status_.at(mesh_device->id()) == ProgramBinaryStatus::Committed,
             "Expected Program Binaries to be committed to DRAM.");
     } else {
         // Allocate kernel binary buffers of max size across all devices, to ensure we have lock step allocation.
@@ -483,11 +442,6 @@ std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() {
 
 const std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() const {
     return pimpl_->get_programs();
-}
-
-void MeshWorkload::add_program_and_compile(
-    const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device) {
-    pimpl_->add_program_and_compile(device_range, std::move(program), mesh_device);
 }
 
 // For testing purposes only

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -42,7 +42,6 @@ private:
 
     bool runs_on_noc_multicast_only_cores();
     bool runs_on_noc_unicast_only_cores();
-    Program& add_program_impl(const MeshCoordinateRange& device_range, Program&& program);
     void load_binaries(MeshCommandQueue& mesh_cq);
     void generate_dispatch_commands(MeshCommandQueue& mesh_cq);
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -43,6 +43,7 @@ private:
     bool runs_on_noc_multicast_only_cores();
     bool runs_on_noc_unicast_only_cores();
     void compile(MeshDevice* mesh_device);
+    Program& add_program_impl(const MeshCoordinateRange& device_range, Program&& program);
     void load_binaries(MeshCommandQueue& mesh_cq);
     void generate_dispatch_commands(MeshCommandQueue& mesh_cq);
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
@@ -93,6 +94,7 @@ public:
     uint64_t get_id() const { return id; }
 
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
+    void add_program_and_compile(const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device);
     std::unordered_map<MeshCoordinateRange, Program>& get_programs() { return programs_; }
     const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const { return programs_; }
 

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -42,7 +42,6 @@ private:
 
     bool runs_on_noc_multicast_only_cores();
     bool runs_on_noc_unicast_only_cores();
-    void compile(MeshDevice* mesh_device);
     Program& add_program_impl(const MeshCoordinateRange& device_range, Program&& program);
     void load_binaries(MeshCommandQueue& mesh_cq);
     void generate_dispatch_commands(MeshCommandQueue& mesh_cq);
@@ -94,9 +93,9 @@ public:
     uint64_t get_id() const { return id; }
 
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
-    void add_program_and_compile(const MeshCoordinateRange& device_range, Program&& program, MeshDevice& mesh_device);
     std::unordered_map<MeshCoordinateRange, Program>& get_programs() { return programs_; }
     const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const { return programs_; }
+    void compile(MeshDevice* mesh_device);
 
     // For testing purposes only
     void set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq);

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -1767,6 +1767,12 @@ void ProgramImpl::set_dfb_data_fmt_and_tile(const std::vector<CoreRange>& crs, J
         for (const auto& dfb : dfbs_on_core) {
             const CBIndex cb_index = static_cast<CBIndex>(dfb->id);
             const DataFormat data_format = dfb->config.data_format;
+            // Populate this DFB's CB-indexed JIT metadata only when a format was specified.
+            // A format-less DFB has no compute consumer, so its JIT slot is intentionally left
+            // at the defaults instead of deriving a tile size from DataFormat::Invalid.
+            if (data_format == DataFormat::Invalid) {
+                continue;
+            }
             const auto& tile_opt = dfb->config.tile;
             const auto& unpack_geom = dfb->config.unpack_face_geometry;
             build_options.set_cb_data_fmt_tile_and_face_geometry(cb_index, data_format, tile_opt, unpack_geom);

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1016,6 +1016,9 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
         program.impl().validate_circular_buffer_core_ranges(validation_device);
         program.impl().validate_circular_buffer_region(validation_device);
         program.impl().allocate_dataflow_buffers(validation_device);
+        // Pre-size Metal 2.0 RTA/CRTA buffers from schema when not already reserved
+        // (e.g. MakeProgramFromSpec). Idempotent if SetProgramRunArgs already sized them.
+        program.impl().reserve_runtime_arg_buffers();
         // Metal 2.0 scratchpads stack on the DFB allocations, so allocate them AFTER the DFBs are placed.
         // Scratchpads are passed as implicit CRTAs, so they must be allocated before the CRTAs are committed.
         program.impl().allocate_scratchpads(validation_device);

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -771,15 +771,19 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
     }
     program_impl.apply_dfb_size_overrides(size_overrides);
     AttachBorrowedDFBBuffers(program_impl, tensor_by_param);
+    program_impl.mark_program_run_args_initialized();
 }
 
 void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args) {
     log_debug(tt::LogMetal, "Updating tensor args (partial fast-path)");
 
+    detail::ProgramImpl& program_impl = program.impl();
+    TT_FATAL(
+        program_impl.program_run_args_initialized(),
+        "UpdateTensorArgs called on Program before SetProgramRunArgs. Call SetProgramRunArgs at least once first.");
+
     // Validate the TensorArgument list (shared with the full-path validator).
     ValidateTensorArgs(program, tensor_args);
-
-    detail::ProgramImpl& program_impl = program.impl();
 
     // Build a tensor_parameter_name -> MeshTensor lookup.
     // As in SetProgramRunArgs, this assumes lockstep mesh allocation:
@@ -1135,11 +1139,15 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
 void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation) {
     log_debug(tt::LogMetal, "Updating ProgramRunArgs (partial fast-path)");
 
+    detail::ProgramImpl& program_impl = program.impl();
+    TT_FATAL(
+        program_impl.program_run_args_initialized(),
+        "UpdateProgramRunArgs: CRTA buffer not allocated because SetProgramRunArgs has not been called. Call "
+        "SetProgramRunArgs at least once before a partial update.");
+
     if (!skip_validation) {
         ValidateUpdateProgramRunArgs(program, params);
     }
-
-    detail::ProgramImpl& program_impl = program.impl();
 
     // Patch the supplied args in place. Omitted (enqueue-invariant) named args and tensor params
     // are left untouched, retaining the value installed by the most recent SetProgramRunArgs.

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -524,12 +524,13 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
     };
 
     // Append a kernel's scratchpad CRTA section to `out`, in binding order: one word per scratchpad
-    // binding, holding the scratchpad's allocated L1 base address. The address is 0 here on the first
-    // SetProgramRunArgs (the scratchpad is allocated later, at program-compile time, and the slot is
-    // then patched in place — see ProgramImpl::allocate_scratchpads); on any later re-assembly the
-    // handle already carries the allocated address, so it is filled directly. The section is always
-    // present (sized by the kernel's scratchpad bindings), so the buffer's word count is stable across
-    // re-set calls (install_crtas asserts that).
+    // binding, holding the scratchpad's allocated L1 base address. On the factory path,
+    // reserve_runtime_arg_buffers + allocate_scratchpads may already have filled this; on the
+    // legacy order (SetProgramRunArgs before allocate_scratchpads) the address is 0 here and is
+    // patched later. On any re-assembly the handle already carries the allocated address, so it
+    // is filled directly. The section is always present (sized by the kernel's scratchpad
+    // bindings), so the buffer's word count is stable across re-set calls (install_crtas asserts
+    // that).
     auto append_scratchpad_crtas = [](const auto& scratchpad_handles, std::vector<uint32_t>& out) {
         for (const auto& handle : scratchpad_handles) {
             out.push_back(handle.allocated_address);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -3192,4 +3192,26 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     return Program(std::move(program_impl));
 }
 
+distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
+    distributed::MeshDevice& mesh_device,
+    const std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec>& program_specs,
+    bool skip_validation) {
+    distributed::MeshWorkload workload;
+    for (const auto& [device_range, program_spec] : program_specs) {
+        workload.add_program_and_compile(
+            device_range, MakeProgramFromSpec(mesh_device, program_spec, skip_validation), mesh_device);
+    }
+    return workload;
+}
+
+distributed::MeshWorkload MakeMeshWorkloadFromSpec(
+    distributed::MeshDevice& mesh_device, const ProgramSpec& program_spec, bool skip_validation) {
+    distributed::MeshWorkload workload;
+    workload.add_program_and_compile(
+        distributed::MeshCoordinateRange(mesh_device.shape()),
+        MakeProgramFromSpec(mesh_device, program_spec, skip_validation),
+        mesh_device);
+    return workload;
+}
+
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -29,6 +29,7 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/context/metal_env_accessor.hpp"
 #include "impl/dispatch/dispatch_core_manager.hpp"
+#include "distributed/mesh_workload_impl.hpp"
 #include <core_descriptor.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <variant>
@@ -2816,11 +2817,9 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
     return processors;
 }
 
-// ============================================================================
-// Public Entry Point
-// ============================================================================
+namespace {
 
-Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
+Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
     log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.name);
 
     // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)
@@ -3192,25 +3191,44 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     return Program(std::move(program_impl));
 }
 
+}  // namespace
+
+// ============================================================================
+// Public Entry Points
+// ============================================================================
+
+Program MakeProgramFromSpec(distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
+    Program program = BuildProgramFromSpec(mesh_device, spec, skip_validation);
+    program.impl().compile_and_allocate(&mesh_device, false);
+    return program;
+}
+
 distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
     distributed::MeshDevice& mesh_device,
     const std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec>& program_specs,
     bool skip_validation) {
+    const distributed::MeshCoordinateRange mesh_extent(mesh_device.shape());
     distributed::MeshWorkload workload;
+    TT_FATAL(!program_specs.empty(), "At least one ProgramSpec is required to create a MeshWorkload.");
     for (const auto& [device_range, program_spec] : program_specs) {
-        workload.add_program_and_compile(
-            device_range, MakeProgramFromSpec(mesh_device, program_spec, skip_validation), mesh_device);
+        TT_FATAL(
+            mesh_extent.contains(device_range),
+            "Device range {} is outside MeshDevice shape {}",
+            device_range,
+            mesh_device.shape());
+        workload.impl().add_program(device_range, BuildProgramFromSpec(mesh_device, program_spec, skip_validation));
     }
+    workload.impl().compile(&mesh_device);
     return workload;
 }
 
 distributed::MeshWorkload MakeMeshWorkloadFromSpec(
     distributed::MeshDevice& mesh_device, const ProgramSpec& program_spec, bool skip_validation) {
     distributed::MeshWorkload workload;
-    workload.add_program_and_compile(
+    workload.impl().add_program(
         distributed::MeshCoordinateRange(mesh_device.shape()),
-        MakeProgramFromSpec(mesh_device, program_spec, skip_validation),
-        mesh_device);
+        BuildProgramFromSpec(mesh_device, program_spec, skip_validation));
+    workload.impl().compile(&mesh_device);
     return workload;
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -556,6 +556,65 @@ std::vector<std::string> ProgramImpl::get_registered_kernel_names() const {
     return names;
 }
 
+void ProgramImpl::reserve_runtime_arg_buffers() {
+    if (!metal2_registry_) {
+        return;
+    }
+
+    for (const std::string& kernel_name : get_registered_kernel_names()) {
+        const KernelRTASchema* schema = get_kernel_rta_schema(kernel_name);
+        if (schema == nullptr) {
+            continue;
+        }
+
+        std::shared_ptr<Kernel> kernel = get_kernel_by_spec_name(kernel_name);
+        if (kernel == nullptr) {
+            continue;
+        }
+
+        // CRTA word count is fully determined by ProgramSpec resolution:
+        //   [ named | tensor bindings | scratchpads | common varargs ]
+        // vararg_section_offset == named + bindings + scratchpads.
+        const KernelCrtaLayout layout = kernel->get_crta_layout();
+        const size_t crta_words =
+            static_cast<size_t>(layout.vararg_section_offset) + schema->num_common_runtime_varargs;
+
+        // Per-node RTAs: named count + per-node vararg count from the schema.
+        const size_t named_rta_words = schema->runtime_arg_names.size();
+
+        // Reserve unique RTAs first so set_common_runtime_args can validate against
+        // max_runtime_args_per_core_ once CRTAs are installed.
+        for (const CoreCoord& core : kernel->logical_cores()) {
+            size_t vararg_words = 0;
+            if (auto it = schema->num_runtime_varargs_per_node.find(core);
+                it != schema->num_runtime_varargs_per_node.end()) {
+                vararg_words = it->second;
+            }
+            const size_t rta_words = named_rta_words + vararg_words;
+            if (rta_words == 0) {
+                continue;
+            }
+            // set_runtime_args may only allocate on the first call; skip if already sized
+            // (e.g. SetProgramRunArgs ran earlier on a non-factory path).
+            if (!kernel->runtime_args(core).empty()) {
+                continue;
+            }
+            std::vector<uint32_t> zeros(rta_words, 0u);
+            kernel->set_runtime_args(core, zeros);
+        }
+
+        if (crta_words == 0) {
+            continue;
+        }
+        // set_common_runtime_args may only be called once; SetProgramRunArgs overwrites in place after.
+        if (!kernel->common_runtime_args().empty()) {
+            continue;
+        }
+        std::vector<uint32_t> zeros(crta_words, 0u);
+        kernel->set_common_runtime_args(zeros);
+    }
+}
+
 void ProgramImpl::register_tensor_parameter(
     const std::string& name,
     const TensorSpec& spec,
@@ -1306,20 +1365,6 @@ void detail::ProgramImpl::allocate_scratchpads(const IDevice* device) {
 
                 handle.allocated_address = static_cast<uint32_t>(addr);
 
-                // Patch the allocated address into the kernel's CRTA buffer. This runs at Program-compile
-                // time, upstream of where dispatch delivers runtime args to the device:
-                //  - FD: the fast/mesh path snapshots the CRTA buffer into the command stream
-                //  - SD: the slow-dispatch path writes it via WriteRuntimeArgsToDevice
-                //
-                // An implicit CRTA slot to hold the scratchpad address is reserved at Program creation.
-                // (The actual CRTA buffer itself is allocated when SetProgramRunArgs runs.)
-                // Now, we populate the scratchpad address.
-                //
-                TT_FATAL(
-                    !kernel->common_runtime_args().empty(),
-                    "CRTA buffer is not allocated; cannot populate scratchpad addresses for kernel {}. "
-                    "Ensure that SetProgramRunArgs is called before attempting to enqueue a Program.",
-                    kernel->name());
                 TT_FATAL(
                     handle.allocated_address != 0,
                     "Internal error: scratchpad '{}' on kernel '{}' "
@@ -1327,8 +1372,20 @@ void detail::ProgramImpl::allocate_scratchpads(const IDevice* device) {
                     handle.accessor_name,
                     kernel->name());
 
-                RuntimeArgsData& crta = kernel->common_runtime_args_data();
-                crta.data()[handle.addr_crta_word] = handle.allocated_address;
+                // Patch the allocated address into the kernel's CRTA buffer if it exists.
+                // On the Metal 2.0 factory path, reserve_runtime_arg_buffers pre-sizes the CRTA
+                // buffer before this runs, so the address is updated here. If CRTA is not yet allocated
+                // (legacy order: SetProgramRunArgs first), SetProgramRunArgs copies
+                // handle.allocated_address into the scratchpad section when it builds the buffer.
+                // This allows for allocation of scratchpad and the CRTA buffer to be order agnostic.
+                //
+                // Usage of the CRTA buffer:
+                //  - FD: the fast/mesh path snapshots the CRTA buffer into the command stream
+                //  - SD: the slow-dispatch path writes it via WriteRuntimeArgsToDevice
+                if (!kernel->common_runtime_args().empty()) {
+                    RuntimeArgsData& crta = kernel->common_runtime_args_data();
+                    crta.data()[handle.addr_crta_word] = handle.allocated_address;
+                }
             }
         }
     }
@@ -2281,6 +2338,23 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     compiled_.insert(build_env.build_key());
 
     Inspector::program_compile_finished(this, device, build_env.build_key());
+}
+
+void detail::ProgramImpl::compile_and_allocate(IDevice* device, bool force_slow_dispatch) {
+    this->compile(device, force_slow_dispatch);
+    this->allocate_circular_buffers(device);
+    this->validate_circular_buffer_core_ranges(device);
+    this->validate_circular_buffer_region(device);
+    this->finalize_dataflow_buffer_configs();
+    this->allocate_dataflow_buffers(device);
+
+    // Pre-size Metal 2.0 RTA/CRTA host buffers from the registered schema before scratchpad allocation and
+    // finalize_offsets. This is a no-op for programs without a Metal 2.0 registry.
+    this->reserve_runtime_arg_buffers();
+
+    // Metal 2.0 scratchpads stack on the DFB allocations and their locations are passed as implicit CRTAs.
+    this->allocate_scratchpads(device);
+    this->validate_dataflow_buffer_region(device);
 }
 
 void detail::ProgramImpl::set_runtime_id(ProgramId id) { this->runtime_id = id; }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2217,6 +2217,9 @@ void ProgramImpl::generate_trace_dispatch_commands(distributed::MeshDevice* mesh
 
 void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     TTZoneScopedD(PROGRAM);
+
+    const auto& cluster = MetalContext::instance(extract_context_id(device)).get_cluster();
+
     const auto& build_env =
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id());
 
@@ -2231,6 +2234,13 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     }
 
     Inspector::program_compile_started(this, device, build_env.build_key());
+
+    // Currently JIT compile on Quasar mock devices is non functional
+    if (cluster.get_target_device_type() == tt::TargetDevice::Mock && device->arch() == tt::ARCH::QUASAR) {
+        compiled_.insert(build_env.build_key());
+        Inspector::program_compile_finished(this, device, build_env.build_key());
+        return;
+    }
 
     TT_FATAL(
         device->is_initialized(),

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -221,6 +221,7 @@ public:
         const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const;
     std::vector<std::vector<CoreCoord>> logical_cores() const;
     void compile(IDevice* device, bool force_slow_dispatch = false);
+    void compile_and_allocate(IDevice* device, bool force_slow_dispatch);
     void invalidate_circular_buffer_allocation();
     void invalidate_dataflow_buffer_allocation();
     // Always used in conjunction with validate_circular_buffer_region and compile
@@ -422,6 +423,10 @@ public:
 
     // Metal 2.0: Get all registered kernel names (for completeness validation)
     std::vector<std::string> get_registered_kernel_names() const;
+
+    // Metal 2.0: Pre-size RTA/CRTA host buffers from the registered schema + CRTA layout so
+    // finalize_offsets can compute dispatch sizes before SetProgramRunArgs fills values.
+    void reserve_runtime_arg_buffers();
 
 private:
     HWCommandQueue* last_used_command_queue_for_testing = nullptr;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -428,6 +428,9 @@ public:
     // finalize_offsets can compute dispatch sizes before SetProgramRunArgs fills values.
     void reserve_runtime_arg_buffers();
 
+    bool program_run_args_initialized() const { return program_run_args_initialized_; }
+    void mark_program_run_args_initialized() { program_run_args_initialized_ = true; }
+
 private:
     HWCommandQueue* last_used_command_queue_for_testing = nullptr;
 
@@ -439,6 +442,7 @@ private:
     ProgramTransferInfo program_transfer_info;
 
     bool finalized_{false};
+    bool program_run_args_initialized_{false};
     // Used only when devices do not have virtualization enabled and used to check that programs are only rerun on
     // the same device
     std::optional<uint64_t> cached_device_hash_;


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #49433 

Implement MakeMeshWorkloadFromSpec with eager JIT compilation

* Created and implemented Metal 2.0 API factory method MakeMeshWorkloadFromSpec and MakeMeshWorkloadFromSpecs
* Factory methods eagerly compile programs, allocate device buffers, and finalize program offsets in the mesh workload
* Added unit tests to verify factory method creates a valid MeshWorkload object
* Disable non-functional program JIT compile on Quasar mock devices

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/metal-2-0-MakeMeshWorkloadFromSpecs)