### PR TITLE
#49481 #49112: GLM-5.1 sparse (DSA) prefill serving through the prefill runner

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -79,6 +79,26 @@ class PrefillRunParams:
         return self.mesh_shape[self.tp_axis]
 
 
+class KvCaches(tuple):
+    """The device KV cache(s) a prefill model owns, returned by ``allocate_kv_cache`` as an ORDERED
+    tuple of tensors. Callers index positionally:
+
+      * ``kv_caches[0]`` — ALWAYS the primary KV cache (the MLA KVPE cache for the DeepSeek-V3 family).
+      * ``kv_caches[1:]`` — any SECONDARY caches the model also owns. A sparse-attention (DSA) model
+        like GLM-5.1 puts its lightning-indexer block-cyclic key cache at index 1, so the engine can
+        build a single MERGED migration table over both (config 0 = KVPE, config 1 = index). A dense
+        model returns just ``KvCaches([kvpe])`` (length 1).
+
+    A tuple rather than a bare tensor plus optional allocate hooks: every model implements the same
+    single ``allocate_kv_cache`` and just returns as many caches as it owns — a model that grows a
+    third cache appends it at index 2, no new adapter method or engine argument. The engine allocates
+    these once, OWNS their lifetime — it passes them into every runtime call that touches them
+    (compile / prefill_chunk / build_kv_chunk_table / kv_cache_pcc_check) and frees them with the mesh
+    at shutdown."""
+
+    __slots__ = ()
+
+
 class PrefillModelAdapter(ABC):
     """Per-model plumbing the prefill engine needs. One instance per model.
 
@@ -122,21 +142,19 @@ class PrefillModelAdapter(ABC):
         the cache-populate run wrote. None only if the cache is explicitly empty."""
 
     @abstractmethod
-    def allocate_kv_cache(
-        self, *, mesh_device: "ttnn.MeshDevice", hf_config, params: PrefillRunParams
-    ) -> "ttnn.Tensor":
-        """Allocate (and zero) this model's KV cache on device and return it. This is
-        the single place a model's KV layout is defined. The engine OWNS the returned
-        cache's lifetime: it allocates it once, passes it into every runtime call that
-        touches it (compile / prefill_chunk / build_kv_chunk_table / kv_cache_pcc_check),
-        and frees it with the mesh at shutdown. ``params`` carries the per-rank knobs
-        (max_seq_len, mesh_shape, this rank's num_layers, num_users, …)."""
+    def allocate_kv_cache(self, *, mesh_device: "ttnn.MeshDevice", hf_config, params: PrefillRunParams) -> KvCaches:
+        """Allocate (and zero) this model's KV cache(s) on device and return them as a ``KvCaches``
+        (ordered tuple): index 0 the primary KV cache, then any secondary caches the model owns. A
+        dense model returns ``KvCaches([kvpe])``; a sparse-attention (DSA) model appends its index
+        cache (``KvCaches([kvpe, index])``). This is the single place a model's KV layout is defined.
+        The engine OWNS the returned caches' lifetime — see ``KvCaches``. ``params`` carries the
+        per-rank knobs (max_seq_len, mesh_shape, this rank's num_layers, num_users, …)."""
 
     @abstractmethod
     def build_runtime(self, *, mesh_device: "ttnn.MeshDevice", hf_config, params: PrefillRunParams):
         """Construct the model for this rank and return a runtime handle. The runtime
-        is stateless w.r.t. the KV cache — it receives the engine-owned cache as an
-        argument on each call. The engine then calls ``.compile(kv_cache)`` and drives
+        is stateless w.r.t. the KV cache — it receives the engine-owned ``KvCaches`` as an
+        argument on each call. The engine then calls ``.compile(kv_caches)`` and drives
         it (make_chunk_input, prefill_chunk, and — when enabled — build_kv_chunk_table /
         kv_cache_pcc_check / set_layer_ack_channel). ``params`` carries the per-rank knobs."""
 
@@ -216,10 +234,10 @@ DEFAULT_MODEL = "deepseek_v3_d_p"
 ADAPTER_PATHS = {
     "deepseek_v3_d_p": "models.demos.deepseek_v3_d_p.tt.runners.adapters.deepseek_v3:DeepSeekV3Adapter",
     "kimi_k2_6": "models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6:KimiK26Adapter",
-    # Sparse-attention (DSA) variants — test-only today (config + sparse-MLA reference parity;
-    # no prefill serving runtime wired). See adapters/sparse_mla.py.
+    # GLM-5.1: sparse-attention (DSA) variant with a full prefill serving runtime (adapters/glm_5_1.py).
+    "glm_5_1": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1:GLM51Adapter",
+    # DeepSeek-V3.2-Exp: DSA, still test-only (config + sparse-MLA reference parity; serving not wired).
     "deepseek_v32": "models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla:DeepSeekV32Adapter",
-    "glm_5_1": "models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla:GLM51Adapter",
 }
 
 _ADAPTER_INSTANCES: dict = {}

--- a/models/demos/common/prefill/runners/ADDING_A_PREFILL_MODEL.md
+++ b/models/demos/common/prefill/runners/ADDING_A_PREFILL_MODEL.md
@@ -64,12 +64,14 @@ class MyModelAdapter(PrefillModelAdapter):
         """The TTNN weight-cache dir for this model + mesh (or None if disabled).
         Mirror the layout the cache-populate run wrote so the runner reads the same files."""
 
