### PR TITLE
[Performance] SP×TP seq-sharded DSA indexer

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -612,12 +612,13 @@ class TtIndexer:
         # indexer_score wants per-head weights [1, H_idx, S/sp, 1]; wts is [1, 1, S/sp, H_idx].
         weights = ttnn.permute(wts, (0, 3, 2, 1))
 
-        # SPIKE (throwaway): TP×SP query parallelism. rope-then-split — q_dev/weights were roped on the
-        # FULL S/sp slab (block-cyclic-correct), now split their rows over TP so each chip scores only
-        # S/(sp·tp) rows. Uses the FLAT both-axes score (cluster_axis=None, block_cyclic_chunk_local=seq_len
-        # = Sq'·tp) — LINEAR-approximate under rotation (expected to fail test_sparse_mla_rotated); this
-        # spike only measures the perf ceiling. topk runs on the sub-rows; indices are all-gathered back
-        # over TP to the [1,1,S/sp,k] contract so mla.py/sparse_sdpa are unchanged.
+        # TP×SP query parallelism (rope-then-split). q_dev/weights were roped on the FULL S/sp slab
+        # (block-cyclic-correct, cluster_axis=sp_axis), so every row already carries its true position; now
+        # split those rows over TP so each chip scores only S/(sp·tp) of them — indexer_score + topk shrink
+        # ~TP×. RoPE is per-row so the split is safe (no 2-D rope op needed). The score is told the TP axis via
+        # seq_subshard_axis below, so its EXACT block-cyclic geometry adds each device's tp_rank*Sq' sub-offset
+        # (rotation-safe). topk runs on the sub-rows; indices are all-gathered back over TP to the [1,1,S/sp,k]
+        # contract so mla.py / sparse_sdpa are unchanged (both DeepSeek and GLM ride this one path).
         tpsp = self._blockcyclic and self.tp_factor > 1
         if tpsp:
             q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),D_idx]
@@ -655,8 +656,11 @@ class TtIndexer:
                 weights,
                 chunk_start_idx=start_pos,
                 program_config=cfg,
-                # SPIKE: TP×SP uses the FLAT both-axes causal offset (cluster_axis=None); SP-only stays named.
-                cluster_axis=None if tpsp else self.sp_axis,
+                cluster_axis=self.sp_axis,
+                # TP×SP: name the TP axis the query was sub-sharded over so the score adds each device's
+                # tp_rank*Sq' block-cyclic sub-offset — rotation-EXACT (vs the flat cluster_axis=None path,
+                # which is linear-approximate under a mid-slab start). None when the query stays SP-only.
+                seq_subshard_axis=self.tp_axis if tpsp else None,
                 cache_batch_idx=None,  # k_full is already sliced to this slot (batch-1) → no in-kernel select
                 block_cyclic_sp_axis=self.sp_axis,
                 block_cyclic_chunk_local=seq_len,  # cache slab == chunk_size_global / sp (== Sq'·tp when TP-split)
@@ -687,7 +691,7 @@ class TtIndexer:
         idx = ttnn.experimental.topk_large_indices(
             logits, k=min(self.index_args.index_topk, end_pos), valid_length=topk_valid_length
         )
-        # SPIKE: topk ran on the TP-seq-sharded rows ([1,1,S/(sp·tp),k]); regather over TP back to the
+        # TP×SP: topk ran on the TP-seq-sharded rows ([1,1,S/(sp·tp),k]); regather over TP back to the
         # [1,1,S/sp,k] contract so sparse_sdpa/mla.py are unchanged. (Redundant TP-round-trip for GLM's
         # head→seq reshard, which re-splits it; correct regardless. tp=1: no-op.)
         if tpsp:

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -61,7 +61,9 @@ class TtIndexer:
 
     @staticmethod
     def _cache_short_name(weight_name: str) -> str:
-        return weight_name.split(".")[-1]  # "indexer.wq_b" -> "wq_b"
+        # wq_b's replicated layout uses a distinct cache stem so the pre-replication TP-sharded
+        # tensorbin cannot satisfy completeness checks or be loaded by cache-only construction.
+        return "wq_b_repl" if weight_name == "indexer.wq_b" else weight_name.split(".")[-1]
 
     @classmethod
     def check_cache_complete(cls, cache_path, cache_name_prefix: str) -> bool:
@@ -168,7 +170,9 @@ class TtIndexer:
         # "wq_b_repl" (not "wq_b") so a stale col-sharded tensorbin can never alias this layout. wk /
         # weights_proj contract over hidden (TP-sharded) → upload transposed+sharded, reduced by _tp_rs_ag.
         result = {
-            "wq_b": repl(wq_b, "wq_b_repl", transpose=True),  # [q_lora_rank, H_idx*D_idx] replicated (all heads)
+            "wq_b": repl(
+                wq_b, cls._cache_short_name("indexer.wq_b"), transpose=True
+            ),  # [q_lora_rank, H_idx*D_idx] replicated (all heads)
             "wk": shard(wk, 0, "wk"),  # [dim, D_idx] sharded on dim
             "weights_proj": shard(wproj, 0, "weights_proj"),  # [dim, H_idx] sharded on dim
             "k_norm": repl(knorm, "k_norm"),  # [D_idx]

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -621,8 +621,14 @@ class TtIndexer:
         # contract so mla.py / sparse_sdpa are unchanged (both DeepSeek and GLM ride this one path).
         tpsp = self._blockcyclic and self.tp_factor > 1
         if tpsp:
+            q_full, weights_full = (
+                q_dev,
+                weights,
+            )  # release the full-S slabs once TP-split (mesh_partition allocates new)
             q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),D_idx]
             weights = ttnn.mesh_partition(weights, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),1]
+            ttnn.deallocate(q_full)
+            ttnn.deallocate(weights_full)
             sq_local = seq_len // self.tp_factor
             qc = 64 if sq_local % 64 == 0 else 32  # q_chunk must divide the per-chip query tile count
         else:
@@ -695,7 +701,9 @@ class TtIndexer:
         # [1,1,S/sp,k] contract so sparse_sdpa/mla.py are unchanged. (Redundant TP-round-trip for GLM's
         # head→seq reshard, which re-splits it; correct regardless. tp=1: no-op.)
         if tpsp:
+            idx_local = idx  # the TP-sharded top-k; all_gather allocates the regathered [1,1,S/sp,k] replacement
             idx = self._tp_all_gather(idx, dim=2)
+            ttnn.deallocate(idx_local)
         return idx
 
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -19,6 +19,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tt.mla.mla_config import get_indexer_key_chunk
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_perm_matrix
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
@@ -635,9 +636,10 @@ class TtIndexer:
             qc = 64
         # Causality is fused inside indexer_score (future columns -> -inf from chunk_start_idx), so no triu
         # mask here. All H_idx heads are resident on-chip (wq_b replicated), so head_group_size=0 reads the
