### PR TITLE
ttnn: shared-ownership CMakeLists.txt for all of experimental/'s movable ops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -301,6 +301,12 @@ ttnn/cpp/ttnn/operations/kernel_helper_functions/**/CMakeLists.txt @tenstorrent/
 ttnn/cpp/ttnn/operations/matmul/**/CMakeLists.txt @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/kernel_lib/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/kernel_lib/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+# experimental/ is physically shared by many teams. Its top-level
+# CMakeLists.txt is jointly owned by whichever teams/individuals currently
+# have ops migrated into it (see the file itself for the up-to-date list)
+# plus infra, so no single team (or ttnn-core) has to be pinged to add/remove
+# one of their own ops there.
+ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-sdpa @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-developers-external-experience @cglagovichTT @jonathansuTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/adaptive_pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/adaptive_pool/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass @jonathansuTT

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -305,8 +305,11 @@ ttnn/cpp/ttnn/kernel_lib/**/CMakeLists.txt @tenstorrent/metalium-developers-conv
 # CMakeLists.txt is jointly owned by whichever teams/individuals currently
 # have ops migrated into it (see the file itself for the up-to-date list)
 # plus infra, so no single team (or ttnn-core) has to be pinged to add/remove
-# one of their own ops there.
-ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-sdpa @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-developers-external-experience @cglagovichTT @jonathansuTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+# one of their own ops there. metalium-developers-ops-leads is listed because
+# it's the status-quo fallback owner for several ops here that have no
+# team-specific CODEOWNERS rule of their own — not a deliberate, active
+# owner, just what already resolves today.
+ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-sdpa @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-developers-external-experience @cglagovichTT @jonathansuTT @tenstorrent/metalium-developers-ops-leads @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/adaptive_pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/adaptive_pool/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass @jonathansuTT

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -260,24 +260,8 @@ target_link_libraries(
         TTNN::Ops::Embedding::Backward
         TTNN::Ops::Examples
         TTNN::Ops::Experimental
-        TTNN::Ops::Experimental::BcastTo
-        TTNN::Ops::Experimental::MultiScaleDeformableAttn
-        TTNN::Ops::Experimental::Copy
-        TTNN::Ops::Experimental::TensorPrefetcher
-        TTNN::Ops::Experimental::Dropout
         TTNN::Ops::Experimental::DeepSeekPrefill
-        TTNN::Ops::Experimental::DeepseekMoEPostCombineTilize
-        TTNN::Ops::Experimental::DeepSeek::MoE::MoEGateMM
-        TTNN::Ops::Experimental::DeepSeek::MoE::DeepSeekMoeGate
-        TTNN::Ops::Experimental::DeepSeek::MoE::GeneralizedMoeGate
-        TTNN::Ops::Experimental::TopkRouterGpt
-        TTNN::Ops::Experimental::Deepseek::MLA::Matmul_WO
-        TTNN::Ops::Experimental::PlusOne
-        TTNN::Ops::Experimental::Reshape
-        TTNN::Ops::Experimental::SSM
         TTNN::Ops::Experimental::Transformer
-        TTNN::Ops::Experimental::UnaryBackward
-        TTNN::Ops::Experimental::Test
         TTNN::Ops::Full
         TTNN::Ops::FullLike
         TTNN::Ops::IndexFill
@@ -501,24 +485,8 @@ add_subdirectory(cpp/ttnn/operations/embedding)
 add_subdirectory(cpp/ttnn/operations/embedding_backward)
 add_subdirectory(cpp/ttnn/operations/examples)
 add_subdirectory(cpp/ttnn/operations/experimental)
-add_subdirectory(cpp/ttnn/operations/experimental/bcast_to)
-add_subdirectory(cpp/ttnn/operations/experimental/multi_scale_deformable_attn)
-add_subdirectory(cpp/ttnn/operations/experimental/copy)
-add_subdirectory(cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill)
-add_subdirectory(cpp/ttnn/operations/experimental/tensor_prefetcher)
-add_subdirectory(cpp/ttnn/operations/experimental/dropout)
-add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm)
-add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate)
-add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate)
-add_subdirectory(cpp/ttnn/operations/experimental/topk_router_gpt)
-add_subdirectory(cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo)
-add_subdirectory(cpp/ttnn/operations/experimental/plusone)
-add_subdirectory(cpp/ttnn/operations/experimental/reshape)
-add_subdirectory(cpp/ttnn/operations/experimental/ssm)
-add_subdirectory(cpp/ttnn/operations/experimental/test)
 add_subdirectory(cpp/ttnn/operations/experimental/transformer)