-    def allocate_kv_cache(self, *, mesh_device, hf_config, params: PrefillRunParams):
-        """Allocate (and zero) this model's KV cache on device and return it — the single
-        place your model's KV layout is defined. The ENGINE owns the returned tensor: it
-        allocates it once, passes it into every runtime call that touches it, and frees it
-        with the mesh at shutdown. `params` carries max_seq_len / mesh_shape / this rank's
-        num_layers / num_users / ... ."""
+    def allocate_kv_cache(self, *, mesh_device, hf_config, params: PrefillRunParams) -> KvCaches:
+        """Allocate (and zero) this model's KV cache(s) on device and return them as a `KvCaches`
+        (ordered tuple) — the single place your model's KV layout is defined. Index 0 is the primary
+        KV cache; a dense model returns `KvCaches([kvpe])`, a sparse-attention (DSA) model appends its
+        secondary cache (`KvCaches([kvpe, index])`) instead of implementing a second method. The
+        ENGINE owns the returned caches: it allocates them once, passes them into every runtime call
+        that touches them, and frees them with the mesh at shutdown. `params` carries max_seq_len /
+        mesh_shape / this rank's num_layers / num_users / ... ."""
 
     def build_runtime(self, *, mesh_device, hf_config, params: PrefillRunParams):
         """Construct the model for this rank and return the runtime handle (section 2).

--- a/models/demos/common/prefill/runners/migration.py
+++ b/models/demos/common/prefill/runners/migration.py
@@ -57,8 +57,19 @@ def serialize_kv_chunk_table(
     cfg.chunk_n_tokens = chunk_n_tokens
     cfg.chunk_size_bytes = chunk_size_bytes
     table = table_builder(config=cfg, chunk_size_bytes=chunk_size_bytes, num_users=num_users)
-    disagg.export_to_protobuf_file(table, path)
-    logger.info(f"[migration] KV chunk address table serialized to {path} (entries={table.total_entries()})")
+    return serialize_prebuilt_kv_chunk_table(table=table, path=path)
+
+
+def serialize_prebuilt_kv_chunk_table(*, table, path: str) -> str:
+    """Serialize an already-built KvChunkAddressTable (single- OR multi-config) to a protobuf file for
+    the worker's SET_TABLE, log it, and return `path`. This is the model-agnostic serialize step;
+    callers that need to build a multi-config table (e.g. a sparse model merging its KVPE + index
+    caches) construct the table themselves and hand it here."""
+    ttnn.experimental.disaggregation.export_to_protobuf_file(table, path)
+    logger.info(
+        f"[migration] KV chunk address table serialized to {path} "
+        f"(configs={table.num_configs()}, entries={table.total_entries()})"
+    )
     return path
 
 

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -402,8 +402,8 @@ def _lease_reclaim(d2d_in, d2d_out) -> None:
         d2d_in.release_fabric_links()
 
 
-def _compute_and_send(runtime, kv_cache, rank: int, c: int, inp, meta: dict, d2d_out) -> float:
-    """Run one chunk: prefill into the engine-owned kv_cache, forward the output downstream (non-last
+def _compute_and_send(runtime, kv_caches, rank: int, c: int, inp, meta: dict, d2d_out) -> float:
+    """Run one chunk: prefill into the engine-owned kv_caches, forward the output downstream (non-last
     rank) and grant the outbound sender so it ships over fabric. Returns the compute-start epoch
     (NTP-comparable). CHUNK_START is logged BEFORE the forward, with this chunk's metadata, so the
     slot/KV-range is visible per rank even if prefill_chunk hangs. The trailing metadata is kept after
@@ -414,7 +414,7 @@ def _compute_and_send(runtime, kv_cache, rank: int, c: int, inp, meta: dict, d2d
         f"slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})"
     )
     out = runtime.prefill_chunk(
-        inp, kv_cache, slot_id=meta["slot_id"], actual_start=meta["actual_start"], actual_end=meta["actual_end"]
+        inp, kv_caches, slot_id=meta["slot_id"], actual_start=meta["actual_start"], actual_end=meta["actual_end"]
     )
     if SYNC_PER_CHUNK:
         # Block on device completion so the delta is this rank's forward alone, not the downstream-start
@@ -442,7 +442,7 @@ def _drain_and_log_e2e(runtime, rank: int, d2d_out, first_compute_start, n_done:
 
 
 def run_request_loop(
-    runtime, kv_cache, rank: int, num_ranks: int, *, hidden_size: int, h2d_service=None, d2d_in=None, d2d_out=None
+    runtime, kv_caches, rank: int, num_ranks: int, *, hidden_size: int, h2d_service=None, d2d_in=None, d2d_out=None
 ) -> None:
     """Production serving loop — UNBOUNDED. rank 0 reads each chunk from the H2D socket (the external
     producer decides the count); downstream ranks read from D2D. Runs until the producer/scheduler
@@ -473,14 +473,14 @@ def run_request_loop(
             if d2d_out is not None:
                 _forward_shutdown(d2d_out, rank, hidden_size)
             break
-        t = _compute_and_send(runtime, kv_cache, rank, c, inp, meta, d2d_out)
+        t = _compute_and_send(runtime, kv_caches, rank, c, inp, meta, d2d_out)
         if first is None:
             first = t
         c += 1
     _drain_and_log_e2e(runtime, rank, d2d_out, first, c, t0)
 
 
-def run_standalone_loop(runtime, kv_cache, rank: int, num_ranks: int, *, d2d_in=None, d2d_out=None) -> None:
+def run_standalone_loop(runtime, kv_caches, rank: int, num_ranks: int, *, d2d_in=None, d2d_out=None) -> None:
     """Bring-up / benchmark loop — BOUNDED, golden-trace input. rank 0 drives NUM_CHUNKS chunks from the
     trace; downstream ranks receive the same count over D2D. Every rank knows NUM_CHUNKS (propagated via
     global_env), so each loops a fixed range independently — no end-of-stream marker needed. With
@@ -516,7 +516,7 @@ def run_standalone_loop(runtime, kv_cache, rank: int, num_ranks: int, *, d2d_in=
         else:
             inp, meta = _d2d_recv(d2d_in)
             slot_id = meta["slot_id"]
-        t = _compute_and_send(runtime, kv_cache, rank, c, inp, meta, d2d_out)
+        t = _compute_and_send(runtime, kv_caches, rank, c, inp, meta, d2d_out)
         if first is None:
             first = t
     # Every rank must finish receiving + forwarding the final chunk before any rank reclaims its
@@ -540,7 +540,7 @@ def run_standalone_loop(runtime, kv_cache, rank: int, num_ranks: int, *, d2d_in=
             )
         # Pass the raw trace path; the validation helper resolves it (descends the vllm hash subdir).
         pcc_check(
-            kv_cache,
+            kv_caches,
             slot_id=slot_id,
             n_chunks=n_chunks,
             trace_dir=os.environ.get("PREFILL_TRACE_DIR", ADAPTER.prefill_trace_default),
@@ -672,9 +672,6 @@ def _serve_standalone(
 ) -> None:
     """Bring-up / benchmark path: golden-trace input on rank 0, D2D-socket transport between ranks,
     per-rank KV PCC. Self-contained (no external producer); covers num_ranks 1..N."""
-    # The per-chunk loop only writes the primary cache (index 0); the runtime already holds any
-    # secondary caches (handed over in compile()).
-    kv_cache = kv_caches[0]
     # Warm-up sync — the ONLY barrier. Every rank finishes compile before any chunk enters the
     # pipeline, so a downstream rank isn't still warming up while an upstream one races ahead. The
     # per-chunk loop takes no barrier. Trade-off: a rank that dies during compile hangs the others here.
@@ -693,7 +690,7 @@ def _serve_standalone(
         ttnn.distributed_context_barrier()
 
     logger.info(f"[pp rank {rank}] setup complete, entering standalone loop")
-    run_standalone_loop(runtime, kv_cache, rank, num_ranks, d2d_in=d2d_in, d2d_out=d2d_out)
+    run_standalone_loop(runtime, kv_caches, rank, num_ranks, d2d_in=d2d_in, d2d_out=d2d_out)
 
     if d2d_in is not None or d2d_out is not None:
         # Free the services while the mesh + command queues are still alive (their dtors free a command
@@ -714,10 +711,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     they are disabled for num_ranks>1 (pipelined migration is future work). Shutdown for num_ranks>1 is
     rough: downstream ranks block in D2D recv when rank 0 stops, so they exit on teardown / SIGKILL."""
     single_rank = num_ranks == 1
-    # The per-chunk loop only writes the primary cache (index 0); the runtime already holds any
-    # secondary caches (handed over in compile()). The migration table below is built from the whole
-    # KvCaches tuple.
-    kv_cache = kv_caches[0]
 
     # Migration is only wired for the single-rank case; on the pipeline it would silently no-op. Fail
     # loud so an enabled-migration pipeline run can't be mistaken for a working one.
@@ -812,7 +805,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     logger.info(f"[pp rank {rank}] setup complete, entering request loop")
     run_request_loop(
         runtime,
-        kv_cache,
+        kv_caches,
         rank,
         num_ranks,
         hidden_size=hf_config.hidden_size,

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -649,15 +649,18 @@ def main() -> None:
     )
 
     runtime = ADAPTER.build_runtime(mesh_device=mesh_device, hf_config=hf_config, params=params)
-    # The engine owns the KV cache: allocate it once (the adapter defines the layout), pass it into
-    # every runtime call, and let it free with the mesh at shutdown.
-    kv_cache = ADAPTER.allocate_kv_cache(mesh_device=mesh_device, hf_config=hf_config, params=params)
-    runtime.compile(kv_cache)
+    # The engine owns the KV cache(s): allocate them once (the adapter defines the layout) as an opaque
+    # KvCaches, hand that container to every runtime call, and let it free with the mesh at shutdown. The
+    # runner stays model-agnostic — it never unpacks the container; the (model-specific) runtime pulls out
+    # the primary cache and any secondary cache (e.g. a sparse/DSA model's index cache) it needs, and folds
+    # both into the merged migration table (see build_kv_chunk_table).
+    kv_caches = ADAPTER.allocate_kv_cache(mesh_device=mesh_device, hf_config=hf_config, params=params)
+    runtime.compile(kv_caches)
 
     if os.environ.get("PREFILL_STANDALONE", "0") == "1":
-        _serve_standalone(runtime, kv_cache, mesh_device, hf_config, rank, num_ranks, is_first_rank)
+        _serve_standalone(runtime, kv_caches, mesh_device, hf_config, rank, num_ranks, is_first_rank)
     else:
-        _serve_request(runtime, kv_cache, mesh_device, hf_config, rank, num_ranks, is_first_rank)
+        _serve_request(runtime, kv_caches, mesh_device, hf_config, rank, num_ranks, is_first_rank)
 
     ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
     ttnn.close_mesh_device(mesh_device)
@@ -665,10 +668,13 @@ def main() -> None:
 
 
 def _serve_standalone(
-    runtime, kv_cache, mesh_device, hf_config, rank: int, num_ranks: int, is_first_rank: bool
+    runtime, kv_caches, mesh_device, hf_config, rank: int, num_ranks: int, is_first_rank: bool
 ) -> None:
     """Bring-up / benchmark path: golden-trace input on rank 0, D2D-socket transport between ranks,
     per-rank KV PCC. Self-contained (no external producer); covers num_ranks 1..N."""
+    # The per-chunk loop only writes the primary cache (index 0); the runtime already holds any
+    # secondary caches (handed over in compile()).
+    kv_cache = kv_caches[0]
     # Warm-up sync — the ONLY barrier. Every rank finishes compile before any chunk enters the
     # pipeline, so a downstream rank isn't still warming up while an upstream one races ahead. The
     # per-chunk loop takes no barrier. Trade-off: a rank that dies during compile hangs the others here.
@@ -698,7 +704,7 @@ def _serve_standalone(
         gc.collect()
 
 
-def _serve_request(runtime, kv_cache, mesh_device, hf_config, rank: int, num_ranks: int, is_first_rank: bool) -> None:
+def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ranks: int, is_first_rank: bool) -> None:
     """Production serving: token chunks + PrefillMetadata arrive over the H2D socket from an external
     producer (prefill_producer.py / the scheduler); unbounded (runs to SIGTERM). Same pipeline
     mechanics as standalone (num_ranks 1..N over D2D); the only difference is the trigger (H2D input)
@@ -708,6 +714,10 @@ def _serve_request(runtime, kv_cache, mesh_device, hf_config, rank: int, num_ran
     they are disabled for num_ranks>1 (pipelined migration is future work). Shutdown for num_ranks>1 is
     rough: downstream ranks block in D2D recv when rank 0 stops, so they exit on teardown / SIGKILL."""
     single_rank = num_ranks == 1
+    # The per-chunk loop only writes the primary cache (index 0); the runtime already holds any
+    # secondary caches (handed over in compile()). The migration table below is built from the whole
+    # KvCaches tuple.
+    kv_cache = kv_caches[0]
 
     # Migration is only wired for the single-rank case; on the pipeline it would silently no-op. Fail
     # loud so an enabled-migration pipeline run can't be mistaken for a working one.
@@ -760,9 +770,11 @@ def _serve_request(runtime, kv_cache, mesh_device, hf_config, rank: int, num_ran
             # Full migration bring-up: the runtime builds the model-specific KV chunk table from
             # its device cache layout; the runner publishes it (+ device map) to the worker and blocks
             # on WORKER_READY before the request loop opens (the worker gates on SetTable + AssignDevMap).
+            # A sparse model's KvCaches carries its index cache too, so the table describes BOTH caches
+            # in one (merged); a dense model's is a single-config table.
             table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
             wait_ready_ms = int(os.environ.get("PREFILL_MIGRATION_WAIT_READY_MS", "120000"))
-            runtime.build_kv_chunk_table(kv_cache, path=table_path)
+            runtime.build_kv_chunk_table(kv_caches, path=table_path)
             publish_table_and_wait_ready(
                 mesh_device=mesh_device,
                 mesh_shape=GLOBAL_MESH_SHAPE,
@@ -773,9 +785,10 @@ def _serve_request(runtime, kv_cache, mesh_device, hf_config, rank: int, num_ran
             # Mock integration (prefill_producer.py): serialize the KV chunk table so an external
             # producer can read it back via ttnn.experimental.disaggregation.import_from_protobuf_file
             # and locate each chunk — WITHOUT the migration_endpoint worker (no MigrationLayerClient,
-            # no WORKER_READY). One galaxy => one complete table spanning all NUM_LAYERS / NUM_USERS.
+            # no WORKER_READY). One galaxy => one complete table spanning all NUM_LAYERS / NUM_USERS
+            # (both caches, merged, for a sparse model).
             table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
-            runtime.build_kv_chunk_table(kv_cache, path=table_path)
+            runtime.build_kv_chunk_table(kv_caches, path=table_path)
             # Also publish the fabric_node -> ASIC unique_id device map so the producer can resolve chips
             # for its device-less UMD read (read_dram_umd) without touching the ControlPlane.
             device_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -14,8 +14,11 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
+from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import build_weights
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
-from models.demos.deepseek_v3_d_p.tt.mla.utils import reverse_reorder_tensor_chunks
+from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
+from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, reverse_reorder_tensor_chunks
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     BH_NUM_DRAM_BANKS,
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
@@ -23,6 +26,7 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     create_kv_chunk_address_table_ds,
     create_kv_chunk_address_table_kimi,
     init_kvpe_cache,
+    populate_kv_chunk_address_table_kimi,
 )
 from tests.ttnn.utils_for_testing import assert_equal
 
@@ -432,3 +436,227 @@ def test_kimi_kv_cache_mock(
                 chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
                 expected_chunk = reference_bf8[batch_idx : batch_idx + 1, :, position:pos_end, :]
                 assert_equal(chunk_torch, expected_chunk)
+
+
+# sp x tp
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    ids=["8x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        },
+    ],
+    ids=["line"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [5 * 1024], ids=["seq5k"])
+@pytest.mark.parametrize("variant", ["glm_5_1"], indirect=True, ids=["glm"])
+@pytest.mark.skipif(not is_blackhole(), reason="GLM DSA (indexer / sparse SDPA) is Blackhole-only")
+@pytest.mark.timeout(0)
+def test_glm_kv_cache_table(
+    mesh_device,
+    seq_len,
+    variant,
+    config_only,
+    device_params,
+):
+    """
+    Readback test for the GLM (glm_5_1) INDEXER key cache. Stands up a single sparse GLM MLA layer with
+    random weights, runs one forward at seq_len=5k to fill the indexer's block-cyclic key cache
+    (tt_index_cache: [1, 1, S/sp, index_head_dim] bfp8, 1 layer / 1 user — caller-allocated and passed
+    into forward(index_kv_cache=...), the same ownership as the MLA KVPE cache), then builds a KV
+    chunk address table over THAT cache with create_kv_chunk_address_table_kimi and reads every 32-token
+    chunk back, comparing to the gathered cache. The index cache row is index_head_dim(128) wide, so a
+    32-token DRAM-bank chunk is [1, 1, 32, 128] bfp8 = 4 tiles. For a single full-seq chunk the
+    block-cyclic layout coincides with the sequential (Kimi) layout, so no chunk reorder is needed.
+    """
+    config = config_only
+    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
+    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+
+    sp_axis = 0
+    tp_axis = 1
+    mesh_shape = list(mesh_device.shape)
+    config.max_seq_len = seq_len
+    logger.info(
+        f"model={variant.name} num_heads={config.num_attention_heads} hidden={config.hidden_size} topology={topology}"
+    )
+
+    # Random GLM weights, incl. the indexer weights the sparse path needs (the random_weights fixture is
+    # dense-only, so build_weights — random by default — is used to also populate indexer.*).
+    weights, _ = build_weights(variant, config, seed=42)
+
+    # Single-chunk block-cyclic forward: chunk == full sequence. Even with one chunk the input is
+    # arranged through the block-cyclic positions (so an SP-contiguous shard lands the block-cyclic rows
+    # on each chip), matching update_padded_kv_cache's writer layout — not relying on the aligned
+    # single-chunk case collapsing to natural order.
+    chunk_size_global = seq_len
+    sp = mesh_shape[sp_axis]
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_chunked=True,
+        slot_num=1,
+        layer_num=1,
+    )
+    rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
+    rope_tensors = rope.get_rope_tensors_indexed(cache_seq_len_global=seq_len, chunk_size_global=chunk_size_global)
+
+    # KVPE cache: uncompressed bf16 + ROW_MAJOR, the format sparse_sdpa reads natively (see MLA.forward).
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    # Indexer key cache: caller-owned (like the KVPE cache), NOT self-allocated by the indexer. Block-cyclic
+    # bfp8 TILE, index_head_dim(128) wide, 1 layer / 1 user; passed into forward(index_kv_cache=...) so the
+    # indexer writes its roped keys into it. write_k typecasts to this cache's dtype before the in-place write.
+    tt_index_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=mla_tt._indexer.index_args.index_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        num_users=1,
+        dtype=ttnn.bfloat8_b,
+    )
+
+    torch.manual_seed(42)
+    hidden = torch.randn(seq_len, config.hidden_size, dtype=torch.bfloat16)
+    # Gather rows into block-cyclic (device-major) order: shard row r holds natural position p[r], so an
+    # SP-contiguous split puts each chip's block-cyclic rows on it (identity for a single aligned chunk,
+    # but keeps the layout correct/general).
+    p = blockcyclic_positions(sp, chunk_size_global, seq_len)
+    chunk_in = hidden[p]
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+    tt_hidden = ttnn.from_torch(
+        chunk_in.reshape(1, 1, seq_len, config.hidden_size),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+    )
+
+    tt_out = mla_tt.forward(
+        tt_hidden, rope_tensors, tt_kvpe_cache, actual_start=0, cache_user_id=0, index_kv_cache=tt_index_cache
+    )
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"[glm] forward complete: out shape {tuple(tt_out.shape)}")
+
+    # Build ONE multi-config KV chunk address table (commit 7a5be3a5e76) holding BOTH caches instead of
+    # two separate tables, using the same config ordering as the serving path (build_and_serialize_kv_chunk_table):
+    # config 0 = the MLA KVPE cache (bf16 ROW_MAJOR, kvpe_head_dim wide); config 1 = the block-cyclic
+    # index-key cache (bfp8 TILE, index_head_dim wide). The two configs share the
+    # device-group / fabric-host side table but each carries its own grid + chunk_size_bytes and is
+    # addressed by config_id on every accessor (set / read_device_chunk). Both caches are
+    # [num_users*num_layers, 1, S/sp, head_dim], ND-sharded 32-tokens-per-bank (round-robin over the DRAM
+    # banks) — the layout populate_kv_chunk_address_table_kimi addresses.
+    index_kbuf = tt_index_cache
+    index_head_dim = mla_tt._indexer.index_args.index_head_dim  # 128
+    kvpe_head_dim = config.kv_lora_rank + config.qk_rope_head_dim  # 576
+
+    # index config: [1, 1, 32, 128] bfp8 = (32/32)*(128/32) = 4 tiles; a 32x32 bfp8 tile is 1024 data + 64
+    # exponent bytes. kvpe config: bf16 ROW_MAJOR, [1, 1, 32, 576] = 32*576*2 bytes contiguous.
+    INDEX_CHUNK_SIZE_BYTES = 4 * 1088  # 4352
+    KVPE_CHUNK_SIZE_BYTES = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK * kvpe_head_dim * 2  # 36864
+    KVPE_CONFIG_ID, INDEX_CONFIG_ID = 0, 1
+
+    def _table_config(chunk_size_bytes):
+        c = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+        c.num_layers = 1
+        c.max_sequence_length = seq_len
+        c.num_slots = 1
+        c.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        c.chunk_size_bytes = chunk_size_bytes
+        return c
+
+    index_config = _table_config(INDEX_CHUNK_SIZE_BYTES)
+    kvpe_config = _table_config(KVPE_CHUNK_SIZE_BYTES)
+
+    # A list of configs -> config i is named "i" (id i). config 0 = kvpe, config 1 = index (serving order).
+    lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable([kvpe_config, index_config])
+    assert lookup_table.num_configs() == 2, f"expected 2 configs, got {lookup_table.num_configs()}"
+
+    populate_kv_chunk_address_table_kimi(
+        lookup_table=lookup_table,
+        config=index_config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=index_kbuf,
+        chunk_size_bytes=INDEX_CHUNK_SIZE_BYTES,
+        num_users=1,
+        config_id=INDEX_CONFIG_ID,
+    )
+    populate_kv_chunk_address_table_kimi(
+        lookup_table=lookup_table,
+        config=kvpe_config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=tt_kvpe_cache,
+        chunk_size_bytes=KVPE_CHUNK_SIZE_BYTES,
+        num_users=1,
+        config_id=KVPE_CONFIG_ID,
+    )
+
+    # --- readback the index cache (config 1, bfp8 TILE) ---
+    # Gather the index cache to a single [1, 1, seq_len, index_head_dim] torch tensor (SP-concat on seq,
+    # TP is replicated so take the first column group), then compare every 32-token chunk to the readback.
+    index_kbuf_torch = ttnn.to_torch(
+        index_kbuf,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)[:1, :1, :, :]
+
+    chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, index_head_dim]
+    for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        pos_end = position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0, config_id=INDEX_CONFIG_ID)
+        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bfp8_bytes(raw_bytes, chunk_shape)
+        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+        expected_chunk = index_kbuf_torch[:, :, position:pos_end, :]
+        assert_equal(chunk_torch, expected_chunk)
+    logger.info(f"[glm] index-cache (config {INDEX_CONFIG_ID}) address-table readback verified over {seq_len} tokens")
+
+    # --- readback the MLA KVPE cache (config 0, bf16 ROW_MAJOR) ---
+    # The KVPE cache is UNCOMPRESSED bf16 ROW_MAJOR (not bfp8 TILE), so a 32-token DRAM-bank chunk is
+    # [1, 1, 32, kvpe_head_dim] bf16 = 32*kvpe_head_dim*2 bytes contiguous, decoded via tensor_from_bf16_bytes
+    # (the RM/bf16 analogue of tensor_from_bfp8_bytes).
+    tt_kvpe_cache_torch = ttnn.to_torch(
+        tt_kvpe_cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)[:1, :1, :, :]
+
+    kvpe_chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_head_dim]
+    for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        pos_end = position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0, config_id=KVPE_CONFIG_ID)
+        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bf16_bytes(raw_bytes, kvpe_chunk_shape)
+        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+        expected_chunk = tt_kvpe_cache_torch[:, :, position:pos_end, :]
+        assert_equal(chunk_torch, expected_chunk)
+    logger.info(
+        f"[glm] kvpe-cache (config {KVPE_CONFIG_ID}, bf16 RM) address-table readback verified over {seq_len} tokens"
+    )

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/__init__.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/__init__.py
@@ -11,11 +11,11 @@ imports this package at module load.
 """
 
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.deepseek_v3 import DeepSeekV3Adapter
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1 import GLM51Adapter
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6 import KimiK26Adapter
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla import (
     DeepSeekV32Adapter,
-    GLM51Adapter,
     GLM52Adapter,
     SparseMLAPrefillAdapter,
 )

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""GLM-5.1 prefill adapter.
+
+Same MLA + MoE family as DeepSeek-V3 / Kimi, so it subclasses ``MLAPrefillAdapter`` and
+inherits the serving path (``build_runtime`` / ``allocate_kv_cache`` / ``weight_cache_path``).
+GLM diverges in two ways the adapter has to account for:
+
+  * The DSA (sparse) attention indexer. This is resolved from the config at model-build time
+    (``resolve_has_indexer`` reads the ``index_*`` attrs), so no adapter wiring is needed beyond
+    handing the runtime a config that carries them — ``glm_hf_config`` does.
+  * ``model_type`` ``glm_moe_dsa`` is not registered with transformers, so ``AutoConfig`` (the
+    base ``load_hf_config``) cannot load it; the config is hand-built via ``glm_hf_config``.
+
+Like Kimi it has a single expert group with a device gate, so the MoE routing all-gather's
+semaphores go to L1_SMALL (needs the L1_SMALL carve-out at mesh-open).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+from models.demos.common.prefill.adapter import KvCaches
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config, glm_hf_config
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
+
+
+class GLM51Adapter(MLAPrefillAdapter):
+    # --- identity & runner defaults ---
+    name = "glm_5_1"
+    model_config = GLM51Config
+    # Config is hand-built (see load_hf_config); this stays empty so an accidental AutoConfig read
+    # yields an obvious empty path. Real weights come from the TTNN cache.
+    hf_model_default = ""
+    # Shared read-only prefill TTNN cache (mirrors Kimi's /mnt default); override with PREFILL_TTNN_CACHE.
+    ttnn_cache_default = "/mnt/models/deepseek-prefill-cache/GLM-5_1-Cache"
+    default_gate_mode = "DEVICE_FP32"  # GLM: single expert group
+    prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
+
+    # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
+    l1_small_size = 512
+    routing_use_l1_small_for_semaphores = True
+
+    def load_hf_config(self):
+        """GLM's ``glm_moe_dsa`` isn't AutoConfig-loadable, so return the hand-built HF-attribute
+        config (carries the dims + the DSA ``index_*`` attrs the sparse path resolves against). The
+        runner overwrites ``max_seq_len`` after; seed the builder with it so rope config is consistent."""
+        max_seq = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 8192))
+        return glm_hf_config(max_seq=max_seq)
+
+    def allocate_kv_cache(self, *, mesh_device, hf_config, params) -> KvCaches:
+        """GLM is sparse (DSA), so it owns TWO device caches, returned as a KvCaches tuple (both with
+        the same block-cyclic, user-major layout of ``num_users * num_layers`` slots, so the merged
+        migration table can address them identically):
+
+          * index 0 — the MLA KVPE cache. sparse_sdpa reads it natively and requires it UNCOMPRESSED
+            (bf16 ROW_MAJOR), not the dense bf8/TILE cache the base MLA adapter allocates.
+          * index 1 — the lightning-indexer's per-user block-cyclic KEY cache (bfp8 TILE,
+            ``index_head_dim`` wide).
+
+        The engine owns both, exactly like the dense KVPE cache."""
+        import ttnn
+        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+
+        kvpe_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=hf_config.qk_rope_head_dim + hf_config.kv_lora_rank,
+            mesh_device=mesh_device,
+            seq_len=params.max_seq_len,
+            mesh_shape=list(params.mesh_shape),
+            sp_axis=params.sp_axis,
+            num_kvpe_cache_layers=params.num_layers,
+            num_users=params.num_users,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        index_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=hf_config.index_head_dim,
+            mesh_device=mesh_device,
+            seq_len=params.max_seq_len,
+            mesh_shape=list(params.mesh_shape),
+            sp_axis=params.sp_axis,
+            num_kvpe_cache_layers=params.num_layers,
+            num_users=params.num_users,
+            dtype=ttnn.bfloat8_b,
+        )
+        return KvCaches([kvpe_cache, index_cache])
+
+    # --- test metadata (HF download coordinates + PCC thresholds + golden trace) ---
+    hf_repo_id = "zai-org/GLM-5.1-FP8"
+    env_var = "GLM51_HF_MODEL"
+    mla_ref_cache_env = "GLM51_MLA_REF_CACHE"
+    ref_cache_env = "TT_GLM51_PREFILL_HOST_REF_CACHE"
+    ttnn_cache_env = "TT_GLM51_PREFILL_TTNN_CACHE"
+    supports_pretrained = True
+    mla_pcc_threshold = 0.995
+    moe_pcc_threshold = 0.971
+    prefill_trace_layout = "chunked_group_a_v1"
+    test_prefill_trace_default = (
+        "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
+    )
+
+    @property
+    def config_builder(self) -> Callable:
+        """The sparse-MLA reference tests resolve GLM's config through this (conftest
+        _resolve_config_only); serving goes through load_hf_config. Both hand off to glm_hf_config."""
+        return glm_hf_config

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
@@ -27,7 +27,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
-from models.demos.common.prefill.adapter import PrefillModelAdapter, PrefillRunParams
+from models.demos.common.prefill.adapter import KvCaches, PrefillModelAdapter, PrefillRunParams
 
 # NOTE: the heavy model stack (TtPrefillRuntime / TtPrefillTransformer, the MoE gate, transformers'
 # AutoConfig) is imported lazily inside the methods that need it. This keeps `import ...adapters` cheap
@@ -88,20 +88,25 @@ class MLAPrefillAdapter(PrefillModelAdapter):
     # ------------------------------------------------------------------
     # KV cache + runtime build
     # ------------------------------------------------------------------
-    def allocate_kv_cache(self, *, mesh_device, hf_config, params: PrefillRunParams):
+    def allocate_kv_cache(self, *, mesh_device, hf_config, params: PrefillRunParams) -> KvCaches:
         """Allocate the MLA kvpe KV cache (qk_rope_head_dim + kv_lora_rank per token;
-        one shared cache of num_users * num_layers user-major slots). The engine owns
-        the returned tensor and passes it into every runtime call."""
+        one shared cache of num_users * num_layers user-major slots). Dense MLA has no
+        secondary cache, so the returned KvCaches holds just the one at index 0. The engine
+        owns the returned caches and passes them into every runtime call."""
         from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import allocate_mla_kvpe_cache
 
