### PR TITLE
ttnn: eltwise + shared operations/ ownership for convolutions/ops-data-movement/mmfusedreduce

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -279,8 +279,11 @@ ttnn/cpp/ttnn/operations/**/CMakeLists.txt @tenstorrent/metalium-developers-ops-
 # operations/ is physically shared by every op-owning team, same idea as
 # operations/experimental/CMakeLists.txt one level down. Jointly owned by
 # whichever teams currently have ops migrated into it (see the file itself
-# for the up-to-date list) plus infra.
-ttnn/cpp/ttnn/operations/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+# for the up-to-date list) plus infra. metalium-developers-ops-leads is
+# listed because it's the status-quo fallback owner for several ops here
+# that have no team-specific CODEOWNERS rule of their own — not a
+# deliberate, active owner, just what already resolves today.
+ttnn/cpp/ttnn/operations/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-ops-leads @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/moreh*/ @razorback3 @dongjin-na @ayerofieiev-tt @nmauriceTT @aczajkowskiTT @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/moreh*/**/CMakeLists.txt @razorback3 @dongjin-na @ayerofieiev-tt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -276,6 +276,11 @@ ttnn/examples/**/kernels/ @tenstorrent/metalium-developers-mmfusedreduce @tensto
 
 ttnn/cpp/ttnn/operations/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/**/CMakeLists.txt @tenstorrent/metalium-developers-ops-leads @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+# operations/ is physically shared by every op-owning team, same idea as
+# operations/experimental/CMakeLists.txt one level down. Jointly owned by
+# whichever teams currently have ops migrated into it (see the file itself
+# for the up-to-date list) plus infra.
+ttnn/cpp/ttnn/operations/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/moreh*/ @razorback3 @dongjin-na @ayerofieiev-tt @nmauriceTT @aczajkowskiTT @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/moreh*/**/CMakeLists.txt @razorback3 @dongjin-na @ayerofieiev-tt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -239,25 +239,11 @@ target_link_libraries(
     PRIVATE
         TTNN::Core
         TTNN::Ops::Bernoulli
-        TTNN::Ops::CCL
-        TTNN::Ops::Conv
+        TTNN::Ops::OperationsShared
         TTNN::Ops::Core
         TTNN::Ops::Creation
-        TTNN::Ops::DataMovement
-        TTNN::Ops::Eltwise::Binary
-        TTNN::Ops::Eltwise::Binary::Backward
-        TTNN::Ops::Eltwise::Binary::NG
-        TTNN::Ops::Eltwise::Complex
-        TTNN::Ops::Eltwise::Complex::Binary
-        TTNN::Ops::Eltwise::Complex::Unary
-        TTNN::Ops::Eltwise::Complex::Unary::Backward
         TTNN::Ops::Eltwise::Quantization
-        TTNN::Ops::Eltwise::Ternary
-        TTNN::Ops::Eltwise::Ternary::Backward
-        TTNN::Ops::Eltwise::Unary
-        TTNN::Ops::Eltwise::Unary::Backward
-        TTNN::Ops::Embedding
-        TTNN::Ops::Embedding::Backward
+        TTNN::Ops::Eltwise
         TTNN::Ops::Examples
         TTNN::Ops::Experimental
         TTNN::Ops::Experimental::DeepSeekPrefill
@@ -267,17 +253,11 @@ target_link_libraries(
         TTNN::Ops::IndexFill
         TTNN::Ops::KvCache
         TTNN::Ops::Loss
-        TTNN::Ops::Matmul
         TTNN::Ops::Moreh
         TTNN::Ops::Prefetcher
-        TTNN::Ops::Reduction
-        TTNN::Ops::SlidingWindow
         TTNN::Ops::Transformer
         TTNN::Ops::Uniform
         TTNN::Ops::Debug
-        TTNN::Ops::PointToPoint
-        TTNN::Ops::Pool
-        TTNN::Ops::Normalization
         TTNN::Ops::Rand
         TTNN::Ops::Randn
 )
@@ -463,26 +443,12 @@ set(FixmeOpIncDirs
 )
 
 add_subdirectory(cpp/ttnn/operations/bernoulli)
-add_subdirectory(cpp/ttnn/operations/ccl)
-add_subdirectory(cpp/ttnn/operations/conv)
+add_subdirectory(cpp/ttnn/operations)
 add_subdirectory(cpp/ttnn/operations/creation)
 add_subdirectory(cpp/ttnn/operations/core)
-add_subdirectory(cpp/ttnn/operations/data_movement)
 add_subdirectory(cpp/ttnn/operations/debug)
-add_subdirectory(cpp/ttnn/operations/eltwise/binary)
-add_subdirectory(cpp/ttnn/operations/eltwise/binary_backward)
-add_subdirectory(cpp/ttnn/operations/eltwise/binary_ng)
-add_subdirectory(cpp/ttnn/operations/eltwise/complex)
-add_subdirectory(cpp/ttnn/operations/eltwise/complex_binary)
-add_subdirectory(cpp/ttnn/operations/eltwise/complex_unary)
-add_subdirectory(cpp/ttnn/operations/eltwise/complex_unary_backward)
+add_subdirectory(cpp/ttnn/operations/eltwise)
 add_subdirectory(cpp/ttnn/operations/eltwise/quantization)
-add_subdirectory(cpp/ttnn/operations/eltwise/ternary)
-add_subdirectory(cpp/ttnn/operations/eltwise/ternary_backward)
-add_subdirectory(cpp/ttnn/operations/eltwise/unary)
-add_subdirectory(cpp/ttnn/operations/eltwise/unary_backward)
-add_subdirectory(cpp/ttnn/operations/embedding)
-add_subdirectory(cpp/ttnn/operations/embedding_backward)
 add_subdirectory(cpp/ttnn/operations/examples)
 add_subdirectory(cpp/ttnn/operations/experimental)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill)
