### PR TITLE
sparse_mla: layer-stacked indexer cache + fix KVPE-prefix gather OOM

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -475,6 +475,10 @@ def run_chunked_transformer(
 
     # ONE shared KV cache holding all layers' slots [num_layers, 1, seq_local, 576]; layer i uses
     # cache_layer_idx=i. The ring scratch buffer is shared across layers inside TtPrefillTransformer.
+    # Sparse (DSA) requires an UNCOMPRESSED bf16/fp8_e4m3 ROW_MAJOR KVPE cache (sparse_sdpa reads it
+    # natively; mla.forward asserts) — NOT the init_kvpe_cache bfloat8_b/TILE default that dense
+    # ring_mla wants. Match the cache format to the path.
+    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if resolve_has_indexer(config) else {}
     tt_kvpe_cache = init_kvpe_cache(
         kvpe_cache_head_dim=kvpe_dim,
         mesh_device=mesh_device,
@@ -483,6 +487,7 @@ def run_chunked_transformer(
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_layers,
         num_users=1,
+        **kvpe_dtype_layout,
     )
 
     # Sparse (DSA) layers read a block-cyclic indexer key cache that is caller-owned and passed into

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -497,8 +497,11 @@ def run_chunked_transformer(
     # top-k within bf16 noise). Dense (non-sparse) variants get None (natural-path / dense MLA use no cache).
     tt_index_kv_cache = None
     if resolve_has_indexer(config):
+        # A sparse config must carry index_head_dim; assert rather than silently defaulting so a
+        # misconfigured (missing-field) sparse setup fails loudly with a clear message.
+        assert getattr(config, "index_head_dim", None) is not None, "sparse config must provide index_head_dim"
         tt_index_kv_cache = init_kvpe_cache(
-            kvpe_cache_head_dim=getattr(config, "index_head_dim", 128),
+            kvpe_cache_head_dim=config.index_head_dim,
             mesh_device=mesh_device,
             seq_len=SEQ_CACHE,
             mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -40,6 +40,7 @@ from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
@@ -484,6 +485,24 @@ def run_chunked_transformer(
         num_users=1,
     )
 
+    # Sparse (DSA) layers read a block-cyclic indexer key cache that is caller-owned and passed into
+    # forward, exactly like the KVPE cache. It is user-major layer-stacked
+    # [num_users*num_layers, 1, T, D_idx], so the indexer addresses slot user*num_layers + cache_layer_idx —
+    # allocate it with the SAME num_kvpe_cache_layers=num_layers as the KVPE cache. bf8 (half the memory,
+    # top-k within bf16 noise). Dense (non-sparse) variants get None (natural-path / dense MLA use no cache).
+    tt_index_kv_cache = None
+    if resolve_has_indexer(config):
+        tt_index_kv_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=getattr(config, "index_head_dim", 128),
+            mesh_device=mesh_device,
+            seq_len=SEQ_CACHE,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=num_layers,
+            num_users=1,
+            dtype=ttnn.bfloat8_b,
+        )
+
     mesh_device.enable_program_cache()
 
     # min PCC per layer across chunks (for the summary)
@@ -518,6 +537,7 @@ def run_chunked_transformer(
             actual_end=kv_actual + CHUNK,
             cache_user_id=0,
             return_intermediates=True,
+            index_kv_cache=tt_index_kv_cache,
         )
         ttnn.synchronize_device(mesh_device)
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -195,6 +195,7 @@ class TtIndexer:
         ccl_topology,
         seq_len: int = 1024,
         slot_num: int = 1,
+        layer_num: int = 1,
         is_chunked: bool = False,
     ):
         """Architecture constants are read from the HF config (DS defaults below; GLM sets
@@ -217,6 +218,13 @@ class TtIndexer:
         self.hifi4_fp32_compute_kernel_config = hifi4_fp32_compute_kernel_config
         self.weight_cache_path = weight_cache_path
         self.layer_idx = layer_idx
+        # Total local layers in the shared key cache. The block-cyclic index_kv_cache is user-major
+        # [num_users*layer_num, 1, T, D_idx] — the SAME layout as the MLA KVPE cache — so the flat slot
+        # for (user, layer) is cache_user_id*layer_num + cache_layer_idx, where cache_layer_idx is the
+        # LOCAL per-rank cache slot passed to forward (mirrors the KVPE cache; NOT self.layer_idx, which is
+        # GLOBAL and diverges from the local slot under pipeline parallelism). Computed in forward, used by
+        # write_k and _gather_index_kbuf.
+        self.layer_num = layer_num
         self.tt_ccl = tt_ccl
         self.ccl_num_links = ccl_num_links
         self.ccl_topology = ccl_topology
@@ -390,11 +398,17 @@ class TtIndexer:
         ttnn.deallocate(nope)
         return out
 
-    def _gather_index_kbuf(self, index_kbuf: ttnn.Tensor) -> ttnn.Tensor:
-        """Read the block-cyclic ND-sharded key cache back to a replicated full-T [num_users,1,T,D_idx]
+    def _gather_index_kbuf(self, index_kbuf: ttnn.Tensor, cache_batch_idx: int) -> ttnn.Tensor:
+        """Read the block-cyclic ND-sharded key cache back to a replicated full-T [1,1,T,D_idx]
         (block-cyclic order preserved, bf16 TILE) for indexer_score_dsa's block-cyclic reader — the
-        analogue of ttMLA._gather_kvpe_prefix, but the score op consumes TILE so no RM/typecast step.
-        The op selects this user's slot via cache_batch_idx; the unwritten suffix is never scored
+        analogue of ttMLA._gather_kvpe_prefix, and it uses the same fix.
+
+        SLOT SELECT BEFORE THE GATHER: index_kbuf is user-major [num_users*layer_num, 1, T, D_idx]
+        (same layout as the MLA KVPE cache). Slice the active (user, layer) slot out of dim 0 FIRST, then
+        SP all-gather only that single [1,1,T,D_idx] slot — NOT the whole B-slot cache. Gathering all
+        slots materializes a full-T copy of every user/layer (OOMs at high num_layers, exactly like the
+        MLA kvpe gather did). The gathered kv is then batch-1, so indexer_score needs NO cache_batch_idx
+        (the op requires kB==1 when cache_batch_idx is unset). The unwritten suffix is never scored
         (future positions are causally masked).
 
         PERF TODO: this SP all-gather is currently a blocking barrier — it materializes the whole full-T
@@ -404,12 +418,22 @@ class TtIndexer:
         overlapping the CCL with the op's own compute instead of paying a full gather up front. Op-level
         change (ring indexer_score), not a host-side reorder."""
         cache_i = ttnn.to_memory_config(index_kbuf, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
-        full = self._sp_all_gather(cache_i, dim=2)  # [B,1,T,D_idx] replicated, block-cyclic
+        if cache_i.shape[0] > 1:  # user-major slot select BEFORE the gather (single-slot cache → skip)
+            sel = ttnn.slice(
+                cache_i,
+                [cache_batch_idx, 0, 0, 0],
+                [cache_batch_idx + 1, 1, cache_i.shape[2], cache_i.shape[3]],
+            )
+            ttnn.deallocate(cache_i)
+            cache_i = sel
+        full = self._sp_all_gather(cache_i, dim=2)  # [1,1,T,D_idx] replicated, block-cyclic
         if self.sp_factor > 1:
             ttnn.deallocate(cache_i)
         return full
 
-    def write_k(self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0, index_kbuf=None):
+    def write_k(
+        self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0, cache_layer_idx=0, index_kbuf=None
+    ):
         """Device K stem (wk + TP all-reduce + k_norm + device rope) written into the device index-key
         cache. forward() calls this on every chunk so the key-cache stays complete — else later chunks
         score against missing keys for the early prefix. (Dense v3.1 binds a NullIndexer, so write_k never
@@ -445,8 +469,8 @@ class TtIndexer:
                 index_kbuf,
                 k,
                 slot_idx=cache_user_id,
-                layer_idx=0,
-                num_layers=1,
+                layer_idx=cache_layer_idx,
+                num_layers=self.layer_num,
                 kv_actual_global=start_pos,
                 cluster_axis=self.sp_axis,
             )
@@ -489,6 +513,7 @@ class TtIndexer:
         start_pos: int = 0,
         rope_tensors: dict = None,
         cache_user_id: int = 0,
+        cache_layer_idx: int = 0,
         index_kv_cache: ttnn.Tensor = None,
     ) -> ttnn.Tensor:
         """Indexer forward → top-k key indices [1, 1, S/sp, k] over the device index-key cache, SP-sharded
@@ -518,12 +543,17 @@ class TtIndexer:
                 "block-cyclic indexer requires an externally-allocated index_kv_cache passed to forward() "
                 "(same ownership as the MLA KVPE cache); none was provided"
             )
+        # Flat user-major slot into the shared [num_users*layer_num, 1, T, D_idx] cache — same formula as
+        # ttMLA._cache_batch_idx for the KVPE cache (cache_layer_idx is the LOCAL per-rank cache slot).
+        # Written by write_k and sliced by _gather_index_kbuf.
+        cache_batch_idx = cache_user_id * self.layer_num + cache_layer_idx
         self.write_k(
             hidden_states,
             seq_len,
             start_pos,
             rope_tensors=rope_tensors,
             cache_user_id=cache_user_id,
+            cache_layer_idx=cache_layer_idx,
             index_kbuf=index_kv_cache,
         )
 
@@ -574,8 +604,8 @@ class TtIndexer:
         # indexer_score wants per-head weights [1, H_idx/tp, S/sp, 1]; wts is [1, 1, S/sp, H_idx/tp].
         weights = ttnn.permute(wts, (0, 3, 2, 1))
         if self._blockcyclic:
-            # Gather the per-user block-cyclic key cache to replicated full-T; the op reads it back in
-            # logical order via invP, selects this user's slot via cache_batch_idx, and applies the
+            # _gather_index_kbuf slices this (user, layer) slot then gathers it to replicated full-T; the op
+            # reads it back in logical order via invP (batch-1, so cache_batch_idx=None) and applies the
             # straddle for a non-slab-aligned start_pos (padded chunk). Scores the FULL preallocated width T:
             # positions past each query are causally -inf, and top-k below drops those (-inf -> sentinel).
             #
@@ -586,7 +616,7 @@ class TtIndexer:
             # top-k below is told the valid length (valid_length=end_pos) so it never reads or ranks that
             # stale tail — which is the future top-k would drop anyway (causally -inf), so the selection is
             # unchanged.
-            k_full = self._gather_index_kbuf(index_kv_cache)  # [num_users, 1, T, D_idx] bf16 TILE, block-cyclic
+            k_full = self._gather_index_kbuf(index_kv_cache, cache_batch_idx)  # [1,1,T,D_idx] bf16 TILE, block-cyclic
             logits = ttnn.experimental.indexer_score_dsa(
                 q_dev,
                 k_full,
@@ -594,7 +624,7 @@ class TtIndexer:
                 chunk_start_idx=start_pos,
                 program_config=cfg,
                 cluster_axis=self.sp_axis,
-                cache_batch_idx=cache_user_id,
+                cache_batch_idx=None,  # k_full is already sliced to this slot (batch-1) → no in-kernel select
                 block_cyclic_sp_axis=self.sp_axis,
                 block_cyclic_chunk_local=seq_len,  # per-chip chunk == chunk_size_global / sp
                 kv_len=end_pos,

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -441,6 +441,7 @@ class ttMLA:
                 ccl_topology=self.ccl_topology,
                 seq_len=seq_len,
                 slot_num=slot_num,
+                layer_num=self.layer_num,
                 is_chunked=is_chunked,
             )
         else:
@@ -1038,6 +1039,7 @@ class ttMLA:
             start_pos=kv_actual_isl or 0,
             rope_tensors=rope_tensors,
             cache_user_id=cache_user_id,
+            cache_layer_idx=cache_layer_idx,
             index_kv_cache=index_kv_cache,
         )
 
@@ -1179,10 +1181,12 @@ class ttMLA:
 
         cache_batch_idx = self._cache_batch_idx(cache_user_id, cache_layer_idx)
 
-        # Chunked: the prefix lives in the BLOCK-CYCLIC cache. Gather it on device and hand it to
-        # sparse_sdpa still block-cyclic — the op remaps the natural top-k indices to physical pages
-        # in-kernel (block_cyclic_chunk_local = per-shard chunk = seq_len_local), so no host reorder.
-        # The whole multi-user cache is handed over; sparse_sdpa selects this slot via cache_batch_idx.
+        # Chunked: the prefix lives in the BLOCK-CYCLIC cache. Slice this (user, layer) slot out and
+        # gather ONLY that slot on device, then hand it to sparse_sdpa still block-cyclic — the op remaps
+        # the natural top-k indices to physical pages in-kernel (block_cyclic_chunk_local = per-shard
+        # chunk = seq_len_local), so no host reorder. Slicing the slot BEFORE the gather keeps the
+        # all-gather to a single [1,1,T,576] slot (gathering the whole B=num_users*num_layers cache OOMs
+        # at 78 layers). The gathered kv is batch-1, so cache_batch_idx is unset (None) below.
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
             kvpe_cache,
             tt_kvpe,
@@ -1192,12 +1196,13 @@ class ttMLA:
             kv_actual_global=kv_actual_isl,
             cluster_axis=self.sp_axis,
         )
