### PR TITLE
[CI] Re-enable Gemma4-31B vLLM nightly (cap max_model_len + KV pool)

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -50,40 +50,6 @@ jobs:
 
           # Note: This matrix must be kept in sync with the original static matrix
           #
-          # The two Gemma4-31B vLLM entries below are temporarily disabled —
-          # the full unquantized KV cache for the global-attention layers
-          # runs out of DRAM on both 1x4 (BH-Quietbox-2) and 1x8 (WH-T3K).
-          # Re-enable once KV cache quantization lands — TODO: file follow-up issue.
-          #
-          # Disabled entries preserved verbatim for the re-enable:
-          #
-          #   {
-          #     "name": "[WH-T3K] Gemma4-31B",
-          #     "model": "google/gemma-4-31B-it",
-          #     "server-timeout": 45,
-          #     "benchmark-timeout": 5,
-          #     "runner-label": "config-t3000",
-          #     "arch": "arch-wormhole_b0",
-          #     "mesh-device": "T3K",
-          #     "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",
-          #     "additional-server-args": "--async-scheduling",
-          #     "multimodal": false,
-          #     "owner_id": "U08TJ70UFRT"
-          #   },
-          #   {
-          #     "name": "[BH-QB-2] Gemma4-31B",
-          #     "model": "google/gemma-4-31B-it",
-          #     "server-timeout": 20,
-          #     "benchmark-timeout": 5,
-          #     "runner-label": "BH-Quietbox-2",
-          #     "arch": "arch-blackhole",
-          #     "mesh-device": "P150x4",
-          #     "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",
-          #     "additional-server-args": "--async-scheduling",
-          #     "multimodal": false,
-          #     "owner_id": "U08TJ70UFRT"
-          #   },
-          #
           # The WH-T3K Gemma4-26B-A4B entry below is temporarily disabled —
           # DRAM OOM during KV cache allocation (layer 25/30) causes EngineCore
           # init failure on WH-T3K. Full unquantized KV cache no longer fits.
@@ -197,6 +163,32 @@ jobs:
               "mesh-device": "P150x4",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 300000000}",
               "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "multimodal": false,
+              "owner_id": "U08TJ70UFRT"
+            },
+            {
+              "name": "[WH-T3K] Gemma4-31B",
+              "model": "google/gemma-4-31B-it",
+              "server-timeout": 45,
+              "benchmark-timeout": 5,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",
+              "additional-server-args": "--max_model_len 32768 --max_num_seqs 1 --async-scheduling",
+              "multimodal": false,
+              "owner_id": "U08TJ70UFRT"
+            },
+            {
+              "name": "[BH-QB-2] Gemma4-31B",
+              "model": "google/gemma-4-31B-it",
+              "server-timeout": 20,
+              "benchmark-timeout": 5,
+              "runner-label": "BH-Quietbox-2",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x4",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",
+              "additional-server-args": "--max_model_len 32768 --max_num_seqs 1 --async-scheduling",
               "multimodal": false,
               "owner_id": "U08TJ70UFRT"
             },

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -75,6 +75,12 @@ jobs:
           #     "owner_id": "U08TJ70UFRT"
           #   },
           #
+          # KNOWN ERROR — [WH-T3K] Gemma4-31B (kept enabled below to track):
+          # device hang (fast-dispatch timeout) during decode on WH-T3K only;
+          # the same serving config passes on [BH-QB-2] Gemma4-31B. Not a
+          # serving/KV-config issue — a tt-metal dispatch-layer hang.
+          # Tracked in https://github.com/tenstorrent/tt-metal/issues/49494
+          #
           # Disabled due to Metal timeout in reduce-scatter async tests
           # https://github.com/tenstorrent/vllm/issues/416
           # Originally disabled in:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -578,6 +578,13 @@ jobs:
             google/gemma-4-*)
               export TT_LEAN_DECODE_WARMUP=1
               export GEMMA4_TRACE_PREFILL_SEQ_LENS=128
+              # 31B: with hybrid KV groups disabled every layer allocates a
+              # full-length KV buffer, and the default all-user pool OOMs DRAM
+              # on QB2/T3K. Cap the pool (the real DRAM lever, distinct from
+              # --max_model_len). See tt-metal #49257 / #49083.
+              if [ "$HF_MODEL" = "google/gemma-4-31B-it" ]; then
+                export GEMMA4_MAX_TOKENS_ALL_USERS=32768
+              fi
               ;;
           esac
 


### PR DESCRIPTION
## Summary

Re-enables the two **Gemma4-31B** vLLM nightly entries (WH-T3K, BH-QB-2), sized so the model fits DRAM and admits on its hardware.

The **12B / 26B-A4B** `--max_model_len 131072` cap is **not** part of this PR — that lands separately in #49405; this branch is 31B-only and depends on #49405 for the 12B/26B entries to stay green.

## Changes (`.github/workflows/vllm-nightly-tests-impl.yaml`)

- **Re-enable Gemma4-31B** (`[WH-T3K]`, `[BH-QB-2]`) — moved back into the active matrix.
- **31B**: `--max_model_len 32768` **plus** `GEMMA4_MAX_TOKENS_ALL_USERS=32768` (gated to `google/gemma-4-31B-it` in the gemma4 env block). With hybrid KV groups disabled every layer allocates a full-length KV buffer, so the DRAM pool is sized by `GEMMA4_MAX_TOKENS_ALL_USERS`, **not** `--max_model_len`; 32768 fits DRAM (no OOM) and admits at 1.00x.
- Document the `[WH-T3K] Gemma4-31B` known error inline (see below).

## Validation — CI run [28973232245](https://github.com/tenstorrent/tt-metal/actions/runs/28973232245)

| Entry | Result |
|---|---|
| [BH-QB-2] Gemma4-31B | ✅ pass |
| [WH-T3K] Gemma4-31B | ❌ known error (see below) |

(12B/26B passed in that run because it predated dropping their cap here; those are covered by #49405.)

## Known error

`[WH-T3K] Gemma4-31B` hits a **device fast-dispatch timeout during decode** — a tt-metal dispatch-layer hang, **not** a serving/KV-config issue (server boots, KV pool sized correctly, admission 1.00x, prefill + 9 decode tokens run before the hang; the *same* config passes on BH-QB-2). Documented inline and tracked in **#49494**. The entry is intentionally **kept enabled** to track the fix rather than disabled.

## Related

- #49405 — 12B/26B `max_model_len` cap (prerequisite for the 12B/26B nightly entries)
- #49494 — WH-T3K 31B decode hang (known error tracked here)
- #49257 — hybrid KV cache / long context; #49083 + #49320 — BH prefill hang (now passing)
- tenstorrent/vllm#439 — token-chunked prefill (would let `max_model_len` be restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)