### PR TITLE
[Bug fix]: Avoid accesses to local cb/dfb interface on MATH

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -265,8 +265,14 @@ private:
         // TODO: Unregister with the debugger
     }
 
-    DFBInterface& local_dfb_interface_;
     uint16_t logical_dfb_id_;
+
+    // MATH TRISC does not own fifo state (see trisc firmware: cb_interface / g_dfb_interface
+    // exist only on UNPACK/PACK). Compute kernels still construct DataflowBuffer on all TRISC
+    // threads; MATH carries logical_dfb_id_ only and no-ops sync / runtime-interface accessors.
+#if !(defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_MATH))
+    DFBInterface& local_dfb_interface_;
+#endif
 
 #ifdef ARCH_QUASAR
     // Metadata for implicit sync

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -18,14 +18,43 @@
 #endif
 #endif  // COMPILE_FOR_TRISC
 
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_MATH)
+#define DFB_IS_COMPUTE_MATH 1
+#else
+#define DFB_IS_COMPUTE_MATH 0
+#endif
+
+#if DFB_IS_COMPUTE_MATH
+inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id) : logical_dfb_id_(logical_dfb_id) {}
+#else
 inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
-    : local_dfb_interface_(get_local_cb_interface(logical_dfb_id)), logical_dfb_id_(logical_dfb_id) {}
+    : logical_dfb_id_(logical_dfb_id), local_dfb_interface_(get_local_cb_interface(logical_dfb_id)) {}
+#endif
 
-inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interface_.fifo_page_size; }
+inline uint32_t DataflowBuffer::get_entry_size() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.fifo_page_size;
+#endif
+}
 
-inline uint32_t DataflowBuffer::get_stride_size() const { return local_dfb_interface_.fifo_page_size; }
+inline uint32_t DataflowBuffer::get_stride_size() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.fifo_page_size;
+#endif
+}
 
-inline uint32_t DataflowBuffer::get_total_num_entries() const { return local_dfb_interface_.fifo_num_pages; }
+inline uint32_t DataflowBuffer::get_total_num_entries() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.fifo_num_pages;
+#endif
+}
+
 
 inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
 #ifdef COMPILE_FOR_TRISC
@@ -56,6 +85,24 @@ inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
     UNPACK((llk_pop_tiles(logical_dfb_id_, num_entries)));
 #else
     cb_pop_front(logical_dfb_id_, num_entries);
+#endif
+}
+
+inline void DataflowBuffer::finish_impl() {}
+
+inline uint32_t DataflowBuffer::get_write_ptr_impl() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.fifo_wr_ptr;
+#endif
+}
+
+inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.fifo_rd_ptr;
 #endif
 }
 
@@ -100,20 +147,16 @@ inline uint32_t DataflowBuffer::read_tile_value(uint32_t tile_index, uint32_t el
 
 #else
 
-inline bool DataflowBuffer::pages_reservable_at_back(int32_t num_pages) const { return cb_pages_reservable_at_back(logical_dfb_id_, num_pages); }
-
-inline bool DataflowBuffer::pages_available_at_front(int32_t num_pages) const { return cb_pages_available_at_front(logical_dfb_id_, num_pages); }
-
-inline void DataflowBuffer::write_barrier_impl(const Noc &noc) const {
-    noc.async_write_barrier();
+inline bool DataflowBuffer::pages_reservable_at_back(int32_t num_pages) const {
+    return cb_pages_reservable_at_back(logical_dfb_id_, num_pages);
 }
 
+inline bool DataflowBuffer::pages_available_at_front(int32_t num_pages) const {
+    return cb_pages_available_at_front(logical_dfb_id_, num_pages);
+}
+
+inline void DataflowBuffer::write_barrier_impl(const Noc& noc) const { noc.async_write_barrier(); }
+
 #endif
-
-inline void DataflowBuffer::finish_impl() {}
-
-inline uint32_t DataflowBuffer::get_write_ptr_impl() const { return local_dfb_interface_.fifo_wr_ptr; }
-
-inline uint32_t DataflowBuffer::get_read_ptr_impl() const { return local_dfb_interface_.fifo_rd_ptr; }
 
 #endif  // !ARCH_QUASAR

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -18,16 +18,45 @@
 
 #include "api/kernel_thread_globals.h"
 
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_MATH)
+#define DFB_IS_COMPUTE_MATH 1
+#else
+#define DFB_IS_COMPUTE_MATH 0
+#endif
+
+#if DFB_IS_COMPUTE_MATH
+inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id) : logical_dfb_id_(logical_dfb_id) {}
+#else
 inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
-    : local_dfb_interface_(g_dfb_interface[logical_dfb_id]), logical_dfb_id_(logical_dfb_id) {}
+    : logical_dfb_id_(logical_dfb_id), local_dfb_interface_(g_dfb_interface[logical_dfb_id]) {}
+#endif
 
-inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interface_.entry_size; }
+inline uint32_t DataflowBuffer::get_entry_size() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.entry_size;
+#endif
+}
 
-inline uint32_t DataflowBuffer::get_stride_size() const { return local_dfb_interface_.stride_size; }
+inline uint32_t DataflowBuffer::get_stride_size() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.stride_size;
+#endif
+}
 
-inline uint32_t DataflowBuffer::get_total_num_entries() const { return local_dfb_interface_.num_entries; }
+inline uint32_t DataflowBuffer::get_total_num_entries() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return local_dfb_interface_.num_entries;
+#endif
+}
 
 inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
+#if !DFB_IS_COMPUTE_MATH
     WAYPOINT("RBW");
     dfb::PackedTileCounter packed_tc =
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
@@ -57,9 +86,11 @@ inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
     }
 #endif
     WAYPOINT("RBD");
+#endif
 }
 
 inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
+#if !DFB_IS_COMPUTE_MATH
     dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
@@ -90,9 +121,11 @@ inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
         local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
     }
 #endif
+#endif
 }
 
 inline void DataflowBuffer::wait_front_impl(uint16_t num_entries) {
+#if !DFB_IS_COMPUTE_MATH
     WAYPOINT("WFW");
     dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
@@ -108,9 +141,11 @@ inline void DataflowBuffer::wait_front_impl(uint16_t num_entries) {
     while (overlay::llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
 #endif
     WAYPOINT("WFD");
+#endif
 }
 
 inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
+#if !DFB_IS_COMPUTE_MATH
     dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
@@ -129,9 +164,11 @@ inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
     }
     local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
 #endif
+#endif
 }
 
 inline void DataflowBuffer::finish_impl() {
+#if !DFB_IS_COMPUTE_MATH
 #ifndef COMPILE_FOR_TRISC
     if (ptiles_read_ > 0) {
         handle_final_credits<true>(ptiles_read_, ptxn_id_index_);
@@ -167,10 +204,13 @@ inline void DataflowBuffer::finish_impl() {
         }
     }
     WAYPOINT("AAD");
+#endif
 }
 
 inline uint32_t DataflowBuffer::get_write_ptr_impl() const {
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#elif defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
     return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr +
            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_offset;
 #elif !defined(COMPILE_FOR_TRISC)
@@ -183,7 +223,9 @@ inline uint32_t DataflowBuffer::get_write_ptr_impl() const {
 }
 
 inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#elif defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
     return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr +
            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_offset;
 #elif !defined(COMPILE_FOR_TRISC)


### PR DESCRIPTION
### Summary
DFB holds reference to local_cb/dfb_interface which was causing linker error on MATH. MATH is already a nop on many DFB apis but extended it to avoid additional accesses. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-linker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-linker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/dfb-linker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-linker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-linker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-linker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-linker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-linker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-linker)