-        return allocate_mla_kvpe_cache(
-            mesh_device=mesh_device,
-            hf_config=hf_config,
-            max_seq_len=params.max_seq_len,
-            mesh_shape=params.mesh_shape,
-            sp_axis=params.sp_axis,
-            num_layers=params.num_layers,
-            num_users=params.num_users,
+        return KvCaches(
+            [
+                allocate_mla_kvpe_cache(
+                    mesh_device=mesh_device,
+                    hf_config=hf_config,
+                    max_seq_len=params.max_seq_len,
+                    mesh_shape=params.mesh_shape,
+                    sp_axis=params.sp_axis,
+                    num_layers=params.num_layers,
+                    num_users=params.num_users,
+                )
+            ]
         )
 
     def build_runtime(self, *, mesh_device, hf_config, params: PrefillRunParams):

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/sparse_mla.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-"""Sparse-attention (DSA) prefill adapters: DeepSeek-V3.2-Exp and GLM-5.1.
+"""Sparse-attention (DSA) prefill adapters: DeepSeek-V3.2-Exp and GLM-5.2.
 
-Both add a lightning indexer (DeepSeek Sparse Attention) on top of the MLA + MoE
-family. Two things set them apart from the dense ``DeepSeekV3Adapter`` / ``KimiK26Adapter``:
+(GLM-5.1 has a full serving runtime and lives in its own ``glm_5_1.py``; the test-only DSA
+variants stay here.) Both add a lightning indexer (DeepSeek Sparse Attention) on top of the MLA
++ MoE family. Two things set them apart from the dense ``DeepSeekV3Adapter`` / ``KimiK26Adapter``:
 
   * Their HF ``model_type`` (``deepseek_v32`` / ``glm_moe_dsa``) is NOT registered with
     transformers, so ``AutoConfig`` cannot load them — the config is HAND-BUILT via
@@ -25,7 +26,6 @@ from typing import Callable
 
 from models.demos.common.prefill.adapter import PrefillRunParams
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
-from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
 
@@ -79,40 +79,6 @@ class DeepSeekV32Adapter(SparseMLAPrefillAdapter):
         from models.demos.deepseek_v3_d_p.reference.deepseek_v3_2_config import deepseek_v32_hf_config
 
         return deepseek_v32_hf_config
-
-
-class GLM51Adapter(SparseMLAPrefillAdapter):
-    # --- identity ---
-    name = "glm_5_1"
-    model_config = GLM51Config
-
-    # --- test metadata ---
-    # FP8 repo: the 55k golden trace was generated from the FP8 checkpoint, so the auto-download fallback
-    # must match that precision (bf16 zai-org/GLM-5.1 would diverge from the trace).
-    hf_repo_id = "zai-org/GLM-5.1-FP8"
-    env_var = "GLM51_HF_MODEL"
-    mla_ref_cache_env = "GLM51_MLA_REF_CACHE"
-    mla_pcc_threshold = 0.995
-    moe_pcc_threshold = 0.971
-
-    # --- full-transformer / chunked pytest path ---
-    # GLM runs the same test set as Kimi (single-shot + chunked transformer) against a vLLM golden trace
-    # (approach B: no reference_model_cls — glm_moe_dsa isn't AutoConfig-loadable). Serving is still NOT
-    # wired (base's allocate_kv_cache / build_runtime raise); these fields only enable the pytest
-    # pretrained path (supports_pretrained gates it, and it's consumed exclusively by the test files).
-    supports_pretrained = True
-    ttnn_cache_env = "TT_GLM51_PREFILL_TTNN_CACHE"
-    ref_cache_env = "TT_GLM51_PREFILL_HOST_REF_CACHE"
-    prefill_trace_layout = "chunked_group_a_v1"
-    test_prefill_trace_default = (
-        "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
-    )
-
-    @property
-    def config_builder(self) -> Callable:
-        from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
-
-        return glm_hf_config
 
 
 class GLM52Adapter(SparseMLAPrefillAdapter):

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -17,19 +17,57 @@ NOTE: per-layer LayerAck channel + scheduler-driven migration are NOT here
 (owned by the runner / scheduler / worker side).
 """
 
-from models.demos.common.prefill.runners.migration import serialize_kv_chunk_table
+import ttnn
+from models.demos.common.prefill.runners.migration import serialize_kv_chunk_table, serialize_prebuilt_kv_chunk_table
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     PREFILL_CHUNK_OUTPUT_TOKENS,
     create_kv_chunk_address_table_kimi,
+    populate_kv_chunk_address_table_kimi,
 )
+
+# A KV chunk is one DRAM bank's worth of tokens (NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK=32) x head_dim.
+_TILE_DIM = 32  # bfp8 is tiled 32x32
+_BFP8_TILE_BYTES = 1088  # one 32x32 bfp8 tile: 1024 data + 64 exponent bytes
+_BF16_BYTES = 2
 
 # bfp8 [1, 1, 32, 576] KV chunk: 18 tiles * 1088 B = 19584 B.
 _CHUNK_SIZE_BYTES = 19584
 
 
+def _dram_chunk_size_bytes(cache) -> int:
+    """Bytes of one 32-token DRAM-bank chunk ([.., 32, head_dim]) of `cache`, from its dtype:
+      * bfp8_b  (block-float, TILE):  (head_dim / 32) tiles x 1088 B/tile (1024 data + 64 exponent).
+      * bfloat16 (ROW_MAJOR):         32 tokens x head_dim x 2 B, contiguous.
+    Derived from the tensor so each cache (dense bf8 KVPE, bf16 sparse KVPE, bf8 index) sizes itself."""
+    head_dim = cache.shape[-1]
+    if cache.dtype == ttnn.bfloat8_b:
+        # bfp8 is tiled 32x32, so head_dim must be a whole number of tiles — otherwise integer division
+        # would silently undersize the chunk and corrupt the address table.
+        if head_dim % _TILE_DIM != 0:
+            raise ValueError(f"bfloat8_b KV cache head_dim {head_dim} must be a multiple of {_TILE_DIM} (tiled)")
+        return (head_dim // _TILE_DIM) * _BFP8_TILE_BYTES
+    if cache.dtype == ttnn.bfloat16:
+        # The bf16 contiguous sizing below assumes a ROW_MAJOR cache (32 tokens x head_dim packed with no
+        # tile padding). A TILE-laid-out bf16 cache would need the tiled sizing instead, so reject it here.
+        if cache.layout != ttnn.ROW_MAJOR_LAYOUT:
+            raise ValueError(f"bfloat16 KV cache must be ROW_MAJOR for contiguous chunk sizing, got {cache.layout}")
+        return NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK * head_dim * _BF16_BYTES
+    raise ValueError(f"unsupported KV cache dtype for chunk sizing: {cache.dtype}")
+
+
 def build_and_serialize_kv_chunk_table(
-    *, mesh_device, kvpe_cache, seq_len, num_layers, mesh_shape, sp_axis, num_users, chunk_size_global, path
+    *,
+    mesh_device,
+    kvpe_cache,
+    seq_len,
+    num_layers,
+    mesh_shape,
+    sp_axis,
+    num_users,
+    chunk_size_global,
+    path,
+    index_kv_cache=None,
 ) -> str:
     """Build the MLA block-cyclic KV chunk address table and serialize it to ``path`` for the
     inference server's SET_TABLE. Returns the path on success.
@@ -41,12 +79,29 @@ def build_and_serialize_kv_chunk_table(
     max_seq_len) lists the wrong, block-cyclically-scattered chunks and fails its PCC check.
 
     ``chunk_size_global`` is the block-cyclic period; the kimi builder hardcodes it as
-    PREFILL_CHUNK_OUTPUT_TOKENS, so a non-default period is rejected here rather than mismapped."""
+    PREFILL_CHUNK_OUTPUT_TOKENS, so a non-default period is rejected here rather than mismapped.
+
+    ``index_kv_cache`` (sparse/DSA models only): when given, a single MERGED table describes BOTH
+    caches — config 0 = the KVPE cache, config 1 = the index-key cache — sharing one device-group
+    side table. None (dense models) → the usual single-config table over the KVPE cache alone."""
     assert chunk_size_global == PREFILL_CHUNK_OUTPUT_TOKENS, (
         f"create_kv_chunk_address_table_kimi assumes a block-cyclic period of "
         f"PREFILL_CHUNK_OUTPUT_TOKENS={PREFILL_CHUNK_OUTPUT_TOKENS}, but chunk_size_global={chunk_size_global}. "
         f"A different period would mismap every position; re-introduce a parametrized builder if needed."
     )
+
+    if index_kv_cache is not None:
+        return _build_and_serialize_merged_kv_chunk_table(
+            mesh_device=mesh_device,
+            kvpe_cache=kvpe_cache,
+            index_kv_cache=index_kv_cache,
+            seq_len=seq_len,
+            num_layers=num_layers,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_users=num_users,
+            path=path,
+        )
 
     def _builder(*, config, chunk_size_bytes, num_users):
         return create_kv_chunk_address_table_kimi(
@@ -69,3 +124,43 @@ def build_and_serialize_kv_chunk_table(
         chunk_size_bytes=_CHUNK_SIZE_BYTES,
         path=path,
     )
+
+
+def _build_and_serialize_merged_kv_chunk_table(
+    *, mesh_device, kvpe_cache, index_kv_cache, seq_len, num_layers, mesh_shape, sp_axis, num_users, path
+) -> str:
+    """Sparse (DSA) path: build ONE KvChunkAddressTable holding BOTH caches instead of two tables —
+    config 0 = the KVPE cache, config 1 = the index-key cache. Each config carries its own
+    chunk_size_bytes (derived from the cache's dtype + head_dim); the device-group / fabric-host side
+    table is shared across both. Mirrors test_glm_kv_cache_table's merged readback."""
+    disagg = ttnn.experimental.disaggregation
+
+    def _table_config(cache):
+        cfg = disagg.KvChunkAddressTableConfig()
+        cfg.num_layers = num_layers
+        cfg.max_sequence_length = seq_len
+        cfg.num_slots = num_users
+        cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        cfg.chunk_size_bytes = _dram_chunk_size_bytes(cache)
+        return cfg
+
+    # config 0 = KVPE, config 1 = index (a list of configs -> config i is named "i").
+    caches = (kvpe_cache, index_kv_cache)
+    configs = [_table_config(c) for c in caches]
+    table = disagg.KvChunkAddressTable(configs)
+
+    for config_id, (cache, cfg) in enumerate(zip(caches, configs)):
+        populate_kv_chunk_address_table_kimi(
+            lookup_table=table,
+            config=cfg,
+            mesh_device=mesh_device,
+            mesh_shape=mesh_shape,
+            seq_len=seq_len,
+            sp_axis=sp_axis,
+            tt_kvpe_cache=cache,
+            chunk_size_bytes=cfg.chunk_size_bytes,
+            num_users=num_users,
+            config_id=config_id,
+        )
+
+    return serialize_prebuilt_kv_chunk_table(table=table, path=path)

--- a/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm51.json
+++ b/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm51.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "PREFILL_MODEL": "glm_5_1",
+    "PREFILL_KV_ONLY_LAST_LAYER": "0",
+    "PREFILL_GATE_FALLBACK_MODE": "DEVICE_FP32"
+  }
+}

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -93,9 +93,6 @@ class TtPrefillRuntime:
         assert config.model_cfg is not None, "TtPrefillRuntimeConfig.model_cfg must be set by the model adapter"
         # Per-layer LayerAck callback, built once in set_layer_ack_channel() after compile.
         self._on_layer_complete = None