-        # key cache ONCE — but that needs L1 headroom, so k_chunk shrinks to 64 (vs 256 for a head-sharded
-        # slice).
-        cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=qc, k_chunk_size=min(64, end_pos), head_group_size=0)
+        # key cache ONCE — but that needs L1 headroom, so k_chunk is bounded by resident head count
+        # (DSA_INDEXER_CONFIG, measured per model: DeepSeek@64h=64, GLM@32h=224; larger OOMs).
+        k_chunk = get_indexer_key_chunk(a.index_n_heads)
+        cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=qc, k_chunk_size=min(k_chunk, end_pos), head_group_size=0)
         # SP-sharded queries (rotation-safe): each chip scores its S/sp rows vs the full block-cyclic key
         # cache, with a per-device causal offset from cluster_axis=sp_axis (chip r: chunk_start = start_pos
         # + r*Sq, Sq=S/sp=seq_len). All H_idx heads on-chip -> the logit is COMPLETE (no partial-logit

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -320,6 +320,23 @@ class TtIndexer:
             cluster_axis=self.sp_axis,
         )
 
+    def _tp_all_gather(self, t, dim):
+        """All-gather across the TP axis → the TP-seq-shards reassembled to the SP block's full rows,
+        replicated on TP. tp=1: no-op. (Spike helper for TP×SP query parallelism: regathers the top-k
+        indices that were computed on TP-seq-sharded query rows back to the [1,1,S/sp,k] contract.)"""
+        if self.tp_factor == 1:
+            return t
+        return ttnn.experimental.all_gather_async(
+            t,
+            dim=dim,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.ccl_topology,
+            cluster_axis=self.tp_axis,
+        )
+
     def _build_rope_tables(self):
         """Precompute the indexer's natural-path RoPE tables via RotarySetup.get_indexer_rope_tables
         (single source of rope-convention logic). ``index_rope_interleave`` picks the layout + matching
@@ -592,17 +609,32 @@ class TtIndexer:
         # though as a uniform positive multiplier it cannot change the top-k selection regardless.
         wts = ttnn.multiply(wts, a.index_n_heads**-0.5 * a.index_head_dim**-0.5)  # [1,1,S/sp,H_idx] repl on tp
 
+        # indexer_score wants per-head weights [1, H_idx, S/sp, 1]; wts is [1, 1, S/sp, H_idx].
+        weights = ttnn.permute(wts, (0, 3, 2, 1))
+
+        # SPIKE (throwaway): TP×SP query parallelism. rope-then-split — q_dev/weights were roped on the
+        # FULL S/sp slab (block-cyclic-correct), now split their rows over TP so each chip scores only
+        # S/(sp·tp) rows. Uses the FLAT both-axes score (cluster_axis=None, block_cyclic_chunk_local=seq_len
+        # = Sq'·tp) — LINEAR-approximate under rotation (expected to fail test_sparse_mla_rotated); this
+        # spike only measures the perf ceiling. topk runs on the sub-rows; indices are all-gathered back
+        # over TP to the [1,1,S/sp,k] contract so mla.py/sparse_sdpa are unchanged.
+        tpsp = self._blockcyclic and self.tp_factor > 1
+        if tpsp:
+            q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),D_idx]
+            weights = ttnn.mesh_partition(weights, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),1]
+            sq_local = seq_len // self.tp_factor
+            qc = 64 if sq_local % 64 == 0 else 32  # q_chunk must divide the per-chip query tile count
+        else:
+            qc = 64
         # Causality is fused inside indexer_score (future columns -> -inf from chunk_start_idx), so no triu
         # mask here. All H_idx heads are resident on-chip (wq_b replicated), so head_group_size=0 reads the
         # key cache ONCE — but that needs L1 headroom, so k_chunk shrinks to 64 (vs 256 for a head-sharded
-        # slice). q_chunk=64 divides the per-chip query tile count (S/sp).
-        cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=min(64, end_pos), head_group_size=0)
+        # slice).
+        cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=qc, k_chunk_size=min(64, end_pos), head_group_size=0)
         # SP-sharded queries (rotation-safe): each chip scores its S/sp rows vs the full block-cyclic key
         # cache, with a per-device causal offset from cluster_axis=sp_axis (chip r: chunk_start = start_pos
         # + r*Sq, Sq=S/sp=seq_len). All H_idx heads on-chip -> the logit is COMPLETE (no partial-logit
         # all-reduce). topk stays SP-sharded ([1,1,S/sp,k]) -> fed straight to sparse_mla.
-        # indexer_score wants per-head weights [1, H_idx, S/sp, 1]; wts is [1, 1, S/sp, H_idx].
-        weights = ttnn.permute(wts, (0, 3, 2, 1))
         if self._blockcyclic:
             # _gather_index_kbuf slices this (user, layer) slot then gathers it to replicated full-T; the op
             # reads it back in logical order via invP (batch-1, so cache_batch_idx=None) and applies the
@@ -623,10 +655,11 @@ class TtIndexer:
                 weights,
                 chunk_start_idx=start_pos,
                 program_config=cfg,
-                cluster_axis=self.sp_axis,
+                # SPIKE: TP×SP uses the FLAT both-axes causal offset (cluster_axis=None); SP-only stays named.
+                cluster_axis=None if tpsp else self.sp_axis,
                 cache_batch_idx=None,  # k_full is already sliced to this slot (batch-1) → no in-kernel select
                 block_cyclic_sp_axis=self.sp_axis,
-                block_cyclic_chunk_local=seq_len,  # per-chip chunk == chunk_size_global / sp
+                block_cyclic_chunk_local=seq_len,  # cache slab == chunk_size_global / sp (== Sq'·tp when TP-split)
                 kv_len=end_pos,
             )
             ttnn.deallocate(k_full)
@@ -651,9 +684,15 @@ class TtIndexer:
         # wrote the real prefix); valid_length bounds top-k to that prefix so the tail is never read or ranked.
         # The natural path's cache is exact-sized (no tail), so it needs no bound.
         topk_valid_length = end_pos if self._blockcyclic else None
-        return ttnn.experimental.topk_large_indices(
+        idx = ttnn.experimental.topk_large_indices(
             logits, k=min(self.index_args.index_topk, end_pos), valid_length=topk_valid_length
         )
+        # SPIKE: topk ran on the TP-seq-sharded rows ([1,1,S/(sp·tp),k]); regather over TP back to the
+        # [1,1,S/sp,k] contract so sparse_sdpa/mla.py are unchanged. (Redundant TP-round-trip for GLM's
+        # head→seq reshard, which re-splits it; correct regardless. tp=1: no-op.)
+        if tpsp:
+            idx = self._tp_all_gather(idx, dim=2)
+        return idx
 
 
 class NullIndexer:

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -138,9 +138,9 @@ class TtIndexer:
 
         mem = ttnn.DRAM_MEMORY_CONFIG if device else None
 
-        def repl(t, short):  # k_norm runs on the reduced 128-wide key, so it is replicated across TP
+        def repl(t, short, transpose=False):  # replicate across TP (transpose=True: host [out,in] -> device [in,out])
             return ttnn.as_tensor(
-                t.contiguous().to(torch.bfloat16),
+                (t.T if transpose else t).contiguous().to(torch.bfloat16),
                 device=device,
                 layout=ttnn.TILE_LAYOUT,
                 dtype=ttnn.bfloat16,
@@ -162,11 +162,13 @@ class TtIndexer:
                 cache_file_name=_cache_name(short),
             )
 
-        # wq_b is column-parallel: shard its H_idx*D_idx OUTPUT across tp (each chip builds H_idx/tp
-        # heads; qr is replicated → no reduce). wk / weights_proj contract over hidden (TP-sharded), so
-        # they upload transposed and sharded on that contraction axis → partials reduced by _tp_rs_ag.
+        # wq_b is REPLICATED (all H_idx heads on every chip) so the indexer_score head-sum is COMPLETE
+        # on-chip — no TP logit all-reduce. (Was col-parallel/TP-head-sharded; replicating trades a small
+        # matmul/score compute bump for dropping the ~end_pos-wide 2-CCL logit all-reduce.) Cache name
+        # "wq_b_repl" (not "wq_b") so a stale col-sharded tensorbin can never alias this layout. wk /
+        # weights_proj contract over hidden (TP-sharded) → upload transposed+sharded, reduced by _tp_rs_ag.
         result = {
-            "wq_b": shard(wq_b, 1, "wq_b"),  # [q_lora_rank, H_idx*D_idx] col-sharded on out
+            "wq_b": repl(wq_b, "wq_b_repl", transpose=True),  # [q_lora_rank, H_idx*D_idx] replicated (all heads)
             "wk": shard(wk, 0, "wk"),  # [dim, D_idx] sharded on dim
             "weights_proj": shard(wproj, 0, "weights_proj"),  # [dim, H_idx] sharded on dim
             "k_norm": repl(knorm, "k_norm"),  # [D_idx]
@@ -563,45 +565,39 @@ class TtIndexer:
             self._idx_wq_b,
             compute_kernel_config=self.default_compute_kernel_config,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )  # [1, 1, S/sp, (H_idx/tp)*D_idx] — queries stay SP-sharded (no all-gather; each chip scores its own rows)
-        heads_local = a.index_n_heads // self.tp_factor  # this chip's indexer heads (col-parallel wq_b)
+        )  # [1, 1, S/sp, H_idx*D_idx] — ALL heads (wq_b replicated); queries stay SP-sharded (rotation-safe)
         q, _, _ = ttnn.experimental.nlp_create_qkv_heads(
-            q, num_heads=heads_local, num_kv_heads=0, transpose_k_heads=False, memory_config=ttnn.DRAM_MEMORY_CONFIG
-        )  # [1, H_idx/tp, S/sp, D_idx]
+            q, num_heads=a.index_n_heads, num_kv_heads=0, transpose_k_heads=False, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )  # [1, H_idx, S/sp, D_idx] — all heads resident
         if self._blockcyclic:  # block-cyclic indexed rope (same op/tables as the key rope + MLA q_pe)
             q_dev = self._bc_rope_pe(q, rope_tensors, start_pos)
         else:
             q_dev = self._device_rope_pe(q, glob, start_pos, sp_shard=True)  # per-chip natural query positions
 
-        # weights_proj: device stem -> reduce-scatter the H_idx heads across tp (each chip keeps the
-        # reduced H_idx/tp slice matching its wq_b heads) -> SP gather -> scale -> [1, 1, glob, H_idx/tp].
+        # weights_proj: device stem -> FULL all-reduce over tp (all H_idx heads, matching the replicated
+        # wq_b heads) -> scale -> [1, 1, S/sp, H_idx].
         wts = ttnn.linear(
             hidden_states,
             self._idx_wproj,
             compute_kernel_config=self.default_compute_kernel_config,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
-        wts = self._tp_rs_ag(wts, rs_only=True)  # reduce-scatter on the head dim -> this chip's heads
+        wts = self._tp_rs_ag(wts)  # full all-reduce (RS+AG) over tp -> all H_idx head-weights, replicated
         # Indexer softmax scale = index_head_dim**-0.5 (NO mscale), matching the reference IndexerCPU
         # (model.py: softmax_scale = head_dim**-0.5). Distinct from MLA's qk_head_dim*mscale**2 scale —
         # though as a uniform positive multiplier it cannot change the top-k selection regardless.
-        wts = ttnn.multiply(wts, a.index_n_heads**-0.5 * a.index_head_dim**-0.5)  # SP-sharded [1,1,S/sp,H_idx/tp]
+        wts = ttnn.multiply(wts, a.index_n_heads**-0.5 * a.index_head_dim**-0.5)  # [1,1,S/sp,H_idx] repl on tp
 
-        # Causality is fused inside indexer_score (future columns -> -inf from chunk_start_idx),
-        # so no triu mask add here. Each chip scores only its H_idx/tp heads -> a PARTIAL logit
-        # (the head-sum is separable; the -inf mask is head-independent so it survives the sum).
-        # HB=0 keeps all H_idx/tp heads resident (fits L1 for tp>=2, i.e. <=32 heads/chip); tp=1 has
-        # all 64 heads on one chip and must head-stream (HB=16).
-        hb = 0 if self.tp_factor > 1 else 16
-        # Indexer kernel knobs: QC=2 (q_chunk=64), KC=8 (k_chunk=256) capped to Skv/32 (the op requires
-        # KC <= Skv/32; inert at the model's DSA K). HB=0 keeps all heads resident; HB=16 streams (tp=1).
-        cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=min(256, end_pos), head_group_size=hb)
-        # SP-sharded queries: each chip scores only its S/sp rows vs the full key cache, with a per-device
-        # causal offset so the mask is correct without computing the full glob logits on every chip. The op
-        # derives that offset itself from the mesh coordinate: with cluster_axis=sp_axis, chip r uses
-        # chunk_start = chunk_start_idx + r*Sq, and Sq = S/sp = seq_len here, so chunk_start = start_pos +
-        # sp_rank*seq_len. topk below then stays SP-sharded ([1,1,S/sp,k]) — fed straight to sparse_mla.
-        # indexer_score wants per-head weights [1, H_idx/tp, S/sp, 1]; wts is [1, 1, S/sp, H_idx/tp].
+        # Causality is fused inside indexer_score (future columns -> -inf from chunk_start_idx), so no triu
+        # mask here. All H_idx heads are resident on-chip (wq_b replicated), so head_group_size=0 reads the
+        # key cache ONCE — but that needs L1 headroom, so k_chunk shrinks to 64 (vs 256 for a head-sharded
+        # slice). q_chunk=64 divides the per-chip query tile count (S/sp).
+        cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=min(64, end_pos), head_group_size=0)
+        # SP-sharded queries (rotation-safe): each chip scores its S/sp rows vs the full block-cyclic key
+        # cache, with a per-device causal offset from cluster_axis=sp_axis (chip r: chunk_start = start_pos
+        # + r*Sq, Sq=S/sp=seq_len). All H_idx heads on-chip -> the logit is COMPLETE (no partial-logit
+        # all-reduce). topk stays SP-sharded ([1,1,S/sp,k]) -> fed straight to sparse_mla.
+        # indexer_score wants per-head weights [1, H_idx, S/sp, 1]; wts is [1, 1, S/sp, H_idx].
         weights = ttnn.permute(wts, (0, 3, 2, 1))
         if self._blockcyclic:
             # _gather_index_kbuf slices this (user, layer) slot then gathers it to replicated full-T; the op
@@ -639,15 +635,9 @@ class TtIndexer:
                 program_config=cfg,
                 cluster_axis=self.sp_axis,
             )
-        # All-reduce(SUM) the partial logits over tp -> full head-summed logit before top-k. The op emits
-        # ROW_MAJOR; _tp_rs_ag (reduce_scatter+all_gather) runs in TILE, so round-trip the layout.
-        if self.tp_factor > 1:
-            # The op emits ROW_MAJOR; round-trip to TILE for the all-reduce. Passing RM straight to the
-            # CCL is correct but ~10 ms slower — ttnn's RM reduce_scatter/all_gather tilize-with-padding
-            # internally and add RM concats, costing more than this explicit ~6 ms tilize/untilize.
-            logits = ttnn.to_layout(logits, ttnn.TILE_LAYOUT)
-            logits = self._tp_rs_ag(logits)  # RS+AG over tp_axis == all-reduce SUM (reduce accumulates fp32)
-            logits = ttnn.to_layout(logits, ttnn.ROW_MAJOR_LAYOUT)
+        # wq_b replicated -> each chip already holds the COMPLETE head-summed logit, so there is NO
+        # partial-logit all-reduce over tp. This is the win: the removed step was a 2-CCL (RS+AG) all-reduce
+        # spanning the full end_pos-wide logit (+ a TILE<->ROW_MAJOR round-trip), the indexer's dominant cost.
         # Top-k key indices [1,1,S/sp,k] (ROW_MAJOR uint32). Future/pad -inf columns surface as the
         # 0xFFFFFFFF sentinel that sparse_mla drops. topk_large_indices: 16 <= k <= 2048, multiple of 16.
         # index_topk is a multiple of 16, so k is too iff end_pos is — assert it at the caller contract

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -384,3 +384,27 @@ def get_sdpa_config(seq_len_local: int) -> dict | None:
     Returns None if no config is found for the given seq_len_local.
     """
     return MLA_SDPA_CONFIG.get(seq_len_local)
