### PR TITLE
Support untilize (to_layout) from batched HEIGHT_SHARDED TILE input to interleaved row-major with non-tile-aligned H/W

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -351,6 +351,75 @@ def test_to_layout_sharded_batched_unpad(dtype, device):
     assert_quality(torch_input_tensor, ttnn.to_torch(output), dtype)
 
 
+def _height_sharded_l1_config(grid_end, shard_shape):
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(*grid_end))])
+    shard_spec = ttnn.ShardSpec(core_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("output_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+@pytest.mark.parametrize(
+    "shape, grid_end, shard_shape",
+    [
+        # issue_test.py repro: 1024 padded [32,64] matrices, 16 per core over an 8x8 grid; logical
+        # height 17 is not tile-aligned so every matrix carries 15 interior pad rows to be stripped.
+        ([32, 32, 17, 64], (7, 7), (512, 64)),
+        # batch == 1 per core but many matrices total: each core holds exactly one [32,64] matrix.
+        # The old writer advanced the interleaved output pointer by the padded height (32) instead of
+        # the logical height (17), so every matrix past core 0 landed at the wrong row. 64 matrices.
+        ([64, 1, 17, 64], (7, 7), (32, 64)),
+        # matrix taller than one tile: H 40 -> padded 64 => 2 tile-rows per matrix, 2 matrices/core
+        # over 8 cores. Exercises block_height_ntiles > 1 together with batch > 1.
+        ([16, 1, 40, 64], (7, 0), (128, 64)),
+        # width not tile-aligned: W 50 -> padded 64. Exercises per-row column unpadding (write 50 of
+        # 64 columns) on top of the interior row unpadding.
+        ([32, 32, 17, 50], (7, 7), (512, 64)),
+        # single logical matrix row-split across cores (global batch == 1): the legacy contiguous
+        # path, which must keep working unchanged. H 500 -> padded 512, 64 rows/core over 8 cores.
+        ([1, 1, 500, 64], (7, 0), (64, 64)),
+    ],
+    ids=["repro_1024x16", "batch1_per_core", "multi_tile_row_matrix", "width_unpad", "single_matrix_split"],
+)
+def test_to_layout_sharded_to_interleaved_unpad(dtype, output_buffer_type, shape, grid_end, shard_shape, device):
+    # Height-sharded TILE input -> ROW_MAJOR INTERLEAVED output. untilize-with-unpadding must strip
+    # each matrix's interior tile pad rows (and any column padding) and land every matrix at its own
+    # logical row offset in the interleaved output. Regression for the batched HEIGHT_SHARDED ->
+    # INTERLEAVED path, previously blocked by a "Can only write unbatched output interleaved" fatal.
+    input_mem_config = _height_sharded_l1_config(grid_end, shard_shape)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, output_buffer_type)
+
+    torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=input_mem_config)
+
+    output = ttnn.to_layout(ttnn_input_tensor, ttnn.ROW_MAJOR_LAYOUT, memory_config=output_mem_config)
+
+    assert output.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert output.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+    assert output.memory_config().buffer_type == output_buffer_type
+    assert_quality(torch_input_tensor, ttnn.to_torch(output), dtype)
+
+
+def test_to_layout_sharded_to_interleaved_matrix_split_unsupported(device):
+    # A multi-matrix batch (global batch == 2) whose padded matrices ([64, 64]) straddle core
+    # boundaries (shard height 32 < padded matrix height 64) is not supported for interleaved output.
+    # It must raise a clear precondition error instead of silently writing garbage.
+    input_mem_config = _height_sharded_l1_config((3, 0), (32, 64))  # 4 cores, half a matrix each
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+    torch_input_tensor = torch.randn([2, 1, 40, 64], dtype=torch.bfloat16)  # H 40 -> padded 64
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=input_mem_config)
+
+    output = ttnn.to_layout(ttnn_input_tensor, ttnn.ROW_MAJOR_LAYOUT, memory_config=output_mem_config)
+
+    assert output.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert output.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+    assert output.memory_config().buffer_type == output_buffer_type
+    assert_quality(torch_input_tensor, ttnn.to_torch(output), dtype)
+
+
 @pytest.mark.parametrize("batch_size", [9, 32])
 @pytest.mark.parametrize("sentence_size", [32, 256])
 def test_int_untilize(device, batch_size, sentence_size):

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -365,11 +365,10 @@ def _height_sharded_l1_config(grid_end, shard_shape):
         # many whole matrices per core: 1024 padded [32, 64] matrices, 16 per core over an 8x8 grid;
         # logical height 17 is not tile-aligned so every matrix carries 15 interior pad rows to strip.
         ([32, 32, 17, 64], (7, 7), (512, 64)),
-        # batch == 1 per core, 64 matrices total: each core holds exactly one padded [32, 64] matrix.
-        # The old writer advanced the interleaved output pointer by the padded height (32) instead of
-        # the logical height, so every matrix past core 0 landed at the wrong row. The h17 rows carry
-        # interior row padding (17 real of 32) to strip; the h32 rows are tile-aligned (no row
-        # padding) and pair with non-tile-aligned widths (49/50) to isolate per-row column unpadding.
+        # batch == 1 per core, 64 matrices total: each core holds exactly one padded [32, 64] matrix,
+        # so each matrix lands at output row core_index * logical_height. The h17 rows carry interior
+        # row padding (17 real of 32) to strip; the h32 rows are tile-aligned (no row padding) and
+        # pair with non-tile-aligned widths (49/50) to isolate per-row column unpadding.
         ([64, 1, 17, 49], (7, 7), (32, 64)),
         ([64, 1, 32, 49], (7, 7), (32, 64)),
         ([64, 1, 17, 50], (7, 7), (32, 64)),
@@ -381,8 +380,9 @@ def _height_sharded_l1_config(grid_end, shard_shape):
         # width not tile-aligned: W 50 -> padded 64. Exercises per-row column unpadding (write 50 of
         # 64 columns) on top of the interior row unpadding.
         ([32, 32, 17, 50], (7, 7), (512, 64)),
