### PR TITLE
tttv2: wire on-device decode loop into Llama-3.2-3B (close T3K b1 decode gap)

### DIFF
--- a/models/common/models/llama32_3b/model.py
+++ b/models/common/models/llama32_3b/model.py
@@ -1122,10 +1122,21 @@ class EagerLlama32_3BExecutor:
 class TracedLlama32_3BExecutor:
     """Thin wrapper: passes Llama32_3B model to TracedLLMExecutor."""
 
-    def __init__(self, model: Llama32_3BTransformer1D, mesh_device: ttnn.MeshDevice, model_args=None):
+    def __init__(
+        self,
+        model: Llama32_3BTransformer1D,
+        mesh_device: ttnn.MeshDevice,
+        model_args=None,
+        ondevice_decode_loop: bool = False,
+    ):
         if model_args is not None:
             model.model_args = model_args
-        self._engine = TracedLLMExecutor(model, mesh_device, iter_named_modules=_iter_llama_executor_named_modules)
+        self._engine = TracedLLMExecutor(
+            model,
+            mesh_device,
+            iter_named_modules=_iter_llama_executor_named_modules,
+            ondevice_decode_loop=ondevice_decode_loop,
+        )
 
     @property
     def model(self):

--- a/models/common/tests/demos/llama32_3b/demo.py
+++ b/models/common/tests/demos/llama32_3b/demo.py
@@ -88,7 +88,7 @@ EXPECTED_METRICS_BATCH32 = {
 
 # Perf workload: natural-length prefill (these sample prompts are ~90-125 tokens -> 128 bucket,
 # matching TTTv1), 200 decode steps. Accuracy uses the 511-token teacher-forcing refpt.
-_PERF_NUM_DECODE_TOKENS = 200
+_PERF_NUM_DECODE_TOKENS = int(os.environ.get("PERF_NUM_DECODE_TOKENS", "200"))
 
 PERF_TOLERANCE = 0.05
 
@@ -462,7 +462,29 @@ def _run_perf_benchmark(
     hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-3B-Instruct")
     tokenizer = AutoTokenizer.from_pretrained(hf_model)
 
-    traced_executor = TracedLlama32_3BExecutor(model, mesh_device)
+    # On-device sampling toggle for N150/N300/T3K evidence-gathering (see sampling handoff docs):
+    #   host            -> sampling_params=None (host-argmax, the default shipped path)
+    #   on_device       -> greedy temp=0,k=1,p=0  => trace-captured TOP-K op path with k=1
+    #   on_device_topk  -> temp=0,k=32,p=0.08      => trace-captured TOP-K op path with k=32
+    #                      (PERF.md-parity recipe). Both on-device modes route through the same
+    #                      per-device ttnn.topk -> all-gather of the [*,k] tuples -> ttnn.sampling
+    #                      op path (the model is built with allow_force_argmax=False, so the
+    #                      full-vocab argmax all-gather is never taken); they differ only in k.
+    sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
+    _on_device_params = {
+        "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
+        "on_device_topk": SamplingParams(temperature=0.0, top_k=32, top_p=0.08),
+    }
+    sampling_params = (
+        _on_device_params[sampling_mode]
+        if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
+        else None
+    )
+    logger.info(f"[{case_name}] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
+
+    # Free-running perf run: enable the executor's on-device decode loop on the on-device sampling
+    # path (inert on host/force-argmax; gated to the top-k path by _decode_loop_active).
+    traced_executor = TracedLlama32_3BExecutor(model, mesh_device, ondevice_decode_loop=sampling_params is not None)
     try:
         ma = model.model_args
         assert ma is not None
@@ -481,26 +503,6 @@ def _run_perf_benchmark(
         # Natural-length tokenization (matches TTTv1): the executor buckets each user's real
         # length to get_padded_prefill_len. These sample prompts are ~90-125 tokens -> 128 bucket.
         input_tokens, prompt_lens = tokenize_prompts(prompts, tokenizer, max_prefill_len=max_prefill_len)
-
-        # On-device sampling toggle for N150/N300/T3K evidence-gathering (see sampling handoff docs):
-        #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0  => trace-captured TOP-K op path with k=1
-        #   on_device_topk  -> temp=0,k=32,p=0.08      => trace-captured TOP-K op path with k=32
-        #                      (PERF.md-parity recipe). Both on-device modes route through the same
-        #                      per-device ttnn.topk -> all-gather of the [*,k] tuples -> ttnn.sampling
-        #                      op path (the model is built with allow_force_argmax=False, so the
-        #                      full-vocab argmax all-gather is never taken); they differ only in k.
-        sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
-        _on_device_params = {
-            "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
-            "on_device_topk": SamplingParams(temperature=0.0, top_k=32, top_p=0.08),
-        }
-        sampling_params = (
-            _on_device_params[sampling_mode]
-            if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
-            else None
-        )
-        logger.info(f"[{case_name}] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
 
         result = run_perf_benchmark(
             traced_executor,


### PR DESCRIPTION
# tttv2: wire on-device decode loop into Llama-3.2-3B (close T3K b1 decode gap)

Closes #49345.

## Summary

Follow-up to #49284 (Close T3K batch-1 decode gap, small models). That PR introduced the on-device
decode loop as an `ondevice_decode_loop` constructor parameter on `TracedLLMExecutor` and removed the
old `TTT_ONDEVICE_DECODE_LOOP` env var, but wired the new parameter through the **1B** executor/demo
only. As a result **Llama-3.2-3B's decode loop was left OFF**, silently regressing 3B T3K batch-1
decode (loop-OFF ≈ 68.8 t/s/u).

This PR mirrors the 1B wiring for 3B, restoring same-box TTTv1 parity.

## Changes

- `TracedLlama32_3BExecutor.__init__` accepts `ondevice_decode_loop: bool = False` and forwards it to
  `TracedLLMExecutor` (wrapper-level API parity with 1B; callers never touch `_engine`).
- The 3B perf demo builds the executor with `ondevice_decode_loop = sampling_params is not None`, so the
  loop engages only on the on-device sampling path. It is inert on host / teacher-forcing / force-argmax
  (gated by `_decode_loop_active`), so the accuracy / teacher-forcing path is unchanged.
- Adds a `PERF_NUM_DECODE_TOKENS` env override (default 200) so a short decode window can be profiled
  without editing the demo.

No shared-module changes, no TTTv1 changes, no rebuild required.

## Result: the gap does not reproduce on healthy hardware

On a healthy T3K (warm, modal-of-3, token-identical output, `on_device_topk`):

| stack | t/s/u (mean) | ms/step |
|---|---|---|
| **TTTv2 3B (this PR, loop ON)** | **81.0** (81.0 / 80.9 / 81.0) | 12.35 |
| TTTv1 3B (`simple_text_demo`) | 80.5 (80.53 / 80.66 / 79.88) | 12.44 |

TTTv2 is at parity / marginally ahead **and stutter-free** (TTTv1 shows occasional 22–27 ms per-iter
stutters that the on-device loop + page-table-on-change refresh avoid). Mean-to-mean TTTv2 wins; TTTv1
only appears faster if its single best 128th-token step (11.9 ms) is compared against TTTv2's full-run
mean.

The originally reported "77.2 vs 80.4 = 96% device-side gap" was measured on a degraded box and does
not reproduce on healthy hardware — the same pattern already seen for Mistral-7B and Qwen3-32B.

## Why there is no further device-side lever

Per-token device profiling (the tooling #49345 asked for) shows 3B decode is **CCL / overhead-bound**:
9.6% of the DRAM roofline (roofline ≈ 1.5 ms/step vs 12.35 ms measured). Matmul math is only ~34% of the
step (~4.2 ms); the remaining ~7 ms is 8-chip CCL latency + op-to-op gaps (distributed RMSNorm
all-gathers + attention/MLP reduce-scatters, ~4 collectives per layer × 28 layers). Additional findings:

- All decode matmul and collective program configs are identical to the tuned TTTv1 reference
  (shared `find_grid` / `dram_matmul_config` logic).
- DRAM-sharded decode matmuls already run on 12 cores = 12 Wormhole DRAM banks (max DRAM readers).
- Precision is already tuned: gate/up (W1/W3) BFP4/LoFi, down (W2) BFP8/HiFi2, attention BFP8/HiFi2.
- The only profiler advice for a decode matmul was W2 `in0_block_w=1`; it is identical to TTTv1, W2 is
  ~7% of the step, and raising it trades DRAM readers for block width on a bank-bound op (ceiling ≪1% of
  a CCL-bound step). Recorded as a shared, non-3B-specific future candidate, not a gap.
- No pathological op-to-op stall (unlike the Qwen-Coder Untilize host-stall); the large op-to-op gaps are
  genuine 8-chip collective latency the device is actually running.

## Testing

- **Perf (T3K, batch-1, `on_device_topk`, loop ON):** 81.0 t/s/u modal-of-3, token-identical output.
- **Token accuracy (teacher-forcing):** top-1 90.8%, top-5 98.8% — PASS (unchanged; loop is off on this path).
- **Watcher-clean:** `TT_METAL_WATCHER=10 TT_METAL_WATCHER_DISABLE_ETH=1` decode run — 0 errors, clean
  detach. (Full-eth watcher hits the known idle_erisc L1 overflow on T3K; disabling eth watcher is the
  standard workaround and covers the Tensix cores where the changed ops run.)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apascual/49345-close-llama3b-decode-gap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/49345-close-llama3b-decode-gap)