-        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache)
+        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, cache_batch_idx)
         ttnn.deallocate(tt_kvpe)
 
-        # Sparse attention runs over latent V; project to v_head_dim afterwards.
+        # Sparse attention runs over latent V; project to v_head_dim afterwards. The prefix is already
+        # sliced to this slot (batch-1), so no cache_batch_idx.
         attn_out = self._sparse_mla(
-            tt_q, kvpe_dev, indices, block_cyclic_chunk_local=seq_len_local, cache_batch_idx=cache_batch_idx
+            tt_q, kvpe_dev, indices, block_cyclic_chunk_local=seq_len_local, cache_batch_idx=None
         )
         ttnn.deallocate(kvpe_dev)
         ttnn.deallocate(tt_q)
@@ -1401,22 +1406,37 @@ class ttMLA:
             ttnn.deallocate(out_all_heads)
         return ret
 
-    def _gather_kvpe_prefix(self, kvpe_cache):
+    def _gather_kvpe_prefix(self, kvpe_cache, cache_batch_idx):
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
         ND-sharded / block-cyclic across SP, in the op's format (bf16 or fp8_e4m3, ROW_MAJOR — the
         sparse cache is uncompressed). sparse_sdpa consumes it replicated and remaps the
         natural-position indices to physical block-cyclic pages in-kernel (invP), so the buffer is