-        # Secondary (sparse/DSA) index-key cache, handed in via compile() and passed to every forward.
-        # None for dense models. Engine-owned lifetime (like kv_cache); the runtime only holds a reference.
-        self._index_kv_cache = None
 
         assert (
             config.max_seq_len % config.chunk_size == 0
@@ -204,18 +201,14 @@ class TtPrefillRuntime:
 
     def compile(self, kv_caches: KvCaches) -> None:
         """Warm up one chunk so the per-chunk loop hits no first-run cost. The engine passes the
-        `KvCaches` tuple it owns; the warm-up writes into them (slot 0) and is harmless.
-
-        The runtime holds any secondary caches (index 1+ — the DSA index cache for a sparse model;
-        absent for dense) and passes them into every subsequent forward, so the per-chunk loop only
-        has to carry the primary cache tensor (index 0)."""
+        `KvCaches` tuple it owns; the warm-up writes into them (slot 0) and is harmless. The runtime
+        holds NO cache state — the same `kv_caches` is passed back into every prefill_chunk."""
         assert self.model_built
-        self._index_kv_cache = kv_caches[1] if len(kv_caches) > 1 else None
         chunk = self.config.chunk_size
         logger.info(f"TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
         t0 = time.perf_counter()
         tt_input = self.make_chunk_input([0] * chunk)
-        self.prefill_chunk(tt_input, kv_caches[0], slot_id=0, actual_start=0, actual_end=chunk)
+        self.prefill_chunk(tt_input, kv_caches, slot_id=0, actual_start=0, actual_end=chunk)
         ttnn.synchronize_device(self.mesh_device)
         warmup_ms = (time.perf_counter() - t0) * 1000.0
         logger.info(
@@ -226,12 +219,12 @@ class TtPrefillRuntime:
     def prefill_chunk(
         self,
         input_tensor: ttnn.Tensor,
-        kv_cache: ttnn.Tensor,
+        kv_caches: KvCaches,
         slot_id: int,
         actual_start: int,
         actual_end: int,
     ) -> Optional[ttnn.Tensor]:
-        """Prefill ONE chunk into user `slot_id`'s slice of the engine-owned `kv_cache`.
+        """Prefill ONE chunk into user `slot_id`'s slice of the engine-owned `kv_caches`.
 
         On the last rank (and single-rank) this returns None — the populated cache is
         the output (read by the decode stage / migration consumer). On a non-last
@@ -255,8 +248,10 @@ class TtPrefillRuntime:
             input_tensor: on the first rank, one chunk's tokens as an SP-sharded uint32 ROW_MAJOR DRAM
                 tensor (prepare_prefill_input_tensor, block-cyclic, chip-major); on a non-first rank,
                 the upstream hidden-state activation. Deallocated here.
-            kv_cache: the engine-owned KV cache (from the adapter's allocate_kv_cache); this chunk's
-                KV is written into it. The same tensor is passed on every call.
+            kv_caches: the engine-owned KV cache(s) (from the adapter's allocate_kv_cache), an ordered
+                tuple — index 0 the primary KV cache this chunk's KV is written into, index 1+ any
+                secondary caches (a sparse/DSA model's index cache at 1). The same tuple is passed on
+                every call; the runtime holds none of it.
             slot_id: cache user slot to fill, in [0, num_users).
             actual_start: absolute KV pos of the chunk's first real token (the cache write offset).
             actual_end: absolute KV pos past the chunk's last real token.
@@ -274,13 +269,13 @@ class TtPrefillRuntime:
 
         out = self.model.forward(
             input_tensor,
-            kv_cache,
+            kv_caches[0],
             actual_isl=actual_end - actual_start,
             on_layer_complete=self._on_layer_complete,
             actual_start=actual_start,
             actual_end=actual_end,
             cache_user_id=slot_id,
-            index_kv_cache=self._index_kv_cache,
+            index_kv_cache=kv_caches[1] if len(kv_caches) > 1 else None,
         )
         ttnn.deallocate(input_tensor)
         # Non-last rank: forward returns the hidden-state activation to forward downstream.
@@ -336,14 +331,14 @@ class TtPrefillRuntime:
         )
 
     def kv_cache_pcc_check(
-        self, kv_cache: ttnn.Tensor, *, slot_id: int, n_chunks: int, trace_dir=None, first_layer_idx: int = 0
+        self, kv_caches: KvCaches, *, slot_id: int, n_chunks: int, trace_dir=None, first_layer_idx: int = 0
     ) -> float:
         """Optional bring-up hook (not part of the core runtime contract; never called in production
-        serving). PCC the populated engine-owned `kv_cache` for `slot_id` against the golden trace;
-        returns the min per-layer PCC and asserts on failure (unless PREFILL_STANDALONE_CHUNKED_RECORD_ONLY=1).
-        Thin forwarder into the model's validation module so the PCC logic lives in one place."""
+        serving). PCC the populated engine-owned primary KV cache (`kv_caches[0]`) for `slot_id`
+        against the golden trace; returns the min per-layer PCC and asserts on failure (unless
+        PREFILL_STANDALONE_CHUNKED_RECORD_ONLY=1). Thin forwarder into the model's validation module."""
         from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import kv_cache_pcc_check
 
         return kv_cache_pcc_check(
-            self, kv_cache, slot_id=slot_id, n_chunks=n_chunks, trace_dir=trace_dir, first_layer_idx=first_layer_idx
+            self, kv_caches[0], slot_id=slot_id, n_chunks=n_chunks, trace_dir=trace_dir, first_layer_idx=first_layer_idx
         )

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -12,6 +12,7 @@ from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
+from models.demos.common.prefill.adapter import KvCaches
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.runners.input_prep import prepare_prefill_input_tensor
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
@@ -92,6 +93,9 @@ class TtPrefillRuntime:
         assert config.model_cfg is not None, "TtPrefillRuntimeConfig.model_cfg must be set by the model adapter"
         # Per-layer LayerAck callback, built once in set_layer_ack_channel() after compile.
         self._on_layer_complete = None
