### PR TITLE
Fix Tier CI scheduled-run failures

### DIFF
--- a/models/demos/gemma4/tests/unit/test_packed_verify.py
+++ b/models/demos/gemma4/tests/unit/test_packed_verify.py
@@ -56,6 +56,36 @@ _MOE_UNSUPPORTED_REASON = (
     "checkpoints (e.g. gemma-4-26B-A4B). Dense targets (12B, 31B) run this test."
 )
 
+def _is_pli_model(model_path):
+    """True for per-layer-input (MatFormer) checkpoints (e.g. gemma-4-E2B/E4B).
+
+    These models carry a per-layer input embedding (``hidden_size_per_layer_input``)
+    that must be fed to every layer. Packed verify drives ``self(...)`` through
+    ``ttnn_packed_verify_forward`` without threading PLI, so a PLI model falls into
+    ``Gemma4Model._compute_per_layer_inputs(None, None)`` and raises. PLI is not
+    wired through the speculative-verify path yet, so packed verify is unsupported
+    on these checkpoints (tracked in #49022). Dense non-PLI targets (12B, 31B) are
+    unaffected. Detect it cheaply from the config (no weights loaded) so we can skip
+    before ``from_pretrained`` — which also avoids writing the weight cache on the
+    read-only NAS mount used by CI e2e.
+    """
+    try:
+        from transformers import AutoConfig
+
+        cfg = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        tc = getattr(cfg, "text_config", cfg)
+        return bool(getattr(tc, "hidden_size_per_layer_input", 0))
+    except Exception:
+        return False
+
+
+_PLI_UNSUPPORTED_REASON = (
+    "packed verify does not thread per-layer inputs (PLI) through the verify forward, so "
+    "PLI/MatFormer checkpoints (e.g. gemma-4-E2B/E4B) hit _compute_per_layer_inputs(None, None) "
+    "and raise. Unsupported until PLI is wired through the speculative-verify path (see #49022). "
+    "Dense non-PLI targets (12B, 31B) run this test."
+)
+
 _L1_OVERFLOW_REASON = (
     "packed-verify global-layer SDPA (head_dim=512, fp32-accum, P candidates folded into "
     "heads) exceeds this core's L1 at the current TP. The per-core footprint shrinks ~TP×, "
@@ -85,6 +115,9 @@ def test_packed_verify_matches_sequential(mesh_device, reset_seeds):
 
     if _is_moe_model(model_path):
         pytest.skip(_MOE_UNSUPPORTED_REASON)
+
+    if _is_pli_model(model_path):
+        pytest.skip(_PLI_UNSUPPORTED_REASON)
 
     # Single-device (TP=1) is unsupported for packed verify on the 12B model: the
     # global layers (global_head_dim=512) run the packed SDPA with fp32_dest_acc_en
@@ -235,6 +268,9 @@ def test_packed_verify_batch_perf(mesh_device, reset_seeds):
         pytest.skip("set HF_MODEL (target) to run")
     if _is_moe_model(model_path):
         pytest.skip(_MOE_UNSUPPORTED_REASON)
+
+    if _is_pli_model(model_path):
+        pytest.skip(_PLI_UNSUPPORTED_REASON)
     if mesh_device.get_num_devices() == 1:
         pytest.skip("single-device L1 limit: use a TP mesh (e.g. 1x4)")
 

--- a/models/demos/gemma4/tests/unit/test_packed_verify.py
+++ b/models/demos/gemma4/tests/unit/test_packed_verify.py
@@ -56,6 +56,7 @@ _MOE_UNSUPPORTED_REASON = (
     "checkpoints (e.g. gemma-4-26B-A4B). Dense targets (12B, 31B) run this test."
 )
 
+
 def _is_pli_model(model_path):
     """True for per-layer-input (MatFormer) checkpoints (e.g. gemma-4-E2B/E4B).
 

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -393,7 +393,7 @@ sizes:
       wh_n300:
         trace_region_size: 30000000
       wh_llmbox_perf:
-        trace_region_size: 30000000
+        trace_region_size: 30100000
       wh_galaxy_perf:
         trace_region_size: 30000000
       bh_p150:


### PR DESCRIPTION
## Summary
Draft PR collecting fixes for failures seen in the latest Tier 1/2/3 scheduled CI runs on `main`. More fixes will be added as we work through the failures.

### Changes so far

1. **gemma-3-27b `wh_llmbox_perf` trace region size**: bumped `30000000` → `30100000`. The Tier 2 e2e run failed with `Creating trace buffers of size 30009344B on MeshDevice 0, but only 30000000B is allocated for trace region.` The new value gives headroom above the required size.

2. **gemma4: skip packed-verify tests on PLI (MatFormer) models (E2B/E4B)**. `test_packed_verify_matches_sequential` / `test_packed_verify_batch_perf` fail on gemma-4-E4B (Tier 2/3 e2e + unit) with `ValueError: Model has per-layer inputs configured but input_ids_torch/embeds_torch are missing`. `ttnn_packed_verify_forward` never threads per-layer inputs through the model forward, so PLI checkpoints hit `_compute_per_layer_inputs(None, None)` and raise. Packed verify does not support PLI models — mirror the existing `_is_moe_model` skip with an `_is_pli_model` skip. Dense non-PLI targets (12B, 31B) still run the test. Tracked in #49022; introduced by #48835.

## Test plan
- [ ] Tier 2 e2e Gemma-3-27B [wh_llmbox_perf] passes trace buffer allocation
- [ ] Tier 2/3 Gemma-4-E4B packed-verify tests skip cleanly (no ValueError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/fix-tier-ci-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/fix-tier-ci-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/fix-tier-ci-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/fix-tier-ci-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/fix-tier-ci-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/fix-tier-ci-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/fix-tier-ci-failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/fix-tier-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/fix-tier-ci-failures)