### PR TITLE
sparse_sdpa_msa: add in-kernel block-cyclic KV remap

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
@@ -1,15 +1,14 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Requires TT_MESH_GRAPH_DESC_PATH (the single_bh_galaxy descriptor) in the environment.
+"""sp>1 block-cyclic remap coverage for sparse_sdpa_msa (multi-device).
 
-"""sp>1 block-cyclic remap coverage for sparse_sdpa_msa (galaxy SP=8).
-
-The post-commit file only covers sp=1, where the invP block remap is the identity. This exercises the
-REAL permutation at sp=8: K/V are laid out block-cyclic (shard-major) across the SP axis exactly as the
+The post-commit file only covers sp=1, where the invP block remap is the identity. This runs the REAL
+permutation at sp=2 and sp=4 via the `mesh_device` fixture (auto-skips when the devices aren't present, so
+it's safe off-multi-device): K/V are laid out block-cyclic (shard-major) across the SP axis exactly as the
 AllGather'd chunked-prefill cache is, block-ids stay NATURAL, and the op must remap each logical block to
-its physical block and reproduce the natural-order golden. Inputs are replicated across the mesh (sp is
-read from the mesh shape), so every device computes the same result; each is checked against the golden.
+its physical block and reproduce the natural-order golden. Inputs are replicated across the mesh (sp is read
+from the mesh shape), so every device computes the same result; each is checked against the golden.
 """
 
 import pytest
@@ -37,38 +36,37 @@ def _natural_to_block_cyclic(t, sp, n_chunks, chunk_local):
     return t.reshape(1, H, T, d).contiguous()
 
 
-@pytest.fixture(scope="module")
-def sp_mesh():
-    mesh = ttnn.open_mesh_device(ttnn.MeshShape(8, 4))  # deployed SP=8 x TP=4 galaxy
-    yield mesh
-    ttnn.close_mesh_device(mesh)
+@pytest.mark.parametrize("mesh_device", [(1, 2), (1, 4)], indirect=True)  # SP along cols; fixture skips if absent
+@pytest.mark.parametrize("n_chunks", [8])  # sp*n_chunks = nblk >= topk(16): 2*8=16, 4*8=32
+def test_msa_native_block_cyclic_sp_gt1_pcc(mesh_device, n_chunks):
+    rows, cols = tuple(mesh_device.shape)
+    sp_axis, sp = 1, cols
+    if sp < 2:
+        pytest.skip(f"needs sp>1 (mesh shape {(rows, cols)})")
 
-
-@pytest.mark.parametrize("n_chunks", [2, 4])
-def test_msa_native_block_cyclic_sp8_pcc(sp_mesh, n_chunks):
-    rows, cols = tuple(sp_mesh.shape)
-    sp_axis, sp = 0, rows  # SP is the row axis
     H, n_kv, S, d = 32, 1, BLK_KV, 128
-    chunk_local = S  # == q_isl; guard allows q_isl or tp*q_isl
+    chunk_local = S  # tp=1 (pure-SP mesh) -> guard requires chunk_local == q_isl (= S)
     T = sp * n_chunks * chunk_local
-    topk = 16  # TOPK * idx.element_size() (4B) must be 64B-aligned -> topk a multiple of 16; nblk = T/128 >= 16
+    nblk = T // BLK_KV
+    topk = 16  # multiple of 16 (indices row 64B-aligned) and <= nblk
+    assert nblk >= topk and (T // sp) // chunk_local > 1, f"non-trivial permutation needs nblk>=topk: nblk={nblk}"
     q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=topk, d=d, causal=False, seed=T)
 
     gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)  # natural-order, layout-agnostic
     k_bc = _natural_to_block_cyclic(k, sp, n_chunks, chunk_local)
     v_bc = _natural_to_block_cyclic(v, sp, n_chunks, chunk_local)
 
-    repl = ttnn.ReplicateTensorToMesh(sp_mesh)
+    repl = ttnn.ReplicateTensorToMesh(mesh_device)
 
     def dev_rm(x, dt):
         return ttnn.from_torch(
-            x, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=sp_mesh,
+            x, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG, mesh_mapper=repl,
         )
 
     def dev_tile(x, dt):
         return ttnn.from_torch(
-            x.to(torch.bfloat16), dtype=dt, layout=ttnn.TILE_LAYOUT, device=sp_mesh,
+            x.to(torch.bfloat16), dtype=dt, layout=ttnn.TILE_LAYOUT, device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG, mesh_mapper=repl,
         )
 

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
@@ -60,14 +60,22 @@ def test_msa_native_block_cyclic_sp_gt1_pcc(mesh_device, n_chunks):
 
     def dev_rm(x, dt):
         return ttnn.from_torch(
-            x, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG, mesh_mapper=repl,
+            x,
+            dtype=dt,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=repl,
         )
 
     def dev_tile(x, dt):
         return ttnn.from_torch(
-            x.to(torch.bfloat16), dtype=dt, layout=ttnn.TILE_LAYOUT, device=mesh_device,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG, mesh_mapper=repl,
+            x.to(torch.bfloat16),
+            dtype=dt,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=repl,
         )
 
     out = ttnn.transformer.sparse_sdpa_msa(

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
@@ -4,11 +4,14 @@
 """sp>1 block-cyclic remap coverage for sparse_sdpa_msa (multi-device).
 
 The post-commit file only covers sp=1, where the invP block remap is the identity. This runs the REAL
-permutation at sp=2 and sp=4 via the `mesh_device` fixture (auto-skips when the devices aren't present, so
-it's safe off-multi-device): K/V are laid out block-cyclic (shard-major) across the SP axis exactly as the
-AllGather'd chunked-prefill cache is, block-ids stay NATURAL, and the op must remap each logical block to
-its physical block and reproduce the natural-order golden. Inputs are replicated across the mesh (sp is read
-from the mesh shape), so every device computes the same result; each is checked against the golden.
+permutation at sp=2 and sp=4 via the `mesh_device` fixture (auto-skips when the devices aren't present).
+Inputs are replicated across the mesh; K/V are laid out block-cyclic (shard-major, as the AllGather'd
+chunked-prefill cache is), block-ids stay NATURAL. The check is remap-transparency: the block-cyclic op
+must match the PLAIN op (natural-order K/V, no remap) run with identical inputs and the same per-device
+chunk_start. Under causal this is the key case — the diagonal-block mask must stay keyed on the logical
+block id, not the remapped physical one; if the remap leaked into the mask, bc would diverge from plain.
+Op-vs-golden correctness is covered single-device (post-commit file); here plain is additionally checked
+against the layout-agnostic golden in the non-causal case.
 """
 
 import pytest
@@ -28,8 +31,7 @@ DEVICE_PCC = 0.99
 
 def _natural_to_block_cyclic(t, sp, n_chunks, chunk_local):
     """Natural [1,H,T,d] (T = n_chunks*sp*chunk_local, order (chunk, shard, local)) -> block-cyclic
-    shard-major (shard, chunk, local), the layout AllGather produces from the per-shard cache. Inverse of
-    the model's old _blockcyclic_to_natural."""
+    shard-major (shard, chunk, local), the layout AllGather produces from the per-shard cache."""
     H, T, d = t.shape[1], t.shape[2], t.shape[3]
     t = t.reshape(1, H, n_chunks, sp, chunk_local, d)
     t = t.permute(0, 1, 3, 2, 4, 5)  # (chunk, shard) -> (shard, chunk)
@@ -37,22 +39,21 @@ def _natural_to_block_cyclic(t, sp, n_chunks, chunk_local):
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 2), (1, 4)], indirect=True)  # SP along cols; fixture skips if absent
-@pytest.mark.parametrize("n_chunks", [8])  # sp*n_chunks = nblk >= topk(16): 2*8=16, 4*8=32
-def test_msa_native_block_cyclic_sp_gt1_pcc(mesh_device, n_chunks):
+@pytest.mark.parametrize("n_chunks", [8])
+@pytest.mark.parametrize("causal", [False, True])  # True: diagonal-block mask must stay on the logical id
+def test_msa_native_block_cyclic_sp_gt1_matches_plain(mesh_device, n_chunks, causal):
     rows, cols = tuple(mesh_device.shape)
     sp_axis, sp = 1, cols
     if sp < 2:
         pytest.skip(f"needs sp>1 (mesh shape {(rows, cols)})")
 
-    H, n_kv, S, d = 32, 1, BLK_KV, 128
+    H, n_kv, S, d = 32, 1, 2 * BLK_KV, 128  # S = 2 blocks -> chunk_local spans >1 block (non-trivial invP divide)
     chunk_local = S  # tp=1 (pure-SP mesh) -> guard requires chunk_local == q_isl (= S)
     T = sp * n_chunks * chunk_local
     nblk = T // BLK_KV
     topk = 16  # multiple of 16 (indices row 64B-aligned) and <= nblk
-    assert nblk >= topk and (T // sp) // chunk_local > 1, f"non-trivial permutation needs nblk>=topk: nblk={nblk}"
-    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=topk, d=d, causal=False, seed=T)
-
-    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)  # natural-order, layout-agnostic
+    assert nblk >= topk and chunk_local // BLK_KV > 1 and n_chunks > 1, f"degenerate remap params: nblk={nblk}"
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=topk, d=d, causal=causal, seed=T)
     k_bc = _natural_to_block_cyclic(k, sp, n_chunks, chunk_local)
     v_bc = _natural_to_block_cyclic(v, sp, n_chunks, chunk_local)
 
@@ -68,29 +69,38 @@ def test_msa_native_block_cyclic_sp_gt1_pcc(mesh_device, n_chunks):
             mesh_mapper=repl,
         )
 
-    def dev_tile(x, dt):
+    def dev_tile(x):
         return ttnn.from_torch(
             x.to(torch.bfloat16),
-            dtype=dt,
+            dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=repl,
         )
 
-    out = ttnn.transformer.sparse_sdpa_msa(
-        dev_rm(q.to(torch.float32), ttnn.bfloat16),
-        dev_tile(k_bc, ttnn.bfloat16),
-        dev_tile(v_bc, ttnn.bfloat16),
-        dev_rm(indices.to(torch.int32), ttnn.uint32),
-        scale=d**-0.5,
-        block_size=BLK_KV,
-        block_cyclic_sp_axis=sp_axis,
-        block_cyclic_chunk_local=chunk_local,
-    )
+    # Both runs get the same per-device chunk_start (compute_chunk_start_local, from the mesh coord); the only
+    # difference is K/V layout + the remap, so equal outputs prove the remap is correctness-transparent.
+    def run_op(k_in, v_in, bc):
+        kw = dict(scale=d**-0.5, block_size=BLK_KV, chunk_start_idx=0 if causal else None)
+        if bc:
+            kw.update(block_cyclic_sp_axis=sp_axis, block_cyclic_chunk_local=chunk_local)
+        out = ttnn.transformer.sparse_sdpa_msa(
+            dev_rm(q.to(torch.float32), ttnn.bfloat16),
+            dev_tile(k_in),
+            dev_tile(v_in),
+            dev_rm(indices.to(torch.int32), ttnn.uint32),
+            **kw,
+        )
+        return [ttnn.to_torch(s)[:, :H] for s in ttnn.get_device_tensors(out)]
 
-    # Inputs replicated -> every device must reproduce the natural golden (proves the sp>1 invP permutation).
-    for i, shard in enumerate(ttnn.get_device_tensors(out)):
-        o = ttnn.to_torch(shard)[:, :H]
-        p = pcc(o, gold)
-        assert p >= DEVICE_PCC, f"sp={sp} block-cyclic PCC {p:.5f} on device {i} (n_chunks={n_chunks}, T={T})"
+    plain = run_op(k, v, bc=False)
+    blockc = run_op(k_bc, v_bc, bc=True)
+    for i, (p_out, b_out) in enumerate(zip(plain, blockc)):
+        p = pcc(b_out, p_out)
+        assert p >= DEVICE_PCC, f"sp={sp} causal={causal}: block-cyclic != plain on dev {i} (pcc={p:.5f}, T={T})"
+
+    if not causal:  # non-causal is device-uniform -> also anchor plain to the layout-agnostic golden (correctness)
+        gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+        p = pcc(plain[0], gold)
+        assert p >= DEVICE_PCC, f"sp={sp}: plain op vs golden pcc={p:.5f}"

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Requires TT_MESH_GRAPH_DESC_PATH (the single_bh_galaxy descriptor) in the environment.
+
+"""sp>1 block-cyclic remap coverage for sparse_sdpa_msa (galaxy SP=8).
+
+The post-commit file only covers sp=1, where the invP block remap is the identity. This exercises the
+REAL permutation at sp=8: K/V are laid out block-cyclic (shard-major) across the SP axis exactly as the
+AllGather'd chunked-prefill cache is, block-ids stay NATURAL, and the op must remap each logical block to
+its physical block and reproduce the natural-order golden. Inputs are replicated across the mesh (sp is
+read from the mesh shape), so every device computes the same result; each is checked against the golden.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import (
+    BLK_KV,
+    make_msa_inputs,
+    pcc,
+    sparse_attention_ref_msa,
+)
+
+DEVICE_PCC = 0.99
+
+
+def _natural_to_block_cyclic(t, sp, n_chunks, chunk_local):
+    """Natural [1,H,T,d] (T = n_chunks*sp*chunk_local, order (chunk, shard, local)) -> block-cyclic
+    shard-major (shard, chunk, local), the layout AllGather produces from the per-shard cache. Inverse of
+    the model's old _blockcyclic_to_natural."""
+    H, T, d = t.shape[1], t.shape[2], t.shape[3]
+    t = t.reshape(1, H, n_chunks, sp, chunk_local, d)
+    t = t.permute(0, 1, 3, 2, 4, 5)  # (chunk, shard) -> (shard, chunk)
+    return t.reshape(1, H, T, d).contiguous()
+
+
+@pytest.fixture(scope="module")
+def sp_mesh():
+    mesh = ttnn.open_mesh_device(ttnn.MeshShape(8, 4))  # deployed SP=8 x TP=4 galaxy
+    yield mesh
+    ttnn.close_mesh_device(mesh)
+
+
+@pytest.mark.parametrize("n_chunks", [2, 4])
+def test_msa_native_block_cyclic_sp8_pcc(sp_mesh, n_chunks):
+    rows, cols = tuple(sp_mesh.shape)
+    sp_axis, sp = 0, rows  # SP is the row axis
+    H, n_kv, S, d = 32, 1, BLK_KV, 128
+    chunk_local = S  # == q_isl; guard allows q_isl or tp*q_isl
+    T = sp * n_chunks * chunk_local
+    topk = 16  # TOPK * idx.element_size() (4B) must be 64B-aligned -> topk a multiple of 16; nblk = T/128 >= 16
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=topk, d=d, causal=False, seed=T)
+
+    gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)  # natural-order, layout-agnostic
+    k_bc = _natural_to_block_cyclic(k, sp, n_chunks, chunk_local)
+    v_bc = _natural_to_block_cyclic(v, sp, n_chunks, chunk_local)
+
+    repl = ttnn.ReplicateTensorToMesh(sp_mesh)
+
+    def dev_rm(x, dt):
+        return ttnn.from_torch(
+            x, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=sp_mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG, mesh_mapper=repl,
+        )
+
+    def dev_tile(x, dt):
+        return ttnn.from_torch(
+            x.to(torch.bfloat16), dtype=dt, layout=ttnn.TILE_LAYOUT, device=sp_mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG, mesh_mapper=repl,
+        )
+
+    out = ttnn.transformer.sparse_sdpa_msa(
+        dev_rm(q.to(torch.float32), ttnn.bfloat16),
+        dev_tile(k_bc, ttnn.bfloat16),
+        dev_tile(v_bc, ttnn.bfloat16),
+        dev_rm(indices.to(torch.int32), ttnn.uint32),
+        scale=d**-0.5,
+        block_size=BLK_KV,
+        block_cyclic_sp_axis=sp_axis,
+        block_cyclic_chunk_local=chunk_local,
+    )
+
+    # Inputs replicated -> every device must reproduce the natural golden (proves the sp>1 invP permutation).
+    for i, shard in enumerate(ttnn.get_device_tensors(out)):
+        o = ttnn.to_torch(shard)[:, :H]
+        p = pcc(o, gold)
+        assert p >= DEVICE_PCC, f"sp={sp} block-cyclic PCC {p:.5f} on device {i} (n_chunks={n_chunks}, T={T})"

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
@@ -206,6 +206,8 @@ def run_op_msa_native(
     q_dtype=ttnn.bfloat16,
     chunk_start_idx=None,
     cluster_axis=None,
+    block_cyclic_sp_axis=None,
+    block_cyclic_chunk_local=None,
 ):
     """Run the native op. K/V are pre-tiled; q/indices/output stay row-major."""
     _, H, _, d = q.shape
@@ -234,6 +236,8 @@ def run_op_msa_native(
         block_size=block_size,
         chunk_start_idx=chunk_start_idx,  # set -> enable token-level diagonal-block causal mask
         cluster_axis=cluster_axis,
+        block_cyclic_sp_axis=block_cyclic_sp_axis,  # set -> K/V are block-cyclic; op remaps block ids in-kernel
+        block_cyclic_chunk_local=block_cyclic_chunk_local,
     )
     # Output dtype matches q. fp8 can't be to_torch'd directly, so typecast fp8 -> bf16 on device first.
     if tt_out.dtype == ttnn.fp8_e4m3:

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -252,3 +252,52 @@ def test_msa_native_causal_vs_noncausal_differs(device):
     out_causal = run_op_msa_native(q, k, v, indices, device, chunk_start_idx=0)
     out_block_only = run_op_msa_native(q, k, v, indices, device)  # chunk_start_idx=None -> legacy path
     assert pcc(out_causal, out_block_only) < 0.999, "causal mask had no effect vs block-only"
+
+
+# ---- block-cyclic remap: block-ids are NATURAL positions but the K/V cache is stored block-cyclic across SP
+# ---- shards. sp is DERIVED from the mesh (block_cyclic_sp_axis = the striped axis). On ONE device the mesh is
+# ---- 1x1 so sp=1 and the block-granular remap reduces to identity (shard=0, BC_SLAB_STRIDE_GAP=0 => phys=block)
+# ---- — enough to smoke the whole BC path (API, chunk_local cross-check, BC_ENABLE reader+writer branch, T
+# ---- hashing). The sp>1 PERMUTATION arithmetic needs a real SP mesh; that multi-device coverage is deferred to
+# ---- a nightly multidevice file (a mesh_device fixture can't share this single-device file), mirroring
+# ---- test_sparse_sdpa's block-cyclic coverage. ----
+@run_for_blackhole()
+def test_msa_native_block_cyclic_sp1_identity(device):
+    """sp=1 (from the 1x1 device-mesh): block-cyclic == natural, so the op must reproduce the natural golden
+    while exercising the BC_ENABLE path, across cache sizes T. T is hashed for this path (BC_SHARD_STRIDE_GAP is
+    a compile-time define), so each distinct T is a DISTINCT program — asserted below."""
+    H, n_kv, S, d, topk = 32, 1, 128, _D, 16  # S == chunk_local (mult of block_size); TOPK*4 must be 64B-aligned
+    Ts = (2048, 4096)  # nblk = T/128 >= topk; distinct T -> distinct program (T hashed for the BC path)
+    device.clear_program_cache()
+    for T in Ts:
+        nblk = T // BLK_KV
+        q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=min(topk, nblk), d=d, causal=False, seed=T)
+        gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5)
+        out = run_op_msa_native(q, k, v, indices, device, block_cyclic_sp_axis=0, block_cyclic_chunk_local=S)
+        p = pcc(out, gold)
+        assert p >= DEVICE_PCC, f"PCC {p:.5f} (sp=1 identity block-cyclic, T={T})"
+    n = device.num_program_cache_entries()
+    assert n == len(Ts), f"block-cyclic should hash cache size T: got {n} entries (expected {len(Ts)})"
+
+
+@run_for_blackhole()
+def test_msa_native_block_cyclic_sp1_bit_exact(device):
+    """The remap is pure addressing, not arithmetic: at sp=1 invP is the identity, so the block-cyclic path reads
+    the exact same tiles in the same order as the plain path and must produce a BIT-IDENTICAL result (stronger
+    than PCC — proves the BC_ENABLE branch and the extra phys_block computation perturb nothing)."""
+    H, n_kv, S, d, topk, T = 32, 1, 128, _D, 16, 2048
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=7)
+    plain = run_op_msa_native(q, k, v, indices, device)
+    bc = run_op_msa_native(q, k, v, indices, device, block_cyclic_sp_axis=0, block_cyclic_chunk_local=S)
+    assert torch.equal(plain, bc), f"block-cyclic sp=1 must be bit-identical to non-BC; max|delta|={(plain - bc).abs().max().item()}"
+
+
+@run_for_blackhole()
+def test_msa_native_block_cyclic_chunk_local_rejected(device, expect_error):
+    """The chunk_local cross-check rejects a value that is neither q_isl nor tp*q_isl. On a single device
+    sp=1/tp=1, so the only legal chunk_local is q_isl (= S); any other value must raise before dispatch."""
+    H, n_kv, S, d, topk = 32, 1, 128, _D, 2
+    T = 256
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=1)
+    with expect_error(RuntimeError, "block_cyclic_chunk_local"):
+        run_op_msa_native(q, k, v, indices, device, block_cyclic_sp_axis=0, block_cyclic_chunk_local=S - 32)

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -289,7 +289,9 @@ def test_msa_native_block_cyclic_sp1_bit_exact(device):
     q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=7)
     plain = run_op_msa_native(q, k, v, indices, device)
     bc = run_op_msa_native(q, k, v, indices, device, block_cyclic_sp_axis=0, block_cyclic_chunk_local=S)