+        # Secondary (sparse/DSA) index-key cache, handed in via compile() and passed to every forward.
+        # None for dense models. Engine-owned lifetime (like kv_cache); the runtime only holds a reference.
+        self._index_kv_cache = None
 
         assert (
             config.max_seq_len % config.chunk_size == 0
@@ -198,15 +202,20 @@ class TtPrefillRuntime:
             )
         return self.make_placeholder_activation()
 
-    def compile(self, kv_cache: ttnn.Tensor) -> None:
-        """Warm up one chunk so the per-chunk loop hits no first-run cost. The engine
-        passes the cache it owns; the warm-up writes into it (slot 0) and is harmless."""
+    def compile(self, kv_caches: KvCaches) -> None:
+        """Warm up one chunk so the per-chunk loop hits no first-run cost. The engine passes the
+        `KvCaches` tuple it owns; the warm-up writes into them (slot 0) and is harmless.
+
+        The runtime holds any secondary caches (index 1+ — the DSA index cache for a sparse model;
+        absent for dense) and passes them into every subsequent forward, so the per-chunk loop only
+        has to carry the primary cache tensor (index 0)."""
         assert self.model_built
+        self._index_kv_cache = kv_caches[1] if len(kv_caches) > 1 else None
         chunk = self.config.chunk_size
         logger.info(f"TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
         t0 = time.perf_counter()
         tt_input = self.make_chunk_input([0] * chunk)
-        self.prefill_chunk(tt_input, kv_cache, slot_id=0, actual_start=0, actual_end=chunk)
+        self.prefill_chunk(tt_input, kv_caches[0], slot_id=0, actual_start=0, actual_end=chunk)
         ttnn.synchronize_device(self.mesh_device)
         warmup_ms = (time.perf_counter() - t0) * 1000.0
         logger.info(
@@ -271,6 +280,7 @@ class TtPrefillRuntime:
             actual_start=actual_start,
             actual_end=actual_end,
             cache_user_id=slot_id,
+            index_kv_cache=self._index_kv_cache,
         )
         ttnn.deallocate(input_tensor)
         # Non-last rank: forward returns the hidden-state activation to forward downstream.
@@ -297,20 +307,24 @@ class TtPrefillRuntime:
 
         self._on_layer_complete = on_layer_complete
 
-    def build_kv_chunk_table(self, kv_cache: ttnn.Tensor, path: str) -> str:
-        """Build + serialize the KV-chunk address table for the engine-owned `kv_cache` to
+    def build_kv_chunk_table(self, kv_caches: KvCaches, path: str) -> str:
+        """Build + serialize the KV-chunk address table for the engine-owned `KvCaches` to
         `path` and return it.
 
         The table maps each natural KV position to its true block-cyclic storage chip + offset
         (the MLA chunked-prefill cache layout), so the migration worker copies the right chunks.
         The runner publishes the serialized table to the worker — this method only describes the
         cache layout; it issues no migration comms. Single-rank only (config.num_layers == the
-        full model)."""
+        full model).
+
+        For a sparse/DSA model (a secondary cache at index 1), the result is a single MERGED table
+        describing BOTH caches — config 0 = the KVPE cache, config 1 = the index-key cache. A dense
+        model (only index 0) → the usual single-config table over the KVPE cache alone."""
         from models.demos.deepseek_v3_d_p.tt.runners.kv_chunk_table import build_and_serialize_kv_chunk_table
 
         return build_and_serialize_kv_chunk_table(
             mesh_device=self.mesh_device,
-            kvpe_cache=kv_cache,
+            kvpe_cache=kv_caches[0],
             seq_len=self.config.max_seq_len,
             num_layers=self.config.num_layers,
             mesh_shape=self.config.mesh_shape,
@@ -318,6 +332,7 @@ class TtPrefillRuntime:
             num_users=self.config.num_users,
             chunk_size_global=self.config.chunk_size,  # block-cyclic period (prefill chunk size)
             path=path,
+            index_kv_cache=kv_caches[1] if len(kv_caches) > 1 else None,
         )
 
     def kv_cache_pcc_check(

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -187,6 +187,51 @@ def create_kv_chunk_address_table_kimi(
         lookup_table: Populated KvChunkAddressTable
     """
     lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
+    return populate_kv_chunk_address_table_kimi(
+        lookup_table=lookup_table,
+        config=config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=tt_kvpe_cache,
+        chunk_size_bytes=chunk_size_bytes,
+        num_users=num_users,
+        config_id=0,
+    )
+
+
+def populate_kv_chunk_address_table_kimi(
+    lookup_table,
+    config,
+    mesh_device,
+    mesh_shape,
+    seq_len,
+    sp_axis,
+    tt_kvpe_cache,
+    chunk_size_bytes,
+    num_users=1,
+    config_id=0,
+):
+    """
+    Populate ONE config (``config_id``) of an existing KvChunkAddressTable from a device cache tensor.
+
+    Factored out of create_kv_chunk_address_table_kimi so a single multi-config table can hold several
+    caches at once (the serving convention is config 0 = the MLA KVPE cache, config 1 = the block-cyclic
+    index-key cache); each config carries its own grid + chunk_size_bytes and is addressed by config_id.
+    The device-group
+    side table and fabric-node host map are SHARED across configs — re-registering them here per config is
+    safe (add_device_group dedups identical replica sets; set_fabric_node_host is idempotent).
+
+    Args:
+        lookup_table: an existing KvChunkAddressTable (single- or multi-config).
+        config: the KvChunkAddressTableConfig for THIS config_id (read for num_layers).
+        config_id: which config of the table to populate (default 0, the single-config case).
+        (remaining args as in create_kv_chunk_address_table_kimi)
+
+    Returns:
+        lookup_table: the same table, with config_id populated.
+    """
     host_name = socket.gethostname()
 
     rank = ttnn.distributed_context_get_rank()
@@ -249,7 +294,7 @@ def create_kv_chunk_address_table_kimi(
                         location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
                         location.size_bytes = chunk_size_bytes
                         location.device_group_index = group_idx
-                        lookup_table.set(layer, position, slot, location)
+                        lookup_table.set(layer, position, slot, location, config_id)
 
                         curr_bank_id = (curr_bank_id + 1) % num_dram_banks
                         if curr_bank_id == 0:

--- a/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
@@ -321,6 +321,20 @@ void bind_disaggregation_api(nb::module_& mod) {
         Used to compare KV-table reads against the live KV cache byte-for-byte.
         )");
 
+    mod.def(
+        "tensor_from_bf16_bytes",
+        [](const nb::bytes& raw_bytes, const std::vector<uint32_t>& shape) {
+            return ttnn::experimental_disaggregation::tensor_from_bf16_bytes(
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(raw_bytes.c_str()), raw_bytes.size()), shape);
+        },
+        nb::arg("raw_bytes"),
+        nb::arg("shape"),
+        R"(
+        Wrap raw bfloat16 bytes (2 bytes/element, ROW_MAJOR layout) as a host-side ttnn.Tensor
+        with the given shape — no quantization round-trip. The bf16/ROW_MAJOR analogue of
+        tensor_from_bfp8_bytes, for uncompressed (bf16 ROW_MAJOR) KV caches.
+        )");
+
     // Protobuf serialization — the runner publishes the table to the
     // migration_worker (SET_TABLE consumes a serialized protobuf file path).
     mod.def(

--- a/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.cpp
+++ b/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <utility>
 
+#include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt_stl/assert.hpp>
@@ -37,6 +38,40 @@ ttnn::Tensor tensor_from_bfp8_bytes(std::span<const uint8_t> raw_bytes, const st
     tt::tt_metal::TensorSpec spec(tensor_shape, layout);
 
     tt::tt_metal::HostBuffer host_buffer(std::move(packed));
+    return ttnn::Tensor(std::move(host_buffer), std::move(spec));
+}
+
+ttnn::Tensor tensor_from_bf16_bytes(std::span<const uint8_t> raw_bytes, const std::vector<uint32_t>& shape) {
+    TT_FATAL(
+        raw_bytes.size() % sizeof(bfloat16) == 0,
+        "tensor_from_bf16_bytes: raw byte size {} is not a multiple of {} (bfloat16 is 2 bytes)",
+        raw_bytes.size(),
+        sizeof(bfloat16));
+
+    size_t n_elems = raw_bytes.size() / sizeof(bfloat16);
+    size_t shape_volume = 1;
+    for (uint32_t dim : shape) {
+        shape_volume *= dim;
+    }
+    TT_FATAL(
+        n_elems == shape_volume,
+        "tensor_from_bf16_bytes: {} bf16 elements decoded from {} raw bytes do not match the requested "
+        "shape's volume {} — the shape/byte count are inconsistent",
+        n_elems,
+        raw_bytes.size(),
+        shape_volume);
+
+    std::vector<bfloat16> data(n_elems);
+    std::memcpy(data.data(), raw_bytes.data(), raw_bytes.size());
+
+    tt::tt_metal::Shape tensor_shape(ttsl::Span<const uint32_t>(shape.data(), shape.size()));
+    tt::tt_metal::TensorLayout layout(
+        tt::tt_metal::DataType::BFLOAT16,
+        tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
+        tt::tt_metal::MemoryConfig{});
+    tt::tt_metal::TensorSpec spec(tensor_shape, layout);
+
+    tt::tt_metal::HostBuffer host_buffer(std::move(data));
     return ttnn::Tensor(std::move(host_buffer), std::move(spec));
 }
 

--- a/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.hpp
+++ b/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.hpp
@@ -17,4 +17,9 @@ namespace ttnn::experimental_disaggregation {
 // Used to compare KV-table reads against the live KV cache byte-for-byte.
 ttnn::Tensor tensor_from_bfp8_bytes(std::span<const uint8_t> raw_bytes, const std::vector<uint32_t>& shape);
 
+// Wrap raw bfloat16 bytes (2 bytes/element, ROW_MAJOR layout) as a host-side
+// ttnn::Tensor with the given shape — no quantization round-trip. The RM/bf16
+// analogue of tensor_from_bfp8_bytes, for uncompressed (bf16 ROW_MAJOR) KV caches.
+ttnn::Tensor tensor_from_bf16_bytes(std::span<const uint8_t> raw_bytes, const std::vector<uint32_t>& shape);
+
 }  // namespace ttnn::experimental_disaggregation


### PR DESCRIPTION
Wires GLM-5.1's sparse MLA (lightning-indexer + sparse SDPA) chunked prefill to run end-to-end through the common prefill runner, and fixes the deep-layer DRAM OOM that blocked it at full (78) layer counts.

Runner integration:
  * glm_5_1 prefill adapter (adapters/glm_5_1.py) + glm51.json manifest, registered in ADAPTER_PATHS / adapters __init__; the test-only GLM stub is dropped from sparse_mla.py. GLM's KVPE cache is allocated bf16/ROW_MAJOR (sparse_sdpa reads it uncompressed) and it owns a second block-cyclic index-key cache via allocate_index_kv_cache (None for dense models).
  * index_kv_cache is threaded through the serving path the runner drives: TtPrefillRuntime.compile/prefill_chunk -> TtPrefillTransformer -> TtPrefillBlock -> ttMLA.forward -> TtIndexer.forward. The runtime holds it (engine-owned, like the KVPE cache) so the per-chunk loop stays model-agnostic.

Layer-stacked indexer cache + OOM fix (PR #49469):
  * The block-cyclic indexer key cache is now user-major, layer-stacked like the KVPE cache (num_users*layer_num slots); write/score address the (user, layer) slot via cache_layer_idx, so a multi-layer model no longer clobbers slot 0.
  * _gather_kvpe_prefix and _gather_index_kbuf slice the active (user, layer) slot BEFORE the SP all-gather, gathering a single [1,1,T,*] slot instead of the whole num_users*num_layers cache (~5 GB at 78 layers -> OOM). Retains main's kv_len / valid_length score bounding.

Migration table + helpers:
  * Merged multi-config KV chunk address table: one table holds both the KVPE cache (config 0) and the index-key cache (config 1); build_kv_chunk_table takes an optional index_kv_cache and populate_kv_chunk_address_table_kimi fills a given config. tensor_from_bf16_bytes (+ nanobind) added for bf16/ROW_MAJOR readback.
  * test_glm_kv_cache_table exercises the merged 2-config table readback.

Builds on the multi-config KvChunkAddressTable already in main. Validated on a single BH galaxy: 78-layer GLM, 11x5120 chunked prefill runs to completion; KVPE cache PCC vs the vLLM golden matches through the mid layers and drifts in the deep-layer nope latent (min ~0.845), reproduced identically by both slice variants (a model-precision accumulation, not a serving-path issue).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppopovic/layer_multi_config_cherry_pick)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppopovic/layer_multi_config_cherry_pick)