### PR TITLE
[Feature] Support Row Major interleaved input/output on the legacy GroupNorm path

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -194,8 +194,7 @@ def test_group_norm_DRAM_oft_unit_shapes(
     base.test_group_norm_DRAM_oft(device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x, eps, specify_grid)
 
 
-# Layout combinations on the legacy ROW_MAJOR DRAM path.
-@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only")
+@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only, see #52279")
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])
 @pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x", base.GROUP_NORM_ROW_MAJOR_SHAPES)
 @pytest.mark.parametrize("welford_mode", ["legacy"])
@@ -205,11 +204,10 @@ def test_group_norm_DRAM_oft_unit_shapes(
         (ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT),
         (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
         (ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
-        (ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT),
     ],
-    ids=["RM_IN_TILE_OUT", "TILE_IN_RM_OUT", "RM_IN_RM_OUT", "TILE_IN_TILE_OUT"],
+    ids=["RM_IN_TILE_OUT", "TILE_IN_RM_OUT", "RM_IN_RM_OUT"],
 )
-def test_group_norm_DRAM_row_major_layouts(
+def test_group_norm_DRAM_row_major(
     device,
     N,
     C,
@@ -241,7 +239,7 @@ def test_group_norm_DRAM_row_major_layouts(
 
 
 # Optional weight/bias and input-mask coverage, one representative shape.
-@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only")
+@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only, see #52279")
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])
 @pytest.mark.parametrize("use_input_mask", [True, False], ids=["mask", "no_mask"])
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -366,3 +366,32 @@ def test_group_norm_DRAM_row_major_affine_and_mask(
         atol=0.069,
         frobenius_threshold=0.025,
     )
+
+
+# Regression: ROW_MAJOR out + large block_ht on no_mcast used to undersize c_10 and hang.
+@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only, see #52279")
+@pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])
+@pytest.mark.timeout(300)
+def test_group_norm_DRAM_row_major_no_mcast_large_block_ht(device):
+    """c_10 (cb_ex_external) must be sized for num_out_blocks_padded on the no_mcast path.
+
+    N=8 >= num_virtual_rows=8 selects no_mcast; 768/32 = 24 ch/group straddles tiles,
+    so the ROW_MAJOR-output override raises num_out_blocks from 16 to block_ht =
+    8704/32 = 272. The sender reader then reserves ceil(272 * 16B / 2048B) = 3 pages
+    per iteration; the CB must be at least that large.
+    """
+    base.run_group_norm_DRAM(
+        device,
+        8,
+        768,
+        1,
+        8704,
+        32,
+        16,
+        8,
+        8,
+        "legacy",
+        use_input_mask=True,
+        input_layout=ttnn.TILE_LAYOUT,
+        output_layout=ttnn.ROW_MAJOR_LAYOUT,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -238,6 +238,46 @@ def test_group_norm_DRAM_row_major(
     )
 
 
+# Welford + interleaved ROW_MAJOR must fail (legacy-only feature).
+@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only, see #52279")
+@pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])
+@pytest.mark.parametrize(
+    "input_layout, output_layout",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT),
+        (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+    ids=["RM_IN_TILE_OUT", "TILE_IN_RM_OUT", "RM_IN_RM_OUT"],
+)
+def test_group_norm_DRAM_row_major_rejects_welford(device, input_layout, output_layout, expect_error):
+    N, C, H, W = 1, 480, 1, 64
+    num_groups = 8
+    grid_size = ttnn.CoreGrid(y=1, x=1)
+
+    tt_input = ttnn.from_torch(
+        torch.rand((N, 1, H * W, C), dtype=torch.bfloat16),
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    if input_layout == ttnn.TILE_LAYOUT:
+        tt_input = ttnn.tilize_with_zero_padding(tt_input, use_multicore=True)
+
+    with expect_error(RuntimeError, "not supported on the Welford path"):
+        ttnn.group_norm(
+            tt_input,
+            num_groups=num_groups,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            output_layout=output_layout,
+            core_grid=grid_size,
+            inplace=False,
+            num_out_blocks=1,
+            use_welford=True,
+        )
+
+
 # Optional weight/bias and input-mask coverage, one representative shape.
 @skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only, see #52279")
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -16,6 +16,45 @@ from models.common.utility_functions import is_blackhole, run_for_blackhole, ski
 import tests.ttnn.unit_tests.operations.fused.test_group_norm_DRAM as base
 
 
+# Legacy ROW_MAJOR shapes, PR #49501.
+GROUP_NORM_ROW_MAJOR_SHAPES = [
+    # Model shapes that should benefit
+    # (N,    C,    H,    W,     g, nob, cy, cx)
+    (1, 512, 128, 128, 32, 1, 8, 8),
+    (1, 512, 64, 64, 32, 1, 8, 8),
+    (1, 256, 256, 256, 32, 8, 8, 8),
+    (1, 128, 1, 512, 32, 1, 8, 8),
+    # Model shapes that should avoid regression due to fallback
+    (1, 1152, 128, 128, 32, 2, 8, 4),
+    (1, 1920, 16, 16, 32, 1, 4, 4),
+    (1, 1536, 8, 8, 32, 1, 2, 8),
+    (1, 480, 1, 64, 8, 1, 1, 1),
+    # Model shapes that should stay unaffected
+    (1, 256, 256, 256, 32, 4, 8, 8),
+    (1, 512, 256, 256, 32, 4, 8, 8),
+    (1, 256, 1024, 1024, 32, 48, 8, 8),
+    (1, 128, 1, 262144, 32, 64, 8, 4),
+    # Synthetic grid-utilization
+    (1, 512, 1, 1024, 32, 2, 1, 8),
+    (1, 512, 1, 2048, 32, 2, 2, 8),
+    (1, 512, 1, 3072, 32, 2, 3, 8),
+    (1, 512, 1, 4096, 32, 2, 4, 8),
+    (1, 512, 1, 5120, 32, 2, 5, 8),
+    (1, 512, 1, 6144, 32, 2, 6, 8),
+    (1, 512, 1, 7168, 32, 2, 7, 8),
+    (1, 512, 1, 8192, 32, 2, 8, 8),
+    # Synthetic batch-imbalance
+    (9, 768, 1, 512, 32, 2, 8, 8),
+    (10, 768, 1, 512, 32, 2, 8, 8),
+    (16, 768, 1, 512, 32, 2, 8, 8),
+    (17, 768, 1, 512, 32, 2, 8, 8),
+    # Synthetic that should take fused path
+    (1, 768, 1, 512, 32, 2, 8, 8),
+    (2, 768, 1, 512, 32, 2, 8, 8),
+    (8, 768, 1, 512, 32, 2, 8, 8),
+]
+
+
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",
@@ -196,7 +235,7 @@ def test_group_norm_DRAM_oft_unit_shapes(
 
 @skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only, see #52279")
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])
-@pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x", base.GROUP_NORM_ROW_MAJOR_SHAPES)
+@pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x", GROUP_NORM_ROW_MAJOR_SHAPES)
 @pytest.mark.parametrize("welford_mode", ["legacy"])
 @pytest.mark.parametrize(
     "input_layout, output_layout",

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -10,8 +10,8 @@ from loguru import logger
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.common.utility_functions import is_blackhole, run_for_blackhole
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
+from models.common.utility_functions import is_blackhole, run_for_blackhole, skip_for_blackhole
 
 import tests.ttnn.unit_tests.operations.fused.test_group_norm_DRAM as base
 
@@ -49,7 +49,7 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
 
 
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
-def test_group_norm_DRAM_rejects_non_uniform_mcast_groups(device):
+def test_group_norm_DRAM_rejects_non_uniform_mcast_groups(device, expect_error):
     """Regression test for GH#40912: N=2 with grid (8,5) creates num_virtual_rows=5
     which is not divisible by num_batches=2, producing non-uniform mcast groups
     that deadlock due to exact-equality semaphore waits in the sender kernel."""
@@ -76,7 +76,7 @@ def test_group_norm_DRAM_rejects_non_uniform_mcast_groups(device):
         [torch_weight, torch_bias], C, num_groups, device, core_grid=bad_grid, return_mask=True
     )
 
-    with pytest.raises(RuntimeError, match="core_grid"):
+    with expect_error(RuntimeError, "core_grid"):
         ttnn.group_norm(
             input_tensor_tilized,
             num_groups=num_groups,
@@ -192,3 +192,139 @@ def test_group_norm_DRAM_oft_unit_shapes(
     device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x, eps, specify_grid
 ):
     base.test_group_norm_DRAM_oft(device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x, eps, specify_grid)
+
+
+# Layout combinations on the legacy ROW_MAJOR DRAM path.
+@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only")
+@pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])
+@pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x", base.GROUP_NORM_ROW_MAJOR_SHAPES)
+@pytest.mark.parametrize("welford_mode", ["legacy"])
+@pytest.mark.parametrize(
+    "input_layout, output_layout",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT),
+        (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT),
+    ],
+    ids=["RM_IN_TILE_OUT", "TILE_IN_RM_OUT", "RM_IN_RM_OUT", "TILE_IN_TILE_OUT"],
+)
+def test_group_norm_DRAM_row_major_layouts(
+    device,
+    N,
+    C,
+    H,
+    W,
+    num_groups,
+    num_out_blocks,
+    cores_y,
+    cores_x,
+    welford_mode,
+    input_layout,
+    output_layout,
+):
+    base.run_group_norm_DRAM(
+        device,
+        N,
+        C,
+        H,
+        W,
+        num_groups,
+        num_out_blocks,
+        cores_y,
+        cores_x,
+        welford_mode,
+        use_input_mask=True,
+        input_layout=input_layout,
+        output_layout=output_layout,
+    )
+
+
+# Optional weight/bias and input-mask coverage, one representative shape.
+@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only")
+@pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True, ids=["l1small0"])
+@pytest.mark.parametrize("use_input_mask", [True, False], ids=["mask", "no_mask"])
+@pytest.mark.parametrize(
+    "has_weight, has_bias",
+    [(True, True), (False, False), (True, False), (False, True)],
+    ids=["weight_and_bias", "no_affine", "weight_only", "bias_only"],
+)
+@pytest.mark.parametrize(
+    "input_layout, output_layout",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT),
+        (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+    ids=["RM_IN_TILE_OUT", "TILE_IN_RM_OUT", "RM_IN_RM_OUT"],
+)
+def test_group_norm_DRAM_row_major_affine_and_mask(
+    device,
+    use_input_mask,
+    has_weight,
+    has_bias,
+    input_layout,
+    output_layout,
+):
+    torch.manual_seed(0)
+
+    N, C, H, W = 1, 480, 1, 64
+    num_groups = 8
+    num_out_blocks = 1
+    grid_size = ttnn.CoreGrid(y=1, x=1)
+    num_virtual_cols = ttnn.operations.normalization.dram_group_norm_virtual_columns(grid_size, C, num_groups)
+
+    torch_input = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_weight = torch.rand((C,), dtype=torch.bfloat16) if has_weight else None
+    torch_bias = torch.rand((C,), dtype=torch.bfloat16) if has_bias else None
+    torch_output = (
+        torch.nn.functional.group_norm(torch_input, num_groups, weight=torch_weight, bias=torch_bias, eps=1e-12)
+        .permute(0, 2, 3, 1)
+        .view(N, 1, H * W, C)
+    )
+
+    gamma_t = beta_t = input_mask = None
+    if has_weight:
+        gamma_t = ttnn.dram_group_norm_params_from_torch(
+            torch_weight, C, num_groups, device, core_grid=grid_size, return_mask=False
+        )
+    if has_bias:
+        beta_t = ttnn.dram_group_norm_params_from_torch(
+            torch_bias, C, num_groups, device, core_grid=grid_size, return_mask=False
+        )
+    if use_input_mask:
+        input_mask = ttnn.to_device(
+            ttnn.create_group_norm_input_mask(C, num_groups, num_virtual_cols, ttnn.bfloat16), device
+        )
+
+    tt_input = ttnn.from_torch(
+        torch_input.permute(0, 2, 3, 1).view(N, 1, H * W, C),
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    if input_layout == ttnn.TILE_LAYOUT:
+        tt_input = ttnn.tilize_with_zero_padding(tt_input, use_multicore=True)
+
+    tt_output = ttnn.group_norm(
+        tt_input,
+        num_groups=num_groups,
+        input_mask=input_mask,
+        weight=gamma_t,
+        bias=beta_t,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_layout=output_layout,
+        core_grid=grid_size,
+        inplace=False,
+        num_out_blocks=num_out_blocks,
+        use_welford=False,
+    )
+    assert_numeric_metrics(
+        torch_output,
+        ttnn.to_torch(ttnn.from_device(tt_output)),
+        pcc_threshold=0.999,
+        rtol=0.060,
+        atol=0.069,
+        frobenius_threshold=0.025,
+    )

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 import ttnn
 
-from models.common.utility_functions import run_for_blackhole, skip_for_blackhole
+from models.common.utility_functions import run_for_blackhole, is_wormhole_b0
 from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
@@ -138,10 +138,17 @@ OPTIONAL_WEIGHT_BIAS_AFFINE_PARAMS = [
 ]
 OPTIONAL_WEIGHT_BIAS_AFFINE_IDS = ["no_affine", "weight_only", "bias_only"]
 
+# ttnn.empty produces a ROW_MAJOR interleaved input. On Blackhole the non-sharded path
+# rejects that up front; on Wormhole ROW_MAJOR is allowed, so the same shape reaches
+# the device-op tile-height check instead.
+_NEGATIVE_TEST_MSG = (
+    "must be a multiple of the tile height"
+    if is_wormhole_b0()
+    else "interleaved \\(non-sharded\\) input must be in TILE layout"
+)
+
 NEGATIVE_TESTS_PARAMS = [
-    # Shape is rejected by the device op because its per-batch H*W (16) is not a
-    # multiple of the tile height (32).
-    ((2, 1, 16, 32), 8, "must be a multiple of the tile height"),
+    ((2, 1, 16, 32), 8, _NEGATIVE_TEST_MSG),
 ]
 
 
@@ -1464,7 +1471,6 @@ def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, specify_grid):
     ), "High-accuracy config should have lower Frobenius error than low-accuracy config"
 
 
