### PR TITLE
[Bugfix] Add NOC-distinctness legality check to the Metal 2.0 API

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -116,7 +116,6 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
     const DataMovementHardwareConfig consumer_cfg{
-        // NOC_1: distinct NOC from the RISCV_0/NOC_0 producer (Gen1 dedicated-NOC distinctness rule).
         .gen1_config =
             DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1},
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
@@ -328,7 +327,6 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
     const DataMovementHardwareConfig consumer_cfg{
-        // NOC_1: distinct NOC from the RISCV_0/NOC_0 producer (Gen1 dedicated-NOC distinctness rule).
         .gen1_config =
             DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1},
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -116,7 +116,9 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
     const DataMovementHardwareConfig consumer_cfg{
-        .gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1},
+        // NOC_1: distinct NOC from the RISCV_0/NOC_0 producer (Gen1 dedicated-NOC distinctness rule).
+        .gen1_config =
+            DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1},
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
 
@@ -326,7 +328,9 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
     const DataMovementHardwareConfig consumer_cfg{
-        .gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1},
+        // NOC_1: distinct NOC from the RISCV_0/NOC_0 producer (Gen1 dedicated-NOC distinctness rule).
+        .gen1_config =
+            DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1},
         .gen2_config = DataMovementHardwareConfig::Gen2Config{.disable_dfb_implicit_sync_for_all = true},
     };
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -233,7 +233,7 @@ void run_single_dfb_program(
     const experimental::DataMovementHardwareConfig dm_consumer_cfg{
         .gen1_config =
             experimental::DataMovementHardwareConfig::Gen1Config{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1},
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = tt::tt_metal::NOC::NOC_1},
         .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{},
     };
 
@@ -1689,7 +1689,10 @@ static void run_dfb_size_override_test(
     const experimental::DataMovementHardwareConfig dm_consumer_cfg{
         .gen1_config =
             experimental::DataMovementHardwareConfig::Gen1Config{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1},
+                // NOC_1 keeps the consumer on a distinct NOC from the RISCV_0/NOC_0 producer: two
+                // dedicated-NOC DM kernels on a node must use different NOCs on Gen1 (else the device hangs).
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::NOC::NOC_1},
         .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{},
     };
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -1689,10 +1689,7 @@ static void run_dfb_size_override_test(
     const experimental::DataMovementHardwareConfig dm_consumer_cfg{
         .gen1_config =
             experimental::DataMovementHardwareConfig::Gen1Config{
-                // NOC_1 keeps the consumer on a distinct NOC from the RISCV_0/NOC_0 producer: two
-                // dedicated-NOC DM kernels on a node must use different NOCs on Gen1 (else the device hangs).
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::NOC::NOC_1},
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = tt::tt_metal::NOC::NOC_1},
         .gen2_config = experimental::DataMovementHardwareConfig::Gen2Config{},
     };
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -89,9 +89,17 @@ inline KernelSpec MakeMinimalDMKernel(const std::string& name, uint32_t num_thre
 }
 
 // Helper to create a minimal valid KernelSpec for data movement (Gen1/WH/BH)