-add_subdirectory(cpp/ttnn/operations/experimental/unary_backward)
 add_subdirectory(cpp/ttnn/operations/full)
 add_subdirectory(cpp/ttnn/operations/full_like)
 add_subdirectory(cpp/ttnn/operations/index_fill)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -259,35 +259,21 @@ target_link_libraries(
         TTNN::Ops::Embedding
         TTNN::Ops::Embedding::Backward
         TTNN::Ops::Examples
-        TTNN::Ops::Experimental::AdaptivePool
+        TTNN::Ops::Experimental
         TTNN::Ops::Experimental::BcastTo
         TTNN::Ops::Experimental::MultiScaleDeformableAttn
-        TTNN::Ops::Experimental::CCL
-        TTNN::Ops::Experimental::CNN
-        TTNN::Ops::Experimental::Conv3d
         TTNN::Ops::Experimental::Copy
         TTNN::Ops::Experimental::TensorPrefetcher
         TTNN::Ops::Experimental::Dropout
         TTNN::Ops::Experimental::DeepSeekPrefill
-        TTNN::Ops::Experimental::IsIn
-        TTNN::Ops::Experimental::Matmul
-        TTNN::Ops::Experimental::PaddedSlice
-        TTNN::Ops::Experimental::MinimalMatmul
         TTNN::Ops::Experimental::DeepseekMoEPostCombineTilize
         TTNN::Ops::Experimental::DeepSeek::MoE::MoEGateMM
         TTNN::Ops::Experimental::DeepSeek::MoE::DeepSeekMoeGate
         TTNN::Ops::Experimental::DeepSeek::MoE::GeneralizedMoeGate
-        TTNN::Ops::Experimental::TopkLargeIndices
         TTNN::Ops::Experimental::TopkRouterGpt
         TTNN::Ops::Experimental::Deepseek::MLA::Matmul_WO
-        TTNN::Ops::Experimental::IndexerScore
-        TTNN::Ops::Experimental::MoEGPT
-        TTNN::Ops::Experimental::PagedCache
         TTNN::Ops::Experimental::PlusOne
-        TTNN::Ops::Experimental::Quasar
-        TTNN::Ops::Experimental::Reduction
         TTNN::Ops::Experimental::Reshape
-        TTNN::Ops::Experimental::SliceWrite
         TTNN::Ops::Experimental::SSM
         TTNN::Ops::Experimental::Transformer
         TTNN::Ops::Experimental::UnaryBackward
@@ -514,35 +500,21 @@ add_subdirectory(cpp/ttnn/operations/eltwise/unary_backward)
 add_subdirectory(cpp/ttnn/operations/embedding)
 add_subdirectory(cpp/ttnn/operations/embedding_backward)
 add_subdirectory(cpp/ttnn/operations/examples)
-add_subdirectory(cpp/ttnn/operations/experimental/adaptive_pool)
-add_subdirectory(cpp/ttnn/operations/experimental/quasar)
+add_subdirectory(cpp/ttnn/operations/experimental)
 add_subdirectory(cpp/ttnn/operations/experimental/bcast_to)
 add_subdirectory(cpp/ttnn/operations/experimental/multi_scale_deformable_attn)
-add_subdirectory(cpp/ttnn/operations/experimental/ccl)
-add_subdirectory(cpp/ttnn/operations/experimental/cnn)
-add_subdirectory(cpp/ttnn/operations/experimental/conv3d)
 add_subdirectory(cpp/ttnn/operations/experimental/copy)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill)
 add_subdirectory(cpp/ttnn/operations/experimental/tensor_prefetcher)
 add_subdirectory(cpp/ttnn/operations/experimental/dropout)
-add_subdirectory(cpp/ttnn/operations/experimental/isin)
-add_subdirectory(cpp/ttnn/operations/experimental/matmul)
-add_subdirectory(cpp/ttnn/operations/experimental/minimal_matmul)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate)
-add_subdirectory(cpp/ttnn/operations/experimental/topk_large_indices)
 add_subdirectory(cpp/ttnn/operations/experimental/topk_router_gpt)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo)
-add_subdirectory(cpp/ttnn/operations/experimental/indexer_score)
-add_subdirectory(cpp/ttnn/operations/experimental/ccl/moe_gpt)
-add_subdirectory(cpp/ttnn/operations/experimental/padded_slice)
-add_subdirectory(cpp/ttnn/operations/experimental/paged_cache)
 add_subdirectory(cpp/ttnn/operations/experimental/plusone)
