### PR TITLE
[skip ci] Enable ETH deployment tests in health-check diag tiers

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
+++ b/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
@@ -163,12 +163,16 @@ TESTS = {
     "gddr_full": "*DramDeployment_*",
 }
 
+# Tests executed per tier. ETH deployment tests (added in tt-metal #49215 and
+# compiled via tests/tt_metal/tt_metal/deployment/sources.cmake) are enabled here
+# to match the tier layout documented in run_diag.sh:
+#   light  -> eth link_up
+#   medium -> light + eth bandwidth + GDDR fast-pattern
+#   deploy -> full GDDR patterns + eth bandwidth
 TIER_TESTS = {
-    # ETH tests are temporarily disabled; they will be re-enabled once the ETH
-    # tests are updated.
-    "light": [],  # "eth_link_up"
-    "medium": ["gddr_fast"],  # "eth_link_up", "eth_bandwidth"
-    "deploy": ["gddr_full"],  # "eth_link_up", "eth_bandwidth"
+    "light": ["eth_link_up"],
+    "medium": ["gddr_fast", "eth_link_up", "eth_bandwidth"],
+    "deploy": ["gddr_full", "eth_link_up", "eth_bandwidth"],
 }
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Enable the ETH deployment tests in `diag_runner.py` `TIER_TESTS`. They were compiled
and registered in #49215 but left disabled in every tier, so `run_diag.sh` never ran them.

```python
TIER_TESTS = {
    "light":  ["eth_link_up"],
    "medium": ["gddr_fast", "eth_link_up", "eth_bandwidth"],
    "deploy": ["gddr_full", "eth_link_up", "eth_bandwidth"],
}
```

## Why

Matches the tier layout already documented in `run_diag.sh` (light = eth link_up;
medium = + eth bandwidth; deploy = + eth bandwidth). Unblocks the scheduled BH Galaxy
fabric health check (DCAMP-683 / DCAMP-991).

## Test plan

- `run_diag.sh medium --dry-run` shows `eth_link_up` + `eth_bandwidth` in planned calls.
- `run_diag.sh medium` on a BH Galaxy node: eth tests execute and land in `diag_report.json`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/eth_tests_include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/eth_tests_include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/eth_tests_include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/eth_tests_include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/eth_tests_include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/eth_tests_include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/eth_tests_include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/eth_tests_include)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/eth_tests_include)