### PR TITLE
[LLK] Fix #14213: [Bug Report] TTI_SFPSTORE with instr_mod = 2 return a tile with 512 bfloat16, 512 zero value

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -15,7 +15,7 @@ inline void rand_init(uint32_t seed) {
     init_prng_seed(seed);
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void rand(uint32_t from, uint32_t scale) {
     // Load scale param to lreg1
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
@@ -44,7 +44,25 @@ inline void rand(uint32_t from, uint32_t scale) {
         // lreg0 = lreg0 * scale + from
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
 
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_7, 0);
+        if constexpr (!is_fp32_dest_acc_en) {
+            // LRegs hold fp32. A 16-bit Dest SFPSTORE truncates the mantissa
+            // toward zero; round-to-nearest (half to even) fp32 -> bf16 first to
+            // avoid the truncation bias (fewer distinct samples / range skew).
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
+        }
+
+        // InstrModLoadStore::DEFAULT stores in the Dest's configured width (fp32
+        // under fp32_dest_acc_en, else 16-bit), filling the whole tile in both
+        // modes. A fixed FP16B store wrote only the 16-bit Dest view (half a
+        // 32-bit-Dest tile); a fixed FP32 store into a 16-bit Dest is the mirror
+        // corruption.
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -15,7 +15,7 @@ inline void rand_init(uint32_t seed) {
     init_prng_seed(seed);
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void rand(uint32_t from, uint32_t scale) {
     // Load scale param to lreg1
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
@@ -46,7 +46,25 @@ inline void rand(uint32_t from, uint32_t scale) {
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
         TTI_SFPNOP;
 
-        TTI_SFPSTORE(0, InstrModLoadStore::FP32, 3, 0);
+        if constexpr (!is_fp32_dest_acc_en) {
+            // LRegs hold fp32. A 16-bit Dest SFPSTORE truncates the mantissa
+            // toward zero; round-to-nearest (half to even) fp32 -> bf16 first to
+            // avoid the truncation bias (fewer distinct samples / range skew).
+            TTI_SFP_STOCH_RND(
+                sfpi::SFPSTOCHRND_RND_EVEN,
+                0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG0,
+                sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
+        }
+
+        // InstrModLoadStore::DEFAULT stores in the Dest's configured width (fp32
+        // under fp32_dest_acc_en, else 16-bit), filling the whole tile in both
+        // modes. A fixed FP16B store wrote only the 16-bit Dest view (half a
+        // 32-bit-Dest tile); a fixed FP32 store into a 16-bit Dest is the mirror
+        // corruption.
+        TTI_SFPSTORE(0, InstrModLoadStore::DEFAULT, 3, 0);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rand.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rand.h
@@ -29,7 +29,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void rand_tile(uint32_t idst, uint32_t from, uint32_t scale) {
-    MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, rand, (APPROX), idst, VectorMode::RC, from, scale));
+    MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, rand, (APPROX, DST_ACCUM_MODE), idst, VectorMode::RC, from, scale));
 }
 
 /**

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_rand.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_rand.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Regression test for the SFPU `rand` generator store width.
+#
+# `rand` fills a Dest tile with uniform floats in [from, from + scale). Its
+# SFPSTORE must write in the Dest's *configured* width: a store that writes the
+# wrong Dest view (e.g. a 16-bit store into a 32-bit Dest) leaves half of the
+# tile unwritten -- historically "512 correct, 512 zero". This test drives rand
+# in both fp32-dest-accumulation modes and asserts the whole tile is filled with
+# in-range values, so a store-width regression is caught on-card.
+#
+# There is no host model of the Tensix PRNG, so the check is a distribution
+# invariant (full fill + range), not an exact golden.
+
+import pytest
+import torch
+from helpers.format_config import DataFormat
+from helpers.llk_params import ApproximationMode, DestAccumulation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import APPROX_MODE
+
+# Must match the constexpr values in sources/sfpu_rand_test.cpp.
+RAND_FROM = 1024.0
+RAND_SCALE = 256.0
+TILE_ELEMENTS = 1024
+
+
+def _run_sfpu_rand(formats, dest_acc, input_dimensions=[32, 32]):
+    num_elements = input_dimensions[0] * input_dimensions[1]
+
+    # Zeroed input: the kernel copies it into Dest before rand overwrites, so any
+    # Dest row the generator fails to write stays 0 and fails the range check.
+    src_A = torch.zeros(num_elements, dtype=torch.float32)
+    src_B = torch.zeros(num_elements, dtype=torch.float32)
+
+    configuration = TestConfig(
+        "sources/sfpu_rand_test.cpp",
+        formats,
+        templates=[
+            APPROX_MODE(ApproximationMode.No),
+        ],
+        runtimes=[],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=1,
+            tile_count_B=1,
+            tile_count_res=1,
+        ),
+        unpack_to_dest=formats.input_format.is_32_bit(),
+        dest_acc=dest_acc,
+        compile_time_formats=True,
+    )
+
+    res_from_L1 = configuration.run().result
+    res_from_L1 = res_from_L1[:TILE_ELEMENTS]
+    assert len(res_from_L1) == TILE_ELEMENTS, "Unexpected result tile length"
+
+    torch_format = format_dict[formats.output_format]
+    res = torch.tensor(res_from_L1, dtype=torch_format).to(torch.float32)
+
+    lo = RAND_FROM
+    hi = RAND_FROM + RAND_SCALE
+    # bf16 rounding near 1024-1280 is ~8 ULP; fp32 is exact.
+    tol = 8.0 if formats.output_format == DataFormat.Float16_b else 1.0
+
+    num_zeros = int((res == 0).sum().item())
+    tile_min = res.min().item()
+    tile_max = res.max().item()
+
+    # Whole tile must be filled with in-range values. A store-width regression
+    # (the original bug) leaves ~half the tile at 0.0, which is far below `from`.
+    assert num_zeros == 0, f"{num_zeros}/{TILE_ELEMENTS} elements are 0 (tile not fully written by rand)"
+    assert tile_min >= lo - tol, f"min {tile_min} below range [{lo}, {hi}) (tol={tol})"
+    assert tile_max <= hi + tol, f"max {tile_max} above range [{lo}, {hi}) (tol={tol})"
+    # rand must produce a distribution, not a constant fill.
+    assert res.std().item() > 0.0, "rand produced a constant tile"
+
+
+@parametrize(
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float32,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+)
+def test_sfpu_rand(formats, dest_acc):
+    if formats.input_format == DataFormat.Float32 and dest_acc == DestAccumulation.No:
+        pytest.skip("Float32 with dest_acc=No is not supported")
+    if formats.input_format == DataFormat.Float16_b and dest_acc == DestAccumulation.Yes:
+        pytest.skip("Float16_b with dest_acc=Yes is not supported")
+
+    _run_sfpu_rand(formats, dest_acc)

--- a/tt_metal/tt-llk/tests/sources/sfpu_rand_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_rand_test.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// LLK SFPU rand test kernel.
+//
+// Mirrors the production rand compute path (ttnn uniform / randn / bernoulli):
+//   init_sfpu -> rand_tile_init(seed) -> rand_tile(0, from, scale) -> pack_tile.
+// rand is the SFPU PRNG generator in
+//   tt_metal/hw/ckernels/{arch}/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+// which fills the whole Dest tile with uniform floats in [from, from + scale).
+//
+// The kernel copies a zeroed input tile into Dest (so any Dest row the generator
+// fails to write stays 0 and is caught by the range check), then overwrites the
+// whole tile with rand. The store width must track the Dest accumulation width;
+// this test runs both fp32_dest_acc modes so a store that writes the wrong Dest
+// view (leaving half the tile unwritten) is caught on-card.
+//
+// Compile-time configuration emitted by the Python harness:
+//   UNPACK_A_IN / MATH_FORMAT / PACK_OUT : DataFormat of the tile
+//   APPROX_MODE          : SFPU approximation mode
+//   is_fp32_dest_acc_en  : 32-bit vs 16-bit Dest accumulation
+//   unpack_to_dest       : whether the input is unpacked straight into Dest
+//
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_debug.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// rand parameters as raw fp32 bit patterns. `from` is kept well above zero and
+// the range narrow so that any unwritten (zero) Dest row, or a value collapsed
+// out of range, is unambiguously detected by the Python range check.
+constexpr std::uint32_t RAND_FROM  = 0x44800000u;  // 1024.0f
+constexpr std::uint32_t RAND_SCALE = 0x43800000u;  //  256.0f  -> range [1024, 1280)
+constexpr std::uint32_t RAND_SEED  = 0x00001234u;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        UNPACK_A_IN, UNPACK_A_IN, UNPACK_A_IN, UNPACK_A_IN, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, FACE_R_DIM, 4 /* num_faces */, UNPACK_A_IN, UNPACK_A_IN);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[0]), UNPACK_A_IN, UNPACK_A_IN);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "ckernel_sfpu.h"
+#include "llk_lib_math_wrappers.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "params.h"
+
+using namespace ckernel;
+
+static constexpr bool DST_ACCUM_MODE = is_fp32_dest_acc_en;
+
+#include "llk_sfpu/ckernel_sfpu_rand.h"
+#include "llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h"
+
+void run_kernel(RUNTIME_PARAMETERS)
+{
+    const bool is_int_fpu_en = false;
+
+    // Seed the zeroed input tile into Dest tile 0, then overwrite it with rand.
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(MATH_FORMAT, MATH_FORMAT);
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, is_int_fpu_en, PackMode::Default>(
+        4 /* num_faces */, MATH_FORMAT);
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+        0 /* dst_index */, MATH_FORMAT, MATH_FORMAT);
+    // Reset dest addressing so the SFPU op starts at the tile-0 base.
+    _llk_math_eltwise_unary_datacopy_uninit_<BroadcastType::NONE, unpack_to_dest>();
+
+    // rand_tile_init(seed): configure the SFPU addr mode and seed the PRNG.
+    SFPU_UNARY_INIT_FN_ARGS(unused, sfpu::rand_init, (APPROX_MODE), RAND_SEED);
+
+    // rand_tile(0, from, scale): fill the whole tile. VectorMode::RC drives 4
+    // faces (8 rows each), matching the production rand_tile API.
+    SFPU_UNARY_CALL(
+        DstSync::SyncHalf,
+        is_fp32_dest_acc_en,
+        rand,
+        (APPROX_MODE, is_fp32_dest_acc_en),
+        0 /* dst_index */,
+        VectorMode::RC,
+        RAND_FROM,
+        RAND_SCALE);
+
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(PACK_OUT, PACK_OUT, 16 * 16 * 4 /* tile_size */);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(PACK_OUT);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* tile_index */, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

SFPU rand store width tracks Dest accumulation

Fixes #14213

### Notes for reviewers

Diffstat: 5 files changed, 273 insertions(+), 5 deletions(-).

Files touched:
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h`
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h`
- `tt_metal/hw/inc/api/compute/eltwise_unary/rand.h`
- `tt_metal/tt-llk/tests/python_tests/test_sfpu_rand.py`
- `tt_metal/tt-llk/tests/sources/sfpu_rand_test.cpp`

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-14213-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-14213-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-14213-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-14213-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-14213-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-14213-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-14213-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-14213-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-14213-v1)