-add_subdirectory(cpp/ttnn/operations/experimental/reduction)
 add_subdirectory(cpp/ttnn/operations/experimental/reshape)
-add_subdirectory(cpp/ttnn/operations/experimental/slice_write)
 add_subdirectory(cpp/ttnn/operations/experimental/ssm)
 add_subdirectory(cpp/ttnn/operations/experimental/test)
 add_subdirectory(cpp/ttnn/operations/experimental/transformer)

--- a/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
@@ -5,13 +5,15 @@
 # here and self-approve, without ttnn-core or infra needing to be pinged, and
 # without touching ttnn/CMakeLists.txt.
 #
-# Only the ops below have been migrated in so far — everything else under
-# experimental/ is still add_subdirectory()'d directly from
-# ttnn/CMakeLists.txt, either because it has no team/individual owner in
-# CODEOWNERS at all (a gap to close separately, not a CMake problem), or
-# because it's one CMake target spanning multiple teams' code and needs an
-# actual target split before ownership can split too (e.g. transformer/).
-# Folding in more is later work, one owner at a time.
+# Everything under experimental/ is migrated in here now except transformer/,
+# which is one CMake target spanning multiple teams' code and needs an
+# actual target split before ownership can split too.
+#
+# A number of the ops below have no team-specific CODEOWNERS rule at all and
+# fall back to the generic ops-leads catch-all — that's the status quo, kept
+# as-is here rather than guessed at. metalium-developers-ops-leads is listed
+# on this file for exactly that reason, not because it's the deliberate,
+# active owner of those ops.
 
 # metalium-developers-convolutions
 add_subdirectory(adaptive_pool)
@@ -46,10 +48,29 @@ add_subdirectory(minimal_matmul)
 add_subdirectory(padded_slice)
 add_subdirectory(slice_write)
 
-# Umbrella target for everything migrated into this file so far: ttnncpp
-# links this one target instead of enumerating these 15 op libraries itself.
-# Add/remove entries here when adding/removing one of the ops above — never
-# in ttnn/CMakeLists.txt.
+# No team-specific CODEOWNERS rule — falls back to the ops-leads catch-all
+# today. Kept as the status quo owner rather than guessed at.
+add_subdirectory(bcast_to)
+add_subdirectory(copy)
+add_subdirectory(deepseek/mla/matmul_wo)
+add_subdirectory(deepseek/moe/deepseek_moe_gate)
+add_subdirectory(deepseek/moe/generalized_moe_gate)
+add_subdirectory(deepseek/moe/moe_gate_mm)
+add_subdirectory(deepseek_moe_post_combine_tilize)
+add_subdirectory(dropout)
+add_subdirectory(multi_scale_deformable_attn)
+add_subdirectory(plusone)
+add_subdirectory(reshape)
+add_subdirectory(ssm)
+add_subdirectory(tensor_prefetcher)
+add_subdirectory(test)
+add_subdirectory(topk_router_gpt)
+add_subdirectory(unary_backward)
+
+# Umbrella target for everything migrated into this file: ttnncpp links this
+# one target instead of enumerating these op libraries itself. Add/remove
+# entries here when adding/removing one of the ops above — never in
+# ttnn/CMakeLists.txt.
 add_library(ttnn_op_experimental_shared INTERFACE)
 add_library(TTNN::Ops::Experimental ALIAS ttnn_op_experimental_shared)
 target_link_libraries(
@@ -70,6 +91,22 @@ target_link_libraries(
         TTNN::Ops::Experimental::MinimalMatmul
         TTNN::Ops::Experimental::PaddedSlice
         TTNN::Ops::Experimental::SliceWrite
+        TTNN::Ops::Experimental::BcastTo
+        TTNN::Ops::Experimental::Copy
+        TTNN::Ops::Experimental::Deepseek::MLA::Matmul_WO
+        TTNN::Ops::Experimental::DeepSeek::MoE::DeepSeekMoeGate
+        TTNN::Ops::Experimental::DeepSeek::MoE::GeneralizedMoeGate
+        TTNN::Ops::Experimental::DeepSeek::MoE::MoEGateMM
+        TTNN::Ops::Experimental::DeepseekMoEPostCombineTilize
+        TTNN::Ops::Experimental::Dropout
+        TTNN::Ops::Experimental::MultiScaleDeformableAttn
+        TTNN::Ops::Experimental::PlusOne
+        TTNN::Ops::Experimental::Reshape
+        TTNN::Ops::Experimental::SSM
+        TTNN::Ops::Experimental::TensorPrefetcher
+        TTNN::Ops::Experimental::Test
+        TTNN::Ops::Experimental::TopkRouterGpt
+        TTNN::Ops::Experimental::UnaryBackward
 )
 
 # target_link_libraries() alone is not enough: per the CMake docs, an OBJECT
@@ -101,4 +138,20 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::MinimalMatmul>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::PaddedSlice>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::SliceWrite>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::BcastTo>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Copy>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Deepseek::MLA::Matmul_WO>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeek::MoE::DeepSeekMoeGate>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeek::MoE::GeneralizedMoeGate>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeek::MoE::MoEGateMM>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepseekMoEPostCombineTilize>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Dropout>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::MultiScaleDeformableAttn>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::PlusOne>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Reshape>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::SSM>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::TensorPrefetcher>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Test>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::TopkRouterGpt>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::UnaryBackward>
 )

