### PR TITLE
[Bug fix] Unblock Blaze kernel compilation with mock device

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -214,6 +214,20 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
 
     const auto& cluster = MetalContext::instance().get_cluster();
 
+    // MockChip has no TLB manager (get_tlb_manager() == nullptr), so skip TLB window
+    // setup entirely: pcie_writer_ stays unset. Safe under Mock because the runtime I/O
+    // paths that use pcie_writer_ -- read()/write() and notify_sender() -- never execute
+    // for mock devices (mock only exercises socket construction / JIT).
+    //
+    // TODO(emule): this over-skips for Emule. SWEmuleChip also lacks a TLB manager but has
+    // real memory-backed I/O, so it should skip only the TLB-window path and still install
+    // the cluster.write_core() fallback for pcie_writer_. As written, pcie_writer_ is left
+    // null, so enabling D2H socket runtime I/O under emule would null-deref in
+    // notify_sender(). Compile/JIT-only mock (loudbox) flows are unaffected.
+    if (cluster.is_mock_or_emulated()) {
+        return;
+    }
+
     if (mesh_device) {
         sender_device_id = mesh_device->get_device(sender_core_.device_coord)->id();
         sender_virtual_core = mesh_device->worker_core_from_logical_core(sender_core_.core_coord);

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -223,7 +223,7 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
     // real memory-backed I/O, so it should skip only the TLB-window path and still install
     // the cluster.write_core() fallback for pcie_writer_. As written, pcie_writer_ is left
     // null, so enabling D2H socket runtime I/O under emule would null-deref in
-    // notify_sender(). Compile/JIT-only mock (loudbox) flows are unaffected.
+    // notify_sender().
     if (cluster.is_mock_or_emulated()) {
         return;
     }

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -18,6 +18,7 @@
 #include "impl/internal/service/service_core_manager_impl.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
+#include "llrt/tt_cluster.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -112,10 +113,16 @@ void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload,
         }
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
+    auto& ctx = tt::tt_metal::MetalContext::instance();
+    if (ctx.rtoptions().get_fast_dispatch()) {
         mesh_workload.impl().compile(mesh_cq.device());
         mesh_workload.impl().load_binaries(mesh_cq);
         mesh_workload.impl().generate_dispatch_commands(mesh_cq);
+    } else if (ctx.get_cluster().is_mock_or_emulated()) {
+        // Slow dispatch normally JIT-compiles inside LaunchProgram, but the SD mesh CQ
+        // short-circuits for mock devices (no hardware to dispatch to). Compile here so
+        // kernel artifacts are still produced; the SD CQ then no-ops the skipped dispatch.
+        mesh_workload.impl().compile(mesh_cq.device());
     }
     mesh_cq.enqueue_mesh_workload(mesh_workload, blocking);
 }

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -248,6 +248,20 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
 
     const auto& cluster = MetalContext::instance().get_cluster();
 
+    // MockChip has no TLB manager (get_tlb_manager() == nullptr), so skip TLB window
+    // setup entirely: pcie_writer stays unset. Safe under Mock because the runtime I/O
+    // paths that use pcie_writer -- write() (HOST_PUSH) and notify_receiver() -- never
+    // execute for mock devices (mock only exercises socket construction / JIT).
+    //
+    // TODO(emule): this over-skips for Emule. SWEmuleChip also lacks a TLB manager but has
+    // real memory-backed I/O, so it should skip only the TLB-window path and still install
+    // the cluster.write_core() fallback for pcie_writer. As written, pcie_writer is left
+    // null, so enabling H2D socket runtime I/O under emule would null-deref in
+    // notify_receiver() / write(). Compile/JIT-only mock (loudbox) flows are unaffected.
+    if (cluster.is_mock_or_emulated()) {
+        return;
+    }
+
     // Receiver core type is recorded explicitly at construction (the DRAM-recv
     // ctor sets Dram, every other path is Tensix). Used only to resolve the
     // virtual coordinate — logical coords overlap across core types, so this

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -257,7 +257,7 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
     // real memory-backed I/O, so it should skip only the TLB-window path and still install
     // the cluster.write_core() fallback for pcie_writer. As written, pcie_writer is left
     // null, so enabling H2D socket runtime I/O under emule would null-deref in
-    // notify_receiver() / write(). Compile/JIT-only mock (loudbox) flows are unaffected.
+    // notify_receiver() / write().
     if (cluster.is_mock_or_emulated()) {
         return;
     }

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -44,6 +44,8 @@ PinnedMemoryImpl::PinnedMemoryImpl(PinnedMemoryImpl&& other) noexcept :
     map_to_noc_(std::exchange(other.map_to_noc_, false)),
     use_64bit_address_space_(std::exchange(other.use_64bit_address_space_, false)),
     host_offset_(std::exchange(other.host_offset_, 0)),