+//
+// The NOC is derived from the processor (RISCV_0 -> NOC_0, RISCV_1 -> NOC_1) so that the common
+// pairing of an RISCV_0 kernel with an RISCV_1 kernel on the same node gets distinct NOCs. On Gen1,
+// two dedicated-NOC DM kernels sharing a NOC hang the device (validation rejects it), so a helper
+// that always defaulted to NOC_0 would produce a pair that fails validation.
 inline KernelSpec MakeMinimalGen1DMKernel(
     const std::string& name,
     tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0) {
+    const tt::tt_metal::NOC noc = (processor == tt::tt_metal::DataMovementProcessor::RISCV_0)
+                                      ? tt::tt_metal::NOC::NOC_0
+                                      : tt::tt_metal::NOC::NOC_1;
     return KernelSpec{
         .unique_id = KernelSpecName{name},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
@@ -101,6 +109,7 @@ inline KernelSpec MakeMinimalGen1DMKernel(
                 .gen1_config =
                     DataMovementHardwareConfig::Gen1Config{
                         .processor = processor,
+                        .noc = noc,
                     },
             },
     };

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3088,7 +3088,8 @@ TEST_F(ProgramSpecTestGen1, DMKernelSelfLoopOnGen1Succeeds) {
 }
 
 TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
-    // RISCV_0 and RISCV_1 on the same node — should succeed
+    // RISCV_0 and RISCV_1 on the same node — should succeed. (MakeMinimalGen1DMKernel gives them
+    // distinct NOCs, so they also satisfy the dedicated-NOC distinctness rule.)
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -3172,6 +3173,72 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
+}
+
+TEST_F(ProgramSpecTestGen1, TwoDMKernelsSameNocDedicatedFails) {
+    // Two DM kernels on distinct processors (RISCV_0, RISCV_1) but pinned to the SAME NOC in
+    // dedicated mode. Each kernel's NoC traffic is statically compiled to its config.noc, so both
+    // would drive NOC_0 and hang the device. Validation must reject this.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
+    auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
+    // Force both onto NOC_0 (the helper would otherwise assign complementary NOCs). noc_mode
+    // defaults to DM_DEDICATED_NOC.
+    std::get<DataMovementHardwareConfig>(k0.hw_config).gen1_config->noc = NOC::NOC_0;
+    std::get<DataMovementHardwareConfig>(k1.hw_config).gen1_config->noc = NOC::NOC_0;
+
+    spec.kernels = {k0, k1};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("pinned to NOC_0")));
+}
+
+TEST_F(ProgramSpecTestGen1, TwoDMKernelsDistinctNocDedicatedSucceeds) {
+    // Two dedicated-NOC DM kernels on distinct processors AND distinct NOCs — the correct pairing.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
+    auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
+    std::get<DataMovementHardwareConfig>(k0.hw_config).gen1_config->noc = NOC::NOC_0;
+    std::get<DataMovementHardwareConfig>(k1.hw_config).gen1_config->noc = NOC::NOC_1;
+
+    spec.kernels = {k0, k1};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestGen1, TwoDMKernelsSameNocDynamicSucceeds) {
+    // In DM_DYNAMIC_NOC mode, two DM kernels may intentionally share a NOC (it frees the other NOC
+    // for fabric). The NOC-distinctness rule is dedicated-mode only, so this is accepted even though
+    // both kernels name NOC_0.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
+    auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
+    auto& cfg0 = std::get<DataMovementHardwareConfig>(k0.hw_config).gen1_config;
+    cfg0->noc = NOC::NOC_0;
+    cfg0->noc_mode = NOC_MODE::DM_DYNAMIC_NOC;
+    auto& cfg1 = std::get<DataMovementHardwareConfig>(k1.hw_config).gen1_config;
+    cfg1->noc = NOC::NOC_0;
+    cfg1->noc_mode = NOC_MODE::DM_DYNAMIC_NOC;
+
+    spec.kernels = {k0, k1};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestGen1, ReaderAndWriterRolesOnSameNodeSucceed) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3241,6 +3241,95 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsSameNocDynamicSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
+TEST_F(ProgramSpecTestGen1, DMProcessorBeyondRiscv1Fails) {
+    // Gen1 has only RISCV_0 (BRISC) and RISCV_1 (NCRISC); RISCV_2..7 are Gen2/Quasar-only. A Gen1 DM
+    // kernel requesting one must be rejected (parity with the legacy CreateDataMovementKernel guard).
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto kernel = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_0);
+    std::get<DataMovementHardwareConfig>(kernel.hw_config).gen1_config->processor = DataMovementProcessor::RISCV_2;
+
+    spec.kernels = {kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Gen1 has only")));
+}
+
+TEST_F(ProgramSpecTestGen1, TwoDMKernelsMixedNocModeFails) {
+    // NOC mode configures shared per-core NOC hardware (and is compiled into each kernel binary), so
+    // two DM kernels on the same node must agree on it. One dedicated + one dynamic is incoherent.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    // Distinct processors and distinct NOCs (helper defaults: RISCV_0->NOC_0, RISCV_1->NOC_1), so
+    // neither the processor nor the NOC-distinctness check fires — only the mode disagreement trips.
+    auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
+    auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
+    std::get<DataMovementHardwareConfig>(k0.hw_config).gen1_config->noc_mode = NOC_MODE::DM_DEDICATED_NOC;
+    std::get<DataMovementHardwareConfig>(k1.hw_config).gen1_config->noc_mode = NOC_MODE::DM_DYNAMIC_NOC;
+
+    spec.kernels = {k0, k1};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("different NOC modes")));
+}
+
+TEST_F(ProgramSpecTestGen1, DMKernelsSameProcessorAndNocOnDistinctNodesSucceeds) {
+    // Node-scoping guard: two DM kernels with identical processor (RISCV_0), NOC (NOC_0), and
+    // DM_DEDICATED_NOC mode are legal when placed on DISTINCT nodes — the processor- and
+    // NOC-distinctness censuses are per-node. This would wrongly fail if either map were keyed
+    // without the node component.
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto k_a = MakeMinimalGen1DMKernel("k_a", DataMovementProcessor::RISCV_0);  // NOC_0, dedicated
+    auto k_b = MakeMinimalGen1DMKernel("k_b", DataMovementProcessor::RISCV_0);  // NOC_0, dedicated
+
+    spec.kernels = {k_a, k_b};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_a", node_a, {"k_a"}),
+        MakeMinimalWorkUnit("wu_b", node_b, {"k_b"}),
+    };
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestGen1, DMKernelsDifferentNocModesOnDistinctNodesSucceeds) {
+    // Node-scoping guard for NOC-mode agreement: a DM_DEDICATED_NOC kernel on one node and a
+    // DM_DYNAMIC_NOC kernel on another are legal — agreement is enforced per-node, not globally.
+    // This would wrongly fail if node_noc_mode were keyed without the node component.
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto k_a = MakeMinimalGen1DMKernel("k_a", DataMovementProcessor::RISCV_0);
+    auto k_b = MakeMinimalGen1DMKernel("k_b", DataMovementProcessor::RISCV_0);
+    std::get<DataMovementHardwareConfig>(k_a.hw_config).gen1_config->noc_mode = NOC_MODE::DM_DEDICATED_NOC;
+    std::get<DataMovementHardwareConfig>(k_b.hw_config).gen1_config->noc_mode = NOC_MODE::DM_DYNAMIC_NOC;
+
+    spec.kernels = {k_a, k_b};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_a", node_a, {"k_a"}),
+        MakeMinimalWorkUnit("wu_b", node_b, {"k_b"}),
+    };
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
 TEST_F(ProgramSpecTestGen1, ReaderAndWriterRolesOnSameNodeSucceed) {
     // A READER and a WRITER role resolve to distinct processors (RISCV_1 and RISCV_0
     // respectively), so two role-driven DM kernels coexist on one node without conflict.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -866,22 +866,44 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     "KernelSpec '{}' targets Gen1 (WH/BH) but specifies neither a role hint "
                     "(READER/WRITER) nor an explicit Gen1 config. One is required.",
                     kernel.unique_id);