--- a/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
@@ -1,0 +1,104 @@
+# experimental/ is one physical directory shared by many teams' ops, so this
+# file is jointly owned by every team (or named individual, for ops without a
+# team owner) with a subdirectory listed below (see CODEOWNERS) rather than
+# by ttnn-core. Any of those owners can add/remove their own experimental ops
+# here and self-approve, without ttnn-core or infra needing to be pinged, and
+# without touching ttnn/CMakeLists.txt.
+#
+# Only the ops below have been migrated in so far — everything else under
+# experimental/ is still add_subdirectory()'d directly from
+# ttnn/CMakeLists.txt, either because it has no team/individual owner in
+# CODEOWNERS at all (a gap to close separately, not a CMake problem), or
+# because it's one CMake target spanning multiple teams' code and needs an
+# actual target split before ownership can split too (e.g. transformer/).
+# Folding in more is later work, one owner at a time.
+
+# metalium-developers-convolutions
+add_subdirectory(adaptive_pool)
+add_subdirectory(conv3d)
+add_subdirectory(cnn)
+
+# metalium-developers-ops-data-movement
+add_subdirectory(ccl)
+add_subdirectory(ccl/moe_gpt)
+
+# metalium-developers-mmfusedreduce
+add_subdirectory(matmul)
+add_subdirectory(quasar)
+add_subdirectory(reduction)
+
+# metalium-developers-sdpa
+add_subdirectory(indexer_score)
+add_subdirectory(topk_large_indices)
+
+# metallium-maintainers-llama-models
+add_subdirectory(paged_cache)
+
+# metalium-developers-external-experience
+add_subdirectory(isin)
+
+# cglagovichTT, jonathansuTT (named individuals, not a team)
+add_subdirectory(minimal_matmul)
+
+# Jointly owned by convolutions + ops-data-movement — already covered by this
+# file's CODEOWNERS union above, so no separate decision was needed to fold
+# these in.
+add_subdirectory(padded_slice)
+add_subdirectory(slice_write)
+
+# Umbrella target for everything migrated into this file so far: ttnncpp
+# links this one target instead of enumerating these 15 op libraries itself.
+# Add/remove entries here when adding/removing one of the ops above — never
+# in ttnn/CMakeLists.txt.
+add_library(ttnn_op_experimental_shared INTERFACE)
+add_library(TTNN::Ops::Experimental ALIAS ttnn_op_experimental_shared)
+target_link_libraries(
+    ttnn_op_experimental_shared
+    INTERFACE
+        TTNN::Ops::Experimental::AdaptivePool
+        TTNN::Ops::Experimental::Conv3d
+        TTNN::Ops::Experimental::CNN
+        TTNN::Ops::Experimental::CCL
+        TTNN::Ops::Experimental::MoEGPT
+        TTNN::Ops::Experimental::Matmul
+        TTNN::Ops::Experimental::Quasar
+        TTNN::Ops::Experimental::Reduction
+        TTNN::Ops::Experimental::IndexerScore
+        TTNN::Ops::Experimental::TopkLargeIndices
+        TTNN::Ops::Experimental::PagedCache
+        TTNN::Ops::Experimental::IsIn
+        TTNN::Ops::Experimental::MinimalMatmul
+        TTNN::Ops::Experimental::PaddedSlice
+        TTNN::Ops::Experimental::SliceWrite
+)
+
+# target_link_libraries() alone is not enough: per the CMake docs, an OBJECT
+# library named in a target's INTERFACE_LINK_LIBRARIES (as these leaves are,
+# via the INTERFACE keyword above) is treated as a plain Interface Library by
+# further consumers — only usage requirements propagate, not its compiled
+# objects. So with the default LIB_TYPE=OBJECT, ttnncpp would silently end up
+# without these ops' code (undefined symbols at final link time). Splice the
+# object files in directly via generator expression so they still land in
+# whatever ultimately links this umbrella target. TARGET_OBJECTS resolves to
+# nothing (and is harmless) for leaves that aren't OBJECT libraries — e.g.
+# SHARED or STATIC, both of which ttnn can compile these as depending on
+# build options — so this is safe unconditionally.
+target_sources(
+    ttnn_op_experimental_shared
+    INTERFACE
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::AdaptivePool>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Conv3d>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::CNN>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::CCL>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::MoEGPT>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Matmul>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Quasar>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::Reduction>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::IndexerScore>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::TopkLargeIndices>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::PagedCache>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::IsIn>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::MinimalMatmul>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::PaddedSlice>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::SliceWrite>
+)


