### PR TITLE
Fix ttnn.outer BFLOAT8_B scalar assertion

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_outer.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_outer.py
@@ -9,9 +9,13 @@ import ttnn
 from functools import partial
 from models.common.utility_functions import torch_random
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_allclose, assert_with_pcc
 
 pytestmark = pytest.mark.use_module_device
+
+# Scalar bf8 outer: looser than comp_pcc fallback; seed=0 ~1.125 abs diff, atol covers near-zero products.
+_BF8_SCALAR_OUTER_RTOL = 0.05
+_BF8_SCALAR_OUTER_ATOL = 2.0
 
 
 # Contract: a:[..., N], b:[..., M] -> [..., N, M].
@@ -74,9 +78,21 @@ def test_outer_tile_layout(a_shape, b_shape, dtype, mem_a, mem_b, device):
 
     out_tt = ttnn.outer(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     out_pt = _golden(a_pt, b_pt)
+    out_actual = ttnn.to_torch(out_tt)
 
-    assert tuple(ttnn.to_torch(out_tt).shape) == tuple(out_pt.shape)
-    assert_with_pcc(out_pt, ttnn.to_torch(out_tt), pcc=_pcc_threshold(dtype))
+    assert tuple(out_actual.shape) == tuple(
+        out_pt.shape
+    ), f"expected shape {tuple(out_pt.shape)}, got {tuple(out_actual.shape)}"
+    # BFLOAT8_B scalar output: PCC undefined; use relaxed allclose for quant error.
+    if dtype == ttnn.bfloat8_b and out_actual.numel() == 1:
+        assert_allclose(
+            out_pt,
+            out_actual,
+            rtol=_BF8_SCALAR_OUTER_RTOL,
+            atol=_BF8_SCALAR_OUTER_ATOL,
+        )
+    else:
+        assert_with_pcc(out_pt, out_actual, pcc=_pcc_threshold(dtype))
 
 
 @pytest.mark.parametrize("a_shape, b_shape", SHAPE_PAIRS)


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/49482

### PR Category
Test Only

### Summary

Fixes four CI failures ([Link](https://github.com/tenstorrent/tt-metal/actions/runs/28950336592/job/85899052498)) in `test_outer_tile_layout` for **BFLOAT8_B** inputs with shape `[1]×[1]` (all DRAM/L1 memory-config combinations). This is a **test tolerance fix**, not an `ttnn.outer` kernel bug. After the `comp_pcc` improvement that correctly falls back to `allclose` when PCC is undefined (constant / single-element tensors), the default `atol=1e-4` is too strict for normal BFLOAT8_B block-float quantization on scalar outer products.

**Observed values (seed=0):**
- Golden: `-40.125`
- Device: `-39.0`
- Abs diff: `1.125` (~2.8%)

All other `test_outer_tile_layout` cases (152/156) already pass, including BFLOAT16 `[1]×[1]`. Failures show up once `comp_pcc` stops returning `1.0` on NaN PCC (#48326). On current `main` without that fix, this case may still false-pass via the old PCC path.

**Root cause**

1. `ttnn.outer([1], [1])` produces a **1×1** output.
2. Pearson correlation (PCC) is **undefined** for a single scalar value (zero variance).
3. `comp_pcc()` correctly detects NaN PCC and falls back to `torch.allclose` with default tolerances (`rtol=1e-5`, `atol=1e-4`).
4. BFLOAT8_B per-tile quantization can legitimately differ by ~1–3% on scalar products; the strict allclose check fails with `AssertionError: 0.0` (the allclose boolean, not "PCC = 0").

**Fix** is to use explicit relaxed `allclose` for the scalar BFLOAT8_B case only. Tolerances (`rtol=0.05`, `atol=2.0`) are scoped to this edge case and align with realistic block-float error on values in the `[-100, 100]` input range used by the test. `atol=2.0` is intentionally loose for near-zero products where relative error can be large on tiny magnitudes.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/outer_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/outer_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/outer_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/outer_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/outer_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/outer_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/outer_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/outer_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/outer_pcc)