-        # single logical matrix row-split across cores (global batch == 1): the legacy contiguous
-        # path, which must keep working unchanged. H 500 -> padded 512, 64 rows/core over 8 cores.
+        # single logical matrix row-split across cores (global batch == 1): H 500 -> padded 512, 64
+        # rows/core over 8 cores; every core copies its row range and the last core trims the
+        # trailing pad rows (500..511).
         ([1, 1, 500, 64], (7, 0), (64, 64)),
     ],
     ids=[
@@ -398,10 +398,10 @@ def _height_sharded_l1_config(grid_end, shard_shape):
     ],
 )
 def test_to_layout_sharded_to_interleaved_unpad(dtype, output_buffer_type, shape, grid_end, shard_shape, device):
-    # Height-sharded TILE input -> ROW_MAJOR INTERLEAVED output. untilize-with-unpadding must strip
-    # each matrix's interior tile pad rows (and any column padding) and land every matrix at its own
-    # logical row offset in the interleaved output. Regression for the batched HEIGHT_SHARDED ->
-    # INTERLEAVED path, previously blocked by a "Can only write unbatched output interleaved" fatal.
+    # Height-sharded TILE input -> ROW_MAJOR INTERLEAVED output. untilize-with-unpadding strips each
+    # matrix's interior tile pad rows (and any column padding) and lands every matrix at its own
+    # logical row offset in the interleaved output, for any batch and any alignment of matrices to
+    # cores.
     input_mem_config = _height_sharded_l1_config(grid_end, shard_shape)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, output_buffer_type)
 

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -368,6 +368,8 @@ def _height_sharded_l1_config(grid_end, shard_shape):
         # batch == 1 per core but many matrices total: each core holds exactly one [32,64] matrix.
         # The old writer advanced the interleaved output pointer by the padded height (32) instead of
         # the logical height (17), so every matrix past core 0 landed at the wrong row. 64 matrices.
+        ([64, 1, 17, 49], (7, 7), (32, 64)),
+        ([64, 1, 17, 50], (7, 7), (32, 64)),
         ([64, 1, 17, 64], (7, 7), (32, 64)),
         # matrix taller than one tile: H 40 -> padded 64 => 2 tile-rows per matrix, 2 matrices/core
         # over 8 cores. Exercises block_height_ntiles > 1 together with batch > 1.
@@ -379,7 +381,15 @@ def _height_sharded_l1_config(grid_end, shard_shape):
         # path, which must keep working unchanged. H 500 -> padded 512, 64 rows/core over 8 cores.
         ([1, 1, 500, 64], (7, 0), (64, 64)),
     ],
-    ids=["repro_1024x16", "batch1_per_core", "multi_tile_row_matrix", "width_unpad", "single_matrix_split"],
+    ids=[
+        "repro_1024x16",
+        "batch1_per_core_w49",
+        "batch1_per_core_w50",
+        "batch1_per_core_w64",
+        "multi_tile_row_matrix",
+        "width_unpad",
+        "single_matrix_split",
+    ],
 )
 def test_to_layout_sharded_to_interleaved_unpad(dtype, output_buffer_type, shape, grid_end, shard_shape, device):
     # Height-sharded TILE input -> ROW_MAJOR INTERLEAVED output. untilize-with-unpadding must strip