+
+
+# DSA lightning-indexer scoring config, keyed by resident index-head count (index_n_heads). The
+# indexer runs indexer_score with head_group_size=0, so ALL index heads stay on-chip and the key
+# chunk is L1-bound, scaling ~1/heads. Values are the measured per-model optima (k_chunk sweep on
+# LoudBox / Blackhole at Sq=640, T=56320): a larger k_chunk OOMs L1 (DeepSeek@64h fits <=96,
+# GLM@32h fits <=256). DeepSeek is flat so 64 is optimal and L1-safe; GLM is ~8% faster at 224.
+DSA_INDEXER_CONFIG: dict[int, dict[str, int]] = {
+    64: {"k_chunk_size": 64},  # DeepSeek V3.2
+    32: {"k_chunk_size": 224},  # GLM 5.1 / 5.2
+}
+
+
+def get_indexer_key_chunk(index_n_heads: int) -> int:
+    """Indexer_score k_chunk_size for a resident index-head count. Raises on an unmapped head count:
+    k_chunk is L1-bound and a too-large value OOMs, so a new model must be swept (largest L1-safe
+    k_chunk) and added to DSA_INDEXER_CONFIG rather than silently defaulted."""
+    cfg = DSA_INDEXER_CONFIG.get(index_n_heads)
+    if cfg is None:
+        raise KeyError(
+            f"No DSA indexer k_chunk_size tuned for index_n_heads={index_n_heads}; sweep the largest "
+            f"L1-safe k_chunk and add it to DSA_INDEXER_CONFIG (tuned: {sorted(DSA_INDEXER_CONFIG)})."
+        )
+    return cfg["k_chunk_size"]

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1974,6 +1974,32 @@ def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
     assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
 
 
