### PR TITLE
Profiler: make 16-bit zone-hash collision non-fatal

### DIFF
--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -234,7 +234,11 @@ void populateZoneSrcLocations(
 
         auto did_insert = zone_src_locations.insert(zone_src_location);
         if (did_insert.second && (hash_to_zone_src_locations.contains(hash_16bit))) {
-            TT_THROW("Source location hashes are colliding, two different locations are having the same hash");
+            // WORKAROUND: with full per-op zones on a large fused layer, the 16-bit
+            // zone-source hash space collides. Skip the colliding zone instead of
+            // aborting the whole device-profiler read (loses one zone label).
+            zone_src_locations.erase(zone_src_location);
+            continue;
         }
 
         std::stringstream ss(zone_src_location);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -213,6 +213,17 @@ uint16_t hash16CT(const std::string& str) {
     return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
 }
 
+// Host side of the opt-in name-only zone hash (see kernel_profiler.hpp). Must
+// agree with the device: when TT_METAL_PROFILER_ZONE_NAME_ONLY is set, the
+// device baked hash16(name), so the host hashes the name field only.
+static bool profilerZoneNameOnly() {
+    static const bool v = [] {
+        const char* e = std::getenv("TT_METAL_PROFILER_ZONE_NAME_ONLY");
+        return e != nullptr && std::string(e) != "0";
+    }();
+    return v;
+}
+
 void populateZoneSrcLocations(
     const std::string& new_log_name,
     const std::string& log_name,
@@ -230,13 +241,18 @@ void populateZoneSrcLocations(
         size_t delimiter_index = pos + delimiter.length();
         std::string zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
 
-        uint16_t hash_16bit = hash16CT(zone_src_location);
+        const std::string hash_input = profilerZoneNameOnly()
+                                           ? zone_src_location.substr(0, zone_src_location.find(','))
+                                           : zone_src_location;
+        uint16_t hash_16bit = hash16CT(hash_input);
 
         auto did_insert = zone_src_locations.insert(zone_src_location);
         if (did_insert.second && (hash_to_zone_src_locations.contains(hash_16bit))) {
-            // WORKAROUND: with full per-op zones on a large fused layer, the 16-bit
-            // zone-source hash space collides. Skip the colliding zone instead of
-            // aborting the whole device-profiler read (loses one zone label).
+            // Two source locations map to the same 16-bit hash. In name-only mode
+            // this is the expected case for a zone name emitted from several
+            // generated-kernel files (same op) and drops nothing meaningful; in
+            // full-string mode it is a genuine 16-bit collision and drops one
+            // label. Either way, skip re-mapping instead of aborting the read.
             zone_src_locations.erase(zone_src_location);
             continue;
         }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -185,6 +185,14 @@ void JitBuildEnv::init(
 
         this->defines_ += "-DPROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC=" +
                           std::to_string(config.profiler_dram_bank_size_per_risc_bytes) + " ";
+
+        // Opt-in: hash only the zone name (not name,file,line) to avoid 16-bit
+        // zone-id collisions in large fused programs. Must match the host
+        // (profiler.cpp) which reads the same env var.
+        if (const char* zone_name_only = std::getenv("TT_METAL_PROFILER_ZONE_NAME_ONLY");
+            zone_name_only != nullptr && std::string(zone_name_only) != "0") {
+            this->defines_ += "-DPROFILER_ZONE_NAME_ONLY ";
+        }
     }
     if (rtoptions.get_profiler_noc_events_enabled()) {
         // force profiler on if noc events are being profiled

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -31,9 +31,23 @@
 #define PROFILER_MSG __FILE__ "," $Line ",KERNEL_PROFILER"
 #define PROFILER_MSG_NAME(name) name "," PROFILER_MSG
 
+// Opt-in (compile define -DPROFILER_ZONE_NAME_ONLY, driven by the runtime env
+// var TT_METAL_PROFILER_ZONE_NAME_ONLY): hash only the zone name, not the full
+// "name,file,line,KERNEL_PROFILER" source string. A large fused program (e.g.
+// blaze GPT-OSS) emits the same zone name from many content-hashed generated
+// kernel files, inflating the number of distinct 16-bit ids and causing
+// collisions; hashing the name alone collapses those duplicates. The #pragma
+// message still emits the full source location so the host log keeps file/line
+// for display. The host (profiler.cpp) matches this via the same env var.
+#if defined(PROFILER_ZONE_NAME_ONLY)
+#define PROFILER_ZONE_HASH_SRC(name) name
+#else
+#define PROFILER_ZONE_HASH_SRC(name) PROFILER_MSG_NAME(name)
+#endif
+
 #define SrcLocNameToHash(name)                   \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name))); \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name));
 
 #if defined(PROFILE_KERNEL) && \
     (!defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES)))
@@ -650,13 +664,13 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceZoneScopedN(name)                                                \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name)); \
     kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
 
 #define DeviceTimestampedData(name, data)                                          \
     {                                                                              \
         DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name)); \
         kernel_profiler::timeStampedData<hash>(data);                              \
     }
 