-        LEFT in block-cyclic order — no host reorder. Pipeline (all on device): ND→interleaved, SP
+        LEFT in block-cyclic order — no host reorder.
+
+        SLOT SELECT BEFORE THE GATHER: the persistent cache is [B, 1, seq_len_cache, 576], B =
+        num_users*num_layers (user-major slots). Slice the active (user, layer) slot out of dim 0 FIRST,
+        then all-gather only that single [1, 1, seq_len_cache, 576] slot over SP — NOT the whole B-slot
+        cache. At 78 layers the full-cache gather is ~5 GB (×2 in-flight → OOM against the near-full
+        78-layer weights); the single-slot gather is B× smaller. The gathered kv is then batch-1, so
+        sparse_sdpa needs NO cache_batch_idx (the op requires B==1 when cache_batch_idx is unset). This
+        mirrors the dense ring_mla single-slot gather (kv_cache_batch_idx → batch-1 scratch).
+
+        Pipeline (all on device): ND→interleaved, slot slice (no-op for a single-slot cache), SP
         all-gather to full-T (no-op at sp==1). The cache is already in the op format, so there is NO
-        read-back dtype/layout conversion — the all-gather moves the native cache format directly.
-        Returns the WHOLE multi-user cache [B, 1, seq_len_cache, 576] (block-cyclic, B =
-        num_users*num_layers user-major slots); sparse_sdpa selects this user/layer slot itself via
-        cache_batch_idx (no host slot-slice). The unwritten suffix is never addressed since indices
-        stay < populated."""
+        read-back dtype/layout conversion. The unwritten suffix is never addressed since indices stay
+        < populated."""
         cache_i = ttnn.to_memory_config(kvpe_cache, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
+        if cache_i.shape[0] > 1:  # user-major slot select BEFORE the gather (single-slot cache → skip)
+            sel = ttnn.slice(
+                cache_i,
+                [cache_batch_idx, 0, 0, 0],
+                [cache_batch_idx + 1, 1, cache_i.shape[2], cache_i.shape[3]],
+            )
+            ttnn.deallocate(cache_i)
+            cache_i = sel
         full = self._all_gather(
             cache_i, dim=2, cluster_axis=self.sp_axis
-        )  # → [B,1,seq_len_cache,576] repl, block-cyclic
+        )  # → [1,1,seq_len_cache,576] repl, block-cyclic
         if self.sp_factor > 1:
             ttnn.deallocate(cache_i)
         return full

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -413,6 +413,7 @@ class TtPrefillBlock(LightweightModule):
         return_kv_intermediates: bool = False,
         actual_isl: Optional[int] = None,
         padding_side: str = "right",