+@pytest.mark.parametrize("mesh_device", [(1, 4)], ids=["sp1xtp4"], indirect=True)
+def test_indexer_score_sp1_tp4_rejects_undersized_causal_window(mesh_device, expect_error):
+    """Validation must include every TP sub-shard when the named SP axis has size one."""
+    heads, chunk, t, chunk_start = 8, 256, 256, 32
+    q_g, k_g, w_g = _global_inputs(heads, chunk, t, seed=42)
+    mesh_shape = tuple(mesh_device.shape)
+    shard_tp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(None, 2))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_tp_seq)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_tp_seq)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    # Rank 3 owns [chunk_start + 3*Sq, chunk_start + 4*Sq) = [224, 288), which exceeds T=256.
+    with expect_error(RuntimeError, "exceeds T"):
+        ttnn.experimental.indexer_score_dsa(
+            q_dev,
+            k_dev,
+            w_dev,
+            chunk_start_idx=chunk_start,
+            cluster_axis=0,
+            seq_subshard_axis=1,
+            block_cyclic_sp_axis=0,
+            block_cyclic_chunk_local=chunk,
+            program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
+        )
+
+
 @pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["sp2xtp2"], indirect=True)
 def test_indexer_score_sp2_tp2_seq_subshard_rotated(mesh_device):
     """Named SP + TP seq-subshard must reproduce the prefill writer's mapping for a rotated chunk."""

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1949,7 +1949,8 @@ def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_erro
 def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
     """A size-one SP axis is still a valid SP×TP query shard: TP rank t owns rows [t*Sq,(t+1)*Sq),
     so its causal diagonal must start at chunk_start + t*Sq even though the block-cyclic K permutation is
-    the identity for sp=1. This is the QuietBox chunked-indexer layout."""
+    the identity for sp=1. An omitted chunk_start must likewise deduct the full TP-sharded chunk from T.
+    This is the QuietBox chunked-indexer layout."""
     heads, chunk, t, chunk_start = 8, 256, 512, 128
     q_g, k_g, w_g = _global_inputs(heads, chunk, t, seed=42)
     mesh_shape = tuple(mesh_device.shape)
@@ -1972,6 +1973,23 @@ def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
     out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(1, 2)))
     ref = indexer_score_dsa_ref(q_g, k_g, w_g, chunk_start)
     assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
+
+    out_default = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        cluster_axis=0,
+        seq_subshard_axis=1,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=chunk,
+        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
+    )
+    out_default_t = ttnn.to_torch(
+        out_default, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(1, 2))
+    )
+    default_start = t - chunk
+    ref_default = indexer_score_dsa_ref(q_g, k_g, w_g, default_start)
+    assert_indexer_match(out_default_t, ref_default, chunk, t, check_neg=True)
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 4)], ids=["sp1xtp4"], indirect=True)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1945,6 +1945,67 @@ def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_erro
         ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, cluster_axis=0, **kw)
 
 
+@pytest.mark.parametrize("mesh_device", [(1, 4)], ids=["sp1xtp4"], indirect=True)
+def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
+    """A size-one SP axis is still a valid SP×TP query shard: TP rank t owns rows [t*Sq,(t+1)*Sq),
+    so its causal diagonal must start at chunk_start + t*Sq even though the block-cyclic K permutation is
+    the identity for sp=1. This is the QuietBox chunked-indexer layout."""
+    heads, chunk, t, chunk_start = 8, 256, 512, 128
+    q_g, k_g, w_g = _global_inputs(heads, chunk, t, seed=42)
+    mesh_shape = tuple(mesh_device.shape)
+    shard_tp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(None, 2))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_tp_seq)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_tp_seq)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        chunk_start_idx=chunk_start,
+        cluster_axis=0,
+        seq_subshard_axis=1,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=chunk,
+        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(1, 2)))
+    ref = indexer_score_dsa_ref(q_g, k_g, w_g, chunk_start)
+    assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["sp2xtp2"], indirect=True)
+def test_indexer_score_sp2_tp2_seq_subshard_rotated(mesh_device):
+    """Named SP + TP seq-subshard must reproduce the prefill writer's mapping for a rotated chunk."""
+    heads, sp, chunk, t, chunk_start = 8, 2, 256, 512, 160
+    q_g, k_nat, w_g = _global_inputs(heads, chunk, t, seed=42)
+    k_bc = _to_slab(k_nat, sp, chunk)
+    mesh_shape = tuple(mesh_device.shape)
+    shard_sp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_sp_seq)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_sp_seq)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
+    q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=1)
+    w_dev = ttnn.mesh_partition(w_dev, dim=2, cluster_axis=1)
+
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        chunk_start_idx=chunk_start,
+        cluster_axis=0,
+        seq_subshard_axis=1,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=chunk // sp,
+        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
+    )
+    shards = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(out.cpu())]
+    per_sp = [torch.cat(shards[r * 2 : (r + 1) * 2], dim=2) for r in range(sp)]
+    out_t = torch.cat(per_sp, dim=2)
+    ref = _straddle_ref(q_g, k_nat, w_g, sp, chunk, chunk_start, t)
+    assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
+
+
 # ---- Mid-slab-boundary STRADDLE (drives the need for the straddle geometry, #48500 slice #2) ----
 # A NON-slab-aligned chunk_start makes each device's queries cross a cache-slab boundary, so the causal
 # diagonal must JUMP by (chunk_global - cl) at q-row (cl - offset). Scaled-down stand-in for the maxedge

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -31,9 +31,20 @@ uint32_t max_linearized_rank(const Tensor& q, std::optional<uint32_t> cluster_ax
     return max_rank;
 }
 
