### PR TITLE
[Feature] indexer_score_msa: expose cache_batch_idx + kv_len (paged/prefill KV cache)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -160,11 +160,19 @@ def run_msa(
     q_dtype=ttnn.bfloat16,
     k_dtype=ttnn.bfloat16,
     compute_kernel_config=None,
+    cache_batch_idx=None,
+    kv_len=None,
 ):
     """Run indexer_score_msa (raw dot, constant `scale` gate, per-group planes) and return torch.
 
     No weights tensor: M3 has no learned gates, only `scale` (run as a constant gate in-op).
+    cache_batch_idx / kv_len are the same runtime, hash-excluded persistent-cache knobs as DSA.
     """
+    persistent = {}
+    if cache_batch_idx is not None:
+        persistent["cache_batch_idx"] = cache_batch_idx
+    if kv_len is not None:
+        persistent["kv_len"] = kv_len
     out = ttnn.experimental.indexer_score_msa(
         to_device(q, device, dtype=q_dtype),
         to_device(k, device, dtype=k_dtype),
@@ -172,6 +180,7 @@ def run_msa(
         scale=scale,
         num_groups=num_groups,
         block_size=block_size,
+        **persistent,
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
@@ -1435,6 +1444,326 @@ def test_indexer_score_block_pool_exact_vs_unpooled(device):
     # bf16 max is exact selection of identical values -> the visible block maxes must match bit-for-bit
     # (forced-local blocks are +inf on both sides: inf == inf under torch.equal).
     assert torch.equal(pooled[~masked].float(), ref[~masked])
+
+
+# ---------------------------------------------------------------------------
+# MSA persistent KV cache: cache_batch_idx (indexed slot) and kv_len (valid prefix) are the same runtime,
+# hash-excluded pass-throughs the DSA frontend exposes; the device op + all 3 kernels are mode-agnostic for
+# them. The g1 (Hi=1) shape drives MSA's fused-streaming K read -- the path that must apply the indexed-slot
+# page offset (a wrong-slot read silently returns slot 0) and the runtime kv_len mask.
+# ---------------------------------------------------------------------------
+MSA_PERSIST = dict(dim=128, sq=64, t=256, chunk_start=128)
+
+
+def _msa_scale_w(heads, sq, scale):
+    """MSA's constant gate materialized for the reference (the op synthesizes it in-kernel)."""
+    return torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)
+
+
+@pytest.mark.parametrize("num_groups", [1, 4], ids=["g1_fused", "g4"])
+def test_indexer_score_msa_indexed_cache(device, num_groups):
+    """MSA cache_batch_idx selects a slot of a shared [B,1,T,D] cache; every slot scores correctly AND
+    switching slots does not recompile (the slot is hash-excluded). g1 (Hi=1) drives the fused-streaming K
+    read -- the path that must add the indexed-slot page offset, so a wrong-slot read fails the per-slot
+    reference. g4 exercises the same on the non-fused per-group-plane path."""
+    c = MSA_PERSIST
+    B, heads, scale = 3, num_groups, c["dim"] ** -0.5  # Hi == num_groups: g1 -> fused single head, g4 -> 4 planes
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
+    g = torch.Generator().manual_seed(17)
+    q = torch.randn(1, heads, c["sq"], c["dim"], generator=g, dtype=torch.bfloat16)
+    k_cache = torch.randn(B, 1, c["t"], c["dim"], generator=g, dtype=torch.bfloat16)  # slots differ
+    q_dev, k_dev = to_device(q, device), to_device(k_cache, device)
+    w_scale = _msa_scale_w(heads, c["sq"], scale)
+
+    def run(b):
+        return ttnn.to_torch(
+            ttnn.experimental.indexer_score_msa(
+                q_dev,
+                k_dev,
+                num_groups=num_groups,
+                chunk_start_idx=c["chunk_start"],
+                scale=scale,
+                program_config=cfg,
+                cache_batch_idx=b,
+            )
+        )
+
+    def check(out, b):
+        ref = indexer_score_msa_ref(q, k_cache[b : b + 1], w_scale, c["chunk_start"], num_groups)
+        assert_grouped_match(out, ref, num_groups, c["sq"], c["t"])
+
+    check(run(0), 0)
+    entries = device.num_program_cache_entries()
+    for b in range(1, B):
+        check(run(b), b)
+    assert device.num_program_cache_entries() == entries, "switching cache_batch_idx recompiled"
+
+
+@pytest.mark.parametrize("num_groups", [1, 4], ids=["g1_fused", "g4"])
+def test_indexer_score_msa_runtime_kv_len(device, num_groups):
+    """MSA over an oversized T=512 buffer scored at several kv_len<=T: only [0,kv_len) is valid, matches the
+    reference there, and growing kv_len does NOT recompile (kv_len is hash-excluded). g1 drives the
+    fused-streaming K read (kv_len masking on the fused path); g4 the per-group-plane path."""
+    heads, scale, dim, sq, t, chunk_start = num_groups, num_groups, 128, 64, 512, 0
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
+    g = torch.Generator().manual_seed(29)
+    q = torch.randn(1, heads, sq, dim, generator=g, dtype=torch.bfloat16)
+    k = torch.randn(1, 1, t, dim, generator=g, dtype=torch.bfloat16)
+    q_dev, k_dev = to_device(q, device), to_device(k, device)
+    w_scale = _msa_scale_w(heads, sq, scale)
+
+    def run(kv_len):
+        return ttnn.to_torch(
+            ttnn.experimental.indexer_score_msa(
+                q_dev,
+                k_dev,
+                num_groups=num_groups,
+                chunk_start_idx=chunk_start,
+                scale=scale,
+                program_config=cfg,
+                kv_len=kv_len,
+            )
+        )
+
+    def check(out, kv_len):
+        ref = indexer_score_msa_ref(q, k[:, :, :kv_len, :], w_scale, chunk_start, num_groups)
+        assert_grouped_match(out[:, :, :, :kv_len], ref, num_groups, sq, kv_len)
+
+    check(run(64), 64)  # most work units fully past kv_len
+    entries = device.num_program_cache_entries()
+    for kv_len in (128, 256, 512):
+        check(run(kv_len), kv_len)
+    assert device.num_program_cache_entries() == entries, "changing kv_len recompiled"
+
+
+def test_indexer_score_msa_block_pool_kv_len(device):
+    """block_size pooling + a block-aligned runtime kv_len: only blocks within the valid prefix are written
+    and match the pooled reference there. Pins the pooled-path kv_len composition (the writer emits whole
+    blocks; kv_len is guarded to a block boundary)."""
+    heads, num_groups, dim, sq, t = 4, 4, GLX_DIM, 128, 2048
+    chunk_start, scale = 512, GLX_DIM**-0.5
+    kv_len = 1024  # block-aligned (8 * 128), < T=2048; causal window 512+128=640 <= kv_len
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    out = run_msa(
+        q,
+        k,
+        chunk_start,
+        device,
+        scale=scale,
+        num_groups=num_groups,
+        block_size=BLOCK_POOL_BS,
+        program_config=cfg,
+        kv_len=kv_len,
+    )
+    w_scale = _msa_scale_w(heads, sq, scale)
+    ref = indexer_score_msa_ref(q, k[:, :, :kv_len, :], w_scale, chunk_start, num_groups, block_size=BLOCK_POOL_BS)
+    nb = kv_len // BLOCK_POOL_BS
+    assert_pooled_match(out[:, :, :, :nb], ref, num_groups, sq, nb, pcc_floor=0.995)
+
+
+def test_indexer_score_msa_rejects_kv_len_not_block_aligned(device, expect_error):
+    """With block_size>0 a runtime kv_len must be a multiple of block_size (whole blocks are written); a
+    tile-aligned-but-not-block-aligned kv_len is rejected -- on a WARM cache too, since kv_len is re-validated
+    on a program-cache hit."""
+    heads, num_groups, dim, sq, t = 4, 4, GLX_DIM, 128, 2048
+    chunk_start, scale = 512, GLX_DIM**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    q, k, _ = make_inputs(heads, dim, sq, t)
+    q_dev, k_dev = to_device(q, device), to_device(k, device)
+
+    # Warm the program cache with a block-aligned kv_len; the mis-aligned one then hits the SAME program.
+    ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        num_groups=num_groups,
+        chunk_start_idx=chunk_start,
+        scale=scale,
+        block_size=BLOCK_POOL_BS,
+        program_config=cfg,
+        kv_len=1024,
+    )
+    with expect_error(RuntimeError, "multiple of block_size"):
+        ttnn.experimental.indexer_score_msa(
+            q_dev,
+            k_dev,
+            num_groups=num_groups,
+            chunk_start_idx=chunk_start,
+            scale=scale,
+            block_size=BLOCK_POOL_BS,
+            program_config=cfg,
+            kv_len=1024 + 32,  # tile-aligned, not a multiple of 128
+        )
+
+
+def test_indexer_score_msa_indexed_cache_nd_sharded_k(device):
+    """MSA indexed cache that is ND-sharded across DRAM banks (each [1,1,T,D] slot is one shard): the fused
+    single-head reader (Hi=1) resolves the sharded banks through a TensorAccessor AND applies the indexed-slot
+    page offset, so every slot still scores correctly. Mirrors the DSA ND-sharded indexed-cache test for MSA's
+    fused-streaming K read (a dropped/wrong offset would silently return slot 0)."""
+    c = MSA_PERSIST
+    B, heads, scale = 2, 1, c["dim"] ** -0.5  # Hi=1 -> fused single-head read
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
+    g = torch.Generator().manual_seed(19)
+    q = torch.randn(1, heads, c["sq"], c["dim"], generator=g, dtype=torch.bfloat16)
+    k_cache = torch.randn(B, 1, c["t"], c["dim"], generator=g, dtype=torch.bfloat16)  # slots differ
+    q_dev = to_device(q, device)
+    k_mem = _nd_sharded_dram_config(device, rows_per_shard=c["t"])  # each [1,1,T,D] slot is one shard
+    k_dev = ttnn.from_torch(k_cache, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=k_mem)
+    assert k_dev.memory_config().is_sharded()
+    w_scale = _msa_scale_w(heads, c["sq"], scale)
+
+    for b in range(B):
+        out = ttnn.to_torch(
+            ttnn.experimental.indexer_score_msa(
+                q_dev,
+                k_dev,
+                num_groups=1,
+                chunk_start_idx=c["chunk_start"],
+                scale=scale,
+                program_config=cfg,
+                cache_batch_idx=b,
+            )
+        )
+        ref = indexer_score_msa_ref(q, k_cache[b : b + 1], w_scale, c["chunk_start"], 1)
+        assert_grouped_match(out, ref, 1, c["sq"], c["t"])
+
+
+@pytest.mark.parametrize(
+    "q_chunk, k_chunk, head_group",
+    [
+        (32, 32, 0),  # all heads resident, single-tile k chunks (per-column fallback path)
+        (32, 128, 0),  # KC=4 chunked k: kv_len can land mid-chunk and zero whole trailing chunks
+        (32, 32, 8),  # head streaming in groups of 8 (per-column accumulate_row_streaming path)
+    ],
+    ids=["fallback_kc1", "chunked_k_kc4", "stream_hb8"],
+)
+def test_indexer_score_msa_runtime_kv_len_compute_paths(device, q_chunk, k_chunk, head_group):
+    """MSA runtime kv_len swept over the raw-dot compute paths (per-column fallback / chunked-k / head
+    streaming) -- brings MSA to the 4-path parity of the DSA kv_len sweep. num_groups=1 (streaming and
+    fallback are single-plane paths). Growing kv_len must NOT recompile (kv_len is hash-excluded)."""
+    heads, dim, sq, t, chunk_start = 64, 128, 64, 512, 0  # oversized T=512
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
+    g = torch.Generator().manual_seed(31)
+    q = torch.randn(1, heads, sq, dim, generator=g, dtype=torch.bfloat16)
+    k = torch.randn(1, 1, t, dim, generator=g, dtype=torch.bfloat16)
+    q_dev, k_dev = to_device(q, device), to_device(k, device)
+    w_scale = _msa_scale_w(heads, sq, scale)
+
+    def run(kv_len):
+        return ttnn.to_torch(
+            ttnn.experimental.indexer_score_msa(
+                q_dev,
+                k_dev,
+                num_groups=1,
+                chunk_start_idx=chunk_start,
+                scale=scale,
+                program_config=cfg,
+                kv_len=kv_len,
+            )
+        )
+
+    def check(out, kv_len):
+        ref = indexer_score_msa_ref(q, k[:, :, :kv_len, :], w_scale, chunk_start, 1)
+        assert_grouped_match(out[:, :, :, :kv_len], ref, 1, sq, kv_len)
+
+    check(run(64), 64)  # most work units fully past kv_len
+    entries = device.num_program_cache_entries()
+    for kv_len in (128, 256, 512):
+        check(run(kv_len), kv_len)
+    assert device.num_program_cache_entries() == entries, "changing kv_len recompiled"
+
+
+def test_indexer_score_msa_indexed_cache_rejects(device, expect_error):
+    """MSA mirrors the DSA indexed-cache rejections: an out-of-range cache_batch_idx (>= B) is rejected on a
+    WARM cache (re-validated on hit), and a multi-slot cache with NO cache_batch_idx is ambiguous and rejected.
+    Confirms the MSA frontend forwards cache_batch_idx into the shared validation."""
+    c = MSA_PERSIST
+    B, heads, scale = 2, 1, c["dim"] ** -0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
+    g = torch.Generator().manual_seed(21)
+    q = torch.randn(1, heads, c["sq"], c["dim"], generator=g, dtype=torch.bfloat16)
+    k_cache = torch.randn(B, 1, c["t"], c["dim"], generator=g, dtype=torch.bfloat16)
+    q_dev, k_dev = to_device(q, device), to_device(k_cache, device)
+
+    # Warm the program cache with a valid slot; the OOB slot then hits the SAME program and must still fail.
+    ttnn.experimental.indexer_score_msa(
+        q_dev, k_dev, num_groups=1, chunk_start_idx=c["chunk_start"], scale=scale, program_config=cfg, cache_batch_idx=0
+    )
+    with expect_error(RuntimeError, "cache_batch_idx"):
+        ttnn.experimental.indexer_score_msa(
+            q_dev,
+            k_dev,
+            num_groups=1,
+            chunk_start_idx=c["chunk_start"],
+            scale=scale,
+            program_config=cfg,
+            cache_batch_idx=B,
+        )
+    with expect_error(RuntimeError, "batch must be 1"):
+        ttnn.experimental.indexer_score_msa(
+            q_dev, k_dev, num_groups=1, chunk_start_idx=c["chunk_start"], scale=scale, program_config=cfg
+        )
+
+
+def test_indexer_score_msa_rejects_bad_kv_len(device, expect_error):
+    """MSA mirrors the DSA base kv_len rejections (block_size=0): kv_len must be tile-aligned, within (0, T],
+    and leave room for the causal window (chunk_start + Sq <= kv_len). Each violation fails on a WARM cache
+    too (kv_len is hash-excluded and re-validated on a program-cache hit)."""
+    heads, dim, sq, t, chunk_start = 1, 128, 64, 512, 0
+    scale = dim**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
+    g = torch.Generator().manual_seed(33)
+    q = torch.randn(1, heads, sq, dim, generator=g, dtype=torch.bfloat16)
+    k = torch.randn(1, 1, t, dim, generator=g, dtype=torch.bfloat16)
+    q_dev, k_dev = to_device(q, device), to_device(k, device)
+
+    # Warm with a valid kv_len; each bad one then hits the SAME program and must still fail on the hit.
+    ttnn.experimental.indexer_score_msa(
+        q_dev, k_dev, num_groups=1, chunk_start_idx=chunk_start, scale=scale, program_config=cfg, kv_len=128
+    )
+    for bad in (t + 32, 100, 32):  # above T / not tile-aligned / causal window (>= chunk_start+Sq=64) violated
+        with expect_error(RuntimeError, "kv_len"):
+            ttnn.experimental.indexer_score_msa(
+                q_dev, k_dev, num_groups=1, chunk_start_idx=chunk_start, scale=scale, program_config=cfg, kv_len=bad
+            )
+
+
+def test_indexer_score_msa_indexed_cache_block_pool(device):
+    """MSA indexed cache combined with block-max-pool: cache_batch_idx selects a slot of a shared cache and
+    the pooled writer emits per-block scores for that slot. Exercises the slot page offset on the block-pool
+    path (the kv_len+pool test uses a single-slot cache), matching M3's paged block-selection deployment."""
+    heads, num_groups, dim, sq, t = 4, 4, GLX_DIM, 128, 2048
+    B, chunk_start, scale = 2, 512, GLX_DIM**-0.5
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
+    g = torch.Generator().manual_seed(23)
+    q = torch.randn(1, heads, sq, dim, generator=g, dtype=torch.bfloat16)
+    k_cache = torch.randn(B, 1, t, dim, generator=g, dtype=torch.bfloat16)  # slots differ
+    q_dev, k_dev = to_device(q, device), to_device(k_cache, device)
+    w_scale = _msa_scale_w(heads, sq, scale)
+
+    def run(b):
+        return ttnn.to_torch(
+            ttnn.experimental.indexer_score_msa(
+                q_dev,
+                k_dev,
+                num_groups=num_groups,
+                chunk_start_idx=chunk_start,
+                scale=scale,
+                block_size=BLOCK_POOL_BS,
+                program_config=cfg,
+                cache_batch_idx=b,
+            )
+        )
+
+    run(0)
+    entries = device.num_program_cache_entries()  # one pooled program cached now
+    for b in range(B):
+        ref = indexer_score_msa_ref(q, k_cache[b : b + 1], w_scale, chunk_start, num_groups, block_size=BLOCK_POOL_BS)
+        assert_pooled_match(run(b), ref, num_groups, sq, t // BLOCK_POOL_BS, pcc_floor=0.995)
+    assert device.num_program_cache_entries() == entries, "switching cache_batch_idx recompiled"
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -87,6 +87,18 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
             "indexer_score kv_len {} must be in (0, T={}] (the allocated k length)",
             kv_len,
             T);