-    assert torch.equal(plain, bc), f"block-cyclic sp=1 must be bit-identical to non-BC; max|delta|={(plain - bc).abs().max().item()}"
+    assert torch.equal(
+        plain, bc
+    ), f"block-cyclic sp=1 must be bit-identical to non-BC; max|delta|={(plain - bc).abs().max().item()}"
 
 
 @run_for_blackhole()

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/transformer/sdpa/device/block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared)
 #include <tt-metalium/base_types.hpp>
 
 namespace ttnn::operations::experimental::indexer_score {
@@ -37,10 +38,8 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
 // sparse_sdpa): the caller names the mesh axis the cache was striped over (block_cyclic_sp_axis) and passes
 // the per-shard chunk length (block_cyclic_chunk_local); sp = the mesh extent on that axis (DERIVED, not
 // free). Hashed (it shapes the reader binary). sp == 1 is the identity, represented as no block_cyclic at all.
-struct BlockCyclicLayout {
-    uint32_t sp;           // SP shard count the cache was gathered across (derived from the mesh sp axis)
-    uint32_t chunk_local;  // per-shard chunk length (elements); == chunk_size_global / sp == per-chip seq_len
-};
+// Shared type (sp, chunk_local) with sparse_sdpa / sparse_sdpa_msa — see block_cyclic_layout.hpp.
+using ttnn::prim::BlockCyclicLayout;
 
 struct operation_attributes_t {
     // Absolute chunk_start of rank 0. Rank r uses chunk_start_idx + r*Sq; the per-device value is derived

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -28,17 +28,8 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
     return cfg.head_group_size == 0 ? Hi : static_cast<uint32_t>(cfg.head_group_size);
 }
 
-// Block-cyclic (per-SP-shard) K cache layout. Chunked prefill stores each of `sp` SP shards' per-chunk slab
-// (chunk_local keys) back-to-back in its local cache, so after the SP all-gather the [B,1,T,D] k holds keys in
-// a PERMUTED physical order: physical row r holds the natural token at
-// P[r] = (lr/chunk_local)*chunk_global + c*chunk_local + (lr%chunk_local), where c = r/sll, lr = r%sll,
-// sll = T/sp, chunk_global = sp*chunk_local. The reader reads K back in LOGICAL token order (invP per tile),
-// so the causal mask and block-max-pool -- both keyed on the logical column -- stay byte-identical and the
-// score columns come out in natural token order. RESOLVED at the ttnn entry (interface + naming match
-// sparse_sdpa): the caller names the mesh axis the cache was striped over (block_cyclic_sp_axis) and passes
-// the per-shard chunk length (block_cyclic_chunk_local); sp = the mesh extent on that axis (DERIVED, not
-// free). Hashed (it shapes the reader binary). sp == 1 is the identity, represented as no block_cyclic at all.
-// Shared type (sp, chunk_local) with sparse_sdpa / sparse_sdpa_msa — see block_cyclic_layout.hpp.
+// Shared type (sp, chunk_local) with sparse_sdpa / sparse_sdpa_msa — see block_cyclic_layout.hpp; the
+// indexer reader reads K in logical order via this invP (reader_indexer_score.cpp).
 using ttnn::prim::BlockCyclicLayout;
 
 struct operation_attributes_t {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -17,6 +17,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp"  // shared invP remap
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"  // block-max-pool: calculate_and_prepare_reduce_scaler
 
 #include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -56,23 +56,6 @@ constexpr uint32_t bc_sp = get_compile_time_arg_val(bc_ct_base + 2);
 constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(bc_ct_base + 3);
 constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(bc_ct_base + 4);
 
-template <uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
-FORCE_INLINE uint32_t logical_to_chunked_physical(uint32_t n) {
-    const uint32_t block_idx = n / ChunkLocal;
-    const uint32_t slab = block_idx / Sp;
-    const uint32_t shard = block_idx - slab * Sp;
-    return n + shard * ShardStrideGap - slab * SlabStrideGap;
-}
-
-template <bool BlockCyclic, uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
-FORCE_INLINE uint32_t logical_to_physical_page(uint32_t page) {
-    if constexpr (BlockCyclic) {
-        return logical_to_chunked_physical<ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(page);
-    } else {
-        return page;
-    }
-}
-
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
 struct McastDir {
     uint32_t role;            // McastRole: none (DRAM read), sender (read + mcast), receiver (wait for mcast)
@@ -267,7 +250,7 @@ inline void read_k_chunk(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
             for (uint32_t k_col = 0; k_col < k_tiles_in_unit; ++k_col) {
-                const uint32_t seq_tile = logical_to_physical_page<
+                const uint32_t seq_tile = tt::block_cyclic::logical_to_physical_page<
                     block_cyclic,
                     bc_chunk_local,
                     bc_sp,
@@ -303,7 +286,7 @@ inline void read_k_chunk_streaming(
         uint32_t ptr = cb.get_write_ptr();
         for (uint32_t c = cbase; c < c_end; ++c) {
             if (c < k_tiles_in_unit) {
-                const uint32_t seq_tile = logical_to_physical_page<
+                const uint32_t seq_tile = tt::block_cyclic::logical_to_physical_page<
                     block_cyclic,
                     bc_chunk_local,
                     bc_sp,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/block_cyclic_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/block_cyclic_layout.hpp
@@ -8,16 +8,11 @@
 
 namespace ttnn::prim {
 
-// Block-cyclic ("slab") KV layout, shared by sparse_sdpa (DSA) and sparse_sdpa_msa. When set, the gathered
+// Block-cyclic ("slab") KV layout, shared by sparse_sdpa, sparse_sdpa_msa, and indexer_score. When set, the gathered
 // `indices` are NATURAL positions but the kv cache is stored block-cyclic across `sp` SP shards with per-shard
 // chunk `chunk_local` (the chunked-prefill cache, written by update_padded_kv_cache). The gather kernels remap
 // each natural index -> physical page/block on the fly (invP, the inverse of the writer's blockcyclic_positions),
 // so the host does NOT reorder the kv buffer back to natural order before the op.
-//
-// Both fields are resolved+validated at the ttnn entry: `sp` is read from the mesh axis the cache was striped
-// over (a caller cannot pass an sp that disagrees with the device), and `chunk_local` is cross-checked against
-// q's per-chip seq length. `sp`/`chunk_local` are folded into the program hash (BC_* are compile-time defines),
-// so they must be the resolved values, not a mesh axis index.
 struct BlockCyclicLayout {
     uint32_t sp;           // SP shard count the cache was written across (resolved from the mesh)
     uint32_t chunk_local;  // per-shard chunk length (chunk_size_global / sp == per-chip seq_len_local)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/block_cyclic_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/block_cyclic_layout.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace ttnn::prim {
+
+// Block-cyclic ("slab") KV layout, shared by sparse_sdpa (DSA) and sparse_sdpa_msa. When set, the gathered
+// `indices` are NATURAL positions but the kv cache is stored block-cyclic across `sp` SP shards with per-shard
+// chunk `chunk_local` (the chunked-prefill cache, written by update_padded_kv_cache). The gather kernels remap
+// each natural index -> physical page/block on the fly (invP, the inverse of the writer's blockcyclic_positions),
+// so the host does NOT reorder the kv buffer back to natural order before the op.
+//
+// Both fields are resolved+validated at the ttnn entry: `sp` is read from the mesh axis the cache was striped
+// over (a caller cannot pass an sp that disagrees with the device), and `chunk_local` is cross-checked against
+// q's per-chip seq length. `sp`/`chunk_local` are folded into the program hash (BC_* are compile-time defines),
+// so they must be the resolved values, not a mesh axis index.
+struct BlockCyclicLayout {
+    uint32_t sp;           // SP shard count the cache was written across (resolved from the mesh)
+    uint32_t chunk_local;  // per-shard chunk length (chunk_size_global / sp == per-chip seq_len_local)
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
@@ -6,19 +6,16 @@
 // chunked-prefill cache stores, per shard, `[chunk0_local, chunk1_local, ...]`; AllGather over the SP axis
 // then yields a shard-major buffer, while the ops index in natural (logical) token order. This maps a
 // logical index to its physical position so the gather reads the block-cyclic buffer in place — no host
-// reorder. Shared by sparse_sdpa (rows), sparse_sdpa_msa (blocks), and indexer_score (tiles): the unit is
-// the caller's; each passes chunk_local and the two gaps in its own unit.
+// reorder. Unit-agnostic (pure index math): each op works in its own granularity — sparse_sdpa in rows,
+// sparse_sdpa_msa in blocks, indexer_score in tiles — and passes n / chunk_local / both stride gaps in it.
 #pragma once
 
 #include <stdint.h>
 
 namespace tt::block_cyclic {
 
-// Natural order is slab-major (chunk after chunk, shard-within); the physical buffer is shard-major (each
-// shard's whole region, slabs-within), so the map is a transpose of the (slab, shard) decomposition:
-//   block_idx = n / chunk_local;  slab = block_idx / sp;  shard = block_idx % sp
-//   physical  = n + shard*shard_stride_gap - slab*slab_stride_gap
-// All args are compile-time constants at every call site, so this folds to one divide (mul+shift) + shift/mask.
+// invP of the (slab, shard) transpose (see file header). Args are compile-time constants at every call
+// site, so this folds to one divide (mul+shift) + shift/mask.
 inline uint32_t logical_to_chunked_physical(
     uint32_t n, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
     const uint32_t block_idx = n / chunk_local;  // = slab*sp + shard

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
@@ -7,21 +7,32 @@
 // then yields a shard-major buffer, while the ops index in natural (logical) token order. This maps a
 // logical index to its physical position so the gather reads the block-cyclic buffer in place — no host
 // reorder. Unit-agnostic (pure index math): each op works in its own granularity — sparse_sdpa in rows,
-// sparse_sdpa_msa in blocks, indexer_score in tiles — and passes n / chunk_local / both stride gaps in it.
+// sparse_sdpa_msa in blocks, indexer_score in tiles — and bakes chunk_local / both stride gaps as template args.
 #pragma once
 
 #include <stdint.h>
 
 namespace tt::block_cyclic {
 
-// invP of the (slab, shard) transpose (see file header). Args are compile-time constants at every call
-// site, so this folds to one divide (mul+shift) + shift/mask.
-FORCE_INLINE uint32_t logical_to_chunked_physical(
-    uint32_t n, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
-    const uint32_t block_idx = n / chunk_local;  // = slab*sp + shard
-    const uint32_t slab = block_idx / sp;
-    const uint32_t shard = block_idx - slab * sp;
-    return n + shard * shard_stride_gap - slab * slab_stride_gap;
+// invP of the (slab, shard) transpose (see file header). The divisors are template (compile-time) args, so
+// this folds to one divide (mul+shift) + shift/mask.
+template <uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
+FORCE_INLINE uint32_t logical_to_chunked_physical(uint32_t n) {
+    const uint32_t block_idx = n / ChunkLocal;  // = slab*Sp + shard
+    const uint32_t slab = block_idx / Sp;
+    const uint32_t shard = block_idx - slab * Sp;
+    return n + shard * ShardStrideGap - slab * SlabStrideGap;
+}
+
+// Natural -> physical dispatch. BlockCyclic == false (a contiguous, natural-order cache) folds to the
+// identity, so a natural-order cache emits no remap arithmetic.
+template <bool BlockCyclic, uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
+FORCE_INLINE uint32_t logical_to_physical_page(uint32_t page) {
+    if constexpr (BlockCyclic) {
+        return logical_to_chunked_physical<ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(page);
+    } else {
+        return page;
+    }
 }
 
 }  // namespace tt::block_cyclic

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Inverse permutation for a cache striped block-cyclic ("slab") across SP shards. A DeepSeek/MiniMax
+// chunked-prefill cache stores, per shard, `[chunk0_local, chunk1_local, ...]`; AllGather over the SP axis
+// then yields a shard-major buffer, while the ops index in natural (logical) token order. This maps a
+// logical index to its physical position so the gather reads the block-cyclic buffer in place — no host
+// reorder. Shared by sparse_sdpa (rows), sparse_sdpa_msa (blocks), and indexer_score (tiles): the unit is
+// the caller's; each passes chunk_local and the two gaps in its own unit.
+#pragma once
+
+#include <stdint.h>
+
+namespace tt::block_cyclic {
+
+// Natural order is slab-major (chunk after chunk, shard-within); the physical buffer is shard-major (each
+// shard's whole region, slabs-within), so the map is a transpose of the (slab, shard) decomposition:
+//   block_idx = n / chunk_local;  slab = block_idx / sp;  shard = block_idx % sp
+//   physical  = n + shard*shard_stride_gap - slab*slab_stride_gap
+// All args are compile-time constants at every call site, so this folds to one divide (mul+shift) + shift/mask.
+inline uint32_t logical_to_chunked_physical(
+    uint32_t n, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
+    const uint32_t block_idx = n / chunk_local;  // = slab*sp + shard
+    const uint32_t slab = block_idx / sp;
+    const uint32_t shard = block_idx - slab * sp;
+    return n + shard * shard_stride_gap - slab * slab_stride_gap;
+}
+
+}  // namespace tt::block_cyclic

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/block_cyclic_remap.hpp
@@ -16,7 +16,7 @@ namespace tt::block_cyclic {
 
 // invP of the (slab, shard) transpose (see file header). Args are compile-time constants at every call
 // site, so this folds to one divide (mul+shift) + shift/mask.
-inline uint32_t logical_to_chunked_physical(
+FORCE_INLINE uint32_t logical_to_chunked_physical(
     uint32_t n, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
     const uint32_t block_idx = n / chunk_local;  // = slab*sp + shard
     const uint32_t slab = block_idx / sp;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
@@ -9,31 +9,13 @@
 
 #include <stdint.h>
 
-#include "block_cyclic_remap.hpp"
+#include "block_cyclic_remap.hpp"  // tt::block_cyclic::logical_to_physical_page (invP remap, rows)
 
 namespace sparse_sdpa {
 
 // Per-NoC trid-ring depth for each gather half (swept: 4 is the sweet spot — with the split halving each
 // NoC's load, a shallow ring beats both the plain burst and the old deep single-NoC ring).
 constexpr uint32_t K_TRID_RING = 4;
-
-// Maps a natural KV index to its physical page in a shard-major, block-cyclic cache.
-template <uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
-FORCE_INLINE uint32_t logical_to_chunked_physical(uint32_t n) {
-    const uint32_t block_idx = n / ChunkLocal;
-    const uint32_t slab = block_idx / Sp;
-    const uint32_t shard = block_idx - slab * Sp;
-    return n + shard * ShardStrideGap - slab * SlabStrideGap;
-}
-
-template <bool BlockCyclic, uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
-FORCE_INLINE uint32_t logical_to_physical_page(uint32_t page) {
-    if constexpr (BlockCyclic) {
-        return logical_to_chunked_physical<ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(page);
-    } else {
-        return page;
-    }
-}
 
 template <
     bool BlockCyclic,
@@ -62,7 +44,8 @@ FORCE_INLINE void trid_ring_gather(
         }
         experimental::set_read_trid(noc, trid);
         const uint32_t page =
-            logical_to_physical_page<BlockCyclic, ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(idx_ptr[base + p]);
+            tt::block_cyclic::logical_to_physical_page<BlockCyclic, ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(
+                idx_ptr[base + p]);
         noc.async_read(kv, k_cb, k_row_bytes, {.page_id = page_offset + page}, {.offset_bytes = p * k_row_bytes});
     }
     const uint32_t to_drain = (cnt < D) ? cnt : D;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include "block_cyclic_remap.hpp"
+
 namespace sparse_sdpa {
 
 // Per-NoC trid-ring depth for each gather half (swept: 4 is the sweet spot — with the split halving each

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
@@ -10,6 +10,7 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
 #include "dataflow_common.hpp"         // fill_vertical_tile_bf16 (causal partial-column mask tile)
+#include "block_cyclic_remap.hpp"      // logical_to_chunked_physical (block-cyclic cache, BC_ENABLE)
 
 constexpr uint32_t sentinel = 0xFFFFFFFFu;
 
@@ -177,8 +178,15 @@ void kernel_main() {
             ASSERT(block_id != sentinel);
 
             // Reader reserves the whole block; writer fills the lower half, reader fills the upper half.
-            uint32_t k_tile0 = k_batch_tile_offset + block_id * k_tiles_per_block;
-            uint32_t v_tile0 = v_batch_tile_offset + block_id * v_tiles_per_block;
+            // Block-cyclic cache: remap the logical block id to its physical block before addressing (invP).
+            // Addressing only — the sentinel search and the diagonal-block causal match stay on the logical id.
+            uint32_t phys_block = block_id;
+#ifdef BC_ENABLE
+            phys_block = tt::block_cyclic::logical_to_chunked_physical(
+                block_id, BC_CHUNK_LOCAL, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP);
+#endif
+            uint32_t k_tile0 = k_batch_tile_offset + phys_block * k_tiles_per_block;
+            uint32_t v_tile0 = v_batch_tile_offset + phys_block * v_tiles_per_block;
             if constexpr (n_kv > 1) {
                 k_tile0 += kv_group * k_group_tile_stride;
                 v_tile0 += kv_group * v_group_tile_stride;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_reader.cpp
@@ -10,7 +10,7 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
 #include "dataflow_common.hpp"         // fill_vertical_tile_bf16 (causal partial-column mask tile)
-#include "block_cyclic_remap.hpp"      // logical_to_chunked_physical (block-cyclic cache, BC_ENABLE)
+#include "block_cyclic_remap.hpp"      // tt::block_cyclic::logical_to_physical_page (block-cyclic cache remap)
 
 constexpr uint32_t sentinel = 0xFFFFFFFFu;
 
@@ -44,8 +44,16 @@ void kernel_main() {
     constexpr uint32_t block_size = get_compile_time_arg_val(21);  // tokens per block (for p%bs, p/bs)
     constexpr uint32_t cb_vmask = get_compile_time_arg_val(22);    // per-token partial-column mask tile
 
+    // Block-cyclic ("slab") cache remap in BLOCK units: baked compile-time so a natural-order cache folds to
+    // identity (block_cyclic false). Kept in lockstep with the writer's block remap.
+    constexpr bool block_cyclic = get_compile_time_arg_val(23) != 0;
+    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(24);
+    constexpr uint32_t bc_sp = get_compile_time_arg_val(25);
+    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(26);
+    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(27);
+
     // K/V use RuntimeTensorShape so T can vary without recompilation.
-    constexpr auto q_args = TensorAccessorArgs<23, 0>();
+    constexpr auto q_args = TensorAccessorArgs<28, 0>();
     constexpr auto k_args =
         TensorAccessorArgs<q_args.next_compile_time_args_offset(), q_args.next_common_runtime_args_offset()>();
     constexpr auto v_args =
@@ -180,11 +188,10 @@ void kernel_main() {
             // Reader reserves the whole block; writer fills the lower half, reader fills the upper half.
             // Block-cyclic cache: remap the logical block id to its physical block before addressing (invP).
             // Addressing only — the sentinel search and the diagonal-block causal match stay on the logical id.
-            uint32_t phys_block = block_id;
-#ifdef BC_ENABLE
-            phys_block = tt::block_cyclic::logical_to_chunked_physical(
-                block_id, BC_CHUNK_LOCAL, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP);
-#endif
+            // Identity for a natural-order cache (block_cyclic false).
+            const uint32_t phys_block = tt::block_cyclic::
+                logical_to_physical_page<block_cyclic, bc_chunk_local, bc_sp, bc_shard_stride_gap, bc_slab_stride_gap>(
+                    block_id);
             uint32_t k_tile0 = k_batch_tile_offset + phys_block * k_tiles_per_block;
             uint32_t v_tile0 = v_batch_tile_offset + phys_block * v_tiles_per_block;
             if constexpr (n_kv > 1) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
@@ -12,7 +12,7 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
 #include "dataflow_common.hpp"         // fill_neginf_tile (persistent causal -inf mask tile)
-#include "block_cyclic_remap.hpp"      // logical_to_chunked_physical (block-cyclic cache, BC_ENABLE)
+#include "block_cyclic_remap.hpp"      // tt::block_cyclic::logical_to_physical_page (block-cyclic cache remap)
 
 constexpr uint32_t one_bf16_packed = 0x3F803F80u;  // bf16(1.0) double-packed; generate_bcast_col_scalar uses >>16
 
@@ -40,7 +40,14 @@ void kernel_main() {
     constexpr uint32_t v_tile_bytes = get_compile_time_arg_val(17);
     constexpr bool CAUSAL_MASK_ENABLED = get_compile_time_arg_val(18) != 0;
     constexpr uint32_t cb_neginf = get_compile_time_arg_val(19);
-    constexpr auto out_args = TensorAccessorArgs<20, 0>();
+
+    // Block-cyclic ("slab") cache remap in BLOCK units; same constants as the reader (see its comment).
+    constexpr bool block_cyclic = get_compile_time_arg_val(20) != 0;
+    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(21);
+    constexpr uint32_t bc_sp = get_compile_time_arg_val(22);
+    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(23);
+    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(24);
+    constexpr auto out_args = TensorAccessorArgs<25, 0>();
     // K/V use RuntimeTensorShape so T can vary without recompilation.
     constexpr auto k_args =
         TensorAccessorArgs<out_args.next_compile_time_args_offset(), out_args.next_common_runtime_args_offset()>();
@@ -102,11 +109,10 @@ void kernel_main() {
             }
             kreq_cb.pop_front(1);
             // Block-cyclic cache: remap the logical block id (from the reader) to its physical block (invP).
-            uint32_t phys_block = block_id;
-#ifdef BC_ENABLE
-            phys_block = tt::block_cyclic::logical_to_chunked_physical(
-                block_id, BC_CHUNK_LOCAL, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP);
-#endif
+            // Identity for a natural-order cache (block_cyclic false).
+            const uint32_t phys_block = tt::block_cyclic::
+                logical_to_physical_page<block_cyclic, bc_chunk_local, bc_sp, bc_shard_stride_gap, bc_slab_stride_gap>(
+                    block_id);
             uint32_t k_tile0 = k_batch_tile_offset + phys_block * k_tiles_per_block;
             uint32_t v_tile0 = v_batch_tile_offset + phys_block * v_tiles_per_block;
             if constexpr (n_kv > 1) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_msa_writer.cpp
@@ -12,6 +12,7 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "sparse_sdpa_msa_gather.hpp"  // per-NoC trid-ring (K_TRID_RING knob)
 #include "dataflow_common.hpp"         // fill_neginf_tile (persistent causal -inf mask tile)
+#include "block_cyclic_remap.hpp"      // logical_to_chunked_physical (block-cyclic cache, BC_ENABLE)
 
 constexpr uint32_t one_bf16_packed = 0x3F803F80u;  // bf16(1.0) double-packed; generate_bcast_col_scalar uses >>16
 
@@ -100,8 +101,14 @@ void kernel_main() {
                 last = rq[1] != 0;
             }
             kreq_cb.pop_front(1);
-            uint32_t k_tile0 = k_batch_tile_offset + block_id * k_tiles_per_block;
-            uint32_t v_tile0 = v_batch_tile_offset + block_id * v_tiles_per_block;
+            // Block-cyclic cache: remap the logical block id (from the reader) to its physical block (invP).
+            uint32_t phys_block = block_id;
+#ifdef BC_ENABLE
+            phys_block = tt::block_cyclic::logical_to_chunked_physical(
+                block_id, BC_CHUNK_LOCAL, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP);
+#endif
+            uint32_t k_tile0 = k_batch_tile_offset + phys_block * k_tiles_per_block;
+            uint32_t v_tile0 = v_batch_tile_offset + phys_block * v_tiles_per_block;
             if constexpr (n_kv > 1) {
                 k_tile0 += kv_group * k_group_tile_stride;
                 v_tile0 += kv_group * v_group_tile_stride;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -11,19 +11,6 @@
 
 namespace ttnn::prim {
 
-// Block-cyclic KV layout. When set, the gathered `indices` are NATURAL token positions, but the kv cache is
-// stored block-cyclic across `sp` SP shards with per-shard chunk `chunk_local` (the DeepSeek chunked-prefill
-// KVPE cache, written by update_padded_kv_cache). The gather kernels remap each natural index -> physical page
-// id on the fly (invP, the inverse of the cache writer's blockcyclic_positions), so the host does NOT have to
-// reorder the kv buffer back to natural order before the op.
-//
-// `sp` is resolved from the cache's mesh axis and `chunk_local` is cross-checked against q's local sequence length
-// at the ttnn entry. Both are compile-time kernel arguments, so `sp` is the resolved shard count, not a mesh axis.
-struct BlockCyclicLayout {
-    uint32_t sp;           // SP shard count the cache was written across (resolved from the mesh)
-    uint32_t chunk_local;  // per-shard chunk length (chunk_size_global / sp == per-chip seq_len_local)
-};
-
 // Sparse MLA prefill (DeepSeek DSA).
 struct SparseSDPAParams {
     float scale = 1.0f;  // compile-time (folded into the program hash)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -6,7 +6,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
-#include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared with sparse_sdpa_msa)
+#include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared)
 #include <optional>
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared with sparse_sdpa_msa)
 #include <optional>
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -203,8 +203,8 @@ ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
     const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
     // Hash compile-time choices. Interleaved K/V T and cache_batch_idx are patched at dispatch.
     // Sharded K/V shapes stay hashed because accessor strides depend on them. The block-cyclic path also
-    // hashes T: BC_SHARD_STRIDE_GAP (= T/sp - chunk_local) is baked as a compile-time define, so a different
-    // cache size must be a distinct program.
+    // hashes T: BC_SHARD_STRIDE_GAP (= (T/sp - chunk_local)/block_size, in blocks) is baked as a compile-time
+    // define, so a different cache size must be a distinct program.
     return tt::tt_metal::operation::hash_operation<SparseSDPAMsaOperation>(
         std::bit_cast<uint32_t>(attrs.scale),
         attrs.block_size,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -150,6 +150,37 @@ void SparseSDPAMsaOperation::validate_on_program_cache_miss(
     TT_FATAL((d * q.element_size()) % dram_align == 0, "q row bytes must be {}B aligned", dram_align);
     TT_FATAL((TOPK * idx.element_size()) % dram_align == 0, "indices row bytes must be {}B aligned", dram_align);
     TT_FATAL((v_dim * q.element_size()) % dram_align == 0, "output row bytes must be {}B aligned", dram_align);
+
+    // Block-cyclic ("slab") cache: the invP block remap bakes T/sp and chunk_local (in blocks) as compile-time
+    // defines, so the layout must divide cleanly. Miss-only — the constants are hashed.
+    if (attrs.has_block_cyclic()) {
+        const uint32_t sp = attrs.block_cyclic->sp;
+        const uint32_t chunk_local = attrs.block_cyclic->chunk_local;
+        const uint32_t T = k.logical_shape()[2];
+        TT_FATAL(
+            sp > 0 && chunk_local > 0,
+            "block_cyclic sp/chunk_local must be > 0 (got sp {}, chunk_local {})",
+            sp,
+            chunk_local);
+        TT_FATAL(T % sp == 0, "block_cyclic: sp ({}) must divide T ({})", sp, T);
+        const uint32_t shard_len = T / sp;
+        TT_FATAL(
+            shard_len % chunk_local == 0,
+            "block_cyclic: chunk_local ({}) must divide shard_len T/sp ({})",
+            chunk_local,
+            shard_len);
+        // Remap is block-granular -> chunk_local and shard_len must be whole numbers of blocks.
+        TT_FATAL(
+            chunk_local % attrs.block_size == 0,
+            "block_cyclic: block_size ({}) must divide chunk_local ({})",
+            attrs.block_size,
+            chunk_local);
+        TT_FATAL(
+            shard_len % attrs.block_size == 0,
+            "block_cyclic: block_size ({}) must divide shard_len T/sp ({})",
+            attrs.block_size,
+            shard_len);
+    }
 }
 
 SparseSDPAMsaOperation::spec_return_value_t SparseSDPAMsaOperation::compute_output_specs(
@@ -171,7 +202,9 @@ SparseSDPAMsaOperation::tensor_return_value_t SparseSDPAMsaOperation::create_out
 ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
     const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
     // Hash compile-time choices. Interleaved K/V T and cache_batch_idx are patched at dispatch.
-    // Sharded K/V shapes stay hashed because accessor strides depend on them.
+    // Sharded K/V shapes stay hashed because accessor strides depend on them. The block-cyclic path also
+    // hashes T: BC_SHARD_STRIDE_GAP (= T/sp - chunk_local) is baked as a compile-time define, so a different
+    // cache size must be a distinct program.
     return tt::tt_metal::operation::hash_operation<SparseSDPAMsaOperation>(
         std::bit_cast<uint32_t>(attrs.scale),
         attrs.block_size,
@@ -180,13 +213,16 @@ ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
         t.q.dtype(),
         t.k.dtype(),
         t.k.memory_config(),
-        t.k.memory_config().is_sharded() ? t.k.logical_shape() : tt::tt_metal::Shape{},
+        (t.k.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.k.logical_shape() : tt::tt_metal::Shape{},
         t.v.dtype(),
         t.v.memory_config(),
-        t.v.memory_config().is_sharded() ? t.v.logical_shape() : tt::tt_metal::Shape{},
+        (t.v.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.v.logical_shape() : tt::tt_metal::Shape{},
         t.v.logical_shape()[3],
         attrs.has_indexed_kv_cache(),
         attrs.causal_enabled(),
+        attrs.has_block_cyclic(),
+        attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
+        attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
         t.indices.logical_shape(),
         t.indices.dtype());
 }
@@ -318,7 +354,8 @@ Tensor sparse_sdpa_msa(
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> chunk_start_idx,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<BlockCyclicLayout> block_cyclic) {
     using OperationType = ttnn::prim::SparseSDPAMsaOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -326,6 +363,7 @@ Tensor sparse_sdpa_msa(
             .block_size = block_size,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,
+            .block_cyclic = block_cyclic,
             .chunk_start_idx = chunk_start_idx,
             .cluster_axis = cluster_axis,
         },

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -152,7 +152,7 @@ void SparseSDPAMsaOperation::validate_on_program_cache_miss(
     TT_FATAL((v_dim * q.element_size()) % dram_align == 0, "output row bytes must be {}B aligned", dram_align);
 
     // Block-cyclic ("slab") cache: the invP block remap bakes T/sp and chunk_local (in blocks) as compile-time
-    // defines, so the layout must divide cleanly. Miss-only — the constants are hashed.
+    // arguments, so the layout must divide cleanly. Miss-only — the constants are hashed.
     if (attrs.has_block_cyclic()) {
         const uint32_t sp = attrs.block_cyclic->sp;
         const uint32_t chunk_local = attrs.block_cyclic->chunk_local;
@@ -203,8 +203,8 @@ ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
     const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
     // Hash compile-time choices. Interleaved K/V T and cache_batch_idx are patched at dispatch.
     // Sharded K/V shapes stay hashed because accessor strides depend on them. The block-cyclic path also
-    // hashes T: BC_SHARD_STRIDE_GAP (= (T/sp - chunk_local)/block_size, in blocks) is baked as a compile-time
-    // define, so a different cache size must be a distinct program.
+    // hashes T: the shard stride gap (= (T/sp - chunk_local)/block_size, in blocks) is baked as a compile-time
+    // argument, so a different cache size must be a distinct program.
     return tt::tt_metal::operation::hash_operation<SparseSDPAMsaOperation>(
         std::bit_cast<uint32_t>(attrs.scale),
         attrs.block_size,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -90,6 +90,7 @@ Tensor sparse_sdpa_msa(
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> chunk_start_idx = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt);
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<BlockCyclicLayout> block_cyclic = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
@@ -6,7 +6,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
-#include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared with sparse_sdpa)
+#include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared)
 #include <optional>
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared with sparse_sdpa)
 #include <optional>
 
 namespace ttnn::prim {
@@ -18,6 +19,8 @@ struct SparseSDPAMsaParams {
     DeviceComputeKernelConfig compute_kernel_config;
     // Selects one [B,n_kv,T,*] cache slot. The value is patched as runtime K/V tile offsets and is not hashed.
     std::optional<uint32_t> cache_batch_idx = std::nullopt;
+    // Set -> the K/V cache is block-cyclic across SP; the gather kernels apply the invP block remap. Hashed.
+    std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
     // Global position of query row 0.
     // Set -> enforce a token-level causal mask on the diagonal block (the query's own block, whose later tokens are
     // future). Unset -> no token-level causality; the op attends the full selected blocks.
@@ -26,6 +29,7 @@ struct SparseSDPAMsaParams {
     std::optional<uint32_t> cluster_axis = std::nullopt;
     bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
     bool causal_enabled() const { return chunk_start_idx.has_value(); }
+    bool has_block_cyclic() const { return block_cyclic.has_value(); }
 };
 
 struct SparseSDPAMsaInputs {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -216,6 +216,24 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     writer_desc.common_runtime_args = writer_crt;
     writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
 
+    // Block-cyclic ("slab") cache: emit the invP remap constants as compile-time defines to both dataflow
+    // kernels, which each remap their gathered block ids. Constants are in BLOCK units (mirrors sparse_sdpa's
+    // add_bc_defines, which is in rows). No runtime arg — T is folded into the program hash for this path.
+    if (attrs.has_block_cyclic()) {
+        const uint32_t bc_sp = attrs.block_cyclic->sp;
+        const uint32_t bc_chunk_local_blk = attrs.block_cyclic->chunk_local / block_size;
+        const uint32_t bc_shard_len_blk = (t.k.logical_shape()[2] / bc_sp) / block_size;
+        std::map<std::string, std::string> bc_defs{
+            {"BC_ENABLE", "1"},
+            {"BC_SP", std::to_string(bc_sp)},
+            {"BC_CHUNK_LOCAL", std::to_string(bc_chunk_local_blk)},
+            {"BC_SHARD_STRIDE_GAP", std::to_string(bc_shard_len_blk - bc_chunk_local_blk)},
+            {"BC_SLAB_STRIDE_GAP", std::to_string(bc_chunk_local_blk * (bc_sp - 1))},
+        };
+        reader_desc.defines = tt::tt_metal::KernelDescriptor::Defines(bc_defs.begin(), bc_defs.end());
+        writer_desc.defines = tt::tt_metal::KernelDescriptor::Defines(bc_defs.begin(), bc_defs.end());
+    }
+
     auto [math_fidelity, math_approx, fp32_acc, packer_l1_acc, dst_full_sync] =
         get_compute_kernel_config_args(tt::tt_metal::hal::get_arch(), attrs.compute_kernel_config);
     (void)packer_l1_acc;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <array>
 #include <bit>
 #include <map>
 #include <string>
@@ -142,6 +143,27 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
         cb(tile_bytes, 2, bf);  // cb_vmask : per-token partial-column mask tile
     }
 
+    // Block-cyclic ("slab") cache: the invP remap is baked as compile-time args, so a natural-order cache folds
+    // to identity. Units are BLOCKS here (sparse_sdpa works in rows, indexer_score in tiles). Reader and writer
+    // take the same block {enable, chunk_local, sp, shard_stride_gap, slab_stride_gap}.
+    const auto block_cyclic_ct = [&attrs, &t, block_size]() {
+        std::array<uint32_t, 5> args{0, 1, 1, 0, 0};
+        if (!attrs.has_block_cyclic()) {
+            return args;
+        }
+        const auto& bc = attrs.block_cyclic.value();
+        const uint32_t chunk_local_blk = bc.chunk_local / block_size;
+        const uint32_t shard_len_blk = (t.k.logical_shape()[2] / bc.sp) / block_size;
+        args = {
+            1,
+            chunk_local_blk,
+            bc.sp,
+            shard_len_blk - chunk_local_blk,
+            chunk_local_blk * (bc.sp - 1),
+        };
+        return args;
+    }();
+
     // ---- compile-time args ----
     // Reader args: scalars, derived geometry, CB ids, element sizes, then q/k/v/indices accessors.
     // K/V use RuntimeTensorShape.
@@ -155,6 +177,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     reader_ct.push_back(attrs.causal_enabled() ? 1u : 0u);  // CAUSAL_MASK_ENABLED
     reader_ct.push_back(block_size);                        // block_size: for diag_block = p/bs, offset = p%bs
     reader_ct.push_back(cb_vmask);                          // reader builds the per-token partial-column tile
+    reader_ct.insert(reader_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
     std::vector<uint32_t> reader_crt;
     tt::tt_metal::TensorAccessorArgs(t.q.buffer()).append_to(reader_ct, reader_crt);
     tt::tt_metal::TensorAccessorArgs(t.k.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
@@ -186,6 +209,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     writer_ct.push_back(v_tile_bytes);
     writer_ct.push_back(attrs.causal_enabled() ? 1u : 0u);  // CAUSAL_MASK_ENABLED
     writer_ct.push_back(cb_neginf);                         // writer builds the persistent -inf mask tile
+    writer_ct.insert(writer_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
     std::vector<uint32_t> writer_crt;
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_ct, writer_crt);
     tt::tt_metal::TensorAccessorArgs(t.k.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
@@ -215,24 +239,6 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     writer_desc.compile_time_args = writer_ct;
     writer_desc.common_runtime_args = writer_crt;
     writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
-
-    // Block-cyclic ("slab") cache: emit the invP remap constants as compile-time defines to both dataflow
-    // kernels, which each remap their gathered block ids. Constants are in BLOCK units (mirrors sparse_sdpa's
-    // add_bc_defines, which is in rows). No runtime arg — T is folded into the program hash for this path.
-    if (attrs.has_block_cyclic()) {
-        const uint32_t bc_sp = attrs.block_cyclic->sp;
-        const uint32_t bc_chunk_local_blk = attrs.block_cyclic->chunk_local / block_size;
-        const uint32_t bc_shard_len_blk = (t.k.logical_shape()[2] / bc_sp) / block_size;
-        std::map<std::string, std::string> bc_defs{
-            {"BC_ENABLE", "1"},
-            {"BC_SP", std::to_string(bc_sp)},
-            {"BC_CHUNK_LOCAL", std::to_string(bc_chunk_local_blk)},
-            {"BC_SHARD_STRIDE_GAP", std::to_string(bc_shard_len_blk - bc_chunk_local_blk)},
-            {"BC_SLAB_STRIDE_GAP", std::to_string(bc_chunk_local_blk * (bc_sp - 1))},
-        };
-        reader_desc.defines = tt::tt_metal::KernelDescriptor::Defines(bc_defs.begin(), bc_defs.end());
-        writer_desc.defines = tt::tt_metal::KernelDescriptor::Defines(bc_defs.begin(), bc_defs.end());
-    }
 
     auto [math_fidelity, math_approx, fp32_acc, packer_l1_acc, dst_full_sync] =
         get_compute_kernel_config_args(tt::tt_metal::hal::get_arch(), attrs.compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -398,6 +398,11 @@ void bind_sdpa(nb::module_& mod) {
 		selects a different cached program. Requires bf16 q; fp8 q with this set is rejected.
             cluster_axis (int, optional): SP mesh axis used to derive the per-device chunk_start
                 (chunk_start_idx + rank*S) under sequence parallelism. Host-side only.
+            block_cyclic_sp_axis (int, optional): when set (with block_cyclic_chunk_local), the K/V cache is
+                striped block-cyclic across SP on this mesh axis; the gather remaps each logical block id to its
+                physical block in-kernel (invP), so no host reorder is needed. sp is read from the mesh.
+            block_cyclic_chunk_local (int, optional): per-shard chunk length (chunk_size_global / sp). Required
+                iff block_cyclic_sp_axis is set; cross-checked against q (must equal q_isl or tp*q_isl).
 
         Returns:
             ttnn.Tensor: [1, H, S, v_dim] ROW-MAJOR, dtype = q.
@@ -416,7 +421,9 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("cache_batch_idx") = nb::none(),
         nb::arg("chunk_start_idx") = nb::none(),
-        nb::arg("cluster_axis") = nb::none());
+        nb::arg("cluster_axis") = nb::none(),
+        nb::arg("block_cyclic_sp_axis") = nb::none(),
+        nb::arg("block_cyclic_chunk_local") = nb::none());
 
     const auto* const chunked_doc =
         R"doc(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.cpp
@@ -19,9 +19,38 @@ ttnn::Tensor sparse_sdpa_msa(
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> chunk_start_idx,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> block_cyclic_sp_axis,
+    std::optional<uint32_t> block_cyclic_chunk_local) {
     const uint32_t d = q.logical_shape()[3];  // head dim, from the tensor
     const float resolved_scale = scale.value_or(1.0f / std::sqrt(static_cast<float>(d)));
+
+    // Block-cyclic cache: resolve sp from the mesh (a caller can't pass an sp that disagrees with the device)
+    // and cross-check chunk_local against q, so the invP remap gets ground-truth layout, not a trusted arg.
+    TT_FATAL(
+        block_cyclic_sp_axis.has_value() == block_cyclic_chunk_local.has_value(),
+        "block_cyclic_sp_axis and block_cyclic_chunk_local must be set together");
+    std::optional<ttnn::prim::BlockCyclicLayout> block_cyclic;
+    if (block_cyclic_sp_axis.has_value()) {
+        const auto mesh_shape = q.device()->get_view().shape();
+        const uint32_t sp_axis = block_cyclic_sp_axis.value();
+        TT_FATAL(
+            sp_axis < mesh_shape.dims(),
+            "block_cyclic_sp_axis ({}) out of range for mesh dims ({})",
+            sp_axis,
+            mesh_shape.dims());
+        const uint32_t sp = mesh_shape[sp_axis];
+        const uint32_t chunk_local = block_cyclic_chunk_local.value();
+        const uint32_t tp = mesh_shape.mesh_size() / sp;
+        const uint32_t q_isl = q.logical_shape()[2];
+        TT_FATAL(
+            chunk_local == q_isl || chunk_local == q_isl * tp,
+            "block_cyclic_chunk_local ({}) must equal q seq-len ({}) or tp*q seq-len ({})",
+            chunk_local,
+            q_isl,
+            q_isl * tp);
+        block_cyclic = ttnn::prim::BlockCyclicLayout{sp, chunk_local};
+    }
 
     // fp8 Q needs 32-bit DEST for tilize; bf16 Q uses the default DEST width.
     const bool q_is_fp8 = (q.dtype() == ttnn::DataType::FP8_E4M3);
@@ -34,7 +63,17 @@ ttnn::Tensor sparse_sdpa_msa(
         /*default_l1_acc=*/false);
 
     return ttnn::prim::sparse_sdpa_msa(
-        q, k, v, indices, resolved_scale, block_size, kernel_config, cache_batch_idx, chunk_start_idx, cluster_axis);
+        q,
+        k,
+        v,
+        indices,
+        resolved_scale,
+        block_size,
+        kernel_config,
+        cache_batch_idx,
+        chunk_start_idx,
+        cluster_axis,
+        block_cyclic);
 }
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa_msa.hpp
@@ -30,6 +30,10 @@ namespace ttnn::transformer {
 // `cluster_axis` derives the per-device start under sequence parallelism (chunk_start = chunk_start_idx + rank*S).
 // Causal masking requires bf16 q: with fp8 q the mask is numerically wrong (fp8-specific;
 // root cause not identified), so fp8 q with `chunk_start_idx` asserts.
+// `block_cyclic_sp_axis`/`block_cyclic_chunk_local` (set together): the K/V cache is striped block-cyclic across
+// SP (chunked prefill, post-AllGather); the gather kernels remap logical block ids to physical in-kernel instead
+// of the caller reordering to natural order. sp is read from the mesh on that axis; chunk_local is the per-shard
+// chunk length (= chunk_size_global / sp), which must equal q_isl or tp*q_isl.
 ttnn::Tensor sparse_sdpa_msa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& k,
@@ -40,6 +44,8 @@ ttnn::Tensor sparse_sdpa_msa(
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> chunk_start_idx = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt);
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
+    std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);
 
 }  // namespace ttnn::transformer


### PR DESCRIPTION
### PR Category
Performance

## Summary

Adds an block-cyclic ("slab") KV remap to `sparse_sdpa_msa`, so the op reads the AllGather'd chunked-prefill KV cache in block-cyclic order rather than requiring the caller to reorder it to natural order first. With `block_cyclic_sp_axis` / `block_cyclic_chunk_local` set, the gather (reader for K, writer for V) remaps each **natural** block-id to its **physical** block via a compile-time inverse permutation (invP); unset ⇒ byte-identical to the previous op.
  
  Third member of the block-cyclic set, mirroring the interface + helper of:
  - **#48428** — `sparse_sdpa`: in-kernel block-cyclic index remap
  - **#48772** — `indexer_score`: slab-aware (block-cyclic) K addressing

  ### Refactor

The block-cyclic remap + layout struct were duplicated across the three ops. This PR extracts them into two shared headers: `block_cyclic_layout.hpp` (`ttnn::prim::BlockCyclicLayout`) and `block_cyclic_remap.hpp` (`logical_to_chunked_physical`). Now used by **all three**: `sparse_sdpa`, `sparse_sdpa_msa`, and `indexer_score`. The remap is unit-agnostic (rows for `sparse_sdpa`, blocks for `sparse_sdpa_msa`, tiles for `indexer_score`).

  ## Results

  The op lets a caller drop the host `untilize → transpose → tilize` reorder (×3 for K/V/index_k, per MSA
  layer).

  | Metric | Measurement |
  |---|---|
  | Host reorder the op lets callers drop (per tensor) | **512 µs/call** |
  | → per MSA layer (K + V + index_k) | **1.54 ms** |
  | → per prefill iter (×27 sparse layers, chunk-2) | **~41.5 ms ≈ 1.8%** of a ~2280 ms iter |

  ### Correctness

  | Coverage | Result |
  |---|---|
  | `sparse_sdpa_msa` sp=1: identity vs natural golden, bit-exact vs non-BC, `chunk_local` guard rejection | pass |
  | `sparse_sdpa_msa` sp=2 / sp=4 multidevice: real permutation vs natural golden | pass |
  | `sparse_sdpa` + `indexer_score` block-cyclic (shared-header consolidation) | pass |
  | Minimax M3 chunked prefill, SP=8 galaxy: per-layer KV PCC | unchanged |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zbaczewski/sparse_sdpa_msa_block_cyclic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zbaczewski/sparse_sdpa_msa_block_cyclic)