-// Largest per-device chunk_start = base + max_rank*Sq. Used by the worst-case window check.
+// Fullest device's chunk_start (= its causal-window end - Sq). Used by the worst-case window check.
+//   * block-cyclic: the devices collectively cover the whole global chunk [chunk_start, +sp*chunk_local),
+//     so the fullest window reaches chunk_start + sp*chunk_local no matter how SP×TP slices it. (For the
+//     SP-only case Sq == chunk_local, so this equals the old chunk_start + (sp-1)*chunk_local.)
+//   * contiguous (incl. a size-1 SP axis, stored as no block-cyclic): each device's row 0 sits at
+//     chunk_start + rank*Sq, where rank is the SP rank PLUS the TP sub-shard rank. The two are
+//     mutually-exclusive-nonzero here (a TP sub-shard needs block_cyclic_sp_axis with sp==1, which forces
+//     SP rank 0; no sub-shard -> TP rank 0), mirroring device_causal_geometry's no-block-cyclic branch.
 uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, uint32_t Sq) {
-    return attrs.chunk_start_idx + max_linearized_rank(q, attrs.cluster_axis) * Sq;
+    if (attrs.block_cyclic.has_value()) {
+        return attrs.chunk_start_idx + attrs.block_cyclic->sp * attrs.block_cyclic->chunk_local - Sq;
+    }
+    const uint32_t tp_rank = attrs.seq_subshard_axis.has_value() ? max_linearized_rank(q, attrs.seq_subshard_axis) : 0u;
+    return attrs.chunk_start_idx + (max_linearized_rank(q, attrs.cluster_axis) + tp_rank) * Sq;
 }
 
 // Miss-only checks: hash-pinned (placement, non-indexed k batch shape) so they can't differ on a hit. The

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -189,6 +189,8 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         attrs.compute_kernel_config,
         attrs.cluster_axis.has_value(),
         attrs.cluster_axis.value_or(0u),
+        attrs.seq_subshard_axis.has_value(),
+        attrs.seq_subshard_axis.value_or(0u),
         attrs.has_indexed_kv_cache(),
         attrs.has_runtime_kv_len(),
         // The block-cyclic layout bakes invP divisors into the reader as compile-time defines, so sp/chunk_local