+        index_kv_cache: Optional[ttnn.Tensor] = None,
     ):
         """
         Args:
@@ -451,6 +452,7 @@ class TtPrefillBlock(LightweightModule):
             actual_start=actual_start,
             cache_user_id=cache_user_id,
             return_kv_intermediates=return_kv_intermediates,
+            index_kv_cache=index_kv_cache,
         )
         kv_intermediates = None
         if return_kv_intermediates:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -294,6 +294,7 @@ class TtPrefillTransformer(LightweightModule):
         actual_start: Optional[int] = None,
         actual_end: Optional[int] = None,
         cache_user_id: int = 0,
+        index_kv_cache: Optional[ttnn.Tensor] = None,
     ):
         """
         Forward pass: [embed] -> [block x N] -> [norm -> lm_head -> sample].
@@ -366,6 +367,7 @@ class TtPrefillTransformer(LightweightModule):
                 cache_user_id=cache_user_id,
                 actual_isl=actual_isl,
                 padding_side=self.padding_side,
+                index_kv_cache=index_kv_cache,
             )
             signpost(f"forward_layer_{i}_end")
             if self.kv_only_last_layer and i == len(self.layers) - 1:


### PR DESCRIPTION
## What

Fixes a DRAM OOM in GLM-5.1 sparse chunked prefill at high layer counts, and makes the sparse indexer key cache layer-stacked like the KVPE cache.