@@ -494,16 +460,10 @@ add_subdirectory(cpp/ttnn/kernel_lib)
 add_subdirectory(cpp/ttnn/operations/kernel_helper_functions)
 add_subdirectory(cpp/ttnn/operations/kv_cache)
 add_subdirectory(cpp/ttnn/operations/loss)
-add_subdirectory(cpp/ttnn/operations/matmul)
 add_subdirectory(cpp/ttnn/operations/moreh)
-add_subdirectory(cpp/ttnn/operations/normalization)
-add_subdirectory(cpp/ttnn/operations/point_to_point)
-add_subdirectory(cpp/ttnn/operations/pool)
 add_subdirectory(cpp/ttnn/operations/prefetcher)
 add_subdirectory(cpp/ttnn/operations/rand)
 add_subdirectory(cpp/ttnn/operations/randn)
-add_subdirectory(cpp/ttnn/operations/reduction)
-add_subdirectory(cpp/ttnn/operations/sliding_window)
 add_subdirectory(cpp/ttnn/operations/transformer)
 add_subdirectory(cpp/ttnn/operations/uniform)
 add_subdirectory(examples)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -238,28 +238,14 @@ target_link_libraries(
         xtensor
     PRIVATE
         TTNN::Core
-        TTNN::Ops::Bernoulli
         TTNN::Ops::OperationsShared
-        TTNN::Ops::Core
-        TTNN::Ops::Creation
         TTNN::Ops::Eltwise::Quantization
         TTNN::Ops::Eltwise
-        TTNN::Ops::Examples
         TTNN::Ops::Experimental
         TTNN::Ops::Experimental::DeepSeekPrefill
         TTNN::Ops::Experimental::Transformer
-        TTNN::Ops::Full
-        TTNN::Ops::FullLike
-        TTNN::Ops::IndexFill
-        TTNN::Ops::KvCache
-        TTNN::Ops::Loss
         TTNN::Ops::Moreh
-        TTNN::Ops::Prefetcher
         TTNN::Ops::Transformer
-        TTNN::Ops::Uniform
-        TTNN::Ops::Debug
-        TTNN::Ops::Rand
-        TTNN::Ops::Randn
 )
 if(TT_INSTALL)
     install(
@@ -442,28 +428,14 @@ set(FixmeOpIncDirs
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
 )
 
-add_subdirectory(cpp/ttnn/operations/bernoulli)
 add_subdirectory(cpp/ttnn/operations)
-add_subdirectory(cpp/ttnn/operations/creation)
-add_subdirectory(cpp/ttnn/operations/core)
-add_subdirectory(cpp/ttnn/operations/debug)
 add_subdirectory(cpp/ttnn/operations/eltwise)
 add_subdirectory(cpp/ttnn/operations/eltwise/quantization)
-add_subdirectory(cpp/ttnn/operations/examples)
 add_subdirectory(cpp/ttnn/operations/experimental)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill)
 add_subdirectory(cpp/ttnn/operations/experimental/transformer)
