### PR TITLE
ttop-create-allocation: add poll loop

### DIFF
--- a/.github/actions/ttop-create-allocation/action.yaml
+++ b/.github/actions/ttop-create-allocation/action.yaml
@@ -53,6 +53,63 @@ runs:
 
     - name: Wait for allocation
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
+        ALLOCATION_NAME: ${{ inputs.allocationName }}
       run: |
         echo "Waiting for allocation to be ready..."
-        kubectl --token ${{ steps.token.outputs.idToken }} -n ${{ inputs.namespace }} wait --for=jsonpath='{.status.phase}'=Allocated allocation/${{ inputs.allocationName }} --timeout=999m
+
+        # GitHub OIDC tokens are short-lived (~10-15 min). A single token cannot
+        # cover a long placement wait: once it expires mid-`kubectl wait`, the
+        # client-go watch loops "Unauthorized" forever and never observes the
+        # phase flip. Instead, poll every few seconds and reissue the token
+        # whenever the API server rejects it as unauthenticated.
+        POLL_INTERVAL=5          # seconds between polls
+        OVERALL_TIMEOUT=59940    # seconds (== 999m); matches the previous 999m cap
+        MAX_AUTH_FAILURES=3      # consecutive auth failures (despite reissue) before giving up
+
+        mint_token() {
+          curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL" \
+            -H "Accept: application/json; api-version=2.0" \
+            -H "Content-Type: application/json" -d "{}" | jq -r '.value'
+        }
+
+        IDTOKEN=$(mint_token)
+        echo "::add-mask::${IDTOKEN}"
+
+        auth_failures=0
+        start=$SECONDS
+        while true; do
+          if (( SECONDS - start >= OVERALL_TIMEOUT )); then
+            echo "Timed out after $((OVERALL_TIMEOUT / 60))m waiting for allocation to reach Allocated."
+            exit 1
+          fi
+
+          set +e
+          output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "allocation/${ALLOCATION_NAME}" -o jsonpath='{.status.phase}' 2>&1)
+          rc=$?
+          set -e
+
+          if (( rc == 0 )); then
+            auth_failures=0
+            if [[ "$output" == "Allocated" ]]; then
+              echo "Allocation ${ALLOCATION_NAME} is Allocated."
+              exit 0
+            fi
+            echo "Allocation phase: '${output:-<empty>}' — waiting..."
+          elif echo "$output" | grep -qiE 'unauthorized|must be logged in|401'; then
+            auth_failures=$((auth_failures + 1))
+            echo "Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) while polling allocation; reissuing token."
+            if (( auth_failures >= MAX_AUTH_FAILURES )); then
+              echo "Repeated auth failures despite token reissue; failing."
+              exit 1
+            fi
+            IDTOKEN=$(mint_token)
+            echo "::add-mask::${IDTOKEN}"
+          else
+            echo "Transient error polling allocation (rc=${rc}): ${output}"
+          fi
+
+          sleep "$POLL_INTERVAL"
+        done

--- a/.github/actions/ttop-create-allocation/action.yaml
+++ b/.github/actions/ttop-create-allocation/action.yaml
@@ -57,7 +57,7 @@ runs:
         NAMESPACE: ${{ inputs.namespace }}
         ALLOCATION_NAME: ${{ inputs.allocationName }}
       run: |
-        echo "Waiting for allocation to be ready..."
+        echo "[info] Waiting for allocation to be ready..."
 
         # GitHub OIDC tokens are short-lived (~10-15 min). A single token cannot
         # cover a long placement wait: once it expires mid-`kubectl wait`, the
@@ -75,42 +75,37 @@ runs:
             -H "Content-Type: application/json" -d "{}" | jq -r '.value'
         }
 
-        IDTOKEN=$(mint_token)
+        IDTOKEN=$(mint_token) || true
         echo "::add-mask::${IDTOKEN}"
 
         auth_failures=0
         start=$SECONDS
         while true; do
           if (( SECONDS - start >= OVERALL_TIMEOUT )); then
-            echo "Timed out after $((OVERALL_TIMEOUT / 60))m waiting for allocation to reach Allocated."
+            echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for allocation to reach Allocated."
             exit 1
           fi
 
-          set +e
-          output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "allocation/${ALLOCATION_NAME}" -o jsonpath='{.status.phase}' 2>&1)
-          rc=$?
-          set -e
+          output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "allocation/${ALLOCATION_NAME}" -o jsonpath='{.status.phase}' 2>&1) && rc=0 || rc=$?
 
           if (( rc == 0 )); then
             auth_failures=0
             if [[ "$output" == "Allocated" ]]; then
-              echo "Allocation ${ALLOCATION_NAME} is Allocated."
+              echo "::notice::Allocation ${ALLOCATION_NAME} is Allocated."
               exit 0
             fi
-            echo "Allocation phase: '${output:-<empty>}' — waiting..."
+            echo "[info] Allocation phase: '${output:-<empty>}' — waiting..."
           elif echo "$output" | grep -qiE 'unauthorized|must be logged in|401'; then
             auth_failures=$((auth_failures + 1))
-            echo "Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) while polling allocation; reissuing token."
+            echo "::warning::Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) while polling allocation; reissuing token."
             if (( auth_failures >= MAX_AUTH_FAILURES )); then
-              echo "Repeated auth failures despite token reissue; failing."
+              echo "::error::Repeated auth failures despite token reissue; failing."
               exit 1
             fi
-            set +e
-            IDTOKEN=$(mint_token)
-            set -e
+            IDTOKEN=$(mint_token) || true
             echo "::add-mask::${IDTOKEN}"
           else
-            echo "Transient error polling allocation (rc=${rc}): ${output}"
+            echo "::warning::Transient error polling allocation (rc=${rc}): ${output}"
           fi
 
           sleep "$POLL_INTERVAL"

--- a/.github/actions/ttop-create-allocation/action.yaml
+++ b/.github/actions/ttop-create-allocation/action.yaml
@@ -105,7 +105,9 @@ runs:
               echo "Repeated auth failures despite token reissue; failing."
               exit 1
             fi
+            set +e
             IDTOKEN=$(mint_token)
+            set -e
             echo "::add-mask::${IDTOKEN}"
           else
             echo "Transient error polling allocation (rc=${rc}): ${output}"


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
https://tenstorrent.atlassian.net/browse/MINFRA-1198

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

- OIDC tokens last ~10–15 min, but allocations can queue longer (observed: 50 min). The old step reused one token across `kubectl wait --timeout=999m`, so it expired mid-wait and the watch looped `Unauthorized` forever until the job timed out.
- Fix: poll `kubectl get ...phase` every 5s and reissue the token on `Unauthorized`. `Allocated` → done.
- Fail after 3 consecutive unauthorized polls

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/fix-ttop-ci-authloop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/fix-ttop-ci-authloop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:williamly/fix-ttop-ci-authloop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/fix-ttop-ci-authloop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/fix-ttop-ci-authloop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/fix-ttop-ci-authloop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/fix-ttop-ci-authloop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/fix-ttop-ci-authloop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/fix-ttop-ci-authloop)