@@ -401,15 +411,26 @@ def test_to_layout_sharded_to_interleaved_unpad(dtype, output_buffer_type, shape
     assert_quality(torch_input_tensor, ttnn.to_torch(output), dtype)
 
 
-def test_to_layout_sharded_to_interleaved_matrix_split_unsupported(device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("output_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+@pytest.mark.parametrize(
+    "shape, grid_end, shard_shape",
+    [
+        ([2, 1, 40, 64], (3, 0), (32, 64)),  # 4 cores, half a matrix each
+    ],
+)
+def test_to_layout_sharded_to_interleaved_matrix_split_across_cores(
+    dtype, output_buffer_type, shape, grid_end, shard_shape, device
+):
     # A multi-matrix batch (global batch == 2) whose padded matrices ([64, 64]) straddle core
-    # boundaries (shard height 32 < padded matrix height 64) is not supported for interleaved output.
-    # It must raise a clear precondition error instead of silently writing garbage.
-    input_mem_config = _height_sharded_l1_config((3, 0), (32, 64))  # 4 cores, half a matrix each
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    # boundaries (shard height 32 < padded matrix height 64). The per-row (matrix, row-in-matrix)
+    # walk resolves each core's rows independently, so this converts correctly even though no core
+    # holds a whole matrix and the interior pad rows land mid-way through cores 1 and 3.
+    input_mem_config = _height_sharded_l1_config(grid_end, shard_shape)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, output_buffer_type)
 
-    torch_input_tensor = torch.randn([2, 1, 40, 64], dtype=torch.bfloat16)  # H 40 -> padded 64
-    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=input_mem_config)
 
     output = ttnn.to_layout(ttnn_input_tensor, ttnn.ROW_MAJOR_LAYOUT, memory_config=output_mem_config)

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -362,8 +362,8 @@ def _height_sharded_l1_config(grid_end, shard_shape):
 @pytest.mark.parametrize(
     "shape, grid_end, shard_shape",
     [
-        # issue_test.py repro: 1024 padded [32,64] matrices, 16 per core over an 8x8 grid; logical
-        # height 17 is not tile-aligned so every matrix carries 15 interior pad rows to be stripped.
+        # many whole matrices per core: 1024 padded [32, 64] matrices, 16 per core over an 8x8 grid;
+        # logical height 17 is not tile-aligned so every matrix carries 15 interior pad rows to strip.
         ([32, 32, 17, 64], (7, 7), (512, 64)),
         # batch == 1 per core, 64 matrices total: each core holds exactly one padded [32, 64] matrix.
         # The old writer advanced the interleaved output pointer by the padded height (32) instead of
@@ -386,7 +386,7 @@ def _height_sharded_l1_config(grid_end, shard_shape):
         ([1, 1, 500, 64], (7, 0), (64, 64)),
     ],
     ids=[
-        "repro_1024x16",
+        "batch16_per_core",
         "batch1_per_core_h17_w49",
         "batch1_per_core_h32_w49",
         "batch1_per_core_h17_w50",

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -365,11 +365,15 @@ def _height_sharded_l1_config(grid_end, shard_shape):
         # issue_test.py repro: 1024 padded [32,64] matrices, 16 per core over an 8x8 grid; logical
         # height 17 is not tile-aligned so every matrix carries 15 interior pad rows to be stripped.
         ([32, 32, 17, 64], (7, 7), (512, 64)),
-        # batch == 1 per core but many matrices total: each core holds exactly one [32,64] matrix.
+        # batch == 1 per core, 64 matrices total: each core holds exactly one padded [32, 64] matrix.
         # The old writer advanced the interleaved output pointer by the padded height (32) instead of
-        # the logical height (17), so every matrix past core 0 landed at the wrong row. 64 matrices.
+        # the logical height, so every matrix past core 0 landed at the wrong row. The h17 rows carry
+        # interior row padding (17 real of 32) to strip; the h32 rows are tile-aligned (no row
+        # padding) and pair with non-tile-aligned widths (49/50) to isolate per-row column unpadding.
         ([64, 1, 17, 49], (7, 7), (32, 64)),
+        ([64, 1, 32, 49], (7, 7), (32, 64)),
         ([64, 1, 17, 50], (7, 7), (32, 64)),
+        ([64, 1, 32, 50], (7, 7), (32, 64)),
         ([64, 1, 17, 64], (7, 7), (32, 64)),
         # matrix taller than one tile: H 40 -> padded 64 => 2 tile-rows per matrix, 2 matrices/core
         # over 8 cores. Exercises block_height_ntiles > 1 together with batch > 1.
@@ -383,9 +387,11 @@ def _height_sharded_l1_config(grid_end, shard_shape):
     ],
     ids=[
         "repro_1024x16",
-        "batch1_per_core_w49",
-        "batch1_per_core_w50",
-        "batch1_per_core_w64",
+        "batch1_per_core_h17_w49",
+        "batch1_per_core_h32_w49",
+        "batch1_per_core_h17_w50",
+        "batch1_per_core_h32_w50",
+        "batch1_per_core_h17_w64",
         "multi_tile_row_matrix",
         "width_unpad",
         "single_matrix_split",

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -781,21 +781,15 @@ def test_untilize_with_unpadding_multicore_nd_shard_to_legacy_shard(
 
 
 # ---------------------------------------------------------------------------
-# Regression test for UntilizeWithUnpaddingMultiCoreShardedProgramFactory when:
-#   * input is legacy HEIGHT_SHARDED (no NdShardSpec needed to reproduce)
-#   * tensor has outer dim > 1 (i.e. global_batch > 1)
-#   * inner H is NOT tile-aligned (so each outer-dim slice carries its own 2-row
-#     tile-padding tail in the physical shard)
-#   * output is INTERLEAVED (L1 or DRAM)
+# Legacy 2D HEIGHT_SHARDED (tiled) input -> INTERLEAVED (L1 or DRAM) untilize-with-unpadding where:
+#   * outer dim > 1 (global_batch > 1: several logical matrices), and
+#   * inner H is NOT tile-aligned, so each matrix carries its own interior tile-padding tail.
 #
-# This used to hit a "Can only write unbatched output interleaved" TT_FATAL, and
-# before that guard the interleaved-output writer mishandled per-outer-dim tile
-# padding (it wrote each slice's tail pad rows and dropped the last slice's real
-# rows -> PCC ~ 1 / outer_dim). The height-sharded -> interleaved writer now walks
-# each core's absolute rows and maps every one to its (matrix, row-in-matrix), so
-# these cases convert bitwise-correctly regardless of how matrices align to cores.
+# The writer walks each core's absolute rows, maps every one to its (matrix, row-in-matrix), strips
+# each matrix's interior pad rows, and lands it at its own row offset in the output -- for any
+# alignment of matrices to cores.
 #
-# Expected behavior: bitwise match (assert_equal passes).
+# Expected behavior: bitwise match (assert_equal).
 # ---------------------------------------------------------------------------
 
 
@@ -807,11 +801,11 @@ def test_untilize_with_unpadding_multicore_nd_shard_to_legacy_shard(
         # Baseline (no outer dim): single shard.
         # Tensor [1,1,30,64] padded [1,1,32,64] => single shard of (32, 64).
         (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [1, 1, 30, 64], [0, 0, 29, 63], (32, 64), 1),
-        # Smallest reproducer: outer dim 2 on dim 0.
+        # Outer dim 2 on dim 0.
         # Tensor [2,1,30,64] padded [2,1,32,64] => physical (64, 64) = 2 shards of (32, 64).
-        # Each shard is one batch slice (32 rows including 2 tile-padded tail rows).
+        # Each shard is one matrix slice (32 rows including 2 tile-padded tail rows).
         (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [2, 1, 30, 64], [1, 0, 29, 63], (32, 64), 2),
-        # Stronger signal: outer dim 4 (used to give PCC ~0.25 on the buggy factory).
+        # Outer dim 4: four matrices, one per core.
         (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [4, 1, 30, 64], [3, 0, 29, 63], (32, 64), 4),
         # Outer product spread across dims 0 and 1 (2 x 2 = 4 slices).
         (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [2, 2, 30, 64], [1, 1, 29, 63], (32, 64), 4),
@@ -826,14 +820,11 @@ def test_untilize_with_unpadding_multicore_nd_shard_to_legacy_shard(
 def test_untilize_with_unpadding_sharded_multi_batch_unpadding_regression(
     device, dtype, shard_layout, tensor_shape, output_end, shard_shape, num_cores, output_buffer_type
 ):
-    """Regression test: legacy 2D sharded input (HEIGHT_SHARDED or WIDTH_SHARDED) +
-    non-tile-aligned H + outer_dim > 1 + interleaved output.
+    """Legacy 2D HEIGHT_SHARDED (tiled) input, non-tile-aligned H, outer_dim > 1, interleaved output.
 
-    When the factory bug is active, the interleaved-output runtime args assume tile
-    padding only exists at the very end of the flattened sharded image. For tensors
-    whose outer product is spread across multiple tile-padded slices, this writes
-    per-slice tile-padding tail rows into the output and drops real rows from the
-    last slice. Expected result: bitwise match; buggy result: PCC ~ 1 / outer_dim.
+    Each outer-dim slice is a logical matrix carrying its own interior tile-padding tail.
+    untilize-with-unpadding strips each matrix's pad rows and lands it at its own row offset in the
+    output; the result must match the sliced torch reference bitwise.
     """
     torch.manual_seed(42)
     torch_tensor = torch.rand(tensor_shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -781,46 +781,22 @@ def test_untilize_with_unpadding_multicore_nd_shard_to_legacy_shard(
 
 
 # ---------------------------------------------------------------------------
-# Regression test for a bug in UntilizeWithUnpaddingMultiCoreShardedProgramFactory
-# when:
+# Regression test for UntilizeWithUnpaddingMultiCoreShardedProgramFactory when:
 #   * input is legacy HEIGHT_SHARDED (no NdShardSpec needed to reproduce)
 #   * tensor has outer dim > 1 (i.e. global_batch > 1)
 #   * inner H is NOT tile-aligned (so each outer-dim slice carries its own 2-row
 #     tile-padding tail in the physical shard)
 #   * output is INTERLEAVED (L1 or DRAM)
 #
-# The factory's interleaved-output runtime args (see
-# ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/
-# untilize_with_unpadding_multi_core_sharded_program_factory.cpp lines 243-254)
-# assume tile padding only exists at the very end of the flattened sharded image
-# and thus write all `num_rows_block` rows for every core EXCEPT the last. That's
-# correct for a HEIGHT_SHARDED tensor whose outer product fits in a single shard,
-# but wrong when each shard contains its own outer-dim slice: rows 30..31 of each
-# non-final shard are tile padding that should NOT be written to the output, and
-# logical rows 28..29 of the final shard's slice get dropped instead.
-
-# For now, such cases where the upper (non last 2 dims) are > 1 and height (second last tensor dim)
-# is not tile-aligned are rejected with the TT_FATAL in the validate_on_program_cache_miss function
-# in the untilize_with_unpadding_device_operation.cpp file, just like the existing behavior of how multi-batched width sharded
-# inputs are rejected.
+# This used to hit a "Can only write unbatched output interleaved" TT_FATAL, and
+# before that guard the interleaved-output writer mishandled per-outer-dim tile
+# padding (it wrote each slice's tail pad rows and dropped the last slice's real
+# rows -> PCC ~ 1 / outer_dim). The height-sharded -> interleaved writer now walks
+# each core's absolute rows and maps every one to its (matrix, row-in-matrix), so
+# these cases convert bitwise-correctly regardless of how matrices align to cores.
 #
-# Expected behavior: bitwise match (assert_equal passes). Buggy behavior: PCC ~
-# 1 / outer_dim (e.g. 0.49 for [2,1,30,64], 0.22 for [4,1,30,64]).
+# Expected behavior: bitwise match (assert_equal passes).
 # ---------------------------------------------------------------------------
-
-
-# Cases with outer_dim > 1 + non-tile-aligned H + interleaved output hit the
-# "Can only write unbatched output interleaved" TT_FATAL in the device op validator
-# (for HEIGHT_SHARDED, WIDTH_SHARDED, and BLOCK_SHARDED). Mark them xfail so they
-# signal if the guard is ever relaxed / the factory is fixed (strict=True causes
-# xpass to fail the test, prompting xfail removal).
-_batched_interleaved_xfail = pytest.mark.xfail(
-    raises=RuntimeError,
-    reason='TT_FATAL: "Can only write unbatched output interleaved" '
-    "(pre-emptive guard for multi-batch sharded -> interleaved untilize_with_unpadding; "
-    "the underlying factory mishandles per-outer-dim tile padding).",
-    strict=True,
-)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -828,38 +804,17 @@ _batched_interleaved_xfail = pytest.mark.xfail(
     "shard_layout, tensor_shape, output_end, shard_shape, num_cores",
     [
         # --- HEIGHT_SHARDED ---
-        # Baseline (no outer dim): should pass even on buggy factory.
+        # Baseline (no outer dim): single shard.
         # Tensor [1,1,30,64] padded [1,1,32,64] => single shard of (32, 64).
         (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [1, 1, 30, 64], [0, 0, 29, 63], (32, 64), 1),
         # Smallest reproducer: outer dim 2 on dim 0.
         # Tensor [2,1,30,64] padded [2,1,32,64] => physical (64, 64) = 2 shards of (32, 64).
         # Each shard is one batch slice (32 rows including 2 tile-padded tail rows).
-        pytest.param(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            [2, 1, 30, 64],
-            [1, 0, 29, 63],
-            (32, 64),
-            2,
-            marks=_batched_interleaved_xfail,
-        ),
-        # Stronger signal: outer dim 4 -> PCC drops to ~0.25 if buggy.
-        pytest.param(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            [4, 1, 30, 64],
-            [3, 0, 29, 63],
-            (32, 64),
-            4,
-            marks=_batched_interleaved_xfail,
-        ),
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [2, 1, 30, 64], [1, 0, 29, 63], (32, 64), 2),
+        # Stronger signal: outer dim 4 (used to give PCC ~0.25 on the buggy factory).
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [4, 1, 30, 64], [3, 0, 29, 63], (32, 64), 4),
         # Outer product spread across dims 0 and 1 (2 x 2 = 4 slices).
-        pytest.param(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            [2, 2, 30, 64],
-            [1, 1, 29, 63],
-            (32, 64),
-            4,
-            marks=_batched_interleaved_xfail,
-        ),
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, [2, 2, 30, 64], [1, 1, 29, 63], (32, 64), 4),
     ],
     ids=lambda p: str(p).replace(" ", "") if isinstance(p, list) else None,
 )

--- a/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
@@ -47,6 +47,10 @@ void kernel_main() {
     uint32_t num_output_rows_unpadded = get_arg_val<uint32_t>(7);
     uint32_t block_start_row_id = get_arg_val<uint32_t>(8);
     uint32_t block_start_row_offset = get_arg_val<uint32_t>(9);
+    // Number of leading matrices (of the `batch` held by this core) that carry real, non-padding
+    // data. Any matrices past this count are still drained from the CB (so compute never blocks)
+    // but no rows are written out. Callers with no padding matrices pass num_real_batches == batch.
+    uint32_t num_real_batches = get_arg_val<uint32_t>(10);
 
     constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(0) == 1;
     constexpr auto dst_args = TensorAccessorArgs<2>();
@@ -62,8 +66,13 @@ void kernel_main() {
     const uint32_t block_height_ntiles = num_rows_block / TILE_HEIGHT;
 
     const auto s = TensorAccessor(dst_args, dst_addr);
-    uint32_t num_rows_unpadded = num_output_rows_unpadded + block_start_row_id;
     for (uint32_t b = 0; b < batch; ++b) {
+        // A real matrix emits its full (unpadded) height; a trailing padding matrix emits nothing,
+        // yet its tiles are still popped below so the compute kernel never stalls on a full CB.
+        uint32_t rows_this_matrix = (b < num_real_batches) ? num_output_rows_unpadded : 0;
+        // block_start_row_id is the matrix's first row in the (unpadded) interleaved output. The
+        // write loop stops once it reaches this threshold, dropping the matrix's interior pad rows.
+        uint32_t num_rows_unpadded = block_start_row_id + rows_this_matrix;
         for (uint32_t block_h = 0; block_h < num_blocks_h; block_h++) {
             uint32_t block_row_offset = block_start_row_offset;
             for (uint32_t block_w = 0; block_w < num_blocks_w; block_w++) {
@@ -83,7 +92,9 @@ void kernel_main() {
                     s);
                 block_row_offset += block_row_size;
             }  // for num_blocks_w
-            block_start_row_id += num_rows_block;
+            // Advance the output pointer by the rows actually written so the next matrix lands
+            // directly after this one — padding rows between matrices are skipped, not stored.
+            block_start_row_id += rows_this_matrix;
         }  // for num_blocks_h
     }  // for batch
 }

--- a/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
@@ -47,10 +47,6 @@ void kernel_main() {
     uint32_t num_output_rows_unpadded = get_arg_val<uint32_t>(7);
     uint32_t block_start_row_id = get_arg_val<uint32_t>(8);
     uint32_t block_start_row_offset = get_arg_val<uint32_t>(9);
-    // Number of leading matrices (of the `batch` held by this core) that carry real, non-padding
-    // data. Any matrices past this count are still drained from the CB (so compute never blocks)
-    // but no rows are written out. Callers with no padding matrices pass num_real_batches == batch.
-    uint32_t num_real_batches = get_arg_val<uint32_t>(10);
 
     constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(0) == 1;
     constexpr auto dst_args = TensorAccessorArgs<2>();
@@ -66,13 +62,8 @@ void kernel_main() {
     const uint32_t block_height_ntiles = num_rows_block / TILE_HEIGHT;
 
     const auto s = TensorAccessor(dst_args, dst_addr);
+    uint32_t num_rows_unpadded = num_output_rows_unpadded + block_start_row_id;
     for (uint32_t b = 0; b < batch; ++b) {
-        // A real matrix emits its full (unpadded) height; a trailing padding matrix emits nothing,
-        // yet its tiles are still popped below so the compute kernel never stalls on a full CB.
-        uint32_t rows_this_matrix = (b < num_real_batches) ? num_output_rows_unpadded : 0;
-        // block_start_row_id is the matrix's first row in the (unpadded) interleaved output. The
-        // write loop stops once it reaches this threshold, dropping the matrix's interior pad rows.
-        uint32_t num_rows_unpadded = block_start_row_id + rows_this_matrix;
         for (uint32_t block_h = 0; block_h < num_blocks_h; block_h++) {
             uint32_t block_row_offset = block_start_row_offset;
             for (uint32_t block_w = 0; block_w < num_blocks_w; block_w++) {
@@ -92,9 +83,7 @@ void kernel_main() {
                     s);
                 block_row_offset += block_row_size;
             }  // for num_blocks_w
-            // Advance the output pointer by the rows actually written so the next matrix lands
-            // directly after this one — padding rows between matrices are skipped, not stored.
-            block_start_row_id += rows_this_matrix;
+            block_start_row_id += num_rows_block;
         }  // for num_blocks_h
     }  // for batch
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -4,7 +4,6 @@
 
 #include "untilize_with_unpadding_multi_core_sharded_program_factory.hpp"
 
-#include <algorithm>
 #include <cmath>
 
 #include "ttnn/operations/cb_utils.hpp"
@@ -156,6 +155,17 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
                 : "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
                   "writer_unary_unpad_batch_rows_sharded.cpp";
         writer_desc.compile_time_args = std::move(writer_ct_args);
+    } else if (a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+        // Height-sharded -> interleaved uses a dedicated writer that walks each core's absolute rows
+        // and drops both interior (row) and column padding per matrix. It handles any alignment of
+        // matrices to core boundaries (whole matrices per core, a single matrix split across cores,
+        // or a batch whose matrices straddle cores), so there is no unbatched restriction.
+        std::vector<uint32_t> writer_ct_args;
+        TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "writer_unary_unpad_sharded_to_interleaved.cpp";
+        writer_desc.compile_time_args = std::move(writer_ct_args);
     } else {
         std::vector<uint32_t> writer_ct_args = {
             (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
@@ -234,18 +244,36 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
         for (const auto& core : all_core_coords) {
             writer_desc.runtime_args.emplace_back(core, writer_rt_args);
         }
-    } else {
-        // Batched height-sharded -> interleaved: each core holds `batch` whole [H_padded, W]
-        // matrices. Untilize strips every matrix's interior tile-pad rows, so the writer must land
-        // each matrix at its own logical row offset in the interleaved output and advance by the
-        // logical matrix height per matrix — it cannot treat the shard as one contiguous block the
-        // way the single-matrix (batch==1) path does. Anything else (WIDTH/BLOCK sharded, or a
-        // single matrix row-split across cores) keeps the original per-core block arithmetic.
-        const bool height_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
-        const bool batched_interleaved = height_sharded && global_batch > 1;
+    } else if (a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+        // General height-sharded -> interleaved. Each core owns the absolute padded rows
+        // [i * shard_h, (i + 1) * shard_h) of the flattened [global_batch * H_padded, W_padded] row
+        // space (enumerated in shard/core order). The kernel maps every row to its (matrix,
+        // row-in-matrix) and writes the real rows to their logical interleaved page, dropping both
+        // interior (row) and column padding. This is correct for any alignment of matrices to core
+        // boundaries, so there is no unbatched restriction.
         const uint32_t matrix_h_padded = a.padded_shape()[-2];
         const uint32_t matrix_h_logical = output.logical_shape()[-2];
+        const uint32_t shard_height = shard_spec.shape[0];
+        const uint32_t cb_row_size = shard_spec.shape[1] * output.element_size();  // CB row stride (padded width)
+        const uint32_t row_size_unpadded =
+            output.logical_shape()[-1] * output.element_size();  // bytes written per row (logical width)
 
+        writer_desc.runtime_args.reserve(all_core_coords.size());
+        for (uint32_t i = 0; i < all_core_coords.size(); ++i) {
+            const CoreCoord& core = all_core_coords[i];
+            const uint32_t start_padded_row = i * shard_height;
+            writer_desc.emplace_runtime_args(
+                core,
+                {dst_buffer,  // dst_addr
+                 start_padded_row,
+                 shard_height,
+                 matrix_h_padded,
+                 matrix_h_logical,
+                 cb_row_size,
+                 row_size_unpadded,
+                 ntiles_per_block});
+        }
+    } else {
         writer_desc.runtime_args.reserve(all_core_coords.size());
         for (uint32_t i = 0; i < all_core_coords.size(); ++i) {
             CoreCoord core = all_core_coords[i];
@@ -255,11 +283,6 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
             uint32_t block_start_row_id_offset;
             uint32_t row_size_unpadded = block_row_size;
             uint32_t num_rows_unpadded = num_rows_block;
-            // Per-matrix block height and matrix count seen by the writer. Defaults reproduce the
-            // legacy single-block behaviour (one matrix per core, all of it real data).
-            uint32_t writer_num_rows_block = num_rows_block;
-            uint32_t writer_batch = 1;
-            uint32_t writer_num_real_batches = 1;
             if (a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
                 block_start_row_offset = i * block_row_size;
                 block_start_row_id_offset = 0;
@@ -269,33 +292,6 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
                 } else {
                     num_rows_unpadded = num_output_rows_unpadded;
                     if (i == last_idx) {
-                        row_size_unpadded = last_block_row_size_unpadded;
-                    }
-                }
-            } else if (height_sharded) {
-                if (batched_interleaved) {
-                    // One writer "block" == one padded matrix; `batch` of them are drained per core.
-                    writer_num_rows_block = matrix_h_padded;
-                    writer_batch = batch;
-                    block_start_row_offset = 0;
-                    block_start_row_id_offset = i * batch * matrix_h_logical;  // this core's first matrix
-                    row_size_unpadded = last_block_row_size_unpadded;          // unpadded width in bytes
-                    num_rows_unpadded = matrix_h_logical;                      // data rows written per matrix
-                    // Tail cores may hold whole padding matrices past the real batch; those are
-                    // popped but not written.
-                    const uint32_t first_matrix = i * batch;
-                    writer_num_real_batches =
-                        first_matrix >= global_batch ? 0u : std::min(batch, global_batch - first_matrix);
-                } else {
-                    block_start_row_offset = 0;
-                    block_start_row_id_offset = i * num_rows_block;
-                    if (i > last_idx) {
-                        row_size_unpadded = 0;
-                        num_rows_unpadded = 0;
-                    } else {
-                        if (i == last_idx) {
-                            num_rows_unpadded = num_output_rows_unpadded;
-                        }
                         row_size_unpadded = last_block_row_size_unpadded;
                     }
                 }
@@ -328,16 +324,15 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
             writer_desc.emplace_runtime_args(
                 core,
                 {dst_buffer,  // dst_addr
-                 writer_num_rows_block,
+                 num_rows_block,
                  block_row_size,
-                 writer_batch,
+                 std::uint32_t{1},
                  std::uint32_t{1},
                  std::uint32_t{1},
                  row_size_unpadded,
                  num_rows_unpadded,
                  block_start_row_id_offset,
-                 block_start_row_offset,
-                 writer_num_real_batches});
+                 block_start_row_offset});
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "untilize_with_unpadding_multi_core_sharded_program_factory.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 #include "ttnn/operations/cb_utils.hpp"
@@ -234,6 +235,17 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
             writer_desc.runtime_args.emplace_back(core, writer_rt_args);
         }
     } else {
+        // Batched height-sharded -> interleaved: each core holds `batch` whole [H_padded, W]
+        // matrices. Untilize strips every matrix's interior tile-pad rows, so the writer must land
+        // each matrix at its own logical row offset in the interleaved output and advance by the
+        // logical matrix height per matrix — it cannot treat the shard as one contiguous block the
+        // way the single-matrix (batch==1) path does. Anything else (WIDTH/BLOCK sharded, or a
+        // single matrix row-split across cores) keeps the original per-core block arithmetic.
+        const bool height_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+        const bool batched_interleaved = height_sharded && global_batch > 1;
+        const uint32_t matrix_h_padded = a.padded_shape()[-2];
+        const uint32_t matrix_h_logical = output.logical_shape()[-2];
+
         writer_desc.runtime_args.reserve(all_core_coords.size());
         for (uint32_t i = 0; i < all_core_coords.size(); ++i) {
             CoreCoord core = all_core_coords[i];
@@ -243,6 +255,11 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
             uint32_t block_start_row_id_offset;
             uint32_t row_size_unpadded = block_row_size;
             uint32_t num_rows_unpadded = num_rows_block;
+            // Per-matrix block height and matrix count seen by the writer. Defaults reproduce the
+            // legacy single-block behaviour (one matrix per core, all of it real data).
+            uint32_t writer_num_rows_block = num_rows_block;
+            uint32_t writer_batch = 1;
+            uint32_t writer_num_real_batches = 1;
             if (a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
                 block_start_row_offset = i * block_row_size;
                 block_start_row_id_offset = 0;
@@ -255,17 +272,32 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
                         row_size_unpadded = last_block_row_size_unpadded;
                     }
                 }
-            } else if (a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                block_start_row_offset = 0;
-                block_start_row_id_offset = i * num_rows_block;
-                if (i > last_idx) {
-                    row_size_unpadded = 0;
-                    num_rows_unpadded = 0;
+            } else if (height_sharded) {
+                if (batched_interleaved) {
+                    // One writer "block" == one padded matrix; `batch` of them are drained per core.
+                    writer_num_rows_block = matrix_h_padded;
+                    writer_batch = batch;
+                    block_start_row_offset = 0;
+                    block_start_row_id_offset = i * batch * matrix_h_logical;  // this core's first matrix
+                    row_size_unpadded = last_block_row_size_unpadded;          // unpadded width in bytes
+                    num_rows_unpadded = matrix_h_logical;                      // data rows written per matrix
+                    // Tail cores may hold whole padding matrices past the real batch; those are
+                    // popped but not written.
+                    const uint32_t first_matrix = i * batch;
+                    writer_num_real_batches =
+                        first_matrix >= global_batch ? 0u : std::min(batch, global_batch - first_matrix);
                 } else {
-                    if (i == last_idx) {
-                        num_rows_unpadded = num_output_rows_unpadded;
+                    block_start_row_offset = 0;
+                    block_start_row_id_offset = i * num_rows_block;
+                    if (i > last_idx) {
+                        row_size_unpadded = 0;
+                        num_rows_unpadded = 0;
+                    } else {
+                        if (i == last_idx) {
+                            num_rows_unpadded = num_output_rows_unpadded;
+                        }
+                        row_size_unpadded = last_block_row_size_unpadded;
                     }
-                    row_size_unpadded = last_block_row_size_unpadded;
                 }
             } else {
                 if (row_major) {
@@ -296,15 +328,16 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
             writer_desc.emplace_runtime_args(
                 core,
                 {dst_buffer,  // dst_addr
-                 num_rows_block,
+                 writer_num_rows_block,
                  block_row_size,
-                 std::uint32_t{1},
+                 writer_batch,
                  std::uint32_t{1},
                  std::uint32_t{1},
                  row_size_unpadded,
                  num_rows_unpadded,
                  block_start_row_id_offset,
-                 block_start_row_offset});
+                 block_start_row_offset,
+                 writer_num_real_batches});
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_sharded_to_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_sharded_to_interleaved.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_sharded_to_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_sharded_to_interleaved.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+// Writer for HEIGHT_SHARDED (tiled) -> ROW_MAJOR INTERLEAVED untilize-with-unpadding.
+//
+// The height-sharded input flattens to a [global_batch * H_padded, W_padded] row space that is
+// split into contiguous per-core row ranges. Every H_padded-tall band is one logical matrix whose
+// first H_logical rows are real data and whose remaining rows are interior tile padding. This core
+// owns the absolute padded rows [start_padded_row, start_padded_row + num_rows).
+//
+// The compute kernel streams the untilized rows into the output CB one tile-row (32 rows) at a
+// time. For each row this kernel derives, from its absolute position, which matrix it belongs to
+// (m) and the row within that matrix (rr). Real rows (rr < H_logical) are written to interleaved
+// output page m * H_logical + rr; padding rows are skipped. Column padding is dropped by writing
+// only row_size_unpadded bytes while advancing the CB read pointer by the full padded block_row_size.
+//
+// This makes no assumption about how matrices line up with core boundaries: a matrix may be split
+// across cores, a core may hold several whole matrices, or any mix — the per-row (m, rr) walk is
+// correct in every case.
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_padded_row = get_arg_val<uint32_t>(1);   // absolute first padded row owned by this core
+    uint32_t num_rows = get_arg_val<uint32_t>(2);           // padded rows owned by this core (multiple of 32)
+    uint32_t matrix_h_padded = get_arg_val<uint32_t>(3);    // padded height of one matrix
+    uint32_t matrix_h_logical = get_arg_val<uint32_t>(4);   // logical (real) height of one matrix
+    uint32_t block_row_size = get_arg_val<uint32_t>(5);     // CB row stride in bytes (padded width)
+    uint32_t row_size_unpadded = get_arg_val<uint32_t>(6);  // bytes written per row (logical width)
+    uint32_t ntiles_per_row = get_arg_val<uint32_t>(7);     // tiles per tile-row (CB wait/pop granularity)
+
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t TILE_HEIGHT = 32;  // TODO: use common source of truth
+
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    // Decompose this core's first padded row into (matrix index, row within matrix). guard against a
+    // zero matrix height (should never happen) so the modulo/division below are well defined.
+    uint32_t m = matrix_h_padded == 0 ? 0 : start_padded_row / matrix_h_padded;
+    uint32_t rr = matrix_h_padded == 0 ? 0 : start_padded_row % matrix_h_padded;
+
+    const uint32_t num_tile_rows = num_rows / TILE_HEIGHT;
+    for (uint32_t t = 0; t < num_tile_rows; t++) {
+        cb_wait_front(cb_id_out0, ntiles_per_row);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+        for (uint32_t j = 0; j < TILE_HEIGHT; j++) {
+            if (rr < matrix_h_logical) {
+                uint64_t dst_noc_addr = s.get_noc_addr(m * matrix_h_logical + rr, 0);
+                noc_async_write(l1_read_addr, dst_noc_addr, row_size_unpadded);
+            }
+            l1_read_addr += block_row_size;
+            rr++;
+            if (rr == matrix_h_padded) {
+                rr = 0;
+                m++;
+            }
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out0, ntiles_per_row);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_sharded_to_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_sharded_to_interleaved.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // Writer for HEIGHT_SHARDED (tiled) -> ROW_MAJOR INTERLEAVED untilize-with-unpadding.
 //
@@ -36,20 +40,27 @@ void kernel_main() {
     constexpr uint32_t TILE_HEIGHT = 32;  // TODO: use common source of truth
 
     const auto s = TensorAccessor(dst_args, dst_addr);
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
 
-    // Decompose this core's first padded row into (matrix index, row within matrix). guard against a
+    // Decompose this core's first padded row into (matrix index, row within matrix); guard against a
     // zero matrix height (should never happen) so the modulo/division below are well defined.
     uint32_t m = matrix_h_padded == 0 ? 0 : start_padded_row / matrix_h_padded;
     uint32_t rr = matrix_h_padded == 0 ? 0 : start_padded_row % matrix_h_padded;
 
     const uint32_t num_tile_rows = num_rows / TILE_HEIGHT;
     for (uint32_t t = 0; t < num_tile_rows; t++) {
-        cb_wait_front(cb_id_out0, ntiles_per_row);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+        cb_out0.wait_front(ntiles_per_row);
+        uint32_t l1_read_addr = cb_out0.get_read_ptr();
         for (uint32_t j = 0; j < TILE_HEIGHT; j++) {
             if (rr < matrix_h_logical) {
-                uint64_t dst_noc_addr = s.get_noc_addr(m * matrix_h_logical + rr, 0);
-                noc_async_write(l1_read_addr, dst_noc_addr, row_size_unpadded);
+                CoreLocalMem<uint32_t> src(l1_read_addr);
+                noc.async_write(
+                    src,
+                    s,
+                    row_size_unpadded,
+                    {.offset_bytes = 0},
+                    {.page_id = m * matrix_h_logical + rr, .offset_bytes = 0});
             }
             l1_read_addr += block_row_size;
             rr++;
@@ -58,7 +69,7 @@ void kernel_main() {
                 m++;
             }
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, ntiles_per_row);
+        noc.async_write_barrier();
+        cb_out0.pop_front(ntiles_per_row);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -108,11 +108,32 @@ void UntilizeWithUnpaddingDeviceOperation::validate_on_program_cache_miss(
                         operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
                         "Output memory config layout must be INTERLEAVED but got {}",
                         operation_attributes.output_mem_config.memory_layout());
+                    // Height-sharded -> interleaved supports two regimes:
+                    //   1. A single logical matrix split (by rows) across cores: no interior
+                    //      padding, each core copies its contiguous row range 1:1 and only the last
+                    //      core trims trailing pad rows.
+                    //   2. A batch of whole [H_padded, W] matrices, shard_h / H_padded of them per
+                    //      core: the writer strips each matrix's interior tile-pad rows and lands
+                    //      every matrix at its logical row offset in the interleaved output.
+                    // Regime 2 requires each shard to hold *whole* matrices — full matrix width and a
+                    // shard height that is a multiple of the padded matrix height. A multi-matrix
+                    // batch whose matrices straddle core boundaries is not supported.
+                    const auto& shard_shape = input_tensor_a.shard_spec().value().shape;
+                    const uint32_t padded_h = input_tensor_a.padded_shape()[-2];
+                    const uint32_t padded_w = input_tensor_a.padded_shape()[-1];
+                    const uint32_t global_batch =
+                        (padded_h * padded_w) == 0 ? 0 : input_tensor_a.physical_volume() / (padded_h * padded_w);
+                    const bool whole_matrices_per_shard =
+                        shard_shape[1] == padded_w && padded_h != 0 && shard_shape[0] % padded_h == 0;
                     TT_FATAL(
-                        input_tensor_a.physical_volume() /
-                                (input_tensor_a.padded_shape()[-2] * input_tensor_a.padded_shape()[-1]) ==
-                            1,
-                        "Can only write unbatched output interleaved");
+                        global_batch == 1 || whole_matrices_per_shard,
+                        "Height-sharded untilize to interleaved output supports a single matrix or shards that each "
+                        "hold whole [H_padded={}, W_padded={}] matrices; got shard shape [{}, {}] with batch {}",
+                        padded_h,
+                        padded_w,
+                        shard_shape[0],
+                        shard_shape[1],
+                        global_batch);
                 }
                 // What else?
             } else if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -108,32 +108,18 @@ void UntilizeWithUnpaddingDeviceOperation::validate_on_program_cache_miss(
                         operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
                         "Output memory config layout must be INTERLEAVED but got {}",
                         operation_attributes.output_mem_config.memory_layout());
-                    // Height-sharded -> interleaved supports two regimes:
-                    //   1. A single logical matrix split (by rows) across cores: no interior
-                    //      padding, each core copies its contiguous row range 1:1 and only the last
-                    //      core trims trailing pad rows.
-                    //   2. A batch of whole [H_padded, W] matrices, shard_h / H_padded of them per
-                    //      core: the writer strips each matrix's interior tile-pad rows and lands
-                    //      every matrix at its logical row offset in the interleaved output.
-                    // Regime 2 requires each shard to hold *whole* matrices — full matrix width and a
-                    // shard height that is a multiple of the padded matrix height. A multi-matrix
-                    // batch whose matrices straddle core boundaries is not supported.
-                    const auto& shard_shape = input_tensor_a.shard_spec().value().shape;
-                    const uint32_t padded_h = input_tensor_a.padded_shape()[-2];
-                    const uint32_t padded_w = input_tensor_a.padded_shape()[-1];
-                    const uint32_t global_batch =
-                        (padded_h * padded_w) == 0 ? 0 : input_tensor_a.physical_volume() / (padded_h * padded_w);
-                    const bool whole_matrices_per_shard =
-                        shard_shape[1] == padded_w && padded_h != 0 && shard_shape[0] % padded_h == 0;
+                    // The height-sharded -> interleaved writer walks each core's absolute rows and
+                    // maps every row to its (matrix, row-in-matrix), so it handles any batch and any
+                    // alignment of matrices to core boundaries (whole matrices per core, a single
+                    // matrix split across cores, or a batch whose matrices straddle cores). It only
+                    // requires that each shard span the full padded matrix width, which height
+                    // sharding always satisfies.
                     TT_FATAL(
-                        global_batch == 1 || whole_matrices_per_shard,
-                        "Height-sharded untilize to interleaved output supports a single matrix or shards that each "
-                        "hold whole [H_padded={}, W_padded={}] matrices; got shard shape [{}, {}] with batch {}",
-                        padded_h,
-                        padded_w,
-                        shard_shape[0],
-                        shard_shape[1],
-                        global_batch);
+                        input_tensor_a.shard_spec().value().shape[1] == input_tensor_a.padded_shape()[-1],
+                        "Height-sharded untilize to interleaved output requires the shard width ({}) to equal the "
+                        "padded tensor width ({})",
+                        input_tensor_a.shard_spec().value().shape[1],
+                        input_tensor_a.padded_shape()[-1]);
                 }
                 // What else?
             } else if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This PR is to solve issue #39074 and #49302 . Main fixes are:

1. Support `untilize_with_unpadding` (and thus `to_layout`) from **HEIGHT_SHARDED TILE** input to **INTERLEAVED row-major** output when the batch (outer dims) > 1 and H/W are not tile-aligned — previously rejected with "Can only write unbatched output interleaved". A new writer walks each core's absolute rows and strips per-matrix interior + column padding, so it works for **any alignment of matrices to cores** (whole matrices per core / one matrix split across cores / matrices straddling cores).
2. Add test cases (`test_to_layout.py`) and enable the previously-`xfailed` multi-batch regression cases in `test_untilize_with_unpadding.py`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ronnie/49302-support_to_layout_high_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ronnie/49302-support_to_layout_high_batch)

Note that all the tests failing in L2 nightly pipeline also failed on the latest main branch with the same failing reason.