-@skip_for_blackhole("interleaved ROW_MAJOR is rejected earlier on Blackhole, so the message differs")
 @pytest.mark.parametrize("input_shape, num_groups, msg_pattern", NEGATIVE_TESTS_PARAMS)
 def test_group_norm_negative_tests(
     input_shape,
@@ -1489,8 +1495,10 @@ def test_group_norm_rejects_non_tile_aligned_spatial(device, expect_error):
     # trailing partial tile would be silently dropped from the mean/variance,
     # producing wrong results. Here N*H*W = 16, which is not a multiple of 32.
     #
-    # A TILE input cannot exercise this (TILE pads the row dim up to 32). A sharded input keeps
-    # the unpadded row dim and reaches the invariant check, so use that to cover it.
+    # A TILE input cannot exercise this (TILE pads the row dim up to 32), and a
+    # ROW_MAJOR interleaved input is rejected earlier as unsupported on the
+    # non-sharded path. A sharded input keeps the unpadded row dim and reaches the
+    # invariant check, so use that to cover it.
     C, HW, num_groups = 320, 16, 32
     torch_input_tensor = torch.rand((1, 1, HW, C), dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(
@@ -1570,7 +1578,9 @@ def test_group_norm_rejects_tile_input_with_inplace(device, expect_error):
 
 
 def test_group_norm_rejects_host_input_mask(device, expect_error):
-    # A host-resident input mask must be rejected; use a TILE input so that check is reached.
+    # TILE layout: a ROW_MAJOR interleaved input is rejected earlier (it is unsupported
+    # on the non-sharded path), which would pre-empt the host-input-mask check this test
+    # targets.
     input_tensor = ttnn.empty((1, 1, 32, 320), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
 

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 import ttnn
 
-from models.common.utility_functions import run_for_blackhole
+from models.common.utility_functions import run_for_blackhole, skip_for_blackhole
 from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
@@ -139,10 +139,9 @@ OPTIONAL_WEIGHT_BIAS_AFFINE_PARAMS = [
 OPTIONAL_WEIGHT_BIAS_AFFINE_IDS = ["no_affine", "weight_only", "bias_only"]
 
 NEGATIVE_TESTS_PARAMS = [
-    # ttnn.empty produces a ROW_MAJOR interleaved input, which the non-sharded path
-    # rejects up front (it is unsupported there); this fires before the tile-height
-    # check that this shape would otherwise trip.
-    ((2, 1, 16, 32), 8, "interleaved \\(non-sharded\\) input must be in TILE layout"),
+    # Shape is rejected by the device op because its per-batch H*W (16) is not a
+    # multiple of the tile height (32).
+    ((2, 1, 16, 32), 8, "must be a multiple of the tile height"),
 ]
 
 
@@ -1465,6 +1464,7 @@ def test_group_norm_no_input_mask(device, N, C, H, W, num_groups, specify_grid):
     ), "High-accuracy config should have lower Frobenius error than low-accuracy config"
 
 
+@skip_for_blackhole("interleaved ROW_MAJOR is rejected earlier on Blackhole, so the message differs")
 @pytest.mark.parametrize("input_shape, num_groups, msg_pattern", NEGATIVE_TESTS_PARAMS)
 def test_group_norm_negative_tests(
     input_shape,
@@ -1489,10 +1489,8 @@ def test_group_norm_rejects_non_tile_aligned_spatial(device, expect_error):
     # trailing partial tile would be silently dropped from the mean/variance,
     # producing wrong results. Here N*H*W = 16, which is not a multiple of 32.
     #
-    # A TILE input cannot exercise this (TILE pads the row dim up to 32), and a
-    # ROW_MAJOR interleaved input is rejected earlier as unsupported on the
-    # non-sharded path. A sharded input keeps the unpadded row dim and reaches the
-    # invariant check, so use that to cover it.
+    # A TILE input cannot exercise this (TILE pads the row dim up to 32). A sharded input keeps
+    # the unpadded row dim and reaches the invariant check, so use that to cover it.
     C, HW, num_groups = 320, 16, 32
     torch_input_tensor = torch.rand((1, 1, HW, C), dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(
@@ -1572,9 +1570,7 @@ def test_group_norm_rejects_tile_input_with_inplace(device, expect_error):
 
 
 def test_group_norm_rejects_host_input_mask(device, expect_error):
-    # TILE layout: a ROW_MAJOR interleaved input is rejected earlier (it is unsupported
-    # on the non-sharded path), which would pre-empt the host-input-mask check this test
-    # targets.
+    # A host-resident input mask must be rejected; use a TILE input so that check is reached.
     input_tensor = ttnn.empty((1, 1, 32, 320), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
 

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -22,9 +22,7 @@ NON_TILE_ALIGNED_ATOL = 0.08
 WELFORD_MODES = ("legacy", "welford_normal", "welford_reciprocal")
 
 GROUP_NORM_DRAM_SHAPES = [
-    (8, 768, 1, 512, 32, 2, 8, 8),  # base case
     (9, 768, 1, 512, 32, 2, 8, 8),  # test batch size 9 (uneven batch sizes)
-    (1, 768, 1, 512, 32, 2, 8, 8),  # test group channel count is less than tile size
     (1, 480, 1, 64, 8, 1, 1, 1),  # test last group ends less than max tile span
     (1, 2560, 1, 512, 32, 2, 8, 8),  # test mcast num_out_blocks 2
     (1, 2560, 1, 1024, 32, 4, 8, 8),  # test mcast num_out_blocks 4
@@ -53,7 +51,6 @@ GROUP_NORM_DRAM_SHAPES = [
     (1, 1152, 128, 128, 32, 2, 8, 4),
     (1, 512, 64, 64, 32, 1, 8, 8),  # SD 1.4 VAE
     (1, 512, 128, 128, 32, 1, 8, 8),  # SD 1.4 VAE
-    (1, 512, 256, 256, 32, 4, 8, 8),  # SD 1.4 VAE
     (1, 256, 256, 256, 32, 8, 8, 8),  # SD 1.4 VAE
     # sd35. 4 indicates the number of device.
     (1, 256 // 4, 256, 256, 32 // 4, 1, 8, 8),
@@ -62,6 +59,45 @@ GROUP_NORM_DRAM_SHAPES = [
     (1, 128, 1, 262144, 32, 64, 8, 4),  # SD 1.4 VAE Issue #21131
     # mochi
     # (21, 128, 480, 848, 32, 140, 8, 8), Failing on single device CI.
+]
+
+# Legacy ROW_MAJOR shapes, PR #49501.
+GROUP_NORM_ROW_MAJOR_SHAPES = [
+    # Model shapes that should benefit
+    # (N,    C,    H,    W,     g, nob, cy, cx)
+    (1, 512, 128, 128, 32, 1, 8, 8),
+    (1, 512, 64, 64, 32, 1, 8, 8),
+    (1, 256, 256, 256, 32, 8, 8, 8),
+    (1, 128, 1, 512, 32, 1, 8, 8),
+    # Model shapes that should avoid regression due to fallback
+    (1, 1152, 128, 128, 32, 2, 8, 4),
+    (1, 1920, 16, 16, 32, 1, 4, 4),
+    (1, 1536, 8, 8, 32, 1, 2, 8),
+    (1, 480, 1, 64, 8, 1, 1, 1),
+    # Model shapes that should stay unaffected
+    (1, 256, 256, 256, 32, 4, 8, 8),
+    (1, 512, 256, 256, 32, 4, 8, 8),
+    (1, 256, 1024, 1024, 32, 48, 8, 8),
+    (1, 128, 1, 262144, 32, 64, 8, 4),
+    # Synthetic grid-utilization
+    (1, 512, 1, 1024, 32, 2, 1, 8),
+    (1, 512, 1, 2048, 32, 2, 2, 8),
+    (1, 512, 1, 3072, 32, 2, 3, 8),
+    (1, 512, 1, 4096, 32, 2, 4, 8),
+    (1, 512, 1, 5120, 32, 2, 5, 8),
+    (1, 512, 1, 6144, 32, 2, 6, 8),
+    (1, 512, 1, 7168, 32, 2, 7, 8),
+    (1, 512, 1, 8192, 32, 2, 8, 8),
+    # Synthetic batch-imbalance
+    (8, 768, 1, 512, 32, 2, 8, 8),
+    (9, 768, 1, 512, 32, 2, 8, 8),
+    (10, 768, 1, 512, 32, 2, 8, 8),
+    (16, 768, 1, 512, 32, 2, 8, 8),
+    (17, 768, 1, 512, 32, 2, 8, 8),
+    # Synthetic that should take fused path
+    (1, 768, 1, 512, 32, 2, 8, 8),
+    (2, 768, 1, 512, 32, 2, 8, 8),
+    (8, 768, 1, 512, 32, 2, 8, 8),
 ]
 
 GROUP_NORM_NO_INPUT_MASK_DRAM_SHAPES = [
@@ -185,6 +221,8 @@ def run_group_norm_DRAM(
     use_input_mask,
     perf_test_mode=False,
     specify_grid=True,
+    input_layout=ttnn.TILE_LAYOUT,
+    output_layout=ttnn.TILE_LAYOUT,
 ):
     torch.manual_seed(0)
     if device.core_grid.y == 7:
@@ -231,7 +269,10 @@ def run_group_norm_DRAM(
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    input_tensor_tilized = ttnn.tilize_with_zero_padding(input_tensor_row_major, use_multicore=True)
+    if input_layout == ttnn.TILE_LAYOUT:
+        input_tensor_tilized = ttnn.tilize_with_zero_padding(input_tensor_row_major, use_multicore=True)
+
+    gn_input_tensor = input_tensor_tilized if input_layout == ttnn.TILE_LAYOUT else input_tensor_row_major
 
     # Create dram group norm params
     [gamma_t, beta_t], input_mask_tensor = ttnn.dram_group_norm_params_from_torch(
@@ -277,13 +318,13 @@ def run_group_norm_DRAM(
         num_itr = 1  # one iter if it is too slow
     for _ in range(num_itr):
         output_tensor = ttnn.group_norm(
-            input_tensor_tilized,
+            gn_input_tensor,
             num_groups=num_groups,
             input_mask=input_mask_tensor if use_input_mask else None,
             weight=gamma_t,
             bias=beta_t,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            output_layout=ttnn.TILE_LAYOUT,
+            output_layout=output_layout,
             core_grid=grid_size if specify_grid else None,
             inplace=False,
             num_out_blocks=num_out_blocks if specify_grid else None,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -13,7 +13,7 @@ import math
 
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
-from models.common.utility_functions import is_blackhole, is_watcher_enabled, run_for_blackhole
+from models.common.utility_functions import is_blackhole, is_watcher_enabled, run_for_blackhole, skip_for_blackhole
 
 
 DEVICE_PARAMS_L1_SMALL_SIZE = [{"l1_small_size": 0}]
@@ -61,44 +61,6 @@ GROUP_NORM_DRAM_SHAPES = [
     # (21, 128, 480, 848, 32, 140, 8, 8), Failing on single device CI.
 ]
 
-# Legacy ROW_MAJOR shapes, PR #49501.
-GROUP_NORM_ROW_MAJOR_SHAPES = [
-    # Model shapes that should benefit
-    # (N,    C,    H,    W,     g, nob, cy, cx)
-    (1, 512, 128, 128, 32, 1, 8, 8),
-    (1, 512, 64, 64, 32, 1, 8, 8),
-    (1, 256, 256, 256, 32, 8, 8, 8),
-    (1, 128, 1, 512, 32, 1, 8, 8),
-    # Model shapes that should avoid regression due to fallback
-    (1, 1152, 128, 128, 32, 2, 8, 4),
-    (1, 1920, 16, 16, 32, 1, 4, 4),
-    (1, 1536, 8, 8, 32, 1, 2, 8),
-    (1, 480, 1, 64, 8, 1, 1, 1),
-    # Model shapes that should stay unaffected
-    (1, 256, 256, 256, 32, 4, 8, 8),
-    (1, 512, 256, 256, 32, 4, 8, 8),
-    (1, 256, 1024, 1024, 32, 48, 8, 8),
-    (1, 128, 1, 262144, 32, 64, 8, 4),
-    # Synthetic grid-utilization
-    (1, 512, 1, 1024, 32, 2, 1, 8),
-    (1, 512, 1, 2048, 32, 2, 2, 8),
-    (1, 512, 1, 3072, 32, 2, 3, 8),
-    (1, 512, 1, 4096, 32, 2, 4, 8),
-    (1, 512, 1, 5120, 32, 2, 5, 8),
-    (1, 512, 1, 6144, 32, 2, 6, 8),
-    (1, 512, 1, 7168, 32, 2, 7, 8),
-    (1, 512, 1, 8192, 32, 2, 8, 8),
-    # Synthetic batch-imbalance
-    (8, 768, 1, 512, 32, 2, 8, 8),
-    (9, 768, 1, 512, 32, 2, 8, 8),
-    (10, 768, 1, 512, 32, 2, 8, 8),
-    (16, 768, 1, 512, 32, 2, 8, 8),
-    (17, 768, 1, 512, 32, 2, 8, 8),
-    # Synthetic that should take fused path
-    (1, 768, 1, 512, 32, 2, 8, 8),
-    (2, 768, 1, 512, 32, 2, 8, 8),
-    (8, 768, 1, 512, 32, 2, 8, 8),
-]
 
 GROUP_NORM_NO_INPUT_MASK_DRAM_SHAPES = [
     (8, 768, 1, 512, 32, 2, 8, 8),  # base case
@@ -398,6 +360,38 @@ def test_group_norm_DRAM(
         use_input_mask=True,
         perf_test_mode=perf_test_mode,
         specify_grid=specify_grid,
+    )
+
+
+# Post-commit smoke coverage for the ROW_MAJOR path; the full sweep over GROUP_NORM_ROW_MAJOR_SHAPES
+# lives in nightly. Tests across all three layout combinations that involve ROW_MAJOR.
+@skip_for_blackhole("interleaved ROW_MAJOR group_norm is Wormhole-only, see #52279")
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+@pytest.mark.parametrize(
+    "input_layout, output_layout",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT),
+        (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+    ids=["RM_IN_TILE_OUT", "TILE_IN_RM_OUT", "RM_IN_RM_OUT"],
+)
+def test_group_norm_DRAM_row_major_smoke(device, input_layout, output_layout):
+    # Issue #26594: N=1, C=480, H=1, W=64, num_groups=8 on a 1x1 grid.
+    run_group_norm_DRAM(
+        device,
+        1,
+        480,
+        1,
+        64,
+        8,
+        1,
+        1,
+        1,
+        "legacy",
+        use_input_mask=True,
+        input_layout=input_layout,
+        output_layout=output_layout,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -70,6 +70,17 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
         a.padded_shape()[2],
         tile_height);
 
+    // ROW_MAJOR (interleaved) input/output is only supported on the legacy (non-Welford) group_norm path.
+    if (args.use_welford && !a.is_sharded()) {
+        const Layout output_layout =
+            std::visit([](const auto& config) -> Layout { return config.output_layout; }, args.program_config);
+        TT_FATAL(
+            a.layout() == Layout::TILE && output_layout == Layout::TILE,
+            "group_norm: ROW_MAJOR interleaved input/output is not supported on the Welford path yet. "
+            "Use TILE layout for both input and output, or use the legacy (non-Welford) path "
+            "(use_welford=false).");
+    }
+
     if (a.is_sharded()) {
         const auto& shard_spec = a.shard_spec().value();
         const auto bbox = shard_spec.grid.bounding_box();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -198,7 +198,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     uint32_t block_ht_group_1 = per_core_Mt_group_1 / num_batches_per_core_group_1;
     uint32_t subblock_wt = get_max_subblock(block_wt, 8);
     uint32_t num_subblocks_w = block_wt / subblock_wt;
-    bool block_wt_last = (per_core_Nt + num_groups_per_core - 1) / num_groups_per_core;
+    uint32_t block_wt_last = (per_core_Nt + num_groups_per_core - 1) / num_groups_per_core;
 
     TT_FATAL(
         block_ht_group_1 > 0,
@@ -230,6 +230,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     bool reader_repack_output = (per_core_N % tile_width) != 0;
     bool tilize_in = a.layout() == Layout::ROW_MAJOR;
     bool untilize_out = output.layout() == Layout::ROW_MAJOR;
+
+    // Groups that straddle tiles need out_block_h == 1, or the untilize corrupts later tile-rows.
+    if (!use_welford && untilize_out && block_wt_last != block_wt) {
+        log_warning(
+            tt::LogOp,
+            "group_norm: ROW_MAJOR output with tile-straddling groups requires out_block_h==1; overriding "
+            "requested num_out_blocks={} with {}.",
+            num_out_blocks,
+            block_ht_group_1);
+        num_out_blocks = block_ht_group_1;
+    }
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -326,6 +337,13 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     if (use_welford) {
         x_CB_size_group_1 = single_tile_size * 1;
         xmm_CB_size_group_1 = single_tile_size * 3;
+    }
+
+    // c_17 holds the whole per-core group, tilized once and reused by all three passes.
+    uint32_t in_tilized_CB_size_group_1 = 0;
+    if (!use_welford && tilize_in) {
+        in_tilized_CB_size_group_1 =
+            groupnorm_tilized_group_tiles(block_ht_group_1, num_out_blocks, block_wt) * in_single_tile_size;
     }
 
     std::vector<CoreCoord> core_coords = grid_to_cores(num_cores, num_actual_cols, num_actual_rows, row_wise);
@@ -466,6 +484,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"per_core_N", per_core_Nt},
         {"per_core_N_bytes", per_core_N_bytes_padded},
         {"per_core_N_bytes_with_stride", per_core_Nt * tile_width * datum_size_bytes},
+        {"datum_size_bytes", datum_size_bytes},
         {"per_core_M", per_core_Mt_group_1},
         {"TILE_HEIGHT", tile_height},
         {"TILE_WIDTH", tile_width},
@@ -596,12 +615,18 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                      : "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/"
                        "writer_unary_gn_rm_gb.cpp");
 
+    std::map<std::string, std::string> writer_defines;
+    if (untilize_out) {
+        writer_defines["UNTILIZE_OUT"] = "1";
+    }
+
     KernelDescriptor writer_desc;
     writer_desc.kernel_source = writer_kernel;
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores_group_1;
     writer_desc.compile_time_args = writer_mcast_sender_compile_time_args_group_1;
     writer_desc.named_compile_time_args = to_named_args_mcast(writer_named_compile_time_args_group_1);
+    writer_desc.defines = KernelDescriptor::Defines(writer_defines.begin(), writer_defines.end());
     writer_desc.config = DataMovementConfigDescriptor{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = writer_noc,
@@ -821,6 +846,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         }}},
     });
 
+    // Resident tilized per-core group.
+    if (in_tilized_CB_size_group_1 > 0) {
+        constexpr uint32_t in_tilized_cb_index = tt::CBIndex::c_17;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = in_tilized_CB_size_group_1,
+            .core_ranges = all_cores_group_1,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(in_tilized_cb_index),
+                .data_format = in_data_format,
+                .page_size = in_single_tile_size,
+            }}},
+        });
+    }
+
     if (untilize_out) {
         constexpr uint32_t out_cb_index = tt::CBIndex::c_30;
         desc.cbs.push_back(CBDescriptor{
@@ -832,6 +871,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                 .page_size = in_single_tile_size,
             }}},
         });
+
+        // c_20 reread scratch; only the legacy path accumulates across groups.
+        if (!use_welford) {
+            constexpr uint32_t reread_rm_cb_index = tt::CBIndex::c_20;
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = in_CB_size_group_1,
+                .core_ranges = all_cores_group_1,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(reread_rm_cb_index),
+                    .data_format = in_data_format,
+                    .page_size = in_single_tile_size,
+                }}},
+            });
+        }
     }
 
     constexpr uint32_t in2_cb_index = tt::CBIndex::c_2;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -174,20 +174,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         "num_groups_per_core ({}) must be <= 16 when use_welfords is true.",
         num_groups_per_core);
 