+    is_mock_(std::exchange(other.is_mock_, false)),
+    mock_host_ptr_(std::exchange(other.mock_host_ptr_, nullptr)),
     device_buffers_(std::move(other.device_buffers_)),
     device_to_mmio_map_(std::move(other.device_to_mmio_map_)),
     barrier_events_(std::move(other.barrier_events_)) {}
@@ -57,6 +59,8 @@ PinnedMemoryImpl& PinnedMemoryImpl::operator=(PinnedMemoryImpl&& other) noexcept
         map_to_noc_ = std::exchange(other.map_to_noc_, false);
         use_64bit_address_space_ = std::exchange(other.use_64bit_address_space_, false);
         host_offset_ = std::exchange(other.host_offset_, 0);
+        is_mock_ = std::exchange(other.is_mock_, false);
+        mock_host_ptr_ = std::exchange(other.mock_host_ptr_, nullptr);
         device_buffers_ = std::move(other.device_buffers_);
         device_to_mmio_map_ = std::move(other.device_to_mmio_map_);
         barrier_events_ = std::move(other.barrier_events_);
@@ -90,6 +94,17 @@ void PinnedMemoryImpl::initialize_from_devices(
         ChipId mmio_device_id = cluster.get_associated_mmio_device(device_id);
         device_to_mmio_map[device_id] = mmio_device_id;
         unique_mmio_devices.insert(mmio_device_id);
+    }
+
+    // Mock/emulated devices have no SysmemManager, so there is no host-memory
+    // mapping to perform. Record the device map and keep the host pointer only;
+    // device/NOC address queries return dummies (see get_device_addr / get_noc_addr).
+    if (cluster.is_mock_or_emulated()) {
+        is_mock_ = true;
+        mock_host_ptr_ = host_buffer;
+        host_offset_ = 0;
+        device_to_mmio_map_ = std::move(device_to_mmio_map);
+        return;
     }
 
     // Determine system page size and align the host buffer down to page boundary
