### PR TITLE
[Bug fix] emule: fix fiber-scheduler teardown hang from non-atomic W_/generation_ publish

### DIFF
--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -440,12 +440,17 @@ void FiberScheduler::run_until_idle() {
     }
 
     unsigned W;
-    {
+    {   // Publish the whole program in ONE critical section: reset counters + progress, size + fill
+        // the ready queues, AND bump generation_ atomically. generation_ must not be bumped in a
+        // separate locked block: a worker preempted past the previous program's wake could then
+        // observe the new W_ paired with a STALE generation_, pass `w < W_`, run inner_loop an
+        // extra time and double-count workers_done_ past W_ — stalling the done_cv_ wait below
+        // forever (watchdog trip / hang). See tt-emule docs/fiber-engine.md.
         std::lock_guard<std::mutex> g(p_->mu_);
-        p_->active_ = static_cast<unsigned>(p_->all_.size());
-        if (p_->active_ == 0) {
+        if (p_->all_.empty()) {
             return;   // nothing to run; the pool stays parked
         }
+        p_->active_ = static_cast<unsigned>(p_->all_.size());
         p_->idle_ = 0;
         p_->running_ = 0;
         p_->workers_done_ = 0;
@@ -453,9 +458,10 @@ void FiberScheduler::run_until_idle() {
         p_->abort_flag_ = false;
         p_->first_eptr_ = nullptr;
         p_->latency_parked_.clear();
+        p_->progress_.store(0);
+        p_->resumptions_.store(0);
         // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
         // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
-        // See tt-emule docs/fiber-engine.md.
         W = std::min<unsigned>(p_->K_, p_->active_);
         p_->W_ = W;
         p_->ready_.assign(W, {});
@@ -464,22 +470,19 @@ void FiberScheduler::run_until_idle() {
             f->home = static_cast<unsigned>(i % W);
             p_->ready_[f->home].push_back(f);
         }
+        ++p_->generation_;
     }
-    p_->progress_.store(0);
-    p_->resumptions_.store(0);
     if (std::getenv("TT_EMULE_FIBER_LOG_N")) {
         std::fprintf(stderr, "[EMULE FIBER] program: %u fibers on W=%u of K=%u workers\n",
                      p_->active_, W, p_->K_);
     }
 
+    // Watchdog up before the pool is released (notify_all below): a parked worker cannot wake until
+    // that notify, so the run is covered. Created after the dispatch block so a throw there can't
+    // leave a joinable thread. See tt-emule docs/fiber-engine.md.
     p_->run_active_.store(true, std::memory_order_release);
     std::thread wd([this] { p_->watchdog(); });
 
-    // Launch: bump the generation under mu_ (after the watchdog is up), then wake the pool.
-    {
-        std::lock_guard<std::mutex> g(p_->mu_);
-        ++p_->generation_;
-    }
     p_->start_cv_.notify_all();
     {   // Block the dispatch thread until every active worker has finished this run.
         std::unique_lock<std::mutex> lk(p_->mu_);

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -440,17 +440,14 @@ void FiberScheduler::run_until_idle() {
     }
 
     unsigned W;
-    {   // Publish the whole program in ONE critical section: reset counters + progress, size + fill
-        // the ready queues, AND bump generation_ atomically. generation_ must not be bumped in a
-        // separate locked block: a worker preempted past the previous program's wake could then
-        // observe the new W_ paired with a STALE generation_, pass `w < W_`, run inner_loop an
-        // extra time and double-count workers_done_ past W_ — stalling the done_cv_ wait below
-        // forever (watchdog trip / hang). See tt-emule docs/fiber-engine.md.
+    {   // Publish counters + progress, W_, the ready queues, and ++generation_ in ONE mu_ critical
+        // section, so a worker released for a generation never pairs a new W_ with a stale generation_.
+        // See tt-emule docs/fiber-engine.md §9.4 (the workers_done_ overshoot / done_cv_ wedge it avoids).
         std::lock_guard<std::mutex> g(p_->mu_);
-        if (p_->all_.empty()) {
+        p_->active_ = static_cast<unsigned>(p_->all_.size());
+        if (p_->active_ == 0) {
             return;   // nothing to run; the pool stays parked
         }
-        p_->active_ = static_cast<unsigned>(p_->all_.size());
         p_->idle_ = 0;
         p_->running_ = 0;
         p_->workers_done_ = 0;
@@ -477,9 +474,9 @@ void FiberScheduler::run_until_idle() {
                      p_->active_, W, p_->K_);
     }
 
-    // Watchdog up before the pool is released (notify_all below): a parked worker cannot wake until
-    // that notify, so the run is covered. Created after the dispatch block so a throw there can't
-    // leave a joinable thread. See tt-emule docs/fiber-engine.md.
+    // Watchdog before notify_all so it covers the run; created after the dispatch block so a throw
+    // there can't leave a joinable thread. (A spurious start_cv_ wakeup could start a worker in the
+    // brief gap before this line — benign: the watchdog spawns at once and a hang can't complete that fast.)
     p_->run_active_.store(true, std::memory_order_release);
     std::thread wd([this] { p_->watchdog(); });
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes a teardown deadlock in the tt-emule software-emulation fiber scheduler
(`tt_metal/impl/emulation/emule_fiber_scheduler.cpp`). This path is emule-only (compiled into the
emulated runtime); the silicon code path is unaffected.

`run_until_idle` published the new `W_` (active-worker count, in the dispatch critical section) and the
`generation_` bump (in a *separate* locked block), with `mu_` released between them. Under worker
oversubscription (K > cores — the emule default is K=64), a worker preempted past the previous program's
wake could resume in that window, observe the **new `W_` paired with a stale `generation_`**, pass the
`w < W_` gate, run `inner_loop` an extra time, and double-count `workers_done_` past `W_`. The teardown
wait `done_cv_.wait(workers_done_ == W)` was then never satisfied and the program hung — surfaced in the
tt-emule regression as `dm_test_concat_iterative` (fiber-watchdog abort) and `dm_test_gather` (900s timeout).

The fix publishes the whole program — counters, `W_`, ready-queue dispatch, and `++generation_` — in a
single `mu_` critical section, so a worker can never observe a new `W_` with a stale `generation_`.

Relates to tenstorrent/tt-emule#266, which pins this commit.

### Notes for reviewers
- The change is confined to `run_until_idle` (first commit +14/−11); the second commit is comment/ordering
  polish only (set `active_` before the empty-program early return; soften the watchdog comment). No silicon
  path is touched.
- The watchdog thread is created after the dispatch block but before `notify_all`, so it covers the run
  while avoiding a joinable `std::thread` on a throw from the dispatch block. A spurious `start_cv_` wakeup
  can technically start a worker in the brief gap before the watchdog spawns — benign (the watchdog spawns
  at once and a hang cannot complete that fast).
- Verification (emule): repro oracle — concat (BH) 7/7 and gather (WH) 4/4 whole-file runs under CPU
  oversubscription, 0 aborts/hangs (was rep-1 / 2-of-3 pre-fix). C++ per-arch regression bit/PCC-identical
  across K=1/64/256 (WH 54/0, BH 19/0); Quasar matches its known-failure allowlist. Full ttnn suites
  (K=64): WH 179/2, BH 179/3 — all failures pre-existing (nightly sdpa 900s timeouts + one flaky BH
  `elt_test_sqrt` ULP), zero fiber-scheduler failures.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arminale/emule-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-deadlock-fix)