### PR TITLE
[Cleanup] Migrate Conv/Pool Kernels from CircularBuffer to DataflowBuffer

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -283,7 +283,9 @@ def test_conv2d_block_sharded_sdxl_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 1025500  # Updated 2026-05-06: op is ~1.6% faster (~1.025ms), see gh#43750
+    expected_duration_ns = (
+        993500  # Updated 2026-07-09: ~3% faster (~0.9935ms) after CircularBuffer->DataflowBuffer kernel port
+    )
 
     # Log the performance result
     print(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -98,17 +98,17 @@ void kernel_main() {
     }
 
     // Experimental API objects
-    experimental::CB reader_indices_cb(cb_reader_indices);
-    experimental::CB act_rm_cb(cb_id_act_row_major_bfloat16);
-    experimental::CB act_cb(cb_id_act);
-    experimental::CB tilized_in0_cb(tilized_in0_cb_id);
-    experimental::CB sharded_act_cb(cb_id_sharded_act);
+    DataflowBuffer reader_indices_dfb(cb_reader_indices);
+    DataflowBuffer act_rm_dfb(cb_id_act_row_major_bfloat16);
+    DataflowBuffer act_dfb(cb_id_act);
+    DataflowBuffer tilized_in0_dfb(tilized_in0_cb_id);
+    DataflowBuffer sharded_act_dfb(cb_id_sharded_act);
     Noc noc;
 
-    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(noc, reader_indices_cb, 0);
+    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(noc, reader_indices_dfb, 0);
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_cb.get_write_ptr());
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_dfb.get_write_ptr());
 
     // Experimental API multicast endpoint
     MulticastEndpoint mcast_ep;
