### PR TITLE
Fix logical_and test to compare golden against device result

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_logical_and_.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_logical_and_.py
@@ -8,8 +8,7 @@ import pytest
 import torch
 import ttnn
 
-from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
-from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import eltwise_logical_and_ as tt_eltwise_logical_and_
 
 
@@ -49,11 +48,8 @@ def run_eltwise_logical_andi_tests(
         output_mem_config=out_mem_config,
     )
 
-    # compare tt and golden outputs
-    success, pcc_value = comp_pcc(ref_value, x)
-    logger.debug(pcc_value)
-
-    assert success
+    # compare tt and golden outputs (logical_and_ writes result into input tensor on device)
+    assert_equal(ref_value, tt_result)
 
 
 test_sweep_args = [


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/49508

### Summary

`test_eltwise_logical_andi_test` in `tests/ttnn/unit_tests/operations/eltwise/test_eltwise_logical_and_.py` was failing with `assert False` (PCC `0.0`, `Max ATOL Delta: 101.0`). The test was validating the device output against the **unmodified host input** instead of the actual result, so it could never pass.

### Root cause

`ttnn.logical_and_` is an **in-place** op, but the in-place write happens on the **device** tensor, not the host `x`. The test computed the device result correctly into `tt_result`, but then compared the golden against `x`:

```python
tt_result = tt_eltwise_logical_and_(x=x, y=y, ...)   # device output (0.0 / 1.0)
...
success, pcc_value = comp_pcc(ref_value, x)           # compares golden vs ORIGINAL input
```

- `ref_value` — golden output, values `0.0` / `1.0`
- `x` — original host input, random floats in `[-100, 100]` (never touched by the device op)
- `tt_result` — the actual device output that should have been checked

Comparing `0/1` against random floats produced `Max ATOL Delta: 101.0` and `PCC: 0.0`. The `"constant tensor, falling back to allclose"` warning was a side effect: `ref_value` is near-constant (mostly `1.0` for random non-zero inputs) while `x` has full variance.

### Fix

Compare the golden against the device result, and use exact equality since logical ops produce exact `0`/`1` outputs. This matches the comparison pattern already used for `logical_and_` elsewhere (`test_binary_composite.py` uses `torch.equal`, and the sweep at `sweeps/eltwise/binary/logical_and/logical_and_.py` uses `assert_equal`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/log_and)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/log_and)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/log_and)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/log_and)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/log_and)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/log_and)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/log_and)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/log_and)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/log_and)