### 1. KVPE-prefix gather OOM (slot-slice before gather)

`_gather_kvpe_prefix` all-gathered the **whole** user-major KVPE cache (`[num_users*num_layers, 1, T, 576]`) to full-T replicated before `sparse_sdpa` selected the slot via `cache_batch_idx`. At GLM-5.1's 78 layers that gather output is ~5 GB/device (×2 in-flight) and OOMs against the near-full 78-layer weights.

Fix: slice the active `(user, layer)` slot out of dim 0 **before** the SP all-gather, so only `[1, 1, T, 576]` is gathered. The gathered kv is then batch-1, so `sparse_sdpa` needs no `cache_batch_idx` (the op requires `B==1` when it is unset). Mirrors the dense `ring_mla` single-slot gather.

### 2. Layer-stacked indexer key cache

The block-cyclic indexer key cache previously hardcoded `layer_idx=0 / num_layers=1` and gathered the whole cache. Make it follow the same user-major, layer-stacked layout as the KVPE cache: `TtIndexer` gains `layer_num`, `forward` gains `cache_layer_idx` (the LOCAL per-rank cache slot, threaded exactly like the KVPE `cache_layer_idx`); the write uses `layer_idx=cache_layer_idx / num_layers=layer_num`, and `_gather_index_kbuf` slices its `user*layer_num + cache_layer_idx` slot before the SP gather (same fix as #1, indexer_score_dsa then gets `cache_batch_idx=None`).

### 3. Wiring + test

Thread `index_kv_cache` through `TtPrefillTransformer.forward` → `TtPrefillBlock.forward` → `mla.forward` (defaults `None`; single-shot and dense are unaffected). Allocate it in the GLM chunked transformer test with `num_kvpe_cache_layers=num_layers` (matching the KVPE cache), and allocate the sparse KVPE cache as bf16/ROW_MAJOR (sparse_sdpa reads it natively — same guard as #49355).

Only the chunked block-cyclic path is affected; single-shot still uses the natural indexer path.

## Testing

**Loudbox (2×4, 8×P150)** — no-regression on the block-cyclic path (`layer_num=1`, slice is a no-op):
- `test_sparse_mla_rotated[glm_5_1-2x4-seq5120]`: full PCC 0.9938, KVPE 0.99991 — **PASS**
- `test_sparse_mla_chunked[glm_5_1-2x4-seq5120]`: output PCC 0.99634 — **PASS**

**Galaxy (8×4)** — `test_glm_prefill_transformer_chunked` (the real B>1 stacked-slot + OOM validation):
- L1 — **PASS**
- L10 — **PASS** (exercises the `user*num_layers + cache_layer_idx` slot + slice at B=10)
- L78 (original OOM repro) — **PASS**

## Follow-up

Folding single-shot onto the block-cyclic path — so the indexer key cache persists and migrates to decode in single-shot too (today single-shot uses a transient in-module buffer) — is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/sparse-indexer-cache-layer-stacked)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/sparse-indexer-cache-layer-stacked)