+
+                // Gen1 has exactly two DM processors: RISCV_0 (BRISC) and RISCV_1 (NCRISC).
+                // RISCV_2..RISCV_7 exist only on Gen2/Quasar. Reject them here, mirroring the legacy
+                // CreateDataMovementKernel "DM0 or DM1 only" guard. Resolving is safe now: the check
+                // above guarantees a role hint or an explicit Gen1 config is present.
+                const DataMovementProcessor processor = ResolveGen1Config(data_movement_config).processor;
+                TT_FATAL(
+                    processor == DataMovementProcessor::RISCV_0 || processor == DataMovementProcessor::RISCV_1,
+                    "KernelSpec '{}' targets Gen1 (WH/BH) but requests DM processor RISCV_{}. Gen1 has only "
+                    "RISCV_0 and RISCV_1; RISCV_2..RISCV_7 exist only on Gen2/Quasar.",
+                    kernel.unique_id,
+                    static_cast<int>(processor));
             }
         }
     }
 
-    // On Gen1 (WH/BH), two DM kernels sharing a node must claim distinct hardware:
+    // On Gen1 (WH/BH), the DM kernels sharing a node must be mutually coherent:
     //   1. Distinct DM processors (RISCV_0 vs RISCV_1) — no two kernels may pin the same RISC.
