### PR TITLE
fix(ring-joint-sdpa): patch scalar runtime args on every core on cache hit

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3870,6 +3870,31 @@ def test_ring_joint_attention_minimax3_gqa_chunked_accuracy():
     )
 
 
+def test_ring_joint_attention_minimax3_gqa_chunked_reuse_kv_hang_regression():
+    """Liveness gate for the RingJointSDPA cross-call chunked-prefill hang.
+
+    GQA chunked prefill reusing one oversized KV buffer: successive chunks share one cached program
+    while logical_n grows. Before the idle-core cache-hit patch, an idle core kept a stale
+    active_ring_iter_mask and skipped a ring iter the injector still multicast to, hanging forever.
+
+    Runs only on bh_quietbox_2_iommu (QuietBox 2, 4 chips, single ring sp_size=4). The hang needs an
+    idle core inside an active row-wide mcast row; on the fixed 10x10 grid that requires
+    all_heads_num_q_chunks = NH*ceil(640/q_chunk) to not be a multiple of the row width. Production
+    q=128 -> 80 = full rows (idle cores only in fully-idle rows, never hangs); q=320 -> 32 leaves a
+    partial active row of 8 idle cores that reproduces it. Verified: hangs without the patch, passes
+    with it. reuse_kv_buffer permutes the output, so this is liveness-only (do_check=False).
+    """
+    run_ring_joint_sdpa_chunked(
+        MESH_CONFIG,
+        MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS["minimax3_55k"],
+        chunk_size=CHUNKED_PREFILL_CHUNK_SIZE,
+        qk_configs=[(320, 512)],
+        persistent_buffer_mode="reuse_max",
+        do_check=False,
+        reuse_kv_buffer=True,
+    )
+
+
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.parametrize("reuse_kv_buffer", [False, True], ids=["fresh_kv", "reuse_kv"])
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -124,11 +124,6 @@ constexpr uint32_t kAllGatherWriterForwardKernelIndex = 4;
 constexpr uint32_t kAllGatherReaderBackwardKernelIndex = 5;
 constexpr uint32_t kAllGatherWriterBackwardKernelIndex = 6;
 
-// Compute runtime args 0/1 are global_q_start/global_q_end (see ring_joint_sdpa.cpp kernel_main).
-// A core with global_q_start == global_q_end got no Q chunks at emplace time and is idle.
-constexpr uint32_t kComputeGlobalQStartArg = 0;
-constexpr uint32_t kComputeGlobalQEndArg = 1;
-
 // Runtime-arg offsets used by cache-hit patching. Descriptor construction appends the same slots through
 // CheckedRuntimeArgList, so future layout edits fail on program creation instead of corrupting cache hits.
 constexpr uint32_t kReaderBaseBufferArgCount = 5;
@@ -568,12 +563,18 @@ void apply_ring_joint_scalar_runtime_args(
     for (uint32_t i = 0; i < num_cores; ++i) {
         const CoreCoord core = {i % layout.grid_size.x, i / layout.grid_size.x};
 
-        // Patch only working cores, matching the emplace-time Q-work distribution. A core with no Q
-        // chunks (global_q_start == global_q_end) never processes KV, so its scalar args are dead.
+        // Patch EVERY core, exactly as the create-time build sets these scalars on all cores
+        // unconditionally. A core with no Q chunks (global_q_start == global_q_end) is NOT dead: in the
+        // GQA / shared-K row-wide multicast path it runs padded handshake iterations (loop_q_count =
+        // *_max_q_per_core) so the injector's mcast rectangle never targets a silent worker. Every such
+        // iteration is gated by active_ring_iter_mask (ring_joint_reader.cpp), so a stale mask makes the
+        // padded receiver skip a ring iter the injector still multicasts to — the injector then blocks
+        // forever waiting for that receiver's ready signal. Previously these cores were skipped on the
+        // assumption their scalars were dead; that held only while every dispatch shared the create-time
+        // logical_n. When logical_n grows across dispatches that reuse one cached program (chunked-prefill
+        // accumulation), the create-miss mask is stale for later hits, deadlocking the mcast handshake
+        // (RingJointSDPA hang, all-gather eth reads left undrained).
         auto& compute_args = GetRuntimeArgs(program, kComputeKernelIndex, core);
-        if (compute_args[kComputeGlobalQStartArg] == compute_args[kComputeGlobalQEndArg]) {
-            continue;
-        }
 
         auto& reader_args = GetRuntimeArgs(program, kReaderKernelIndex, core);
         if (patch_indexed_kv_cache) {


### PR DESCRIPTION
## Problem
RingJointSDPA drops `logical_n` / `kv_actual_isl` from the program hash, so chunked-prefill calls reuse one cached program and re-patch the `logical_n`-derived scalars (`active_ring_iter_mask`, `logical_nt`, masks, `kv_pad_q_mapping`) per dispatch. The cache-hit patch **skipped "idle" cores** (`global_q_start == global_q_end`) assuming their scalar args were dead.

They aren't. In the GQA / shared-K row-wide multicast path an idle core runs padded handshake iterations so the injector's mcast rectangle never targets a silent worker, and every iteration is gated by `active_ring_iter_mask`. When `logical_n` grows across dispatches sharing one program, the skipped idle core keeps the first dispatch's **stale mask**, skips a ring iter the injector still multicasts to, and the injector blocks forever — RingJointSDPA hangs (workers DONE, all-gather eth reads left undrained).

## Solution
Remove the skip so the cache-hit patch stamps **every** core, exactly as the create-time build does. Two now-unused arg-index constants are dropped with it.

Adds `test_ring_joint_attention_minimax3_gqa_chunked_reuse_kv_hang_regression` — a fast, non-skipped liveness gate. It runs on `bh_quietbox_2_iommu` (QuietBox 2, 4-chip single ring); `q_chunk=320` is chosen so idle cores land inside an active mcast row and the hang reproduces on that topology (production `q=128` tiles into whole rows and can't hang there). **Verified: hangs without the fix, passes with it.**

## Why no perf impact
- **Host-only, negligible:** the change is in cache-hit runtime-arg patching — a handful of extra scalar-arg writes for the minority idle cores, once per dispatch. Nothing on the device hot path.
- **Device execution is byte-for-byte unchanged:** no kernel changes, no change to dispatched core count or loop iterations. Idle cores *already* ran the padded handshake iterations by design (that's what keeps the mcast rectangle from hitting a silent worker); the fix only corrects the *mask value* they read — same work, correct data.
- **Just makes the hit path match the miss path:** the create-time build already stamps these masks on all cores unconditionally, so this brings cache-hit patching in line with cache-miss creation.

---

## CI — Blackhole sanity

[![Blackhole sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-hang-ut)](https://github.com/tenstorrent/tt-metal/actions/runs/29036675529)