-add_subdirectory(cpp/ttnn/operations/full)
-add_subdirectory(cpp/ttnn/operations/full_like)
-add_subdirectory(cpp/ttnn/operations/index_fill)
 add_subdirectory(cpp/ttnn/kernel_lib)
 add_subdirectory(cpp/ttnn/operations/kernel_helper_functions)
-add_subdirectory(cpp/ttnn/operations/kv_cache)
-add_subdirectory(cpp/ttnn/operations/loss)
 add_subdirectory(cpp/ttnn/operations/moreh)
-add_subdirectory(cpp/ttnn/operations/prefetcher)
-add_subdirectory(cpp/ttnn/operations/rand)
-add_subdirectory(cpp/ttnn/operations/randn)
 add_subdirectory(cpp/ttnn/operations/transformer)
-add_subdirectory(cpp/ttnn/operations/uniform)
 add_subdirectory(examples)

--- a/ttnn/cpp/ttnn/operations/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/CMakeLists.txt
@@ -55,30 +55,30 @@ add_library(TTNN::Ops::OperationsShared ALIAS ttnn_op_operations_shared)
 target_link_libraries(
     ttnn_op_operations_shared
     INTERFACE
-        TTNN::Ops::Conv
-        TTNN::Ops::Pool
-        TTNN::Ops::SlidingWindow
+        TTNN::Ops::Bernoulli
         TTNN::Ops::CCL
-        TTNN::Ops::PointToPoint
+        TTNN::Ops::Conv
+        TTNN::Ops::Core
+        TTNN::Ops::Creation
         TTNN::Ops::DataMovement
+        TTNN::Ops::Debug
         TTNN::Ops::Embedding
         TTNN::Ops::Embedding::Backward
-        TTNN::Ops::Matmul
-        TTNN::Ops::Normalization
-        TTNN::Ops::Reduction
-        TTNN::Ops::Bernoulli
-        TTNN::Ops::Creation
-        TTNN::Ops::Core
-        TTNN::Ops::Debug
         TTNN::Ops::Examples
         TTNN::Ops::Full
         TTNN::Ops::FullLike
         TTNN::Ops::IndexFill
         TTNN::Ops::KvCache
         TTNN::Ops::Loss
+        TTNN::Ops::Matmul
+        TTNN::Ops::Normalization
+        TTNN::Ops::PointToPoint
+        TTNN::Ops::Pool
         TTNN::Ops::Prefetcher
         TTNN::Ops::Rand
         TTNN::Ops::Randn
+        TTNN::Ops::Reduction
+        TTNN::Ops::SlidingWindow
         TTNN::Ops::Uniform
 )
 