-    //   2. In DM_DEDICATED_NOC mode, distinct NOCs. Each DM kernel's NoC traffic is statically
+    //   2. Agreeing NOC mode. noc_mode configures shared per-core NOC hardware (command-buffer
+    //      partitioning + completion-counter location) and is compiled into each kernel binary as
+    //      the NOC_MODE define (see kernel.cpp), so two kernels on a node with different modes are
+    //      incoherent. Mirrors the KernelGroup-construction guard ("KernelGroup must have the same
+    //      noc mode for all kernels"), surfaced here at spec-validation time with a clearer message.
+    //   3. In DM_DEDICATED_NOC mode, distinct NOCs. Each DM kernel's NoC traffic is statically
     //      compiled to NOC_INDEX == config.noc (see kernel.cpp), so two dedicated-NOC kernels
-    //      pinned to the same NOC deadlock the device. This restores the guarantee the legacy
-    //      CheckDataMovementConfig enforced and that KernelGroup finalize still relies on ("safe
-    //      due to prior correctness validation"). DM_DYNAMIC_NOC kernels are exempt: they may
+    //      pinned to the same NOC deadlock the device. This enforces the NOC-distinctness invariant
+    //      that KernelGroup finalize silently relies on (it writes brisc_noc_id = arg.noc for
+    //      RISCV_0 vs 1 - arg.noc for RISCV_1, which agree only when the two NOCs differ -- "safe
+    //      due to prior correctness validation"). The legacy CheckDataMovementConfig intended this
+    //      check but did not reliably enforce it for the common reader+writer pair (it runs before
+    //      the second DM kernel is registered). DM_DYNAMIC_NOC kernels are exempt: they may
     //      intentionally share a NOC, freeing the other NOC for fabric.
     // (Each kernel's effective node set is derived from WorkUnitSpec membership.)
     if (is_gen1_arch()) {
         // (node, processor) -> the kernel that already claimed it.
         std::map<std::pair<NodeCoord, DataMovementProcessor>, KernelSpecName> claimed_processor;
+        // node -> (noc mode, the kernel that first set it) — all DM kernels on a node must agree.
+        std::map<NodeCoord, std::pair<NOC_MODE, KernelSpecName>> node_noc_mode;
         // (node, noc) -> the kernel that already claimed it (dedicated-NOC kernels only).
         std::map<std::pair<NodeCoord, NOC>, KernelSpecName> claimed_noc;
         for (const auto& kernel : spec.kernels) {
@@ -900,6 +922,21 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                         "KernelSpec '{}' conflicts with '{}' on node ({}, {}): both claim the same DM processor. ",
                         kernel.unique_id,
                         proc_it->second,
+                        node.x,
+                        node.y);
+
+                    // All DM kernels on a node must agree on NOC mode -- it configures shared per-core NOC
+                    // hardware. Independent of the NOC-distinctness check below (which is gated per-kernel on
+                    // DM_DEDICATED_NOC); their source order does not affect behavior.
+                    auto [mode_it, mode_inserted] =
+                        node_noc_mode.try_emplace(node, std::make_pair(gen1.noc_mode, kernel.unique_id));
+                    TT_FATAL(
+                        mode_inserted || mode_it->second.first == gen1.noc_mode,
+                        "KernelSpec '{}' conflicts with '{}' on node ({}, {}): they set different NOC modes (one "
+                        "DM_DEDICATED_NOC, the other DM_DYNAMIC_NOC). All data movement kernels on a node must use "
+                        "the same NOC mode.",
+                        kernel.unique_id,
+                        mode_it->second.second,
                         node.x,
                         node.y);
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -870,11 +870,20 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
-    // On Gen1 (WH/BH), check that no two DM kernels on the same node claim the same processor.
-    // (The kernel's effective node set is derived from WorkUnitSpec membership.)
+    // On Gen1 (WH/BH), two DM kernels sharing a node must claim distinct hardware:
+    //   1. Distinct DM processors (RISCV_0 vs RISCV_1) — no two kernels may pin the same RISC.
+    //   2. In DM_DEDICATED_NOC mode, distinct NOCs. Each DM kernel's NoC traffic is statically
+    //      compiled to NOC_INDEX == config.noc (see kernel.cpp), so two dedicated-NOC kernels
+    //      pinned to the same NOC deadlock the device. This restores the guarantee the legacy
+    //      CheckDataMovementConfig enforced and that KernelGroup finalize still relies on ("safe
+    //      due to prior correctness validation"). DM_DYNAMIC_NOC kernels are exempt: they may
+    //      intentionally share a NOC, freeing the other NOC for fabric.
+    // (Each kernel's effective node set is derived from WorkUnitSpec membership.)
     if (is_gen1_arch()) {
-        // Maps (node, processor) -> the kernel that already claimed it
-        std::map<std::pair<NodeCoord, DataMovementProcessor>, KernelSpecName> claimed;
+        // (node, processor) -> the kernel that already claimed it.
+        std::map<std::pair<NodeCoord, DataMovementProcessor>, KernelSpecName> claimed_processor;
+        // (node, noc) -> the kernel that already claimed it (dedicated-NOC kernels only).
+        std::map<std::pair<NodeCoord, NOC>, KernelSpecName> claimed_noc;
         for (const auto& kernel : spec.kernels) {
             if (!kernel.is_data_movement_kernel()) {
                 continue;
@@ -884,15 +893,31 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             const NodeRangeSet& nodes = collected.kernel_node_set.at(kernel.unique_id);
             for (const auto& range : nodes.ranges()) {
                 for (const auto& node : range) {
-                    auto key = std::make_pair(node, gen1.processor);
-                    auto [it, inserted] = claimed.try_emplace(key, kernel.unique_id);
+                    auto [proc_it, proc_inserted] =
+                        claimed_processor.try_emplace(std::make_pair(node, gen1.processor), kernel.unique_id);
                     TT_FATAL(
-                        inserted,
+                        proc_inserted,
                         "KernelSpec '{}' conflicts with '{}' on node ({}, {}): both claim the same DM processor. ",
                         kernel.unique_id,
-                        it->second,
+                        proc_it->second,
                         node.x,
                         node.y);
+
+                    // NOC-distinctness applies only to statically-pinned (dedicated-NOC) kernels.
+                    if (gen1.noc_mode == NOC_MODE::DM_DEDICATED_NOC) {
+                        auto [noc_it, noc_inserted] =
+                            claimed_noc.try_emplace(std::make_pair(node, gen1.noc), kernel.unique_id);
+                        TT_FATAL(
+                            noc_inserted,
+                            "KernelSpec '{}' conflicts with '{}' on node ({}, {}): both are dedicated-NOC data "
+                            "movement kernels pinned to NOC_{}, which hangs the device. Give them distinct NOCs, or "
+                            "use DM_DYNAMIC_NOC mode to intentionally share a NOC.",
+                            kernel.unique_id,
+                            noc_it->second,
+                            node.x,
+                            node.y,
+                            static_cast<int>(gen1.noc));
+                    }
                 }
             }
         }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
On Gen1 (WH/BH), the DM config allows a power user to specify:
 - **DM core**: RISCV_0 or RISCV_1
 - **NOC**: NOC_0 or NOC_1
 - **noc_mode**: dedicated or dynamic 

However, this requires some legality checks:

1. Two DM kernels on a node must be configured to run on opposite cores.
2. The RISCV_2+ enums are Quasar-only; these are illegal on Gen1.
3. If the `noc_mode` is dedicated, each DM kernel must be assigned a different NOC. (Two dedicated-NOC DM kernels on the same node pinned to the same NOC can hang the device.)
4. Both DM kernels on a node must configure the same `noc_mode`.

In Metal 2.0, only 1 was checked; 2 - 4 were missing. This PR adds the missing legality checks and adds unit tests for these. Note that an illegal configuration was being used by some of the existing Metal 2.0 unit tests; those are fixed.

### Notes for reviewers
I discovered that the legacy checks for item 3 exist, but are buggy. I don't think they ever actually worked properly. I've run a scan to ensure that this new legality check doesn't break anything existing on Metal 2.0.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/add-noc-legality-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/add-noc-legality-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/add-noc-legality-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/add-noc-legality-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/add-noc-legality-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/add-noc-legality-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/add-noc-legality-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/add-noc-legality-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/add-noc-legality-check)