-    // -1 sentinel from GroupNormMultiCoreProgramConfig means "auto select":
-    // pick num_out_blocks from a simple input-size / grid-size heuristic, rounded
-    // up to the next power of two and capped at MAX_HEURISTIC_NUM_OUT_BLOCKS.
+    // -1 sentinel from GroupNormMultiCoreProgramConfig means "auto select".
     // Any other value is taken as an explicit user choice and validated below.
     if (num_out_blocks == static_cast<uint32_t>(-1)) {
-        const uint32_t HEURISTIC_BLOCK_SIZE_BASE = 256 * 256;
-        const uint32_t MAX_HEURISTIC_NUM_OUT_BLOCKS = 256;
-        uint32_t heuristic_num_out_blocks =
-            (shape[1] * shape[2] * shape[3]) / (HEURISTIC_BLOCK_SIZE_BASE * (num_virtual_cols * num_virtual_rows));
-        heuristic_num_out_blocks = heuristic_num_out_blocks ? heuristic_num_out_blocks : 1;
-        num_out_blocks = 1;
-        while (num_out_blocks < heuristic_num_out_blocks && num_out_blocks < MAX_HEURISTIC_NUM_OUT_BLOCKS) {
-            num_out_blocks <<= 1;
-        }
+        num_out_blocks =
+            groupnorm_heuristic_num_out_blocks(shape[1] * shape[2] * shape[3], num_virtual_cols * num_virtual_rows);
     }
 
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "groupnorm_device_operation.hpp"
 #include "groupnorm_program_utils.hpp"
+#include "kernels/groupnorm_constants.hpp"
 
 #include <bit>
 #include <map>
@@ -1341,11 +1342,22 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         });
     }
 
-    // Welford does not use cb_ex_external.
+    // Welford does not use cb_ex_external. Same sizing as the mcast factory: reader/compute
+    // reserve ceil(num_out_blocks_padded * num_mcast_cores * slot_pitch / tile_size) tiles.
     if (!use_welford) {
         constexpr uint32_t ex_cb_external_index = tt::CBIndex::c_10;
+        uint32_t num_out_blocks_padded = num_out_blocks;
+        uint32_t out_block_h_normal = block_ht_group_1 / num_out_blocks;
+        if (block_ht_group_1 % num_out_blocks != 0) {
+            uint32_t residual = block_ht_group_1 - (num_out_blocks * out_block_h_normal);
+            num_out_blocks_padded += (residual / out_block_h_normal + 1);
+        }
+        uint32_t cb_ex_external_tiles =
+            (num_out_blocks_padded * num_cores_per_mcast_group * dfb_ex_external_slot_pitch_bytes + single_tile_size -
+             1) /
+            single_tile_size;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = 2 * single_tile_size * num_cores_per_mcast_group,
+            .total_size = cb_ex_external_tiles * single_tile_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(ex_cb_external_index),

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -209,7 +209,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t block_ht_group_2 = 0;
     uint32_t subblock_wt = get_max_subblock(block_wt, 8);
     uint32_t num_subblocks_w = block_wt / subblock_wt;
-    bool block_wt_last = (per_core_Nt + num_groups_per_core - 1) / num_groups_per_core;
+    uint32_t block_wt_last = (per_core_Nt + num_groups_per_core - 1) / num_groups_per_core;
 
     // support for uneven batches across rows
     bool equal_batches_per_core = true;
@@ -261,6 +261,17 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             grid_size.y,
             Ht);
     }