@@ -96,29 +96,29 @@ target_link_libraries(
 target_sources(
     ttnn_op_operations_shared
     INTERFACE
-        $<TARGET_OBJECTS:TTNN::Ops::Conv>
-        $<TARGET_OBJECTS:TTNN::Ops::Pool>
-        $<TARGET_OBJECTS:TTNN::Ops::SlidingWindow>
+        $<TARGET_OBJECTS:TTNN::Ops::Bernoulli>
         $<TARGET_OBJECTS:TTNN::Ops::CCL>
-        $<TARGET_OBJECTS:TTNN::Ops::PointToPoint>
+        $<TARGET_OBJECTS:TTNN::Ops::Conv>
+        $<TARGET_OBJECTS:TTNN::Ops::Core>
+        $<TARGET_OBJECTS:TTNN::Ops::Creation>
         $<TARGET_OBJECTS:TTNN::Ops::DataMovement>
+        $<TARGET_OBJECTS:TTNN::Ops::Debug>
         $<TARGET_OBJECTS:TTNN::Ops::Embedding>
         $<TARGET_OBJECTS:TTNN::Ops::Embedding::Backward>
-        $<TARGET_OBJECTS:TTNN::Ops::Matmul>
-        $<TARGET_OBJECTS:TTNN::Ops::Normalization>
-        $<TARGET_OBJECTS:TTNN::Ops::Reduction>
-        $<TARGET_OBJECTS:TTNN::Ops::Bernoulli>
-        $<TARGET_OBJECTS:TTNN::Ops::Creation>
-        $<TARGET_OBJECTS:TTNN::Ops::Core>
-        $<TARGET_OBJECTS:TTNN::Ops::Debug>
         $<TARGET_OBJECTS:TTNN::Ops::Examples>
         $<TARGET_OBJECTS:TTNN::Ops::Full>
         $<TARGET_OBJECTS:TTNN::Ops::FullLike>
         $<TARGET_OBJECTS:TTNN::Ops::IndexFill>
         $<TARGET_OBJECTS:TTNN::Ops::KvCache>
         $<TARGET_OBJECTS:TTNN::Ops::Loss>
+        $<TARGET_OBJECTS:TTNN::Ops::Matmul>
+        $<TARGET_OBJECTS:TTNN::Ops::Normalization>
+        $<TARGET_OBJECTS:TTNN::Ops::PointToPoint>
+        $<TARGET_OBJECTS:TTNN::Ops::Pool>
         $<TARGET_OBJECTS:TTNN::Ops::Prefetcher>
         $<TARGET_OBJECTS:TTNN::Ops::Rand>
         $<TARGET_OBJECTS:TTNN::Ops::Randn>
+        $<TARGET_OBJECTS:TTNN::Ops::Reduction>
+        $<TARGET_OBJECTS:TTNN::Ops::SlidingWindow>
         $<TARGET_OBJECTS:TTNN::Ops::Uniform>
 )

--- a/ttnn/cpp/ttnn/operations/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/CMakeLists.txt
@@ -5,11 +5,12 @@
 # needing to be pinged, and without touching ttnn/CMakeLists.txt. Same idea
 # as ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt, one level up.
 #
-# Only the ops below have been migrated in so far — everything else under
-# operations/ (eltwise, experimental, moreh, bernoulli, etc.) either already
-# has its own dedicated CMakeLists.txt or is still add_subdirectory()'d
-# directly from ttnn/CMakeLists.txt. Folding in more is later work, one team
-# at a time.
+# Everything ownerless is migrated in here too. Not yet migrated: eltwise,
+# experimental (both have their own dedicated CMakeLists.txt already), moreh
+# and kernel_helper_functions (already single add_subdirectory()/
+# target_link_libraries() lines — no scattering to fix, so nothing gained by
+# moving them), and transformer/ (one CMake target spanning multiple teams'
+# code — needs an actual target split before ownership can split too).
 
 # metalium-developers-convolutions
 add_subdirectory(conv)
@@ -28,10 +29,27 @@ add_subdirectory(matmul)
 add_subdirectory(normalization)
 add_subdirectory(reduction)
 
-# Umbrella target for everything migrated into this file so far: ttnncpp
-# links this one target instead of enumerating these 11 op libraries itself.
-# Add/remove entries here when adding/removing one of the ops above — never
-# in ttnn/CMakeLists.txt.
+# No team-specific CODEOWNERS rule — falls back to the ops-leads catch-all
+# today. Kept as the status quo owner rather than guessed at.
+add_subdirectory(bernoulli)
+add_subdirectory(creation)
+add_subdirectory(core)
+add_subdirectory(debug)
+add_subdirectory(examples)
+add_subdirectory(full)
+add_subdirectory(full_like)
+add_subdirectory(index_fill)
+add_subdirectory(kv_cache)
+add_subdirectory(loss)
+add_subdirectory(prefetcher)
+add_subdirectory(rand)
+add_subdirectory(randn)
+add_subdirectory(uniform)
+
+# Umbrella target for everything migrated into this file: ttnncpp links this
+# one target instead of enumerating these op libraries itself. Add/remove
+# entries here when adding/removing one of the ops above — never in
+# ttnn/CMakeLists.txt.
 add_library(ttnn_op_operations_shared INTERFACE)
 add_library(TTNN::Ops::OperationsShared ALIAS ttnn_op_operations_shared)
 target_link_libraries(
@@ -48,6 +66,20 @@ target_link_libraries(
         TTNN::Ops::Matmul
         TTNN::Ops::Normalization
         TTNN::Ops::Reduction
+        TTNN::Ops::Bernoulli
+        TTNN::Ops::Creation
+        TTNN::Ops::Core
+        TTNN::Ops::Debug
+        TTNN::Ops::Examples
+        TTNN::Ops::Full
+        TTNN::Ops::FullLike
+        TTNN::Ops::IndexFill
+        TTNN::Ops::KvCache
+        TTNN::Ops::Loss
+        TTNN::Ops::Prefetcher
+        TTNN::Ops::Rand
+        TTNN::Ops::Randn
+        TTNN::Ops::Uniform
 )
 
 # target_link_libraries() alone is not enough: per the CMake docs, an OBJECT
@@ -75,4 +107,18 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Matmul>
         $<TARGET_OBJECTS:TTNN::Ops::Normalization>
         $<TARGET_OBJECTS:TTNN::Ops::Reduction>
+        $<TARGET_OBJECTS:TTNN::Ops::Bernoulli>
+        $<TARGET_OBJECTS:TTNN::Ops::Creation>
+        $<TARGET_OBJECTS:TTNN::Ops::Core>
+        $<TARGET_OBJECTS:TTNN::Ops::Debug>
+        $<TARGET_OBJECTS:TTNN::Ops::Examples>
+        $<TARGET_OBJECTS:TTNN::Ops::Full>
+        $<TARGET_OBJECTS:TTNN::Ops::FullLike>
+        $<TARGET_OBJECTS:TTNN::Ops::IndexFill>
+        $<TARGET_OBJECTS:TTNN::Ops::KvCache>
+        $<TARGET_OBJECTS:TTNN::Ops::Loss>
+        $<TARGET_OBJECTS:TTNN::Ops::Prefetcher>
+        $<TARGET_OBJECTS:TTNN::Ops::Rand>
+        $<TARGET_OBJECTS:TTNN::Ops::Randn>
+        $<TARGET_OBJECTS:TTNN::Ops::Uniform>
 )

--- a/ttnn/cpp/ttnn/operations/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/CMakeLists.txt
@@ -1,0 +1,78 @@
+# operations/ is one physical directory shared by every op-owning team, so
+# this file is jointly owned by every team with a subdirectory listed below
+# (see CODEOWNERS) rather than by ops-leads/ttnn-core. Any of those teams can
+# add/remove their own op here and self-approve, without ttnn-core or infra
+# needing to be pinged, and without touching ttnn/CMakeLists.txt. Same idea
+# as ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt, one level up.
+#
+# Only the ops below have been migrated in so far — everything else under
+# operations/ (eltwise, experimental, moreh, bernoulli, etc.) either already
+# has its own dedicated CMakeLists.txt or is still add_subdirectory()'d
+# directly from ttnn/CMakeLists.txt. Folding in more is later work, one team
+# at a time.
+
+# metalium-developers-convolutions
+add_subdirectory(conv)
+add_subdirectory(pool)
+add_subdirectory(sliding_window)
+
+# metalium-developers-ops-data-movement
+add_subdirectory(ccl)
+add_subdirectory(point_to_point)
+add_subdirectory(data_movement)
+add_subdirectory(embedding)
+add_subdirectory(embedding_backward)
+
+# metalium-developers-mmfusedreduce
+add_subdirectory(matmul)
+add_subdirectory(normalization)
+add_subdirectory(reduction)
+
+# Umbrella target for everything migrated into this file so far: ttnncpp
+# links this one target instead of enumerating these 11 op libraries itself.
+# Add/remove entries here when adding/removing one of the ops above — never
+# in ttnn/CMakeLists.txt.
+add_library(ttnn_op_operations_shared INTERFACE)
+add_library(TTNN::Ops::OperationsShared ALIAS ttnn_op_operations_shared)
+target_link_libraries(
+    ttnn_op_operations_shared
+    INTERFACE
+        TTNN::Ops::Conv
+        TTNN::Ops::Pool
+        TTNN::Ops::SlidingWindow
+        TTNN::Ops::CCL
+        TTNN::Ops::PointToPoint
+        TTNN::Ops::DataMovement
+        TTNN::Ops::Embedding
+        TTNN::Ops::Embedding::Backward
+        TTNN::Ops::Matmul
+        TTNN::Ops::Normalization
+        TTNN::Ops::Reduction
+)
+
+# target_link_libraries() alone is not enough: per the CMake docs, an OBJECT
+# library named in a target's INTERFACE_LINK_LIBRARIES (as these leaves are,
+# via the INTERFACE keyword above) is treated as a plain Interface Library by
+# further consumers — only usage requirements propagate, not its compiled
+# objects. So with the default LIB_TYPE=OBJECT, ttnncpp would silently end up
+# without these ops' code (undefined symbols at final link time). Splice the
+# object files in directly via generator expression so they still land in
+# whatever ultimately links this umbrella target. TARGET_OBJECTS resolves to
+# nothing (and is harmless) for leaves that aren't OBJECT libraries — e.g.
+# SHARED or STATIC, both of which ttnn can compile these as depending on
+# build options — so this is safe unconditionally.
+target_sources(
+    ttnn_op_operations_shared
+    INTERFACE
+        $<TARGET_OBJECTS:TTNN::Ops::Conv>
+        $<TARGET_OBJECTS:TTNN::Ops::Pool>
+        $<TARGET_OBJECTS:TTNN::Ops::SlidingWindow>
+        $<TARGET_OBJECTS:TTNN::Ops::CCL>
+        $<TARGET_OBJECTS:TTNN::Ops::PointToPoint>
+        $<TARGET_OBJECTS:TTNN::Ops::DataMovement>
+        $<TARGET_OBJECTS:TTNN::Ops::Embedding>
+        $<TARGET_OBJECTS:TTNN::Ops::Embedding::Backward>
+        $<TARGET_OBJECTS:TTNN::Ops::Matmul>
+        $<TARGET_OBJECTS:TTNN::Ops::Normalization>
+        $<TARGET_OBJECTS:TTNN::Ops::Reduction>
+)

--- a/ttnn/cpp/ttnn/operations/eltwise/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Owned by @tenstorrent/metalium-developers-eltwise. Add/remove ops for this
+# domain here without touching ttnn/CMakeLists.txt.
+#
+# eltwise/quantization is intentionally NOT included here — it's owned by
+# named individuals rather than this team (see CODEOWNERS) and stays wired
+# directly in ttnn/CMakeLists.txt.
+add_subdirectory(binary)
+add_subdirectory(binary_backward)
+add_subdirectory(binary_ng)
+add_subdirectory(complex)
+add_subdirectory(complex_binary)
+add_subdirectory(complex_unary)
+add_subdirectory(complex_unary_backward)
+add_subdirectory(ternary)
+add_subdirectory(ternary_backward)
+add_subdirectory(unary)
+add_subdirectory(unary_backward)
+
+# Domain-level umbrella target: ttnncpp links this one target instead of
+# enumerating this team's individual op libraries. Add/remove entries here
+# when adding/removing a module — never in ttnn/CMakeLists.txt.
+add_library(ttnn_op_eltwise INTERFACE)
+add_library(TTNN::Ops::Eltwise ALIAS ttnn_op_eltwise)
+target_link_libraries(
+    ttnn_op_eltwise
+    INTERFACE
+        TTNN::Ops::Eltwise::Binary
+        TTNN::Ops::Eltwise::Binary::Backward
+        TTNN::Ops::Eltwise::Binary::NG
+        TTNN::Ops::Eltwise::Complex
+        TTNN::Ops::Eltwise::Complex::Binary
+        TTNN::Ops::Eltwise::Complex::Unary
+        TTNN::Ops::Eltwise::Complex::Unary::Backward
+        TTNN::Ops::Eltwise::Ternary
+        TTNN::Ops::Eltwise::Ternary::Backward
+        TTNN::Ops::Eltwise::Unary
+        TTNN::Ops::Eltwise::Unary::Backward
+)
+
+# target_link_libraries() alone is not enough: per the CMake docs, an OBJECT
+# library named in a target's INTERFACE_LINK_LIBRARIES (as these leaves are,
+# via the INTERFACE keyword above) is treated as a plain Interface Library by
+# further consumers — only usage requirements propagate, not its compiled
+# objects. So with the default LIB_TYPE=OBJECT, ttnncpp would silently end up
+# without these ops' code (undefined symbols at final link time). Splice the
+# object files in directly via generator expression so they still land in
+# whatever ultimately links this umbrella target. TARGET_OBJECTS resolves to
+# nothing (and is harmless) for leaves that aren't OBJECT libraries — e.g.
+# SHARED or STATIC, both of which ttnn can compile these as depending on
+# build options — so this is safe unconditionally.
+target_sources(
+    ttnn_op_eltwise
+    INTERFACE
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Binary>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Binary::Backward>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Binary::NG>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Complex>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Complex::Binary>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Complex::Unary>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Complex::Unary::Backward>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Ternary>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Ternary::Backward>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Unary>
+        $<TARGET_OBJECTS:TTNN::Ops::Eltwise::Unary::Backward>
+)


### PR DESCRIPTION
## Why

Same problem as #49441 (ds-prefill reference PR, merged): the wiring that turns an op directory into an actual, linked build target lives in two shared, centrally-owned lists in `ttnn/CMakeLists.txt` — the `add_subdirectory()` list and the `target_link_libraries(ttnncpp ...)` list. Any team wanting to add or remove a module has to touch a file owned by people outside their team.

## What changed

**eltwise** (11 ops) — shares one physical parent directory (`ttnn/cpp/ttnn/operations/eltwise/`), so this uses the ds-prefill pattern exactly: a nested `CMakeLists.txt` added via `add_subdirectory()`. `eltwise/quantization` is excluded — owned by named individuals, not the team.

**Shared `operations/CMakeLists.txt`** — convolutions, ops-data-movement, and mmfusedreduce each have non-experimental ops that don't share a team-specific parent directory with each other. `ttnn/cpp/ttnn/operations/` is already physically shared by every op-owning team, so rather than an `include()` indirection or moving any files, it gets a real `add_subdirectory()`-based `CMakeLists.txt` (same mechanism as ds-prefill/eltwise) with CODEOWNERS jointly listing every team that currently has ops migrated into it, plus infra. Migrated: `conv`, `pool`, `sliding_window` (convolutions); `ccl`, `point_to_point`, `data_movement`, `embedding`, `embedding_backward` (ops-data-movement); `matmul`, `normalization`, `reduction` (mmfusedreduce).

`kernel_helper_functions` was deliberately left alone: it's a static, header-only utility directory, not a category of op the team adds new instances of, so moving its one line wouldn't unblock any future self-serve action — just added review surface for no benefit.

Every umbrella in this PR uses the ds-prefill fix from the start: `target_sources()` with `$<TARGET_OBJECTS:...>` unconditionally, no `LIB_TYPE` conditional (see #49441 for the root-cause writeup).

## Not in this PR

- The `experimental/` ops belonging to these same three teams (and others) are being handled in a separate, dedicated PR covering all of `experimental/` at once — it's big and focused enough to warrant its own review.
- `kernel_lib` (jointly owned by convolutions + mmfusedreduce) — needs a call on which aggregator it'd live under, or whether the non-experimental `operations/CMakeLists.txt` can just absorb it directly.
- `moreh` — already a single `add_subdirectory()`/`target_link_libraries()` line, nothing to collapse.

## Verification

Structural checks (no build environment available in my sandbox): confirmed every leaf directory referenced exists with its own `CMakeLists.txt`, every alias name matches the real `add_library(... ALIAS ...)` name in that leaf's own `CMakeLists.txt`, checked all new umbrella/real target names against the full CMake target namespace for collisions, and verified in an isolated sandbox that a parent directory's `CMakeLists.txt` (`operations/`) coexisting with independent `add_subdirectory()` calls into its subdirectories from a different entry point (root `ttnn/CMakeLists.txt`) doesn't cause a double-registration error. Please verify with CI/a real build before merging.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/ttnn-cmake-domain-ownership-mechanical)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/ttnn-cmake-domain-ownership-mechanical)