### PR DESCRIPTION
## Why

Same problem as #49441 (ds-prefill reference PR, merged): the wiring that turns an op directory into an actual, linked build target lives in two shared, centrally-owned lists in `ttnn/CMakeLists.txt` — the `add_subdirectory()` list and the `target_link_libraries(ttnncpp ...)` list. Any team wanting to add or remove a module has to touch a file owned by people outside their team.

`experimental/` is already one physical directory shared by many teams' ops, so it can use the exact `add_subdirectory()`-based pattern ds-prefill and eltwise use — just with CODEOWNERS on the shared file listing every owner who has something migrated into it, instead of a single team. This is a dedicated PR covering all of `experimental/` at once, since it's big and focused enough to warrant its own review rather than being folded into some other domain-specific PR.

## What changed

Added `ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt` with an `add_subdirectory()` for each migrated op, and one `INTERFACE` umbrella target (`TTNN::Ops::Experimental`) that `ttnncpp` links instead of enumerating the op libraries itself.

Migrated every op with a clear owner in CODEOWNERS today:
- convolutions: `adaptive_pool`, `conv3d`, `cnn`
- ops-data-movement: `ccl`, `ccl/moe_gpt`
- mmfusedreduce: `matmul`, `quasar`, `reduction`
- sdpa: `indexer_score`, `topk_large_indices`
- llama-models: `paged_cache`
- external-experience: `isin`
- named individuals (cglagovichTT, jonathansuTT — not a team): `minimal_matmul`
- `padded_slice`, `slice_write`: jointly owned by convolutions + ops-data-movement — already covered by this file's CODEOWNERS union, no separate decision needed

Plus the 16 ops with **no** team-specific CODEOWNERS rule at all — `bcast_to`, `copy`, `deepseek/mla/matmul_wo`, `deepseek/moe/deepseek_moe_gate`, `deepseek/moe/generalized_moe_gate`, `deepseek/moe/moe_gate_mm`, `deepseek_moe_post_combine_tilize`, `dropout`, `multi_scale_deformable_attn`, `plusone`, `reshape`, `ssm`, `tensor_prefetcher`, `test`, `topk_router_gpt`, `unary_backward`. I checked commit history for these too, not just CODEOWNERS — they're dominated by broad, repo-wide sweeps (Device 2.0 API migrations, SFPU cleanups) rather than a dedicated team actively developing them, so there's no real owner to discover and assign. Per Andrew: rather than guess, these are folded in using whatever CODEOWNERS already resolves them to today — the generic `ops-leads` catch-all — kept as the explicit status quo, not a deliberate new assignment. `metalium-developers-ops-leads` is on this file's CODEOWNERS line with a comment explaining why.

With this, everything under `experimental/` is migrated except:
- `experimental/transformer` — one CMake target whose code spans llama-models' owned subpaths and otherwise-unowned code. Needs an actual C++ target split before ownership can split too — not a mechanical move.
- `deepseek_prefill` — already has its own dedicated aggregator from #49441 (merged) — not part of this shared file.

Every umbrella in this series uses the ds-prefill fix from the start: `target_sources()` with `$<TARGET_OBJECTS:...>` unconditionally, no `LIB_TYPE` conditional (see #49441 for the root-cause writeup).

## Verification

Structural checks (no build environment available in my sandbox): confirmed every leaf directory referenced exists with its own `CMakeLists.txt` and an unconditional `add_library(... ALIAS ...)` target (no special build guards to account for), every alias name matches exactly between each leaf's own `CMakeLists.txt` and the umbrella's `target_link_libraries()`/`target_sources()`, and checked the new umbrella/real target names against the full CMake target namespace for collisions. Please verify with CI/a real build before merging.