@@ -158,6 +173,9 @@ const tt::umd::SysmemBuffer& PinnedMemoryImpl::get_buffer(ChipId device_id) cons
 }
 
 void* PinnedMemoryImpl::get_host_ptr() {
+    if (is_mock_) {
+        return mock_host_ptr_;
+    }
     if (device_buffers_.empty()) {
         throw std::runtime_error("No buffers available in PinnedMemory");
     }
@@ -167,6 +185,9 @@ void* PinnedMemoryImpl::get_host_ptr() {
 }
 
 const void* PinnedMemoryImpl::get_host_ptr() const {
+    if (is_mock_) {
+        return mock_host_ptr_;
+    }
     if (device_buffers_.empty()) {
         throw std::runtime_error("No buffers available in PinnedMemory");
     }
@@ -176,10 +197,19 @@ const void* PinnedMemoryImpl::get_host_ptr() const {
 }
 
 uint64_t PinnedMemoryImpl::get_device_addr(ChipId device_id) const {
+    if (is_mock_) {
+        return 0;
+    }
     return get_buffer(device_id).get_device_io_addr() + static_cast<uint64_t>(host_offset_);
 }
 
 std::optional<PinnedMemory::NocAddr> PinnedMemoryImpl::get_noc_addr(ChipId device_id) const {
+    if (is_mock_) {
+        // No sysmem mapping under mock; hand back a dummy NOC address. device_id is
+        // echoed back so the H2D/D2H socket's "mapped to the same device as the
+        // {receiver,sender} core" FATAL check passes.
+        return PinnedMemory::NocAddr{.pcie_xy_enc = 0, .addr = 0, .device_id = device_id};
+    }
     auto mmio_it = device_to_mmio_map_.find(device_id);
     if (mmio_it == device_to_mmio_map_.end()) {
         return std::nullopt;

--- a/tt_metal/distributed/pinned_memory_impl.hpp
+++ b/tt_metal/distributed/pinned_memory_impl.hpp
@@ -93,6 +93,15 @@ private:
     // Offset from the aligned mapped base to the actual host buffer start
     size_t host_offset_ = 0;
 
+    // Mock/emulated devices have no SysmemManager (MockChip::get_sysmem_manager()
+    // returns nullptr), so there is nothing to map host memory to. In that case we
+    // keep the host pointer only and hand out dummy device/NOC addresses: this lets
+    // H2D/D2H socket construction proceed (it just bakes these as compile-time args
+    // for JIT and never dereferences the buffer at compile time). The runtime
+    // write_tensor/read_tensor path is not exercised under mock.
+    bool is_mock_ = false;
+    void* mock_host_ptr_ = nullptr;
+
     // Map from device ID to SysmemBuffer (keyed by MMIO device ID)
     std::unordered_map<ChipId, std::unique_ptr<tt::umd::SysmemBuffer>> device_buffers_;
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -426,10 +426,6 @@ ContextId MetalContext::create_default_instance_implicit_locked() {
         TT_THROW("Only one silicon MetalContext instance may exist; context_id 0 is already in use.");
     }
 
-    // Only the programmatic mock path needs to seed the descriptor. Env-var mock
-    // (TT_METAL_MOCK_CLUSTER_DESC_PATH) is parsed centrally by RunTimeOptions and surfaces
-    // via rtoptions().get_target_device() == Mock, which the ContextDescriptor reads in
-    // init_context_descriptor -- so no env-var detection is needed here.
     MetalEnvDescriptor desc{};
     if (auto mock_cluster_desc = experimental::get_mock_cluster_desc()) {
         log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", *mock_cluster_desc);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -426,6 +426,10 @@ ContextId MetalContext::create_default_instance_implicit_locked() {
         TT_THROW("Only one silicon MetalContext instance may exist; context_id 0 is already in use.");
     }
 
+    // Only the programmatic mock path needs to seed the descriptor. Env-var mock
+    // (TT_METAL_MOCK_CLUSTER_DESC_PATH) is parsed centrally by RunTimeOptions and surfaces
+    // via rtoptions().get_target_device() == Mock, which the ContextDescriptor reads in
+    // init_context_descriptor -- so no env-var detection is needed here.
     MetalEnvDescriptor desc{};
     if (auto mock_cluster_desc = experimental::get_mock_cluster_desc()) {
         log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", *mock_cluster_desc);
@@ -716,8 +720,13 @@ std::shared_ptr<distributed::multihost::DistributedContext> MetalContext::get_di
 void MetalContext::init_context_descriptor(
     int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) {
     TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    // Source the mock flag from rtoptions (the centralized env-var/programmatic parsing)
+    // rather than re-detecting env vars here. get_target_device() == Mock is true for both
+    // env-var and programmatic mock, and -- crucially -- false for Emule (which sets the same
+    // TT_METAL_MOCK_CLUSTER_DESC_PATH but functionally executes kernels and must not skip
+    // firmware init) and for Simulator.
     std::string mock_cluster_desc_path =
-        env_->get_descriptor().is_mock_device() ? env_->get_descriptor().mock_cluster_desc_path() : "";
+        rtoptions().get_target_device() == tt::TargetDevice::Mock ? rtoptions().get_mock_cluster_desc_path() : "";
     context_descriptor_ = std::make_shared<ContextDescriptor>(
         env_,
         this,

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -353,8 +353,13 @@ RunTimeOptions::RunTimeOptions() : system_kernel_dir("/usr/share/tenstorrent/ker
 
     InitializeFromEnvVars();
 
-    if (this->runtime_target_device_ != tt::TargetDevice::Silicon) {
-        log_info(tt::LogMetal, "Disabling multi-erisc mode with simulator/mock target device");
+    // Mock devices mirror real silicon of the same architecture: leave the 2-erisc default (and any
+    // TT_METAL_DISABLE_MULTI_AERISC override) intact so that HAL construction and kernel compilation match
+    // what a real device would produce. Architecture gating still happens downstream (only Blackhole's HAL
+    // acts on the flag). The simulator and emule backends cannot model dual-erisc, so force it off for them.
+    if (this->runtime_target_device_ == tt::TargetDevice::Simulator ||
+        this->runtime_target_device_ == tt::TargetDevice::Emule) {
+        log_info(tt::LogMetal, "Disabling multi-erisc mode with simulator/emule target device");
         this->enable_2_erisc_mode = false;
     }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Addresses several issues when compiling with mock for Blaze tests (https://github.com/tenstorrent/tt-blaze/issues/1873):
- Compilation was skipped for mock+slow dispatch; need to un-skip
- 2-erisc mode was always off with mock, causing build key mismatch compared to real device.
- Added more guards to avoid null pointer dereference.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/mock-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/mock-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ruizhang/mock-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/mock-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/mock-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/mock-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/mock-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/mock-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/mock-fixes)