@@ -135,7 +135,7 @@ void kernel_main() {
     // Striding to next row happens using stride_h_bytes
     constexpr uint32_t stride_h_bytes = (conv_act_size_w)*conv_act_c_bytes * dilation_h;
 
-    uint32_t act_l1_read_addr = sharded_act_cb.get_read_ptr();
+    uint32_t act_l1_read_addr = sharded_act_dfb.get_read_ptr();
     experimental::set_read_state<conv_act_c_read_bytes>(noc, act_l1_read_addr);
     uint32_t reader_idx = 0;
     uint32_t l1_write_addr_act = 0;
@@ -146,7 +146,7 @@ void kernel_main() {
 
     // Reset reader_idx to finish act_block_h_datums
     for (uint32_t block_h_index = 0; block_h_index < act_num_blocks_h; block_h_index++) {
-        act_l1_read_addr = sharded_act_cb.get_read_ptr();
+        act_l1_read_addr = sharded_act_dfb.get_read_ptr();
         uint32_t old_reader_idx = reader_idx;
         for (uint32_t block_w_index = 0; block_w_index < act_num_blocks_w; block_w_index++) {
             reader_idx = old_reader_idx;
@@ -162,8 +162,8 @@ void kernel_main() {
                     uint16_t end_ind = two_reader_indices >> 16;
                     for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
                         if (remaining_indexes == TILE_HEIGHT) {
-                            l1_write_addr_act = act_rm_cb.get_write_ptr();
-                            act_rm_cb.reserve_back(ntile_width);
+                            l1_write_addr_act = act_rm_dfb.get_write_ptr();
+                            act_rm_dfb.reserve_back(ntile_width);
                         }
                         read_channels<weight_size_h, weight_size_w>(
                             noc,
@@ -177,15 +177,15 @@ void kernel_main() {
 
                         if (--remaining_indexes == 0) {
                             noc.async_read_barrier();
-                            act_rm_cb.push_back(ntile_width);
-                            l1_write_addr_act = act_rm_cb.get_write_ptr();
+                            act_rm_dfb.push_back(ntile_width);
+                            l1_write_addr_act = act_rm_dfb.get_write_ptr();
                             remaining_indexes = TILE_HEIGHT;
                         }
                     }
                 }
                 if (remaining_indexes && remaining_indexes != TILE_HEIGHT) {
                     noc.async_read_barrier();
-                    act_rm_cb.push_back(ntile_width);
+                    act_rm_dfb.push_back(ntile_width);
                 }
                 reader_idx++;
 
@@ -194,8 +194,8 @@ void kernel_main() {
                 act_l1_read_addr += conv_act_c_read_bytes;
             } else {
                 for (uint32_t tile_h_index = 0; tile_h_index < ntile_height; tile_h_index++) {
-                    act_rm_cb.reserve_back(ntile_width);
-                    act_rm_cb.push_back(ntile_width);
+                    act_rm_dfb.reserve_back(ntile_width);
+                    act_rm_dfb.push_back(ntile_width);
                 }
             }
 
@@ -203,7 +203,7 @@ void kernel_main() {
             // Compute should function like regular mm
 #ifndef SKIP_MCAST
             for (uint32_t act_w_outer_i = 0; act_w_outer_i < num_input_cores; act_w_outer_i++) {
-                act_cb.reserve_back(act_block_num_tiles);
+                act_dfb.reserve_back(act_block_num_tiles);
                 if (act_w_outer_i == this_core_id) {
                     // MCAST SENDER: send entire tilized input to other cores in column
                     // wait until all act mcast destinations have atomically incremented the act semaphore_addr (i.e.
@@ -216,14 +216,15 @@ void kernel_main() {
                     act_mcast_receiver_sem.set(INVALID);
 
                     // compute tilizes and pops cb_id_act and pushes to tilized_in0_cb_id
-                    tilized_in0_cb.wait_front(act_block_num_tiles);
+                    tilized_in0_dfb.wait_front(act_block_num_tiles);
 
                     // Now we have the block in the CB address, we can mcast to dests!
-                    auto tilized_src =
-                        use<CircularBuffer::AddrSelector::READ_PTR>(tilized_in0_cb);
+                    // A bare DataflowBuffer NOC source already resolves to get_read_ptr() (see
+                    // noc_traits_t<DataflowBuffer>).
+                    auto tilized_src = tilized_in0_dfb;
 
                     // Multicast tilized activations to all reader cores (including self)
-                    mcast_dst.addr = act_cb.get_write_ptr();
+                    mcast_dst.addr = act_dfb.get_write_ptr();
                     noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                         tilized_src,
                         mcast_ep,
@@ -271,10 +272,10 @@ void kernel_main() {
                     act_mcast_receiver_sem.wait(VALID);
                 }
 
-                act_cb.push_back(act_block_num_tiles);
+                act_dfb.push_back(act_block_num_tiles);
 
             }  // num_input_cores
-            tilized_in0_cb.pop_front(act_block_num_tiles);
+            tilized_in0_dfb.pop_front(act_block_num_tiles);
 #endif
         }
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -8,14 +8,15 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/reconfig_data_format.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // Compute one block (one kernel-tap slice) of a 1D depthwise conv.
 //
 // Per output tile:
 //   dst[0]  = in0 * in1                                                 (FPU mul)
-//   if idx > 0: dst[0] += prior partial loaded from scratch_cb          (FPU add via DST reuse)
-//   pack dst[0] -> out_cb on the last tap, else scratch_cb
+//   if idx > 0: dst[0] += prior partial loaded from scratch_dfb          (FPU add via DST reuse)
+//   pack dst[0] -> out_dfb on the last tap, else scratch_dfb
 //
 // `idx` is the kernel-tap block index (0 .. num_taps-1, num_taps == filter_h*filter_w). The very
 // first call (idx == 0) initializes the partial with the tap-0 product; subsequent calls accumulate
@@ -24,33 +25,33 @@
 // that corrupt block-float (BFLOAT8_B/BFLOAT4_B) outputs in the round-tripped variant — while
 // still using FPU (not SFPU) for the add.
 //
-// The partial lives in scratch_cb; only the last tap (idx == num_taps-1) packs into out_cb. The host
-// aliases scratch_cb to out_cb for a single height block (in-place), but uses a separate buffer when
-// in0_num_blocks_h > 1, where out_cb (the persistent sharded output) cannot double as the read-back
+// The partial lives in scratch_dfb; only the last tap (idx == num_taps-1) packs into out_dfb. The host
+// aliases scratch_dfb to out_dfb for a single height block (in-place), but uses a separate buffer when
+// in0_num_blocks_h > 1, where out_dfb (the persistent sharded output) cannot double as the read-back
 // scratch — block N would otherwise read back block N-1's already-written output.
 //
 // srcB (cfg92) tile descriptor: must match in1 for the mul, and is repopulated from DST for the
 // dest-reuse add. We force srcB back to in1's format every iteration so block-float weights are
 // decoded correctly.
 inline void mul_and_accumulate_block(
-    experimental::CB in0_cb,
-    experimental::CB in1_cb,
-    experimental::CB scratch_cb,
-    experimental::CB out_cb,
+    DataflowBuffer in0_dfb,
+    DataflowBuffer in1_dfb,
+    DataflowBuffer scratch_dfb,
+    DataflowBuffer out_dfb,
     uint32_t block_num_tiles,
     uint32_t idx,
     uint32_t num_taps) {
-    const uint32_t in0_cb_id = in0_cb.get_cb_id();
-    const uint32_t in1_cb_id = in1_cb.get_cb_id();
-    const uint32_t scratch_cb_id = scratch_cb.get_cb_id();
-    // The last tap writes the finished output to out_cb; earlier taps write the partial to scratch_cb.
+    const uint32_t in0_cb_id = in0_dfb.get_id();
+    const uint32_t in1_cb_id = in1_dfb.get_id();
+    const uint32_t scratch_cb_id = scratch_dfb.get_id();
+    // The last tap writes the finished output to out_dfb; earlier taps write the partial to scratch_dfb.
     const bool is_last_tap = (idx + 1 == num_taps);
-    experimental::CB dst_cb = is_last_tap ? out_cb : scratch_cb;
-    const uint32_t dst_cb_id = dst_cb.get_cb_id();
+    DataflowBuffer dst_dfb = is_last_tap ? out_dfb : scratch_dfb;
+    const uint32_t dst_cb_id = dst_dfb.get_id();
 
     for (uint32_t i = 0; i < block_num_tiles; i++) {
-        in1_cb.wait_front(1);
-        in0_cb.wait_front(1);
+        in1_dfb.wait_front(1);
+        in0_dfb.wait_front(1);
 
         tile_regs_acquire();
         // mul: srcA = in0 (bf16), srcB = in1 (bf8/bf16) -> dst[0]
@@ -59,37 +60,36 @@ inline void mul_and_accumulate_block(
         mul_tiles(in0_cb_id, in1_cb_id, 0, 0, 0);
 
         if (idx != 0) {
-            // dest-reuse add: dst[0] += scratch_cb (the prior tap's partial). srcA gets scratch_cb
+            // dest-reuse add: dst[0] += scratch_dfb (the prior tap's partial). srcA gets scratch_dfb
             // (cfg52 must match its format); srcB is filled from dst[0] by the dest-reuse path.
             reconfig_data_format_srca(scratch_cb_id);
             binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
                 scratch_cb_id);
-            scratch_cb.wait_front(1);
+            scratch_dfb.wait_front(1);
             binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
                 scratch_cb_id, 0, 0);
-            scratch_cb.pop_front(1);
+            scratch_dfb.pop_front(1);
 
             // Restore srcA to in0's format for the next iteration's mul unpack.
             reconfig_data_format_srca(in0_cb_id);
         }
         tile_regs_commit();
 
-        // scratch_cb and out_cb share the output data format, so packing to either target needs no
+        // scratch_dfb and out_dfb share the output data format, so packing to either target needs no
         // pack reconfig.
-        dst_cb.reserve_back(1);
+        dst_dfb.reserve_back(1);
         tile_regs_wait();
         pack_tile(0, dst_cb_id);
-        dst_cb.push_back(1);
+        dst_dfb.push_back(1);
         tile_regs_release();
 
-        in0_cb.pop_front(1);
-        in1_cb.pop_front(1);
+        in0_dfb.pop_front(1);
+        in1_dfb.pop_front(1);
     }
 }
 
 template <uint32_t in0_block_w, uint32_t kernel_width, uint32_t block_num_tiles>
-inline void mul_and_accumulate_coalesced_block(
-    experimental::CB in0_cb, experimental::CB in1_cb, experimental::CB out_cb) {
+inline void mul_and_accumulate_coalesced_block(DataflowBuffer in0_dfb, DataflowBuffer in1_dfb, DataflowBuffer out_dfb) {
     static_assert(kernel_width > 1);
     static_assert(in0_block_w % kernel_width == 0);
     static_assert(block_num_tiles % in0_block_w == 0);
@@ -97,12 +97,12 @@ inline void mul_and_accumulate_coalesced_block(
     constexpr uint32_t in_channels_ntiles = in0_block_w / kernel_width;
     constexpr uint32_t act_block_h_ntiles = block_num_tiles / in0_block_w;
 
-    const uint32_t in0_cb_id = in0_cb.get_cb_id();
-    const uint32_t in1_cb_id = in1_cb.get_cb_id();
-    const uint32_t out_cb_id = out_cb.get_cb_id();
+    const uint32_t in0_cb_id = in0_dfb.get_id();
+    const uint32_t in1_cb_id = in1_dfb.get_id();
+    const uint32_t out_cb_id = out_dfb.get_id();
 
-    in0_cb.wait_front(block_num_tiles);
-    in1_cb.wait_front(block_num_tiles);
+    in0_dfb.wait_front(block_num_tiles);
+    in1_dfb.wait_front(block_num_tiles);
 
     for (uint32_t h = 0; h < act_block_h_ntiles; ++h) {
         for (uint32_t c = 0; c < in_channels_ntiles; ++c) {
@@ -119,16 +119,16 @@ inline void mul_and_accumulate_coalesced_block(
             }
             tile_regs_commit();
 
-            out_cb.reserve_back(1);
+            out_dfb.reserve_back(1);
             tile_regs_wait();
             pack_tile(0, out_cb_id);
-            out_cb.push_back(1);
+            out_dfb.push_back(1);
             tile_regs_release();
         }
     }
 
-    in0_cb.pop_front(block_num_tiles);
-    in1_cb.pop_front(block_num_tiles);
+    in0_dfb.pop_front(block_num_tiles);
+    in1_dfb.pop_front(block_num_tiles);
 }
 
 void kernel_main() {
@@ -143,17 +143,17 @@ void kernel_main() {
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(8);
     constexpr uint32_t kernel_width = get_compile_time_arg_val(9);
     constexpr bool coalesce_kw_reads = get_compile_time_arg_val(10) == 1;
-    // Read-back scratch for the dest-reuse accumulation. The host points this at out_cb for a single
+    // Read-back scratch for the dest-reuse accumulation. The host points this at out_dfb for a single
     // height block (in-place) or at a dedicated scratch CB for multiple blocks.
     constexpr uint32_t partials_cb_id = get_compile_time_arg_val(11);
 
-    experimental::CB cb_tilized_in0(tilized_in0_cb_id);
-    experimental::CB cb_in1(in1_cb_id);
-    experimental::CB cb_out(out_cb_id);
-    experimental::CB cb_partials(partials_cb_id);
+    DataflowBuffer dfb_tilized_in0(tilized_in0_cb_id);
+    DataflowBuffer dfb_in1(in1_cb_id);
+    DataflowBuffer dfb_out(out_cb_id);
+    DataflowBuffer dfb_partials(partials_cb_id);
 
-    // binary_op_init_common configures pack for out_cb, math for in0/in1, and unpack for in0/in1.
-    // The pack target never changes (we only ever pack to out_cb), so no further pack reconfig is
+    // binary_op_init_common configures pack for out_dfb, math for in0/in1, and unpack for in0/in1.
+    // The pack target never changes (we only ever pack to out_dfb), so no further pack reconfig is
     // needed for the lifetime of the kernel.
     binary_op_init_common(in0_cb_id, in1_cb_id, out_cb_id);
 
@@ -167,13 +167,19 @@ void kernel_main() {
             reconfig_data_format_srca(tilized_in0_cb_id);
             if constexpr (coalesce_kw_reads) {
                 mul_and_accumulate_coalesced_block<in0_block_w, kernel_width, in0_block_num_tiles>(
-                    cb_tilized_in0, cb_in1, cb_out);
+                    dfb_tilized_in0, dfb_in1, dfb_out);
             } else {
-                // Accumulate kernel-tap in0_block_w_i of in0_num_blocks_w through cb_partials, writing
-                // the final tap to cb_out. The host points cb_partials at cb_out for a single height
+                // Accumulate kernel-tap in0_block_w_i of in0_num_blocks_w through dfb_partials, writing
+                // the final tap to dfb_out. The host points dfb_partials at dfb_out for a single height
                 // block (in-place, no extra buffer) or at a dedicated scratch CB for multiple blocks.
                 mul_and_accumulate_block(
-                    cb_tilized_in0, cb_in1, cb_partials, cb_out, in0_block_num_tiles, in0_block_w_i, in0_num_blocks_w);
+                    dfb_tilized_in0,
+                    dfb_in1,
+                    dfb_partials,
+                    dfb_out,
+                    in0_block_num_tiles,
+                    in0_block_w_i,
+                    in0_num_blocks_w);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -14,6 +14,7 @@
 #include "api/compute/tilize.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // #include "api/debug/dprint.h"
@@ -61,10 +62,10 @@ void tilize_in(
 }  // tilize_in()
 
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
-inline void tilize_single_block(experimental::CB in_cb) {
-    in_cb.wait_front(in_block_w);
+inline void tilize_single_block(DataflowBuffer in_dfb) {
+    in_dfb.wait_front(in_block_w);
     fast_tilize_block(in_cb_id, in_block_w, out_cb_id);
-    in_cb.pop_front(in_block_w);
+    in_dfb.pop_front(in_block_w);
 }
 
 template <uint32_t in_cb_id, uint32_t window_reuse_offset>
@@ -74,10 +75,10 @@ inline uint32_t update_in_cb(uint32_t in_cb_addr) {
 }
 
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id, uint32_t tilized_cb_row_offset>
-inline void tilize_single_block_with_out_cb_update(experimental::CB in_cb, uint32_t& out_cb_addr) {
+inline void tilize_single_block_with_out_cb_update(DataflowBuffer in_dfb, uint32_t& out_cb_addr) {
     PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr));
     PACK((out_cb_addr += tilized_cb_row_offset));
-    tilize_single_block<in_cb_id, in_block_w, out_cb_id>(in_cb);
+    tilize_single_block<in_cb_id, in_block_w, out_cb_id>(in_dfb);
 }
 
 template <
@@ -93,16 +94,16 @@ template <
     uint32_t tilized_cb_second_reader_offset,
     uint32_t image_width_in_tiles>
 inline void tilize_in_reuse_split_reader(
-    experimental::CB in1_cb,
-    experimental::CB in2_cb,
-    experimental::CB out_cb,
+    DataflowBuffer in1_dfb,
+    DataflowBuffer in2_dfb,
+    DataflowBuffer out_dfb,
     uint32_t act_cb_start_address,
     uint32_t act_cb_second_reader_start_address) {
     // with activation reuse, the activation buffers are sized to fit one output image width only,
     // so we need to interleave waits and pops on the two buffers to allow parallelization;
     // we reserve back tilized CB to store whole act block h - and then we update write pointers so that
     // we fill in first row of the first half (NCRISC), first row of the second half (BRISC) and so on
-    out_cb.reserve_back(out_cb_tiles);
+    out_dfb.reserve_back(out_cb_tiles);
     fast_tilize_init_with_dt(in1_cb_id, in_block_w, out_cb_id);
 
     uint32_t in1_cb_addr = act_cb_start_address;
@@ -128,9 +129,9 @@ inline void tilize_in_reuse_split_reader(
         in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
         for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
             tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in1_cb, out_cb_addr);
+                in1_dfb, out_cb_addr);
             tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in2_cb, out_cb_addr_second_reader);
+                in2_dfb, out_cb_addr_second_reader);
         }
     }
 
@@ -140,7 +141,7 @@ inline void tilize_in_reuse_split_reader(
     for (uint32_t image_col = 0; image_col < max_leftover; ++image_col) {
         if (image_col < leftover_in1) {
             tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in1_cb, out_cb_addr);
+                in1_dfb, out_cb_addr);
 
             if (image_col == image_width_in_tiles - 1) {
                 in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
@@ -149,7 +150,7 @@ inline void tilize_in_reuse_split_reader(
 
         if (image_col < leftover_in2) {
             tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in2_cb, out_cb_addr_second_reader);
+                in2_dfb, out_cb_addr_second_reader);
 
             if (image_col == image_width_in_tiles - 1) {
                 in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
@@ -162,25 +163,25 @@ inline void tilize_in_reuse_split_reader(
     // starts from whichever mid-region offset the last tilize_single_block left
     // and trips the LLK bounds assert (see GH #42510).
     PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr_init));
-    out_cb.push_back(out_cb_tiles);
+    out_dfb.push_back(out_cb_tiles);
     fast_tilize_uninit(in2_cb_id, out_cb_id, in_block_w);
 }
 
 template <uint32_t out_subblock_w, uint32_t out_block_w>
 inline void reblock_and_untilize(
-    experimental::CB interm_cb,
-    experimental::CB out_cb,
+    DataflowBuffer interm_dfb,
+    DataflowBuffer out_dfb,
     uint32_t num_out_subblocks_in_col,
     uint32_t out_subblock_num_tiles,
     uint32_t out_subblock_h) {
-    const uint32_t interm_cb_id = interm_cb.get_cb_id();
-    const uint32_t out_cb_id = out_cb.get_cb_id();
+    const uint32_t interm_cb_id = interm_dfb.get_id();
+    const uint32_t out_cb_id = out_dfb.get_id();
     uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
-    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
+    interm_dfb.wait_front(num_tiles_in_row_of_subblocks);
     uint32_t within_block_index = 0;
     for (uint32_t h = 0; h < out_subblock_h; h++) {
         uint32_t block_offset = 0;
-        out_cb.reserve_back(out_block_w);
+        out_dfb.reserve_back(out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < out_subblock_w; w++) {
@@ -193,10 +194,10 @@ inline void reblock_and_untilize(
             tile_regs_release();
             block_offset += out_subblock_num_tiles;
         }
-        out_cb.push_back(out_block_w);
+        out_dfb.push_back(out_block_w);
         within_block_index += out_subblock_w;
     }
-    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
+    interm_dfb.pop_front(num_tiles_in_row_of_subblocks);
 }
 
 void kernel_main() {
@@ -279,16 +280,16 @@ void kernel_main() {
         skip_compute = (bool)get_arg_val<uint32_t>(0);
     }
 
-    experimental::CB cb_in0(in0_cb_id);
-    experimental::CB cb_in0_second_reader(in0_cb_second_reader_id);
-    experimental::CB cb_tilized_in0(tilized_in0_cb_id);
-    experimental::CB cb_mm_in0(mm_in0_cb_id);
-    experimental::CB cb_in1(in1_cb_id);
-    experimental::CB cb_matmul_partials(matmul_partials_cb);
-    experimental::CB cb_mm_out(mm_out_cb_id);
-    experimental::CB cb_out(out_cb_id);
-    experimental::CB cb_bias(bias_cb_id);
-    experimental::CB cb_untilize_mode_out(untilize_mode_out_cb_id);
+    DataflowBuffer dfb_in0(in0_cb_id);
+    DataflowBuffer dfb_in0_second_reader(in0_cb_second_reader_id);
+    DataflowBuffer dfb_tilized_in0(tilized_in0_cb_id);
+    DataflowBuffer dfb_mm_in0(mm_in0_cb_id);
+    DataflowBuffer dfb_in1(in1_cb_id);
+    DataflowBuffer dfb_matmul_partials(matmul_partials_cb);
+    DataflowBuffer dfb_mm_out(mm_out_cb_id);
+    DataflowBuffer dfb_out(out_cb_id);
+    DataflowBuffer dfb_bias(bias_cb_id);
+    DataflowBuffer dfb_untilize_mode_out(untilize_mode_out_cb_id);
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(mm_in0_cb_id, in1_cb_id, out_cb_id);
     matmul_block_init(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
@@ -374,9 +375,9 @@ void kernel_main() {
                                 tilized_cb_row_offset,
                                 tilized_cb_second_reader_offset,
                                 image_width_in_tiles>(
-                                cb_in0,
-                                cb_in0_second_reader,
-                                cb_tilized_in0,
+                                dfb_in0,
+                                dfb_in0_second_reader,
+                                dfb_tilized_in0,
                                 act_cb_start_address,
                                 act_cb_second_reader_start_address);
                         }
@@ -386,17 +387,17 @@ void kernel_main() {
                     matmul_block_init(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
                 }
 
-                cb_mm_in0.wait_front(in0_block_num_tiles);
+                dfb_mm_in0.wait_front(in0_block_num_tiles);
 
                 uint32_t in0_index_subblock_offset = 0;
                 if constexpr (check_skip_compute) {
                     if (skip_compute) {
-                        cb_mm_in0.pop_front(in0_block_num_tiles);
+                        dfb_mm_in0.pop_front(in0_block_num_tiles);
                         continue;
                     }
                 }
 
-                cb_in1.wait_front(in1_block_num_tiles);
+                dfb_in1.wait_front(in1_block_num_tiles);
 
                 if (last_inner_dim_block) {
                     if constexpr (!fuse_bias) {
@@ -417,7 +418,7 @@ void kernel_main() {
                         if (enable_reload) {
                             // Reconfigure input
                             copy_tile_to_dst_init_short_with_dt(in1_cb_id, matmul_partials_cb);
-                            cb_matmul_partials.wait_front(out_subblock_num_tiles);
+                            dfb_matmul_partials.wait_front(out_subblock_num_tiles);
                             tile_regs_acquire();
 
                             uint32_t start_dst_index = 0;
@@ -425,7 +426,7 @@ void kernel_main() {
                             copy_block_matmul_partials(
                                 matmul_partials_cb, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
-                            cb_matmul_partials.pop_front(out_subblock_num_tiles);
+                            dfb_matmul_partials.pop_front(out_subblock_num_tiles);
                             // Reconfigure srcA back
                             reconfig_data_format_srca(matmul_partials_cb, in1_cb_id);
                             matmul_block_init(
@@ -470,9 +471,9 @@ void kernel_main() {
                         }
 #endif
                         tile_regs_commit();
-                        experimental::CB curr_out_cb =
-                            curr_matmul_out_cb == matmul_partials_cb ? cb_matmul_partials : cb_mm_out;
-                        curr_out_cb.reserve_back(out_subblock_num_tiles);
+                        DataflowBuffer curr_out_dfb =
+                            curr_matmul_out_cb == matmul_partials_cb ? dfb_matmul_partials : dfb_mm_out;
+                        curr_out_dfb.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
                         if constexpr (packer_l1_acc) {
@@ -491,7 +492,7 @@ void kernel_main() {
                         pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
 
                         tile_regs_release();
-                        curr_out_cb.push_back(out_subblock_num_tiles);
+                        curr_out_dfb.push_back(out_subblock_num_tiles);
 
                         in1_index_subblock_offset += out_subblock_w;
                     }  // for in1_num_subblocks
@@ -508,8 +509,8 @@ void kernel_main() {
                         if (in0_block_w_i < in0_num_blocks_w - 1) {
                             // Wait for l1 accumulation to populate interm buffer,
                             // then pop to update fifo rd pointer
-                            cb_matmul_partials.wait_front(out_block_num_tiles);
-                            cb_matmul_partials.pop_front(out_block_num_tiles);
+                            dfb_matmul_partials.wait_front(out_block_num_tiles);
+                            dfb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
                                 UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
                                 PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
@@ -520,8 +521,8 @@ void kernel_main() {
                     } else {
                         // Last iteration does spill and reload to output buffer
                         if (in0_block_w_i < in0_num_blocks_w - 2) {
-                            cb_matmul_partials.wait_front(out_block_num_tiles);
-                            cb_matmul_partials.pop_front(out_block_num_tiles);
+                            dfb_matmul_partials.wait_front(out_block_num_tiles);
+                            dfb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
                                 UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
                                 PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
@@ -551,8 +552,8 @@ void kernel_main() {
                     }
                 }
 
-                cb_mm_in0.pop_front(in0_block_num_tiles);
-                cb_in1.pop_front(in1_block_num_tiles);
+                dfb_mm_in0.pop_front(in0_block_num_tiles);
+                dfb_in1.pop_front(in1_block_num_tiles);
             }  // for in0_num_blocks_w
             if constexpr (matmul_partials_cb == mm_out_cb_id && partials_cb_uses_output) {
                 UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
@@ -574,8 +575,8 @@ void kernel_main() {
                 reconfig_data_format(in1_cb_id, matmul_partials_cb, mm_in0_cb_id, bias_cb_id);
                 add_bcast_rows_init_short(matmul_partials_cb, bias_cb_id);
 
-                cb_bias.wait_front(bias_ntiles_w);
-                cb_matmul_partials.wait_front(out_block_num_tiles);
+                dfb_bias.wait_front(bias_ntiles_w);
+                dfb_matmul_partials.wait_front(out_block_num_tiles);
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     uint32_t in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
@@ -597,15 +598,15 @@ void kernel_main() {
 #endif
                         tile_regs_commit();
                         // do not pop front bias as it may be used again for subsequent blocks
-                        cb_matmul_partials.pop_front(out_subblock_num_tiles);
+                        dfb_matmul_partials.pop_front(out_subblock_num_tiles);
 
-                        cb_untilize_mode_out.reserve_back(out_subblock_num_tiles);
+                        dfb_untilize_mode_out.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, untilize_mode_out_cb_id);
                         }
                         tile_regs_release();
-                        cb_untilize_mode_out.push_back(out_subblock_num_tiles);
+                        dfb_untilize_mode_out.push_back(out_subblock_num_tiles);
 
                         in1_index_subblock_offset += out_subblock_w;
                     }  // for in1_num_subblocks
@@ -632,7 +633,7 @@ void kernel_main() {
                     copy_tile_to_dst_init_short(matmul_partials_cb);
                     for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                         reblock_and_untilize<out_subblock_w, out_block_w>(
-                            cb_matmul_partials, cb_out, in1_num_subblocks, out_subblock_num_tiles, out_subblock_h);
+                            dfb_matmul_partials, dfb_out, in1_num_subblocks, out_subblock_num_tiles, out_subblock_h);
                     }
                     pack_untilize_uninit(matmul_partials_cb);
                 } else {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // Multicast rectangle: defines the NOC coordinate range for multicast destinations.
@@ -20,10 +21,10 @@ using McastDst = noc_traits_t<MulticastEndpoint>::dst_args_mcast_type;
 
 // Zero out all tiles for a given circular buffer.
 template <uint32_t cb_id>
-FORCE_INLINE void zero_out_tiles(Noc noc, experimental::CB cb) {
+FORCE_INLINE void zero_out_tiles(Noc noc, DataflowBuffer dfb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_num_pages;
-    noc.async_write_zeros(cb, tile_size * num_tiles);
+    noc.async_write_zeros(dfb, tile_size * num_tiles);
     noc.write_zeros_l1_barrier();
 }
 
@@ -78,7 +79,7 @@ FORCE_INLINE void read_kernel_w(Noc noc, uint32_t& l1_write_addr_act, uint32_t& 
 
 template <uint32_t cb_id_act, uint32_t act_cb_tiles, uint32_t window_reuse_offset>
 FORCE_INLINE void pass_to_the_next_image_width(
-    experimental::CB cb_act,
+    DataflowBuffer dfb_act,
     uint32_t& l1_write_addr_act,
     uint32_t cb_start_addr,
     uint32_t& pixel_row,
@@ -86,7 +87,7 @@ FORCE_INLINE void pass_to_the_next_image_width(
     uint32_t& new_batch_image_rows_to_fill) {
     pixel_column = 0;
     pixel_row++;
-    cb_act.reserve_back(act_cb_tiles);
+    dfb_act.reserve_back(act_cb_tiles);
     l1_write_addr_act = cb_start_addr + pixel_row * window_reuse_offset;
     get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
 
@@ -96,18 +97,18 @@ FORCE_INLINE void pass_to_the_next_image_width(
 }
 
 template <uint32_t cb_id_act, uint32_t act_cb_w_tiles>
-FORCE_INLINE void push_full_tile_height(Noc noc, experimental::CB cb_act) {
+FORCE_INLINE void push_full_tile_height(Noc noc, DataflowBuffer dfb_act) {
     noc.async_read_barrier();
-    cb_act.push_back(act_cb_w_tiles);
+    dfb_act.push_back(act_cb_w_tiles);
 }
 
 template <uint32_t cb_id_act, uint32_t act_cb_w_tiles, uint32_t image_width_tiles>
 FORCE_INLINE void push_remaining_tiles(
-    experimental::CB cb_act, uint32_t remaining_tiles_to_push, uint32_t cb_start_addr) {
+    DataflowBuffer dfb_act, uint32_t remaining_tiles_to_push, uint32_t cb_start_addr) {
     constexpr uint32_t tiles_to_push = image_width_tiles * act_cb_w_tiles;
     for (uint32_t i = 0; i < remaining_tiles_to_push; i += image_width_tiles) {
         get_local_cb_interface(cb_id_act).fifo_wr_ptr = cb_start_addr;
-        cb_act.push_back(tiles_to_push);
+        dfb_act.push_back(tiles_to_push);
     }
 }
 
@@ -122,7 +123,7 @@ template <
     uint32_t act_block_w_extra_align_bytes>
 FORCE_INLINE void read_first_image_row_window(
     Noc noc,
-    experimental::CB cb_act,
+    DataflowBuffer dfb_act,
     uint32_t& l1_write_addr_act,
     uint32_t reader_offset,
     uint16_t ind,
@@ -136,7 +137,7 @@ FORCE_INLINE void read_first_image_row_window(
     pixel_column++;
     // if full tile, push back
     if ((pixel_column & 31) == 0) {
-        push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, cb_act);
+        push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, dfb_act);
     }
 }
 
@@ -195,7 +196,7 @@ template <
     bool single_core_processes_multiple_batches>
 FORCE_INLINE void read_sticks_activation_reuse(
     Noc noc,
-    experimental::CB cb_act,
+    DataflowBuffer dfb_act,
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
     uint32_t reader_offset,
     uint32_t& l1_write_addr_act,
@@ -211,7 +212,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
     uint32_t pixel_row = 0, pixel_column = 0;
     uint32_t new_batch_image_rows_to_fill = 0;
 
-    cb_act.reserve_back(act_cb_tiles);
+    dfb_act.reserve_back(act_cb_tiles);
 
     if (num_segments == 0) {
         return;
@@ -230,7 +231,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
             cb_id_act,
             act_cb_w_tiles,
             conv_act_c_read_bytes,
-            act_block_w_extra_align_bytes>(noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
+            act_block_w_extra_align_bytes>(noc, dfb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
     }
 
     num_segments--;
@@ -261,7 +262,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
                     cb_id_act,
                     act_cb_w_tiles,
                     conv_act_c_read_bytes,
-                    act_block_w_extra_align_bytes>(noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
+                    act_block_w_extra_align_bytes>(noc, dfb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
             }
 
             start_ind = start_ind + second_row_width;
@@ -281,7 +282,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
                             act_cb_w_tiles,
                             conv_act_c_read_bytes,
                             act_block_w_extra_align_bytes>(
-                            noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
+                            noc, dfb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
                     }
 
                     start_ind = start_ind + third_row_width;
@@ -291,7 +292,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
     }
     // Move on to the next output image width
     pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-        cb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
+        dfb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
 
     // ------ HANDLE REMAINING INPUT, WHERE WE READ JUST THE LAST KERNEL WIDTH OF THE WINDOW ------
     while (num_segments--) {
@@ -323,13 +324,13 @@ FORCE_INLINE void read_sticks_activation_reuse(
 
             pixel_column++;
             if ((pixel_column & 31) == 0) {
-                push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, cb_act);
+                push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, dfb_act);
 
                 // Move on to the next output image width
                 if constexpr (!readers_process_full_image_widths) {
                     if (pixel_column == image_width_padded_to_tile) {
                         pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-                            cb_act,
+                            dfb_act,
                             l1_write_addr_act,
                             cb_start_addr,
                             pixel_row,
@@ -343,7 +344,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
         if constexpr (readers_process_full_image_widths) {
             // Move on to the next output image width
             pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-                cb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
+                dfb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
         }
 
         load_next_segment<window_inner, single_core_processes_multiple_batches>(
@@ -352,7 +353,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
 }
 
 template <uint32_t dram_addr_index, uint32_t page_size_index, uint32_t tensor_args_index, uint32_t cb_reader_index>
-void load_config_tensor_if_in_dram(Noc noc, experimental::CB reader_cb, uint32_t core_index) {
+void load_config_tensor_if_in_dram(Noc noc, DataflowBuffer reader_dfb, uint32_t core_index) {
 #ifdef CONFIG_TENSOR_IN_DRAM
     // TODO: Instead of all cores reading from dram, only the first column reads, and does an MCAST to all the other
     // cores in the row.
@@ -361,9 +362,9 @@ void load_config_tensor_if_in_dram(Noc noc, experimental::CB reader_cb, uint32_t
     const auto config_tensor_args = TensorAccessorArgs<tensor_args_index>();
     const auto config_accessor = TensorAccessor(config_tensor_args, config_dram_addr);
 
-    noc.async_read(config_accessor, reader_cb, config_page_size, {.page_id = core_index}, {});
+    noc.async_read(config_accessor, reader_dfb, config_page_size, {.page_id = core_index}, {});
     noc.async_read_barrier();
-    reader_cb.push_back(1);
+    reader_dfb.push_back(1);
 #endif
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -13,7 +13,7 @@
 #include "api/debug/dprint_pages.h"
 #endif
 
-// Multicasts activation data from src_dfb to dst_cb across cores in the multicast rectangle.
+// Multicasts activation data from src_dfb to dst_dfb across cores in the multicast rectangle.
 // Three cases depending on the sender's role and number of multicast destinations:
 //   is_receiver_core && act_mcast_num_cores > 0:  mcast with INCLUDE_SRC loopback
 //   is_receiver_core && act_mcast_num_cores == 0: local self-write (mcast loopback hangs with 0 destinations)
@@ -49,7 +49,7 @@ void multicast_data(
     }
 }
 
-// Multicast activation data from the local circular buffer to multiple destinations (dst_cb in receiver cores).
+// Multicast activation data from the local circular buffer to multiple destinations (dst_dfb in receiver cores).
 // This function sends a block of data (the activation block) using NOC multicast commands, it avoids waiting for the
 // whole block to be available in the source CB before starting the multicast, instead waits for enough tiles to do one
 // multicast of NOC_MAX_BURST_SIZE size. This is because under the hood, the multicast splits the data into chunks of

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -13,7 +13,7 @@
 #include "api/debug/dprint_pages.h"
 #endif
 
-// Multicasts activation data from src_cb to dst_cb across cores in the multicast rectangle.
+// Multicasts activation data from src_dfb to dst_cb across cores in the multicast rectangle.
 // Three cases depending on the sender's role and number of multicast destinations:
 //   is_receiver_core && act_mcast_num_cores > 0:  mcast with INCLUDE_SRC loopback
 //   is_receiver_core && act_mcast_num_cores == 0: local self-write (mcast loopback hangs with 0 destinations)
@@ -24,11 +24,12 @@ void multicast_data(
     Noc noc,
     MulticastEndpoint mcast_ep,
     bool is_receiver_core,
-    experimental::CB src_cb,
+    DataflowBuffer src_dfb,
     uint32_t src_offset,
     McastDst& dst,
     uint32_t total_bytes) {
-    auto src = use<CircularBuffer::AddrSelector::READ_PTR>(src_cb);
+    // A bare DataflowBuffer NOC source already resolves to get_read_ptr() (see noc_traits_t<DataflowBuffer>).
+    auto src = src_dfb;
     if (is_receiver_core) {
         if constexpr (act_mcast_num_cores > 0) {
             noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
@@ -66,9 +67,9 @@ template <
 void mcast_block_chunked(
     Noc noc,
     MulticastEndpoint mcast_ep,
-    experimental::CB src_cb_obj,
+    DataflowBuffer src_dfb_obj,
     bool is_receiver_core,
-    experimental::CB dst_cb_obj,
+    DataflowBuffer dst_dfb_obj,
     const McastRect& rect) {
     // Build mcast dst once; only .addr is updated per burst
     // number of full bursts
@@ -95,14 +96,14 @@ void mcast_block_chunked(
         .noc_y_start = rect.noc_y_start,
         .noc_x_end = rect.noc_x_end,
         .noc_y_end = rect.noc_y_end,
-        .addr = dst_cb_obj.get_write_ptr()};
+        .addr = dst_dfb_obj.get_write_ptr()};
 
     constexpr uint32_t wait_tile_start_cnt = std::min(block_tile_count, wait_tile_full_cnt);
     uint32_t wait_tile_curr = wait_tile_start_cnt;
     for (uint32_t i = 0; i < mcast_full_burst_cnt; i++) {
-        src_cb_obj.wait_front(wait_tile_curr);
+        src_dfb_obj.wait_front(wait_tile_curr);
         multicast_data<act_mcast_num_dest_cores>(
-            noc, mcast_ep, is_receiver_core, src_cb_obj, src_offset, dst, mcast_noc_burst_size);
+            noc, mcast_ep, is_receiver_core, src_dfb_obj, src_offset, dst, mcast_noc_burst_size);
         src_offset += mcast_noc_burst_size;
         dst.addr += mcast_noc_burst_size;
 
@@ -118,9 +119,9 @@ void mcast_block_chunked(
         }
     }
     if constexpr (mcast_leftover_burst_size > 0) {
-        src_cb_obj.wait_front(block_tile_count);
+        src_dfb_obj.wait_front(block_tile_count);
         multicast_data<act_mcast_num_dest_cores>(
-            noc, mcast_ep, is_receiver_core, src_cb_obj, src_offset, dst, mcast_leftover_burst_size);
+            noc, mcast_ep, is_receiver_core, src_dfb_obj, src_offset, dst, mcast_leftover_burst_size);
     }
 
     // In case we only do local l1 writes, we need to wait for the barrier to complete
@@ -165,11 +166,11 @@ void kernel_main() {
     Semaphore<> act_mcast_sender_sem(get_compile_time_arg_val(16));
     Semaphore<> act_mcast_receiver_sem(get_compile_time_arg_val(17));
     MulticastEndpoint mcast_ep;
-    experimental::CB cb_act_obj(cb_id_act);
-    experimental::CB cb_act_rm_obj(cb_id_act_row_major_bfloat16);
-    experimental::CB cb_tilized_in0_obj(tilized_in0_cb_id);
-    experimental::CB cb_reader_indices_obj(cb_reader_indices);
-    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    DataflowBuffer dfb_act_obj(cb_id_act);
+    DataflowBuffer dfb_act_rm_obj(cb_id_act_row_major_bfloat16);
+    DataflowBuffer dfb_tilized_in0_obj(tilized_in0_cb_id);
+    DataflowBuffer dfb_reader_indices_obj(cb_reader_indices);
+    DataflowBuffer dfb_sharded_act_obj(cb_id_sharded_act);
 
     Semaphore<> reserve_done_sem(0);
     Semaphore<> write_done_sem(0);
@@ -182,7 +183,7 @@ void kernel_main() {
     }
 
     if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act_row_major_bfloat16>(noc, cb_act_rm_obj);
+        zero_out_tiles<cb_id_act_row_major_bfloat16>(noc, dfb_act_rm_obj);
     }
 
     uint32_t i = 0;
@@ -196,10 +197,10 @@ void kernel_main() {
 
     tt_l1_ptr uint32_t* act_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(i));
 
-    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(noc, cb_reader_indices_obj, dram_config_reader_index);
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(noc, dfb_reader_indices_obj, dram_config_reader_index);
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr());
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb_reader_indices_obj.get_write_ptr());
 
     // Set up receiver semaphore VALID value, to be mcasted to destinations after the data has been mcasted
     act_mcast_receiver_sem.set(VALID);
@@ -213,7 +214,7 @@ void kernel_main() {
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
 
     // Fully create act matrix and tilize it before mcast
-    uint32_t act_l1_read_addr = cb_sharded_act_obj.get_read_ptr();
+    uint32_t act_l1_read_addr = dfb_sharded_act_obj.get_read_ptr();
 
     if constexpr (!split_reader_cb_shared) {
         experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
@@ -231,9 +232,9 @@ void kernel_main() {
         uint32_t reader_offset = act_l1_read_addr;
         for (uint32_t outer = 0; outer < window_outer; outer++) {
             reader_idx = start_reader_idx;
-            cb_act_rm_obj.reserve_back(act_block_num_tiles_read);
+            dfb_act_rm_obj.reserve_back(act_block_num_tiles_read);
             if (is_sender_core) {
-                uint32_t l1_write_addr_act = cb_act_rm_obj.get_write_ptr();
+                uint32_t l1_write_addr_act = dfb_act_rm_obj.get_write_ptr();
                 if constexpr (split_reader_cb_shared) {
                     reserve_done_sem.set(VALID);
                     experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
@@ -261,13 +262,13 @@ void kernel_main() {
                     write_done_sem.set(INVALID);
                 }
             }
-            cb_act_rm_obj.push_back(act_block_num_tiles_read);
+            dfb_act_rm_obj.push_back(act_block_num_tiles_read);
 
 #ifndef SKIP_MCAST
             // Round robin self-mcast and receive tilized act matrix in cb_id_act
             // Compute should function like regular mm
             for (uint32_t act_w_outer_i = 0; act_w_outer_i < act_w_num_outer; act_w_outer_i++) {
-                cb_act_obj.reserve_back(act_block_num_tiles);
+                dfb_act_obj.reserve_back(act_block_num_tiles);
                 if (act_w_outer_i == act_mcast_sender_id) {
                     // MCAST SENDER: send entire tilized input to other cores in column
                     // wait until all act mcast destinations have atomically incremented the act semaphore_addr
@@ -283,7 +284,7 @@ void kernel_main() {
                         NOC_MAX_BURST_SIZE,
                         act_block_num_tiles,
                         act_mcast_tile_size_bytes>(
-                        noc, mcast_ep, cb_tilized_in0_obj, is_receiver_core, cb_act_obj, act_mcast_rect);
+                        noc, mcast_ep, dfb_tilized_in0_obj, is_receiver_core, dfb_act_obj, act_mcast_rect);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                     // same vc even though cmd bufs are different Also, this only works because we are setting VCs
@@ -327,10 +328,10 @@ void kernel_main() {
                     // wait on act semaphore value to become VALID (set by mcast sender after it multicasts data)
                     act_mcast_receiver_sem.wait(VALID);
                 }
-                cb_act_obj.push_back(act_block_num_tiles);
+                dfb_act_obj.push_back(act_block_num_tiles);
             }  // act_w_num_outer
 
-            cb_tilized_in0_obj.pop_front(act_block_num_tiles);
+            dfb_tilized_in0_obj.pop_front(act_block_num_tiles);
 #endif
         }
         start_reader_idx = reader_idx;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -28,16 +28,16 @@ void kernel_main() {
     constexpr bool split_reader_enabled = get_compile_time_arg_val(27);
     constexpr bool activation_reuse_enabled = get_compile_time_arg_val(28);
 
-    experimental::CB cb_act(cb_id_act);
-    experimental::CB cb_sharded_act(cb_id_sharded_act);
-    experimental::CB cb_reader_idx(cb_reader_indices);
+    DataflowBuffer dfb_act(cb_id_act);
+    DataflowBuffer dfb_sharded_act(cb_id_sharded_act);
+    DataflowBuffer dfb_reader_idx(cb_reader_indices);
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_idx.get_write_ptr());
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb_reader_idx.get_write_ptr());
 
     uint32_t runtime_arg_idx = 0;
     uint32_t core_index = get_arg_val<uint32_t>(runtime_arg_idx++);
-    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(Noc(), cb_reader_idx, core_index);
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(Noc(), dfb_reader_idx, core_index);
     // Activation reuse args (offset by 4 from index 29: address + page_size + 2 TensorAccessorArgs)
     constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(33);
     constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(34);
@@ -53,7 +53,7 @@ void kernel_main() {
     Noc noc;
 
     if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act>(noc, cb_act);
+        zero_out_tiles<cb_id_act>(noc, dfb_act);
     }
 
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
@@ -74,7 +74,7 @@ void kernel_main() {
     // the other path away this has shown to be a big perf win
 
     // coalesce reads along weight_size_w
-    uint32_t act_l1_read_addr = cb_sharded_act.get_read_ptr();
+    uint32_t act_l1_read_addr = dfb_sharded_act.get_read_ptr();
 
     static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
     experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
@@ -82,7 +82,7 @@ void kernel_main() {
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     uint32_t start_reader_idx = 0;
     uint32_t l1_write_addr_act = 0;
-    const uint32_t cb_start_addr = cb_act.get_write_ptr();
+    const uint32_t cb_start_addr = dfb_act.get_write_ptr();
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
         if constexpr (activation_reuse_enabled) {
             l1_write_addr_act = cb_start_addr;
@@ -93,8 +93,8 @@ void kernel_main() {
             reader_idx = start_reader_idx;
 
             if constexpr (!activation_reuse_enabled) {
-                cb_act.reserve_back(act_block_num_tiles);
-                l1_write_addr_act = cb_act.get_write_ptr();
+                dfb_act.reserve_back(act_block_num_tiles);
+                l1_write_addr_act = dfb_act.get_write_ptr();
 
                 read_sticks<
                     dilation_w,
@@ -106,7 +106,7 @@ void kernel_main() {
                     stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
 
                 noc.async_read_barrier();
-                cb_act.push_back(act_block_num_tiles);
+                dfb_act.push_back(act_block_num_tiles);
                 reader_offset += window_outer_offset;
             } else {
                 read_sticks_activation_reuse<
@@ -126,7 +126,7 @@ void kernel_main() {
                     window_reuse_offset,
                     single_core_processes_multiple_batches>(
                     noc,
-                    cb_act,
+                    dfb_act,
                     packed_reader_indices_ptr,
                     act_l1_read_addr,
                     l1_write_addr_act,
@@ -147,7 +147,7 @@ void kernel_main() {
         // to avoid blocking compute kernels
         if constexpr (need_to_push_remaining_tiles) {
             push_remaining_tiles<cb_id_act, act_block_w_tiles, image_width_tiles>(
-                cb_act, remaining_tiles_to_push, cb_start_addr);
+                dfb_act, remaining_tiles_to_push, cb_start_addr);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/compile_time_args.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
@@ -62,14 +63,14 @@ void kernel_main() {
         reader_offset += conv_act_size_w_padded;
     }
 
-    experimental::CB act_cb(cb_id_act);
-    experimental::CB sharded_act_cb(cb_id_sharded_act);
-    experimental::CB reader_indices_cb(cb_reader_indices);
+    DataflowBuffer act_dfb(cb_id_act);
+    DataflowBuffer sharded_act_dfb(cb_id_sharded_act);
+    DataflowBuffer reader_indices_dfb(cb_reader_indices);
     Noc noc;
 
     // LOOP TO FILL READER INDICES
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_cb.get_write_ptr());
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_dfb.get_write_ptr());
 
     uint32_t reader_idx = 0;
 
@@ -81,7 +82,7 @@ void kernel_main() {
 
     reader_offset_idx = 0;
     uint32_t act_l1_offset = 0;
-    uint32_t act_l1_read_addr = sharded_act_cb.get_read_ptr();
+    uint32_t act_l1_read_addr = sharded_act_dfb.get_read_ptr();
 
     if constexpr (coalesced_read_bytes <= NOC_MAX_BURST_SIZE) {
         experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
@@ -92,8 +93,8 @@ void kernel_main() {
             // Reset reader_idx to finish act_block_h_datums
             reader_idx = start_reader_idx;
 
-            act_cb.reserve_back(act_block_num_tiles);
-            uint32_t l1_write_addr_act = act_cb.get_write_ptr();
+            act_dfb.reserve_back(act_block_num_tiles);
+            uint32_t l1_write_addr_act = act_dfb.get_write_ptr();
             uint32_t reader_offset = act_l1_read_addr + (reader_offsets[reader_offset_idx] * conv_act_c_read_bytes);
             // #pragma GCC unroll 4 // unroll didn't help, but act_block_h_datums (loop bound) being const does help
             uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
@@ -114,7 +115,7 @@ void kernel_main() {
                 }
             }
             noc.async_read_barrier();
-            act_cb.push_back(act_block_num_tiles);
+            act_dfb.push_back(act_block_num_tiles);
 
             reader_offset_idx += window_inner;
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -60,7 +60,7 @@ void kernel_main() {
 
     if constexpr (split_reader_enabled) {
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
+            zero_out_tiles<cb_id_act_second_reader>(noc, DataflowBuffer(cb_id_act_second_reader));
         }
     }
 
@@ -69,11 +69,11 @@ void kernel_main() {
     const uint32_t weights_mcast_sender_noc_y = get_arg_val<uint32_t>(i++);
     Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
     Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
-    experimental::CB cb_weight_obj(cb_id_weight);
-    experimental::CB cb_bias_obj(bias_cb_id);
-    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
-    experimental::CB cb_reader_indices_obj(cb_reader_indices);
-    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    DataflowBuffer dfb_weight_obj(cb_id_weight);
+    DataflowBuffer dfb_bias_obj(bias_cb_id);
+    DataflowBuffer dfb_act_second_obj(cb_id_act_second_reader);
+    DataflowBuffer dfb_reader_indices_obj(cb_reader_indices);
+    DataflowBuffer dfb_sharded_act_obj(cb_id_sharded_act);
 
     const uint32_t remaining_tiles_to_push =
         split_reader_enabled && activation_reuse_enabled ? get_arg_val<uint32_t>(i++) : 0;
@@ -81,21 +81,21 @@ void kernel_main() {
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_reader_indices_obj.wait_front(1);
+        dfb_reader_indices_obj.wait_front(1);
 #endif
     }
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb_reader_indices_obj.get_write_ptr())
                              : nullptr;
     uint32_t reader_idx = 0;
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     constexpr uint32_t coalesced_read_bytes =
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    const uint32_t act_l1_read_addr = split_reader_enabled ? dfb_sharded_act_obj.get_read_ptr() : 0;
     uint32_t start_reader_idx =
         split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1 : 0;
-    const uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
+    const uint32_t cb_start_addr = split_reader_enabled ? dfb_act_second_obj.get_write_ptr() : 0;
 
     // read in bias if enabled (done only once for all batches)
     bool load_bias = true;
@@ -121,8 +121,8 @@ void kernel_main() {
                 reader_idx = start_reader_idx;
 
                 if constexpr (!activation_reuse_enabled) {
-                    cb_act_second_obj.reserve_back(act_block_num_tiles);
-                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                    dfb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = dfb_act_second_obj.get_write_ptr();
                     read_sticks<
                         dilation_w,
                         coalesced_read_bytes,
@@ -132,7 +132,7 @@ void kernel_main() {
                         weight_size_w,
                         stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
                     noc.async_read_barrier();
-                    cb_act_second_obj.push_back(act_block_num_tiles);
+                    dfb_act_second_obj.push_back(act_block_num_tiles);
 
                     reader_offset += window_outer_offset;
                 } else {
@@ -153,7 +153,7 @@ void kernel_main() {
                         window_reuse_offset,
                         single_core_processes_multiple_batches>(
                         noc,
-                        cb_act_second_obj,
+                        dfb_act_second_obj,
                         packed_reader_indices_ptr,
                         act_l1_read_addr,
                         l1_write_addr_act,
@@ -165,14 +165,14 @@ void kernel_main() {
                             // Last core sometimes has less work to do, but we still need to push the same number of
                             // tiles to avoid blocking compute kernels
                             push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
-                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
+                                dfb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
                         }
                     }
                 }
             }
 
             // Receive weights
-            cb_weight_obj.reserve_back(weight_block_num_tiles);
+            dfb_weight_obj.reserve_back(weight_block_num_tiles);
             if (bh == 0) {
                 // Set weights semaphore value to INVALID
                 weights_mcast_receiver_sem.set(INVALID);
@@ -185,12 +185,12 @@ void kernel_main() {
                 weights_mcast_receiver_sem.wait(VALID);
             }
 
-            cb_weight_obj.push_back(weight_block_num_tiles);
+            dfb_weight_obj.push_back(weight_block_num_tiles);
         }
 
         if constexpr (fuse_bias) {
             if (load_bias) {
-                cb_bias_obj.reserve_back(bias_ntiles);
+                dfb_bias_obj.reserve_back(bias_ntiles);
 
                 // Set weights semaphore value to INVALID
                 weights_mcast_receiver_sem.set(INVALID);
@@ -201,7 +201,7 @@ void kernel_main() {
                 // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
                 weights_mcast_receiver_sem.wait(VALID);
 
-                cb_bias_obj.push_back(bias_ntiles);
+                dfb_bias_obj.push_back(bias_ntiles);
                 load_bias = false;
             }
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -69,7 +69,7 @@ void kernel_main() {
 
     if constexpr (split_reader_enabled) {
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
+            zero_out_tiles<cb_id_act_second_reader>(noc, DataflowBuffer(cb_id_act_second_reader));
         }
     }
 
@@ -81,11 +81,11 @@ void kernel_main() {
     Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
     Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
     MulticastEndpoint mcast_ep;
-    experimental::CB cb_weight_obj(cb_id_weight);
-    experimental::CB cb_bias_obj(bias_cb_id);
-    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
-    experimental::CB cb_reader_indices_obj(cb_reader_indices);
-    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    DataflowBuffer dfb_weight_obj(cb_id_weight);
+    DataflowBuffer dfb_bias_obj(bias_cb_id);
+    DataflowBuffer dfb_act_second_obj(cb_id_act_second_reader);
+    DataflowBuffer dfb_reader_indices_obj(cb_reader_indices);
+    DataflowBuffer dfb_sharded_act_obj(cb_id_sharded_act);
     // Pre-built mcast destination; .addr is updated per mcast call
     McastDst mcast_dst = {
         .noc_x_start = mcast_rect.noc_x_start,
@@ -100,22 +100,22 @@ void kernel_main() {
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_reader_indices_obj.wait_front(1);
+        dfb_reader_indices_obj.wait_front(1);
 #endif
     }
 
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb_reader_indices_obj.get_write_ptr())
                              : nullptr;
     uint32_t reader_idx = 0;
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     constexpr uint32_t coalesced_read_bytes =
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-    uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    uint32_t act_l1_read_addr = split_reader_enabled ? dfb_sharded_act_obj.get_read_ptr() : 0;
     // coalesce reads along weight_size_w
     uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
-    uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
+    uint32_t cb_start_addr = split_reader_enabled ? dfb_act_second_obj.get_write_ptr() : 0;
     uint32_t reader_offset = act_l1_read_addr;
 
 #ifndef SKIP_MCAST
@@ -164,8 +164,8 @@ void kernel_main() {
                 reader_idx = start_reader_idx;
 
                 if constexpr (!activation_reuse_enabled) {
-                    cb_act_second_obj.reserve_back(act_block_num_tiles);
-                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                    dfb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = dfb_act_second_obj.get_write_ptr();
                     read_sticks<
                         dilation_w,
                         coalesced_read_bytes,
@@ -175,7 +175,7 @@ void kernel_main() {
                         weight_size_w,
                         stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
                     noc.async_read_barrier();
-                    cb_act_second_obj.push_back(act_block_num_tiles);
+                    dfb_act_second_obj.push_back(act_block_num_tiles);
 
                     reader_offset += window_outer_offset;
                 } else {
@@ -196,7 +196,7 @@ void kernel_main() {
                         window_reuse_offset,
                         single_core_processes_multiple_batches>(
                         noc,
-                        cb_act_second_obj,
+                        dfb_act_second_obj,
                         packed_reader_indices_ptr,
                         act_l1_read_addr,
                         l1_write_addr_act,
@@ -208,14 +208,14 @@ void kernel_main() {
                             // Last core sometimes has less work to do, but we still need to push the same number of
                             // tiles to avoid blocking compute kernels
                             push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
-                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
+                                dfb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
                         }
                     }
                 }
             }
 
             // Do weights read + mcast
-            cb_weight_obj.reserve_back(weight_block_num_tiles);
+            dfb_weight_obj.reserve_back(weight_block_num_tiles);
             if (bh == 0) {
                 uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id + weight_h_offset;
 
@@ -230,7 +230,7 @@ void kernel_main() {
                         // DPRINT("weight_tile_id={}\n", weight_tile_id);
                         noc.async_read(
                             s_weight,
-                            cb_weight_obj,
+                            dfb_weight_obj,
                             weight_tile_nbytes,
                             {.page_id = weight_tile_id},
                             {.offset_bytes = weight_write_offset});
@@ -251,9 +251,9 @@ void kernel_main() {
 
                 // Now we have the block in the CB address, we can mcast to dests!
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                mcast_dst.addr = cb_weight_obj.get_write_ptr();
+                mcast_dst.addr = dfb_weight_obj.get_write_ptr();
                 noc.async_write_multicast(
-                    use<experimental::CB::AddrSelector::WRITE_PTR>(cb_weight_obj),
+                    CoreLocalMem<uint32_t>(dfb_weight_obj.get_write_ptr()),
                     mcast_ep,
                     weights_block_size_bytes,
                     weights_mcast_num_cores,
@@ -279,20 +279,20 @@ void kernel_main() {
                 weight_current_block_start_tile_id += weight_next_block_stride_h;
             }
 
-            cb_weight_obj.push_back(weight_block_num_tiles);
+            dfb_weight_obj.push_back(weight_block_num_tiles);
         }  // for num_blocks_weight_h
         weight_h_offset += weight_inner_block_stride_h;
 
         if constexpr (fuse_bias) {
             if (load_bias) {
-                cb_bias_obj.reserve_back(bias_ntiles);
+                dfb_bias_obj.reserve_back(bias_ntiles);
 
                 uint32_t bias_write_offset = 0;
                 uint32_t bias_block_size_bytes = 0;
                 for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
                     noc.async_read(
                         s_bias,
-                        cb_bias_obj,
+                        dfb_bias_obj,
                         bias_pagesize,
                         {.page_id = bias_tile},
                         {.offset_bytes = bias_write_offset});
@@ -311,9 +311,9 @@ void kernel_main() {
 
                 // Now we have the block in the CB address, we can mcast to dests!
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                mcast_dst.addr = cb_bias_obj.get_write_ptr();
+                mcast_dst.addr = dfb_bias_obj.get_write_ptr();
                 noc.async_write_multicast(
-                    use<experimental::CB::AddrSelector::WRITE_PTR>(cb_bias_obj),
+                    CoreLocalMem<uint32_t>(dfb_bias_obj.get_write_ptr()),
                     mcast_ep,
                     bias_block_size_bytes,
                     weights_mcast_num_cores,
@@ -336,7 +336,7 @@ void kernel_main() {
                     false);
 #endif
 
-                cb_bias_obj.push_back(bias_ntiles);
+                dfb_bias_obj.push_back(bias_ntiles);
                 load_bias = false;
             }
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/debug/dprint.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
@@ -44,8 +45,8 @@ void kernel_main() {
         fuse_bias ? get_tile_size(bias_cb_id) : 0;  // dummy but valid value in case bias is not enabled
     const auto s_bias = TensorAccessor(s_bias_args, bias_addr_dram_base);
 
-    experimental::CB weight_cb(cb_id_weight);
-    experimental::CB bias_cb(bias_cb_id);
+    DataflowBuffer weight_dfb(cb_id_weight);
+    DataflowBuffer bias_dfb(bias_cb_id);
     Noc noc;
 
     bool to_load_bias = true;
@@ -66,7 +67,7 @@ void kernel_main() {
             // Stride = in_channels*out_channels*sizeof(elem)/num_cores.
             for (uint32_t remote_weight_block_index = 0; remote_weight_block_index < remote_weight_height_blocks;
                  remote_weight_block_index++) {
-                weight_cb.reserve_back(weight_block_num_tiles);
+                weight_dfb.reserve_back(weight_block_num_tiles);
                 if (is_active) {
                     uint32_t weight_current_block_start_tile_id = weight_block_start_tile_id;
 
@@ -86,7 +87,7 @@ void kernel_main() {
                                  ++weight_tile_w_i) {
                                 noc.async_read(
                                     s_weight,
-                                    weight_cb,
+                                    weight_dfb,
                                     weight_tile_nbytes,
                                     {.page_id = weight_tile_id},
                                     {.offset_bytes = weight_write_offset});
@@ -99,18 +100,18 @@ void kernel_main() {
                     }
                     noc.async_read_barrier();
                 }
-                weight_cb.push_back(weight_block_num_tiles);
+                weight_dfb.push_back(weight_block_num_tiles);
                 weight_block_start_tile_id += weight_next_block_other_core_stride_h;
             }
             weight_start_tile_id += weight_next_block_this_core_stride_h;
             if (to_load_bias) {
                 if constexpr (fuse_bias) {
-                    bias_cb.reserve_back(weight_block_width_ntiles);
+                    bias_dfb.reserve_back(weight_block_width_ntiles);
                     uint32_t bias_write_offset = 0;
                     for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
                         noc.async_read(
                             s_bias,
-                            bias_cb,
+                            bias_dfb,
                             bias_pagesize,
                             {.page_id = bias_start_tile_id},
                             {.offset_bytes = bias_write_offset});
@@ -118,7 +119,7 @@ void kernel_main() {
                         bias_start_tile_id += 1;
                     }
                     noc.async_read_barrier();
-                    bias_cb.push_back(weight_block_width_ntiles);
+                    bias_dfb.push_back(weight_block_width_ntiles);
                 }
                 to_load_bias = false;
             }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -56,12 +56,12 @@ void kernel_main() {
     constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
     constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
 
-    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    DataflowBuffer dfb_act_second_obj(cb_id_act_second_reader);
     const uint32_t split_reader_cb_write_addr =
-        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset : 0;
+        (split_reader_cb_shared) ? dfb_act_second_obj.get_write_ptr() + act_write_offset : 0;
     // In case of double buffering the split reader can write to two different addresses
     const uint32_t split_reader_cb_write_addr_last =
-        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
+        (split_reader_cb_shared) ? dfb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
     const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
 
     // mcast args
@@ -73,26 +73,26 @@ void kernel_main() {
     Noc noc;
     Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
     Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
-    experimental::CB cb_weight_obj(cb_id_weight);
-    experimental::CB cb_bias_obj(bias_cb_id);
-    experimental::CB cb_reader_indices_obj(cb_reader_indices);
-    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    DataflowBuffer dfb_weight_obj(cb_id_weight);
+    DataflowBuffer dfb_bias_obj(bias_cb_id);
+    DataflowBuffer dfb_reader_indices_obj(cb_reader_indices);
+    DataflowBuffer dfb_sharded_act_obj(cb_id_sharded_act);
 
     const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
 
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_reader_indices_obj.wait_front(1);
+        dfb_reader_indices_obj.wait_front(1);
 #endif
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>(noc, cb_act_second_obj);
+            zero_out_tiles<cb_id_act_second_reader>(noc, dfb_act_second_obj);
         }
     }
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         (split_reader_enabled && is_sender_core)
-            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb_reader_indices_obj.get_write_ptr())
             : nullptr;
 
     // Initial setup for second reader (starting from second reader's data)
@@ -107,7 +107,7 @@ void kernel_main() {
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
     constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
 
-    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    const uint32_t act_l1_read_addr = split_reader_enabled ? dfb_sharded_act_obj.get_read_ptr() : 0;
     // read in bias if enabled (done only once for all batches)
     bool load_bias = true;
 
@@ -126,7 +126,7 @@ void kernel_main() {
                 if constexpr (split_reader_enabled) {
                     reader_idx = start_reader_idx;
                     if constexpr (!split_reader_cb_shared) {
-                        cb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
+                        dfb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
                     }
 
                     if (is_sender_core) {
@@ -135,7 +135,7 @@ void kernel_main() {
                             reserve_done_sem.set(INVALID);
                             prev_addr = l1_write_addr_act;
                         } else {
-                            l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                            l1_write_addr_act = dfb_act_second_obj.get_write_ptr();
                         }
                         experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
                         read_activation_data<
@@ -164,7 +164,7 @@ void kernel_main() {
                         }
                     }
                     if constexpr (!split_reader_cb_shared) {
-                        cb_act_second_obj.push_back(act_block_num_tiles_split_last);
+                        dfb_act_second_obj.push_back(act_block_num_tiles_split_last);
                     }
                 }
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
@@ -173,7 +173,7 @@ void kernel_main() {
                     // read weight blocks inner dim
                     // read weight slice - 1 block of weights in width dim and full weight matrix height
                     // read slice only once for all activation blocks
-                    cb_weight_obj.reserve_back(weight_block_num_tiles);
+                    dfb_weight_obj.reserve_back(weight_block_num_tiles);
                     // Set weights semaphore value to INVALID
                     weights_mcast_receiver_sem.set(INVALID);
 
@@ -183,7 +183,7 @@ void kernel_main() {
                     // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
                     weights_mcast_receiver_sem.wait(VALID);
 
-                    cb_weight_obj.push_back(weight_block_num_tiles);
+                    dfb_weight_obj.push_back(weight_block_num_tiles);
                 }  // for weight_block_height_num_outer
             }
             if constexpr (split_reader_enabled) {
@@ -196,7 +196,7 @@ void kernel_main() {
             }
             if constexpr (fuse_bias) {
                 if (load_bias) {
-                    cb_bias_obj.reserve_back(bias_ntiles);
+                    dfb_bias_obj.reserve_back(bias_ntiles);
 
                     // Set weights semaphore value to INVALID
                     weights_mcast_receiver_sem.set(INVALID);
@@ -207,7 +207,7 @@ void kernel_main() {
                     // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
                     weights_mcast_receiver_sem.wait(VALID);
 
-                    cb_bias_obj.push_back(bias_ntiles);
+                    dfb_bias_obj.push_back(bias_ntiles);
                     load_bias = false;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -63,12 +63,12 @@ void kernel_main() {
     constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
     constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
 
-    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    DataflowBuffer dfb_act_second_obj(cb_id_act_second_reader);
     const uint32_t split_reader_cb_write_addr =
-        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset : 0;
+        (split_reader_cb_shared) ? dfb_act_second_obj.get_write_ptr() + act_write_offset : 0;
     // In case of double buffering the split reader can write to two different addresses
     const uint32_t split_reader_cb_write_addr_last =
-        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
+        (split_reader_cb_shared) ? dfb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
     const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
 
     constexpr uint32_t ct_arg_idx = 36;
@@ -93,10 +93,10 @@ void kernel_main() {
     Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
     Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
     MulticastEndpoint mcast_ep;
-    experimental::CB cb_weight_obj(cb_id_weight);
-    experimental::CB cb_bias_obj(bias_cb_id);
-    experimental::CB cb_reader_indices_obj(cb_reader_indices);
-    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    DataflowBuffer dfb_weight_obj(cb_id_weight);
+    DataflowBuffer dfb_bias_obj(bias_cb_id);
+    DataflowBuffer dfb_reader_indices_obj(cb_reader_indices);
+    DataflowBuffer dfb_sharded_act_obj(cb_id_sharded_act);
     // Pre-built mcast destination; .addr is updated per mcast call
     McastDst mcast_dst = {
         .noc_x_start = mcast_rect.noc_x_start,
@@ -115,16 +115,16 @@ void kernel_main() {
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_reader_indices_obj.wait_front(1);
+        dfb_reader_indices_obj.wait_front(1);
 #endif
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>(noc, cb_act_second_obj);
+            zero_out_tiles<cb_id_act_second_reader>(noc, dfb_act_second_obj);
         }
     }
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         (split_reader_enabled && is_sender_core)
-            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb_reader_indices_obj.get_write_ptr())
             : nullptr;
     // Initial setup for second reader (starting from second reader's data)
     // Only read reader indices on cores that have sharded input (is_sender_core).
@@ -138,7 +138,7 @@ void kernel_main() {
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
     constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
 
-    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    const uint32_t act_l1_read_addr = split_reader_enabled ? dfb_sharded_act_obj.get_read_ptr() : 0;
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
@@ -178,7 +178,7 @@ void kernel_main() {
                 if constexpr (split_reader_enabled) {
                     reader_idx = start_reader_idx;
                     if constexpr (!split_reader_cb_shared) {
-                        cb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
+                        dfb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
                     }
                     if (is_sender_core) {
                         if constexpr (split_reader_cb_shared) {
@@ -186,7 +186,7 @@ void kernel_main() {
                             reserve_done_sem.set(INVALID);
                             prev_addr = l1_write_addr_act;
                         } else {
-                            l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                            l1_write_addr_act = dfb_act_second_obj.get_write_ptr();
                         }
                         experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
                         read_activation_data<
@@ -215,7 +215,7 @@ void kernel_main() {
                         }
                     }
                     if constexpr (!split_reader_cb_shared) {
-                        cb_act_second_obj.push_back(act_block_num_tiles_split_last);
+                        dfb_act_second_obj.push_back(act_block_num_tiles_split_last);
                     }
                     if (skip_work) {
                         continue;
@@ -225,7 +225,7 @@ void kernel_main() {
                 const uint32_t height_block_offset = height_block_index * height_stride_factor;
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
                      weight_tile_h_outer_i++) {
-                    cb_weight_obj.reserve_back(weight_block_num_tiles);
+                    dfb_weight_obj.reserve_back(weight_block_num_tiles);
 
                     const uint32_t outer_block_offset = weight_tile_h_outer_i * tiles_per_full_block;
                     uint32_t tile_id = weight_start_tile_id + height_block_offset + outer_block_offset;
@@ -237,7 +237,7 @@ void kernel_main() {
                              ++weight_tile_w_i) {
                             noc.async_read(
                                 s_weight,
-                                cb_weight_obj,
+                                dfb_weight_obj,
                                 weight_tile_nbytes,
                                 {.page_id = weight_tile_id++},
                                 {.offset_bytes = weight_write_offset});
@@ -256,9 +256,9 @@ void kernel_main() {
 
                     // Now we have the block in the CB address, we can mcast to dests!
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    mcast_dst.addr = cb_weight_obj.get_write_ptr();
+                    mcast_dst.addr = dfb_weight_obj.get_write_ptr();
                     noc.async_write_multicast(
-                        use<experimental::CB::AddrSelector::WRITE_PTR>(cb_weight_obj),
+                        CoreLocalMem<uint32_t>(dfb_weight_obj.get_write_ptr()),
                         mcast_ep,
                         weights_block_size_bytes,
                         weights_mcast_num_cores,
@@ -279,7 +279,7 @@ void kernel_main() {
                         mcast_rect.noc_y_end,
                         weights_mcast_num_cores);
 #endif
-                    cb_weight_obj.push_back(weight_block_num_tiles);
+                    dfb_weight_obj.push_back(weight_block_num_tiles);
                 }  // for weight_block_height_num_outer
             }
             if constexpr (split_reader_enabled) {
@@ -295,7 +295,7 @@ void kernel_main() {
             }
             if constexpr (fuse_bias) {
                 if (load_bias) {
-                    cb_bias_obj.reserve_back(bias_ntiles);
+                    dfb_bias_obj.reserve_back(bias_ntiles);
 
                     uint32_t bias_write_offset = 0;
                     uint32_t bias_block_size_bytes = 0;
@@ -303,7 +303,7 @@ void kernel_main() {
                          ++bias_tile) {
                         noc.async_read(
                             s_bias,
-                            cb_bias_obj,
+                            dfb_bias_obj,
                             bias_pagesize,
                             {.page_id = bias_tile},
                             {.offset_bytes = bias_write_offset});
@@ -322,9 +322,9 @@ void kernel_main() {
 
                     // Now we have the block in the CB address, we can mcast to dests!
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    mcast_dst.addr = cb_bias_obj.get_write_ptr();
+                    mcast_dst.addr = dfb_bias_obj.get_write_ptr();
                     noc.async_write_multicast(
-                        use<experimental::CB::AddrSelector::WRITE_PTR>(cb_bias_obj),
+                        CoreLocalMem<uint32_t>(dfb_bias_obj.get_write_ptr()),
                         mcast_ep,
                         bias_block_size_bytes,
                         weights_mcast_num_cores,
@@ -346,7 +346,7 @@ void kernel_main() {
                         weights_mcast_num_cores);
 #endif
 
-                    cb_bias_obj.push_back(bias_ntiles);
+                    dfb_bias_obj.push_back(bias_ntiles);
                     load_bias = false;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define ALWI inline __attribute__((always_inline))
@@ -41,51 +42,50 @@ ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val, bool unco
 }
 
 template <uint32_t cb_id, uint32_t clear_value_cb_id>
-ALWI void clear_out_tiles(Noc noc, experimental::CB cb, experimental::CB clear_cb) {
+ALWI void clear_out_tiles(Noc noc, DataflowBuffer dfb, DataflowBuffer clear_dfb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_pages = get_local_cb_interface(cb_id).fifo_num_pages;
     const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_page_size / tile_size;
 
     UnicastEndpoint self_ep;
-    const auto src = experimental::local_addr(clear_cb.get_read_ptr(), noc.get_noc_id());
+    const auto src = experimental::local_addr(clear_dfb.get_read_ptr(), noc.get_noc_id());
 
     for (uint32_t i = 0; i < num_tiles * num_pages; ++i) {
-        noc.async_read(self_ep, cb, tile_size, src, {.offset_bytes = i * tile_size});
+        noc.async_read(self_ep, dfb, tile_size, src, {.offset_bytes = i * tile_size});
     }
     noc.async_read_barrier();
 }
 
 template <uint32_t clear_value_cb_id>
-ALWI void clear_out_tiles(
-    Noc noc, experimental::CB dst_cb, experimental::CB clear_value_cb, uint32_t num_tiles) {
+ALWI void clear_out_tiles(Noc noc, DataflowBuffer dst_dfb, DataflowBuffer clear_value_dfb, uint32_t num_tiles) {
     constexpr uint32_t tile_size = get_tile_size(clear_value_cb_id);
 
     UnicastEndpoint self_ep;
-    const auto src = experimental::local_addr(clear_value_cb.get_read_ptr(), noc.get_noc_id());
+    const auto src = experimental::local_addr(clear_value_dfb.get_read_ptr(), noc.get_noc_id());
 
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        noc.async_read(self_ep, dst_cb, tile_size, src, {.offset_bytes = i * tile_size});
+        noc.async_read(self_ep, dst_dfb, tile_size, src, {.offset_bytes = i * tile_size});
     }
     noc.async_read_barrier();
 }
 
 // Zero out all tiles for a given circular buffer.
 template <uint32_t cb_id>
-ALWI void zero_out_tiles(Noc noc, experimental::CB cb) {
+ALWI void zero_out_tiles(Noc noc, DataflowBuffer dfb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_num_pages;
-    noc.async_write_zeros(cb, tile_size * num_tiles);
+    noc.async_write_zeros(dfb, tile_size * num_tiles);
     noc.write_zeros_l1_barrier();
 }
 
 template <uint32_t config_dram_addr, uint32_t config_page_size, uint32_t tensor_args_index, uint32_t cb_reader_index>
-ALWI void load_config_tensor_if_in_dram(Noc noc, experimental::CB reader_cb, uint32_t core_index) {
+ALWI void load_config_tensor_if_in_dram(Noc noc, DataflowBuffer reader_dfb, uint32_t core_index) {
     constexpr auto config_tensor_args = TensorAccessorArgs<tensor_args_index>();
     const auto config_accessor = TensorAccessor(config_tensor_args, config_dram_addr);
 
-    noc.async_read(config_accessor, reader_cb, config_page_size, {.page_id = core_index}, {});
+    noc.async_read(config_accessor, reader_dfb, config_page_size, {.page_id = core_index}, {});
     noc.async_read_barrier();
-    reader_cb.push_back(1);
+    reader_dfb.push_back(1);
 }
 
 template <
@@ -95,7 +95,7 @@ template <
     bool split_reader,
     uint32_t multi_buffering_factor>
 ALWI void fill_scalar(
-    experimental::CB scalar_cb,
+    DataflowBuffer scalar_dfb,
     uint32_t& scalar_start,
     uint32_t& scalar_end,
     uint32_t& scalar_value,
@@ -103,7 +103,7 @@ ALWI void fill_scalar(
     uint32_t& counter,
     volatile uint16_t* config_ptr) {
     constexpr uint32_t num_readers = split_reader ? 2 : 1;
-    scalar_cb.reserve_back(1);
+    scalar_dfb.reserve_back(1);
 
     while (counter >= scalar_end && scalar_end < reader_nindices) {
         scalar_index++;
@@ -118,15 +118,15 @@ ALWI void fill_scalar(
         // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
         // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
         // between the first and second face.
-        fill_with_val(scalar_cb.get_write_ptr(), FACE_WIDTH, scalar_value, false);
+        fill_with_val(scalar_dfb.get_write_ptr(), FACE_WIDTH, scalar_value, false);
     }
     counter += num_readers;
 
-    scalar_cb.push_back(1);
+    scalar_dfb.push_back(1);
 }
 
-ALWI void zero_out_page(Noc noc, experimental::CB cb) {
-    const uint32_t page_size = get_local_cb_interface(cb.get_cb_id()).fifo_page_size;
-    noc.async_write_zeros(cb, page_size);
+ALWI void zero_out_page(Noc noc, DataflowBuffer dfb) {
+    const uint32_t page_size = get_local_cb_interface(dfb.get_id()).fifo_page_size;
+    noc.async_write_zeros(dfb, page_size);
     noc.write_zeros_l1_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
@@ -13,6 +13,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/add_int_sfpu.h"
 #include "api/compute/copy_dest_values.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define DEBUG_PRINT 0
@@ -75,20 +76,20 @@ void kernel_main() {
     constexpr uint32_t kernel_w = get_compile_time_arg_val(36);
     constexpr uint32_t indexes_32_bit = get_compile_time_arg_val(37);
 
-    // experimental::CB wrappers for CB operations
-    experimental::CB in_scalar_cb(in_scalar_cb_id_0);
-    experimental::CB in_idx_cb(in_idx_cb_id);
-    experimental::CB pack_tmp_cb(pack_tmp_cb_id);
-    experimental::CB pack_idx_tmp_cb(pack_idx_tmp_cb_id);
-    experimental::CB right_inc_cb(right_inc_cb_id);
-    experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
-    experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
-    experimental::CB out_idx_cb(out_idx_cb_id);
-    experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
-    experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
-    experimental::CB compute_tmp_idx_cb(compute_tmp_idx_cb_id);
-    experimental::CB clear_value_cb(clear_value_cb_id);
-    experimental::CB in_cb_0(in_cb_id_0);
+    // DataflowBuffer wrappers for CB operations
+    DataflowBuffer in_scalar_dfb(in_scalar_cb_id_0);
+    DataflowBuffer in_idx_dfb(in_idx_cb_id);
+    DataflowBuffer pack_tmp_dfb(pack_tmp_cb_id);
+    DataflowBuffer pack_idx_tmp_dfb(pack_idx_tmp_cb_id);
+    DataflowBuffer right_inc_dfb(right_inc_cb_id);
+    DataflowBuffer down_left_wrap_inc_dfb(down_left_wrap_inc_cb_id);
+    DataflowBuffer up_left_wrap_inc_dfb(up_left_wrap_inc_cb_id);
+    DataflowBuffer out_idx_dfb(out_idx_cb_id);
+    DataflowBuffer intra_kernel_right_inc_dfb(intra_kernel_right_inc_cb_id);
+    DataflowBuffer intra_kernel_down_left_wrap_inc_dfb(intra_kernel_down_left_wrap_inc_cb_id);
+    DataflowBuffer compute_tmp_idx_dfb(compute_tmp_idx_cb_id);
+    DataflowBuffer clear_value_dfb(clear_value_cb_id);
+    DataflowBuffer in_dfb_0(in_cb_id_0);
 
     constexpr DataFormat copy_format = indexes_32_bit ? DataFormat::UInt32 : DataFormat::UInt16;
 
@@ -121,7 +122,7 @@ void kernel_main() {
                                                                            : kernel_w / max_sticks_for_reduction + 1;
     constexpr uint32_t interm_reduction_chunks = is_large_kernel ? w_chunks * kernel_h : 1;
 
-    in_scalar_cb.wait_front(1);
+    in_scalar_dfb.wait_front(1);
 
     uint32_t current_idx_col;
     uint32_t current_idx_row;
@@ -131,13 +132,13 @@ void kernel_main() {
     current_idx_row = start_row;
 
     constexpr uint32_t sticks_per_chunk = kernel_w <= max_sticks_for_reduction ? kernel_w : max_sticks_for_reduction;
-    right_inc_cb.wait_front(1);
-    down_left_wrap_inc_cb.wait_front(1);
-    up_left_wrap_inc_cb.wait_front(1);
+    right_inc_dfb.wait_front(1);
+    down_left_wrap_inc_dfb.wait_front(1);
+    up_left_wrap_inc_dfb.wait_front(1);
     if constexpr (is_large_kernel) {
-        intra_kernel_right_inc_cb.wait_front(1);
-        intra_kernel_down_left_wrap_inc_cb.wait_front(1);
-        clear_value_cb.wait_front(1);
+        intra_kernel_right_inc_dfb.wait_front(1);
+        intra_kernel_down_left_wrap_inc_dfb.wait_front(1);
+        clear_value_dfb.wait_front(1);
     }
 
     unary_op_init_common(in_cb_id_0, in_cb_id_0);
@@ -159,14 +160,14 @@ void kernel_main() {
             reconfig_data_format_srca(compute_tmp_idx_cb_id);
             copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
             if (first_iteration) {  // move the initial indexes from the reader to DST
-                in_idx_cb.wait_front(1);
+                in_idx_dfb.wait_front(1);
                 copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
-                in_idx_cb.pop_front(1);
+                in_idx_dfb.pop_front(1);
                 first_iteration = false;
             } else {  // move incremented indexes from compute back to DST
-                compute_tmp_idx_cb.wait_front(1);
+                compute_tmp_idx_dfb.wait_front(1);
                 copy_tile(compute_tmp_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
-                compute_tmp_idx_cb.pop_front(1);
+                compute_tmp_idx_dfb.pop_front(1);
             }
             if constexpr (is_large_kernel) {
                 // clear the accumulation tiles since they will contain garbage data which is partially loaded
@@ -183,7 +184,7 @@ void kernel_main() {
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
                 bool last_chunk = chunk == interm_reduction_chunks - 1;
 
-                in_cb_0.wait_front(1);
+                in_dfb_0.wait_front(1);
                 reconfig_data_format_srca(in_cb_id_0);
                 copy_tile_to_dst_init_short(in_cb_id_0);
                 copy_tile(in_cb_id_0, mpwi_cb_tile_idx, data_dst_idx);
@@ -246,7 +247,7 @@ void kernel_main() {
                     }
                 }
 
-                in_cb_0.pop_front(1);
+                in_dfb_0.pop_front(1);
             }
 
             // After all chunks: if not last C block, restore base indices for next C block
@@ -259,27 +260,27 @@ void kernel_main() {
             tile_regs_commit();
             tile_regs_wait();
 
-            pack_tmp_cb.reserve_back(1);
+            pack_tmp_dfb.reserve_back(1);
             pack_reconfig_data_format(pack_tmp_cb_id);
             pack_tile<true>(data_dst_idx, pack_tmp_cb_id, mpwi_cb_tile_idx);  // for reader (output data)
-            pack_tmp_cb.push_back(1);
+            pack_tmp_dfb.push_back(1);
 
-            pack_idx_tmp_cb.reserve_back(1);
+            pack_idx_tmp_dfb.reserve_back(1);
             pack_reconfig_data_format(pack_idx_tmp_cb_id);
             pack_tile<true>(index_dst_idx, pack_idx_tmp_cb_id, mpwi_cb_tile_idx);  // for reader (output indexes)
-            pack_idx_tmp_cb.push_back(1);
+            pack_idx_tmp_dfb.push_back(1);
 
             // Only push to compute_tmp_idx_cb_id if there's a next iteration that will consume it
             // This prevents leaving stale data in the CB between program runs when using caching
             bool is_last_iteration = (n == num_out_sticks_this_core - 1) && last_c_block;
             if (!is_last_iteration) {
-                compute_tmp_idx_cb.reserve_back(1);
+                compute_tmp_idx_dfb.reserve_back(1);
                 pack_reconfig_data_format(compute_tmp_idx_cb_id);
                 pack_tile<true>(
                     index_scratch_out_dst_idx,
                     compute_tmp_idx_cb_id,
                     mpwi_cb_tile_idx);  // for compute (incremented indexes)
-                compute_tmp_idx_cb.push_back(1);
+                compute_tmp_idx_dfb.push_back(1);
             }
 
             tile_regs_release();
@@ -287,13 +288,13 @@ void kernel_main() {
     }
 
     // This prevents leaving stale data in the CB between program runs when using caching
-    in_scalar_cb.pop_front(1);
-    right_inc_cb.pop_front(1);
-    down_left_wrap_inc_cb.pop_front(1);
-    up_left_wrap_inc_cb.pop_front(1);
+    in_scalar_dfb.pop_front(1);
+    right_inc_dfb.pop_front(1);
+    down_left_wrap_inc_dfb.pop_front(1);
+    up_left_wrap_inc_dfb.pop_front(1);
     if constexpr (is_large_kernel) {
-        intra_kernel_right_inc_cb.pop_front(1);
-        intra_kernel_down_left_wrap_inc_cb.pop_front(1);
-        clear_value_cb.pop_front(1);
+        intra_kernel_right_inc_dfb.pop_front(1);
+        intra_kernel_down_left_wrap_inc_dfb.pop_front(1);
+        clear_value_dfb.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -11,6 +11,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/add_int_sfpu.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define DEBUG_PRINT 0
@@ -100,13 +101,13 @@ void kernel_main() {
 
     constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
 
-    experimental::CB in_scalar_cb_0(in_scalar_cb_id_0);
-    experimental::CB in_scalar_cb_1(in_scalar_cb_id_1);
-    experimental::CB in_cb_0(in_cb_id_0);
-    experimental::CB in_cb_1(in_cb_id_1);
-    experimental::CB out_cb(out_cb_id);
-    experimental::CB pre_tilize_cb(pre_tilize_cb_id);
-    experimental::CB fast_tilize_cb(fast_tilize_cb_id);
+    DataflowBuffer in_scalar_dfb_0(in_scalar_cb_id_0);
+    DataflowBuffer in_scalar_dfb_1(in_scalar_cb_id_1);
+    DataflowBuffer in_dfb_0(in_cb_id_0);
+    DataflowBuffer in_dfb_1(in_cb_id_1);
+    DataflowBuffer out_dfb(out_cb_id);
+    DataflowBuffer pre_tilize_dfb(pre_tilize_cb_id);
+    DataflowBuffer fast_tilize_dfb(fast_tilize_cb_id);
 
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb);
@@ -119,7 +120,7 @@ void kernel_main() {
 
     // wait for initialization to complete
     if constexpr (one_scalar_per_core) {
-        in_scalar_cb_0.wait_front(1);
+        in_scalar_dfb_0.wait_front(1);
     }
 
     // if max out sticks is non-zero then this will be used as the number of out sticks for every core
@@ -136,13 +137,13 @@ void kernel_main() {
         const bool use_reader1_scalar = !reader0 && !one_scalar_per_core;
         const uint32_t curr_scalar_cb_id = use_reader1_scalar ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
         const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
-        experimental::CB curr_scalar_cb = use_reader1_scalar ? in_scalar_cb_1 : in_scalar_cb_0;
-        experimental::CB curr_in_cb = reader0 ? in_cb_0 : in_cb_1;
+        DataflowBuffer curr_scalar_dfb = use_reader1_scalar ? in_scalar_dfb_1 : in_scalar_dfb_0;
+        DataflowBuffer curr_in_dfb = reader0 ? in_dfb_0 : in_dfb_1;
         if constexpr (!one_scalar_per_core) {
-            curr_scalar_cb.wait_front(1);
+            curr_scalar_dfb.wait_front(1);
         }
         if (is_output_tiled && !tilize_stick_counter) {
-            out_cb.reserve_back(in_ntiles_c);
+            out_dfb.reserve_back(in_ntiles_c);
         }
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
             const bool last_c_block = c_i == in_nblocks_c - 1;
@@ -156,7 +157,7 @@ void kernel_main() {
                     ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
                     : number_of_tiles * num_faces_in_output_tile;
             if constexpr (!is_output_tiled) {
-                out_cb.reserve_back(output_faces);
+                out_dfb.reserve_back(output_faces);
             }
             if constexpr (tilize_reconfig) {
                 if (first_c_block || last_c_block) {
@@ -166,7 +167,7 @@ void kernel_main() {
             }
             tile_regs_acquire();
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
-                curr_in_cb.wait_front(1);
+                curr_in_dfb.wait_front(1);
                 unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                     curr_in_cb_id,
                     curr_scalar_cb_id,
@@ -175,7 +176,7 @@ void kernel_main() {
                 for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
                     reduce_tile_math<REDUCE_OP, REDUCE_DIM>(math_tile_idx, num_faces_in_input_tile);
                 }
-                curr_in_cb.pop_front(1);
+                curr_in_dfb.pop_front(1);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -183,26 +184,26 @@ void kernel_main() {
                 // TILED output: accumulate sticks and perform tilization when needed
                 if (last_c_block) {
                     pack_untilize_dest<partial_iter_output_tiles>(pre_tilize_cb_id, 1, 0);
-                    pre_tilize_cb.push_back(partial_iter_output_tiles);
+                    pre_tilize_dfb.push_back(partial_iter_output_tiles);
                     tilize_stick_counter++;
                     tilize_stick_total++;
                 } else {
                     pack_untilize_dest<max_tiles_per_iter>(pre_tilize_cb_id, 1, 0);
-                    pre_tilize_cb.push_back(max_tiles_per_iter);
+                    pre_tilize_dfb.push_back(max_tiles_per_iter);
                 }
                 tile_regs_release();
 
                 bool last_tile = num_out_sticks_this_core - tilize_stick_total < last_tile_height;
                 if (tilize_stick_counter == TILE_HEIGHT || (last_tile && tilize_stick_counter == last_tile_height)) {
                     if (last_tile && last_tile_height != TILE_HEIGHT) {
-                        pre_tilize_cb.wait_front(last_tile_height * in_ntiles_c);
+                        pre_tilize_dfb.wait_front(last_tile_height * in_ntiles_c);
                         // if the last tile is not whole we won't have pushed enough sticks, so we need to
                         // push some filler sticks to reach TILE_HEIGHT to make sure the CB pointers are correct
                         // before calling tilize
                         uint32_t filler_stick_tiles =
                             (TILE_HEIGHT - last_tile_height) *
                             ((in_nblocks_c - 1) * max_tiles_per_iter + partial_iter_output_tiles);
-                        pre_tilize_cb.push_back(filler_stick_tiles);
+                        pre_tilize_dfb.push_back(filler_stick_tiles);
                     }
                     PACK((pack_untilize_uninit(pre_tilize_cb_id)));
 
@@ -216,18 +217,18 @@ void kernel_main() {
                     // advance by the same number of bytes per round so their rd/wr pointers
                     // stay aligned. The producer-view wait_front/pop_front/reserve_back below
                     // continues to drive the producer pointer ledger.
-                    fast_tilize_cb.push_back(in_ntiles_c);
-                    fast_tilize_cb.wait_front(in_ntiles_c);
+                    fast_tilize_dfb.push_back(in_ntiles_c);
+                    fast_tilize_dfb.wait_front(in_ntiles_c);
 
                     fast_tilize_init(fast_tilize_cb_id, in_ntiles_c, out_cb_id);
                     fast_tilize_block(fast_tilize_cb_id, in_ntiles_c, out_cb_id);
                     fast_tilize_uninit(fast_tilize_cb_id, out_cb_id, in_ntiles_c);
 
-                    out_cb.push_back(in_ntiles_c);
-                    fast_tilize_cb.pop_front(in_ntiles_c);
-                    fast_tilize_cb.reserve_back(in_ntiles_c);
-                    pre_tilize_cb.pop_front(TILE_HEIGHT * in_ntiles_c);
-                    pre_tilize_cb.reserve_back(TILE_HEIGHT * in_ntiles_c);
+                    out_dfb.push_back(in_ntiles_c);
+                    fast_tilize_dfb.pop_front(in_ntiles_c);
+                    fast_tilize_dfb.reserve_back(in_ntiles_c);
+                    pre_tilize_dfb.pop_front(TILE_HEIGHT * in_ntiles_c);
+                    pre_tilize_dfb.reserve_back(TILE_HEIGHT * in_ntiles_c);
 
                     tilize_stick_counter = 0;
 
@@ -254,12 +255,12 @@ void kernel_main() {
                 } else {
                     pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0);
                 }
-                out_cb.push_back(output_faces);
+                out_dfb.push_back(output_faces);
                 tile_regs_release();
             }
         }
         if constexpr (!one_scalar_per_core) {
-            curr_scalar_cb.pop_front(1);
+            curr_scalar_dfb.pop_front(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -38,8 +38,8 @@ template <
     uint32_t sticks_per_chunk,
     uint32_t in_idx_cb_id>
 void fill_indexes(uint32_t init_index) {
-    DataflowBuffer idx_cb(in_idx_cb_id);
-    volatile tt_l1_ptr IndexType* idx_ptr = reinterpret_cast<volatile tt_l1_ptr IndexType*>(idx_cb.get_write_ptr());
+    DataflowBuffer idx_dfb(in_idx_cb_id);
+    volatile tt_l1_ptr IndexType* idx_ptr = reinterpret_cast<volatile tt_l1_ptr IndexType*>(idx_dfb.get_write_ptr());
     uint32_t kernel_idx = 0;
 
     for (uint32_t h = 0; h < kernel_h; ++h) {
@@ -125,8 +125,8 @@ ALWI void initialize_return_indices_data() {
     constexpr uint32_t row_stride = dilation_h * in_w - eff_kernel_w - (dilation_w - 1);
 
     // initialize the index CB
-    DataflowBuffer idx_cb(in_idx_cb_id);
-    idx_cb.reserve_back(1);
+    DataflowBuffer idx_dfb(in_idx_cb_id);
+    idx_dfb.reserve_back(1);
     fill_indexes<
         typename IndexType<indexes_32_bit>::type,
         kernel_h,
@@ -137,14 +137,14 @@ ALWI void initialize_return_indices_data() {
         is_large_kernel,
         sticks_per_chunk,
         in_idx_cb_id>(init_index);
-    idx_cb.push_back(1);
+    idx_dfb.push_back(1);
 
     // initialize the increment CBs
     // TODO we used to fill the 16 bit values two at a time, but this technically resulted in overflow with odd
     // c dimensions so for now we do it one at a time for both 16 and 32 bit indexes
     if constexpr (indexes_32_bit) {
-        auto fill_inc_32 = [&](DataflowBuffer& inc_cb, uint32_t inc) __attribute__((always_inline)) {
-            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
+        auto fill_inc_32 = [&](DataflowBuffer& inc_dfb, uint32_t inc) __attribute__((always_inline)) {
+            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_dfb.get_write_ptr());
             for (uint32_t k = 0; k < window_size_hw; ++k) {
                 for (uint32_t c = 0; c < fill_c; ++c) {
                     ptr[k * TILE_WIDTH + c] = inc;
@@ -152,37 +152,37 @@ ALWI void initialize_return_indices_data() {
             }
         };
 
-        DataflowBuffer right_inc_cb(right_inc_cb_id);
-        right_inc_cb.reserve_back(1);
-        fill_inc_32(right_inc_cb, right_inc);
-        right_inc_cb.push_back(1);
+        DataflowBuffer right_inc_dfb(right_inc_cb_id);
+        right_inc_dfb.reserve_back(1);
+        fill_inc_32(right_inc_dfb, right_inc);
+        right_inc_dfb.push_back(1);
 
-        DataflowBuffer down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
-        down_left_wrap_inc_cb.reserve_back(1);
-        fill_inc_32(down_left_wrap_inc_cb, down_left_wrap_inc);
-        down_left_wrap_inc_cb.push_back(1);
+        DataflowBuffer down_left_wrap_inc_dfb(down_left_wrap_inc_cb_id);
+        down_left_wrap_inc_dfb.reserve_back(1);
+        fill_inc_32(down_left_wrap_inc_dfb, down_left_wrap_inc);
+        down_left_wrap_inc_dfb.push_back(1);
 
-        DataflowBuffer up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
-        up_left_wrap_inc_cb.reserve_back(1);
-        fill_inc_32(up_left_wrap_inc_cb, up_left_wrap_inc);
-        up_left_wrap_inc_cb.push_back(1);
+        DataflowBuffer up_left_wrap_inc_dfb(up_left_wrap_inc_cb_id);
+        up_left_wrap_inc_dfb.reserve_back(1);
+        fill_inc_32(up_left_wrap_inc_dfb, up_left_wrap_inc);
+        up_left_wrap_inc_dfb.push_back(1);
 
         if constexpr (is_large_kernel) {
-            DataflowBuffer intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
-            intra_kernel_right_inc_cb.reserve_back(1);
-            fill_inc_32(intra_kernel_right_inc_cb, intra_kernel_right_inc);
-            intra_kernel_right_inc_cb.push_back(1);
+            DataflowBuffer intra_kernel_right_inc_dfb(intra_kernel_right_inc_cb_id);
+            intra_kernel_right_inc_dfb.reserve_back(1);
+            fill_inc_32(intra_kernel_right_inc_dfb, intra_kernel_right_inc);
+            intra_kernel_right_inc_dfb.push_back(1);
 
-            DataflowBuffer intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
-            intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
-            fill_inc_32(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
-            intra_kernel_down_left_wrap_inc_cb.push_back(1);
+            DataflowBuffer intra_kernel_down_left_wrap_inc_dfb(intra_kernel_down_left_wrap_inc_cb_id);
+            intra_kernel_down_left_wrap_inc_dfb.reserve_back(1);
+            fill_inc_32(intra_kernel_down_left_wrap_inc_dfb, intra_kernel_down_left_wrap_inc);
+            intra_kernel_down_left_wrap_inc_dfb.push_back(1);
         }
     } else {
-        auto fill_inc = [&](DataflowBuffer& inc_cb, uint32_t inc) __attribute__((always_inline)) {
+        auto fill_inc = [&](DataflowBuffer& inc_dfb, uint32_t inc) __attribute__((always_inline)) {
             uint16_t inc_16 = (uint16_t)inc;
             uint32_t inc_32_bit = (uint32_t)inc_16 | ((uint32_t)inc_16 << 16);
-            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
+            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_dfb.get_write_ptr());
             for (uint32_t k = 0; k < window_size_hw; ++k) {
                 for (uint32_t c = 0; c < fill_c_32_bit; ++c) {
                     ptr[k * HALF_TILE_WIDTH + c] = inc_32_bit;
@@ -190,31 +190,31 @@ ALWI void initialize_return_indices_data() {
             }
         };
 
-        DataflowBuffer right_inc_cb(right_inc_cb_id);
-        right_inc_cb.reserve_back(1);
-        fill_inc(right_inc_cb, right_inc);
-        right_inc_cb.push_back(1);
+        DataflowBuffer right_inc_dfb(right_inc_cb_id);
+        right_inc_dfb.reserve_back(1);
+        fill_inc(right_inc_dfb, right_inc);
+        right_inc_dfb.push_back(1);
 
-        DataflowBuffer down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
-        down_left_wrap_inc_cb.reserve_back(1);
-        fill_inc(down_left_wrap_inc_cb, down_left_wrap_inc);
-        down_left_wrap_inc_cb.push_back(1);
+        DataflowBuffer down_left_wrap_inc_dfb(down_left_wrap_inc_cb_id);
+        down_left_wrap_inc_dfb.reserve_back(1);
+        fill_inc(down_left_wrap_inc_dfb, down_left_wrap_inc);
+        down_left_wrap_inc_dfb.push_back(1);
 
-        DataflowBuffer up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
-        up_left_wrap_inc_cb.reserve_back(1);
-        fill_inc(up_left_wrap_inc_cb, up_left_wrap_inc);
-        up_left_wrap_inc_cb.push_back(1);
+        DataflowBuffer up_left_wrap_inc_dfb(up_left_wrap_inc_cb_id);
+        up_left_wrap_inc_dfb.reserve_back(1);
+        fill_inc(up_left_wrap_inc_dfb, up_left_wrap_inc);
+        up_left_wrap_inc_dfb.push_back(1);
 
         if constexpr (is_large_kernel) {
-            DataflowBuffer intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
-            intra_kernel_right_inc_cb.reserve_back(1);
-            fill_inc(intra_kernel_right_inc_cb, intra_kernel_right_inc);
-            intra_kernel_right_inc_cb.push_back(1);
+            DataflowBuffer intra_kernel_right_inc_dfb(intra_kernel_right_inc_cb_id);
+            intra_kernel_right_inc_dfb.reserve_back(1);
+            fill_inc(intra_kernel_right_inc_dfb, intra_kernel_right_inc);
+            intra_kernel_right_inc_dfb.push_back(1);
 
-            DataflowBuffer intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
-            intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
-            fill_inc(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
-            intra_kernel_down_left_wrap_inc_cb.push_back(1);
+            DataflowBuffer intra_kernel_down_left_wrap_inc_dfb(intra_kernel_down_left_wrap_inc_cb_id);
+            intra_kernel_down_left_wrap_inc_dfb.reserve_back(1);
+            fill_inc(intra_kernel_down_left_wrap_inc_dfb, intra_kernel_down_left_wrap_inc);
+            intra_kernel_down_left_wrap_inc_dfb.push_back(1);
         }
     }
 }
@@ -256,11 +256,11 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
     static_assert(MAX_TILES_PER_REDUCTION == 1, "MAX_TILES_PER_REDUCTION must be 1 for MPWI");
     constexpr uint32_t max_write_inc = TILE_WIDTH * BYTES_PER_ELEM;
 
-    DataflowBuffer in_cb(in_cb_id);
-    DataflowBuffer out_cb(out_cb_id);
-    DataflowBuffer out_idx_cb(out_idx_cb_id);
-    DataflowBuffer pack_tmp_cb(pack_tmp_cb_id);
-    DataflowBuffer pack_idx_tmp_cb(pack_idx_tmp_cb_id);
+    DataflowBuffer in_dfb(in_cb_id);
+    DataflowBuffer out_dfb(out_cb_id);
+    DataflowBuffer out_idx_dfb(out_idx_cb_id);
+    DataflowBuffer pack_tmp_dfb(pack_tmp_cb_id);
+    DataflowBuffer pack_idx_tmp_dfb(pack_idx_tmp_cb_id);
     Noc noc;
     UnicastEndpoint self_ep;
 
@@ -273,13 +273,13 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
 
         uint32_t write_offset = 0;
         if constexpr (reader_id == 0) {
-            in_cb.reserve_back(1);
+            in_dfb.reserve_back(1);
         }
         // page zeroing is only necessary for tiled block output format so that scale is not affected by
         // junk/padding data
         if constexpr (zero_pages && reader_id == 0) {
             if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
-                zero_out_page(noc, in_cb);
+                zero_out_page(noc, in_dfb);
             }
         }
         for (uint32_t h = 0; h < kernel_h; ++h) {
@@ -291,7 +291,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                         in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
                     noc.async_read(
                         self_ep,
-                        in_cb,
+                        in_dfb,
                         read_bytes * w_multiple,
                         experimental::local_addr(read_offset),
                         {.offset_bytes = write_offset});
@@ -303,9 +303,9 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                 if (push_chunk) {
                     if constexpr (reader_id == 0) {  // push a chunk
                         noc.async_read_barrier();
-                        in_cb.push_back(1);
+                        in_dfb.push_back(1);
                         if (!kernel_complete) {
-                            in_cb.reserve_back(1);
+                            in_dfb.reserve_back(1);
                             write_offset = 0;
                         }
                     } else {
@@ -321,31 +321,31 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                             uint32_t output_faces =
                                 c_i == in_nblocks_c - 1 ? num_faces_in_last_output_tile : num_faces_in_output_tile;
 
-                            out_cb.reserve_back(output_faces);
-                            out_idx_cb.reserve_back(output_faces);
+                            out_dfb.reserve_back(output_faces);
+                            out_idx_dfb.reserve_back(output_faces);
 
-                            pack_tmp_cb.wait_front(1);
+                            pack_tmp_dfb.wait_front(1);
                             noc.async_read(
                                 self_ep,
-                                out_cb,
+                                out_dfb,
                                 output_faces * FACE_WIDTH * BYTES_PER_ELEM,
-                                experimental::local_addr(pack_tmp_cb.get_read_ptr()),
+                                experimental::local_addr(pack_tmp_dfb.get_read_ptr()),
                                 {});
 
-                            pack_idx_tmp_cb.wait_front(1);
+                            pack_idx_tmp_dfb.wait_front(1);
                             constexpr uint32_t BYTES_PER_ELEM_IDX = indexes_32_bit ? 4 : 2;
                             noc.async_read(
                                 self_ep,
-                                out_idx_cb,
+                                out_idx_dfb,
                                 output_faces * FACE_WIDTH * BYTES_PER_ELEM_IDX,
-                                experimental::local_addr(pack_idx_tmp_cb.get_read_ptr()),
+                                experimental::local_addr(pack_idx_tmp_dfb.get_read_ptr()),
                                 {});
                             noc.async_read_barrier();
-                            pack_tmp_cb.pop_front(1);
-                            pack_idx_tmp_cb.pop_front(1);
+                            pack_tmp_dfb.pop_front(1);
+                            pack_idx_tmp_dfb.pop_front(1);
 
-                            out_cb.push_back(output_faces);
-                            out_idx_cb.push_back(output_faces);
+                            out_dfb.push_back(output_faces);
+                            out_idx_dfb.push_back(output_faces);
                         }
                     }
                 }
@@ -436,10 +436,10 @@ void kernel_main() {
 
     // fill the clear cb
     if constexpr (reader_id == 0) {
-        DataflowBuffer clear_value_cb(clear_value_cb_id);
-        fill_with_val(clear_value_cb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
-        clear_value_cb.push_back(1);
-        clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), DataflowBuffer(in_cb_id), clear_value_cb);
+        DataflowBuffer clear_value_dfb(clear_value_cb_id);
+        fill_with_val(clear_value_dfb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+        clear_value_dfb.push_back(1);
+        clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), DataflowBuffer(in_cb_id), clear_value_dfb);
     }
 
     if constexpr (reader_id == 0) {
@@ -473,28 +473,28 @@ void kernel_main() {
         // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
         // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
         // between the first and second face.
-        DataflowBuffer in_scalar_cb(in_scalar_cb_id_0);
-        fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
-        in_scalar_cb.push_back(1);
+        DataflowBuffer in_scalar_dfb(in_scalar_cb_id_0);
+        fill_with_val(in_scalar_dfb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
+        in_scalar_dfb.push_back(1);
     }
     const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
 
-    DataflowBuffer in_shard_cb(in_shard_cb_id);
-    const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
-    DataflowBuffer in_reader_indices_cb(in_reader_indices_cb_id);
+    DataflowBuffer in_shard_dfb(in_shard_cb_id);
+    const uint32_t in_l1_read_base_addr = in_shard_dfb.get_read_ptr();
+    DataflowBuffer in_reader_indices_dfb(in_reader_indices_cb_id);
     if constexpr (config_in_dram) {
         if (reader_id == 0) {
             load_config_tensor_if_in_dram<
                 reader_dram_addr,
                 reader_page_size,
                 reader_tensor_args_index,
-                in_reader_indices_cb_id>(Noc(), in_reader_indices_cb, core_nhw_index);
+                in_reader_indices_cb_id>(Noc(), in_reader_indices_dfb, core_nhw_index);
 
         } else {
-            in_reader_indices_cb.wait_front(1);
+            in_reader_indices_dfb.wait_front(1);
         }
     }
-    uint32_t reader_indices_l1_addr = in_reader_indices_cb.get_read_ptr();
+    uint32_t reader_indices_l1_addr = in_reader_indices_dfb.get_read_ptr();
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -38,7 +38,7 @@ template <
     uint32_t sticks_per_chunk,
     uint32_t in_idx_cb_id>
 void fill_indexes(uint32_t init_index) {
-    experimental::CB idx_cb(in_idx_cb_id);
+    DataflowBuffer idx_cb(in_idx_cb_id);
     volatile tt_l1_ptr IndexType* idx_ptr = reinterpret_cast<volatile tt_l1_ptr IndexType*>(idx_cb.get_write_ptr());
     uint32_t kernel_idx = 0;
 
@@ -125,7 +125,7 @@ ALWI void initialize_return_indices_data() {
     constexpr uint32_t row_stride = dilation_h * in_w - eff_kernel_w - (dilation_w - 1);
 
     // initialize the index CB
-    experimental::CB idx_cb(in_idx_cb_id);
+    DataflowBuffer idx_cb(in_idx_cb_id);
     idx_cb.reserve_back(1);
     fill_indexes<
         typename IndexType<indexes_32_bit>::type,
@@ -143,7 +143,7 @@ ALWI void initialize_return_indices_data() {
     // TODO we used to fill the 16 bit values two at a time, but this technically resulted in overflow with odd
     // c dimensions so for now we do it one at a time for both 16 and 32 bit indexes
     if constexpr (indexes_32_bit) {
-        auto fill_inc_32 = [&](experimental::CB& inc_cb, uint32_t inc) __attribute__((always_inline)) {
+        auto fill_inc_32 = [&](DataflowBuffer& inc_cb, uint32_t inc) __attribute__((always_inline)) {
             volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
             for (uint32_t k = 0; k < window_size_hw; ++k) {
                 for (uint32_t c = 0; c < fill_c; ++c) {
@@ -152,34 +152,34 @@ ALWI void initialize_return_indices_data() {
             }
         };
 
-        experimental::CB right_inc_cb(right_inc_cb_id);
+        DataflowBuffer right_inc_cb(right_inc_cb_id);
         right_inc_cb.reserve_back(1);
         fill_inc_32(right_inc_cb, right_inc);
         right_inc_cb.push_back(1);
 
-        experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+        DataflowBuffer down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
         down_left_wrap_inc_cb.reserve_back(1);
         fill_inc_32(down_left_wrap_inc_cb, down_left_wrap_inc);
         down_left_wrap_inc_cb.push_back(1);
 
-        experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+        DataflowBuffer up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
         up_left_wrap_inc_cb.reserve_back(1);
         fill_inc_32(up_left_wrap_inc_cb, up_left_wrap_inc);
         up_left_wrap_inc_cb.push_back(1);
 
         if constexpr (is_large_kernel) {
-            experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+            DataflowBuffer intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
             intra_kernel_right_inc_cb.reserve_back(1);
             fill_inc_32(intra_kernel_right_inc_cb, intra_kernel_right_inc);
             intra_kernel_right_inc_cb.push_back(1);
 
-            experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+            DataflowBuffer intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
             intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
             fill_inc_32(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
             intra_kernel_down_left_wrap_inc_cb.push_back(1);
         }
     } else {
-        auto fill_inc = [&](experimental::CB& inc_cb, uint32_t inc) __attribute__((always_inline)) {
+        auto fill_inc = [&](DataflowBuffer& inc_cb, uint32_t inc) __attribute__((always_inline)) {
             uint16_t inc_16 = (uint16_t)inc;
             uint32_t inc_32_bit = (uint32_t)inc_16 | ((uint32_t)inc_16 << 16);
             volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
@@ -190,28 +190,28 @@ ALWI void initialize_return_indices_data() {
             }
         };
 
-        experimental::CB right_inc_cb(right_inc_cb_id);
+        DataflowBuffer right_inc_cb(right_inc_cb_id);
         right_inc_cb.reserve_back(1);
         fill_inc(right_inc_cb, right_inc);
         right_inc_cb.push_back(1);
 
-        experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+        DataflowBuffer down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
         down_left_wrap_inc_cb.reserve_back(1);
         fill_inc(down_left_wrap_inc_cb, down_left_wrap_inc);
         down_left_wrap_inc_cb.push_back(1);
 
-        experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+        DataflowBuffer up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
         up_left_wrap_inc_cb.reserve_back(1);
         fill_inc(up_left_wrap_inc_cb, up_left_wrap_inc);
         up_left_wrap_inc_cb.push_back(1);
 
         if constexpr (is_large_kernel) {
-            experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+            DataflowBuffer intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
             intra_kernel_right_inc_cb.reserve_back(1);
             fill_inc(intra_kernel_right_inc_cb, intra_kernel_right_inc);
             intra_kernel_right_inc_cb.push_back(1);
 
-            experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+            DataflowBuffer intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
             intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
             fill_inc(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
             intra_kernel_down_left_wrap_inc_cb.push_back(1);
@@ -256,11 +256,11 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
     static_assert(MAX_TILES_PER_REDUCTION == 1, "MAX_TILES_PER_REDUCTION must be 1 for MPWI");
     constexpr uint32_t max_write_inc = TILE_WIDTH * BYTES_PER_ELEM;
 
-    experimental::CB in_cb(in_cb_id);
-    experimental::CB out_cb(out_cb_id);
-    experimental::CB out_idx_cb(out_idx_cb_id);
-    experimental::CB pack_tmp_cb(pack_tmp_cb_id);
-    experimental::CB pack_idx_tmp_cb(pack_idx_tmp_cb_id);
+    DataflowBuffer in_cb(in_cb_id);
+    DataflowBuffer out_cb(out_cb_id);
+    DataflowBuffer out_idx_cb(out_idx_cb_id);
+    DataflowBuffer pack_tmp_cb(pack_tmp_cb_id);
+    DataflowBuffer pack_idx_tmp_cb(pack_idx_tmp_cb_id);
     Noc noc;
     UnicastEndpoint self_ep;
 
@@ -436,10 +436,10 @@ void kernel_main() {
 
     // fill the clear cb
     if constexpr (reader_id == 0) {
-        experimental::CB clear_value_cb(clear_value_cb_id);
+        DataflowBuffer clear_value_cb(clear_value_cb_id);
         fill_with_val(clear_value_cb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
         clear_value_cb.push_back(1);
-        clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), experimental::CB(in_cb_id), clear_value_cb);
+        clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), DataflowBuffer(in_cb_id), clear_value_cb);
     }
 
     if constexpr (reader_id == 0) {
@@ -473,15 +473,15 @@ void kernel_main() {
         // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
         // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
         // between the first and second face.
-        experimental::CB in_scalar_cb(in_scalar_cb_id_0);
+        DataflowBuffer in_scalar_cb(in_scalar_cb_id_0);
         fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
         in_scalar_cb.push_back(1);
     }
     const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
 
-    experimental::CB in_shard_cb(in_shard_cb_id);
+    DataflowBuffer in_shard_cb(in_shard_cb_id);
     const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
-    experimental::CB in_reader_indices_cb(in_reader_indices_cb_id);
+    DataflowBuffer in_reader_indices_cb(in_reader_indices_cb_id);
     if constexpr (config_in_dram) {
         if (reader_id == 0) {
             load_config_tensor_if_in_dram<

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -50,8 +50,8 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      (kernel_h * kernel_w) <= 16 && !last_tile_is_partial;
 
-    experimental::CB in_cb(in_cb_id);
-    experimental::CB clear_cb(clear_value_cb_id);
+    DataflowBuffer in_dfb(in_cb_id);
+    DataflowBuffer clear_dfb(clear_value_cb_id);
     Noc noc;
     UnicastEndpoint self_ep;
 
@@ -63,14 +63,14 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                 (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
         }
 
-        in_cb.reserve_back(1);
+        in_dfb.reserve_back(1);
         uint32_t write_offset = 0;
         uint32_t processed_sticks = 0;
         // page zeroing is only necessary for tiled block output format so that scale is not affected by
         // junk/padding data
         if constexpr (zero_pages) {
             if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
-                zero_out_page(noc, in_cb);
+                zero_out_page(noc, in_dfb);
             }
         }
         // When the CB intentionally holds more rows than the kernel window (medium kernels,
@@ -85,7 +85,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                 constexpr uint32_t tail_offset_bytes = total_elems_to_reduce * row_stride_elems * BYTES_PER_ELEM;
                 constexpr uint32_t tail_elems = (num_tilized_rows - total_elems_to_reduce) * row_stride_elems;
                 fill_with_val(
-                    in_cb.get_write_ptr() + tail_offset_bytes, tail_elems, static_cast<uint16_t>(bf16_init_value));
+                    in_dfb.get_write_ptr() + tail_offset_bytes, tail_elems, static_cast<uint16_t>(bf16_init_value));
             }
         }
         for (uint32_t h = 0; h < kernel_h; ++h) {
@@ -95,7 +95,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                     in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
                 noc.async_read(
                     self_ep,
-                    in_cb,
+                    in_dfb,
                     read_bytes * w_multiple,
                     experimental::local_addr(read_offset),
                     {.offset_bytes = write_offset});
@@ -111,8 +111,8 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                     if ((processed_sticks % max_sticks_for_reduction) == 0 ||
                         processed_sticks == total_elems_to_reduce) {
                         noc.async_read_barrier();
-                        in_cb.push_back(1);
-                        in_cb.reserve_back(1);
+                        in_dfb.push_back(1);
+                        in_dfb.reserve_back(1);
                         write_offset = 0;
                         // If next is last chunk, fill whole buffer with the init_value. note for max pool we do
                         // not need to fill the CB for the partial chunk since as long as we have N>1 chunks we
@@ -124,7 +124,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                             // clear the in CB
                             if ((total_elems_to_reduce - processed_sticks) < max_sticks_for_reduction &&
                                 processed_sticks != total_elems_to_reduce) {
-                                clear_out_tiles<clear_value_cb_id>(noc, in_cb, clear_cb, in_cb_ntiles);
+                                clear_out_tiles<clear_value_cb_id>(noc, in_dfb, clear_dfb, in_cb_ntiles);
                             }
                         }
                     }
@@ -154,7 +154,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
         }
         if constexpr (!is_large_kernel) {
             noc.async_read_barrier();
-            in_cb.push_back(1);
+            in_dfb.push_back(1);
         }
     }
 }
@@ -233,24 +233,24 @@ void kernel_main() {
          interm_reduction_chunks <= multi_buffering_factor);
     constexpr uint32_t in_cb_ntiles = in_cb_sz / (TILE_WIDTH * TILE_HEIGHT);  // only use the non-multi buffering size
 
-    experimental::CB clear_value_cb(clear_value_cb_id);
-    experimental::CB in_scalar_cb(in_scalar_cb_id);
-    experimental::CB in_shard_cb(in_shard_cb_id);
-    experimental::CB reader_indices_cb(in_reader_indices_cb_id);
-    experimental::CB config_cb(config_cb_id);
+    DataflowBuffer clear_value_dfb(clear_value_cb_id);
+    DataflowBuffer in_scalar_dfb(in_scalar_cb_id);
+    DataflowBuffer in_shard_dfb(in_shard_cb_id);
+    DataflowBuffer reader_indices_dfb(in_reader_indices_cb_id);
+    DataflowBuffer config_dfb(config_cb_id);
 
     // fill the clear cb
     if constexpr (is_avg_pool || need_to_initialize_in_cb) {
         if constexpr (reader_id == 0) {
-            fill_with_val(clear_value_cb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
-            clear_value_cb.push_back(1);
+            fill_with_val(clear_value_dfb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+            clear_value_dfb.push_back(1);
         }
         if constexpr (reader_id == 1) {
-            clear_value_cb.wait_front(1);
+            clear_value_dfb.wait_front(1);
         }
         // for average pool clear out tiles runs in loop, no need to initialize here
         if constexpr (!is_avg_pool || !is_large_kernel) {
-            clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), experimental::CB(in_cb_id), clear_value_cb);
+            clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), DataflowBuffer(in_cb_id), clear_value_dfb);
         }
     }
 
@@ -259,25 +259,25 @@ void kernel_main() {
         // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
         // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
         // between the first and second face.
-        fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
-        in_scalar_cb.push_back(1);
+        fill_with_val(in_scalar_dfb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
+        in_scalar_dfb.push_back(1);
     }
     const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
 
-    const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
+    const uint32_t in_l1_read_base_addr = in_shard_dfb.get_read_ptr();
     if constexpr (config_in_dram) {
         if (reader_id == 0) {
             load_config_tensor_if_in_dram<
                 reader_dram_addr,
                 reader_page_size,
                 reader_tensor_args_index,
-                in_reader_indices_cb_id>(Noc(), reader_indices_cb, core_nhw_index);
+                in_reader_indices_cb_id>(Noc(), reader_indices_dfb, core_nhw_index);
 
         } else {
-            reader_indices_cb.wait_front(1);
+            reader_indices_dfb.wait_front(1);
         }
     }
-    uint32_t reader_indices_l1_addr = reader_indices_cb.get_read_ptr();
+    uint32_t reader_indices_l1_addr = reader_indices_dfb.get_read_ptr();
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
 
@@ -291,7 +291,7 @@ void kernel_main() {
     uint32_t scalar_end;
     uint32_t counter = reader_id;
     if constexpr (!one_scalar_per_core) {
-        uint32_t config_l1_addr = config_cb.get_read_ptr();
+        uint32_t config_l1_addr = config_dfb.get_read_ptr();
         if constexpr (config_in_dram) {
             if (reader_id == 0) {
                 constexpr uint32_t config_tensor_args_index =
@@ -300,9 +300,9 @@ void kernel_main() {
                     config_dram_addr,
                     config_page_size,
                     config_tensor_args_index,
-                    config_cb_id>(Noc(), config_cb, core_nhw_index);
+                    config_cb_id>(Noc(), config_dfb, core_nhw_index);
             } else {
-                config_cb.wait_front(1);
+                config_dfb.wait_front(1);
             }
         }
         config_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(config_l1_addr);
@@ -333,7 +333,7 @@ void kernel_main() {
                     reader_nindices,
                     use_split_reader,
                     multi_buffering_factor>(
-                    in_scalar_cb, scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
+                    in_scalar_dfb, scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
             }
             read_kernel_with_top_left_index<
                 in_nblocks_c,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
     const auto grid_tensor_accessor = TensorAccessor(grid_args, grid_addr);
     const auto input_tensor_accessor = TensorAccessor(src_args, input_addr);
 
-    experimental::CB grid_cb(grid_cb_index);
+    DataflowBuffer grid_dfb(grid_cb_index);
     Noc noc;
 
     const uint32_t end_id = start_page_id + num_pages;
@@ -57,11 +57,11 @@ void kernel_main() {
     problem.
 
     However, if there was no previous read for the appropriate stick, the memory in that location is invalid, and could
-    include NaN and Inf values. For that reason we zero out the input_cb at the start.
+    include NaN and Inf values. For that reason we zero out the input_dfb at the start.
     */
-    experimental::CB input_cb(input_cb_index);
-    experimental::CB scalar_cb(scalar_cb_index);
-    zero_out_tiles<input_cb_index>(noc, input_cb);
+    DataflowBuffer input_dfb(input_cb_index);
+    DataflowBuffer scalar_dfb(scalar_cb_index);
+    zero_out_tiles<input_cb_index>(noc, input_dfb);
 
     // Calculate starting batch from starting spatial position (avoid division in loop)
     uint32_t curr_batch = start_page_id / output_hw_size;
@@ -71,11 +71,12 @@ void kernel_main() {
     // Outer loop: iterate over spatial positions (output sticks)
     for (uint32_t spatial_pos = start_page_id; spatial_pos < end_id; ++spatial_pos) {
         // Read the grid stick for this spatial position (contains grid_batches sets of coordinates)
-        noc.async_read(grid_tensor_accessor, grid_cb, grid_stick_nbytes, {.page_id = spatial_pos}, {});
+        noc.async_read(grid_tensor_accessor, grid_dfb, grid_stick_nbytes, {.page_id = spatial_pos}, {});
         noc.async_read_barrier();
 
         // Cast to appropriate pointer type for grid data access
-        volatile tt_l1_ptr uint16_t* grid_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(grid_cb.get_write_ptr());
+        volatile tt_l1_ptr uint16_t* grid_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(grid_dfb.get_write_ptr());
 
         // Inner loop: process grid_batches coordinate sets within this spatial position
         for (uint32_t grid_idx = 0; grid_idx < grid_batches; ++grid_idx) {
@@ -91,7 +92,7 @@ void kernel_main() {
                 input_chunk_nbytes,
                 last_chunk_partial,
                 input_cb_index,
-                scalar_cb_index>(noc, input_cb, scalar_cb, grid_ptr, grid_idx, input_tensor_accessor, batch_offset);
+                scalar_cb_index>(noc, input_dfb, scalar_dfb, grid_ptr, grid_idx, input_tensor_accessor, batch_offset);
         }
 
         // Update batch tracking (avoid division in loop)

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -21,16 +21,16 @@
 // The scalar page is zeroed so the interpolation weight is 0, making the
 // padded output harmless (written to the shard but masked by valid_sticks).
 template <uint32_t scalar_cb_index, uint32_t in_nblocks_c>
-ALWI void push_noop_sticks(Noc noc, experimental::CB input_cb, experimental::CB scalar_cb) {
+ALWI void push_noop_sticks(Noc noc, DataflowBuffer input_dfb, DataflowBuffer scalar_dfb) {
     for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
-        input_cb.reserve_back(1);
-        input_cb.push_back(1);
+        input_dfb.reserve_back(1);
+        input_dfb.push_back(1);
     }
 
-    scalar_cb.reserve_back(1);
-    zero_out_page(noc, scalar_cb);
+    scalar_dfb.reserve_back(1);
+    zero_out_page(noc, scalar_dfb);
     noc.async_read_barrier();
-    scalar_cb.push_back(1);
+    scalar_dfb.push_back(1);
 }
 
 ALWI void advance_grid_index_bounded(
@@ -95,13 +95,13 @@ void kernel_main() {
 
     // Zero out input CB to handle invalid coordinates properly
     Noc noc;
-    experimental::CB input_cb(input_cb_index);
-    experimental::CB scalar_cb(scalar_cb_index);
-    zero_out_tiles<input_cb_index>(noc, input_cb);
+    DataflowBuffer input_dfb(input_cb_index);
+    DataflowBuffer scalar_dfb(scalar_cb_index);
+    zero_out_tiles<input_cb_index>(noc, input_dfb);
 
     // Get local grid data base address (already in L1)
-    experimental::CB grid_cb(grid_cb_index);
-    const uint32_t l1_grid_base_addr = grid_cb.get_read_ptr();
+    DataflowBuffer grid_dfb(grid_cb_index);
+    const uint32_t l1_grid_base_addr = grid_dfb.get_read_ptr();
 
     // Clamp this core's stick count to exclude height-sharding padding.
     // Padding sticks contain garbage that would produce invalid NOC addresses.
@@ -155,11 +155,11 @@ void kernel_main() {
                 last_chunk_partial,
                 input_cb_index,
                 scalar_cb_index>(
-                noc, input_cb, scalar_cb, grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
+                noc, input_dfb, scalar_dfb, grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
         } else {
             // Padding stick from height-sharding — push zero-weight data to CBs
             // so the compute kernel receives the expected number of items.
-            push_noop_sticks<scalar_cb_index, in_nblocks_c>(noc, input_cb, scalar_cb);
+            push_noop_sticks<scalar_cb_index, in_nblocks_c>(noc, input_dfb, scalar_dfb);
         }
 
         // Always advance once after processing

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -19,7 +20,7 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(dst_args, dst_addr);
 
-    experimental::CB out_cb(cb_id_out0);
+    DataflowBuffer out_dfb(cb_id_out0);
     Noc noc;
 
     uint32_t end_stick_id = start_stick_id + num_sticks_to_write;
@@ -29,15 +30,15 @@ void kernel_main() {
     for (uint32_t stick_id = start_stick_id; stick_id < end_stick_id; stick_id++) {
         {
             // Wait for ntiles_c pages in output CB (one full stick)
-            out_cb.wait_front(ntiles_c);
+            out_dfb.wait_front(ntiles_c);
 
             // Write the complete stick
-            noc.async_write(out_cb, s0, output_stick_size, {}, {.page_id = stick_id});
+            noc.async_write(out_dfb, s0, output_stick_size, {}, {.page_id = stick_id});
 
             noc.async_write_barrier();
 
             // Pop the ntiles_c pages we just consumed
-            out_cb.pop_front(ntiles_c);
+            out_dfb.pop_front(ntiles_c);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
@@ -28,7 +28,7 @@ ALWI void process_grid_point_nearest(
     uint32_t grid_idx,
     const TensorAccessor& input_tensor_accessor,
     uint32_t batch_offset,
-    experimental::CB output_cb,
+    DataflowBuffer output_dfb,
     uint32_t output_write_offset,
     uint32_t fill_stick_addr) {
     // Compute scaling factors to match prepare_grid.cpp
@@ -96,7 +96,7 @@ ALWI void process_grid_point_nearest(
         const uint32_t input_stick_index = batch_offset + (nearest_h * input_width) + nearest_w;
         noc.async_read(
             input_tensor_accessor,
-            output_cb,
+            output_dfb,
             input_stick_nbytes,
             {.page_id = input_stick_index},
             {.offset_bytes = output_write_offset});
@@ -104,7 +104,7 @@ ALWI void process_grid_point_nearest(
         UnicastEndpoint self_ep;
         noc.async_read(
             self_ep,
-            output_cb,
+            output_dfb,
             input_stick_nbytes,
             experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
             {.offset_bytes = output_write_offset});
@@ -184,19 +184,19 @@ void kernel_main() {
     const uint32_t starting_batch = global_grid_stick_start / grid_hw;
 
     // Get local grid data base address (already in L1)
-    experimental::CB grid_cb(grid_cb_index);
-    experimental::CB output_cb(output_cb_index);
-    experimental::CB fill_cb(fill_cb_index);
+    DataflowBuffer grid_dfb(grid_cb_index);
+    DataflowBuffer output_dfb(output_cb_index);
+    DataflowBuffer fill_dfb(fill_cb_index);
     Noc noc;
 
-    const uint32_t l1_grid_base_addr = grid_cb.get_write_ptr();
+    const uint32_t l1_grid_base_addr = grid_dfb.get_write_ptr();
 
     // Process each grid stick assigned to this core
     uint32_t grid_stick_idx = 0;
     uint32_t l1_grid_addr = l1_grid_base_addr;
 
-    uint32_t fill_stick_addr = fill_cb.get_write_ptr();
-    zero_out_page(noc, fill_cb);
+    uint32_t fill_stick_addr = fill_dfb.get_write_ptr();
+    zero_out_page(noc, fill_dfb);
 
     // For split reader: track grid point index starting from reader_id
     uint32_t in_grid_row_idx = 0;
@@ -225,7 +225,7 @@ void kernel_main() {
 
         if constexpr (!is_sharded) {
             noc.async_read(
-                grid_tensor_accessor, grid_cb, grid_stick_nbytes, {.page_id = grid_stick_idx + start_page_id}, {});
+                grid_tensor_accessor, grid_dfb, grid_stick_nbytes, {.page_id = grid_stick_idx + start_page_id}, {});
             noc.async_read_barrier();
         }
         uint32_t output_write_offset =
@@ -247,7 +247,7 @@ void kernel_main() {
                 in_grid_row_idx,
                 input_tensor_accessor,
                 batch_offset,
-                output_cb,
+                output_dfb,
                 output_write_offset,
                 fill_stick_addr);
         } else {
@@ -255,7 +255,7 @@ void kernel_main() {
             UnicastEndpoint self_ep;
             noc.async_read(
                 self_ep,
-                output_cb,
+                output_dfb,
                 input_stick_nbytes,
                 experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
                 {.offset_bytes = output_write_offset});

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "api/numeric/bfloat16.h"
 
@@ -143,7 +144,7 @@ ALWI void read_four_corner_inputs(
     int32_t w0,
     int32_t w1,
     uint32_t input_height,
-    experimental::CB input_cb) {
+    DataflowBuffer input_dfb) {
     // Boundary checks (recompute for performance)
     const bool h0_valid = is_coordinate_valid(h0, input_height);
     const bool h1_valid = is_coordinate_valid(h1, input_height);
@@ -157,7 +158,7 @@ ALWI void read_four_corner_inputs(
         const uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             read_bytes,
             {.page_id = north_west_stick_index, .offset_bytes = src_byte_offset},
             {.offset_bytes = write_offset});
@@ -168,7 +169,7 @@ ALWI void read_four_corner_inputs(
         const uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             read_bytes,
             {.page_id = north_east_stick_index, .offset_bytes = src_byte_offset},
             {.offset_bytes = write_offset});
@@ -179,7 +180,7 @@ ALWI void read_four_corner_inputs(
         const uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             read_bytes,
             {.page_id = south_west_stick_index, .offset_bytes = src_byte_offset},
             {.offset_bytes = write_offset});
@@ -190,7 +191,7 @@ ALWI void read_four_corner_inputs(
         const uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             read_bytes,
             {.page_id = south_east_stick_index, .offset_bytes = src_byte_offset},
             {.offset_bytes = write_offset});
@@ -209,7 +210,7 @@ ALWI void read_four_corner_inputs_with_fill(
     int32_t w0,
     int32_t w1,
     uint32_t input_height,
-    experimental::CB input_cb,
+    DataflowBuffer input_dfb,
     uint32_t fill_stick_addr) {
     const bool h0_valid = is_coordinate_valid(h0, input_height);
     const bool h1_valid = is_coordinate_valid(h1, input_height);
@@ -224,12 +225,12 @@ ALWI void read_four_corner_inputs_with_fill(
         const uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             input_stick_nbytes,
             {.page_id = north_west_stick_index},
             {.offset_bytes = write_offset});
     } else {
-        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+        noc.async_read(self_ep, input_dfb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
     write_offset += input_stick_nbytes;
 
@@ -237,12 +238,12 @@ ALWI void read_four_corner_inputs_with_fill(
         const uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             input_stick_nbytes,
             {.page_id = north_east_stick_index},
             {.offset_bytes = write_offset});
     } else {
-        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+        noc.async_read(self_ep, input_dfb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
     write_offset += input_stick_nbytes;
 
@@ -250,12 +251,12 @@ ALWI void read_four_corner_inputs_with_fill(
         const uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             input_stick_nbytes,
             {.page_id = south_west_stick_index},
             {.offset_bytes = write_offset});
     } else {
-        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+        noc.async_read(self_ep, input_dfb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
     write_offset += input_stick_nbytes;
 
@@ -263,12 +264,12 @@ ALWI void read_four_corner_inputs_with_fill(
         const uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
         noc.async_read(
             input_tensor_accessor,
-            input_cb,
+            input_dfb,
             input_stick_nbytes,
             {.page_id = south_east_stick_index},
             {.offset_bytes = write_offset});
     } else {
-        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+        noc.async_read(self_ep, input_dfb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
 }
 
@@ -295,8 +296,8 @@ template <
     typename GridPtrType>
 ALWI void process_grid_point(
     Noc noc,
-    experimental::CB input_cb,
-    experimental::CB scalar_cb,
+    DataflowBuffer input_dfb,
+    DataflowBuffer scalar_dfb,
     GridPtrType grid_ptr,
     uint32_t grid_idx,
     const TensorAccessor& input_tensor_accessor,
@@ -366,10 +367,10 @@ ALWI void process_grid_point(
 
     // Store bilinear interpolation weights for this grid point. The same weights apply to every
     // channel chunk, so we push the scalar CB only once.
-    scalar_cb.reserve_back(1);
-    const uint32_t l1_write_scalar_addr = scalar_cb.get_write_ptr();
+    scalar_dfb.reserve_back(1);
+    const uint32_t l1_write_scalar_addr = scalar_dfb.get_write_ptr();
     fill_four_val(l1_write_scalar_addr, weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf);
-    scalar_cb.push_back(1);
+    scalar_dfb.push_back(1);
 
     // Iterate over channel chunks. For the common case in_nblocks_c == 1 the loop runs once and the
     // behavior matches the original non-chunked reader (chunk_bytes == input_stick_nbytes,
@@ -386,7 +387,7 @@ ALWI void process_grid_point(
         const uint32_t chunk_bytes = (c_i == last_chunk_idx) ? partial_chunk_nbytes : input_chunk_nbytes;
         const uint32_t write_stride = (last_chunk_partial && c_i == last_chunk_idx) ? chunk_bytes : base_write_stride;
 
-        input_cb.reserve_back(1);
+        input_dfb.reserve_back(1);
 
         read_four_corner_inputs(
             noc,
@@ -401,9 +402,9 @@ ALWI void process_grid_point(
             w0,
             w1,
             input_height,
-            input_cb);
+            input_dfb);
 
         noc.async_read_barrier();
-        input_cb.push_back(1);
+        input_dfb.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_bilinear_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_bilinear_interleaved.cpp
@@ -46,14 +46,14 @@ void kernel_main() {
 
     const uint32_t end_stick_id = start_stick_id + num_sticks;
 
-    experimental::CB input_cb(input_cb_id);
-    experimental::CB scalar_cb(scalar_cb_id);
-    experimental::CB fill_cb(fill_cb_id);
+    DataflowBuffer input_dfb(input_cb_id);
+    DataflowBuffer scalar_dfb(scalar_cb_id);
+    DataflowBuffer fill_dfb(fill_cb_id);
     Noc noc;
 
-    uint32_t fill_stick_addr = fill_cb.get_write_ptr();
+    uint32_t fill_stick_addr = fill_dfb.get_write_ptr();
     if constexpr (fill_is_zero) {
-        zero_out_page(noc, fill_cb);
+        zero_out_page(noc, fill_dfb);
     } else {
         volatile tt_l1_ptr uint32_t* fill_ptr32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fill_stick_addr);
         if constexpr (element_size == 2) {
@@ -118,7 +118,7 @@ void kernel_main() {
         const uint16_t weight_sw_bf = fixed_to_bf16(weight_sw_q16);
         const uint16_t weight_se_bf = fixed_to_bf16(weight_se_q16);
 
-        input_cb.reserve_back(1);
+        input_dfb.reserve_back(1);
 
         read_four_corner_inputs_with_fill(
             noc,
@@ -131,16 +131,16 @@ void kernel_main() {
             w0,
             w1,
             input_height,
-            input_cb,
+            input_dfb,
             fill_stick_addr);
 
-        scalar_cb.reserve_back(1);
-        const uint32_t l1_write_scalar_addr = scalar_cb.get_write_ptr();
+        scalar_dfb.reserve_back(1);
+        const uint32_t l1_write_scalar_addr = scalar_dfb.get_write_ptr();
         fill_four_val(l1_write_scalar_addr, weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf);
-        scalar_cb.push_back(1);
+        scalar_dfb.push_back(1);
 
         noc.async_read_barrier();
-        input_cb.push_back(1);
+        input_dfb.push_back(1);
 
         ++spatial_pos_in_batch;
         if (spatial_pos_in_batch == hw_size) {

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
@@ -33,14 +33,14 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<11>();
     const auto input_tensor_accessor = TensorAccessor(src_args, input_addr);
 
-    experimental::CB output_cb(output_cb_id);
-    experimental::CB fill_cb(fill_cb_id);
+    DataflowBuffer output_dfb(output_cb_id);
+    DataflowBuffer fill_dfb(fill_cb_id);
     Noc noc;
     UnicastEndpoint self_ep;
 
-    uint32_t fill_stick_addr = fill_cb.get_write_ptr();
+    uint32_t fill_stick_addr = fill_dfb.get_write_ptr();
     if constexpr (fill_is_zero) {
-        zero_out_page(noc, fill_cb);
+        zero_out_page(noc, fill_dfb);
     } else {
         volatile tt_l1_ptr uint32_t* fill_ptr32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fill_stick_addr);
         const uint32_t fill_value_packed = (fill_value_bf16 << 16) | fill_value_bf16;
@@ -57,7 +57,7 @@ void kernel_main() {
     for (uint32_t local_stick_idx = 0; local_stick_idx < num_sticks;) {
         uint32_t sticks_this_burst =
             (num_sticks - local_stick_idx) < burst_size ? (num_sticks - local_stick_idx) : burst_size;
-        output_cb.reserve_back(sticks_this_burst);
+        output_dfb.reserve_back(sticks_this_burst);
         uint32_t write_offset = 0;
 
         for (uint32_t i = 0; i < sticks_this_burst; i++, local_stick_idx++) {
@@ -89,14 +89,14 @@ void kernel_main() {
                     batch_idx * (input_height * input_width) + nearest_y * input_width + nearest_x;
                 noc.async_read(
                     input_tensor_accessor,
-                    output_cb,
+                    output_dfb,
                     input_stick_nbytes_unaligned,
                     {.page_id = input_stick_index},
                     {.offset_bytes = write_offset});
             } else {
                 noc.async_read(
                     self_ep,
-                    output_cb,
+                    output_dfb,
                     input_stick_nbytes_unaligned,
                     experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
                     {.offset_bytes = write_offset});
@@ -105,6 +105,6 @@ void kernel_main() {
         }
 
         noc.async_read_barrier();
-        output_cb.push_back(sticks_this_burst);
+        output_dfb.push_back(sticks_this_burst);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/writer_rotate_nearest_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/writer_rotate_nearest_interleaved.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -20,19 +21,19 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<4>();
     const auto output_tensor_accessor = TensorAccessor(dst_args, output_addr);
 
-    experimental::CB output_cb(output_cb_id);
+    DataflowBuffer output_dfb(output_cb_id);
     Noc noc;
 
     for (uint32_t local_stick_idx = 0; local_stick_idx < num_sticks;) {
         uint32_t sticks_this_burst =
             (num_sticks - local_stick_idx) < burst_size ? (num_sticks - local_stick_idx) : burst_size;
-        output_cb.wait_front(sticks_this_burst);
+        output_dfb.wait_front(sticks_this_burst);
         uint32_t read_offset = 0;
 
         for (uint32_t i = 0; i < sticks_this_burst; i++, local_stick_idx++) {
             const uint32_t global_stick_idx = start_stick_id + local_stick_idx;
             noc.async_write(
-                output_cb,
+                output_dfb,
                 output_tensor_accessor,
                 output_stick_nbytes,
                 {.offset_bytes = read_offset},
@@ -40,6 +41,6 @@ void kernel_main() {
             read_offset += output_stick_nbytes;
         }
         noc.async_write_barrier();
-        output_cb.pop_front(sticks_this_burst);
+        output_dfb.pop_front(sticks_this_burst);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/pack_untilize.h"
 #include "internal/circular_buffer_interface.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // Push 1 stick or partial stick to a cb (a (partial) stick consists of num_pages pages, in our case, size of a page is
@@ -25,12 +26,12 @@ inline void llk_push_pages_bilinear(const std::int32_t operand, const std::int32
 }
 
 template <uint32_t tiles_per_reduction>
-inline void reduce_h_fused(experimental::CB in_cb, experimental::CB scalar_cb, experimental::CB out_cb) {
-    const uint32_t in_cb_id = in_cb.get_cb_id();
-    const uint32_t in_scalar_cb_id = scalar_cb.get_cb_id();
-    const uint32_t out_cb_id = out_cb.get_cb_id();
+inline void reduce_h_fused(DataflowBuffer in_dfb, DataflowBuffer scalar_dfb, DataflowBuffer out_dfb) {
+    const uint32_t in_cb_id = in_dfb.get_id();
+    const uint32_t in_scalar_cb_id = scalar_dfb.get_id();
+    const uint32_t out_cb_id = out_dfb.get_id();
     tile_regs_acquire();
-    in_cb.wait_front(4);
+    in_dfb.wait_front(4);
 
     // Template parameters for unpack_tilizeA_B_block:
     constexpr bool use_neginf_srcA = false;  // Don't use negative infinity for source A
@@ -48,7 +49,7 @@ inline void reduce_h_fused(experimental::CB in_cb, experimental::CB scalar_cb, e
         reduce_tile_math<REDUCE_OP, REDUCE_DIM>(
             c_i, num_faces);  // Reduce the 2 faces (containing 4 rows for bilinear interpolation)
     }
-    in_cb.pop_front(4);
+    in_dfb.pop_front(4);
 
     tile_regs_wait();
     tile_regs_commit();
@@ -87,24 +88,24 @@ void kernel_main() {
     constexpr bool use_neginf_srcA = false;  // Don't use negative infinity for source A
     constexpr bool zero_srcA_reduce = true;  // Zero source A for reduce operation
 
-    experimental::CB tilize_reduce_cb0(tilize_reduce_cb_0);
-    experimental::CB tilize_reduce_cb1(tilize_reduce_cb_1);
-    experimental::CB scalar_cb_1(in_scalar_cb_id1);
-    experimental::CB scalar_cb_2(in_scalar_cb_id2);
-    experimental::CB out_cb(out_cb_id);
+    DataflowBuffer tilize_reduce_dfb0(tilize_reduce_cb_0);
+    DataflowBuffer tilize_reduce_dfb1(tilize_reduce_cb_1);
+    DataflowBuffer scalar_dfb_1(in_scalar_cb_id1);
+    DataflowBuffer scalar_dfb_2(in_scalar_cb_id2);
+    DataflowBuffer out_dfb(out_cb_id);
 
     tilizeA_B_reduce_init<use_neginf_srcA, zero_srcA_reduce>(
         tilize_reduce_cb_0, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id);
     pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id); /* face geometry comes from out_cb metadata */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
-        experimental::CB cur_in_cb = (i % 2 == 0) ? tilize_reduce_cb0 : tilize_reduce_cb1;
-        experimental::CB cur_scalar_cb = (i % 2 == 0) ? scalar_cb_1 : scalar_cb_2;
+        DataflowBuffer cur_in_dfb = (i % 2 == 0) ? tilize_reduce_dfb0 : tilize_reduce_dfb1;
+        DataflowBuffer cur_scalar_dfb = (i % 2 == 0) ? scalar_dfb_1 : scalar_dfb_2;
 
         for (uint32_t j = 0; j < blocks - 1; j++) {
-            reduce_h_fused<max_tiles_per_iter>(cur_in_cb, cur_scalar_cb, out_cb);
-            cur_scalar_cb.pop_front(1);
+            reduce_h_fused<max_tiles_per_iter>(cur_in_dfb, cur_scalar_dfb, out_dfb);
+            cur_scalar_dfb.pop_front(1);
         }
-        reduce_h_fused<partial_iter_output_tiles>(cur_in_cb, cur_scalar_cb, out_cb);
-        cur_scalar_cb.pop_front(1);
+        reduce_h_fused<partial_iter_output_tiles>(cur_in_dfb, cur_scalar_dfb, out_dfb);
+        cur_scalar_dfb.pop_front(1);
     }
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -4,6 +4,7 @@
 
 #include <ttnn/operations/pool/device/kernels/fixed_point_arithmetic.hpp>
 #include "bilinear_weights_lut.hpp"
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 //
@@ -242,9 +243,9 @@ struct BilinearIndexAdvancer {
 // each core runs two threads (reader/writer) that alternate producing pixels.
 //
 // Architecture:
-//   - Input: Halo-padded tensor in L1 circular buffer (halo_cb)
-//   - Output: Interpolation data written to tilize_reduce_cb (4 neighbors per pixel)
-//            + weights written to in_scalar_cb (4 BF16 weights per pixel)
+//   - Input: Halo-padded tensor in L1 circular buffer (halo_dfb)
+//   - Output: Interpolation data written to tilize_reduce_dfb (4 neighbors per pixel)
+//            + weights written to in_scalar_dfb (4 BF16 weights per pixel)
 //   - Downstream: Compute kernel performs weighted reduction
 //
 // Data Flow (per output pixel):
@@ -295,13 +296,13 @@ void kernel_main() {
     constexpr uint32_t blocks = get_compile_time_arg_val(14);
     constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(15);
 
-    experimental::CB halo_cb(halo_cb_id);
-    experimental::CB tilize_reduce_cb(tilize_reduce_cb_id);
-    experimental::CB scalar_cb(in_scalar_cb_id);
+    DataflowBuffer halo_dfb(halo_cb_id);
+    DataflowBuffer tilize_reduce_dfb(tilize_reduce_cb_id);
+    DataflowBuffer scalar_dfb(in_scalar_cb_id);
     Noc noc;
     UnicastEndpoint self_ep;
 
-    uint32_t l1_read_addr = halo_cb.get_read_ptr();
+    uint32_t l1_read_addr = halo_dfb.get_read_ptr();
 
     // Split work between reader and writer threads
     // Reader gets ceiling(N/2), writer gets floor(N/2)
@@ -357,7 +358,7 @@ void kernel_main() {
         // Process each channel block
         uint32_t block_offset = 0;
         for (uint32_t i = 0; i < blocks; i++) {
-            tilize_reduce_cb.reserve_back(4);
+            tilize_reduce_dfb.reserve_back(4);
 
             uint32_t current_block_size_bytes = (i == blocks - 1) ? last_block_size_bytes : input_block_size_bytes;
 
@@ -366,7 +367,7 @@ void kernel_main() {
             // Read 4 neighbor stick segments
             noc.async_read(
                 self_ep,
-                tilize_reduce_cb,
+                tilize_reduce_dfb,
                 current_block_size_bytes,
                 experimental::local_addr(y1x1_addr + block_offset),
                 {.offset_bytes = write_offset});
@@ -374,7 +375,7 @@ void kernel_main() {
 
             noc.async_read(
                 self_ep,
-                tilize_reduce_cb,
+                tilize_reduce_dfb,
                 current_block_size_bytes,
                 experimental::local_addr(y1x2_addr + block_offset),
                 {.offset_bytes = write_offset});
@@ -382,7 +383,7 @@ void kernel_main() {
 
             noc.async_read(
                 self_ep,
-                tilize_reduce_cb,
+                tilize_reduce_dfb,
                 current_block_size_bytes,
                 experimental::local_addr(y2x1_addr + block_offset),
                 {.offset_bytes = write_offset});
@@ -390,21 +391,21 @@ void kernel_main() {
 
             noc.async_read(
                 self_ep,
-                tilize_reduce_cb,
+                tilize_reduce_dfb,
                 current_block_size_bytes,
                 experimental::local_addr(y2x2_addr + block_offset),
                 {.offset_bytes = write_offset});
 
             // Write weights for compute kernel
             fill_four_val(
-                scalar_cb.get_write_ptr(),
+                scalar_dfb.get_write_ptr(),
                 weight_top_left_bf16,
                 weight_top_right_bf16,
                 weight_bottom_left_bf16,
                 weight_bottom_right_bf16);
-            scalar_cb.push_back(1);
+            scalar_dfb.push_back(1);
 
-            tilize_reduce_cb.push_back(4);
+            tilize_reduce_dfb.push_back(4);
             block_offset += current_block_size_bytes;
         }
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_nearest_float.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_nearest_float.cpp
@@ -6,6 +6,7 @@
 
 #include <api/dataflow/dataflow_api.h>
 #include <ttnn/operations/pool/device/kernels/fixed_point_arithmetic.hpp>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -29,7 +30,7 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<9>();
     const auto input_tensor_accessor = TensorAccessor(src_args, input_buffer_addr);
 
-    experimental::CB out_cb(cb_id_out);
+    DataflowBuffer out_dfb(cb_id_out);
     Noc noc;
 
     // Process sticks assigned to this core
@@ -62,16 +63,16 @@ void kernel_main() {
                                       clamped_src_x * num_pages_per_width + in_stick_offset;
 
         // Reserve space in output CB
-        out_cb.reserve_back(1);
+        out_dfb.reserve_back(1);
 
         // Read source stick from DRAM
-        noc.async_read(input_tensor_accessor, out_cb, aligned_stick_nbytes, {.page_id = src_stick_id}, {});
+        noc.async_read(input_tensor_accessor, out_dfb, aligned_stick_nbytes, {.page_id = src_stick_id}, {});
 
         // Wait for read to complete
         noc.async_read_barrier();
 
         // Push to CB
-        out_cb.push_back(1);
+        out_dfb.push_back(1);
 
         page_id++;
     }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_unary_stick_layout_interleaved_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -17,19 +18,19 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<2>();
     const auto s0 = TensorAccessor(src_args, src_addr);
 
-    experimental::CB in_cb(cb_id_in0);
+    DataflowBuffer in_dfb(cb_id_in0);
     Noc noc;
 
     const uint32_t end_id = start_page_id + num_pages;
 
     // reader copied the data from DRAM to CB buffer.
     for (uint32_t i = start_page_id; i < end_id; ++i) {
-        in_cb.reserve_back(1);
+        in_dfb.reserve_back(1);
 
-        noc.async_read(s0, in_cb, page_size, {.page_id = i}, {});
+        noc.async_read(s0, in_dfb, page_size, {.page_id = i}, {});
 
         noc.async_read_barrier();
 
-        in_cb.push_back(1);
+        in_dfb.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_interleaved.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -30,7 +31,7 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<8>();
     const auto s0 = TensorAccessor(dst_args, dst_addr);
 
-    experimental::CB out_cb(cb_id_out0);
+    DataflowBuffer out_dfb(cb_id_out0);
     Noc noc;
 
     constexpr uint32_t in_width = width / scale_w;
@@ -42,7 +43,7 @@ void kernel_main() {
     uint32_t current_stick = block_height * start_block_id;
 
     for (uint32_t b = start_block_id; b < end_block_id; b++) {
-        out_cb.wait_front(num_tiles_per_block_row);
+        out_dfb.wait_front(num_tiles_per_block_row);
 
         for (uint32_t in_block_row = 0; in_block_row < block_height; ++in_block_row) {
             uint32_t curr_index = current_stick % (in_width * in_height);
@@ -62,12 +63,16 @@ void kernel_main() {
                     uint32_t offset = j * width + k;
 
                     noc.async_write(
-                        out_cb, s0, output_page_size, {.offset_bytes = read_offset}, {.page_id = start_index + offset});
+                        out_dfb,
+                        s0,
+                        output_page_size,
+                        {.offset_bytes = read_offset},
+                        {.page_id = start_index + offset});
                 }
             }
             current_stick++;
         }
         noc.async_write_barrier();
-        out_cb.pop_front(num_tiles_per_block_row);
+        out_dfb.pop_front(num_tiles_per_block_row);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -24,19 +25,19 @@ void kernel_main() {
         ((in_nsticks_per_core * scale_h + 1) / 2) *
         scale_w;  // divided by 2 because each core has 2 readers which get near equal number of output sticks
 
-    experimental::CB in_cb(in_cb_id);
-    experimental::CB out_cb(out_cb_id);
-    experimental::CB config_cb(config_cb_id);
+    DataflowBuffer in_dfb(in_cb_id);
+    DataflowBuffer out_dfb(out_cb_id);
+    DataflowBuffer config_dfb(config_cb_id);
     Noc noc;
     UnicastEndpoint remote_ep;
 
-    uint32_t l1_read_addr = in_cb.get_read_ptr();
+    uint32_t l1_read_addr = in_dfb.get_read_ptr();
     uint32_t write_offset = 0;
     if (!is_reader) {
         write_offset = out_nsticks_per_core * stick_nbytes;
     }
 
-    uint32_t config_l1_addr = config_cb.get_read_ptr();
+    uint32_t config_l1_addr = config_dfb.get_read_ptr();
     // Interpreted as a vector of 32bit elements to lessen the number of l1 reads
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
 
@@ -62,7 +63,7 @@ void kernel_main() {
             for (uint32_t sw = 0; sw < scale_w; sw++) {
                 noc.async_read(
                     remote_ep,
-                    out_cb,
+                    out_dfb,
                     stick_nbytes,
                     {.noc_x = corex, .noc_y = corey, .addr = src_addr},
                     {.offset_bytes = write_offset});

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_nearest_float.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_nearest_float.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include <api/dataflow/dataflow_api.h>
+#include "api/dataflow/dataflow_buffer.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -21,23 +22,23 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<2>();
     const auto output_tensor_accessor = TensorAccessor(dst_args, output_buffer_addr);
 
-    experimental::CB out_cb(cb_id_out);
+    DataflowBuffer out_dfb(cb_id_out);
     Noc noc;
 
     // Process sticks assigned to this core
     uint32_t stick_id = start_stick_id;
     for (uint32_t i = 0; i < num_sticks; i++) {
         // Wait for data in CB
-        out_cb.wait_front(1);
+        out_dfb.wait_front(1);
 
         // Write to output DRAM
-        noc.async_write(out_cb, output_tensor_accessor, aligned_stick_nbytes, {}, {.page_id = stick_id});
+        noc.async_write(out_dfb, output_tensor_accessor, aligned_stick_nbytes, {}, {.page_id = stick_id});
 
         // Wait for write to complete
         noc.async_write_barrier();
 
         // Pop from CB
-        out_cb.pop_front(1);
+        out_dfb.pop_front(1);
 
         stick_id++;
     }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/45010 - first cut at changing Conv/Pool kernels from using CBs to using DFBs

DFBs use CBs under the hood for WH/BH, but this helps prepare for Quasar and Metal 2.0.

```
class DataflowBuffer {
public:
#ifdef ARCH_QUASAR
    using DFBInterface = LocalDFBInterface;
#else
    using DFBInterface = LocalCBInterface;
#endif
```

This only focuses on what can be currently converted over cleanly/mechanically. A second pass will be needed for the remaining blocked CB usage patterns (see https://github.com/tenstorrent/tt-metal/issues/49368)

SDXL time for a WH sanity test deterministically reduced by about 3% across reruns and rebase, so the time was lowered.

Single card model perf [passes
](https://github.com/tenstorrent/tt-metal/actions/runs/29024024978)

BH sanity failure is due to an unrelated segfault, this matches [main](https://github.com/tenstorrent/tt-metal/actions/runs/29020650291/job/861)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/45010/DFB_Conv_Pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/45010/DFB_Conv_Pool)