+    // Groups that straddle tiles need out_block_h == 1, or the untilize corrupts later tile-rows.
+    if (!use_welford && output.layout() == Layout::ROW_MAJOR && block_wt_last != block_wt) {
+        log_warning(
+            tt::LogOp,
+            "group_norm: ROW_MAJOR output with tile-straddling groups requires out_block_h==1; overriding "
+            "requested num_out_blocks={} with {}.",
+            num_out_blocks,
+            block_ht_group_1);
+        num_out_blocks = block_ht_group_1;
+    }
+
     TT_FATAL(
         num_out_blocks > 0 && num_out_blocks <= block_ht_group_1,
         "num_out_blocks ({}) must be in [1, block_h ({})]. "
@@ -455,6 +466,18 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         x_CB_size_group_2 = single_tile_size * 1;
         xmm_CB_size_group_1 = single_tile_size * 3;
         xmm_CB_size_group_2 = single_tile_size * 3;
+    }
+
+    // c_17 holds the whole per-core group, tilized once and reused by all three passes.
+    uint32_t in_tilized_CB_size_group_1 = 0;
+    uint32_t in_tilized_CB_size_group_2 = 0;
+    if (!use_welford && tilize_in) {
+        in_tilized_CB_size_group_1 =
+            groupnorm_tilized_group_tiles(block_ht_group_1, num_out_blocks, block_wt) * in_single_tile_size;
+        if (!equal_batches_per_core) {
+            in_tilized_CB_size_group_2 =
+                groupnorm_tilized_group_tiles(block_ht_group_2, num_out_blocks, block_wt) * in_single_tile_size;
+        }
     }
 
     // Application Setup
@@ -769,12 +792,18 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
                      : "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/"
                        "writer_unary_gn_rm_gb.cpp");
 
+    std::map<std::string, std::string> writer_defines;
+    if (untilize_out) {
+        writer_defines["UNTILIZE_OUT"] = "1";
+    }
+
     KernelDescriptor writer_desc_g1;
     writer_desc_g1.kernel_source = writer_kernel;
     writer_desc_g1.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc_g1.core_ranges = all_cores_group_1;
     writer_desc_g1.compile_time_args = writer_mcast_sender_compile_time_args_group_1;
     writer_desc_g1.named_compile_time_args = to_named_args_no_mcast(writer_named_compile_time_args_group_1);
+    writer_desc_g1.defines = KernelDescriptor::Defines(writer_defines.begin(), writer_defines.end());
     writer_desc_g1.config = DataMovementConfigDescriptor{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = writer_noc,
@@ -788,6 +817,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         writer_desc_g2.core_ranges = all_cores_group_2;
         writer_desc_g2.compile_time_args = writer_mcast_sender_compile_time_args_group_2;
         writer_desc_g2.named_compile_time_args = to_named_args_no_mcast(writer_named_compile_time_args_group_2);
+        writer_desc_g2.defines = KernelDescriptor::Defines(writer_defines.begin(), writer_defines.end());
         writer_desc_g2.config = DataMovementConfigDescriptor{
             .processor = DataMovementProcessor::RISCV_1,
             .noc = writer_noc,
@@ -1049,6 +1079,31 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         }}},
     });
 
+    // Resident tilized per-core group.
+    if (in_tilized_CB_size_group_1 > 0) {
+        constexpr uint32_t in_tilized_cb_index = tt::CBIndex::c_17;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = in_tilized_CB_size_group_1,
+            .core_ranges = all_cores_group_1,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(in_tilized_cb_index),
+                .data_format = in_data_format,
+                .page_size = in_single_tile_size,
+            }}},
+        });
+        if (in_tilized_CB_size_group_2 > 0) {
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = in_tilized_CB_size_group_2,
+                .core_ranges = all_cores_group_2,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(in_tilized_cb_index),
+                    .data_format = in_data_format,
+                    .page_size = in_single_tile_size,
+                }}},
+            });
+        }
+    }
+
     if (untilize_out) {
         constexpr uint32_t out_cb_index = tt::CBIndex::c_30;
         desc.cbs.push_back(CBDescriptor{
@@ -1069,6 +1124,28 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
                 .page_size = in_single_tile_size,
             }}},
         });
+
+        if (!use_welford) {
+            constexpr uint32_t reread_rm_cb_index = tt::CBIndex::c_20;
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = in_CB_size_group_1,
+                .core_ranges = all_cores_group_1,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(reread_rm_cb_index),
+                    .data_format = in_data_format,
+                    .page_size = in_single_tile_size,
+                }}},
+            });
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = in_CB_size_group_2,
+                .core_ranges = all_cores_group_2,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(reread_rm_cb_index),
+                    .data_format = in_data_format,
+                    .page_size = in_single_tile_size,
+                }}},
+            });
+        }
     }
 
     constexpr uint32_t in2_cb_index = tt::CBIndex::c_2;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -185,20 +185,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         "this.",
         num_groups_per_core);
 
-    // -1 sentinel from GroupNormMultiCoreProgramConfig means "auto select":
-    // pick num_out_blocks from a simple input-size / grid-size heuristic, rounded
-    // up to the next power of two and capped at MAX_HEURISTIC_NUM_OUT_BLOCKS.
+    // -1 sentinel from GroupNormMultiCoreProgramConfig means "auto select".
     // Any other value is taken as an explicit user choice and validated below.
     if (num_out_blocks == static_cast<uint32_t>(-1)) {
-        const uint32_t HEURISTIC_BLOCK_SIZE_BASE = 256 * 256;
-        const uint32_t MAX_HEURISTIC_NUM_OUT_BLOCKS = 256;
-        uint32_t heuristic_num_out_blocks =
-            (shape[1] * shape[2] * shape[3]) / (HEURISTIC_BLOCK_SIZE_BASE * (num_virtual_cols * num_virtual_rows));
-        heuristic_num_out_blocks = heuristic_num_out_blocks ? heuristic_num_out_blocks : 1;
-        num_out_blocks = 1;
-        while (num_out_blocks < heuristic_num_out_blocks && num_out_blocks < MAX_HEURISTIC_NUM_OUT_BLOCKS) {
-            num_out_blocks <<= 1;
-        }
+        num_out_blocks =
+            groupnorm_heuristic_num_out_blocks(shape[1] * shape[2] * shape[3], num_virtual_cols * num_virtual_rows);
     }
 
     // subblock

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -71,6 +71,21 @@ uint32_t groupnorm_tilized_group_tiles(uint32_t block_ht, uint32_t num_out_block
     return num_out_blocks_padded * out_block_h_normal * block_wt;
 }
 
+uint32_t groupnorm_heuristic_num_out_blocks(uint32_t volume, uint32_t num_virtual_cores) {
+    constexpr uint32_t HEURISTIC_BLOCK_SIZE_BASE = 256 * 256;
+    constexpr uint32_t MAX_HEURISTIC_NUM_OUT_BLOCKS = 256;
+    if (num_virtual_cores == 0) {
+        return 1;
+    }
+    uint32_t heuristic = volume / (HEURISTIC_BLOCK_SIZE_BASE * num_virtual_cores);
+    heuristic = heuristic ? heuristic : 1;
+    uint32_t num_out_blocks = 1;
+    while (num_out_blocks < heuristic && num_out_blocks < MAX_HEURISTIC_NUM_OUT_BLOCKS) {
+        num_out_blocks <<= 1;
+    }
+    return num_out_blocks;
+}
+
 bool groupnorm_legacy_rm_input_fits_l1(
     uint32_t Ht,
     uint32_t W,
@@ -93,7 +108,7 @@ bool groupnorm_legacy_rm_input_fits_l1(
         num_virtual_cols -= 1;
     }
     if (num_virtual_cols == 0) {
-        return false;  // Invalid grid; report "does not fit" so we take the composite path.
+        return false;  // Invalid grid; report "does not fit" (fall back to the composite path)
     }
     const uint32_t num_virtual_rows = (grid_x / num_virtual_cols) * grid_y;
     if (num_virtual_rows == 0 || Ht < num_virtual_rows) {
@@ -114,14 +129,7 @@ bool groupnorm_legacy_rm_input_fits_l1(
     // num_out_blocks: -1 means use the factory's power-of-two heuristic.
     uint32_t num_out_blocks;
     if (num_out_blocks_arg < 0) {
-        const uint32_t HEURISTIC_BLOCK_SIZE_BASE = 256 * 256;
-        const uint32_t MAX_HEURISTIC_NUM_OUT_BLOCKS = 256;
-        uint32_t heuristic = (per_batch_hw * W) / (HEURISTIC_BLOCK_SIZE_BASE * (num_virtual_cols * num_virtual_rows));
-        heuristic = heuristic ? heuristic : 1;
-        num_out_blocks = 1;
-        while (num_out_blocks < heuristic && num_out_blocks < MAX_HEURISTIC_NUM_OUT_BLOCKS) {
-            num_out_blocks <<= 1;
-        }
+        num_out_blocks = groupnorm_heuristic_num_out_blocks(per_batch_hw * W, num_virtual_cols * num_virtual_rows);
     } else {
         num_out_blocks = num_out_blocks_arg == 0 ? 1 : static_cast<uint32_t>(num_out_blocks_arg);
     }
@@ -151,6 +159,13 @@ bool groupnorm_legacy_rm_input_fits_l1(
     }
 
     return est * 100 <= available_l1 * kGroupnormTilizedL1UsagePercent;
+}
+
+bool groupnorm_legacy_rm_prefer_composite_for_perf(
+    uint32_t num_cores, uint32_t num_virtual_rows, uint32_t num_batches) {
+    const bool imbalanced =
+        num_virtual_rows != 0 && num_batches >= num_virtual_rows && (num_batches % num_virtual_rows) != 0;
+    return num_cores <= kGroupnormLegacyRmMinCoresForOnChip || imbalanced;
 }
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -60,6 +60,99 @@ bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfi
     });
 }
 
