### PR TITLE
[Test] Sparse-MLA perf test improvements

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -43,10 +43,13 @@ SPARSE_VARIANTS = ["deepseek_v32", "glm_5_1"]
 # ---------------------------------------------------------------------------
 # Box-adaptive candidate meshes (sp, tp), keyed by physical device count. Each box lists ONLY shapes
 # that fit it, so off-box shapes are never generated (no "needs N devices" skips). Shapes must be
-# TP>=2 (the dense 128-head epilogue overflows L1 at TP=1). Coverage rationale:
-#   QuietBox (4):  (2,2) TP=2 for GLM + DeepSeek; (1,4) gives DeepSeek a TP=4 point (GLM caps at TP=2).
-#   LoudBox  (8):  (2,4) TP=4 and (4,2) TP=2 (the full-box GLM shape).
-#   Galaxy   (32): (8,4) production TP=4 + (8,2) TP=2 plane so GLM is exercised.
+# TP>=2 (the dense 128-head epilogue overflows L1 at TP=1). BOTH variants run every listed mesh: GLM's
+# thin per-chip head shard at tp=4 (64/4=16 < 32) is handled by the head→sequence reshard in
+# ttMLA._sparse_mla (#48727) + the head-replicated seq-sharded indexer, so GLM is no longer TP-capped.
+# Coverage rationale:
+#   QuietBox (4):  (2,2) TP=2 and (1,4) TP=4 — both variants at both TP.
+#   LoudBox  (8):  (2,4) TP=4 and (4,2) TP=2 — both variants at both TP.
+#   Galaxy   (32): (8,4) production TP=4 + (8,2) TP=2 plane.
 # Mesh shape is NOT correctness-invariant, so accuracy sweeps the whole box set; determinism and
 # chunked pin to each variant's anchor (highest supported TP) — see _sparse_cases(anchor_only=True).
 SPARSE_MESH_BY_DEVICES = {

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -10,8 +10,8 @@ never dense), completeness covers the indexer files, and a sparse cache-only con
 warns and stays sparse (mirrors dense's lenient placeholder load) instead of silently going dense.
 
 The `matches_config` test is host-only (no device); the build→cache-only→PCC test runs on a TP>=2
-mesh so the sparse epilogue / GLM (TP≤2) fit. Validity gating (so collected==run) is the same as
-test_sparse_mla.py — here we just fix one (4,2) mesh that both variants support.
+mesh so the dense 128-head epilogue fits (TP=1 overflows L1). Validity gating (so collected==run) is
+the same as test_sparse_mla.py — here we just fix one (4,2) mesh that both variants support.
 """
 
 import shutil

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -82,6 +82,8 @@ context (no manual rope bump).
 """
 
 import copy
+import datetime
+import json
 import os
 from dataclasses import dataclass
 from unittest import mock
@@ -125,6 +127,11 @@ VARIANTS = ("deepseek_v32", "glm_5_1")
 VARIANT = os.environ.get("DS_PERF_VARIANT", "deepseek_v32")
 _CONFIG_BUILDERS = {"deepseek_v32": deepseek_v32_hf_config, "glm_5_1": glm_hf_config}
 
+# Fabric transport being profiled — single source for BOTH the impl's device_params and the run manifest,
+# so the recorded provenance can never drift from what actually ran (FABRIC_2D is the production transport;
+# FABRIC_1D exhibited the multi-hop line-broadcast hang).
+PERF_FABRIC = ttnn.FabricConfig.FABRIC_2D
+
 
 def _subdir(variant: str, mode: str) -> str:
     """Per-(variant, mode) tracy profiler subdir (raw device reports + per-scenario summary CSVs). Keeps
@@ -155,6 +162,105 @@ def _scenario_csv(out_dir, scenario: str, variant: str, mode: str) -> str:
     """Per-(scenario, variant, mode) summary CSV path under the tracy profiler dir (next to the raw reports)."""
     root, ext = os.path.splitext(_csv_name(variant, mode))
     return os.path.join(out_dir, f"{root}_{scenario}{ext}")
+
+
+_REPO_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _git_head() -> dict:
+    """Commit + branch of the working tree, read straight from the .git metadata — NO subprocess, NO
+    dirty/diff. The workflow makes the recorded commit truthful by construction: the caller commits before
+    profiling, and the skill's run wrapper enforces a clean tree when not run by hand — so there is no
+    working-tree delta to fingerprint. Handles a linked worktree (`.git` is a file redirecting to a gitdir,
+    as the baseline sweep uses) and both HEAD forms: a symbolic ref (resolved via the loose ref, then
+    packed-refs in the common dir) or a bare detached SHA. Best-effort — any failure degrades to nulls so
+    provenance never breaks the run."""
+    try:
+        d = _REPO_DIR
+        while not os.path.exists(os.path.join(d, ".git")):
+            parent = os.path.dirname(d)
+            if parent == d:
+                return {"commit": None, "branch": None}
+            d = parent
+        git_entry = os.path.join(d, ".git")
+        if os.path.isfile(git_entry):  # worktree: '.git' file → 'gitdir: <path>'
+            gitdir = open(git_entry).read().split("gitdir:", 1)[1].strip()
+            gitdir = os.path.normpath(os.path.join(d, gitdir))
+        else:
+            gitdir = git_entry
+        commondir_file = os.path.join(gitdir, "commondir")  # refs/packed-refs live in the common dir
+        common = (
+            os.path.normpath(os.path.join(gitdir, open(commondir_file).read().strip()))
+            if os.path.exists(commondir_file)
+            else gitdir
+        )
+        head = open(os.path.join(gitdir, "HEAD")).read().strip()
+        if not head.startswith("ref:"):
+            return {"commit": head, "branch": None}  # detached HEAD → bare SHA
+        ref = head.split("ref:", 1)[1].strip()
+        branch = ref[len("refs/heads/") :] if ref.startswith("refs/heads/") else ref
+        loose = os.path.join(common, ref)
+        if os.path.exists(loose):
+            return {"commit": open(loose).read().strip(), "branch": branch}
+        packed = os.path.join(common, "packed-refs")  # ref may only exist packed
+        if os.path.exists(packed):
+            for line in open(packed):
+                line = line.strip()
+                if line and not line.startswith(("#", "^")) and line.endswith(" " + ref):
+                    return {"commit": line.split(" ", 1)[0], "branch": branch}
+        return {"commit": None, "branch": branch}
+    except Exception as e:  # noqa: BLE001 — provenance must never break the run
+        logger.warning(f"run manifest: could not read git HEAD ({e}); commit/branch will be null")
+        return {"commit": None, "branch": None}
+
+
+def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, workload) -> None:
+    """Drop a lean run_manifest.json into the tracy ``reports/<ts>/`` dir. Records ONLY what cannot be
+    reconstructed from git (given the commit) or from the co-located ops CSV:
+      * commit / branch — the code-state anchor (read subprocess-free from .git; no dirty flag — the
+        workflow commits before profiling);
+      * device / mesh / fabric — where and how it ran (runtime facts, not in source);
+      * build.so_mtime — the stale-build guard (not in git, not in the CSV);
+      * command — a copy-paste reproducer (env-prefixed).
+    Deliberately omitted because they are recoverable: commit subject/time & the full model config (from
+    ``git show <commit>`` + reference/{variant}_config.py), the workload sizes (derived from config + mesh
+    + scenario), and per-op measurements (the ops_perf_results CSV sitting in this same dir). Never raises."""
+    try:
+        so = os.path.normpath(os.path.join(_REPO_DIR, *([os.pardir] * 5), "ttnn", "ttnn", "_ttnn.so"))
+        so_mtime = (
+            datetime.datetime.fromtimestamp(os.path.getmtime(so), datetime.timezone.utc).isoformat()
+            if os.path.exists(so)
+            else None
+        )
+        reproducer = (
+            f"DS_PERF_VARIANT={variant} DS_PERF_SCENARIO={scenario} DS_PERF_ATTN_MODE={attn_mode} "
+            f"DS_PERF_CACHE={CACHE_TOKENS} DS_PERF_CHUNK={CHUNK_TOKENS} DS_PERF_LONG_CACHE={LONG_CACHE_TOKENS} "
+            f"{command}"
+        )
+        head = _git_head()
+        manifest = {
+            "schema_version": 2,
+            "variant": variant,
+            "scenario": scenario,
+            "attn_mode": attn_mode,
+            "commit": head["commit"],
+            "branch": head["branch"],
+            "device": {
+                "num_devices": workload.num_devices,
+                "box": workload.system_name,
+                "mesh_sp": workload.sp,
+                "mesh_tp": workload.tp,
+                "fabric": getattr(PERF_FABRIC, "name", str(PERF_FABRIC)),
+            },
+            "build": {"so_mtime": so_mtime},
+            "command": reproducer,
+        }
+        path = os.path.join(report_dir, "run_manifest.json")
+        with open(path, "w") as f:
+            json.dump(manifest, f, indent=2)
+        logger.info(f"run manifest written to {path}")
+    except Exception as e:  # noqa: BLE001 — provenance must never break the run
+        logger.warning(f"run manifest: failed to write ({e}); this dump will lack provenance")
 
 
 def _local_cache_tokens(galaxy_cache: int, sp: int) -> int:
@@ -257,7 +363,7 @@ def _require_perf(request):
     "device_params",
     [
         {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_config": PERF_FABRIC,
             "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
@@ -476,6 +582,24 @@ def test_mla_chunked_perf(variant, scenario, attn_mode):
     csv_out = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, scenario, variant, attn_mode)
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
+
+    # Provenance: drop run_manifest.json next to the raw report so every dump self-documents the code,
+    # command, device, config and measured total that produced it. The reports/<ts>/ dir is never
+    # clobbered, so this survives across subsequent runs (unlike the summary CSV).
+    try:
+        from tracy.process_model_log import get_latest_ops_log_filename
+
+        report_dir = os.path.dirname(get_latest_ops_log_filename(subdir))
+        _write_run_manifest(
+            report_dir,
+            variant=variant,
+            scenario=scenario,
+            attn_mode=attn_mode,
+            command=command,
+            workload=workload,
+        )
+    except Exception as e:  # noqa: BLE001 — provenance must never break the run
+        logger.warning(f"run manifest: could not resolve report dir ({e}); skipping")
 
     # cold only: per-cache-fill-iteration breakdown. The aggregate above sums all chunks; this shows
     # how the per-chunk critical path grows as the cache fills (the point of the cold scenario). Each

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -90,6 +90,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_m
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import make_hidden
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 
@@ -234,11 +235,13 @@ def _require_perf(request):
     "device_params",
     [
         {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
         }
     ],
-    ids=["line"],
+    ids=["fabric2d"],
     indirect=True,
 )
 @pytest.mark.parametrize("variant", ["deepseek_v32"], indirect=True, ids=["deepseek_v32"])

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -583,9 +583,10 @@ def test_mla_chunked_perf(variant, scenario, attn_mode):
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
 
-    # Provenance: drop run_manifest.json next to the raw report so every dump self-documents the code,
-    # command, device, config and measured total that produced it. The reports/<ts>/ dir is never
-    # clobbered, so this survives across subsequent runs (unlike the summary CSV).
+    # Provenance: drop run_manifest.json next to the raw report so every dump self-documents the commit,
+    # command, and device/mesh/fabric that produced it (config and per-op measurements are deliberately
+    # omitted — recoverable from git + reference config + the co-located ops CSV). The reports/<ts>/ dir
+    # is never clobbered, so this survives across subsequent runs (unlike the summary CSV).
     try:
         from tracy.process_model_log import get_latest_ops_log_filename
 

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tracy perf harness for the DeepSeek V3.2 MLA (DSA) chunked-prefill layer.
+Tracy perf harness for the DeepSeek V3.2 / GLM-5.1 MLA (DSA) chunked-prefill layer.
 
 Production scenario (defaults): process one **5k-token chunk** with **50k tokens already cached**,
 on the Galaxy **SP=8 × TP=4** mesh.
@@ -40,31 +40,39 @@ Three scenarios (DS_PERF_SCENARIO; the driver sweeps all three):
     Galaxy-equal on every box (LoudBox=128k, QuietBox=64k box-local cache).
 
 Two-test pattern (mirrors tests/nightly/blackhole/sdpa):
-  * test_mla_chunked_perf_impl  — the work to profile. Builds the v32 ttMLA and, per DS_PERF_SCENARIO,
-    either measures one forward over the (zero-init) block-cyclic caches (warm/long) or forwards a chunk
-    loop that fills them (cold), wrapping the measured forward(s) in signpost("start"/"stop"). Run under tracy.
-  * test_mla_chunked_perf       — the driver, parametrized over [warm, cold, long] × [sparse, dense].
-    Spawns the impl under tracy via run_device_profiler (passing DS_PERF_SCENARIO + DS_PERF_ATTN_MODE),
-    reads the device ops log for the signposted region, prints a per-op table, and writes a per-(scenario,
-    mode) CSV under the per-mode profiler dir.
+  * test_mla_chunked_perf_impl  — the work to profile. Builds the DSA ttMLA (variant from DS_PERF_VARIANT)
+    and, per DS_PERF_SCENARIO, either measures one forward over the (zero-init) block-cyclic caches
+    (warm/long) or forwards a chunk loop that fills them (cold), wrapping the measured forward(s) in
+    signpost("start"/"stop"). Run under tracy.
+  * test_mla_chunked_perf       — the driver, parametrized over [deepseek_v32, glm_5_1] × [warm, cold,
+    long] × [sparse, dense]. Spawns the impl under tracy via run_device_profiler (passing DS_PERF_VARIANT
+    + DS_PERF_SCENARIO + DS_PERF_ATTN_MODE), reads the device ops log for the signposted region, prints a
+    per-op table, and writes a per-(scenario, variant, mode) CSV under the per-(variant, mode) profiler dir.
+
+variant axis — deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 (64 / 32). Both run the SAME TP=4
+  meshes: GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence reshard in
+  ttMLA._sparse_mla (#48727) plus the head-replicated seq-sharded indexer, so GLM is no longer TP-capped.
+  All model dims come from the single-source reference config (reference/{deepseek_v3_2,glm_5_1}_config.py).
 
 attn_mode axis — a baseline to compare the sparse impl against:
   * sparse — v3.2 DSA: indexer builds top-k index keys, sparse_sdpa attends only the top-k=2048 keys.
   * dense  — v3.1 baseline: has_indexer=False -> NullIndexer + full-prefix ring MLA (ring_joint_sdpa
     over the whole prefix, no indexer/top-k). Needs no cache fill (ring reads the prefix by logical_n).
-  Each mode writes its own profiler subdir (deepseek_v32_{sparse,dense}_mla_perf) so the runs never
-  clobber and the CSVs stay directly comparable.
+  Each (variant, mode) writes its own profiler subdir ({variant}_{sparse,dense}_mla_perf) so the runs
+  never clobber and the CSVs stay directly comparable.
 
-Run (Blackhole Galaxy/LoudBox/QuietBox) — all six combos, or narrow via -k:
+Run (Blackhole Galaxy/LoudBox/QuietBox) — all combos (2 variants × 3 scenarios × 2 modes), or narrow via -k:
     pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf -s
-    pytest -m perf ...::test_mla_chunked_perf -k "cold and sparse" -s
-    pytest -m perf ...::test_mla_chunked_perf -k dense -s
+    pytest -m perf ...::test_mla_chunked_perf -k "glm_5_1 and cold and sparse" -s
+    pytest -m perf ...::test_mla_chunked_perf -k "deepseek_v32 and dense" -s
 
-Knobs (env): DS_PERF_SCENARIO (warm|cold|long, default warm for a standalone impl run),
-DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120), DS_PERF_LONG_CACHE (default 512000),
-DS_PERF_CSV (summary filename, per-scenario suffix appended; written under the tracy profiler dir
-generated/profiler/deepseek_v32_sparse_mla_perf/). DS_PERF_CHUNK is the Galaxy-global target chunk; smaller
-boxes scale BOTH the measured chunk and the cache by SP/8; cache must stay a whole chunk multiple.
+Knobs (env): DS_PERF_VARIANT (deepseek_v32|glm_5_1, default deepseek_v32 for a standalone impl run),
+DS_PERF_SCENARIO (warm|cold|long, default warm for a standalone impl run), DS_PERF_ATTN_MODE
+(sparse|dense, default sparse), DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120),
+DS_PERF_LONG_CACHE (default 512000), DS_PERF_CSV (summary filename, per-scenario suffix appended; written
+under the tracy profiler dir generated/profiler/{variant}_{mode}_mla_perf/). DS_PERF_CHUNK is the
+Galaxy-global target chunk; smaller boxes scale BOTH the measured chunk and the cache by SP/8; cache must
+stay a whole chunk multiple.
 
 NOTE: warm/long leave both block-cyclic caches at zero init rather than warming with real chunks — only
 op shapes/timing matter here, not values, and those come from the full `total` prefix width (allocation),
@@ -85,6 +93,8 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import random_mla_weights
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_2_config import deepseek_v32_hf_config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import detect_num_devices
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_marker_explicitly_selected
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import make_hidden
@@ -105,15 +115,25 @@ LONG_CACHE_TOKENS = int(os.environ.get("DS_PERF_LONG_CACHE", 512000))
 # profiler subdir + per-scenario CSVs so the two runs never clobber and stay directly comparable.
 ATTN_MODES = ("sparse", "dense")
 ATTN_MODE = os.environ.get("DS_PERF_ATTN_MODE", "sparse")  # the impl selects its mode from this
+# Model-variant axis: deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 (64 / 32). BOTH run the
+# SAME TP=4 meshes — GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence
+# reshard in ttMLA._sparse_mla (#48727) plus the head-replicated seq-sharded indexer, so no TP cap
+# applies. Every model dimension comes from the single-source reference config
+# (reference/{deepseek_v3_2,glm_5_1}_config.py), never hardcoded here. The impl selects its variant
+# from DS_PERF_VARIANT (the driver sweeps both).
+VARIANTS = ("deepseek_v32", "glm_5_1")
+VARIANT = os.environ.get("DS_PERF_VARIANT", "deepseek_v32")
+_CONFIG_BUILDERS = {"deepseek_v32": deepseek_v32_hf_config, "glm_5_1": glm_hf_config}
 
 
-def _subdir(mode: str) -> str:
-    """Per-mode tracy profiler subdir (holds the raw device reports + the per-scenario summary CSVs)."""
-    return f"deepseek_v32_{mode}_mla_perf"
+def _subdir(variant: str, mode: str) -> str:
+    """Per-(variant, mode) tracy profiler subdir (raw device reports + per-scenario summary CSVs). Keeps
+    deepseek_v32/glm_5_1 × sparse/dense runs from clobbering each other."""
+    return f"{variant}_{mode}_mla_perf"
 
 
-def _csv_name(mode: str) -> str:
-    return os.environ.get("DS_PERF_CSV" if mode == "sparse" else "DS_DENSE_PERF_CSV", f"{_subdir(mode)}.csv")
+def _csv_name(variant: str, mode: str) -> str:
+    return os.environ.get("DS_PERF_CSV" if mode == "sparse" else "DS_DENSE_PERF_CSV", f"{_subdir(variant, mode)}.csv")
 
 
 # Three profiling scenarios (select the impl's via DS_PERF_SCENARIO; the driver sweeps all three):
@@ -131,9 +151,9 @@ SCENARIOS = {
 SCENARIO = os.environ.get("DS_PERF_SCENARIO", "warm")
 
 
-def _scenario_csv(out_dir, scenario: str, mode: str) -> str:
-    """Per-(scenario, mode) summary CSV path under the tracy profiler dir (next to the raw reports)."""
-    root, ext = os.path.splitext(_csv_name(mode))
+def _scenario_csv(out_dir, scenario: str, variant: str, mode: str) -> str:
+    """Per-(scenario, variant, mode) summary CSV path under the tracy profiler dir (next to the raw reports)."""
+    root, ext = os.path.splitext(_csv_name(variant, mode))
     return os.path.join(out_dir, f"{root}_{scenario}{ext}")
 
 
@@ -151,9 +171,9 @@ pytestmark = pytest.mark.perf
 
 GALAXY_SP = 8
 GALAXY_TP = 4
-GALAXY_NUM_HEADS = 128
-GALAXY_INDEX_HEADS = 64
-INDEX_HEAD_DIM = 128
+# Head counts / index dims are NOT constants here — they come from the reference config per variant
+# (deepseek_v32: 128/64, glm_5_1: 64/32; see _detect_perf_workload). GALAXY_SP/GALAXY_TP are the
+# production mesh topology (shared by both variants), not model dims, so they stay in the harness.
 
 
 @dataclass(frozen=True)
@@ -191,21 +211,23 @@ def _exact_div(numerator: int, denominator: int, label: str) -> int:
     return numerator // denominator
 
 
-def _detect_perf_workload() -> tuple[PerfWorkload, str | None]:
+def _detect_perf_workload(variant_name: str) -> tuple[PerfWorkload, str | None]:
     num_devices = detect_num_devices()
     system = _SYSTEM_BY_DEVICE_COUNT.get(num_devices)
     if system is None:
         placeholder = PerfWorkload("unsupported", num_devices, (1, 1), CHUNK_TOKENS, 32, 16)
         return placeholder, (
-            "DeepSeek V3.2 sparse MLA perf supports Blackhole QuietBox/LoudBox/Galaxy only "
-            f"(detected {num_devices} chips)"
+            "sparse MLA perf supports Blackhole QuietBox/LoudBox/Galaxy only " f"(detected {num_devices} chips)"
         )
 
     system_name, mesh_shape = system
     sp, tp = mesh_shape
+    # Head counts come from the single-source reference config for the variant (deepseek_v32: 128/64,
+    # glm_5_1: 64/32) — the same builder the config_only fixture resolves, so device and harness agree.
+    cfg = _CONFIG_BUILDERS[variant_name]()
     local_chunk = _exact_div(CHUNK_TOKENS, GALAXY_SP, "DS_PERF_CHUNK")
-    local_heads = _exact_div(GALAXY_NUM_HEADS, GALAXY_TP, "GALAXY_NUM_HEADS")
-    local_index_heads = _exact_div(GALAXY_INDEX_HEADS, GALAXY_TP, "GALAXY_INDEX_HEADS")
+    local_heads = _exact_div(cfg.num_attention_heads, GALAXY_TP, f"{variant_name}.num_attention_heads")
+    local_index_heads = _exact_div(cfg.index_n_heads, GALAXY_TP, f"{variant_name}.index_n_heads")
     workload = PerfWorkload(
         system_name=system_name,
         num_devices=num_devices,
@@ -217,7 +239,7 @@ def _detect_perf_workload() -> tuple[PerfWorkload, str | None]:
     return workload, None
 
 
-PERF_WORKLOAD, PERF_SKIP_REASON = _detect_perf_workload()
+PERF_WORKLOAD, PERF_SKIP_REASON = _detect_perf_workload(VARIANT)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -244,7 +266,7 @@ def _require_perf(request):
     ids=["fabric2d"],
     indirect=True,
 )
-@pytest.mark.parametrize("variant", ["deepseek_v32"], indirect=True, ids=["deepseek_v32"])
+@pytest.mark.parametrize("variant", [VARIANT], indirect=True, ids=[VARIANT])
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test — skip on CI")
 @pytest.mark.timeout(0)
 def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only):
@@ -267,19 +289,16 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
     # table (get_rope_tensors_indexed) requires total = cache + chunk to be a multiple of chunk.
     assert cache % chunk == 0, f"cache {cache} must be a whole number of {chunk}-token chunks"
     assert total % sp == 0 and (total // sp) % 32 == 0, f"total {total} must be tile-aligned per SP={sp} chip"
-    assert (
-        PERF_WORKLOAD.num_attention_heads // tp == GALAXY_NUM_HEADS // GALAXY_TP
-    ), "local MLA heads/chip must match Galaxy"
+    assert config_only.num_attention_heads % tp == 0 and config_only.index_n_heads % tp == 0, (
+        f"{variant.name} heads (MLA={config_only.num_attention_heads}, index={config_only.index_n_heads}) "
+        f"must be divisible by TP={tp}"
+    )
 
+    # Every model dimension (heads, index_*, rope interleave) comes from the single-source reference
+    # config (config_only → reference/{deepseek_v3_2,glm_5_1}_config.py). Mirror the correctness tests:
+    # set only max_seq_len and let ttMLA read all dims from the config — no per-variant overrides here.
     config = copy.deepcopy(config_only)
     config.max_seq_len = total  # rope-table / buffer length (same hack as the correctness tests)
-    config.num_attention_heads = PERF_WORKLOAD.num_attention_heads
-    if hasattr(config, "num_key_value_heads"):
-        config.num_key_value_heads = PERF_WORKLOAD.num_attention_heads
-    config.index_n_heads = PERF_WORKLOAD.index_n_heads
-    config.index_head_dim = getattr(config, "index_head_dim", INDEX_HEAD_DIM)
-    config.index_topk = getattr(config, "index_topk", 2048)
-    config.index_rope_interleave = getattr(config, "index_rope_interleave", False)
     weights = random_mla_weights(config)
 
     # Indexer rope now scales from config.max_seq_len (set above) — no manual bump needed.
@@ -366,16 +385,21 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
 # ============================================================================
 @pytest.mark.parametrize("attn_mode", list(ATTN_MODES), ids=list(ATTN_MODES))
 @pytest.mark.parametrize("scenario", list(SCENARIOS), ids=list(SCENARIOS))
+@pytest.mark.parametrize("variant", list(VARIANTS), ids=list(VARIANTS))
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test — run locally with tracy")
 @pytest.mark.timeout(0)
-def test_mla_chunked_perf(scenario, attn_mode):
+def test_mla_chunked_perf(variant, scenario, attn_mode):
     from tracy.common import PROFILER_ARTIFACTS_DIR
     from tracy.process_model_log import run_device_profiler
 
-    if PERF_SKIP_REASON:
-        pytest.skip(PERF_SKIP_REASON)
+    # Workload is variant-specific (head counts differ); the mesh/SP is shared, but resolve per variant
+    # so labels + head counts are correct for the variant being driven (the parent's module-level VARIANT
+    # may differ from this parametrized variant).
+    workload, skip_reason = _detect_perf_workload(variant)
+    if skip_reason:
+        pytest.skip(skip_reason)
 
-    subdir = _subdir(attn_mode)  # per-mode profiler dir (sparse/dense never clobber each other)
+    subdir = _subdir(variant, attn_mode)  # per-(variant, mode) dir: runs never clobber each other
 
     # merge_device_rows: the deepseek_v3_d_p / tt_transformers convention for collapsing the device
     # dimension of a multi-chip Tracy ops log (see models/demos/deepseek_v3_d_p/utils/perf_utils.py).
@@ -383,7 +407,7 @@ def test_mla_chunked_perf(scenario, attn_mode):
     from tests.nightly.sdpa_perf_utils import post_process_ops_log
 
     galaxy_cache = SCENARIOS[scenario]["cache"]
-    cache = _local_cache_tokens(galaxy_cache, PERF_WORKLOAD.sp)  # box-scaled (matches the impl)
+    cache = _local_cache_tokens(galaxy_cache, workload.sp)  # box-scaled (matches the impl)
     is_cold = SCENARIOS[scenario]["loop"]
 
     # The impl is skipif(CI=="true"); CI=false in the subprocess lets it run there (mirrors the
@@ -397,7 +421,10 @@ def test_mla_chunked_perf(scenario, attn_mode):
     # run_device_profiler defaults op_support_count to ~1333 ops/device — the tracy device-profiler
     # ring buffer silently drops ops beyond it. cold forwards ~11 chunks (~800 ops); raise the cap so a
     # future op-count bump can't silently truncate the log (which would corrupt the per-op totals).
-    with mock.patch.dict(os.environ, {"CI": "false", "DS_PERF_SCENARIO": scenario, "DS_PERF_ATTN_MODE": attn_mode}):
+    with mock.patch.dict(
+        os.environ,
+        {"CI": "false", "DS_PERF_SCENARIO": scenario, "DS_PERF_ATTN_MODE": attn_mode, "DS_PERF_VARIANT": variant},
+    ):
         run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"], op_support_count=5000)
 
     dur_col = "DEVICE KERNEL DURATION [ns]"
@@ -431,10 +458,10 @@ def test_mla_chunked_perf(scenario, attn_mode):
     span = f"full cold prefill 0→{cache}-tok cache" if is_cold else f"one chunk @ {cache}-tok cache"
     table = "\n".join(
         [
-            f"DeepSeek V3.2 MLA chunked perf [{attn_mode}/{scenario}] — {PERF_WORKLOAD.system_name} proxy "
-            f"{PERF_WORKLOAD.chunk_tokens}-tok chunk, {span}, SP={PERF_WORKLOAD.sp}×TP={PERF_WORKLOAD.tp}",
-            f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {galaxy_cache}-tok cache, SP=8×TP=4; "
-            f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={GALAXY_NUM_HEADS // GALAXY_TP}",
+            f"{variant} MLA chunked perf [{attn_mode}/{scenario}] — {workload.system_name} proxy "
+            f"{workload.chunk_tokens}-tok chunk, {span}, SP={workload.sp}×TP={workload.tp}",
+            f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {galaxy_cache}-tok cache, SP={GALAXY_SP}×TP={GALAXY_TP}; "
+            f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={workload.num_attention_heads // GALAXY_TP}",
             f"critical-path device-kernel time over the {'prefill' if is_cold else 'chunk'} "
             f"(device-collapsed: compute=max, collectives=avg across chips): "
             f"{total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} op calls",
@@ -446,7 +473,7 @@ def test_mla_chunked_perf(scenario, attn_mode):
     logger.info("\n" + table)
     print("\n" + table)  # ensure full table reaches stdout even if logging is filtered
 
-    csv_out = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, scenario, attn_mode)
+    csv_out = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, scenario, variant, attn_mode)
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
 
@@ -458,7 +485,7 @@ def test_mla_chunked_perf(scenario, attn_mode):
         ri = region.reset_index(drop=True)
         starts = list(ri.index[ri["OP CODE"] == "MLA_START"])
         bounds = starts + [len(ri)]
-        chunk = PERF_WORKLOAD.chunk_tokens
+        chunk = workload.chunk_tokens
         # Per-op × per-iteration: the SAME per-op table as the aggregate above (OP CODE, count,
         # total_ns, avg_ns, pct — sorted desc), but computed for each iteration's segment and tagged
         # with iteration + cache_depth_tokens, so each op's time can be tracked as the cache fills.
@@ -484,7 +511,7 @@ def test_mla_chunked_perf(scenario, attn_mode):
         iter_header = f"{'iter':>4}{'cache_depth':>12}{'total_ms':>12}{'ops':>6}"
         iter_table = "\n".join(
             [
-                f"cold per-iteration critical path [{PERF_WORKLOAD.system_name}] "
+                f"cold per-iteration critical path [{variant}/{workload.system_name}] "
                 f"(device-collapsed; last iter == the `warm` step):",
                 iter_header,
                 "-" * len(iter_header),
@@ -493,6 +520,6 @@ def test_mla_chunked_perf(scenario, attn_mode):
         )
         logger.info("\n" + iter_table)
         print("\n" + iter_table)
-        iter_csv = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, f"{scenario}_by_iter", attn_mode)
+        iter_csv = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, f"{scenario}_by_iter", variant, attn_mode)
         by_iter_op.to_csv(iter_csv, index=False)
         logger.info(f"per-op×iteration CSV written to {os.path.abspath(iter_csv)}")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
@@ -294,6 +294,11 @@ def _skip_unsupported(model: str, mesh_device) -> None:
     """Shared device guards: too-few-tokens-per-SP-chip (both); and GLM's tp ≤ 2 (64 q-heads,
     sparse_sdpa needs per-chip H = 64/tp ≥ 32 → tp>2 meshes are skipped for GLM)."""
     skip_if_seq_too_small_for_sp(SEQ_LEN, mesh_device)
+    # TODO: this GLM tp>2 skip is now STALE — the head→sequence reshard in ttMLA._sparse_mla (#48727)
+    # and the head-replicated SP×TP seq-sharded indexer let GLM run at tp=4 (the perf + correctness
+    # suites already do). Lifting it here is out of scope for the perf change: these standalone
+    # indexer/kv/output trace tests exercise paths this skip has been masking, so removing it needs its
+    # own HW verification at tp=4 first. Remove once validated.
     if model == "glm_5_1" and mesh_device.shape[1] > 2:
         pytest.skip(f"GLM sparse_sdpa needs per-chip H=64/tp≥32 → tp≤2 (mesh tp={mesh_device.shape[1]})")
 


### PR DESCRIPTION
# Summary
Improvements to the sparse-MLA Tracy perf harness

- **GLM-5.1 variant axis.** The harness now sweeps `[deepseek_v32, glm_5_1] × [warm, cold, long] × [sparse, dense]` (12 combos).
- Head counts and index dims come from the single-source reference configs (`reference/{deepseek_v3_2,glm_5_1}_config.py`)
- **FABRIC_2D transport.** instead of FABRIC_1D.
- **Tracy run manifest.** Each tracy run drops a lean manifest file that enable easy reproduction of the run.
- **Docs.** Removed the stale "GLM TP≤2" cap notes across the sparse-MLA tests

# Scope:
- **Tests Only**, no CI test changes
- `models/demos/deepseek_v3_d_p/tests/sparse_mla/`
- no model / ttnn code / CI tests is touched.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/sparse_test_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasilijevic/sparse_test_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvasilijevic/sparse_test_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/sparse_test_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasilijevic/sparse_test_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/sparse_test_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/sparse_test_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/sparse_test_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/sparse_test_improvements)