@@ -443,11 +445,13 @@ IndexerScoreDeviceOperation::invoke(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> seq_subshard_axis,
     std::optional<BlockCyclicLayout> block_cyclic) {
     return {
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
             .cluster_axis = cluster_axis,
+            .seq_subshard_axis = seq_subshard_axis,
             .apply_relu = apply_relu,
             .num_groups = num_groups,
             .block_size = block_size,
@@ -484,6 +488,7 @@ ttnn::Tensor launch_indexer_score(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> seq_subshard_axis,
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
@@ -502,6 +507,10 @@ ttnn::Tensor launch_indexer_score(
         "(got sp_axis={}, chunk_local={})",
         block_cyclic_sp_axis.has_value(),
         block_cyclic_chunk_local.has_value());
+    // seq_subshard_axis (2D TP sub-shard) only means anything with a block-cyclic layout; reject a stray one.
+    TT_FATAL(
+        !seq_subshard_axis.has_value() || block_cyclic_sp_axis.has_value(),
+        "indexer_score: seq_subshard_axis requires a block-cyclic layout (block_cyclic_sp_axis/chunk_local)");
     std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
     if (block_cyclic_sp_axis.has_value()) {
         const auto mesh_shape = q.device()->get_view().shape();
@@ -523,18 +532,34 @@ ttnn::Tensor launch_indexer_score(
             chunk_local,
             Sq,
             Sq * tp);
-        // Seq sharded across BOTH axes (chunk_local == tp*q_isl, tp > 1) is allowed ONLY with cluster_axis
-        // unset: then chunk_start ranks device (a,b) by its row-major position in the full device list
-        // (a*B+b), giving each its true position -- i.e. the flat linearization IS a row-major nested 2D seq
-        // shard, and the per-device offset/straddle come out correct. With a NAMED cluster_axis the rank is
-        // only that axis's coord, so it misses the other axis's seq offset and chunk_start would be wrong --
-        // reject that.
+        // Seq sharded across BOTH axes (chunk_local == tp*q_isl, tp > 1) needs the second axis's seq offset.
+        // Two ways to supply it:
+        //   (a) cluster_axis=None -> the flat row-major device rank (a*B+b) folds BOTH axes in, so the LINEAR
+        //       chunk_start is each device's position -- but that linear form is only exact for a slab-aligned
+        //       (boundary_chip == 0) start; mid-slab (rotated) starts drift (see device_causal_geometry).
+        //   (b) a NAMED cluster_axis (SP) PLUS seq_subshard_axis (the TP axis) -> the EXACT block-cyclic
+        //       geometry (mirroring rotated_chip_positions) adds the tp_rank*Sq sub-offset. Rotation-exact.
+        // A named cluster_axis WITHOUT seq_subshard_axis would miss the TP offset entirely -- reject that.
+        const bool both_axes = (chunk_local == Sq * tp && tp > 1);
         TT_FATAL(
-            !(chunk_local == Sq * tp && tp > 1 && cluster_axis.has_value()),
-            "indexer_score: block_cyclic_chunk_local == tp*q_isl (tp={} > 1) with a NAMED cluster_axis is not "
-            "supported -- chunk_start would miss the second axis's seq offset. To seq-shard across both axes, "
-            "use cluster_axis=None (flat row-major linearization over all devices).",
+            !(both_axes && cluster_axis.has_value() && !seq_subshard_axis.has_value()),
+            "indexer_score: block_cyclic_chunk_local == tp*q_isl (tp={} > 1) with a NAMED cluster_axis needs "
+            "seq_subshard_axis (the TP axis) so the second axis's seq offset is applied; or use cluster_axis=None.",
             tp);
+        if (seq_subshard_axis.has_value()) {
+            TT_FATAL(
+                cluster_axis.has_value() && both_axes,
+                "indexer_score: seq_subshard_axis needs a named cluster_axis (SP) and a 2D seq shard "
+                "(block_cyclic_chunk_local == tp*q_isl); got has_cluster_axis={}, chunk_local={}, Sq*tp={}",
+                cluster_axis.has_value(),
+                chunk_local,
+                Sq * tp);
+            TT_FATAL(
+                *seq_subshard_axis < mesh_shape.dims() && *seq_subshard_axis != *cluster_axis,
+                "indexer_score: seq_subshard_axis ({}) must be an in-range mesh axis distinct from cluster_axis ({})",
+                *seq_subshard_axis,
+                *cluster_axis);
+        }
         // Store {sp, chunk_local} (matching sparse_sdpa's BlockCyclicLayout); the factory derives the global
         // chunk (sp*chunk_local) and the invP tile divisors from these.
         if (sp > 1) {
@@ -603,6 +628,7 @@ ttnn::Tensor launch_indexer_score(
         cache_batch_idx,
         kv_len,
         cluster_axis,
+        seq_subshard_axis,
         block_cyclic);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
@@ -619,6 +645,7 @@ ttnn::Tensor indexer_score_dsa(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
     std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> seq_subshard_axis,
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local) {
     // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling. Reads its real weights tensor.
@@ -637,6 +664,7 @@ ttnn::Tensor indexer_score_dsa(
         cache_batch_idx,
         kv_len,
         cluster_axis,
+        seq_subshard_axis,
         block_cyclic_sp_axis,
         block_cyclic_chunk_local);
 }
@@ -677,6 +705,7 @@ ttnn::Tensor indexer_score_msa(
         cache_batch_idx,
         kv_len,
         cluster_axis,
+        /*seq_subshard_axis=*/std::nullopt,
         block_cyclic_sp_axis,
         block_cyclic_chunk_local);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -580,8 +580,8 @@ ttnn::Tensor launch_indexer_score(
 
     // base = the absolute chunk_start of this op's rank 0. Omit it -> deduce the start of the gathered chunk:
     //   * block-cyclic: the gathered chunk IS the global chunk (sp*chunk_local) -> base = T - chunk.
-    //   * contiguous: the gathered chunk is sp_ring*Sq (each SP device contributes Sq) -> base = T - sp_ring*Sq,
-    //     the same deduction as before this feature (single chip: sp_ring = 1 -> base = T - Sq).
+    //   * contiguous: the gathered chunk is seq_ring*Sq. Normally seq_ring is the SP ring; for the identity
+    //     block-cyclic SP=1 + TP sub-shard it is the TP ring instead.
     // The deduced window ends at T (incompatible with a growing kv_len < T -- pass chunk_start_idx there).
     uint32_t base = 0;
     if (chunk_start_idx.has_value()) {
@@ -598,18 +598,20 @@ ttnn::Tensor launch_indexer_score(
                 chunk);
             base = T - chunk;
         } else {
-            // sp_ring = max_rank + 1 (get_linearized_index returns coord-min; get_topological_dimension would
-            // over-count on a nonzero-offset sub-mesh). max_linearized_rank is shared with the validated window.
-            const uint32_t sp_ring =
-                ttnn::operations::experimental::indexer_score::max_linearized_rank(q, cluster_axis) + 1;
+            // seq_ring = max_rank + 1 (get_linearized_index returns coord-min; get_topological_dimension would
+            // over-count on a nonzero-offset sub-mesh). A TP sub-shard is possible here only for SP=1, whose
+            // block-cyclic permutation is stored as contiguous, so TP is the sequence-bearing axis.
+            const auto seq_axis = seq_subshard_axis.has_value() ? seq_subshard_axis : cluster_axis;
+            const uint32_t seq_ring =
+                ttnn::operations::experimental::indexer_score::max_linearized_rank(q, seq_axis) + 1;
             TT_FATAL(
-                T >= sp_ring * Sq,
-                "indexer_score: cannot deduce chunk_start_idx -- T={} < sp_ring({})*Sq({}). Pass chunk_start_idx "
-                "explicitly if K does not equal history + the SP-gathered chunk.",
+                T >= seq_ring * Sq,
+                "indexer_score: cannot deduce chunk_start_idx -- T={} < seq_ring({})*Sq({}). Pass chunk_start_idx "
+                "explicitly if K does not equal history + the gathered query chunk.",
                 T,
-                sp_ring,
+                seq_ring,
                 Sq);
-            base = T - sp_ring * Sq;
+            base = T - seq_ring * Sq;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -54,6 +54,7 @@ struct IndexerScoreDeviceOperation {
         std::optional<uint32_t> cache_batch_idx,
         std::optional<uint32_t> kv_len,
         std::optional<uint32_t> cluster_axis,
+        std::optional<uint32_t> seq_subshard_axis,
         std::optional<BlockCyclicLayout> block_cyclic);
 };
 
@@ -91,6 +92,7 @@ ttnn::Tensor indexer_score_dsa(
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_len = std::nullopt,
     std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<uint32_t> seq_subshard_axis = std::nullopt,
     std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
     std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -47,6 +47,11 @@ struct operation_attributes_t {
     // host-side and passed to compute as a RUNTIME arg (hash-excluded), so distinct values reuse one program.
     uint32_t chunk_start_idx{0};             // elements, tile-aligned
     std::optional<uint32_t> cluster_axis{};  // mesh axis that is the SP ring; unset = linear device order
+    // Second mesh axis (TP) that the query sequence is ALSO block-cyclically sub-sharded over, on top of the
+    // SP block-cyclic layout. When set (alongside a named cluster_axis + block_cyclic), each device owns a
+    // Sq-row sub-range [tp_rank*Sq, (tp_rank+1)*Sq) of its SP chip's chunk_local-wide slab; the causal geometry
+    // adds that TP sub-offset to the exact block-cyclic position. unset = query sharded on the SP axis only.
+    std::optional<uint32_t> seq_subshard_axis{};
     // ReLU on each per-head q.kT before the gate-mul. true = DSA/GLM (relu(q.k)*w); false = raw dot (M3 MSA).
     // Compile-time, so the true path is byte-identical to before.
     bool apply_relu{true};

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -73,7 +73,12 @@ inline DeviceCausalGeometry device_causal_geometry(
     const operation_attributes_t& args, uint32_t device_index, uint32_t tp_index, uint32_t Sq) {
     const uint32_t TW = tt::constants::TILE_WIDTH;
     if (!args.block_cyclic.has_value()) {
-        return {(args.chunk_start_idx + device_index * Sq) / TW, 0u, 0u};  // contiguous K -> linear diagonal
+        // Contiguous K -> linear diagonal at chunk_start + (seq-shard rank)*Sq. The rank is device_index for an
+        // SP-only seq shard; but a 2D SP×TP sub-shard whose SP axis is size-1 (e.g. QuietBox sp=1) is stored
+        // as no-block-cyclic (identity permutation), and there the query is seq-sharded over the TP axis, so the
+        // rank is tp_index. The two are mutually exclusive nonzero here (tp_index!=0 requires block_cyclic_sp_axis
+        // set with sp==1, which forces device_index==0; no sub-shard -> tp_index==0), so their sum is the rank.
+        return {(args.chunk_start_idx + (device_index + tp_index) * Sq) / TW, 0u, 0u};
     }
     const uint32_t sp = args.block_cyclic->sp;
     const uint32_t chunk_local = args.block_cyclic->chunk_local;  // cache per-shard slab width (elements)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -70,7 +70,7 @@ struct DeviceCausalGeometry {
     uint32_t straddle_jump_tiles;  // diagonal jump in tiles (0 unless this device straddles)
 };
 inline DeviceCausalGeometry device_causal_geometry(
-    const operation_attributes_t& args, uint32_t device_index, uint32_t Sq) {
+    const operation_attributes_t& args, uint32_t device_index, uint32_t tp_index, uint32_t Sq) {
     const uint32_t TW = tt::constants::TILE_WIDTH;
     if (!args.block_cyclic.has_value()) {
         return {(args.chunk_start_idx + device_index * Sq) / TW, 0u, 0u};  // contiguous K -> linear diagonal
@@ -85,21 +85,23 @@ inline DeviceCausalGeometry device_causal_geometry(
             "indexer_score: device_index {} out of range for block-cyclic sp={} (check cluster_axis vs block_cyclic_sp_axis)",
             device_index,
             sp);
-        // SP-only block-cyclic: device_index is the SP-ring index and owns ONE block (Sq == chunk_local).
-        // Mirror the update_padded_kv_cache writer's update_idxt (== rotated_chip_positions[device_index][0])
-        // so the diagonal starts at this chip's TRUE logical block -- handling the boundary_chip rotation that
-        // the linear chunk_start_idx + c*Sq misses. Only the boundary chip is mid-slab, so only it straddles.
+        // Block-cyclic, named SP axis. device_index is the SP-ring index; its slab starts at the writer's
+        // update_idxt (== rotated_chip_positions[device_index][0]), handling the boundary_chip rotation the
+        // linear form misses. tp_index (SP×TP 2D sub-shard) selects this device's Sq-row sub-range within that
+        // slab: it owns local rows [tp_index*Sq, (tp_index+1)*Sq). lr0 is its first slab-local row; the mapping
+        // and straddle below are EXACT for both the SP-only case (tp_index==0, Sq==chunk_local) and the 2D case.
         const uint32_t boundary_slab = args.chunk_start_idx / chunk_global;
         const uint32_t boundary_chip = (args.chunk_start_idx / chunk_local) % sp;
         const uint32_t offset = args.chunk_start_idx % chunk_local;
         const uint32_t update_idxt = device_index < boundary_chip    ? (boundary_slab + 1) * chunk_local
                                      : device_index == boundary_chip ? boundary_slab * chunk_local + offset
                                                                      : boundary_slab * chunk_local;
-        const uint32_t logical_start =
-            (update_idxt / chunk_local) * chunk_global + device_index * chunk_local + (update_idxt % chunk_local);
+        const uint32_t lr0 = update_idxt + tp_index * Sq;  // this device's first slab-local row (TP sub-offset)
+        const uint32_t loff = lr0 % chunk_local;           // its offset within the current slab
+        const uint32_t logical_start = (lr0 / chunk_local) * chunk_global + device_index * chunk_local + loff;
         uint32_t straddle_q_tile = 0, straddle_jump_tiles = 0;
-        if (device_index == boundary_chip && offset != 0 && offset + Sq > chunk_local) {
-            straddle_q_tile = (chunk_local - offset) / TW;
+        if (loff != 0 && loff + Sq > chunk_local) {  // this device's Sq rows cross a slab boundary
+            straddle_q_tile = (chunk_local - loff) / TW;
             straddle_jump_tiles = (chunk_global - chunk_local) / TW;
         }
         return {logical_start / TW, straddle_q_tile, straddle_jump_tiles};
@@ -168,9 +170,14 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     const uint32_t T = k.logical_shape()[2];
 
     // This device's SP-ring index and chunk_start (tiles), from the coordinate. chunk_t is a compute RUNTIME
-    // arg, so the binary is identical across coords and steps.
+    // arg, so the binary is identical across coords and steps. tp_index = its rank along seq_subshard_axis
+    // (the 2D SP×TP query sub-shard); 0 when not sub-sharded or single-device.
     const uint32_t device_index = device_index_for(args, coord, q);
-    const auto geom = device_causal_geometry(args, device_index, Sq);
+    const uint32_t tp_index =
+        (args.seq_subshard_axis.has_value() && q.device_storage().get_coords().size() > 1)
+            ? ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, args.seq_subshard_axis)
+            : 0u;
+    const auto geom = device_causal_geometry(args, device_index, tp_index, Sq);
     const uint32_t chunk_t = geom.chunk_start_tiles;
 
     const uint32_t Sqt = Sq / tt::constants::TILE_HEIGHT;
@@ -573,7 +580,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
             .compute_kernel = compute_id,
             .writer_kernel = writer_id,
             .worker_cores = cores,
-            .device_index = device_index}};
+            .device_index = device_index,
+            .tp_index = tp_index}};
 }
 
 IndexerScoreProgramFactory::cached_mesh_workload_t IndexerScoreProgramFactory::create_mesh_workload(
@@ -609,7 +617,7 @@ void IndexerScoreProgramFactory::override_runtime_arguments(
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, shared.reader_kernel);
         auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, shared.compute_kernel);
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, shared.writer_kernel);
-        const auto geom = device_causal_geometry(args, shared.device_index, Sq);
+        const auto geom = device_causal_geometry(args, shared.device_index, shared.tp_index, Sq);
         const uint32_t chunk_t = geom.chunk_start_tiles;
         for (const auto& core : shared.worker_cores) {
             auto& reader_rt = reader_args[core.x][core.y];

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
@@ -20,6 +20,9 @@ struct IndexerScoreSharedVariables {
     // This device's linearized SP-ring index (from its mesh coordinate); chunk_start = base + idx*stride.
     // Stored so override_runtime_arguments can recompute chunk_start for new base/stride on a cache hit.
     uint32_t device_index = 0;
+    // This device's TP-rank along seq_subshard_axis (0 when not 2D-sub-sharded); the 2D block-cyclic geometry
+    // adds tp_index*Sq to the slab position. Stored for the same override recompute.
+    uint32_t tp_index = 0;
 };
 
 // Native mesh-workload factory: one program per mesh coordinate so each device derives its own

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -62,6 +62,14 @@ void bind_indexer_score(nb::module_& mod) {
                 chunk_start = chunk_start_idx + r*Sq, where r is its linearized
                 index along this axis (Sq = q seq len). None = linear device order
                 (1 on a single device, so chunk_start_idx is used as-is).
+            seq_subshard_axis: optional int, the SECOND mesh axis (TP) the query seq is
+                block-cyclically sub-sharded over, on top of the SP block-cyclic layout.
+                Set it alongside a named cluster_axis + block_cyclic when the query rows
+                are further split across TP (block_cyclic_chunk_local == tp*q_isl): the
+                exact geometry adds tp_rank*Sq to each device's block-cyclic position, so
+                the causal mask stays correct under rotated (mid-slab) starts — unlike the
+                cluster_axis=None flat path, which is linear-approximate there. Requires a
+                block-cyclic layout and an axis distinct from cluster_axis.
             block_cyclic_sp_axis: optional int. The MESH AXIS the K cache was striped
                 over (chunked prefill + SP all-gather leaves [B,1,T,D] k in per-SP-shard
                 slab / block-cyclic physical order). ``sp`` is DERIVED from the mesh
@@ -90,6 +98,7 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("cache_batch_idx") = std::nullopt,
         nb::arg("kv_len") = std::nullopt,
         nb::arg("cluster_axis") = std::nullopt,
+        nb::arg("seq_subshard_axis") = std::nullopt,
         nb::arg("block_cyclic_sp_axis") = std::nullopt,
         nb::arg("block_cyclic_chunk_local") = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -82,8 +82,11 @@ void bind_indexer_score(nb::module_& mod) {
                 The per-shard chunk length (chunk_size_global / sp). Cross-checked
                 against q: must equal q_isl (Sq, seq sharded only on the SP axis) or
                 tp*q_isl (tp = mesh_size/sp). The tp*q_isl case with tp>1 (seq sharded
-                across BOTH axes) is allowed only with cluster_axis=None (flat row-major
-                linearization over all devices); with a named cluster_axis it is rejected.
+                across BOTH axes) has two forms: with cluster_axis=None it uses flat
+                row-major linearization over all devices (linear-approximate under a
+                mid-slab start); with a named cluster_axis it must also pass
+                seq_subshard_axis naming the TP axis, which gives the rotation-exact 2D
+                geometry (see seq_subshard_axis above).
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",


### PR DESCRIPTION
### What & why

Today `indexer_score` and `top-k` aren't TP-parallel — every TP chip runs them over the full query — and a **2-CCL logit all-reduce** (reduce-scatter + all-gather) is needed to sum the per-chip partial head-logits. This seq-shards the query over TP so both ops become TP-parallel (each chip works `S/(sp·tp)` rows), and replicates `wq_b` so each chip's head-sum is already complete on-chip — **dropping those 2 CCLs**. (Top-k's selected indices are gathered back over TP — one small CCL — so `sparse_sdpa` sees the same `[1,1,S/sp,k]` it always did.)

### Block-cyclic-aware indexer op

Under the block-cyclic KV layout a mid-slab chunk staggers each chip's query positions; a TP-sharded query must be scored *with* that stagger or top-k selects the wrong keys (a flat-geometry prototype regressed `test_sparse_mla_rotated` to 0.95, below the 0.98 gate). This extends `indexer_score`'s exact block-cyclic geometry to a 2D (SP×TP) sub-shard via a new `seq_subshard_axis` — rotation-exact by construction. Mechanics live in `device_causal_geometry` + the `indexer.py` block comment. **`mla.py` and the RoPE op are untouched.**

### Evidence

Correctness: `test_sparse_mla_rotated` 0.73→0.99 (gate 0.98); `accuracy` 12/12 incl. a 4×2 mesh. Measured on **LoudBox (8× Blackhole p150b, SP=2×TP=4 — 1/4-Galaxy proxy)**, sparse vs the merge-base baseline (TP-head-sharded indexer w/ the logit all-reduce); dense (v3.1 ring-MLA, indexer-independent) is the **control**.

**deepseek_v32** — critical-path device-kernel time (ms):
| scenario | sparse before | sparse after | Δ vs baseline | dense (control) |
|---|--:|--:|--:|--:|
| warm | 10.05 | **9.21** | **−8.3%** | 10.27 |
| cold | 95.06 | **86.79** | **−8.7%** | 72.64 |
| long | 32.31 | **19.34** | **−40.2%** | 76.98 |

**glm_5_1** — critical-path device-kernel time (ms):
| scenario | sparse before | sparse after | Δ vs baseline | dense (control) |
|---|--:|--:|--:|--:|
| warm | 9.07 | **7.87** | **−13.3%** | 3.71 |
| cold | 93.57 | **81.42** | **−13.0%** | 31.25 |
| long | 30.45 | **17.43** | **−42.8%** | 19.55 |

The win **grows with prefix** — both the removed all-reduce and the top-k work scale with `end_pos`. Per-op before/after + the code-verified dataflow graph: 📊 [interactive report](https://claude.ai/code/artifact/69360c1f-ffd2-42c1-9878-b03024805633).

### Notes for reviewers

- `seq_subshard_axis` is hashed (`has_value`) so a 2D call can't reuse an SP-only program's cached per-device offset.
- GLM (16 heads/chip) also pays a head→sequence reshard in `ttMLA._sparse_mla`; with this change GLM sparse now overtakes GLM dense at long prefix (17.43 vs 19.55).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/indexer_sp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasilijevic/indexer_sp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvasilijevic/indexer_sp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/indexer_sp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasilijevic/indexer_sp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/indexer_sp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/indexer_sp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/indexer_sp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/indexer_sp32)