+uint32_t groupnorm_tilized_group_tiles(uint32_t block_ht, uint32_t num_out_blocks, uint32_t block_wt) {
+    // Mirrors how the kernel pads num_out_blocks: a leftover remainder becomes extra full-size blocks.
+    const uint32_t out_block_h_normal = block_ht / num_out_blocks;
+    uint32_t num_out_blocks_padded = num_out_blocks;
+    if (block_ht % num_out_blocks != 0) {
+        const uint32_t residual = block_ht - num_out_blocks * out_block_h_normal;
+        num_out_blocks_padded += residual / out_block_h_normal + 1;
+    }
+    return num_out_blocks_padded * out_block_h_normal * block_wt;
+}
+
+bool groupnorm_legacy_rm_input_fits_l1(
+    uint32_t Ht,
+    uint32_t W,
+    uint32_t per_batch_hw,
+    uint32_t num_batches,
+    uint32_t grid_x,
+    uint32_t grid_y,
+    uint32_t num_groups,
+    int num_out_blocks_arg,
+    uint32_t tile_width,
+    uint32_t single_tile_size,
+    bool has_gamma,
+    bool has_beta,
+    bool tilize_in,
+    bool untilize_out,
+    uint64_t available_l1) {
+    // Grid geometry, same formulas as the program factory.
+    uint32_t num_virtual_cols = std::min(grid_x, num_groups);
+    while (num_virtual_cols > 0 && ((W / num_virtual_cols) % tile_width != 0 || (num_groups % num_virtual_cols) != 0)) {
+        num_virtual_cols -= 1;
+    }
+    if (num_virtual_cols == 0) {
+        return false;  // Invalid grid; report "does not fit" so we take the composite path.
+    }
+    const uint32_t num_virtual_rows = (grid_x / num_virtual_cols) * grid_y;
+    if (num_virtual_rows == 0 || Ht < num_virtual_rows) {
+        return false;
+    }
+    const uint32_t per_core_Mt = Ht / num_virtual_rows;
+    const uint32_t per_core_N = W / num_virtual_cols;
+    const uint32_t per_core_Nt = (per_core_N + tile_width - 1) / tile_width;
+    const uint32_t num_channels_per_group = W / num_groups;
+
+    const uint32_t block_wt = find_max_tile_span(per_core_N, num_channels_per_group).first;
+    // Per-core tile height: many batches per core, or one batch split across rows.
+    const uint32_t block_ht = (num_batches >= num_virtual_rows) ? (Ht / num_batches) : per_core_Mt;
+    if (block_ht == 0) {
+        return false;
+    }
+
+    // num_out_blocks: -1 means use the factory's power-of-two heuristic.
+    uint32_t num_out_blocks;
+    if (num_out_blocks_arg < 0) {
+        const uint32_t HEURISTIC_BLOCK_SIZE_BASE = 256 * 256;
+        const uint32_t MAX_HEURISTIC_NUM_OUT_BLOCKS = 256;
+        uint32_t heuristic = (per_batch_hw * W) / (HEURISTIC_BLOCK_SIZE_BASE * (num_virtual_cols * num_virtual_rows));
+        heuristic = heuristic ? heuristic : 1;
+        num_out_blocks = 1;
+        while (num_out_blocks < heuristic && num_out_blocks < MAX_HEURISTIC_NUM_OUT_BLOCKS) {
+            num_out_blocks <<= 1;
+        }
+    } else {
+        num_out_blocks = num_out_blocks_arg == 0 ? 1 : static_cast<uint32_t>(num_out_blocks_arg);
+    }
+    num_out_blocks = std::min(num_out_blocks, block_ht);
+
+    // CB footprint: seven per-out-block CBs, the resident group, and an allowance for the small ones.
+    const uint64_t in0_block_tiles = static_cast<uint64_t>(block_ht / num_out_blocks) * block_wt;
+    const uint64_t per_out_block_cb = in0_block_tiles * single_tile_size;
+    // Only a row-major input allocates the resident group.
+    const uint64_t resident_cb =
+        tilize_in ? static_cast<uint64_t>(groupnorm_tilized_group_tiles(block_ht, num_out_blocks, block_wt)) *
+                        single_tile_size
+                  : 0;
+
+    uint64_t est =
+        resident_cb + 7 * per_out_block_cb + static_cast<uint64_t>(kGroupnormSmallCbAllowanceTiles) * single_tile_size;
+    if (has_gamma) {
+        est += static_cast<uint64_t>(per_core_Nt) * single_tile_size;
+    }
+    if (has_beta) {
+        est += static_cast<uint64_t>(per_core_Nt) * single_tile_size;
+    }
+    // Mask CB; a mask is always allocated. Assumes bf16 tiles, which over-estimates on purpose.
+    est += static_cast<uint64_t>(block_wt) * single_tile_size * 2;
+    if (untilize_out) {
+        est += 2 * per_out_block_cb;  // c_30 untilize out + c_20 reread
+    }
+
+    return est * 100 <= available_l1 * kGroupnormTilizedL1UsagePercent;
+}
+
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {
     if (n <= max_subblock_w) {
         return n;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -71,17 +71,23 @@ std::pair<uint32_t, uint32_t> find_max_tile_span(uint32_t W, uint32_t group_size
 // Tiles the row-major path keeps resident in c_17 for one per-core group.
 uint32_t groupnorm_tilized_group_tiles(uint32_t block_ht, uint32_t num_out_blocks, uint32_t block_wt);
 
+// Auto-select num_out_blocks from tensor volume / virtual core count: next power of two,
+// capped at 256. Shared by the program factories and the L1-fit estimate.
+// `volume` is H * W * C (padded), `num_virtual_cores` is num_virtual_cols * num_virtual_rows.
+uint32_t groupnorm_heuristic_num_out_blocks(uint32_t volume, uint32_t num_virtual_cores);
+
 // Percent of usable L1 we allow the estimate to reach; the margin covers the approximated small CBs.
 inline constexpr uint64_t kGroupnormTilizedL1UsagePercent = 95;
 
-// Allowance, in tiles, for the small scalar/reduction CBs the estimate does not sum individually.
+// Flat tile budget covering the small 1-tile CBs (eps, ex/ex2 partials, etc.)
 inline constexpr uint32_t kGroupnormSmallCbAllowanceTiles = 32;
 
-// Estimates whether a legacy (non-Welford) group_norm fits in L1; if not, group_norm() tilizes or
-// untilizes as separate ops instead. Deliberately over-estimates, so a "fits" answer is always safe.
-// `tilize_in` adds the resident group, `untilize_out` adds the row-major output scratch.
-// `per_batch_hw` is padded_shape[1] * padded_shape[2], `available_l1` is usable per-core L1 in bytes,
-// and `num_out_blocks_arg` takes -1 for auto.
+// At or below this many active cores, prefer composite over fused RM.
+inline constexpr uint32_t kGroupnormLegacyRmMinCoresForOnChip = 32;
+
+// Estimates whether a legacy (non-Welford) group_norm fits in L1; if not, group_norm()
+// tilizes/untilizes as separate ops. Over-estimates on purpose so "fits" is always safe.
+// `tilize_in` adds the resident group; `untilize_out` adds the RM output scratch.
 bool groupnorm_legacy_rm_input_fits_l1(
     uint32_t Ht,
     uint32_t W,
@@ -98,5 +104,9 @@ bool groupnorm_legacy_rm_input_fits_l1(
     bool tilize_in,
     bool untilize_out,
     uint64_t available_l1);
+
+// Prefer composite (host tilize + TILE GN) over fused RM for small grids or uneven batch mapping.
+// num_cores = num_virtual_cols * num_virtual_rows.
+bool groupnorm_legacy_rm_prefer_composite_for_perf(uint32_t num_cores, uint32_t num_virtual_rows, uint32_t num_batches);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -68,4 +68,35 @@ void split_and_form_rectangle_grids(
 
 std::pair<uint32_t, uint32_t> find_max_tile_span(uint32_t W, uint32_t group_size, uint32_t tile_width = 32);
 
+// Tiles the row-major path keeps resident in c_17 for one per-core group.
+uint32_t groupnorm_tilized_group_tiles(uint32_t block_ht, uint32_t num_out_blocks, uint32_t block_wt);
+
+// Percent of usable L1 we allow the estimate to reach; the margin covers the approximated small CBs.
+inline constexpr uint64_t kGroupnormTilizedL1UsagePercent = 95;
+
+// Allowance, in tiles, for the small scalar/reduction CBs the estimate does not sum individually.
+inline constexpr uint32_t kGroupnormSmallCbAllowanceTiles = 32;
+
+// Estimates whether a legacy (non-Welford) group_norm fits in L1; if not, group_norm() tilizes or
+// untilizes as separate ops instead. Deliberately over-estimates, so a "fits" answer is always safe.
+// `tilize_in` adds the resident group, `untilize_out` adds the row-major output scratch.
+// `per_batch_hw` is padded_shape[1] * padded_shape[2], `available_l1` is usable per-core L1 in bytes,
+// and `num_out_blocks_arg` takes -1 for auto.
+bool groupnorm_legacy_rm_input_fits_l1(
+    uint32_t Ht,
+    uint32_t W,
+    uint32_t per_batch_hw,
+    uint32_t num_batches,
+    uint32_t grid_x,
+    uint32_t grid_y,
+    uint32_t num_groups,
+    int num_out_blocks_arg,
+    uint32_t tile_width,
+    uint32_t single_tile_size,
+    bool has_gamma,
+    bool has_beta,
+    bool tilize_in,
+    bool untilize_out,
+    uint64_t available_l1);
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -150,6 +150,10 @@ void kernel_main() {
     // input cbs
     constexpr uint32_t dfb_in0_id = tt::CBIndex::c_0;
     constexpr uint32_t dfb_in_id = tt::CBIndex::c_29;
+#ifdef TILIZE_IN
+    // Holds the whole per-core group, tilized once and kept in L1 for all three passes.
+    constexpr uint32_t dfb_in_resident_id = tt::CBIndex::c_17;
+#endif
     constexpr uint32_t dfb_scaler_id = tt::CBIndex::c_2;
     constexpr uint32_t dfb_scaler_global_id = tt::CBIndex::c_4;
     constexpr uint32_t dfb_eps_id = tt::CBIndex::c_3;
@@ -181,6 +185,10 @@ void kernel_main() {
     constexpr uint32_t dfb_fusion_id = dfb_xmm_id;
     constexpr uint32_t dfb_reread_out_id = tt::CBIndex::c_23;
     constexpr uint32_t dfb_reread_write_out_id = tt::CBIndex::c_22;
+#ifdef UNTILIZE_OUT
+    // Scratch for the row-major output reread; tilized into c_23 below.
+    constexpr uint32_t dfb_reread_rm_id = tt::CBIndex::c_20;
+#endif
 
     // output cb
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
@@ -206,23 +214,19 @@ void kernel_main() {
     bool apply_gamma_beta[block_w];
     constexpr uint32_t data_per_core_N_per_group = (per_core_N * tile_width / group);
 
-#ifdef UNTILIZE_OUT
-    constexpr int dfb_outgamma_id = dfb_in_id;
+    // Gamma/beta wiring, same for both layouts.
+    constexpr int dfb_outgamma_id = do_beta ? dfb_in_id : dfb_out0_id;
     constexpr int dfb_inbeta_id = do_gamma ? dfb_outgamma_id : dfb_reread_write_out_id;
-    constexpr int dfb_outbeta_id = do_gamma ? dfb_out_id : dfb_in_id;
-    constexpr int dfb_untilize_in_id = (do_gamma and not do_beta) ? dfb_outgamma_id
-                                       : do_beta                  ? dfb_outbeta_id
-                                                                  : dfb_reread_write_out_id;
+    constexpr int dfb_outbeta_id = dfb_out0_id;
+#ifdef UNTILIZE_OUT
+    // Untilize the tiled result into the row-major output c_30.
+    constexpr int dfb_untilize_in_id = (do_gamma or do_beta) ? dfb_out0_id : dfb_reread_write_out_id;
     constexpr int dfb_untilize_out_id =
 #ifdef READER_REPACK
         dfb_repack_out_id;
 #else
-        dfb_out0_id;
+        dfb_out_id;
 #endif
-#else
-    constexpr int dfb_outgamma_id = do_beta ? dfb_in_id : dfb_out0_id;
-    constexpr int dfb_inbeta_id = do_gamma ? dfb_outgamma_id : dfb_reread_write_out_id;
-    constexpr int dfb_outbeta_id = dfb_out0_id;
 #endif
 
     DataflowBuffer dfb_beta(dfb_beta_id);
@@ -237,6 +241,9 @@ void kernel_main() {
     DataflowBuffer dfb_ex_partial(dfb_ex_partial_id);
     DataflowBuffer dfb_gamma(dfb_gamma_id);
     DataflowBuffer dfb_in(dfb_in_id);
+#ifdef TILIZE_IN
+    DataflowBuffer dfb_in_resident(dfb_in_resident_id);
+#endif
     DataflowBuffer dfb_in0(dfb_in0_id);
     DataflowBuffer dfb_inbeta(dfb_inbeta_id);
     DataflowBuffer dfb_input_mask(dfb_input_mask_id);
@@ -252,32 +259,20 @@ void kernel_main() {
     DataflowBuffer dfb_msq(dfb_msq_id);
     DataflowBuffer dfb_kmsq(dfb_kmsq_id);
 
-// tilize input from RM to tile layout
 #ifdef TILIZE_IN
-    compute_kernel_hw_startup(dfb_in0_id, dfb_in0_id, dfb_in_id);
-// Tilize in0 -> in (row-major to tiled)
+    // Tilize source: repacked channels or dfb_in0.
 #ifdef READER_REPACK
     constexpr uint32_t dfb_in_rm_id = dfb_repack_id;
-    compute_kernel_lib::tilize<
-        per_core_N,
-        dfb_in_rm_id,
-        dfb_in_id,
-        compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
-        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
-        compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #else
     constexpr uint32_t dfb_in_rm_id = dfb_in0_id;
-    compute_kernel_lib::tilize<
-        per_core_N,
-        dfb_in_rm_id,
-        dfb_in_id,
-        compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
-        compute_kernel_lib::tilize_config::WaitMode::NoWait,
-        compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #endif
-    dfb_in.wait_front(per_core_MN);
+    // Tilize the whole group once and reuse it for all three passes.
+    compute_kernel_hw_startup(dfb_in0_id, dfb_in0_id, dfb_in_resident_id);
+    constexpr uint32_t dfb_input_id = dfb_in_resident_id;
 #else
+    // Already tiled, so feed compute directly.
     compute_kernel_hw_startup(dfb_in0_id, dfb_input_mask_id, dfb_x_id);
+    constexpr uint32_t dfb_input_id = dfb_in0_id;
 #endif
 
     index_b_offset = 0;
@@ -324,25 +319,36 @@ void kernel_main() {
                     out_block_h_actual = out_block_h_normal;
                     out_block_hw_actual = out_block_hw_normal;
                 }
+#ifdef TILIZE_IN
+                // Append this out-block; no pop, so the whole group stays available.
+                compute_kernel_lib::tilize<
+                    block_w,
+                    dfb_in_rm_id,
+                    dfb_in_resident_id,
+                    compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+                    compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+                    compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+                    out_block_h_normal);
+                dfb_in_resident.wait_front((out_block_index + 1) * out_block_hw_normal);
+                uint32_t out_block_base = out_block_index * out_block_hw_normal;
+#else
                 dfb_in0.wait_front(out_block_hw_normal);
+                constexpr uint32_t out_block_base = 0;
+#endif
 
                 index_h_offset = 0;
                 reconfig_data_format_srcb(dfb_in0_id, dfb_input_mask_id);
                 // mask input
-                mul_init(dfb_in0_id, dfb_input_mask_id);
+                mul_init(dfb_input_id, dfb_input_mask_id);
                 dfb_x.reserve_back(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; ++i) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; ++w) {
-                            uint32_t index = w + index_subblock_w_offset + index_h_offset;
+                            uint32_t index = w + index_subblock_w_offset + index_h_offset + out_block_base;
                             uint32_t index_mask = w + index_subblock_w_offset;
-#ifdef TILIZE_IN
-                            mul_tiles(dfb_in_id, dfb_input_mask_id, index, index_mask, w);
-#else
-                            mul_tiles(dfb_in0_id, dfb_input_mask_id, index, index_mask, w);
-#endif
+                            mul_tiles(dfb_input_id, dfb_input_mask_id, index, index_mask, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
@@ -354,9 +360,8 @@ void kernel_main() {
                     }
                     index_h_offset += block_w;
                 }
-#ifdef TILIZE_IN
-                dfb_in.pop_front(out_block_hw_actual);
-#else
+                // Only the tiled path pops here; the row-major group stays resident.
+#ifndef TILIZE_IN
                 dfb_in0.pop_front(out_block_hw_normal);
 #endif
                 dfb_x.push_back(out_block_hw_normal);
@@ -409,12 +414,15 @@ void kernel_main() {
                     out_block_hw_actual = out_block_hw_normal;
                 }
 
+                // The resident group is already there; only the tiled path waits on new rows.
+#ifndef TILIZE_IN
                 dfb_in0.wait_front(out_block_hw_normal);
+#endif
                 // x - E[x]
-                sub_bcast_scalar_init(dfb_in0_id, dfb_ex_global_id);
+                sub_bcast_scalar_init(dfb_input_id, dfb_ex_global_id);
                 // fp32: reset both srcs so fp32 input/mean aren't read through the stale bf16 scaler format.
                 if constexpr (enable_fp32_reconfig) {
-                    reconfig_data_format_srca(dfb_in0_id);
+                    reconfig_data_format_srca(dfb_input_id);
                     reconfig_data_format_srcb(dfb_ex_global_id);
                 }
 
@@ -422,11 +430,16 @@ void kernel_main() {
                 dfb_ex_global.wait_front(1);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
+#ifdef TILIZE_IN
+                    uint32_t row_base = out_block_index * out_block_hw_normal + i * block_w;
+#else
+                    constexpr uint32_t row_base = 0;
+#endif
                     for (uint32_t j = 0; j < num_subblocks_w; j++) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; w++) {
-                            uint32_t index = w + index_subblock_w_offset;
-                            sub_tiles_bcast_scalar(dfb_in0_id, dfb_ex_global_id, index, 0, w);
+                            uint32_t index = w + index_subblock_w_offset + row_base;
+                            sub_tiles_bcast_scalar(dfb_input_id, dfb_ex_global_id, index, 0, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
@@ -436,10 +449,14 @@ void kernel_main() {
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
+#ifndef TILIZE_IN
                     dfb_in0.pop_front(block_w);
+#endif
                 }
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+#ifndef TILIZE_IN
                     dfb_in0.pop_front(out_block_hw_normal - out_block_hw_last);
+#endif
                 }
                 dfb_xmm.push_back(out_block_hw_normal);
 
@@ -620,23 +637,30 @@ void kernel_main() {
                     out_block_hw_actual = out_block_hw_normal;
                 }
 
+#ifndef TILIZE_IN
                 dfb_in0.wait_front(out_block_hw_normal);
+#endif
                 // x - E[x]
-                sub_bcast_scalar_init(dfb_in0_id, dfb_ex_global_id);
+                sub_bcast_scalar_init(dfb_input_id, dfb_ex_global_id);
                 // fp32: reset both srcs so fp32 input/mean aren't read through the stale rsqrt/eps format.
                 if constexpr (enable_fp32_reconfig) {
-                    reconfig_data_format_srca(dfb_in0_id);
+                    reconfig_data_format_srca(dfb_input_id);
                     reconfig_data_format_srcb(dfb_ex_global_id);
                 }
                 dfb_xmm.reserve_back(out_block_hw_normal);
                 dfb_ex_global.wait_front(1);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
+#ifdef TILIZE_IN
+                    uint32_t row_base = out_block_index * out_block_hw_normal + i * block_w;
+#else
+                    constexpr uint32_t row_base = 0;
+#endif
                     for (uint32_t j = 0; j < num_subblocks_w; j++) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; w++) {
-                            uint32_t index = w + index_subblock_w_offset;
-                            sub_tiles_bcast_scalar(dfb_in0_id, dfb_ex_global_id, index, 0, w);
+                            uint32_t index = w + index_subblock_w_offset + row_base;
+                            sub_tiles_bcast_scalar(dfb_input_id, dfb_ex_global_id, index, 0, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
@@ -646,10 +670,14 @@ void kernel_main() {
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
+#ifndef TILIZE_IN
                     dfb_in0.pop_front(block_w);
+#endif
                 }
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+#ifndef TILIZE_IN
                     dfb_in0.pop_front(out_block_hw_normal - out_block_hw_last);
+#endif
                 }
                 dfb_xmm.push_back(out_block_hw_normal);
 
@@ -722,6 +750,18 @@ void kernel_main() {
 
                 // add or copy with previous output results
                 uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
+
+#ifdef UNTILIZE_OUT
+                // Tilize the reread rows so the accumulation below sees tiles.
+                compute_kernel_lib::tilize<
+                    block_w,
+                    dfb_reread_rm_id,
+                    dfb_reread_out_id,
+                    compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+                    compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+                    compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+                    out_block_h_normal);
+#endif
 
                 dfb_reread_out.wait_front(out_block_hw_normal);
                 dfb_reread_write_out.reserve_back(out_block_hw_normal);
@@ -859,17 +899,22 @@ void kernel_main() {
                 // End Optional Beta
 
 #ifdef UNTILIZE_OUT
-                // untilize - DEST capacity auto-detected
+                // Untilize this block for the writer.
                 compute_kernel_lib::untilize<
-                    per_core_N,
+                    block_w,
                     dfb_untilize_in_id,
                     dfb_untilize_out_id,
                     compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
-                    compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
-                    compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
+                    compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+                    compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::UnpackAndPackReconfigure>(
+                    out_block_h_normal);
 #endif
             }
             // End Final Val Calc
+#ifdef TILIZE_IN
+            // All three passes are done with the group.
+            dfb_in_resident.pop_front(num_out_blocks_padded * out_block_hw_normal);
+#endif
             if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
                 if (row_offset == tile_width) {
                     index_g_offset += block_w;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -214,7 +214,6 @@ void kernel_main() {
     bool apply_gamma_beta[block_w];
     constexpr uint32_t data_per_core_N_per_group = (per_core_N * tile_width / group);
 
-    // Gamma/beta wiring, same for both layouts.
     constexpr int dfb_outgamma_id = do_beta ? dfb_in_id : dfb_out0_id;
     constexpr int dfb_inbeta_id = do_gamma ? dfb_outgamma_id : dfb_reread_write_out_id;
     constexpr int dfb_outbeta_id = dfb_out0_id;
@@ -260,7 +259,6 @@ void kernel_main() {
     DataflowBuffer dfb_kmsq(dfb_kmsq_id);
 
 #ifdef TILIZE_IN
-    // Tilize source: repacked channels or dfb_in0.
 #ifdef READER_REPACK
     constexpr uint32_t dfb_in_rm_id = dfb_repack_id;
 #else
@@ -899,7 +897,7 @@ void kernel_main() {
                 // End Optional Beta
 
 #ifdef UNTILIZE_OUT
-                // Untilize this block for the writer.
+                // untilize - DEST capacity auto-detected.
                 compute_kernel_lib::untilize<
                     block_w,
                     dfb_untilize_in_id,
@@ -912,7 +910,7 @@ void kernel_main() {
             }
             // End Final Val Calc
 #ifdef TILIZE_IN
-            // All three passes are done with the group.
+            // All passes done with the group, resident group popped.
             dfb_in_resident.pop_front(num_out_blocks_padded * out_block_hw_normal);
 #endif
             if constexpr (GROUP_SIZE_IS_POWER_OF_2) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_reader_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/groupnorm_reader_rm.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+// Read one out-block of a ROW_MAJOR tensor into `dfb` row by row, for the compute kernel to tilize.
+template <uint32_t tile_width, uint32_t tile_height, uint32_t block_w, uint32_t datum_size_bytes, typename AccessorT>
+void groupnorm_gather_rm_block(
+    Noc& noc,
+    const AccessorT& accessor,
+    DataflowBuffer& dfb,
+    uint32_t base_start_id,
+    uint32_t out_block_start_id_offset,
+    uint32_t index_b_offset,
+    uint32_t index_g_offset,
+    uint32_t num_channels_tiles,
+    uint32_t out_block_h_actual,
+    uint32_t out_block_hw_normal) {
+    constexpr uint32_t row_chunk_bytes = tile_width * datum_size_bytes;
+    uint32_t l1_write_addr = dfb.get_write_ptr();
+    dfb.reserve_back(out_block_hw_normal);
+    for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
+        for (uint32_t r = 0; r < tile_height; r++) {
+            for (uint32_t nt = 0; nt < block_w; nt++) {
+                // Clamp past-the-end columns in the last group; they get masked out later anyway.
+                const uint32_t abs_col = index_g_offset + nt;
+                const uint32_t col = abs_col < num_channels_tiles ? abs_col : num_channels_tiles - 1;
+                const uint32_t page_id_tile =
+                    base_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + index_b_offset + col;
+                const uint32_t tile_row = page_id_tile / num_channels_tiles;
+                const uint32_t tile_col = page_id_tile % num_channels_tiles;
+                const uint32_t rm_row = (tile_row * tile_height) + r;
+                const uint32_t col_off_bytes = tile_col * row_chunk_bytes;
+                noc.async_read(
+                    accessor,
+                    CoreLocalMem<uint32_t>(l1_write_addr),
+                    row_chunk_bytes,
+                    {.page_id = rm_row, .offset_bytes = col_off_bytes},
+                    {});
+                l1_write_addr += row_chunk_bytes;
+            }
+        }
+        noc.async_read_barrier();
+    }
+    dfb.push_back(out_block_hw_normal);
+}

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -11,6 +11,7 @@
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "groupnorm_reader_rm.hpp"
 
 void kernel_main() {
     // clang-format off
@@ -74,6 +75,7 @@ void kernel_main() {
     constexpr uint32_t per_core_N = get_named_compile_time_arg_val("per_core_N");
     const uint32_t per_core_N_bytes = get_named_compile_time_arg_val("per_core_N_bytes");
     const uint32_t per_core_N_bytes_with_stride = get_named_compile_time_arg_val("per_core_N_bytes_with_stride");
+    constexpr uint32_t datum_size_bytes = get_named_compile_time_arg_val("datum_size_bytes");
     constexpr uint32_t per_core_M = get_named_compile_time_arg_val("per_core_M");
     constexpr uint32_t tile_height = get_named_compile_time_arg_val("TILE_HEIGHT");
 
@@ -122,6 +124,10 @@ void kernel_main() {
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
     constexpr uint32_t dfb_x_id = tt::CBIndex::c_24;
     constexpr uint32_t dfb_reread_out_id = tt::CBIndex::c_23;
+#ifdef UNTILIZE_OUT
+    // Scratch for the row-major output reread; compute tilizes it into c_23.
+    constexpr uint32_t dfb_reread_rm_id = tt::CBIndex::c_20;
+#endif
 
     Noc noc;
     Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
@@ -135,6 +141,9 @@ void kernel_main() {
     DataflowBuffer dfb_repack_out(dfb_repack_out_id);
     DataflowBuffer dfb_out0(dfb_out0_id);
     DataflowBuffer dfb_reread_out(dfb_reread_out_id);
+#ifdef UNTILIZE_OUT
+    DataflowBuffer dfb_reread_rm(dfb_reread_rm_id);
+#endif
 
     const uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial_id);
     const DataFormat out_data_format = get_dataformat(dfb_out0_id);
@@ -193,6 +202,23 @@ void kernel_main() {
                         out_block_h_actual = out_block_h_normal;
                     }
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
+#ifdef TILIZE_IN
+                    // Read once: the tilized group stays in L1 for all three passes.
+                    if (cur_read_iteration == 0) {
+                        const auto src_a = TensorAccessor(src0_args, src_addr);
+                        groupnorm_gather_rm_block<tile_width, tile_height, block_w, datum_size_bytes>(
+                            noc,
+                            src_a,
+                            dfb_in0,
+                            start_id,
+                            out_block_start_id_offset,
+                            index_b_offset,
+                            index_g_offset,
+                            num_channels_tiles,
+                            out_block_h_actual,
+                            out_block_hw_normal);
+                    }
+#else
                     const uint32_t src0_tile_bytes = get_tile_size(dfb_in0_id);
                     const auto src_a = TensorAccessor(src0_args, src_addr);
                     uint32_t l1_write_addr;
@@ -212,6 +238,7 @@ void kernel_main() {
                         }
                     }
                     dfb_in0.push_back(out_block_hw_normal);
+#endif
 
 #endif
                     if (cur_read_iteration == 0 || cur_read_iteration == 1) {
@@ -238,6 +265,20 @@ void kernel_main() {
 
                         uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
+#ifdef UNTILIZE_OUT
+                        // Reread the rows we already wrote, so the next group can accumulate onto them.
+                        groupnorm_gather_rm_block<tile_width, tile_height, block_w, datum_size_bytes>(
+                            noc,
+                            dst_a,
+                            dfb_reread_rm,
+                            out_start_id,
+                            out_block_start_id_offset,
+                            index_b_offset,
+                            index_g_offset,
+                            num_channels_tiles,
+                            out_block_h_actual,
+                            out_block_hw_normal);
+#else
                         const uint32_t dst_tile_bytes = get_tile_size(dfb_reread_out_id);
                         uint32_t l1_write_addr;
                         l1_write_addr = dfb_reread_out.get_write_ptr();
@@ -260,6 +301,7 @@ void kernel_main() {
                             }
                         }
                         dfb_reread_out.push_back(out_block_hw_normal);
+#endif
                     }
                     out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -266,7 +266,7 @@ void kernel_main() {
                         uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
 #ifdef UNTILIZE_OUT
-                        // Reread the rows we already wrote, so the next group can accumulate onto them.
+                        // Reread the rows written; the next group accumulates onto them.
                         groupnorm_gather_rm_block<tile_width, tile_height, block_w, datum_size_bytes>(
                             noc,
                             dst_a,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -12,6 +12,7 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "groupnorm_zero_fill.hpp"
+#include "groupnorm_reader_rm.hpp"
 #include "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/groupnorm_constants.hpp"
 
 void kernel_main() {
@@ -206,6 +207,10 @@ void kernel_main() {
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
     constexpr uint32_t dfb_x_id = tt::CBIndex::c_24;
     constexpr uint32_t dfb_reread_out_id = tt::CBIndex::c_23;
+#ifdef UNTILIZE_OUT
+    // Scratch for the row-major output reread; compute tilizes it into c_23.
+    constexpr uint32_t dfb_reread_rm_id = tt::CBIndex::c_20;
+#endif
 
     DataflowBuffer dfb_ex_partial(dfb_ex_partial_id);
     DataflowBuffer dfb_ex2_partial(dfb_ex2_partial_id);
@@ -217,6 +222,9 @@ void kernel_main() {
     DataflowBuffer dfb_repack_out(dfb_repack_out_id);
     DataflowBuffer dfb_out0(dfb_out0_id);
     DataflowBuffer dfb_reread_out(dfb_reread_out_id);
+#ifdef UNTILIZE_OUT
+    DataflowBuffer dfb_reread_rm(dfb_reread_rm_id);
+#endif
 
     constexpr uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial_id);
     const DataFormat out_data_format = get_dataformat(dfb_out0_id);
@@ -323,6 +331,23 @@ void kernel_main() {
                         }
 
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
+#ifdef TILIZE_IN
+                        // Read once: the tilized group stays in L1 for all three passes.
+                        if (cur_read_iteration == 0) {
+                            const auto src_a = TensorAccessor(src0_args, src_addr);
+                            groupnorm_gather_rm_block<tile_width, tile_height, block_w, datum_size_bytes>(
+                                noc,
+                                src_a,
+                                dfb_in0,
+                                start_id,
+                                out_block_start_id_offset,
+                                index_b_offset,
+                                index_g_offset,
+                                num_channels_tiles,
+                                out_block_h_actual,
+                                out_block_hw_normal);
+                        }
+#else
                         const uint32_t src0_tile_bytes = get_tile_size(dfb_in0_id);
                         const auto src_a = TensorAccessor(src0_args, src_addr);
                         uint32_t l1_write_addr;
@@ -342,6 +367,7 @@ void kernel_main() {
                             }
                         }
                         dfb_in0.push_back(out_block_hw_normal);
+#endif
 #endif
                         if (cur_read_iteration== 0 || cur_read_iteration== 1) {
                             if (cur_read_iteration== 0) {
@@ -420,6 +446,20 @@ void kernel_main() {
                             uint32_t block_w_curr =
                                 index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
+#ifdef UNTILIZE_OUT
+                            // Reread the rows we already wrote, so the next group can accumulate onto them.
+                            groupnorm_gather_rm_block<tile_width, tile_height, block_w, datum_size_bytes>(
+                                noc,
+                                dst_a,
+                                dfb_reread_rm,
+                                out_start_id,
+                                out_block_start_id_offset,
+                                index_b_offset,
+                                index_g_offset,
+                                num_channels_tiles,
+                                out_block_h_actual,
+                                out_block_hw_normal);
+#else
                             const uint32_t dst_tile_bytes = get_tile_size(dfb_reread_out_id);
                             uint32_t l1_write_addr;
                             l1_write_addr = dfb_reread_out.get_write_ptr();
@@ -442,6 +482,7 @@ void kernel_main() {
                                 }
                             }
                             dfb_reread_out.push_back(out_block_hw_normal);
+#endif
                         }
                         out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
                     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -447,7 +447,7 @@ void kernel_main() {
                                 index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
 #ifdef UNTILIZE_OUT
-                            // Reread the rows we already wrote, so the next group can accumulate onto them.
+                            // Reread the rows written; the next group accumulates onto them.
                             groupnorm_gather_rm_block<tile_width, tile_height, block_w, datum_size_bytes>(
                                 noc,
                                 dst_a,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -121,6 +121,11 @@ void kernel_main() {
 
     const uint32_t single_tile_size_bytes = get_tile_size(dfb_out_id);
     const uint32_t input_mask_single_tile_size_bytes = get_tile_size(dfb_input_mask_id);
+#ifdef UNTILIZE_OUT
+    constexpr uint32_t tile_hw = get_named_compile_time_arg_val("TILE_HW");
+    constexpr uint32_t tile_height = tile_hw / tile_width;
+    const uint32_t datum_size_bytes = single_tile_size_bytes / tile_hw;
+#endif
 
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr);
 
@@ -262,6 +267,34 @@ void kernel_main() {
                 dfb_out.wait_front(out_block_hw_normal);
                 uint32_t l1_read_addr = dfb_out.get_read_ptr();
 
+#ifdef UNTILIZE_OUT
+                // Row-major output: write back one tile-wide row chunk at a time.
+                const uint32_t row_chunk_bytes = tile_width * datum_size_bytes;
+                for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
+                    for (uint32_t r = 0; r < tile_height; r++) {
+                        for (uint32_t nt = 0; nt < block_w_curr; nt++) {
+                            // Skip columns past the channel width (last group only).
+                            if ((index_g_offset + nt) < row_tile_max_index) {
+                                const uint32_t out_tile_id = out_start_id + out_block_start_id_offset +
+                                                             (mt * num_channels_tiles) + nt + index_b_offset +
+                                                             index_g_offset;
+                                const uint32_t tile_row = out_tile_id / num_channels_tiles;
+                                const uint32_t tile_col = out_tile_id % num_channels_tiles;
+                                const uint32_t rm_row = (tile_row * tile_height) + r;
+                                const uint32_t col_off_bytes = tile_col * row_chunk_bytes;
+                                const uint32_t l1_addr =
+                                    l1_read_addr + ((((mt * tile_height) + r) * block_w + nt) * row_chunk_bytes);
+                                noc.async_write(
+                                    CoreLocalMem<uint32_t>(l1_addr),
+                                    dst_a,
+                                    row_chunk_bytes,
+                                    {},
+                                    {.page_id = rm_row, .offset_bytes = col_off_bytes});
+                            }
+                        }
+                    }
+                }
+#else
                 for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                     for (uint32_t nt = 0; nt < block_w_curr; nt++) {
                         // Checks, only relevant to the last group, that we are not indexing out of bounds
@@ -278,6 +311,7 @@ void kernel_main() {
                         l1_read_addr += single_tile_size_bytes;
                     }
                 }
+#endif
                 out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
                 noc.async_write_barrier();
                 dfb_out.pop_front(out_block_hw_normal);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -271,7 +271,7 @@ Tensor group_norm(
 
     const auto arch = input_tensor.device()->arch();
 
-    // Interleaved (non-sharded) ROW_MAJOR is Wormhole-only, it regresses on Blackhole; see #52279.
+    // Interleaved (non-sharded) ROW_MAJOR is Wormhole-only: it is a perf regression on Blackhole; see #52279.
     if (!input_tensor.is_sharded() && arch != tt::ARCH::WORMHOLE_B0) {
         TT_FATAL(
             input_tensor.layout() == Layout::TILE,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -4,6 +4,7 @@
 
 #include "groupnorm.hpp"
 #include "device/groupnorm_device_operation.hpp"
+#include "device/groupnorm_program_utils.hpp"
 #include "groupnorm_grid_utils.hpp"
 #include "groupnorm_input_mask.hpp"
 
@@ -12,6 +13,7 @@
 
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
+#include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
 
 namespace {
 
@@ -191,21 +193,6 @@ Tensor group_norm(
         input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
         "Unsupported memory layout: Input tensor cannot be width-sharded.");
 
-    // The non-sharded (interleaved) group_norm only has a correct TILE-input /
-    // TILE-output compute path. See #47972 and #48142
-    if (!input_tensor.is_sharded()) {
-        TT_FATAL(
-            input_tensor.layout() == Layout::TILE,
-            "group_norm: interleaved (non-sharded) input must be in TILE layout, got ROW_MAJOR. "
-            "Convert the input with ttnn.to_layout(input, ttnn.TILE_LAYOUT) before calling group_norm. "
-            "ROW_MAJOR is supported only for sharded inputs.");
-        TT_FATAL(
-            output_layout.value_or(Layout::TILE) == Layout::TILE,
-            "group_norm: interleaved (non-sharded) output must be in TILE layout, got ROW_MAJOR output_layout. "
-            "Request TILE output and convert it yourself with ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT). "
-            "ROW_MAJOR output is supported only for sharded inputs.");
-    }
-
     const auto& input_shape = input_tensor.logical_shape();
     TT_FATAL(
         input_shape.rank() == 4, "Invalid tensor shape: Input tensor must have rank 4. (rank={})", input_shape.rank());
@@ -283,6 +270,22 @@ Tensor group_norm(
         out_dtype);
 
     const auto arch = input_tensor.device()->arch();
+
+    // The interleaved (non-sharded) ROW_MAJOR path regresses on Blackhole, so it is enabled only on
+    // Wormhole. Blackhole regression: #12345
+    if (!input_tensor.is_sharded() && arch != tt::ARCH::WORMHOLE_B0) {
+        TT_FATAL(
+            input_tensor.layout() == Layout::TILE,
+            "group_norm: interleaved (non-sharded) input must be in TILE layout, got ROW_MAJOR. "
+            "Convert the input with ttnn.to_layout(input, ttnn.TILE_LAYOUT) before calling group_norm. "
+            "ROW_MAJOR is supported only for sharded inputs, or on Wormhole.");
+        TT_FATAL(
+            output_layout.value_or(Layout::TILE) == Layout::TILE,
+            "group_norm: interleaved (non-sharded) output must be in TILE layout, got ROW_MAJOR output_layout. "
+            "Request TILE output and convert it yourself with ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT). "
+            "ROW_MAJOR output is supported only for sharded inputs, or on Wormhole.");
+    }
+
     const auto math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     const auto approx_mode = true;
     // fp32 input accumulates in the fp32 DEST (like LayerNorm); welford already forces it. A
@@ -427,6 +430,65 @@ Tensor group_norm(
             negative_mask,
             effective_reciprocals);
     }
+
+    // Composite fallbacks, legacy path only. We only reroute when per-batch H*W is tile-aligned:
+    // otherwise the padding would corrupt mean/variance, so let the device op reject it instead.
+    const uint32_t per_batch_hw = input_padded_shape[1] * input_padded_shape[2];
+    const uint32_t tile_h = input_tensor.tensor_spec().tile().get_height();
+    const bool per_batch_hw_tile_aligned = per_batch_hw % tile_h == 0;
+    const Layout requested_out_layout = output_layout.value_or(input_tensor.layout());
+
+    // L1-fit estimate shared by the input and output decisions below.
+    const uint32_t Ht = nhw / ttnn::types::TILE_SIZE;
+    const uint32_t tile_w = input_tensor.tensor_spec().tile().get_width();
+    const uint64_t base_l1 = input_tensor.device()->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    const uint64_t available_l1 = input_tensor.device()->l1_size_per_core() - base_l1;
+    const auto legacy_rm_fits_l1 = [&](bool tilize_in, bool untilize_out) {
+        return ttnn::prim::groupnorm_legacy_rm_input_fits_l1(
+            Ht,
+            input_padded_shape[3],
+            per_batch_hw,
+            input_padded_shape[0],
+            core_grid->x,
+            core_grid->y,
+            static_cast<uint32_t>(num_groups),
+            core_grid_auto_selected ? -1 : num_out_blocks.value_or(1),
+            tile_w,
+            tile_h * tile_w * input_tensor.element_size(),
+            gamma.has_value(),
+            beta.has_value(),
+            tilize_in,
+            untilize_out,
+            available_l1);
+    };
+
+    // If the resident group will not fit in L1, tilize once on host instead of re-tilizing on every pass.
+    Tensor gn_input = input_tensor;
+    if (!use_welford && input_tensor.layout() == Layout::ROW_MAJOR && per_batch_hw_tile_aligned) {
+        if (!legacy_rm_fits_l1(/*tilize_in=*/true, /*untilize_out=*/requested_out_layout == Layout::ROW_MAJOR)) {
+            log_debug(
+                tt::LogOp,
+                "group_norm: tilizing ROW_MAJOR input on host and running the TILE path (composite) -- "
+                "resident tilized group does not fit L1.");
+            // Keep the input's memory config; output_mem_config may well be different.
+            gn_input = ttnn::tilize_with_zero_padding(input_tensor, input_tensor.memory_config());
+        }
+    }
+
+    // Likewise for the output: the fused untilize needs extra CBs, so fall back to untilizing on host.
+    Layout device_out_layout = requested_out_layout;
+    bool untilize_out_on_host = false;
+    if (!use_welford && requested_out_layout == Layout::ROW_MAJOR && per_batch_hw_tile_aligned) {
+        if (!legacy_rm_fits_l1(/*tilize_in=*/gn_input.layout() == Layout::ROW_MAJOR, /*untilize_out=*/true)) {
+            log_debug(
+                tt::LogOp,
+                "group_norm: running the TILE-output path and untilizing on host (composite output) -- "
+                "the fused ROW_MAJOR-output CBs do not fit L1.");
+            device_out_layout = Layout::TILE;
+            untilize_out_on_host = true;
+        }
+    }
+
     // When the user did not pin a core grid, defer num_out_blocks to the program
     // factory's heuristic via the -1 sentinel (see GroupNormMultiCoreProgramConfig).
     // Otherwise honor the explicit num_out_blocks (defaulting to 1 = no chunking).
@@ -435,10 +497,10 @@ Tensor group_norm(
         .im_data_format = group_norm_im_data_format(input_tensor.dtype()),
         .out_data_format = out_dtype,
         .inplace = inplace.value_or(false),
-        .output_layout = output_layout.value_or(input_tensor.layout()),
+        .output_layout = device_out_layout,
         .num_out_blocks = core_grid_auto_selected ? -1 : num_out_blocks.value_or(1)};
-    return ttnn::prim::group_norm(
-        input_tensor,
+    Tensor output = ttnn::prim::group_norm(
+        gn_input,
         epsilon,
         static_cast<uint32_t>(num_groups),
         output_mem_config,
@@ -450,6 +512,10 @@ Tensor group_norm(
         mask,
         negative_mask,
         effective_reciprocals);
+    if (untilize_out_on_host) {
+        output = ttnn::to_layout(output, Layout::ROW_MAJOR);
+    }
+    return output;
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -271,8 +271,7 @@ Tensor group_norm(
 
     const auto arch = input_tensor.device()->arch();
 
-    // The interleaved (non-sharded) ROW_MAJOR path regresses on Blackhole, so it is enabled only on
-    // Wormhole. Blackhole regression: #12345
+    // Interleaved (non-sharded) ROW_MAJOR is Wormhole-only, it regresses on Blackhole; see #52279.
     if (!input_tensor.is_sharded() && arch != tt::ARCH::WORMHOLE_B0) {
         TT_FATAL(
             input_tensor.layout() == Layout::TILE,
@@ -431,8 +430,6 @@ Tensor group_norm(
             effective_reciprocals);
     }
 
-    // Composite fallbacks, legacy path only. We only reroute when per-batch H*W is tile-aligned:
-    // otherwise the padding would corrupt mean/variance, so let the device op reject it instead.
     const uint32_t per_batch_hw = input_padded_shape[1] * input_padded_shape[2];
     const uint32_t tile_h = input_tensor.tensor_spec().tile().get_height();
     const bool per_batch_hw_tile_aligned = per_batch_hw % tile_h == 0;
@@ -462,14 +459,22 @@ Tensor group_norm(
             available_l1);
     };
 
-    // If the resident group will not fit in L1, tilize once on host instead of re-tilizing on every pass.
+    // Composite fallback: L1 does not fit, or fused RM is expected to be slower.
     Tensor gn_input = input_tensor;
     if (!use_welford && input_tensor.layout() == Layout::ROW_MAJOR && per_batch_hw_tile_aligned) {
-        if (!legacy_rm_fits_l1(/*tilize_in=*/true, /*untilize_out=*/requested_out_layout == Layout::ROW_MAJOR)) {
+        const bool fits_l1 =
+            legacy_rm_fits_l1(/*tilize_in=*/true, /*untilize_out=*/requested_out_layout == Layout::ROW_MAJOR);
+        const uint32_t num_virtual_cols = compute_num_virtual_cols(core_grid->x, num_groups, input_padded_shape[3]);
+        const uint32_t num_virtual_rows = num_virtual_cols == 0 ? 0 : (core_grid->x / num_virtual_cols) * core_grid->y;
+        const uint32_t num_cores = num_virtual_cols * num_virtual_rows;
+        const bool prefer_composite = ttnn::prim::groupnorm_legacy_rm_prefer_composite_for_perf(
+            num_cores, num_virtual_rows, input_padded_shape[0]);
+        if (!fits_l1 || prefer_composite) {
             log_debug(
                 tt::LogOp,
                 "group_norm: tilizing ROW_MAJOR input on host and running the TILE path (composite) -- "
-                "resident tilized group does not fit L1.");
+                "reason: {}.",
+                !fits_l1 ? "resident tilized group does not fit L1" : "composite preferred for perf");
             // Keep the input's memory config; output_mem_config may well be different.
             gn_input = ttnn::tilize_with_zero_padding(input_tensor, input_tensor.memory_config());
         }


### PR DESCRIPTION
### PR Category
- Feature

### Summary

- Fixes #26594.
- Addresses #47972 on Wormhole; Blackhole follow-up in #52279.

Adds interleaved `ROW_MAJOR` input/output support to the legacy (non-Welford) DRAM `group_norm` path on **Wormhole**. Callers no longer need an explicit host tilize/untilize around the op for tile-aligned shapes.

Blackhole keeps the existing TILE-in / TILE-out restriction for interleaved tensors (RM path regresses there; see #52279). Welford + interleaved `ROW_MAJOR` remains unsupported.

### Problem

On the non-sharded path, `group_norm` only supported TILE in/out. Interleaved `ROW_MAJOR` was rejected up front, so models had to convert layouts around the op even when the tensor was already RM.

### What's Changed

**API / validation**
- Allow interleaved `ROW_MAJOR` in/out on Wormhole for the legacy path.
- Reject interleaved `ROW_MAJOR` on Blackhole (and non-Wormhole) with a clear message.
- Reject interleaved `ROW_MAJOR` on the Welford path.

**Fused RM path (device)**
- Readers gather RM rows into L1; compute tilizes the per-core group once into a resident CB (`c_17`) and reuses it across mean / variance / normalize.
- Writer untilizes and scatters RM output when requested.
- Shared RM gather helper (`groupnorm_reader_rm.hpp`) used by mcast sender/receiver.

**Composite fallback (host)**
Fall back to host tilize / untilize + TILE `group_norm` when:
1. the resident tilized group (or fused RM-output CBs) does not fit L1, or
2. the perf heuristic prefers composite — small grids (`num_cores ≤ 32`) or uneven batch→virtual-row mapping.

Composite is only used when per-batch `H*W` is tile-aligned; non-aligned RM input stays on the RM path so the device op can reject it correctly.

**Other**
- Shared `groupnorm_heuristic_num_out_blocks` helper.
- `ROW_MAJOR` output with tile-straddling groups forces `out_block_h == 1`.

### Perf (Wormhole)

With the L1-fit + small-grid/imbalance heuristic:
- Previous RM regressions (small grids / uneven batches) land at ~TILE parity via composite.
- Full-grid fused shapes keep their RM wins (often ~+7–28% vs TILE_IN·TILE_OUT).
- Worst case in the verification suite is about −1% vs TILE (noise).

Detailed tables are in the PR discussion.

### Tests

- Nightly `test_group_norm_DRAM_row_major` / `_affine_and_mask`: legacy correctness for `RM_IN_TILE_OUT`, `TILE_IN_RM_OUT`, `RM_IN_RM_OUT` (Wormhole-only).
- Nightly `test_group_norm_DRAM_row_major_rejects_welford`: Welford + interleaved ROW_MAJOR is rejected.
- Unit: arch-aware negative test for interleaved RM (`test_group_norm.py`).
- Unit: DRAM helper accepts RM/TILE layout args (`test_group_norm_DRAM.py`).

### Notes for Reviewers

- Compute CB wiring for resident tilize (c_17) and RM untilize / re-tilize (c_20 → c_23) is worth a focused look.
- L1-fit estimate is conservative; a wrong "fits" only causes an unnecessary composite, not an L1 overflow.
- Perf heuristic is intentionally simple (`cores ≤ 32 || imbalanced`); it trades a few small-grid fused wins for removing the known regressions.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-groupnorm-rowmajor-legacy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-groupnorm-rowmajor-legacy)