+        // Block-max-pool writes whole blocks: the writer emits valid_blocks = valid_tiles / block_tiles (floor),
+        // so a kv_len that lands mid-block would drop the partially-valid boundary block (compute pools it
+        // correctly, but the writer never stores it, leaving a stale output column). block_size is compile-time
+        // and kv_len is a runtime value re-checked on hit, so the cross-check lives here (runs miss AND hit).
+        if (attrs.block_size > 0) {
+            TT_FATAL(
+                kv_len % attrs.block_size == 0,
+                "indexer_score kv_len {} must be a multiple of block_size {} when block-max-pooling (a kv_len "
+                "splitting a block drops the boundary block's score)",
+                kv_len,
+                attrs.block_size);
+        }
     }
 }
 
@@ -638,13 +650,18 @@ ttnn::Tensor indexer_score_msa(
     uint32_t block_size,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis,
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local) {
     // M3 has no learned gates, only a 1/sqrt(d) scale. Rather than materialize a constant [B,Hi,Sq,1] gate
     // tensor (an extra fill op dispatched every call), the reader fills cb_w with `scale` in L1 in-kernel
     // (synthesize_gate); q is passed as the unused weights placeholder so the op infra still has a valid
-    // on-device tensor. MSA fixes apply_relu=false; num_groups/block_size are selection knobs.
+    // on-device tensor. MSA fixes apply_relu=false; num_groups/block_size are selection knobs. The
+    // persistent-KV-cache knobs (cache_batch_idx/kv_len) are the same runtime, hash-excluded pass-throughs as
+    // DSA -- the device op and all 3 kernels are mode-agnostic for them (the fused-streaming K read applies
+    // the indexed-slot offset, and pooled kv_len is guarded to a block boundary in validate).
     return launch_indexer_score(
         q,
         k,
@@ -657,8 +674,8 @@ ttnn::Tensor indexer_score_msa(
         /*gate_scale=*/scale,
         program_config,
         compute_kernel_config,
-        /*cache_batch_idx=*/std::nullopt,
-        /*kv_len=*/std::nullopt,
+        cache_batch_idx,
+        kv_len,
         cluster_axis,
         block_cyclic_sp_axis,
         block_cyclic_chunk_local);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -100,7 +100,8 @@ ttnn::Tensor indexer_score_dsa(
 // tensor). q [B,Hi,Sq,D], k [B,1,T,D] -> score [B,num_groups,Sq,T_out].
 // num_groups: G output planes (no cross-group sum); G==1 = TP=4 group-aligned (Hi=1/device), G>1 needs all
 //   heads resident + k_chunk>=64. block_size: 0 = full [B,G,Sq,T]; >0 = block-max-pool -> [B,G,Sq,T/bs].
-// chunk_start_idx / cluster_axis: same SP-ring semantics as indexer_score_dsa.
+// chunk_start_idx / cluster_axis / cache_batch_idx / kv_len: same semantics as indexer_score_dsa (the last
+// two are runtime, hash-excluded pass-throughs -- no recompile when the slot or valid length changes).
 // num_groups is required (no default): per-GQA-group selection is MSA's purpose, so the caller must state
 // the group count explicitly. It is placed before the defaulted optionals so the signature stays well-formed.
 ttnn::Tensor indexer_score_msa(
@@ -112,6 +113,8 @@ ttnn::Tensor indexer_score_msa(
     uint32_t block_size = 0,
     const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> kv_len = std::nullopt,
     std::optional<uint32_t> cluster_axis = std::nullopt,
     std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
     std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -285,7 +285,11 @@ inline void read_k_chunk(
  *  it while the next reads (overlap). Pushes the full k_chunk_tiles (pad cols stale, compute masks them).
  *  No mcast. mm_col_batch is shared with the compute kernel's DEST column batch (indexer_score_common.hpp). */
 template <typename KAcc>
-inline void read_k_chunk_streaming(Noc noc, const KAcc& k_acc, uint32_t k_tile_start, uint32_t k_tiles_in_unit) {
+inline void read_k_chunk_streaming(
+    Noc noc, const KAcc& k_acc, uint32_t k_tile_start, uint32_t k_tiles_in_unit, uint32_t k_batch_page_offset) {
+    // k_batch_page_offset = indexed-cache slot shift (0 when not indexed), applied on top of the (possibly
+    // block-cyclic remapped) intra-slot page -- identical to read_k_chunk; the fused-streaming path must not
+    // drop it, or an indexed slot would silently read slot 0.
     CircularBuffer cb(cb_k);
     for (uint32_t cbase = 0; cbase < k_tiles_per_unit; cbase += mm_col_batch) {
         const uint32_t c_end = (cbase + mm_col_batch <= k_tiles_per_unit) ? (cbase + mm_col_batch) : k_tiles_per_unit;
@@ -300,7 +304,7 @@ inline void read_k_chunk_streaming(Noc noc, const KAcc& k_acc, uint32_t k_tile_s
                         k_acc,
                         CoreLocalMem<uint32_t>(ptr),
                         k_tile_bytes,
-                        {.page_id = seq_tile * head_dim_tiles + d},
+                        {.page_id = k_batch_page_offset + seq_tile * head_dim_tiles + d},
                         {});
                     ptr += k_tile_bytes;
                 }
@@ -367,7 +371,8 @@ void kernel_main() {
             if (real_band) {
                 span.set(group, band0 + band);
                 if constexpr (fuse_single && fused_stream_k) {
-                    read_k_chunk_streaming(noc, k_acc, span.k_tile_start(), span.k_tiles());  // no mcast: stream
+                    read_k_chunk_streaming(
+                        noc, k_acc, span.k_tile_start(), span.k_tiles(), k_batch_page_offset);  // no mcast: stream
                 } else {
                     // k FIRST: compute waits the whole k chunk, so reading k ahead lets the split q-row0 push
                     // unblock the first matmul.

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -131,6 +131,17 @@ void bind_indexer_score(nb::module_& mod) {
                 math_fidelity is honored (default: HiFi2, or LoFi when q and k
                 are both bfloat8_b); fp32_dest_acc_en / dst_full_sync_en must
                 stay false (the custom LLK is validated for bf16 DEST half-sync).
+            cache_batch_idx: optional int. Selects the batch slot of a shared
+                [B, 1, T, D] k cache (which may then be ND-sharded across DRAM
+                banks). Re-applied each dispatch, so switching slots does not
+                recompile. Same semantics as indexer_score_dsa.
+            kv_len: optional int. Valid prefix of a k allocated at its full T;
+                the rest is masked out. Tile-aligned, in (0, T], with
+                chunk_start_idx + Sq <= kv_len. When block-max-pooling
+                (block_size > 0) it must also be a multiple of block_size (whole
+                blocks are written). Re-applied each dispatch (a serving loop
+                growing kv_len reuses one program). Only columns/blocks within
+                the valid prefix are written.
             cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis. None = linear device order.
@@ -155,6 +166,8 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("block_size") = 0,
         nb::arg("program_config") = IndexerScoreProgramConfig{},
         nb::arg("compute_kernel_config") = std::nullopt,
+        nb::arg("cache_batch_idx") = std::nullopt,
+        nb::arg("kv_len") = std::nullopt,
         nb::arg("cluster_axis") = std::nullopt,
         nb::arg("block_cyclic_sp_axis") = std::nullopt,
         nb::arg("block_cyclic_chunk_local") = std::nullopt);


### PR DESCRIPTION
## What this does

Wires the persistent-KV-cache knobs the shared `indexer_score` device op already supported into the **MSA** frontend (`ttnn.experimental.indexer_score_msa`), so it reaches parity with `indexer_score_dsa`, and fixes two latent bugs that wiring exposed.

## Now supported for the MSA indexer

- **`cache_batch_idx`** — select a batch slot of a shared `[B, 1, T, D]` KV cache (may be ND-sharded across DRAM banks). Hash-excluded, so switching slots does **not** recompile — the multi-user paged-serving primitive.
- **`kv_len`** — runtime valid-prefix mask over an oversized preallocated cache; the rest is masked out. Hash-excluded, so a serving loop growing `kv_len` reuses one program. When block-max-pooling, must be a multiple of `block_size`.

(These were previously DSA-only, hard-coded to `nullopt` on the MSA wrapper. The device op + all 3 kernels were already mode-agnostic for them.)

## Bug fixes (both latent, uncovered by the new wiring)

- **Fused-path slot offset** — `read_k_chunk_streaming` (MSA's fused single-head K read) dropped `k_batch_page_offset`, so an indexed slot silently read slot 0. Now applied. This also latently affected **DSA's Hi=1/device (TP=4) fused path** — the shared-kernel fix covers both flavours.
- **Pooled `kv_len` guard** — added `kv_len % block_size == 0` validation. Without it, a mid-block `kv_len` under pooling made the writer floor `valid_blocks` and silently drop the partially-valid boundary block's score.

## Not in scope

- No change to DSA behavior (it already had both features).
- The MSA serving/prefill driver + per-group block top-k consumer (model-level, needs a real MiniMax-M3 model).

## Testing

**CI runs dispatched on this branch** (badges live-update; see also the auto-generated CI Status section below):

| Pipeline | Badge | Run |
|---|---|---|
| Blackhole sanity | [![Blackhole sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/29021683070) | [#29021683070](https://github.com/tenstorrent/tt-metal/actions/runs/29021683070) |
| L2 nightly — experimental (Blackhole) | [![L2 nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/29021685030) | [#29021685030](https://github.com/tenstorrent/tt-metal/actions/runs/29021685030) |

**Local (Blackhole):**

- **9 new MSA test functions (13 cases)** bringing MSA to DSA parity: indexed cache (basic / ND-sharded / pooled / OOB + multislot rejections), runtime `kv_len` (fallback / chunked-k / streaming compute-path sweep / pooled / bad-value rejections).
- All new cases pass; existing MSA + DSA regression set (46 cases) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer-msa-persistent-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer-msa-persistent-kv-cache)
