### PR TITLE
[Bug Fix]: Fix watcher Tile Counter test hang

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -228,6 +228,9 @@ protected:
     bool watcher_previous_assert_disabled_{};
 
     void SetUp() override {
+        // Save before the skip check: TearDown() runs even when SetUp() skips, so the
+        // restore must be based on the real previous state regardless of skip.
+        watcher_previous_assert_disabled_ = MetalContext::instance().rtoptions().watcher_assert_disabled();
         if (!MetalContext::instance().hal().has_tile_counter_registers()) {
             GTEST_SKIP() << "Tile counters are only used on Quasar";
         }
@@ -236,7 +239,6 @@ protected:
         // TILE_COUNTERS fault, which writes to the watcher mailbox and hangs. Disabling
         // assert here makes ASSERT a no-op so the ISR clears the interrupt and returns,
         // allowing the test to verify that watcher logs the TC mismatch correctly.
-        watcher_previous_assert_disabled_ = MetalContext::instance().rtoptions().watcher_assert_disabled();
         if (!watcher_previous_assert_disabled_) {
             MetalContext::instance().rtoptions().disable_watcher_assert();
         }

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -222,6 +222,35 @@ protected:
     }
 };
 
+// Fixture for tile counter watcher tests.
+class MeshWatcherTileCounterFixture : public MeshWatcherDumpAllFixture {
+protected:
+    bool watcher_previous_assert_disabled_{};
+
+    void SetUp() override {
+        if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+            GTEST_SKIP() << "Tile counters are only used on Quasar";
+        }
+        // Must be set before parent SetUp: the TRISC HW fault ISR (handle_interrupt in
+        // risc_common.h, compiled as part of trisc.cc firmware) calls ASSERT on a
+        // TILE_COUNTERS fault, which writes to the watcher mailbox and hangs. Disabling
+        // assert here makes ASSERT a no-op so the ISR clears the interrupt and returns,
+        // allowing the test to verify that watcher logs the TC mismatch correctly.
+        watcher_previous_assert_disabled_ = MetalContext::instance().rtoptions().watcher_assert_disabled();
+        if (!watcher_previous_assert_disabled_) {
+            MetalContext::instance().rtoptions().disable_watcher_assert();
+        }
+        MeshWatcherDumpAllFixture::SetUp();
+    }
+
+    void TearDown() override {
+        MeshWatcherDumpAllFixture::TearDown();
+        if (!watcher_previous_assert_disabled_) {
+            MetalContext::instance().rtoptions().enable_watcher_assert();
+        }
+    }
+};
+
 class DevicePrintFixture : public DebugToolsMeshFixture {
 protected:
     int memfd_;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -184,11 +184,7 @@ void RunTest(
 }
 
 // Test bypass mode (strided consumer access pattern)
-TEST_F(MeshWatcherDumpAllFixture, TestWatcherTileCounterLogBypass) {
-    const auto& hal = MetalContext::instance().hal();
-    if (!hal.has_tile_counter_registers()) {
-        GTEST_SKIP() << "Tile counters are only used on Quasar";
-    }
+TEST_F(MeshWatcherTileCounterFixture, TestWatcherTileCounterLogBypass) {
     for (auto& mesh_device : this->devices_) {
         this->RunTestOnDevice(
             [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
@@ -199,11 +195,7 @@ TEST_F(MeshWatcherDumpAllFixture, TestWatcherTileCounterLogBypass) {
 }
 
 // Test remapper mode (blocked consumer access pattern)
-TEST_F(MeshWatcherDumpAllFixture, TestWatcherTileCounterLogRemapper) {
-    const auto& hal = MetalContext::instance().hal();
-    if (!hal.has_tile_counter_registers()) {
-        GTEST_SKIP() << "Tile counters are only used on Quasar";
-    }
+TEST_F(MeshWatcherTileCounterFixture, TestWatcherTileCounterLogRemapper) {
     for (auto& mesh_device : this->devices_) {
         this->RunTestOnDevice(
             [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -470,6 +470,9 @@ public:
     bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }
     void disable_watcher_noc_sanitize() { watcher_disabled_features.insert(watcher_noc_sanitize_str); }
 
+    void disable_watcher_assert() { watcher_disabled_features.insert(watcher_assert_str); }
+    void enable_watcher_assert() { watcher_disabled_features.erase(watcher_assert_str); }
+
     bool get_lightweight_kernel_asserts() const { return lightweight_kernel_asserts; }
     void set_lightweight_kernel_asserts(bool enabled) { lightweight_kernel_asserts = enabled; }
 


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/44129

The watcher tile counter test was hanging after `wait_front/pop_front` on running consumers. The `TILE_COUNTERS` hardware fault fires on running consumers during DFB consumption. The TRISC HW fault ISR (handle_interrupt in `risc_common.h`) calls watcher `ASSERT()` which spins forever causing the TRISC to hang.

Changes:
- Added `disable_watcher_assert()` / `enable_watcher_assert()` to rtoptions.
- In `MeshWatcherTileCounterFixture::SetUp()`, save and disable watcher assert before calling parent `SetUp()`, so firmware is compiled without it, making the ISR a no-op that clears the interrupt and returns instead of hanging.

### Notes for reviewers
- The ordering in `MeshWatcherTileCounterFixture::SetUp()` is load-bearing: `disable_watcher_assert()` 
must come before the parent `SetUp()` call because firmware is compiled during device initialization. Setting the flag afterward leaves the ISR compiled with the real  `assert_and_hang()`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_watcher_tc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_watcher_tc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/fix_watcher_tc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_watcher_tc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_watcher_tc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_watcher_tc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_watcher_tc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_watcher_tc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_watcher_tc_tests)