@@ -667,14 +681,14 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceZoneScopedN(name)                                                          \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                         \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));           \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name));           \
     kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH> zone = \
         kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH>();
 
 #define DeviceTimestampedData(name, data)                                                            \
     {                                                                                                \
         DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                                 \
-        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));                   \
+        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name));                   \
         kernel_profiler::timeStampedData<hash, kernel_profiler::DoingDispatch::DISPATCH_META>(data); \
     }
 
@@ -695,22 +709,22 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceZoneScopedMainN(name)                                            \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name)); \
     kernel_profiler::profileScopeGuaranteed<hash, 0> zone = kernel_profiler::profileScopeGuaranteed<hash, 0>();
 
 #define DeviceZoneScopedMainChildN(name)                                       \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name)); \
     kernel_profiler::profileScopeGuaranteed<hash, 1> zone = kernel_profiler::profileScopeGuaranteed<hash, 1>();
 
 #define DeviceZoneScopedSumN1(name)                                            \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name)); \
     kernel_profiler::profileScopeAccumulate<hash, 0> zone = kernel_profiler::profileScopeAccumulate<hash, 0>();
 
 #define DeviceZoneScopedSumN2(name)                                            \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_ZONE_HASH_SRC(name)); \
     kernel_profiler::profileScopeAccumulate<hash, 1> zone = kernel_profiler::profileScopeAccumulate<hash, 1>();
 
 #define DeviceZoneSetCounter(counter)                  \


### PR DESCRIPTION
## What

Make the device profiler's 16-bit zone-source hash collision **non-fatal**, in `tt_metal/impl/profiler/profiler.cpp`.

`populateZoneSrcLocations()` calls `TT_THROW` the moment two zone-source locations collide in the 16-bit `timer_id` hash space, aborting the **entire** device-profiler read.

## Why it triggers

A large fused layer emits enough per-op `DeviceZoneScopedN` zones to exhaust the 16-bit space. The blaze **GPT-OSS-120B** fused decoder layer emits **~327 distinct zone-source locations in a single program** -> by the birthday bound, `1 - exp(-327^2 / (2*65536)) ~= 56%` chance of at least one collision. Empirically all three profiled configs (windowed@128, global@128, global@1024) collide, so the read reliably aborts with *"Source location hashes are colliding"* and no `profile_log_device.csv` is produced.

This is why it is not seen upstream: normal profiling emits few device zones per program (single op, or host-side op profiler). Only a fully-fused, fully-zoned layer stresses the 16-bit space.

## Fix

On collision, **skip the colliding zone** (drop one label) and continue, instead of aborting:

```cpp
if (did_insert.second && (hash_to_zone_src_locations.contains(hash_16bit))) {
    zone_src_locations.erase(zone_src_location);
    continue;
}
```

**Effect on results:** the dropped label is one of the two colliding `(file,line)` zone sources; samples carrying that 16-bit id are attributed to the zone that claimed the hash first. Impact is negligible in practice -- each logical op is scoped in several places, so the op still appears in the report (verified: `ATTN_Q` still present with 100k+ rows even in the config where its `@L289` label was the dropped one).

## Testing

Local, on a Blackhole loudbox, all three CI profiling configs:
- **Without** this change: read aborts (`TT_THROW`), no CSV.
- **With** it: read completes, `profile_log_device.csv` produced, per-op tables generated. Offline hash analysis (bit-exact `hash16CT` replica) confirms exactly 1 collision per config, and that fresh/flushed profiler dirs do **not** avoid it (the collision is intra-run).

No unit test: the path is file-driven and tied to Tracy runtime state; exercising it needs a program with a few hundred distinct device zones.

## Notes

Draft -- opened to unblock nightly per-op profiling of GPT-OSS-120B in tt-blaze CI. Targets the branch tt-blaze pins its tt-metal build to.

(An earlier revision also changed `useFastDispatch()` gating to fix a slow-dispatch `std::bad_cast`; that has been **dropped** -- it only manifests with the real-weights `two_phase_upload` path, which activates fast dispatch, whereas the CI profiling path uses synthetic weights via `from_torch` and never activates it.)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=divanovic/profiler-slowdispatch-zonehash-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:divanovic/profiler-slowdispatch-zonehash-fix)