### PR TITLE
[Quasar] Fix operand A unpack_tilizeA_B l1 index 

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -165,10 +165,15 @@ inline void llk_unpack_tilizeA_B(
     const LocalDFBInterface& local_dfb_interface_b = get_local_dfb_interface(operandB_id);
 
     const std::uint32_t rd_entry_idx_a = local_dfb_interface_a.tc_slots[local_dfb_interface_a.tc_idx].rd_entry_idx;
-    const std::uint32_t tile_row_stride =
-        tensor_shape_A.num_faces_r_dim *
-        tensor_shape_A.face_r_dim;  // used to advance to the next row of tiles in the L1 buffer
-    const std::uint32_t l1_index_a = rd_entry_idx_a * tile_row_stride + tile_index_a;
+    // Compute how many l1_index units fit in one DFB entry.
+    // _llk_unpack_reduce_col_tilizeA_strided_ internally scales
+    // l1_index by num_faces_c_dim, so one l1_index unit = num_faces_c_dim face-rows in L1.
+    const std::uint32_t entry_size_16B = local_dfb_interface_a.entry_size;                           // DFB entry size in 16B
+    const std::uint32_t face_row_16B =                                                               // Buffer Descriptor granularity in 16B
+        SCALE_DATUM_SIZE(unpack_src_format[operandA_id], ckernel::trisc::FACE_C_DIM) >> 4;
+    const std::uint32_t l1_index_per_entry =                                                         // l1_index steps per entry
+        entry_size_16B / (face_row_16B * tensor_shape_A.num_faces_c_dim);
+    const std::uint32_t l1_index_a = rd_entry_idx_a * l1_index_per_entry + tile_index_a;
 
     const std::uint32_t l1_index_b =
         local_dfb_interface_b.tc_slots[local_dfb_interface_b.tc_idx].rd_entry_idx + tile_index_b;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The l1 index for unpack_tilizeA_B operand A was calculated in a way that did not work for different num_entries and entry_size settings. This fix calculates the index in a way that can support different DFB configurations. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/fix_tilizeA_B_index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/fix_tilizeA_B_index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/fix_tilizeA_B_index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/fix_tilizeA_B_index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/fix_tilizeA_B_index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/fix_tilizeA_B_index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/fix_tilizeA_B_index)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/fix_tilizeA_B_index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/fix_tilizeA_B_index)