### PR TITLE
fixing deviated stable branch for gemma4

### DIFF
--- a/models/demos/gemma4/demo/text_demo_v2.py
+++ b/models/demos/gemma4/demo/text_demo_v2.py
@@ -142,9 +142,19 @@ def _host_sample(logits, temperature, top_p):
 
 
 def _device_params():
-    """Blackhole needs a larger trace region; keep a single command queue (host sampling)."""
+    """Blackhole needs a larger trace region; keep a single command queue (host sampling).
+
+    The batch-32 decode trace is the largest (~228 MB at capture), so the
+    Blackhole trace region is sized above that with margin. ``GEMMA4_TRACE_REGION_SIZE``
+    overrides it for configs that need a different budget.
+    """
     if is_blackhole():
-        return {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 200_000_000, "num_command_queues": 1}
+        trace_region_size = int(os.environ.get("GEMMA4_TRACE_REGION_SIZE", 256_000_000))
+        return {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": trace_region_size,
+            "num_command_queues": 1,
+        }
     return {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 30_000_000, "num_command_queues": 1}
 
 
@@ -183,7 +193,7 @@ def _device_params():
         (  # batch-32 (max throughput) — 32 concurrent users (decode batch ceiling)
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",
             True,
-            1024,
+            4096,
             32,
             200,
             True,
@@ -338,11 +348,27 @@ def test_demo_text(
     # target verifier path. Delegated to _run_spec_decode, which builds its own
     # target+drafter, so we return before this test loads a model.
     if request.config.getoption("--speculative"):
-        if batch_size != 1:
-            pytest.skip("speculative decode batch>1 is disabled until it can beat traced target throughput")
         draft_len = request.config.getoption("--spec-draft-len")
         if draft_len is None:
             draft_len = int(os.environ.get("GEMMA4_SPEC_DRAFT_LEN", 3))
+        if batch_size != 1:
+            # Batched (B>1) spec-decode: drafts each user at batch=1 and runs ONE
+            # batched packed verify over all users (KV-amortization win). Greedy,
+            # ragged per-user acceptance. Currently UNTRACED (host-dispatch bound).
+            prompts = load_inputs(input_prompts, batch_size, instruct)
+            _run_spec_decode_batched(
+                prompts=prompts,
+                instruct=instruct,
+                max_seq_len=max_seq_len,
+                max_generated_tokens=max_generated_tokens,
+                page_params=page_params,
+                sampling_params=sampling_params,
+                mesh_device=mesh_device,
+                enable_trace=enable_trace,
+                draft_len=draft_len,
+                num_layers=num_layers,
+            )
+            return
         prompt = load_inputs(input_prompts, 1, instruct)[0]
         _run_spec_decode(
             prompt=prompt,
@@ -431,10 +457,21 @@ def test_demo_text(
         logger.info(f"Bounded sliding: installed {len(per_layer_pts)} per-layer page tables")
 
     # ── Warmup (prefill compile + optional trace) ──────────────────────────
+    # Prefill tracing buys ~nothing (prefill runs only a handful of times) and its
+    # trace buffers scale with chunk_size×batch, overflowing the trace region at
+    # long context (≥4K) with no perf gain. Gate prefill tracing off above a
+    # threshold (decode stays traced); GEMMA4_PREFILL_TRACE_MAX_SEQ overrides.
+    prefill_trace_max = int(os.environ.get("GEMMA4_PREFILL_TRACE_MAX_SEQ", 4096))
+    prefill_enable_trace = enable_trace and max_seq_len < prefill_trace_max
+    if enable_trace and not prefill_enable_trace:
+        logger.info(
+            f"Prefill trace disabled (max_seq_len={max_seq_len} >= {prefill_trace_max}); "
+            f"decode stays traced. Set GEMMA4_PREFILL_TRACE_MAX_SEQ to override."
+        )
     logger.info("Warming up prefill...")
     generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
-        enable_trace=enable_trace,
+        enable_trace=prefill_enable_trace,
         can_sample_on_device=False,
         greedy_only=True,
     )
@@ -459,6 +496,7 @@ def test_demo_text(
         kv_cache=tt_kv_cache,
         prompt_lens=decoding_pos,
         warmup_prefill=False,
+        enable_trace=prefill_enable_trace,
     )
     prefilled_token = _host_sample(prefill_logits, temperature, top_p)
     profiler.end("inference_prefill")
@@ -643,8 +681,12 @@ def _run_spec_decode(
 
     page_table = create_tt_page_table(batch_size, paged_attention_config)
 
+    # Prefill tracing has ~no perf gain and OOMs the trace region at long context
+    # (≥4K); gate it off above a threshold (decode/spec traces stay on).
+    prefill_trace_max = int(os.environ.get("GEMMA4_PREFILL_TRACE_MAX_SEQ", 4096))
+    prefill_enable_trace = enable_trace and max_seq_len < prefill_trace_max
     generator.warmup_model_prefill(
-        kv_cache=tt_kv_cache, enable_trace=enable_trace, can_sample_on_device=False, greedy_only=True
+        kv_cache=tt_kv_cache, enable_trace=prefill_enable_trace, can_sample_on_device=False, greedy_only=True
     )
 
     input_tokens_prefill_pt, encoded_prompts, decoding_pos, prefill_lens = preprocess_inputs_prefill(
@@ -660,6 +702,7 @@ def _run_spec_decode(
         kv_cache=tt_kv_cache,
         prompt_lens=decoding_pos,
         warmup_prefill=False,
+        enable_trace=prefill_enable_trace,
     )
     ttnn.synchronize_device(mesh_device)
     prefill_elapsed = time.perf_counter() - prefill_t0
@@ -669,6 +712,21 @@ def _run_spec_decode(
     prompt_len = int(decoding_pos[0])
     anchor_pos = prompt_len - 1
     anchor_token = int(encoded_prompts[0][anchor_pos])
+
+    # Spec-decode drafts `draft_len` positions AHEAD of the committed position, so
+    # the furthest position touched is (prompt_len-1) + generated + draft_len. The
+    # RoPE / paged-attention structures are sized to max_seq_len, so overshooting
+    # that bound indexes out of range and hangs the device (deterministically at
+    # cur_pos == max_seq_len - draft_len). Reserve the speculative lookahead margin
+    # by clamping generation to stay strictly within max_seq_len.
+    _safe_gen = max_seq_len - prompt_len - (draft_len + 1)
+    if max_generated_tokens > _safe_gen:
+        logger.warning(
+            f"Clamping max_generated_tokens {max_generated_tokens} -> {max(1, _safe_gen)} to keep "
+            f"spec lookahead (draft_len={draft_len}) within max_seq_len={max_seq_len} "
+            f"(prompt_len={prompt_len}); raise max_seq_len for more generated tokens."
+        )
+        max_generated_tokens = max(1, _safe_gen)
 
     # Load the assistant only after target prefill warmup/prefill is complete.
     # Loading it earlier makes the target prefill trace capture run with extra
@@ -760,6 +818,168 @@ def _run_spec_decode(
     logger.info(f"Decode: {ms_per_token:.2f} ms/token @ {tok_s_u:.2f} tok/s/user " f"({tok_s:.2f} tok/s throughput)")
     assert n_tokens > 0, "speculative decode produced no tokens"
     return generated, accepts
+
+
+def _run_spec_decode_batched(
+    prompts,
+    instruct,
+    max_seq_len,
+    max_generated_tokens,
+    page_params,
+    sampling_params,
+    mesh_device,
+    enable_trace,
+    draft_len=None,
+    num_layers=None,
+):
+    """Batched (B>1) greedy speculative decode: B independent users, one shared
+    batched packed verify per iteration (KV-amortization), ragged per-user
+    acceptance. Untraced (host-dispatch bound) — the device win is the batched
+    verify; tracing the ragged loop is a follow-up.
+    """
+    import math
+    import time
+
+    from models.demos.gemma4.tt.common import create_assistant_model
+    from models.demos.gemma4.tt.spec_decode import SpeculativeDecoder
+    from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
+
+    B = len(prompts)
+    model_path = _model_path()
+    assistant_path = os.getenv("GEMMA4_ASSISTANT_MODEL")
+    if not assistant_path:
+        assistant_path = f"{model_path}-assistant"
+        logger.info(f"GEMMA4_ASSISTANT_MODEL unset; defaulting drafter to {assistant_path}")
+    temperature = sampling_params.get("temperature", 0)
+    if temperature and temperature > 0:
+        pytest.skip("batched spec-decode supports greedy only (set temperature=0)")
+    if draft_len is None:
+        draft_len = int(os.environ.get("GEMMA4_SPEC_DRAFT_LEN", 3))
+
+    block_size = page_params["page_block_size"]
+    blocks_per_user = math.ceil(max_seq_len / block_size)
+    paged_attention_config = PagedAttentionConfig(block_size=block_size, max_num_blocks=B * blocks_per_user)
+
+    generator, tt_kv_cache, tokenizer = Gemma4Generator.from_pretrained(
+        mesh_device=mesh_device,
+        model_path=model_path,
+        max_batch_size=B,
+        max_seq_len=max_seq_len,
+        num_layers=num_layers,
+        paged_attention_config=paged_attention_config,
+        bounded_sliding_kv_cache=False,  # spec-decode needs unbounded sliding KV
+    )
+    target = generator.model[0]
+    model_args = generator.model_args
+
+    page_table = create_tt_page_table(B, paged_attention_config)  # [B, blocks_per_user]
+
+    # Prefill tracing has ~no perf gain and OOMs the trace region at long context
+    # (≥4K); gate it off above a threshold (the batched decode trace stays on).
+    prefill_trace_max = int(os.environ.get("GEMMA4_PREFILL_TRACE_MAX_SEQ", 4096))
+    prefill_enable_trace = enable_trace and max_seq_len < prefill_trace_max
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache, enable_trace=prefill_enable_trace, can_sample_on_device=False, greedy_only=True
+    )
+
+    # Per-user prefill into each user's own KV blocks (prompts have distinct lengths).
+    logger.info(f"Spec-decode batched prefill for B={B} users...")
+    anchor_tokens, anchor_positions, prompt_lens = [], [], []
+    prefill_t0 = time.perf_counter()
+    for b in range(B):
+        in_pt, encoded, decoding_pos, p_lens = preprocess_inputs_prefill(
+            [prompts[b]], tokenizer, model_args, instruct, max_generated_tokens, max_prefill_len=max_seq_len
+        )
+        in_pt = torch.stack(in_pt).view(1, -1)
+        prefill_logits = generator.prefill_forward_text(
+            in_pt,
+            page_table=page_table[b : b + 1],
+            kv_cache=tt_kv_cache,
+            prompt_lens=decoding_pos,
+            warmup_prefill=False,
+            enable_trace=prefill_enable_trace,
+        )
+        if hasattr(prefill_logits, "deallocate"):
+            prefill_logits.deallocate(True)
+        prompt_lens.append(int(decoding_pos[0]))
+        anchor_positions.append(int(decoding_pos[0]) - 1)
+        anchor_tokens.append(int(encoded[0][int(decoding_pos[0]) - 1]))
+    ttnn.synchronize_device(mesh_device)
+    prefill_elapsed = time.perf_counter() - prefill_t0
+
+    # Clamp generation so the furthest spec position (pos + draft_len) stays in range.
+    max_prompt = max(prompt_lens)
+    _safe_gen = max_seq_len - max_prompt - (draft_len + 1)
+    if max_generated_tokens > _safe_gen:
+        logger.warning(
+            f"Clamping max_generated_tokens {max_generated_tokens} -> {max(1, _safe_gen)} to keep spec "
+            f"lookahead (draft_len={draft_len}) within max_seq_len={max_seq_len} (max prompt_len={max_prompt})."
+        )
+        max_generated_tokens = max(1, _safe_gen)
+
+    _, assistant = create_assistant_model(
+        mesh_device=mesh_device,
+        target_model=target,
+        mesh_config=target.mesh_config,
+        ccl_manager=target.ccl_manager,
+        assistant_path=assistant_path,
+        max_local_batch_size=B,
+    )
+
+    spec = SpeculativeDecoder(
+        target_model=target,
+        assistant_model=assistant,
+        mesh_device=mesh_device,
+        tt_kv_cache=tt_kv_cache,
+        page_table_torch=page_table,
+        stop_tokens=tokenizer.stop_tokens,
+        draft_len=draft_len,
+    )
+    # The whole batched iteration (batched drafter chain + batched packed verify)
+    # is captured as ONE metal trace and replayed per step; the one-time capture
+    # (setup) is excluded from the steady decode rate. Prefill is NEVER traced.
+    # Default tracing to the demo's enable_trace; GEMMA4_SPEC_TRACE overrides.
+    _trace_env = os.environ.get("GEMMA4_SPEC_TRACE")
+    spec._use_trace = enable_trace if _trace_env is None else (_trace_env == "1")
+
+    logger.info(f"Spec-decode batched generate (B={B}, draft_len={draft_len}, greedy, trace={spec._use_trace})...")
+    t0 = time.time()
+    outs, accepts = spec.generate_batched(
+        anchor_tokens=anchor_tokens,
+        anchor_positions=anchor_positions,
+        max_new_tokens=max_generated_tokens,
+        max_seq_len=max_seq_len,
+        temperature=0.0,
+    )
+    ttnn.synchronize_device(mesh_device)
+    elapsed = time.time() - t0
+
+    total_tokens = sum(len(o) for o in outs)
+    all_accepts = [m for a in accepts for m in a]
+    mean_accept = (sum(all_accepts) / len(all_accepts)) if all_accepts else 0.0
+    # Steady decode excludes one-time trace capture (mirrors the single-user path).
+    setup_s = getattr(spec, "_last_fused_setup_s", 0.0) if spec._use_trace else 0.0
+    steady_s = getattr(spec, "_last_fused_replay_s", elapsed) if spec._use_trace else elapsed
+    tok_s = total_tokens / steady_s if steady_s > 0 else 0.0
+
+    logger.info("\n== BATCHED SPEC-DECODE GENERATION ==")
+    for b in range(B):
+        logger.info(f"[user {b}] {tokenizer.decode(outs[b]).strip()}")
+    logger.info("=== Batched speculative decoding metrics ===")
+    logger.info(f"Users (batch): {B}; prompt tokens (max): {max_prompt}; total generated tokens: {total_tokens}")
+    logger.info(f"Time to First Token (TTFT, mean prefill/user): {prefill_elapsed * 1000.0 / B:.1f} ms")
+    logger.info(
+        f"Drafter: {draft_len} drafts/iter; mean accepted {mean_accept:.2f}/{draft_len} "
+        f"(tokens/iter: {mean_accept + 1:.2f})"
+    )
+    if setup_s > 0:
+        logger.info(f"Spec setup/trace capture: {setup_s:.2f}s (excluded from steady rate)")
+    logger.info(
+        f"Decode: {steady_s:.2f}s steady @ {tok_s:.2f} tok/s aggregate, {tok_s / B:.2f} tok/s/user "
+        f"({'traced' if spec._use_trace else 'untraced'})"
+    )
+    assert total_tokens > 0, "batched speculative decode produced no tokens"
+    return outs, accepts
 
 
 @pytest.mark.parametrize("device_params", [_device_params()], indirect=True)

--- a/models/demos/gemma4/tests/pcc_thresholds.json
+++ b/models/demos/gemma4/tests/pcc_thresholds.json
@@ -3,6 +3,9 @@
     "1x1": {
       "test_attention_prefill[wormhole_b0-seq4096-global-1x1]": 0.98,
       "test_attention_prefill[blackhole-seq4096-global-1x1]": 0.97,
+      "_comment_via_harness_full": "Attention-decode PCC settled at 0.986292 (bit-identical WH/BH) after #47311 removed the reduce's forced-FP32 accumulation — a small precision loss, not a behavioral regression (all argmax correct). Gate lowered from the 0.99 default to accept it; proper LLK fp32-accumulation fix tracked in #48746.",
+      "test_attention_paged_decode_via_harness[wormhole_b0-full-1x1]": 0.986,
+      "test_attention_paged_decode_via_harness[blackhole-full-1x1]": 0.986,
       "test_full_model[wormhole_b0-1x1]": 0.90,
       "test_full_model[blackhole-1x1]": 0.84,
       "test_full_model_parity_warmup_then_inference[wormhole_b0-pli-all-kv-shared-steps4-1x1]": 0.98,

--- a/models/demos/gemma4/tests/test_factory.py
+++ b/models/demos/gemma4/tests/test_factory.py
@@ -401,11 +401,31 @@ def parametrize_batch_seq(configs=None, ids=None):
     return pytest.mark.parametrize("batch_size, seq_len", configs, ids=ids)
 
 
-def parametrize_mesh_with_fabric(mesh_shapes=None):
+# UMD device-enumeration failures that mean the *runner* is unhealthy (a dead
+# ETH core, failed topology discovery, etc.) rather than a bug in our code. When
+# `ttnn.get_num_devices()` raises one of these at import/collection time, there
+# is no device to test on, so the honest outcome is a skip — not a fatal pytest
+# collection error (exit 4) that masks which test was even meant to run.
+_DEVICE_DISCOVERY_FAILURE_MARKERS = (
+    "eth core heartbeat check failed",
+    "topology discovery",
+    "cluster initialization",
+)
+
+
+def _is_device_discovery_failure(exc):
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _DEVICE_DISCOVERY_FAILURE_MARKERS)
+
+
+def parametrize_mesh_with_fabric(mesh_shapes=None, device_params_extra=None):
     """Universal mesh parametrization with FABRIC_1D.
 
     Generates paired mesh_device + device_params parametrization for tests at
     any TP factor. Only includes mesh shapes that fit on the current system.
+
+    ``device_params_extra`` (dict) is merged into every param's device_params —
+    e.g. ``{"trace_region_size": 256_000_000}`` for tests that capture a trace.
 
     Fabric is enabled (FABRIC_1D) for multi-device shapes, and disabled for
     (1, 1). Launching fabric on a 1x1 mesh on a multi-device system fails the
@@ -428,7 +448,26 @@ def parametrize_mesh_with_fabric(mesh_shapes=None):
         pytest -k "1x2"   # N300 (TP=2)                (manual / non-CI)
         pytest -k "1x8"   # T3K (TP=8)                 (manual / non-CI)
     """
-    num_devices = ttnn.get_num_devices()
+    try:
+        num_devices = ttnn.get_num_devices()
+    except RuntimeError as e:
+        # Only swallow genuine hardware-enumeration failures (bad runner); let any
+        # other RuntimeError propagate so real software regressions stay visible.
+        if not _is_device_discovery_failure(e):
+            raise
+        params = [
+            pytest.param(
+                (1, 1),
+                {"fabric_config": None, **dict(device_params_extra or {})},
+                id="device-unavailable",
+                marks=pytest.mark.skip(reason=f"Device discovery failed (unhealthy runner): {e}"),
+            )
+        ]
+
+        def decorator(func):
+            return pytest.mark.parametrize("mesh_device, device_params", params, indirect=True)(func)
+
+        return decorator
 
     if mesh_shapes is None:
         all_shapes = [(1, 1), (1, 2), (1, 4), (1, 8), (1, 32)]
@@ -443,11 +482,12 @@ def parametrize_mesh_with_fabric(mesh_shapes=None):
     if os.getenv("CI") == "true" and len(mesh_shapes) > 1:
         mesh_shapes = [max(mesh_shapes, key=lambda s: s[0] * s[1])]
 
+    extra = dict(device_params_extra or {})
     if not mesh_shapes:
         params = [
             pytest.param(
                 (1, 1),
-                {"fabric_config": None},
+                {"fabric_config": None, **extra},
                 id="1x1",
                 marks=pytest.mark.skip(reason="Not enough devices"),
             )
@@ -456,7 +496,7 @@ def parametrize_mesh_with_fabric(mesh_shapes=None):
         params = [
             pytest.param(
                 s,
-                {"fabric_config": None if s == (1, 1) else ttnn.FabricConfig.FABRIC_1D},
+                {"fabric_config": None if s == (1, 1) else ttnn.FabricConfig.FABRIC_1D, **extra},
                 id=f"{s[0]}x{s[1]}",
             )
             for s in mesh_shapes

--- a/models/demos/gemma4/tests/unit/test_bounded_sliding_kv_cache_model.py
+++ b/models/demos/gemma4/tests/unit/test_bounded_sliding_kv_cache_model.py
@@ -105,8 +105,8 @@ def test_build_hybrid_page_tables_shapes_and_padding():
                 assert torch.equal(pt[u], expected)
 
 
-def test_build_hybrid_page_tables_rejects_non_multiple_sliding_window():
-    with pytest.raises(ValueError, match="must be a multiple of block_size"):
+def test_build_hybrid_page_tables_rejects_non_multiple_sliding_window(expect_error):
+    with expect_error(ValueError, "must be a multiple of block_size"):
         build_hybrid_page_tables(
             num_layers=1,
             sliding_layers_mask=[True],
@@ -434,7 +434,7 @@ def test_attention_decode_bounded_vs_unbounded_parity(cache_len, mesh_device, re
     assert passing_pair, f"bounded vs unbounded (cache_len={cache_len}): {msg_pair}"
 
 
-def test_bounded_pool_rejects_without_modulo(device):
+def test_bounded_pool_rejects_without_modulo(device, expect_error):
     """The relaxed paged_update_cache validation only allows page_table.shape[1] >
     cache.shape[0] when cache_position_modulo is set. Confirm the strict legacy
     check still fires when a caller forgets the kwarg — keeps the bounded layout
@@ -471,7 +471,7 @@ def test_bounded_pool_rejects_without_modulo(device):
 
     # page_table.shape[1] (max_blocks=16) > cache.shape[0] (sliding_blocks=4) → strict check fires
     assert max_blocks > cache_blocks
-    with pytest.raises(RuntimeError, match="max_num_blocks_per_seq must be less than max_num_blocks"):
+    with expect_error(RuntimeError, "max_num_blocks_per_seq must be less than max_num_blocks"):
         ttnn.experimental.paged_update_cache(
             cache_tt,
             xt,

--- a/models/demos/gemma4/tests/unit/test_packed_verify.py
+++ b/models/demos/gemma4/tests/unit/test_packed_verify.py
@@ -1,0 +1,460 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Packed-query verify (spec decode) vs the sequential and batch-dim verifies.
+
+The packed verify folds the K+1 candidates into the query-heads dim of ONE
+batch=1 forward (head-major packed SDPA with an additive mask) and writes the
+new KV loop-free through the persistent staging + paged_fill_cache path. Greedy
+argmax must match the sequential single-token verify chain position-for-position
+(up to the same near-tie caveat as the batch-dim verify); the loop-free KV write
+must also leave the cache state correct across iterations (a chain of packed
+verifies, with rollovers across page boundaries, keeps matching sequential).
+
+Requires HF_MODEL (target). The drafter is irrelevant here.
+"""
+
+import math
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+from ...tests.test_factory import parametrize_mesh_with_fabric
+
+
+def _is_moe_model(model_path):
+    """True for Mixture-of-Experts checkpoints (e.g. gemma-4-26B-A4B).
+
+    Packed verify folds the K+1 candidates into ONE multi-token forward, so it
+    drives the model with seq_len = P = draft_len+1 (e.g. 5) — not a multiple of
+    32. On an MoE checkpoint the experts block routes any seq_len != 1 through
+    its prefill path, which asserts ``seq_len % 32 == 0`` (see
+    gemma4/tt/experts/__init__.py). Dense models (12B, 31B) have no experts block
+    and are unaffected. Padding P up to 32 would run the experts on 32 tokens per
+    verify and erase the packed-verify win, so packed verify is unsupported on
+    MoE. Detect it cheaply from the config (no weights loaded) so we can skip
+    before ``from_pretrained`` — which also avoids writing the weight cache on the
+    read-only NAS mount used by CI e2e.
+    """
+    try:
+        from transformers import AutoConfig
+
+        cfg = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        tc = getattr(cfg, "text_config", cfg)
+        return bool(getattr(tc, "num_experts", 0))
+    except Exception:
+        return False
+
+
+_MOE_UNSUPPORTED_REASON = (
+    "packed verify drives the model with seq_len=P=draft_len+1 (not a multiple of 32); "
+    "MoE experts prefill requires seq_len%32==0, so packed verify is unsupported on MoE "
+    "checkpoints (e.g. gemma-4-26B-A4B). Dense targets (12B, 31B) run this test."
+)
+
+_L1_OVERFLOW_REASON = (
+    "packed-verify global-layer SDPA (head_dim=512, fp32-accum, P candidates folded into "
+    "heads) exceeds this core's L1 at the current TP. The per-core footprint shrinks ~TP×, "
+    "so larger targets need a larger TP mesh: e.g. gemma-4-31B overflows L1 at TP=4 "
+    "(4-chip box) but fits at TP>=8. 12B fits at TP=4. Skipping on this SKU/mesh."
+)
+
+
+def _is_l1_cb_overflow(exc):
+    """True if `exc` is the ttnn L1 circular-buffer capacity throw.
+
+    This is a deterministic, host-side program-validation failure (raised before
+    any on-device launch, so the device stays healthy), matching e.g.:
+        "Statically allocated circular buffers on core range [...] grow to
+         2005824 B which is beyond max L1 size of 1572864 B".
+    Keyed off the message text so it stays model/SKU/mesh-agnostic.
+    """
+    s = str(exc).lower()
+    return "circular buffer" in s and "l1 size" in s
+
+
+@parametrize_mesh_with_fabric()
+def test_packed_verify_matches_sequential(mesh_device, reset_seeds):
+    model_path = os.getenv("HF_MODEL")
+    if not model_path:
+        pytest.skip("set HF_MODEL (target) to run")
+
+    if _is_moe_model(model_path):
+        pytest.skip(_MOE_UNSUPPORTED_REASON)
+
+    # Single-device (TP=1) is unsupported for packed verify on the 12B model: the
+    # global layers (global_head_dim=512) run the packed SDPA with fp32_dest_acc_en
+    # (the odd-PNHt MUL_BCAST power-of-2 fix) AND cannot head-split (nkv_local>1 ⇒ no
+    # single shared KV head), so the per-core flash cross-reduction CBs overflow the
+    # 1.5 MB L1 (~2.8 MB). Capping the reduction fan-in fits L1 but deadlocks the SDPA
+    # kernel on-device. Supported on multi-device (TP) meshes, where TP shrinks the
+    # per-core packed-head footprint ~TP×.
+    if mesh_device.get_num_devices() == 1:
+        pytest.skip(
+            "single-device L1 limit: 12B global-layer packed SDPA exceeds single-device L1 (use a TP mesh, e.g. 1x4)"
+        )
+
+    from models.demos.gemma4.demo.text_demo_v2 import create_tt_page_table
+    from models.demos.gemma4.tt.generator import Gemma4Generator
+    from models.demos.gemma4.tt.spec_decode import SpeculativeDecoder
+    from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
+
+    max_seq_len = 1024
+    block_size = 64
+    paged_attention_config = PagedAttentionConfig(
+        block_size=block_size, max_num_blocks=math.ceil(max_seq_len / block_size)
+    )
+    generator, tt_kv_cache, tokenizer = Gemma4Generator.from_pretrained(
+        mesh_device=mesh_device,
+        model_path=model_path,
+        max_batch_size=1,
+        max_seq_len=max_seq_len,
+        num_layers=None,
+        paged_attention_config=paged_attention_config,
+        bounded_sliding_kv_cache=False,
+    )
+    target = generator.model[0]
+    page_table = create_tt_page_table(1, paged_attention_config)
+    prompt = "The capital of France is"
+    in_pt, encoded, decoding_pos, prefill_lens = preprocess_inputs_prefill(
+        [prompt], tokenizer, generator.model_args, True, 24, max_prefill_len=max_seq_len
+    )
+    in_pt = torch.stack(in_pt).view(1, -1)
+    anchor_token = int(encoded[0][prefill_lens[0] - 1])
+    anchor_pos = prefill_lens[0] - 1
+
+    # assistant_model unused — only the verify paths run.
+    spec = SpeculativeDecoder(
+        target_model=target,
+        assistant_model=None,
+        mesh_device=mesh_device,
+        tt_kv_cache=tt_kv_cache,
+        page_table_torch=page_table,
+        stop_tokens=tokenizer.stop_tokens,
+        draft_len=4,
+    )
+    P = spec.draft_len + 1
+
+    def _prefill():
+        # warmup_prefill=False skips the prefill-trace warmup (and its on-device
+        # sampling/penalty sweep). This correctness test reads logits to host and
+        # does argmax itself, so device sampling is irrelevant here; skipping the
+        # warmup also avoids an unrelated TP>1 penalty-path shape mismatch that
+        # otherwise aborts before the verify code runs.
+        generator.prefill_forward_text(
+            in_pt,
+            page_table=page_table,
+            kv_cache=tt_kv_cache,
+            prompt_lens=decoding_pos,
+            warmup_prefill=False,
+        )
+
+    # ── Reference: sequential single-token verify chain (batch=1 takes the
+    # plain verify path — packing only engages for multi-token calls).
+    _prefill()
+    seq = []
+    tok, pos = anchor_token, anchor_pos
+    for _ in range(3 * P):  # several iterations ⇒ exercises staging rollovers
+        logits, h = spec._verify([tok], [pos])
+        h.deallocate(True)
+        tok = int(torch.argmax(logits[0]))
+        seq.append(tok)
+        pos += 1
+
+    # ── Packed: chain of packed verifies committing the matched chain tokens.
+    _prefill()
+    spec._pv_a_prev = -1
+    packed = []
+    pos = anchor_pos
+    chain = [anchor_token] + seq
+    it = 0
+    while len(packed) < 3 * P:
+        tokens = chain[it * P : it * P + P]  # the already-verified greedy chain
+        positions = [pos + j for j in range(P)]
+        try:
+            lh, h = spec._verify(tokens, positions)  # first call compiles the packed SDPA
+        except RuntimeError as e:
+            if _is_l1_cb_overflow(e):
+                pytest.skip(_L1_OVERFLOW_REASON)
+            raise
+        h.deallocate(True)
+        packed.extend(int(torch.argmax(lh[j])) for j in range(P))
+        pos += P
+        it += 1
+    packed = packed[: len(seq)]
+
+    logger.info(f"sequential: {seq}")
+    logger.info(f"packed:     {packed}")
+    n_match = sum(1 for a, b in zip(seq, packed) if a == b)
+    logger.info(f"match {n_match}/{len(seq)}")
+    assert packed == seq, f"packed verify diverges from sequential: packed={packed} seq={seq}"
+
+
+# ───────────────────────── batched (B>1) packed-verify bench ─────────────────
+#
+# The PR's KV-bandwidth win lives entirely in the verify step: a packed verify
+# reads each user's KV ONCE (batch dim = B, the P=K+1 candidates folded into the
+# query-heads), whereas the batch-alias verify spends one full KV read per
+# pseudo-user (batch dim = B*(K+1)). At batch=1 the decode is weight-bound, so
+# this never shows; only once weights are amortized across a batch does per-user
+# cost become KV-bound and the B-vs-B*(K+1) read ratio matter.
+#
+# This bench drives ``ttnn_packed_verify_forward`` directly at B>1. The packed
+# attention path (``packed_decode_forward`` → ``_packed_verify_sdpa``) is already
+# B-aware (``B = rows // P``, page_table ``[B, blocks]``, mask ``[B, 1, H*P,
+# S_k]``); the only batch=1 lock-ins are the spec-decode host builders and the
+# loop-free *staging* KV write. We sidestep the staging (a write-side optimization
+# that is irrelevant to the read amortization and dwarfed by the full-context read
+# at long ctx) by using the per-position ``paged_update_cache`` *fallback* write
+# (``kv_write_idxs``, no staging), so this isolates exactly the SDPA read claim.
+#
+# Asymmetry that *is* the batch>1 story: the batch-alias verify rides the ordinary
+# decode path, whose per-user position vector is capped at 32 → ``B*(K+1) <= 32``
+# ⇒ B<=8 at P=4. The packed verify keeps batch=B and folds P into heads, so it
+# scales to B=32 where a single-pass batch-alias verify cannot even run; there the
+# honest baseline is P sequential batch-B decodes (the cost of verifying P
+# positions without packing).
+#
+# Env knobs: GEMMA4_BENCH_B="1,8" (comma list), GEMMA4_BENCH_CTX=2048 (prefill
+# length per user), GEMMA4_SPEC_DRAFT_LEN=3 (K; P=K+1), GEMMA4_BENCH_ITERS=20.
+# SKU-adaptive mesh (CI picks the largest that fits), matching matches_sequential.
+# Pinning a fixed TP (e.g. 1x4) breaks on boxes whose NAS weight cache was built at
+# a different TP: the demo populates the cache at the largest mesh's TP, so a TP4
+# pin on an 8-chip box misses the cache and tries to *write* it into the read-only
+# mount. trace_region_size is needed for this test's trace capture.
+@parametrize_mesh_with_fabric(device_params_extra={"trace_region_size": 256_000_000})
+def test_packed_verify_batch_perf(mesh_device, reset_seeds):
+    import time
+
+    model_path = os.getenv("HF_MODEL")
+    if not model_path:
+        pytest.skip("set HF_MODEL (target) to run")
+    if _is_moe_model(model_path):
+        pytest.skip(_MOE_UNSUPPORTED_REASON)
+    if mesh_device.get_num_devices() == 1:
+        pytest.skip("single-device L1 limit: use a TP mesh (e.g. 1x4)")
+
+    from models.demos.gemma4.demo.text_demo_v2 import create_tt_page_table
+    from models.demos.gemma4.tt.generator import Gemma4Generator
+    from models.demos.gemma4.tt.spec_decode import SpeculativeDecoder
+    from models.tt_transformers.tt.common import PagedAttentionConfig
+
+    # CI is a shared, time-boxed runner: perf numbers there are meaningless and
+    # the full sweep (B up to 32, ctx=2048, 20 reps) on a 31B target blows the
+    # job timeout (65k-token prefill + 4 B-values × 20 reps × 2 paths). Under
+    # CI=true default to a light sweep so this still runs as a B>1 packed-verify
+    # smoke/correctness check; local runs keep full fidelity. Any explicit
+    # GEMMA4_BENCH_* override wins in both cases. NOTE: ctx must keep
+    # max_seq_len >= the sliding window (1024) — the sliding-window decode slices
+    # `window` keys from the cache, so a shorter cache overruns it. ctx=1024 gives
+    # max_seq_len=1088 (>= 1024); do not lower it below the window.
+    _ci = os.getenv("CI") == "true"
+    Bs = [int(b) for b in os.environ.get("GEMMA4_BENCH_B", "1,8" if _ci else "1,8,16,32").split(",") if b.strip()]
+    ctx = int(os.environ.get("GEMMA4_BENCH_CTX", 1024 if _ci else 2048))
+    K = int(os.environ.get("GEMMA4_SPEC_DRAFT_LEN", 3))
+    P = K + 1
+    reps = int(os.environ.get("GEMMA4_BENCH_ITERS", 3 if _ci else 20))
+    # A packed-vs-alias argmax flip is a real bug only if the reference (alias)
+    # preferred its token by more than this logit margin; smaller gaps are
+    # near-ties that the ~1e-1 batched-SDPA noise is expected to flip.
+    CONFIDENT_GAP = float(os.environ.get("GEMMA4_BENCH_CONFIDENT_GAP", 5.0))
+    Bmax = max(Bs)
+
+    block_size = 64
+    # Key length S_k = max_seq_len: must cover positions 0..ctx+K and be a
+    # multiple of the SDPA k_chunk (64). The additive mask zeroes out anything
+    # past each row's causal bound, so over-allocating keys is harmless.
+    max_seq_len = math.ceil((ctx + P) / block_size) * block_size
+    blocks_per_user = max_seq_len // block_size
+    paged_attention_config = PagedAttentionConfig(block_size=block_size, max_num_blocks=Bmax * blocks_per_user)
+
+    generator, tt_kv_cache, tokenizer = Gemma4Generator.from_pretrained(
+        mesh_device=mesh_device,
+        model_path=model_path,
+        max_batch_size=Bmax,
+        max_seq_len=max_seq_len,
+        num_layers=None,
+        paged_attention_config=paged_attention_config,
+        bounded_sliding_kv_cache=False,
+    )
+    target = generator.model[0]
+    page_table_torch = create_tt_page_table(Bmax, paged_attention_config)  # [Bmax, blocks_per_user], distinct per user
+
+    spec = SpeculativeDecoder(
+        target_model=target,
+        assistant_model=None,
+        mesh_device=mesh_device,
+        tt_kv_cache=tt_kv_cache,
+        page_table_torch=page_table_torch,
+        stop_tokens=tokenizer.stop_tokens,
+        draft_len=K,
+    )
+    mapper = target._replicate_to_mesh_mapper()
+    tp = target.mesh_config.tp if target.mesh_config else 1
+    H = target.layers[0].self_attn.config.num_attention_heads // tp
+    window = target.hf_config.sliding_window
+    vocab = target.vocab_size
+    NEG = -1e9
+
+    # Prefill Bmax identical users to length `ctx` (distinct KV blocks per user
+    # via the page table). Content is irrelevant to the bench — packed and
+    # batch-alias read the SAME prefilled cache. warmup_prefill=False avoids the
+    # TP>1 prefill-warmup sampling path (see the correctness test above).
+    in_pt = torch.randint(low=10, high=2000, size=(Bmax, ctx), dtype=torch.int32)
+    generator.prefill_forward_text(
+        in_pt, page_table=page_table_torch, kv_cache=tt_kv_cache, prompt_lens=[ctx] * Bmax, warmup_prefill=False
+    )
+
+    c = ctx  # committed/anchor position; verify P fresh positions c..c+K
+    S_k = max_seq_len
+    tokens_per_user = [int(in_pt[0, 0])] + [int(in_pt[0, min(1 + j, ctx - 1)]) for j in range(K)]
+
+    def _from(t, dtype, layout=ttnn.ROW_MAJOR_LAYOUT):
+        return ttnn.from_torch(t, device=mesh_device, layout=layout, dtype=dtype, mesh_mapper=mapper)
+
+    def _masks(B):
+        # head-major rows h*P+p; per-user identical (same c) → tile across B.
+        j = torch.arange(S_k)
+        rf = torch.empty(P, S_k)
+        rs = torch.empty(P, S_k)
+        for p in range(P):
+            upper = c + p
+            rf[p] = torch.where(j <= upper, 0.0, NEG)
+            rs[p] = torch.where((j <= upper) & (j > upper - window), 0.0, NEG)
+        mf = rf.repeat(H, 1).reshape(1, 1, H * P, S_k).repeat(B, 1, 1, 1).to(torch.bfloat16)
+        ms = rs.repeat(H, 1).reshape(1, 1, H * P, S_k).repeat(B, 1, 1, 1).to(torch.bfloat16)
+        return _from(mf, ttnn.bfloat16, ttnn.TILE_LAYOUT), _from(ms, ttnn.bfloat16, ttnn.TILE_LAYOUT)
+
+    def _run(call_fn, n_rows):
+        """Compile (+read logits for correctness), capture, time `reps` replays."""
+        logits, hidden = call_fn()
+        ttnn.synchronize_device(mesh_device)
+        lh = spec._logits_to_host(logits).reshape(n_rows, vocab).float().clone()
+        logits.deallocate(True)
+        hidden.deallocate(True)
+        tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        logits, hidden = call_fn()
+        ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(mesh_device)
+        ms = (time.perf_counter() - t0) / reps * 1e3
+        ttnn.release_trace(mesh_device, tid)
+        logits.deallocate(True)
+        hidden.deallocate(True)
+        return ms, lh
+
+    logger.info(
+        f"=== packed-verify batch bench | ctx={ctx} P={P} (K={K}) reps={reps} tp={tp} H_local={H} S_k={S_k} ==="
+    )
+    rows = []
+    for B in Bs:
+        pt_b = page_table_torch[:B].to(torch.int32)
+        # ── packed: batch dim B, P folded into heads, fallback per-p KV write ──
+        # rows user-major / position-minor: row u*P+p is user u's p-th candidate.
+        x_p = _from(torch.tensor([tokens_per_user] * B, dtype=torch.int64).reshape(1, B * P), ttnn.uint32)
+        pos_p = _from(torch.tensor([[c + p for u in range(B) for p in range(P)]], dtype=torch.int64), ttnn.uint32)
+        mask_full, mask_slide = _masks(B)
+        write_idxs = [_from(torch.full((B,), c + p, dtype=torch.int32), ttnn.int32) for p in range(P)]
+        pt_packed = _from(pt_b, ttnn.int32)
+
+        def _packed_call():
+            return target.ttnn_packed_verify_forward(
+                x=x_p,
+                position_idx=pos_p,
+                attn_mask_full=mask_full,
+                attn_mask_sliding=mask_slide,
+                packed_p=P,
+                page_table=pt_packed,
+                kv_cache=spec.tt_kv_cache,
+                kv_write_idxs=write_idxs,
+                embed_idx_full=None,
+                embed_idx_sliding=None,
+                hot_pt=None,
+            )
+
+        try:
+            packed_ms, packed_lh = _run(_packed_call, B * P)  # first call compiles the packed SDPA
+        except RuntimeError as e:
+            if _is_l1_cb_overflow(e):
+                pytest.skip(_L1_OVERFLOW_REASON)
+            raise
+        for t in (x_p, pos_p, mask_full, mask_slide, pt_packed, *write_idxs):
+            t.deallocate(True)
+
+        # ── batch-alias baseline ──────────────────────────────────────────────
+        if B * P <= 32:
+            # single-pass: B*P pseudo-users, each user's row replicated P times.
+            x_a = spec._tokens_tensor([tokens_per_user[p] for u in range(B) for p in range(P)])
+            pu_a, pi_a = spec._pos_tensors([c + p for u in range(B) for p in range(P)])
+            pt_alias = _from(pt_b.repeat_interleave(P, dim=0), ttnn.int32)
+
+            def _alias_call():
+                return target.ttnn_verify_forward(
+                    x=x_a, current_pos=pu_a, current_pos_cache=pi_a, page_table=pt_alias, kv_cache=spec.tt_kv_cache
+                )
+
+            alias_ms, alias_lh = _run(_alias_call, B * P)
+            for t in (x_a, pu_a, pi_a, pt_alias):
+                t.deallocate(True)
+            # correctness: packed argmax vs batch-alias argmax per row. Both are
+            # batched-SDPA paths whose per-user RoPE + cross-core reductions differ
+            # by ~1e-1, so a divergence is only a bug at a CONFIDENT token — i.e.
+            # when the reference (alias) logit gap between its argmax and packed's
+            # pick is large. Near-ties (small gap) are expected to flip.
+            pa = packed_lh.argmax(dim=-1)
+            aa = alias_lh.argmax(dim=-1)
+            n_match = int((pa == aa).sum())
+            max_diff = float((packed_lh - alias_lh).abs().max())
+            confident_flips = 0
+            for r in range(B * P):
+                if int(pa[r]) != int(aa[r]):
+                    gap = float(alias_lh[r, int(aa[r])] - alias_lh[r, int(pa[r])])
+                    if gap > CONFIDENT_GAP:
+                        confident_flips += 1
+            baseline_kind = f"alias(B*P={B*P})"
+        else:
+            # batch-alias can't fit B*(K+1)>32 users in one decode pass; the
+            # no-packing cost is P sequential batch-B decodes.
+            x_a = spec._tokens_tensor([tokens_per_user[0]] * B)
+            pu_a, pi_a = spec._pos_tensors([c] * B)
+            pt_alias = _from(pt_b, ttnn.int32)
+
+            def _alias_call():
+                return target.ttnn_verify_forward(
+                    x=x_a, current_pos=pu_a, current_pos_cache=pi_a, page_table=pt_alias, kv_cache=spec.tt_kv_cache
+                )
+
+            one_ms, _ = _run(_alias_call, B)
+            for t in (x_a, pu_a, pi_a, pt_alias):
+                t.deallocate(True)
+            alias_ms = one_ms * P
+            n_match, max_diff, confident_flips = None, None, None
+            baseline_kind = f"{P}x batch-{B} decode (B*(K+1)>32: no single-pass alias)"
+
+        speedup = alias_ms / packed_ms if packed_ms > 0 else float("nan")
+        rows.append((B, packed_ms, alias_ms, baseline_kind, speedup, n_match, max_diff, confident_flips))
+        if n_match is not None:
+            corr = f"corr {n_match}/{B*P} match, confident-flips={confident_flips} (max|Δlogit|={max_diff:.2f})"
+        else:
+            corr = "corr n/a (no single-pass alias reference at this B)"
+        logger.info(
+            f"[bench] B={B:>2}: packed={packed_ms:6.2f} ms | baseline({baseline_kind})={alias_ms:6.2f} ms | "
+            f"speedup={speedup:4.2f}x | {corr}"
+        )
+
+    logger.info("=== summary (verify ms/iter; speedup = baseline/packed) ===")
+    for B, p_ms, a_ms, kind, sp, nm, md, cf in rows:
+        logger.info(f"  B={B:>2}  packed {p_ms:6.2f} ms  baseline {a_ms:6.2f} ms [{kind}]  →  {sp:4.2f}x")
+
+    # Bug gate: a CONFIDENT-token flip (reference gap > CONFIDENT_GAP) is a real
+    # divergence; near-tie flips under random-context noise are expected.
+    for B, p_ms, a_ms, kind, sp, nm, md, cf in rows:
+        if cf is not None:
+            assert cf == 0, f"B={B}: {cf} confident-token flips packed vs batch-alias (max|Δlogit|={md:.2f})"

--- a/models/demos/gemma4/tests/unit/test_spec_decode.py
+++ b/models/demos/gemma4/tests/unit/test_spec_decode.py
@@ -3089,3 +3089,177 @@ def test_argmax_cost(mesh_device, reset_seeds):
 
     _check_pad32(1)
     _check_pad32(K + 1)
+
+
+@_needs_assistant
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [pytest.param((1, 4), {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 200_000_000}, id="1x4")],
+    indirect=True,
+)
+def test_spec_decode_batched(mesh_device, reset_seeds):
+    """End-to-end BATCHED (B>1) greedy speculative decode for B independent users.
+
+    Each iteration drafts every user at batch=1 and runs ONE batched packed
+    verify over all B users (the KV-amortization win). Users accept raggedly, so
+    their positions diverge. Validates:
+      * the batched path runs and every user emits tokens;
+      * user-0's batched output matches a batch=1 plain-greedy reference up to the
+        first target near-tie (same contract as test_spec_decode_matches_greedy);
+      * distinct prompts -> distinct outputs (no gross cross-user KV leak);
+    and reports per-user + aggregate throughput.
+    """
+    import time
+
+    near_tie_gap = float(os.environ.get("GEMMA4_SPEC_NEAR_TIE_GAP", 2.0))
+    from models.demos.gemma4.tt.common import create_assistant_model
+    from models.demos.gemma4.tt.generator import Gemma4Generator
+    from models.demos.gemma4.tt.spec_decode import SpeculativeDecoder
+    from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
+
+    model_path = os.getenv("HF_MODEL")
+    if not model_path:
+        pytest.skip("set HF_MODEL (target) to run")
+    num_layers = os.environ.get("GEMMA4_NUM_LAYERS")
+    num_layers = int(num_layers) if num_layers else None
+
+    B = int(os.environ.get("GEMMA4_SPEC_BATCH", 4))
+    max_seq_len = int(os.environ.get("GEMMA4_SPEC_MAX_SEQ", 1024))
+    n_new = int(os.environ.get("GEMMA4_SPEC_TEST_TOKENS", 16))
+    draft_len = int(os.environ.get("GEMMA4_SPEC_DRAFT_LEN", 4))
+    block_size = 64
+    blocks_per_user = math.ceil(max_seq_len / block_size)
+    paged_attention_config = PagedAttentionConfig(block_size=block_size, max_num_blocks=B * blocks_per_user)
+
+    generator, tt_kv_cache, tokenizer = Gemma4Generator.from_pretrained(
+        mesh_device=mesh_device,
+        model_path=model_path,
+        max_batch_size=B,
+        max_seq_len=max_seq_len,
+        num_layers=num_layers,
+        paged_attention_config=paged_attention_config,
+        bounded_sliding_kv_cache=False,
+    )
+    target = generator.model[0]
+    _, assistant = create_assistant_model(
+        mesh_device=mesh_device,
+        target_model=target,
+        mesh_config=target.mesh_config,
+        ccl_manager=target.ccl_manager,
+        assistant_path=ASSISTANT_PATH,
+        max_local_batch_size=int(os.environ.get("GEMMA4_SPEC_ASSIST_BATCH", B)),
+    )
+
+    from models.demos.gemma4.demo.text_demo_v2 import create_tt_page_table
+
+    page_table = create_tt_page_table(B, paged_attention_config)  # [B, blocks_per_user]
+
+    base_prompts = [
+        "The capital of France is",
+        "Water boils at a temperature of",
+        "The largest planet in our solar system is",
+        "The author of Romeo and Juliet is",
+        "The chemical symbol for gold is",
+        "The speed of light is approximately",
+        "The first president of the United States was",
+        "The square root of sixty-four is",
+    ]
+    prompts = [base_prompts[b % len(base_prompts)] for b in range(B)]
+
+    spec = SpeculativeDecoder(
+        target_model=target,
+        assistant_model=assistant,
+        mesh_device=mesh_device,
+        tt_kv_cache=tt_kv_cache,
+        page_table_torch=page_table,
+        stop_tokens=tokenizer.stop_tokens,
+        draft_len=draft_len,
+    )
+
+    # Per-user prefill (distinct lengths -> prefill each user into its own blocks).
+    anchor_tokens, anchor_positions = [], []
+    for b in range(B):
+        in_pt, encoded, decoding_pos, prefill_lens = preprocess_inputs_prefill(
+            [prompts[b]], tokenizer, generator.model_args, True, n_new, max_prefill_len=max_seq_len
+        )
+        in_pt = torch.stack(in_pt).view(1, -1)
+        generator.prefill_forward_text(
+            in_pt,
+            page_table=page_table[b : b + 1],
+            kv_cache=tt_kv_cache,
+            prompt_lens=decoding_pos,
+            warmup_prefill=False,
+        )
+        anchor_positions.append(prefill_lens[0] - 1)
+        anchor_tokens.append(int(encoded[0][prefill_lens[0] - 1]))
+
+    # Batched spec decode.
+    t0 = time.perf_counter()
+    outs, accepts = spec.generate_batched(
+        anchor_tokens=anchor_tokens,
+        anchor_positions=anchor_positions,
+        max_new_tokens=n_new,
+        max_seq_len=max_seq_len,
+        temperature=0.0,
+    )
+    ttnn.synchronize_device(mesh_device)
+    elapsed = time.perf_counter() - t0
+
+    total_tokens = sum(len(o) for o in outs)
+    mean_accepts = [(sum(a) / len(a)) if a else 0.0 for a in accepts]
+    traced = spec._use_trace
+    setup_s = getattr(spec, "_last_fused_setup_s", 0.0) if traced else 0.0
+    replay_s = getattr(spec, "_last_fused_replay_s", elapsed) if traced else elapsed
+    logger.info(
+        f"[batched-spec] B={B} draft_len={draft_len} n_new={n_new} ctx~{max(anchor_positions)+1} traced={traced}"
+    )
+    for b in range(B):
+        logger.info(f"  user {b}: prompt={prompts[b]!r}")
+        logger.info(f"           out='{tokenizer.decode(outs[b]).strip()}' (acc/iter={mean_accepts[b]:.2f})")
+    logger.info(
+        f"[batched-spec] total {total_tokens} tokens in {elapsed:.2f}s wall "
+        f"(setup {setup_s:.2f}s, steady {replay_s:.2f}s) -> "
+        f"{total_tokens/replay_s:.1f} tok/s aggregate, {total_tokens/replay_s/B:.1f} tok/s/user (steady, {'traced' if traced else 'untraced'})"
+    )
+
+    assert all(len(o) > 0 for o in outs), f"some user produced no tokens: {[len(o) for o in outs]}"
+    if len({prompts[b] for b in range(B)}) > 1:
+        distinct = {tuple(o) for o in outs}
+        assert len(distinct) > 1, "distinct prompts collapsed to identical outputs (gross cross-user KV leak)"
+
+    # Correctness anchor: user-0 batched output vs batch=1 plain-greedy reference.
+    in_pt0, encoded0, decoding_pos0, prefill_lens0 = preprocess_inputs_prefill(
+        [prompts[0]], tokenizer, generator.model_args, True, n_new, max_prefill_len=max_seq_len
+    )
+    in_pt0 = torch.stack(in_pt0).view(1, -1)
+    generator.prefill_forward_text(
+        in_pt0, page_table=page_table[0:1], kv_cache=tt_kv_cache, prompt_lens=decoding_pos0, warmup_prefill=False
+    )
+    ref0 = _plain_greedy(spec, anchor_tokens[0], anchor_positions[0], len(outs[0]))
+    gen0 = outs[0]
+    first_div = next((i for i in range(min(len(gen0), len(ref0))) if gen0[i] != ref0[i]), None)
+    if first_div is None:
+        logger.info("[batched-spec] user-0 batched output is TOKEN-IDENTICAL to batch=1 plain greedy")
+        return
+
+    generator.prefill_forward_text(
+        in_pt0, page_table=page_table[0:1], kv_cache=tt_kv_cache, prompt_lens=decoding_pos0, warmup_prefill=False
+    )
+    tok, pos = anchor_tokens[0], anchor_positions[0]
+    for _ in range(first_div):
+        lg, hd = spec._verify([tok], [pos])
+        hd.deallocate(True)
+        tok = int(torch.argmax(lg[0]))
+        pos += 1
+    lg, hd = spec._verify([tok], [pos])
+    hd.deallocate(True)
+    top2 = torch.topk(lg[0].float(), 2)
+    gap = float(top2.values[0] - top2.values[1])
+    logger.info(
+        f"[batched-spec] user-0 first divergence at idx {first_div}: batched={gen0[first_div]} "
+        f"greedy={ref0[first_div]} target top2={top2.indices.tolist()} gap={gap:.4f} (near-tie={near_tie_gap})"
+    )
+    assert gap < near_tie_gap, (
+        f"batched user-0 diverged from plain greedy at a CONFIDENT token (idx {first_div}, "
+        f"top-2 gap={gap:.3f} >= {near_tie_gap}); indicates a batched accept/commit/KV-write bug"
+    )

--- a/models/demos/gemma4/tt/assistant/model.py
+++ b/models/demos/gemma4/tt/assistant/model.py
@@ -77,8 +77,10 @@ class Gemma4AssistantModel:
         dtype=ttnn.bfloat16,
         tensor_cache_path=None,
         mesh_config=None,
+        max_local_batch_size=1,
     ):
         self.mesh_device = mesh_device
+        self.max_local_batch_size = max_local_batch_size
         self.args = assistant_args
         self.text_args = assistant_args.text_args
         self.target = target_model
@@ -118,7 +120,7 @@ class Gemma4AssistantModel:
                 tensor_cache_path=f"{tensor_cache_path}/layer_{i}" if tensor_cache_path else None,
                 mesh_config=mesh_config,
                 max_seq_len=self.text_args.max_seq_len,
-                max_local_batch_size=1,
+                max_local_batch_size=max_local_batch_size,
             )
             self.layers.append(layer)
 

--- a/models/demos/gemma4/tt/attention/decode.py
+++ b/models/demos/gemma4/tt/attention/decode.py
@@ -7,6 +7,8 @@ Decode-mode attention forward pass for Gemma4.
 Uses HF-style ttnn.experimental.rotary_embedding (no transformation matrices).
 """
 
+import os
+
 import ttnn
 
 from .operations import (
@@ -19,8 +21,33 @@ from .operations import (
     concat_heads,
     effective_block_size,
     split_qkv_heads_decode,
+    split_qkv_heads_prefill,
 )
 from .weights import AttentionWeights
+
+# Cache for the L1 height-sharded ``MemoryConfig`` that
+# ``nlp_create_qkv_heads_decode`` produces. The spec only depends on shape
+# constants (B, num_heads_local, head_dim, qkv_dim, kv_replicated/global flags)
+# — all fixed for a given model+batch. By caching across calls we avoid the
+# per-layer probe decode-split that exists ONLY to discover this spec.
+# Populated on the first (un-traced compile) call; inside trace capture the
+# probe is skipped entirely.
+_Q_SHARDED_MEM_CACHE: dict = {}
+
+
+def _q_sharded_mem_key(B, qkv_dim, config, weights, tp):
+    """Hashable key for the q_sharded_mem cache. Captures every input that
+    affects ``nlp_create_qkv_heads_decode``'s output shard spec."""
+    return (
+        int(B),
+        int(qkv_dim),
+        int(config.num_attention_heads),
+        int(config.num_key_value_heads),
+        int(config.head_dim),
+        bool(weights.is_global),
+        bool(weights.kv_replicated),
+        int(tp),
+    )
 
 
 def decode_forward(
@@ -311,4 +338,498 @@ def decode_forward(
     tt_out = apply_output_projection(tt_out, weights)
     tt_out = apply_allreduce(tt_out, mesh_config, ccl_manager, config.hidden_size)
 
+    return tt_out
+
+
+# ── Packed-query verify decode ─────────────────────────────────────────────
+# Verifies P speculative positions per user in ONE attention pass by packing
+# the P positions into the query-heads dim (H_local*P packed heads) and
+# running a single non-causal SDPA with an additive mask that bakes in the
+# per-position causal upper bound (and the sliding-window lower bound on
+# sliding layers). Ported from the gemma4_cody packed-verify path.
+
+
+def _packed_sdpa_grid(config, mesh_device):
+    """SDPA grid for the packed verify — mirrors the single-token decode's
+    choice: small grid for global layers (head_dim=512 needs more L1/core),
+    full device grid for sliding layers."""
+    if config.head_dim >= 512:
+        return ttnn.CoreCoord(8, 4)
+    device_grid = mesh_device.compute_with_storage_grid_size()
+    return ttnn.CoreCoord(device_grid.x, device_grid.y)
+
+
+def _verify_head_splits(B, H_local, nkv_local, P, head_dim, grid=None):
+    """How many QUERY-HEAD-wise sub-ops to split the packed-verify SDPA into.
+
+    The packed verify folds ``H_local*P`` query rows onto ``nkv_local`` KV
+    groups; the per-core SDPA-decode CBs (Q, QK scores, and the flash
+    cross-core reduction buffer) scale with the packed query-head tile count
+    ``PNHt = H_local*P/32``. Global-attention layers (head_dim=512 ⇒ DHt 16,
+    single local KV head at high TP) can overflow the 1.5 MB L1 even at the
+    default k_chunk; we split the packed-head dim across ``n`` full-grid ops +
+    a concat, carrying ``H_local/n`` heads each. Sliding layers (head_dim 256)
+    fit and are left as one op.
+
+    Enabled ONLY when ``nkv_local == 1``: then every query head maps to the
+    lone KV head, so each sub-op can SHARE the full (paged) K/V cache +
+    page_table with NO cache slicing — any head subset is GQA-correct. With >1
+    local KV head a head split would need per-op cache slicing; such configs
+    are left unsplit.
+
+    ``GEMMA4_PV_SDPA_HEAD_SPLITS`` overrides the count (clamped to the largest
+    valid split <= the request)."""
+    if nkv_local != 1:
+        return 1
+    # Valid splits: whole heads per op AND 32-tile-aligned query-row slices.
+    valid = [d for d in range(1, H_local + 1) if H_local % d == 0 and ((H_local // d) * P) % 32 == 0]
+    if not valid:
+        return 1
+    env = os.environ.get("GEMMA4_PV_SDPA_HEAD_SPLITS")
+    if env:
+        want = max(1, min(int(env), H_local))
+        return max(d for d in valid if d <= want)
+    if (H_local * P) * head_dim <= 8192:  # not heavy (sliding) — one op fits
+        return 1
+    # Mirror sdpa_decode_program_factory's core allocation (num_kv_heads == 1)
+    # and CB tile counts; keep grid / max_cores_per_head_batch / k_chunk in sync
+    # with the packed sdpa_program_config. Budget in 2 KB tiles with margin
+    # under the 768-tile (1.5 MB) L1 cap.
+    if grid is None:
+        grid = 32 if head_dim >= 512 else 64
+    max_cores_per_head, k_chunk = 16, 64
+    cores_per_head = max(1, min(grid, max_cores_per_head * B) // max(1, B))
+    DHt, Sk = head_dim // 32, max(1, k_chunk // 32)
+    BUDGET_TILES = 720
+
+    def per_core_tiles(n):
+        pnht = (H_local * P) // (32 * n)
+        return (
+            2 * pnht * DHt  # Q-in + tilized-Q
+            + 5 * pnht * DHt  # 3 out-im + out-stats + out-final
+            + 2 * pnht * Sk  # attn-mask + QK-im
+            + 11 * pnht  # softmax stats CBs
+            + 4 * Sk * DHt  # K + V (double-buffered)
+            + 3  # scale / identity
+            + (pnht * DHt + 2 * pnht) * (cores_per_head - 1)  # cross-core flash reduction
+        )
+
+    for d in valid:  # ascending ⇒ smallest split that fits the budget
+        if per_core_tiles(d) <= BUDGET_TILES:
+            return d
+    return valid[-1]
+
+
+def _packed_verify_sdpa(
+    q_packed, k, v, layer_page_table, attn_mask, scale, pc, n_splits, B, H_local, P, head_dim, block_size, num_kv_heads
+):
+    """Run the packed-verify decode-SDPA, optionally head-split into
+    ``n_splits`` full-grid ops + a concat (see ``_verify_head_splits``).
+    Splitting SHARES the (paged) K/V cache + page_table across sub-ops unsliced
+    — valid only for a single local KV head — and slices only Q and the
+    additive mask on the packed query-head dim. Does NOT free its inputs.
+    Returns [1, B, H_local*P, head_dim]."""
+
+    # Single-device (TP=1) only: the packed layout folds P candidates into the
+    # query-heads dim, so with all heads on one device the SDPA decode's
+    # padded-heads-per-core (PNHt) can be odd (e.g. 3). ttnn asserts
+    # MUL_BCAST_GRANULARITY = min(PNHt * Sk_chunk_t, dst_size) is a power of 2; with
+    # the op-default dst_size=8 and Sk_chunk_t=2 that leaves PNHt*2=6 and aborts.
+    # Match the op's default compute config (HiFi2) but flip fp32_dest_acc_en=True so
+    # dst_size=4 ⇒ min(2*PNHt, 4) is always 2 or 4 (power of 2), no k_chunk/L1
+    # increase, and fp32 accumulation is strictly higher precision. On multi-device
+    # meshes heads split so PNHt is already power-of-2 — leave the op default (None)
+    # there so the packed path stays identical to upstream.
+    _dev = k.device()
+    _num_dev = getattr(_dev, "get_num_devices", lambda: 1)()
+    compute_kernel_config = (
+        ttnn.init_device_compute_kernel_config(
+            _dev.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        if _num_dev == 1
+        else None
+    )
+
+    def _call(q, m):
+        if layer_page_table is not None:
+            return ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                k,
+                v,
+                page_table_tensor=layer_page_table,
+                is_causal=False,
+                attn_mask=m,
+                scale=scale,
+                sliding_window_size=None,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                program_config=pc,
+                compute_kernel_config=compute_kernel_config,
+                block_size=block_size,
+                num_kv_heads=num_kv_heads,
+            )
+        return ttnn.transformer.scaled_dot_product_attention_decode(
+            q,
+            k,
+            v,
+            is_causal=False,
+            attn_mask=m,
+            scale=scale,
+            sliding_window_size=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=pc,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+    if n_splits <= 1:
+        return _call(q_packed, attn_mask)
+    s_k = attn_mask.shape[3] if attn_mask is not None else None
+    rows_per = (H_local // n_splits) * P  # packed query rows per sub-op (32-aligned)
+    parts = []
+    for s in range(n_splits):
+        r0, r1 = s * rows_per, (s + 1) * rows_per
+        q_i = ttnn.slice(q_packed, [0, 0, r0, 0], [1, B, r1, head_dim])
+        m_i = ttnn.slice(attn_mask, [0, 0, r0, 0], [B, 1, r1, s_k]) if attn_mask is not None else None
+        out_i = _call(q_i, m_i)
+        ttnn.deallocate(q_i)
+        if m_i is not None:
+            ttnn.deallocate(m_i)
+        parts.append(out_i)
+    out = ttnn.concat(parts, dim=2)  # [1, B, H_local*P, head_dim]
+    for p in parts:
+        ttnn.deallocate(p)
+    return out
+
+
+def _packed_fill_kv_loopfree_embed(cache, staging, new_seq, embed_idx, hot_pt):
+    """Loop-free packed KV-cache write via PERSISTENT STAGING and a
+    transpose-free ``ttnn.embedding`` row-gather merge — replaces the
+    per-position ``paged_update_cache`` loop, and never reads the committed
+    cache on the hot path.
+
+    ``staging`` is this layer's resident hot-block copy
+    ``[1, nkv, S2, head_dim]`` (S2 = max_batch * PV_HOT_BLOCKS * block_size),
+    slot-indexed: slot ``s`` owns seq ``[s*BLK*bs, (s+1)*BLK*bs)`` and already
+    holds the committed prefix of its hot block(s) — seeded at the first
+    verify, maintained step-to-step by the spec-decode driver. ``new_seq`` is
+    the freshly projected/normed/RoPE'd K (or V) ``[1, nkv, n_new, head_dim]``
+    (user-major / position-minor rows, n_new tile-aligned — caller pads).
+
+    Per step (all fixed-shape ⇒ trace-safe; cost scales with S2, never with
+    max_num_blocks):
+      1. merge: ``ttnn.embedding`` row-gathers the flattened
+         ``concat([staging, new_seq])`` — committed positions copy from staging
+         (identity, or shifted one block on a rollover), the P new positions
+         pull from ``new_seq``. ``embed_idx`` ([1, nkv*S2] u32) bakes the
+         per-head row offset in: ``embed_idx[h*S2 + j] = h*(S2+n_new) +
+         merge_idx[j]``.
+      2. ``assign`` the merged hot blocks back into ``staging`` (persists for
+         the next step — no cache read needed next time).
+      3. one ``paged_fill_cache`` writes each slot's hot block(s) to its
+         physical page(s) named by ``hot_pt`` (-1 = skip ⇒ idle slots / the
+         unused spill block are left untouched).
+    """
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    nkv = staging.shape[1]
+    S2 = staging.shape[2]
+    head_dim = staging.shape[3]
+    src_seq = S2 + new_seq.shape[2]
+
+    # ① merge resident staging with this step's new K/V — no committed-cache read.
+    new_dram = ttnn.to_memory_config(new_seq, dram)
+    src = ttnn.concat([staging, new_dram], dim=2, memory_config=dram)  # [1, nkv, src_seq, hd] TILE
+    ttnn.deallocate(new_dram)
+    # Per-head row-gather merge. Folding all nkv heads into one row axis
+    # (``reshape(src, (nkv*src_seq, hd))`` + a single ``embedding``) mis-orders
+    # the 2nd+ head's tiles in TILE layout, corrupting cache head>=1 whenever a
+    # device holds more than one local KV head (``nkv_local >= 2`` — i.e. TP
+    # configs with ``num_kv_heads // tp >= 2``). Gathering each head's
+    # ``[src_seq, hd]`` block on its own keeps every head tile-contiguous.
+    # ``embed_idx`` bakes a per-head row offset ``h*src_seq``; head 0's slice is
+    # the bare merge_idx, valid for every head's local row-gather.
+    base_idx = ttnn.slice(embed_idx, [0, 0], [1, S2])  # head-0 merge_idx (no head offset)
+    parts = []
+    for h in range(nkv):
+        src_h = ttnn.slice(src, [0, h, 0, 0], [1, h + 1, src_seq, head_dim])
+        src_h2d = ttnn.reshape(src_h, (src_seq, head_dim))
+        merged_h = ttnn.embedding(base_idx, src_h2d, layout=ttnn.TILE_LAYOUT)  # [1, S2, hd]
+        parts.append(ttnn.reshape(merged_h, (1, 1, S2, head_dim)))
+    ttnn.deallocate(src)
+    merged = ttnn.concat(parts, dim=1) if nkv > 1 else parts[0]
+    merged = ttnn.to_memory_config(merged, dram)  # [1, nkv, S2, hd]
+
+    # ② persist updated hot blocks for next step, then ③ one fill launch.
+    ttnn.assign(merged, staging)
+    ttnn.experimental.paged_fill_cache(cache, merged, hot_pt, batch_idx=0)
+    ttnn.deallocate(merged)
+
+
+def packed_decode_forward(
+    hidden_states,
+    cos_cache,
+    sin_cache,
+    weights: AttentionWeights,
+    kv_cache,
+    config,
+    mesh_config,
+    mesh_device,
+    position_idx,
+    kv_write_idxs,
+    attn_mask,
+    packed_p,
+    page_table=None,
+    ccl_manager=None,
+    is_kv_shared=False,
+    rope_packed=None,
+    kv_staging=None,
+    embed_idx=None,
+    hot_pt=None,
+):
+    """Packed multi-token decode attention — P query positions/slot in one pass.
+
+    Hoists QKV projection, prefill-style split, per-head norm, and RoPE OUT of
+    any per-position loop: those run once on the full B*P tensor. The KV write
+    is loop-free when staging is provided (one paged_fill_cache per K/V), else
+    a per-position paged_update_cache fallback.
+
+    Args:
+        hidden_states: [1, 1, B*P, hidden_size]. Rows user-major / position-
+            minor — row u*P+p is slot u's p-th packed token.
+        cos_cache, sin_cache: 2D RoPE caches [max_seq_len, head_dim].
+        position_idx: [1, B*P] uint32 — RoPE position per row (cur_pos_u + p).
+        kv_write_idxs: list of P int32 [B] device tensors — the cache write
+            position for each packed position p (fallback per-p loop only).
+        attn_mask: [B, 1, H_local*P, S_k] head-major additive mask baking in
+            the per-position causal upper bound and (sliding layers) the
+            window lower bound. S_k must be a multiple of k_chunk (64).
+        packed_p: P, the number of packed positions per slot.
+        rope_packed: optional pre-gathered (cos_bp, sin_bp) for this layer
+            type — identical for all layers of a type, so the caller gathers
+            once per type per step.
+        kv_staging: optional [k_staging, v_staging] persistent hot-block
+            buffers (loop-free write path; see _packed_fill_kv_loopfree_embed).
+        embed_idx: [1, nkv_local*S2] uint32 merge gather index (loop-free path).
+        hot_pt: [1, max_batch*PV_HOT_BLOCKS] int32 physical fill pages, -1=skip.
+
+    Returns:
+        [1, 1, B*P, hidden_size] — attention output for every packed position.
+    """
+    P = packed_p
+    tp = mesh_config.tp if mesh_config else 1
+    B = hidden_states.shape[2] // P
+    H_local = config.num_attention_heads // tp
+    head_dim = config.head_dim
+    nkv_local = 1 if weights.kv_replicated else config.num_key_value_heads // tp
+    if config.cache_position_modulo is not None:
+        raise NotImplementedError("packed verify does not support bounded sliding KV caches")
+    if kv_cache is None:
+        raise ValueError("packed_decode_forward requires a KV cache (it attends through the paged cache)")
+    l1 = ttnn.L1_MEMORY_CONFIG
+
+    # ── ① QKV projection (one call on the full B*P, output kept on L1) ──────
+    xqkv = apply_qkv_projection(hidden_states, weights, memory_config=l1)
+    qkv_dim = xqkv.shape[-1]
+
+    # ── ② L1 height-sharded MemoryConfig for the fallback paged_update_cache ─
+    # ``paged_update_cache`` needs the layout ``nlp_create_qkv_heads_decode``
+    # emits; the spec depends only on shape constants, so probe once and cache.
+    cache_key = _q_sharded_mem_key(B, qkv_dim, config, weights, tp)
+    q_sharded_mem = _Q_SHARDED_MEM_CACHE.get(cache_key)
+    if q_sharded_mem is None and kv_staging is None and not is_kv_shared:
+        probe = ttnn.slice(xqkv, [0, 0, 0, 0], [1, 1, B, qkv_dim])
+        q_probe, k_probe, v_probe = split_qkv_heads_decode(
+            probe, config, weights.is_global, tp=tp, kv_replicated=weights.kv_replicated
+        )
+        q_sharded_mem = q_probe.memory_config()
+        _Q_SHARDED_MEM_CACHE[cache_key] = q_sharded_mem
+        for t in (q_probe, k_probe, v_probe, probe):
+            ttnn.deallocate(t)
+
+    # ── ②b Prefill-style split → L1 Q/K/V on B*P ────────────────────────────
+    tt_q, tt_k, tt_v = split_qkv_heads_prefill(
+        xqkv, config, weights.is_global, tp=tp, kv_replicated=weights.kv_replicated, memory_config=l1
+    )
+    # Q: [1, H_local, B*P, head_dim], K/V: [1, nkv_local, B*P, head_dim]
+    ttnn.deallocate(xqkv)
+
+    # ── ③ Per-head norms (one call each on B*P, kept on L1) ─────────────────
+    tt_q = apply_per_head_norm(tt_q, weights.q_norm_weight, config.rms_norm_eps, with_scale=True, memory_config=l1)
+    if not is_kv_shared:
+        tt_k = apply_per_head_norm(tt_k, weights.k_norm_weight, config.rms_norm_eps, with_scale=True, memory_config=l1)
+        tt_v = apply_per_head_norm(tt_v, None, config.rms_norm_eps, with_scale=False, memory_config=l1)
+
+    # ── ④ RoPE on B*P, prefill mode (kernel iterates along S=B*P) ───────────
+    if rope_packed is not None:
+        cos_bp, sin_bp = rope_packed
+        owns_rope = False
+    else:
+        cos_bp = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, cos_cache, layout=ttnn.TILE_LAYOUT))
+        sin_bp = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, sin_cache, layout=ttnn.TILE_LAYOUT))
+        owns_rope = True
+    tt_q = apply_rope(tt_q, cos_bp, sin_bp, token_index=None, memory_config=l1)
+    if not is_kv_shared:
+        tt_k = apply_rope(tt_k, cos_bp, sin_bp, token_index=None, memory_config=l1)
+    if owns_rope:
+        ttnn.deallocate(cos_bp)
+        ttnn.deallocate(sin_bp)
+
+    if is_kv_shared:
+        ttnn.deallocate(tt_k)
+        ttnn.deallocate(tt_v)
+
+    # ── ⑤ KV write — loop-free persistent staging (primary) ────────────────
+    if not is_kv_shared and kv_staging is not None and embed_idx is not None:
+        # Park Q off L1 (idle until the SDPA pack ⑥); merge intermediates live
+        # in DRAM and Q never re-enters L1 before the SDPA call.
+        tt_q = ttnn.to_memory_config(tt_q, ttnn.DRAM_MEMORY_CONFIG)
+        k_cache_w, v_cache_w = kv_cache
+        k_stg, v_stg = kv_staging
+        if k_stg.shape[1] != k_cache_w.shape[1]:
+            raise ValueError("staging nkv must match cache nkv (HMA-shared caches unsupported)")
+        # Pad new rows up to a tile boundary so the merge concat + flatten
+        # reshape stay metadata-only; embed_idx is built against the padded
+        # src_seq, so padded rows are never gathered.
+        n_new = tt_k.shape[2]
+        pad = (-n_new) % 32
+        if pad:
+            k_pad = ttnn.pad(tt_k, [(0, 0), (0, 0), (0, pad), (0, 0)], value=0.0)
+            v_pad = ttnn.pad(tt_v, [(0, 0), (0, 0), (0, pad), (0, 0)], value=0.0)
+            ttnn.deallocate(tt_k)
+            ttnn.deallocate(tt_v)
+            tt_k, tt_v = k_pad, v_pad
+        _packed_fill_kv_loopfree_embed(k_cache_w, k_stg, tt_k, embed_idx, hot_pt)
+        _packed_fill_kv_loopfree_embed(v_cache_w, v_stg, tt_v, embed_idx, hot_pt)
+        ttnn.deallocate(tt_k)
+        ttnn.deallocate(tt_v)
+
+    # ── ⑤ FALLBACK per-p paged_update_cache loop ────────────────────────────
+    elif not is_kv_shared:
+        tt_q = ttnn.to_memory_config(tt_q, ttnn.DRAM_MEMORY_CONFIG)
+        k_cache_w, v_cache_w = kv_cache
+        eff_bs = effective_block_size(k_cache_w, head_dim, nkv_local)
+        # Convert the prefill-style [1, nkv, B*P, hd] to decode layout
+        # [1, B*P, nkv, hd] (DRAM — the full tensors stay resident across the
+        # loop; only the per-p reshard occupies L1).
+        tt_k_bp = ttnn.permute(tt_k, (0, 2, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        tt_v_bp = ttnn.permute(tt_v, (0, 2, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(tt_k)
+        ttnn.deallocate(tt_v)
+        # The prefill-style split may leave the B*P sequence rows tile-padded to a
+        # multiple of 32 (ttnn-version dependent — same guard as the Q pack at ⑥).
+        # Slice back to the logical B*P rows so the (1,B,P,nkv,hd) reshape is
+        # volume-exact (padding is always at the tail). The slice can alias the
+        # parent's DRAM storage, so keep tt_k_bp/tt_v_bp alive until the end-of-loop
+        # cleanup rather than freeing them here.
+        k_src, v_src = tt_k_bp, tt_v_bp
+        if tt_k_bp.shape[1] != B * P:
+            k_src = ttnn.slice(tt_k_bp, [0, 0, 0, 0], [1, B * P, nkv_local, head_dim])
+            v_src = ttnn.slice(tt_v_bp, [0, 0, 0, 0], [1, B * P, nkv_local, head_dim])
+        tt_k_view = ttnn.reshape(k_src, (1, B, P, nkv_local, head_dim))
+        tt_v_view = ttnn.reshape(v_src, (1, B, P, nkv_local, head_dim))
+        for p in range(P):
+            k_p = ttnn.slice(tt_k_view, [0, 0, p, 0, 0], [1, B, p + 1, nkv_local, head_dim])
+            k_p = ttnn.reshape(k_p, (1, B, nkv_local, head_dim))
+            v_p = ttnn.slice(tt_v_view, [0, 0, p, 0, 0], [1, B, p + 1, nkv_local, head_dim])
+            v_p = ttnn.reshape(v_p, (1, B, nkv_local, head_dim))
+            k_p = ttnn.to_memory_config(k_p, q_sharded_mem)
+            v_p = ttnn.to_memory_config(v_p, q_sharded_mem)
+            if page_table is not None:
+                ttnn.experimental.paged_update_cache(
+                    k_cache_w,
+                    k_p,
+                    update_idxs_tensor=kv_write_idxs[p],
+                    page_table=page_table,
+                    block_size=eff_bs,
+                    num_kv_heads=nkv_local,
+                )
+                ttnn.experimental.paged_update_cache(
+                    v_cache_w,
+                    v_p,
+                    update_idxs_tensor=kv_write_idxs[p],
+                    page_table=page_table,
+                    block_size=eff_bs,
+                    num_kv_heads=nkv_local,
+                )
+            else:
+                ttnn.experimental.paged_update_cache(k_cache_w, k_p, update_idxs_tensor=kv_write_idxs[p])
+                ttnn.experimental.paged_update_cache(v_cache_w, v_p, update_idxs_tensor=kv_write_idxs[p])
+            ttnn.deallocate(k_p)
+            ttnn.deallocate(v_p)
+        ttnn.deallocate(tt_k_bp)
+        ttnn.deallocate(tt_v_bp)
+
+    k_cache_use, v_cache_use = kv_cache
+
+    # ── ⑥ Head-major pack Q → [1, B, H_local*P, head_dim] → SDPA ────────────
+    # ROW_MAJOR on purpose: P (< 32) never lands on a tile axis, so the
+    # split/merge reshapes are free views and the rank-5 permute is one strided
+    # copy; in TILE the same reshapes re-tile AND pad P→32. The head-major
+    # order (h*P+p) is load-bearing: SDPA maps packed query head i → KV head
+    # i // group, so a KV group must be a contiguous head block.
+    tt_q = ttnn.to_layout(tt_q, ttnn.ROW_MAJOR_LAYOUT)
+    # The prefill-style split / RoPE may keep the B*P sequence rows tile-padded
+    # to 32 in the logical shape (ttnn-version dependent). Slice back to the
+    # logical B*P rows so the head-major pack reshape is volume-exact (padding
+    # is always at the tail, so the first B*P rows hold the real positions).
+    if tt_q.shape[2] != B * P:
+        tt_q_unpad = ttnn.slice(tt_q, [0, 0, 0, 0], [1, H_local, B * P, head_dim])
+        ttnn.deallocate(tt_q)
+        tt_q = tt_q_unpad
+    tt_q = ttnn.reshape(tt_q, (1, H_local, B, P, head_dim))
+    tt_q = ttnn.permute(tt_q, (0, 2, 1, 3, 4))  # [1, B, H_local, P, hd]
+    tt_q = ttnn.reshape(tt_q, (1, B, H_local * P, head_dim))
+    q_packed = ttnn.to_layout(tt_q, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn.deallocate(tt_q)
+
+    sdpa_program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=_packed_sdpa_grid(config, mesh_device),
+        q_chunk_size=32,
+        k_chunk_size=64,
+        exp_approx_mode=False,
+        max_cores_per_head_batch=16,
+    )
+    _grid = sdpa_program_config.compute_with_storage_grid_size
+    n_sdpa_splits = _verify_head_splits(B, H_local, nkv_local, P, head_dim, grid=_grid.x * _grid.y)
+    eff_bs_sdpa = effective_block_size(k_cache_use, head_dim, nkv_local)
+    tt_sdpa = _packed_verify_sdpa(
+        q_packed,
+        k_cache_use,
+        v_cache_use,
+        page_table,
+        attn_mask,
+        1.0,
+        sdpa_program_config,
+        n_sdpa_splits,
+        B,
+        H_local,
+        P,
+        head_dim,
+        eff_bs_sdpa,
+        nkv_local,
+    )
+    ttnn.deallocate(q_packed)
+
+    # ── ⑦ Unpack head-major SDPA output → concat heads + o_proj + AR ────────
+    tt_sdpa = ttnn.to_layout(tt_sdpa, ttnn.ROW_MAJOR_LAYOUT, memory_config=l1)  # DRAM TILE → L1 RM
+    # Same tile-padding guard as the Q pack: the SDPA output's H_local*P packed
+    # query rows may come back padded to 32; slice to the logical extent so the
+    # unpack reshape is volume-exact.
+    if tt_sdpa.shape[2] != H_local * P:
+        tt_sdpa_unpad = ttnn.slice(tt_sdpa, [0, 0, 0, 0], [1, B, H_local * P, head_dim])
+        ttnn.deallocate(tt_sdpa)
+        tt_sdpa = tt_sdpa_unpad
+    tt_sdpa = ttnn.reshape(tt_sdpa, (1, B, H_local, P, head_dim))
+    tt_sdpa = ttnn.permute(tt_sdpa, (0, 1, 3, 2, 4))  # [1, B, P, H_local, head_dim]
+    tt_sdpa = ttnn.reshape(tt_sdpa, (1, B * P, H_local, head_dim))
+    tt_sdpa = ttnn.to_layout(tt_sdpa, ttnn.TILE_LAYOUT, memory_config=l1)
+
+    # Decode-layout concat: transpose batch/heads then nlp_concat_heads.
+    tt_sdpa = ttnn.transpose(tt_sdpa, 1, 2)
+    tt_out = ttnn.experimental.nlp_concat_heads(tt_sdpa, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn.deallocate(tt_sdpa)
+    tt_out = apply_output_projection(tt_out, weights)
+    tt_out = apply_allreduce(tt_out, mesh_config, ccl_manager, config.hidden_size)
     return tt_out

--- a/models/demos/gemma4/tt/attention/kv_cache.py
+++ b/models/demos/gemma4/tt/attention/kv_cache.py
@@ -13,6 +13,12 @@ import torch
 import ttnn
 from models.demos.gemma4.utils.general_utils import get_cache_file_name
 
+# Hot cache blocks held in staging per decode slot for the loop-free packed KV
+# write: a P-token speculative tail (P <= block_size) straddles at most 2 pages,
+# so each slot reserves 2 staging blocks (cur_pos block + spill). Must match the
+# spec-decode driver's staging bookkeeping (see tt/spec_decode.py).
+PV_HOT_BLOCKS = 2
+
 
 def init_kv_cache(
     mesh_device,
@@ -96,3 +102,45 @@ def init_kv_cache(
     )
 
     return [k_cache, v_cache]
+
+
+def init_kv_staging(
+    mesh_device,
+    config,
+    max_batch_size,
+    block_size,
+    blk=PV_HOT_BLOCKS,
+    cache_dtype=ttnn.bfloat16,
+):
+    """Per-layer staging buffers for the loop-free packed-verify KV write.
+
+    Holds, per decode slot, the ``blk`` "hot" cache blocks it is currently
+    appending into (the partial block at cur_pos + one spill block). The
+    packed-verify write merges this resident copy with the step's new K/V and
+    re-fills the committed cache from it — so the committed cache is never read
+    on the hot path (see ``decode.py::_packed_fill_kv_loopfree_embed``).
+
+    Shape ``[1, num_local_kv_heads, max_batch_size*blk*block_size, head_dim]``
+    in TILE/DRAM — same seq layout as the ``paged_fill_cache`` input. Slot ``s``
+    owns seq positions ``[s*blk*block_size, (s+1)*blk*block_size)``; block-slot
+    0 is the cur_pos block, block-slot 1 the spill block.
+
+    Returns ``[k_staging, v_staging]``.
+    """
+    is_mesh = hasattr(mesh_device, "shape")
+    tp = mesh_device.shape[1] if is_mesh else 1
+    num_local_kv_heads = 1 if config.num_key_value_heads < tp else config.num_key_value_heads // tp
+    stage_shape = [1, num_local_kv_heads, max_batch_size * blk * block_size, config.head_dim]
+    mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if is_mesh else None
+
+    def _zeros():
+        return ttnn.as_tensor(
+            torch.zeros(stage_shape),
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=cache_dtype,
+            mesh_mapper=mesh_mapper,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    return [_zeros(), _zeros()]

--- a/models/demos/gemma4/tt/attention/operations.py
+++ b/models/demos/gemma4/tt/attention/operations.py
@@ -40,9 +40,13 @@ PREFILL_CHUNK_SIZE = int(os.environ.get("GEMMA4_PREFILL_CHUNK_SIZE", "8192"))
 PREFILL_SLIDING_CHUNK_SIZE = int(os.environ.get("GEMMA4_PREFILL_SLIDING_CHUNK_SIZE", "30720"))
 
 
-def apply_qkv_projection(hidden_states, weights: AttentionWeights):
-    """Fused QKV matmul (no bias for Gemma4)."""
-    return ttnn.linear(hidden_states, weights.wqkv)
+def apply_qkv_projection(hidden_states, weights: AttentionWeights, memory_config=None):
+    """Fused QKV matmul (no bias for Gemma4).
+
+    ``memory_config`` lets the packed-verify decode keep the projection output
+    resident on L1; ``None`` keeps the op default (DRAM) for existing callers.
+    """
+    return ttnn.linear(hidden_states, weights.wqkv, memory_config=memory_config)
 
 
 def split_qkv_heads_decode(xqkv_fused, config, is_global: bool, tp: int = 1, kv_replicated: bool = False):
@@ -69,11 +73,19 @@ def split_qkv_heads_decode(xqkv_fused, config, is_global: bool, tp: int = 1, kv_
     )
 
 
-def split_qkv_heads_prefill(xqkv_fused, config, is_global: bool, tp: int = 1, kv_replicated: bool = False):
+def split_qkv_heads_prefill(
+    xqkv_fused, config, is_global: bool, tp: int = 1, kv_replicated: bool = False, memory_config=ttnn.DRAM_MEMORY_CONFIG
+):
     """
     Split fused QKV into separate head tensors for prefill mode.
     When TP > 1, uses local head counts (global / tp).
     When kv_replicated (num_kv_heads < TP), each device has 1 KV head (GQA-assigned).
+
+    ``memory_config`` defaults to DRAM (true prefill: seq_len can be thousands of
+    tokens and would not fit L1). The packed-verify decode caller overrides it to
+    L1 so the split output — and the downstream activation stream — stays
+    resident on L1 (the op only emits sharded output for sharded input, so an L1
+    interleaved input yields L1 interleaved output).
     """
     num_local_heads = config.num_attention_heads // tp
     num_local_kv_heads = 1 if kv_replicated else config.num_key_value_heads // tp
@@ -82,16 +94,20 @@ def split_qkv_heads_prefill(xqkv_fused, config, is_global: bool, tp: int = 1, kv
         num_heads=num_local_heads,
         num_kv_heads=num_local_kv_heads,
         transpose_k_heads=False,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        memory_config=memory_config,
     )
 
 
-def apply_per_head_norm(tensor, weight, eps, with_scale=True):
+def apply_per_head_norm(tensor, weight, eps, with_scale=True, memory_config=None):
     """
     Apply RMSNorm per-head on the head_dim dimension.
 
     Input: [1, num_heads, S, head_dim] or batched prefill [B, num_heads, S, head_dim]
     Process: reshape to [1, 1, num_heads*S, head_dim] (or B*num_heads*S for batch) -> rms_norm -> reshape back
+
+    ``memory_config`` is forwarded to ``rms_norm``; pass L1 to keep the normed
+    activation resident on L1 (packed-verify decode path). ``None`` keeps the
+    op's default (follows the input's layout).
     """
     orig_shape = tensor.shape
     head_dim = orig_shape[-1]
@@ -103,14 +119,14 @@ def apply_per_head_norm(tensor, weight, eps, with_scale=True):
         seq_or_batch = orig_shape[2]
         flat = ttnn.reshape(tensor, (1, 1, num_heads * seq_or_batch, head_dim))
     if with_scale and weight is not None:
-        normed = ttnn.rms_norm(flat, weight=weight, epsilon=eps)
+        normed = ttnn.rms_norm(flat, weight=weight, epsilon=eps, memory_config=memory_config)
     else:
-        normed = ttnn.rms_norm(flat, epsilon=eps)
+        normed = ttnn.rms_norm(flat, epsilon=eps, memory_config=memory_config)
 
     return ttnn.reshape(normed, orig_shape)
 
 
-def apply_rope(tensor, cos_cache, sin_cache, token_index=None):
+def apply_rope(tensor, cos_cache, sin_cache, token_index=None, memory_config=None):
     """
     Apply HF-style rotary position embedding.
 
@@ -123,13 +139,15 @@ def apply_rope(tensor, cos_cache, sin_cache, token_index=None):
         sin_cache: [1, 1, max_seq_len, head_dim] - full sin cache
         token_index: int or None. If int (decode), slices into cache at that position.
                      If None (prefill), applies to full sequence.
+        memory_config: forwarded to the rotary op; the packed-verify decode passes
+                     L1 to keep the rotated tensor resident on L1.
 
     Note: rotary_embedding pads dim 2 to TILE_HEIGHT (32) in decode mode.
     We reshape+slice to restore the original logical shape, following the
     tt_transformers _hf_rope_decode pattern.
     """
     orig_shape = tensor.shape
-    result = ttnn.experimental.rotary_embedding(tensor, cos_cache, sin_cache, token_index)
+    result = ttnn.experimental.rotary_embedding(tensor, cos_cache, sin_cache, token_index, memory_config=memory_config)
 
     # In decode mode (token_index provided), dim 2 gets padded to 32.
     # Reshape to indicate logical vs padded size, then slice back.
@@ -244,6 +262,16 @@ def chunked_prefill_sdpa(tt_q, k_cache, v_cache, page_table, user_id, head_dim, 
         k_chunk_size=128,
         exp_approx_mode=False,
     )
+    # HiFi4 + FP32 dest-acc: restore the softmax-reduce precision #47311 removed.
+    # Matches the non-chunked prefill SDPA so long-context (>32768) prefill keeps
+    # the same accumulation precision as the short-seq path.
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        tt_q.device().arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
 
     # Page table row for this user: [1, num_pages], int32, ROW_MAJOR.
     num_pages = page_table.shape[-1]
@@ -274,6 +302,7 @@ def chunked_prefill_sdpa(tt_q, k_cache, v_cache, page_table, user_id, head_dim, 
             chunk_start_idx=base_offset + start,
             scale=scale,
             program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
         )
         q_chunk.deallocate(True)
         if pad:
@@ -321,6 +350,15 @@ def chunked_prefill_sdpa_sliding(tt_q, tt_k, tt_v, sliding_window, head_dim, sca
     # older key is harmless — sliding_window_size masks it out.
     hist = ((sliding_window + 31) // 32) * 32
     stride = PREFILL_SLIDING_CHUNK_SIZE
+    # HiFi4 + FP32 dest-acc: restore the softmax-reduce precision #47311 removed,
+    # matching the non-chunked prefill SDPA on the long-context (>32768) path.
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        tt_q.device().arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
 
     outs = []
     start = 0
@@ -338,6 +376,7 @@ def chunked_prefill_sdpa_sliding(tt_q, tt_k, tt_v, sliding_window, head_dim, sca
             is_causal=True,
             scale=scale,
             sliding_window_size=sliding_window,
+            compute_kernel_config=compute_kernel_config,
         )
         q_slice.deallocate(True)
         k_slice.deallocate(True)

--- a/models/demos/gemma4/tt/attention/prefill.py
+++ b/models/demos/gemma4/tt/attention/prefill.py
@@ -235,6 +235,16 @@ def _prefill_forward_single(
         k_cache, v_cache = kv_cache
         tt_sdpa = chunked_prefill_sdpa(tt_q, k_cache, v_cache, page_table, user_id, config.head_dim, scale=1.0)
     else:
+        # HiFi4 + FP32 dest-acc SDPA: restore the softmax-reduce precision #47311 removed
+        # (it dropped the reduce's forced-FP32 accumulation). fp32_dest_acc is safe on the
+        # prefill SDPA op (unlike the decode op, where it halves dest for head_dim=512).
+        sdpa_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            tt_q.device().arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
         tt_sdpa = ttnn.transformer.scaled_dot_product_attention(
             tt_q,
             tt_k,
@@ -243,6 +253,7 @@ def _prefill_forward_single(
             scale=1.0,
             sliding_window_size=sliding_window,
             program_config=prefill_sdpa_program_config(config.head_dim, seq_len),
+            compute_kernel_config=sdpa_compute_kernel_config,
         )
     tt_q.deallocate(True)
     kept_kv = None
@@ -396,6 +407,15 @@ def prefill_forward(
                 ttnn.fill_cache(v_cache, tt_v[slot_idx : slot_idx + 1], batch_idx=slot_idx)
 
     sliding_window = config.sliding_window if config.is_sliding else None
+    # HiFi4 + FP32 dest-acc SDPA: restore softmax-reduce precision lost after #47311
+    # (forced-FP32 reduce accumulation removed).
+    sdpa_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        tt_q.device().arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
     tt_sdpa = ttnn.transformer.scaled_dot_product_attention(
         tt_q,
         tt_k,
@@ -403,6 +423,7 @@ def prefill_forward(
         is_causal=True,
         scale=1.0,
         sliding_window_size=sliding_window,
+        compute_kernel_config=sdpa_compute_kernel_config,
     )
     tt_q.deallocate(True)
     kept_kv = None

--- a/models/demos/gemma4/tt/common.py
+++ b/models/demos/gemma4/tt/common.py
@@ -113,6 +113,7 @@ def create_assistant_model(
     dtype=ttnn.bfloat16,
     assistant_path=None,
     state_dict=None,
+    max_local_batch_size=1,
 ):
     """Create the Gemma4 it-assistant drafter, sharing the target's mesh/CCL.
 
@@ -159,5 +160,6 @@ def create_assistant_model(
         dtype=dtype,
         tensor_cache_path=tensor_cache_path,
         mesh_config=mesh_config,
+        max_local_batch_size=max_local_batch_size,
     )
     return assistant_args, model

--- a/models/demos/gemma4/tt/experts/prefill.py
+++ b/models/demos/gemma4/tt/experts/prefill.py
@@ -78,6 +78,22 @@ def _process_prefill_chunk(
     gate_up_config = _build_sparse_matmul_config(TILE_SIZE, intermediate_size)
     down_config = _build_sparse_matmul_config(TILE_SIZE, hidden_size)
 
+    # HiFi4 for the expert matmuls. Matmuls default to LoFi; the gate/up/down accumulate
+    # over the hidden/intermediate dim with bf8 weights, so after #47311 (which removed
+    # the reduce's forced-FP32 accumulation) this is the dominant residual error on the
+    # MoE variant (26B). NOTE: fp32_dest_acc_en is intentionally OFF here — enabling it
+    # halves the matmul dest (8->4 tiles), which on Blackhole corrupts the expert output
+    # and fails the vLLM coherence guard on BH-QB-2 26B (#49068). HiFi4 alone gives the
+    # PCC lift (26B test_full_model 0.9382, vs 0.9328 with fp32_dest_acc) without the
+    # dest-halving — the accumulation flag added no PCC benefit, only BH corruption.
+    expert_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        hidden_grouped.device().arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
     # Gate projection
     gate = ttnn.sparse_matmul(
         hidden_grouped,
@@ -87,6 +103,7 @@ def _process_prefill_chunk(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         output_tile=output_tile,
         program_config=gate_up_config,
+        compute_kernel_config=expert_compute_kernel_config,
         dtype=ttnn.bfloat16,
     )
     sm_intermediate = gate.shape[-1]
@@ -102,6 +119,7 @@ def _process_prefill_chunk(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         output_tile=output_tile,
         program_config=gate_up_config,
+        compute_kernel_config=expert_compute_kernel_config,
         dtype=ttnn.bfloat16,
     )
     hidden_grouped.deallocate(True)
@@ -122,6 +140,7 @@ def _process_prefill_chunk(
         output_tile=output_tile,
         program_config=down_config,
         is_input_a_sparse=True,
+        compute_kernel_config=expert_compute_kernel_config,
         dtype=ttnn.bfloat16,
     )
     down_input.deallocate(True)

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -25,6 +25,29 @@ from models.tt_transformers.tt.model_config import determine_device_name
 GEMMA4_MAX_BATCHED_PREFILL_SEQ_LEN = MAX_BATCHED_PREFILL_SEQ_LEN
 
 
+def _load_text_tokenizer(model_path):
+    # The 12B tokenizer config can advertise multimodal extra_special_tokens as
+    # a list (for example ["<|video|>"]), while this transformers version expects
+    # a dict. The text-only demo does not need those model-specific aliases.
+    try:
+        return AutoTokenizer.from_pretrained(model_path, trust_remote_code=True, extra_special_tokens={})
+    except (ValueError, OSError, EnvironmentError) as e:
+        # The whole Gemma4 family shares one identical tokenizer, but some
+        # checkpoints (e.g. gemma-4-31B-it) ship without local tokenizer files.
+        # On an offline box AutoTokenizer can't fetch them and raises a misleading
+        # "need sentencepiece/tiktoken" error. Fall back to an explicit source
+        # (GEMMA4_TOKENIZER) or the 12B tokenizer, which is byte-identical.
+        fallback = os.environ.get("GEMMA4_TOKENIZER", "google/gemma-4-12B-it")
+        if os.path.normpath(str(fallback)) == os.path.normpath(str(model_path)):
+            raise
+        logger.warning(
+            f"Tokenizer load from '{model_path}' failed ({type(e).__name__}: {e}); "
+            f"falling back to the shared Gemma4 tokenizer '{fallback}'. "
+            f"Override with GEMMA4_TOKENIZER."
+        )
+        return AutoTokenizer.from_pretrained(fallback, trust_remote_code=True, extra_special_tokens={})
+
+
 def _trace_prefill_supported_seq_lens(max_seq_len, has_per_layer_inputs, bounded_sliding):
     """Padded prefill buckets for which capturing a prefill trace is correct AND
     a net win for Gemma4.
@@ -396,7 +419,7 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
         paged_attention_config=None,
         bounded_sliding_kv_cache=False,
     ):
-        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        tokenizer = _load_text_tokenizer(model_path)
         if not hasattr(tokenizer, "stop_tokens"):
             tokenizer.stop_tokens = [tokenizer.eos_token_id]
 

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -161,6 +161,21 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
         _bounded_default = "1" if self._HYBRID_KV_CACHE_GROUPS_ENABLED else "0"
         self._bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", _bounded_default) != "0"
 
+    @classmethod
+    def get_max_tokens_all_users(cls, model_name: str = "", **kwargs) -> int:
+        # The all-user KV-cache pool size is a per-device / per-model tuning knob,
+        # not a model constant: with hybrid KV groups disabled every layer
+        # allocates a full-length KV buffer, so the pool that fits in DRAM is
+        # hardware-specific (e.g. ~49K on QB2/P300x2 for 31B, ~131K for 12B).
+        # Keep that value OUT of the model code — set ``GEMMA4_MAX_TOKENS_ALL_USERS``
+        # from the tt-inference-server model spec's per-device ``env_vars`` block
+        # (gated there by device + model). This generic, value-free hook just
+        # honors that override and otherwise defers to the default.
+        override = os.environ.get("GEMMA4_MAX_TOKENS_ALL_USERS")
+        if override:
+            return int(override)
+        return super().get_max_tokens_all_users(model_name=model_name, **kwargs)
+
     def _maybe_disable_pli_prefill_trace(self, enable_trace: bool, batch_size: int = 1) -> bool:
         return maybe_disable_pli_prefill_trace(enable_trace, self.model[0], batch_size=batch_size)
 

--- a/models/demos/gemma4/tt/spec_decode.py
+++ b/models/demos/gemma4/tt/spec_decode.py
@@ -120,6 +120,10 @@ class SpeculativeDecoder:
         # on-device argmax + re-embed for the draft recurrence and verify-input
         # assembly (see _fused_iter / _capture_fused_trace).
         self._fused_trace = None
+        # Single FUSED batched (B>1) per-iteration trace (batched drafter chain +
+        # batched packed verify). Captured once, replayed per iter (prefill never
+        # traced). See _capture_fused_trace_batched / _generate_fused_traced_batched.
+        self._fused_trace_batched = None
         # Seed mode for the fused greedy trace. "shift" (default) is the fast
         # production mode: it reuses the previous verify hidden row as an
         # approximate drafter seed and repairs the anchor KV at the next verify.
@@ -141,6 +145,19 @@ class SpeculativeDecoder:
         # scratch and corrupt it (manifests as a hang on a *re*-replay). seed()
         # writes into this buffer via ttnn.copy instead of cloning.
         self._anchor_buf = None
+        # Packed-query verify: all K+1 candidates in the query-heads dim of ONE
+        # batch=1 forward (one QKV/norm/RoPE over K+1 rows, one masked SDPA per
+        # layer, loop-free staging KV write) instead of K+1 pseudo-users with
+        # sequential per-candidate KV writes. This is the default multi-token
+        # verify; single-token calls (seed/reseed) keep the plain batch=1 path.
+        # (The fused single-trace paths keep the batch-dim verify.)
+        # S_k (mask key length) is padded to this bucket so the verify trace
+        # shape stays stable as the context grows; a new trace is captured when
+        # the bucket rolls.
+        self._pv_sk_bucket = 1024
+        self._pv_ready = False
+        self._pv_a_prev = -1  # last hot block index (-1 ⇒ staging unseeded)
+        self._pv_traces = {}  # (P, S_k) -> persistent trace inputs/outputs
 
     def _fused_shift_seed_row(self, accepted, K):
         if self._fused_shift_seed == "current":
@@ -178,14 +195,33 @@ class SpeculativeDecoder:
             t, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.uint32, mesh_mapper=self._mapper
         )
 
-    def _page_table(self, batch):
-        # Replicate the single user's block row across the `batch` pseudo-users so
-        # every candidate/verify position indexes the SAME physical KV blocks.
-        user_row = self.page_table_torch[0:1] if self.page_table_torch.dim() > 1 else self.page_table_torch.unsqueeze(0)
+    def _page_table(self, batch, user_idx=0):
+        # Replicate ONE user's block row across the `batch` pseudo-users so every
+        # candidate/verify position indexes the SAME physical KV blocks (the
+        # batch-alias / single-user verify trick). ``user_idx`` selects which
+        # real user's row to replicate (default 0).
+        row = user_idx
+        user_row = (
+            self.page_table_torch[row : row + 1]
+            if self.page_table_torch.dim() > 1
+            else self.page_table_torch.unsqueeze(0)
+        )
         pt = user_row.repeat(batch, 1).to(torch.int32)
         return ttnn.from_torch(
             pt, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32, mesh_mapper=self._mapper
         )
+
+    def _page_table_users(self, B):
+        # Distinct per-user page-table rows [B, blocks] for a true B-user batched
+        # forward (each user attends to its OWN physical KV blocks). Requires
+        # page_table_torch to have >= B rows.
+        pt = self.page_table_torch[:B].to(torch.int32)
+        return ttnn.from_torch(
+            pt, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32, mesh_mapper=self._mapper
+        )
+
+    def _from_b(self, t, dtype, layout=ttnn.ROW_MAJOR_LAYOUT):
+        return ttnn.from_torch(t, device=self.mesh_device, layout=layout, dtype=dtype, mesh_mapper=self._mapper)
 
     # ── host-side input tensors (for copy_host_to_device_tensor into traces) ──
     def _host_tokens(self, tokens):
@@ -284,9 +320,231 @@ class SpeculativeDecoder:
             t = ttnn.to_torch(logits)
         return t[..., : self.target.vocab_size]
 
+    # ── packed-query verify ──────────────────────────────────────────────
+    def _pv_setup(self):
+        """Lazy one-time setup for the packed verify: allocate per-layer hot-
+        block staging buffers (non-KV-shared layers only) and stash the shape
+        constants the host-side index/mask builders need."""
+        if self._pv_ready:
+            return
+        from models.demos.gemma4.tt.attention.kv_cache import PV_HOT_BLOCKS, init_kv_staging
+
+        target = self.target
+        # Paged cache shape: [max_blocks, nkv_local, block_size, head_dim].
+        self._pv_bs = int(self.tt_kv_cache[0][0].padded_shape[2])
+        self._pv_blk = PV_HOT_BLOCKS
+        self._pv_s2 = self._pv_blk * self._pv_bs
+        tp = self._tp
+        first_cfg = target.layers[0].self_attn.config
+        self._pv_h_local = first_cfg.num_attention_heads // tp
+        self._pv_window = target.hf_config.sliding_window
+        self._pv_nkv = {}  # layer_type -> nkv_local (staging/cache head count)
+        for i, layer in enumerate(target.layers):
+            cfg = layer.self_attn.config
+            if cfg.cache_position_modulo is not None:
+                raise NotImplementedError("packed verify does not support bounded sliding KV caches")
+            if i in target.kv_shared_layer_map:
+                continue  # shares source layer's cache+staging; skips KV writes
+            layer.self_attn.kv_staging = init_kv_staging(
+                self.mesh_device, cfg, max_batch_size=1, block_size=self._pv_bs, blk=self._pv_blk
+            )
+            lt = target.hf_config.layer_types[i]
+            self._pv_nkv[lt] = int(layer.self_attn.kv_staging[0].shape[1])
+        self._pv_pages = (self.page_table_torch[0] if self.page_table_torch.dim() > 1 else self.page_table_torch).to(
+            torch.int64
+        )
+        self._pv_ready = True
+
+    def _pv_seed_staging(self, c):
+        """Seed every layer's staging block-slot 0 with the committed content of
+        the hot block at position ``c`` (read from the cache — the only
+        committed-cache read in the design, once per generation)."""
+        bs, S2 = self._pv_bs, self._pv_s2
+        a = c // bs
+        self._pv_a_prev = a
+        if c % bs == 0:
+            return  # fresh block — zeros are fine
+        blk_phys = int(self._pv_pages[a])
+        for i, layer in enumerate(self.target.layers):
+            if i in self.target.kv_shared_layer_map:
+                continue
+            staging = layer.self_attn.kv_staging
+            cache = self.tt_kv_cache[i]
+            for kv in (0, 1):
+                stg = staging[kv]
+                nkv, hd = stg.shape[1], stg.shape[3]
+                block = ttnn.slice(cache[kv], [blk_phys, 0, 0, 0], [blk_phys + 1, nkv, bs, hd])
+                tail = ttnn.slice(stg, [0, 0, bs, 0], [1, nkv, S2, hd])
+                rebuilt = ttnn.concat([block, tail], dim=2)
+                ttnn.assign(rebuilt, stg)
+                for t in (rebuilt, block, tail):
+                    ttnn.deallocate(t)
+
+    def _pv_host_inputs(self, c, P):
+        """Host tensors for one packed verify at anchor position ``c``.
+
+        Returns dict of torch tensors: pos [1,P]u32, masks [1,1,H*P,S_k] bf16
+        (full + sliding), embed_idx per layer type [1,nkv*S2]u32, hot_pt
+        [1,BLK]i32, and S_k.
+        """
+        bs, S2, BLK = self._pv_bs, self._pv_s2, self._pv_blk
+        a, off = c // bs, c % bs
+        roll = 1 if a == self._pv_a_prev + 1 else 0
+        H, W = self._pv_h_local, self._pv_window
+
+        pos = torch.arange(c, c + P, dtype=torch.int32).reshape(1, P)
+
+        # Additive masks, head-major rows h*P+p: causal upper bound c+p; sliding
+        # adds the window lower bound. S_k is bucket-padded for trace stability.
+        NEG = -1e9
+        S_k = ((c + P + self._pv_sk_bucket - 1) // self._pv_sk_bucket) * self._pv_sk_bucket
+        j = torch.arange(S_k)
+        rows_full = torch.empty(P, S_k)
+        rows_slide = torch.empty(P, S_k)
+        for p in range(P):
+            upper = c + p
+            rows_full[p] = torch.where(j <= upper, 0.0, NEG)
+            rows_slide[p] = torch.where((j <= upper) & (j > upper - W), 0.0, NEG)
+        mask_full = rows_full.repeat(H, 1).reshape(1, 1, H * P, S_k).to(torch.bfloat16)
+        mask_slide = rows_slide.repeat(H, 1).reshape(1, 1, H * P, S_k).to(torch.bfloat16)
+
+        # merge_idx over staging positions: committed prefix from staging
+        # (identity, or +bs on a rollover — the prefix came from the spill
+        # block), the P new rows from new_seq (concat index S2+p), stale tail
+        # identity. embed_idx bakes the per-head flattened row offset in
+        # (new_seq is padded to 32 rows in packed_decode_forward).
+        m = torch.arange(S2, dtype=torch.int64)
+        if roll:
+            m[:off] += bs
+        m[off : off + P] = S2 + torch.arange(P)
+        p_pad = ((P + 31) // 32) * 32
+        src_seq = S2 + p_pad
+        embed = {}
+        for lt, nkv in self._pv_nkv.items():
+            off_h = (torch.arange(nkv, dtype=torch.int64) * src_seq).unsqueeze(1)
+            embed[lt] = (m.unsqueeze(0) + off_h).reshape(1, nkv * S2).to(torch.int32)
+
+        hot = torch.full((1, BLK), -1, dtype=torch.int32)
+        hot[0, 0] = int(self._pv_pages[a])
+        if off + P > bs:
+            hot[0, 1] = int(self._pv_pages[a + 1])
+
+        return {"pos": pos, "mask_full": mask_full, "mask_slide": mask_slide, "embed": embed, "hot": hot, "S_k": S_k}
+
+    def _pv_from_torch(self, t, dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=True):
+        return ttnn.from_torch(
+            t,
+            device=self.mesh_device if device else None,
+            layout=layout,
+            dtype=dtype,
+            mesh_mapper=self._mapper,
+        )
+
+    def _pv_device_inputs(self, tokens, h):
+        """Device tensors for one packed verify from host dict ``h``."""
+        return {
+            "x": self._tokens_tensor(tokens),
+            "pos": self._pv_from_torch(h["pos"], ttnn.uint32),
+            "mask_full": self._pv_from_torch(h["mask_full"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT),
+            "mask_slide": self._pv_from_torch(h["mask_slide"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT),
+            "embed": {lt: self._pv_from_torch(e, ttnn.uint32) for lt, e in h["embed"].items()},
+            "hot": self._pv_from_torch(h["hot"], ttnn.int32),
+        }
+
+    def _pv_call(self, dev, P):
+        return self.target.ttnn_packed_verify_forward(
+            x=dev["x"],
+            position_idx=dev["pos"],
+            attn_mask_full=dev["mask_full"],
+            attn_mask_sliding=dev["mask_slide"],
+            packed_p=P,
+            page_table=dev.get("pt"),
+            kv_cache=self.tt_kv_cache,
+            embed_idx_full=dev["embed"].get("full_attention"),
+            embed_idx_sliding=dev["embed"].get("sliding_attention"),
+            hot_pt=dev["hot"],
+        )
+
+    def _verify_packed(self, tokens, positions):
+        """Packed verify (eager). Same contract as ``_verify``."""
+        self._pv_setup()
+        P = len(tokens)
+        c = positions[0]
+        if self._pv_a_prev < 0:
+            self._pv_seed_staging(c)
+        h = self._pv_host_inputs(c, P)
+        dev = self._pv_device_inputs(tokens, h)
+        dev["pt"] = self._page_table(1)
+        logits, hidden = self._pv_call(dev, P)
+        self._pv_a_prev = c // self._pv_bs
+        lh = self._logits_to_host(logits).reshape(P, -1)
+        logits.deallocate(True)
+        for t in (dev["x"], dev["pos"], dev["mask_full"], dev["mask_slide"], dev["hot"], dev["pt"]):
+            t.deallocate(True)
+        for e in dev["embed"].values():
+            e.deallocate(True)
+        return lh, hidden
+
+    def _verify_packed_traced(self, tokens, positions):
+        """Packed verify via trace, keyed by (P, S_k bucket). Persistent device
+        inputs are refreshed per step via copy_host_to_device_tensor; a new
+        trace is captured lazily when P or the S_k bucket changes."""
+        self._pv_setup()
+        P = len(tokens)
+        c = positions[0]
+        if self._pv_a_prev < 0:
+            self._pv_seed_staging(c)
+        h = self._pv_host_inputs(c, P)
+        key = (P, h["S_k"])
+        tr = self._pv_traces.get(key)
+        if tr is None:
+            dev = self._pv_device_inputs(tokens, h)
+            dev["pt"] = self._page_table(1)
+            # Compile run (warm program cache), then capture. Both runs write
+            # the SAME tokens to the SAME positions, so KV writes are idempotent.
+            logits, hidden = self._pv_call(dev, P)
+            ttnn.synchronize_device(self.mesh_device)
+            logits.deallocate(True)
+            hidden.deallocate(True)
+            tid = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+            logits, hidden = self._pv_call(dev, P)
+            ttnn.end_trace_capture(self.mesh_device, tid, cq_id=0)
+            dev.update({"id": tid, "logits": logits, "hidden": hidden})
+            self._pv_traces[key] = dev
+        else:
+            ttnn.copy_host_to_device_tensor(self._host_tokens(tokens), tr["x"])
+            for src, dst in (
+                (self._pv_from_torch(h["pos"], ttnn.uint32, device=False), tr["pos"]),
+                (
+                    self._pv_from_torch(h["mask_full"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=False),
+                    tr["mask_full"],
+                ),
+                (
+                    self._pv_from_torch(h["mask_slide"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=False),
+                    tr["mask_slide"],
+                ),
+                (self._pv_from_torch(h["hot"], ttnn.int32, device=False), tr["hot"]),
+            ):
+                ttnn.copy_host_to_device_tensor(src, dst)
+            for lt, e in h["embed"].items():
+                ttnn.copy_host_to_device_tensor(self._pv_from_torch(e, ttnn.uint32, device=False), tr["embed"][lt])
+            ttnn.execute_trace(self.mesh_device, tr["id"], cq_id=0, blocking=False)
+        tr = self._pv_traces[key]
+        self._pv_a_prev = c // self._pv_bs
+        lh = self._logits_to_host(tr["logits"]).reshape(P, -1)
+        # Persistent hidden — caller must consume before the next replay.
+        return lh, tr["hidden"]
+
     # ── target forwards ───────────────────────────────────────────────────
     def _verify(self, tokens, positions):
         """Batched verify. Returns (logits_host [B,vocab], hidden_device [1,1,B,h])."""
+        # Packed-query verify: all K+1 candidates in one batch=1 pass (positions
+        # packed into the query-heads dim, loop-free staging KV write).
+        # Single-token calls (seed/reseed) keep the plain verify.
+        if len(tokens) > 1:
+            if self._use_trace:
+                return self._verify_packed_traced(tokens, positions)
+            return self._verify_packed(tokens, positions)
         # Tracing: BOTH the batch=1 verify (seed/reseed) and the batch=K+1
         # speculative verify capture + replay correctly. The per-candidate
         # sequential_kv_write loop (the race fix for the shared paged block) is
@@ -388,19 +646,22 @@ class SpeculativeDecoder:
         return drafts, draft_logits
 
     # ── drafting ────────────────────────────────────────────────────────────
-    def _draft(self, anchor_token, anchor_hidden, anchor_pos, temperature=0.0, top_p=1.0, top_k=0):
+    def _draft(self, anchor_token, anchor_hidden, anchor_pos, temperature=0.0, top_p=1.0, top_k=0, user_idx=0):
         """Produce K draft tokens + their logits (host). anchor_hidden stays on device.
 
         Greedy (temperature<=0): the next draft is argmax(q). Sampling: the next
         draft is SAMPLED from the drafter distribution q under the SAME
         temp/top_p/top_k as the target — required for speculative sampling
         correctness AND acceptance (proposing argmax(q) maximizes q(d), which
-        drives the accept ratio min(1, p(d)/q(d)) to ~0)."""
+        drives the accept ratio min(1, p(d)/q(d)) to ~0).
+
+        ``user_idx`` selects which user's KV blocks the drafter cross-attends to
+        (batched generate loops the drafter at batch=1 over each user)."""
         K = self.draft_len
         greedy = not temperature or temperature <= 0
         pos_u, pos_i = self._pos_tensors([anchor_pos])
-        # Drafter page table: batch=1, same user's blocks for both layer types.
-        pt = self._page_table(1)
+        # Drafter page table: batch=1, this user's blocks for both layer types.
+        pt = self._page_table(1, user_idx=user_idx)
         page_tables = {lt: pt for lt in self._shared_kv}
 
         drafts, draft_logits = [], []
@@ -438,12 +699,30 @@ class SpeculativeDecoder:
         single-core internal-untilize path that is catastrophically slow on a
         262144-wide vocab (~9 ms for 1 row, ~28 ms for 5). The multicore argmax
         is fast (~1.6 ms) but ROW-PARALLEL: it returns GARBAGE unless the row
-        (batch) dim is tile-aligned (32) — verified by a correctness probe
-        (1/5 rows -> wrong; padded to 32 -> exact). So pad the rows up to 32,
-        run the multicore untilize + argmax, then slice back to ``rows``. Net
-        ~1.6 ms vs ~9-28 ms for the bare path.
+        (batch) dim is EXACTLY one tile (32) — verified by a correctness probe
+        (1/5 rows -> wrong; padded to 32 -> exact; and >32 rows in one call also
+        returns garbage beyond the first tile). So process the rows in 32-row
+        chunks: pad each ≤32-row chunk up to 32, run the multicore untilize +
+        argmax, slice back, and concat. Net ~1.6 ms/chunk vs ~9-28 ms bare.
         """
         R32 = 32
+        if rows > R32:
+            # Batched packed verify (B*P > 32): argmax each 32-row tile separately
+            # (offsets are multiples of 32, so the TILE slices are tile-aligned)
+            # and concat — a single >32-row multicore argmax garbles later tiles.
+            vocab = logits.shape[-1]
+            chunks = []
+            off = 0
+            while off < rows:
+                n = min(R32, rows - off)
+                part = ttnn.slice(logits, [0, 0, off, 0], [1, 1, off + n, vocab])
+                chunks.append(self._argmax_last(part, n))  # recurse (≤32 rows)
+                part.deallocate(True)
+                off += n
+            out = ttnn.concat(chunks, dim=2)  # [1,1,rows]
+            for c in chunks:
+                c.deallocate(True)
+            return out
         src = logits
         padded = None
         if rows < R32:
@@ -604,6 +883,7 @@ class SpeculativeDecoder:
         """
         if self._use_trace:
             return self._generate_fused_traced(anchor_token, anchor_pos, max_new_tokens)
+        self._pv_a_prev = -1  # re-seed packed-verify staging for the new anchor/request
         self._last_fused_setup_s = 0.0
         K = self.draft_len
         out, accepts = [], []
@@ -845,6 +1125,436 @@ class SpeculativeDecoder:
         self._last_fused_replay_s = time.perf_counter() - replay_t0
         return out, accepts
 
+    # ── batched (B>1) speculative decode ─────────────────────────────────────
+    def _seed_batched(self, tokens, positions):
+        """Batched drafter seed: one batch=B target verify of each user's anchor
+        token at its position (idempotent re-write of the prompt's last KV).
+        Returns the post-norm hidden [1,1,B,backbone]; slice row b for user b's
+        recurrent drafter seed."""
+        x = self._tokens_tensor(tokens)  # [1,B]
+        pu, pi = self._pos_tensors(positions)  # pu [1,32] (B filled), pi [B]
+        pt = self._page_table_users(len(tokens))  # [B, blocks] distinct
+        logits, hidden = self.target.ttnn_verify_forward(
+            x=x, current_pos=pu, current_pos_cache=pi, page_table=pt, kv_cache=self.tt_kv_cache
+        )
+        logits.deallocate(True)
+        for t in (x, pu, pi, pt):
+            t.deallocate(True)
+        return hidden  # [1,1,B,backbone]
+
+    def _packed_H(self):
+        """Local (per-device) query-head count for the packed additive mask."""
+        return self.target.layers[0].self_attn.config.num_attention_heads // self._tp
+
+    def _packed_mask_host(self, cs, B, P, H, window, S_k):
+        """Host bf16 additive masks [B,1,H*P,S_k] for the packed verify (head-major
+        rows h*P+p; per-user causal bound c_b+p, + sliding-window lower bound)."""
+        NEG = -1e9
+        j = torch.arange(S_k)
+        mf = torch.empty(B, 1, H * P, S_k)
+        ms = torch.empty(B, 1, H * P, S_k)
+        for b in range(B):
+            rf = torch.empty(P, S_k)
+            rs = torch.empty(P, S_k)
+            for p in range(P):
+                upper = cs[b] + p
+                rf[p] = torch.where(j <= upper, 0.0, NEG)
+                rs[p] = torch.where((j <= upper) & (j > upper - window), 0.0, NEG)
+            mf[b, 0] = rf.repeat(H, 1)
+            ms[b, 0] = rs.repeat(H, 1)
+        return mf.to(torch.bfloat16), ms.to(torch.bfloat16)
+
+    def _verify_packed_batched(self, tokens_b, cs):
+        """Packed verify for B users at PER-USER anchor positions (ragged).
+
+        Folds each user's P=K+1 candidates into the query-head dim of a batch=B
+        forward — B KV reads total (vs B*(K+1) for the batch-alias verify). Uses
+        the fallback per-position ``paged_update_cache`` write (no staging), so
+        no per-user staging is needed.
+
+        Args:
+            tokens_b: list[B] of P-length token-id lists ([anchor, d1..dK]).
+            cs:       list[B] of anchor positions c_b (user b verifies c_b..c_b+K).
+
+        Returns:
+            (logits_host [B*P, vocab], vhidden device [1,1,B*P,backbone]); row
+            u*P+p is user u's p-th packed position.
+        """
+        target = self.target
+        B = len(tokens_b)
+        P = len(tokens_b[0])
+        H = self._packed_H()
+        window = target.hf_config.sliding_window
+        max_c = max(cs)
+        # S_k (mask key length): cover positions 0..max_c+K, multiple of 64.
+        S_k = ((max_c + P + 63) // 64) * 64
+
+        x = self._from_b(
+            torch.tensor([tok for toks in tokens_b for tok in toks], dtype=torch.int64).reshape(1, B * P), ttnn.uint32
+        )
+        position_idx = self._from_b(
+            torch.tensor([[cs[b] + p for b in range(B) for p in range(P)]], dtype=torch.int64), ttnn.uint32
+        )
+        mf, ms = self._packed_mask_host(cs, B, P, H, window, S_k)
+        mask_full = self._from_b(mf, ttnn.bfloat16, ttnn.TILE_LAYOUT)
+        mask_slide = self._from_b(ms, ttnn.bfloat16, ttnn.TILE_LAYOUT)
+        write_idxs = [
+            self._from_b(torch.tensor([cs[b] + p for b in range(B)], dtype=torch.int32), ttnn.int32) for p in range(P)
+        ]
+        pt = self._page_table_users(B)
+        logits, vhidden = target.ttnn_packed_verify_forward(
+            x=x,
+            position_idx=position_idx,
+            attn_mask_full=mask_full,
+            attn_mask_sliding=mask_slide,
+            packed_p=P,
+            page_table=pt,
+            kv_cache=self.tt_kv_cache,
+            kv_write_idxs=write_idxs,
+            embed_idx_full=None,
+            embed_idx_sliding=None,
+            hot_pt=None,
+        )
+        lh = self._logits_to_host(logits).reshape(B * P, -1)
+        logits.deallocate(True)
+        for t in (x, position_idx, mask_full, mask_slide, pt, *write_idxs):
+            t.deallocate(True)
+        return lh, vhidden
+
+    def _draft_batched(self, anchor_tokens, anchor_hidden_b, anchor_positions):
+        """Batched drafter: propose K tokens for ALL B users in ONE batch=B chain.
+
+        Runs K batched drafter steps (each ``assistant.step`` at batch=B, the
+        drafter cross-attending into every user's own KV via distinct page-table
+        rows). The recurrent hidden [1,1,B,backbone] is carried across steps; the
+        per-step argmax over B rows is read to host to feed the next step. This
+        amortizes the (tiny) drafter over B users instead of B sequential batch=1
+        loops — the key to batched throughput.
+
+        Args:
+            anchor_tokens: list[B] committed token ids to draft from.
+            anchor_hidden_b: [1,1,B,backbone] batched drafter seed (borrowed).
+            anchor_positions: list[B] anchor positions (fixed across the K steps).
+
+        Returns:
+            drafts_b: list[B] of K-length draft-token lists.
+        """
+        K = self.draft_len
+        B = len(anchor_tokens)
+        pos_u, pos_i = self._pos_tensors(anchor_positions)  # pu [1,32] (B filled), pi [B]
+        pt = self._page_table_users(B)
+        page_tables = {lt: pt for lt in self._shared_kv}
+
+        drafts_b = [[] for _ in range(B)]
+        tok_tt = self._tokens_tensor(anchor_tokens)  # [1,B]
+        h = anchor_hidden_b
+        owns_h = False
+        for _ in range(K):
+            logits, h_next = self.assistant.step(tok_tt, h, self._shared_kv, page_tables, pos_u, pos_i)
+            if owns_h:
+                h.deallocate(True)
+            h, owns_h = h_next, True
+            lh = self._logits_to_host(logits).reshape(B, -1)  # [B, vocab]
+            logits.deallocate(True)
+            toks = [int(torch.argmax(lh[b])) for b in range(B)]
+            for b in range(B):
+                drafts_b[b].append(toks[b])
+            tok_tt.deallocate(True)
+            tok_tt = self._tokens_tensor(toks)  # [1,B]
+        if owns_h:
+            h.deallocate(True)
+        tok_tt.deallocate(True)
+        pos_u.deallocate(True)
+        pos_i.deallocate(True)
+        pt.deallocate(True)
+        return drafts_b
+
+    # ── fused batched trace (greedy) ─────────────────────────────────────────
+    def _fused_body_batched(self, tr):
+        """Fused batched iteration op-graph: K batched drafter steps chained on
+        device (argmax + re-embed in-graph), user-major packed-verify input
+        assembled on device, ONE batched packed verify, on-device argmax. Returns
+        the persistent output handles (verify_x [1,B*P], vidx [1,1,B*P], vhidden
+        [1,1,B*P,backbone])."""
+        K = self.draft_len
+        B = tr["B"]
+        P = K + 1
+        page_tables = {lt: tr["d_pt"] for lt in self._shared_kv}
+        tok = tr["anchor_tok"]  # [1,B]
+        h = tr["h"]  # [1,1,B,backbone]
+        draft_cols = []
+        for _ in range(K):
+            logits, h = self.assistant.step(tok, h, self._shared_kv, page_tables, tr["d_pu"], tr["d_pi"])
+            idx = self._argmax_last(logits, rows=B)  # [1,1,B] uint32 RM
+            logits.deallocate(True)
+            tok = ttnn.reshape(idx, (1, B))
+            draft_cols.append(tok)
+        # Assemble user-major x [1,B*P] (row u*P+p) from the P columns [1,B]:
+        # stack -> [1,1,P,B] -> permute -> [1,1,B,P] -> flatten.
+        cols4d = [ttnn.reshape(tr["anchor_tok"], (1, 1, 1, B))] + [ttnn.reshape(c, (1, 1, 1, B)) for c in draft_cols]
+        stacked = ttnn.concat(cols4d, dim=2)  # [1,1,P,B]
+        um = ttnn.permute(stacked, (0, 1, 3, 2))  # [1,1,B,P]
+        stacked.deallocate(True)
+        verify_x = ttnn.reshape(um, (1, B * P))
+        um.deallocate(True)
+        vlogits, vhidden = self.target.ttnn_packed_verify_forward(
+            x=verify_x,
+            position_idx=tr["v_pos"],
+            attn_mask_full=tr["mask_full"],
+            attn_mask_sliding=tr["mask_slide"],
+            packed_p=P,
+            page_table=tr["v_pt"],
+            kv_cache=self.tt_kv_cache,
+            kv_write_idxs=tr["write_idxs"],
+            embed_idx_full=None,
+            embed_idx_sliding=None,
+            hot_pt=None,
+        )
+        vidx = self._argmax_last(vlogits, rows=B * P)  # [1,1,B*P] uint32 RM
+        vlogits.deallocate(True)
+        return verify_x, vidx, vhidden
+
+    def _capture_fused_trace_batched(self, anchor_tokens, seed_hidden_b, anchor_positions, S_k):
+        """Capture ONE fused batched iteration over persistent buffers."""
+        from loguru import logger as _lg
+
+        K = self.draft_len
+        B = len(anchor_tokens)
+        P = K + 1
+        H = self._packed_H()
+        window = self.target.hf_config.sliding_window
+        cs = list(anchor_positions)
+        d_pu, d_pi = self._pos_tensors(cs)
+        v_pos_t = torch.tensor([[cs[b] + p for b in range(B) for p in range(P)]], dtype=torch.int64)
+        mf, ms = self._packed_mask_host(cs, B, P, H, window, S_k)
+        tr = {
+            "B": B,
+            "P": P,
+            "H": H,
+            "window": window,
+            "S_k": S_k,
+            "anchor_tok": self._tokens_tensor(list(anchor_tokens)),  # [1,B]
+            "h": ttnn.clone(seed_hidden_b),  # [1,1,B,backbone]
+            "d_pu": d_pu,
+            "d_pi": d_pi,
+            "d_pt": self._page_table_users(B),
+            "v_pos": self._from_b(v_pos_t, ttnn.uint32),
+            "mask_full": self._from_b(mf, ttnn.bfloat16, ttnn.TILE_LAYOUT),
+            "mask_slide": self._from_b(ms, ttnn.bfloat16, ttnn.TILE_LAYOUT),
+            "v_pt": self._page_table_users(B),
+            "write_idxs": [
+                self._from_b(torch.tensor([cs[b] + p for b in range(B)], dtype=torch.int32), ttnn.int32)
+                for p in range(P)
+            ],
+        }
+        _lg.info(f"[spec-trace] capture batched fused: compile run (B={B}, S_k={S_k})")
+        vx, vidx, vh = self._fused_body_batched(tr)
+        ttnn.synchronize_device(self.mesh_device)
+        vx.deallocate(True)
+        vidx.deallocate(True)
+        vh.deallocate(True)
+        _lg.info("[spec-trace] capture batched fused: begin_trace_capture")
+        tid = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+        vx, vidx, vh = self._fused_body_batched(tr)
+        ttnn.end_trace_capture(self.mesh_device, tid, cq_id=0)
+        _lg.info("[spec-trace] capture batched fused: DONE")
+        tr["id"] = tid
+        tr["verify_x"] = vx
+        tr["vidx"] = vidx
+        tr["vhidden"] = vh
+        self._fused_trace_batched = tr
+
+    def _hidden_rows_to_device_batched(self, rows_b):
+        """Shift-seed: gather packed-verify hidden row ``b*P+rows_b[b]`` per user
+        into the persistent batched recurrent buffer tr["h"] (host round-trip)."""
+        tr = self._fused_trace_batched
+        B, P = tr["B"], tr["P"]
+        vh = tr["vhidden"]
+        vh_t = ttnn.to_torch(ttnn.get_device_tensors(vh)[0]) if self._tp > 1 else ttnn.to_torch(vh)
+        sel = torch.cat([vh_t[:, :, b * P + rows_b[b] : b * P + rows_b[b] + 1, :] for b in range(B)], dim=2)
+        host_h = ttnn.from_torch(
+            sel.contiguous(), layout=ttnn.TILE_LAYOUT, dtype=tr["h"].dtype, mesh_mapper=self._mapper
+        )
+        ttnn.copy_host_to_device_tensor(host_h, tr["h"])
+        host_h.deallocate(True)
+
+    def _generate_fused_traced_batched(self, anchor_tokens, anchor_positions, max_new_tokens, max_seq_len):
+        """Traced batched greedy spec-decode: capture one fused batched iteration
+        (drafter chain + packed verify), then replay once per iteration, updating
+        only host->device inputs (tokens, positions, per-user masks, KV-write
+        indices, shift seed). Prefill is NOT traced (stays eager)."""
+        B = len(anchor_tokens)
+        K = self.draft_len
+        P = K + 1
+        S_k = ((max_seq_len + 63) // 64) * 64
+
+        setup_t0 = time.perf_counter()
+        # Eager (untraced) batched seed, then capture (mirrors the single-user path:
+        # an active verify trace would collide with the fused capture allocations).
+        self._use_trace = False
+        seed_h = self._seed_batched(list(anchor_tokens), list(anchor_positions))
+        self._use_trace = True
+        self._capture_fused_trace_batched(anchor_tokens, seed_h, anchor_positions, S_k)
+        seed_h.deallocate(True)
+        tr = self._fused_trace_batched
+        self._last_fused_setup_s = time.perf_counter() - setup_t0
+
+        toks = list(anchor_tokens)
+        pos = list(anchor_positions)
+        outs = [[] for _ in range(B)]
+        accepts = [[] for _ in range(B)]
+        done = [False] * B
+        pos_cap = max_seq_len - P
+        H = tr["H"]
+        window = tr["window"]
+
+        first = True
+        replay_t0 = time.perf_counter()
+        while not all(done):
+            if not first:
+                cs = list(pos)
+                h_tok = self._host_tokens(toks)
+                ttnn.copy_host_to_device_tensor(h_tok, tr["anchor_tok"])
+                h_tok.deallocate(True)
+                d_hpu, d_hpi = self._host_pos(cs)
+                ttnn.copy_host_to_device_tensor(d_hpu, tr["d_pu"])
+                ttnn.copy_host_to_device_tensor(d_hpi, tr["d_pi"])
+                d_hpu.deallocate(True)
+                d_hpi.deallocate(True)
+                vpos = ttnn.from_torch(
+                    torch.tensor([[cs[b] + p for b in range(B) for p in range(P)]], dtype=torch.int64),
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    dtype=ttnn.uint32,
+                    mesh_mapper=self._mapper,
+                )
+                ttnn.copy_host_to_device_tensor(vpos, tr["v_pos"])
+                vpos.deallocate(True)
+                mf, ms = self._packed_mask_host(cs, B, P, H, window, tr["S_k"])
+                hmf = ttnn.from_torch(mf, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=self._mapper)
+                hms = ttnn.from_torch(ms, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=self._mapper)
+                ttnn.copy_host_to_device_tensor(hmf, tr["mask_full"])
+                ttnn.copy_host_to_device_tensor(hms, tr["mask_slide"])
+                hmf.deallocate(True)
+                hms.deallocate(True)
+                for p in range(P):
+                    wi = ttnn.from_torch(
+                        torch.tensor([cs[b] + p for b in range(B)], dtype=torch.int32),
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        dtype=ttnn.int32,
+                        mesh_mapper=self._mapper,
+                    )
+                    ttnn.copy_host_to_device_tensor(wi, tr["write_idxs"][p])
+                    wi.deallocate(True)
+            first = False
+
+            ttnn.execute_trace(self.mesh_device, tr["id"], cq_id=0, blocking=False)
+
+            vx = (
+                ttnn.to_torch(ttnn.get_device_tensors(tr["verify_x"])[0])
+                if self._tp > 1
+                else ttnn.to_torch(tr["verify_x"])
+            ).reshape(-1)
+            gids = self._ids_to_host(tr["vidx"], B * P)
+
+            rows_b = []
+            for b in range(B):
+                drafts = [int(vx[b * P + 1 + j]) for j in range(K)]
+                g = [gids[b * P + j] for j in range(P)]
+                m = next((i for i in range(K) if drafts[i] != g[i]), K)
+                committed = drafts[:m] + [g[m]]
+                rows_b.append(min(m + 1, K))
+                if done[b]:
+                    continue
+                accepts[b].append(m)
+                for tok in committed:
+                    outs[b].append(tok)
+                    if tok in self.stop_tokens or len(outs[b]) >= max_new_tokens:
+                        done[b] = True
+                        break
+                pos[b] = pos[b] + m + 1
+                toks[b] = committed[-1]
+                if pos[b] >= pos_cap:
+                    done[b] = True
+
+            if not all(done):
+                self._hidden_rows_to_device_batched(rows_b)
+
+        self._last_fused_replay_s = time.perf_counter() - replay_t0
+        return outs, accepts
+
+    def generate_batched(self, anchor_tokens, anchor_positions, max_new_tokens, max_seq_len, temperature=0.0):
+        """Greedy batched speculative decode for B independent users (ragged).
+
+        Each iteration drafts ALL B users in one batch=B drafter chain, runs ONE
+        batched packed verify over all B users (the KV-bandwidth win), and accepts
+        per user — so users advance by their own matched-prefix+1 and their
+        positions diverge. With ``self._use_trace`` the whole iteration is ONE
+        replayed metal trace (prefill is never traced); otherwise it runs eager.
+
+        Returns (outs: list[B] of generated token-id lists, accepts: list[B] of
+        per-iteration accept counts).
+        """
+        if temperature and temperature > 0:
+            raise NotImplementedError("batched spec-decode supports greedy only (temperature<=0)")
+        if self._use_trace:
+            return self._generate_fused_traced_batched(anchor_tokens, anchor_positions, max_new_tokens, max_seq_len)
+        B = len(anchor_tokens)
+        K = self.draft_len
+        P = K + 1
+        toks = list(anchor_tokens)
+        pos = list(anchor_positions)
+        outs = [[] for _ in range(B)]
+        accepts = [[] for _ in range(B)]
+        done = [False] * B
+        # furthest position a verify touches is pos[b]+K; keep it in range.
+        pos_cap = max_seq_len - P
+
+        # Per-user recurrent drafter seed (clone immediately: _seed_batched's
+        # hidden may alias a reused verify-output buffer).
+        seed_h = self._seed_batched(toks, pos)  # [1,1,B,backbone]
+        backbone = seed_h.shape[-1]
+        anchor_h = [ttnn.clone(ttnn.slice(seed_h, [0, 0, b, 0], [1, 1, b + 1, backbone])) for b in range(B)]
+        seed_h.deallocate(True)
+
+        _draft_mode = os.environ.get("GEMMA4_SPEC_DRAFT_MODE", "batched")
+
+        while not all(done):
+            if _draft_mode == "loop":
+                drafts_b = [self._draft(toks[b], anchor_h[b], pos[b], temperature=0.0, user_idx=b)[0] for b in range(B)]
+            else:
+                anchor_hb = ttnn.concat(anchor_h, dim=2)  # [1,1,B,backbone]
+                drafts_b = self._draft_batched(toks, anchor_hb, pos)
+                anchor_hb.deallocate(True)
+
+            tokens_b = [[toks[b]] + drafts_b[b] for b in range(B)]
+            vlogits, vhidden = self._verify_packed_batched(tokens_b, [pos[b] for b in range(B)])
+
+            for b in range(B):
+                row_logits = [vlogits[b * P + j] for j in range(P)]
+                m, committed = self._accept_greedy(drafts_b[b], row_logits)
+                # next drafter seed (shift): position-aligned hidden row min(m+1,K).
+                row = min(m + 1, K)
+                new_h = ttnn.clone(ttnn.slice(vhidden, [0, 0, b * P + row, 0], [1, 1, b * P + row + 1, backbone]))
+                anchor_h[b].deallocate(True)
+                anchor_h[b] = new_h
+                if done[b]:
+                    continue
+                accepts[b].append(m)
+                for tok in committed:
+                    outs[b].append(tok)
+                    if tok in self.stop_tokens or len(outs[b]) >= max_new_tokens:
+                        done[b] = True
+                        break
+                pos[b] = pos[b] + m + 1
+                toks[b] = committed[-1]
+                if pos[b] >= pos_cap:
+                    done[b] = True
+            vhidden.deallocate(True)
+
+        for b in range(B):
+            anchor_h[b].deallocate(True)
+        return outs, accepts
+
     def generate(
         self, anchor_token, anchor_pos, max_new_tokens, anchor_hidden=None, temperature=0.0, top_p=1.0, top_k=0
     ):
@@ -900,6 +1610,7 @@ class SpeculativeDecoder:
                 self._use_trace = True
 
         traced = self._use_trace
+        self._pv_a_prev = -1  # re-seed packed-verify staging for the new anchor/request
         out = []
         accepts = []
         # Own (and free) only what we allocate: a caller-provided anchor_hidden


### PR DESCRIPTION
Gemma4 cherry pick for release done inconsistently.

THis PR aims to fix that.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arg/gemma4_31B_release_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arg/gemma4_31B_release_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arg/gemma4_31B_release_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arg/gemma4_31B_release_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arg/gemma4_31B_release_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arg/gemma4_31B_release_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arg/gemma4_31B_release_stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arg/gemma4_31B_release_stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arg/gemma4_31B_release_stable)