### PR TITLE
SFPU per-op self-contained init (phase 1 pattern, BH+WH LLK)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_generalized_moe_gate_topk_single_face.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_generalized_moe_gate_topk_single_face.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/experimental/ckernel_sfpu_generalized_moe_gate_topk_single_face.h"
 
 using namespace sfpi;
@@ -68,6 +69,7 @@ inline void generalized_moe_gate_finalize_ungrouped(uint32_t eps, uint32_t scale
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void generalized_moe_gate_topk_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     _init_generalized_moe_gate_topk<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void abs_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_relu.h"
 
@@ -42,6 +43,7 @@ inline void calculate_activation() {
 
 template <bool APPROXIMATION_MODE>
 void hardsigmoid_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // For hardsigmoid slope is 1/6, FP32 IEEE 754 representation.
     sfpi::vConstFloatPrgm0 = 0.1666666716337204f;
     sfpi::vConstFloatPrgm1 = 0.5f;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void alt_complex_rotate90_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
 inline void calculate_alt_complex_rotate90() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_conversions.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
@@ -261,6 +262,7 @@ inline void calculate_sfpu_binary_pow(const uint dst_index_in0, const uint dst_i
 
 template <bool APPROXIMATION_MODE>
 inline void sfpu_binary_pow_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;
     sfpi::vConstFloatPrgm1 = -127.0f;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -28,6 +29,12 @@ inline Vec compute_unary_bitwise(Vec v, Vec scalar) {
         return v ^ scalar;
     }
 }
+
+inline void bitwise_and_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void bitwise_or_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void bitwise_xor_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <
     bool APPROXIMATION_MODE,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -6,12 +6,15 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void bitwise_not_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_bitwise_not() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "ckernel.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -70,6 +71,7 @@ inline void calculate_cube_root() {
 
 template <bool APPROXIMATION_MODE>
 inline void cube_root_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 0x1.c09806p0f;
     sfpi::vConstFloatPrgm1 = -0x1.403e6cp0f;
     sfpi::vConstFloatPrgm2 = 0x1.04cdb2p-1f;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -6,10 +6,13 @@
 
 #include <cstdint>
 
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
 
 namespace ckernel::sfpu {
+
+inline void celu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // celu(x) = x for x>=0, alpha*(exp(x/alpha)-1) for x<0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -7,10 +7,13 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_unary_max_min.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
 enum { Max = true, Min = false };  // Clamp Mode
+
+inline void clamp_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpu/ckernel_sfpu_is_fp16_zero.h"
 #include "sfpu/ckernel_sfpu_load_config.h"
 
@@ -13,6 +14,36 @@ using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void greater_than_equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void greater_than_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void less_than_equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void less_than_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void not_equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -6,6 +6,7 @@
 
 #include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -144,6 +145,7 @@ inline void calculate_cumsum(const bool first) {
 
 template <bool APPROXIMATION_MODE /*unused*/>
 inline void cumsum_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     load_replay_buf(0, 16, [] {
         TTI_SFPADD(10, 7, 0, 0, 0);
         TTI_SFPNOP;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -11,6 +11,7 @@
 #include "ckernel_sfpu_recip.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -102,6 +103,7 @@ inline void calculate_digamma() {
 
 template <bool APPROXIMATION_MODE>
 void digamma_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // sfpu_reciprocal_init programs vConstFloatPrgm0/1/2 with the reciprocal's Newton seed;
     // all three stay reserved for it, so digamma must not repurpose Prgm1/Prgm2.
     sfpu_reciprocal_init();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "ckernel_ops.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -56,6 +57,7 @@ inline void calculate_dropout(uint probability, uint scale) {
 
 template <bool APPROXIMATION_MODE>
 inline void dropout_init(const uint seed) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     init_prng_seed(seed);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -6,10 +6,13 @@
 
 #include <cstdint>
 
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
 
 namespace ckernel::sfpu {
+
+inline void elu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
@@ -11,6 +11,7 @@
 #include "sfpu/ckernel_sfpu_converter.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -75,6 +76,7 @@ inline void calculate_erf() {
 
 template <bool APPROXIMATION_MODE>
 void erf_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
@@ -8,6 +8,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
@@ -78,6 +79,7 @@ inline void calculate_erfc() {
 
 template <bool APPROXIMATION_MODE>
 void erfc_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<true>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_log.h"
 #include "ckernel_sfpu_sqrt_custom.h"
 
@@ -58,6 +59,7 @@ inline void calculate_erfinv() {
 
 template <bool APPROXIMATION_MODE>
 void erfinv_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     log_init<false, false, false>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -12,6 +12,7 @@
 #include "ckernel_ops.h"
 // clang-format off: sfpi_inline must be defined before ckernel_sfpu_polyval.h
 #include "sfpi.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 // clang-format on
 #include "ckernel_sfpu_recip.h"
@@ -725,6 +726,12 @@ template <
     bool CLAMP_NEGATIVE = true,
     bool is_fp32_dest_acc_en = false>
 void exp_init() {
+    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
+    // exp setup below -- one self-contained init, no separate shared-common-init call. Same functionality as
+    // _llk_math_eltwise_unary_sfpu_init_<exponential>() (exp uses only ADDR_MOD_7, no op-specific ADDR_MOD_6).
+    sfpu::_init_sfpu_config_reg();
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE && CLAMP_NEGATIVE) {
         // Algorithm is adapted from:
         //      A Fast, Compact Approximation of the Exponential Function

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,6 +9,7 @@
 #include <limits>
 
 #include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
@@ -126,6 +127,7 @@ inline void calculate_exp2() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void exp2_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (is_fp32_dest_acc_en) {
         // Coefficients for minimax polynomial.
         sfpi::vConstFloatPrgm0 = 0x1.62e42ep-1f;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
 /*
@@ -190,6 +191,7 @@ inline void calculate_expm1() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void expm1_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;  // log2(e) == 1 / ln(2)
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm1 = -0.693145752f;    // -ln(2)_hi

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel {
@@ -14,6 +15,7 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
 inline void init_fmod(const uint value, const uint recip) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = Converter::as_float(value);
     sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -8,6 +8,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"  // math::reset_counters, p_setrwc
 
 #include "ckernel_sfpu_exp.h"  // For _sfpu_round_to_nearest_int32_
 #include "sfpu/ckernel_sfpu_polyval.h"
@@ -202,6 +203,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void gelu_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
         sfpi::vConstFloatPrgm0 = 0.5f;
 
@@ -381,6 +383,7 @@ inline void calculate_gelu_tanh() {
 
 template <bool is_fp32_dest_acc_en>
 inline void gelu_tanh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // initialise constants for _sfpu_tanh_fp32_accurate_
     tanh_init<false, true>();
 }
@@ -496,6 +499,7 @@ inline void calculate_gelu_derivative_polynomial() {
 
 template <bool APPROXIMATION_MODE>
 inline void gelu_derivative_polynomial_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!APPROXIMATION_MODE) {
         // Call sfpu_reciprocal_init directly: gelu derivative uses sfpu_reciprocal_iter
         // inline (not _calculate_reciprocal_internal_), so SFPLOADMACRO fast-path init is

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -25,6 +26,8 @@ namespace sfpu {
 // Constants 0.5 and 1.0 are exactly representable in IEEE 754.
 // Clamping to [0, 1] gives exact boundary values (0 or 1),
 // so the final multiply produces exact 0 or exact x at transitions.
+inline void hardmish_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void hardmish() {
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
+
+inline void hardshrink_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_hardshrink(uint32_t param0) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -6,10 +6,13 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
+
+inline void hardtanh_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
 // Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
@@ -6,12 +6,15 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void heaviside_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_heaviside(uint value) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
@@ -22,6 +23,8 @@ namespace sfpu {
            t4) *                                                                                                  \
           t4) *                                                                                                   \
      t4)
+inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
 #pragma GCC unroll 0

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -8,6 +8,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel::sfpu {
@@ -144,6 +145,7 @@ inline void calculate_i1() {
 
 template <bool APPROXIMATION_MODE>
 void i1_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 #include "sfpi.h"
 
@@ -49,7 +50,9 @@ inline void calculate_sum_int_row() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void sum_int_init() {}
+inline void sum_int_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void add_int(const uint dst_offset) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_log.h"
+#include "cmath_common.h"
 
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_log.h"
@@ -164,6 +165,7 @@ inline void calculate_lgamma_stirling_fp32(
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void lgamma_stirling_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // init for sfpu_reciprocal_iter<2> for Blackhole
     sfpi::vConstFloatPrgm0 = 2.0f;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -34,6 +34,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel {
@@ -132,6 +133,7 @@ inline void calculate_log(uint log_base_scale_factor) {
 
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
     const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
     // e represents k << 23 rather than k, so pre-fold the 2^(-23) factor into

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -35,6 +35,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_log.h"
+#include "cmath_common.h"
 
 namespace ckernel {
 namespace sfpu {
@@ -153,6 +154,7 @@ inline void calculate_log1p() {
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log1p_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
     const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
     // e represents k << 23 rather than k, so pre-fold the 2^(-23) factor into

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -8,9 +8,12 @@
 
 #include "ckernel_addrmod.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
+
+inline void logical_not_unary_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
 inline void calculate_logical_not() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_is_fp16_zero.h"
 
@@ -13,6 +14,8 @@ using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void mask_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_mask() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
@@ -10,6 +10,7 @@
 #include "sfpi.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -89,6 +90,7 @@ inline void calculate_mish() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void mish_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // exp does not need an init.
     // calculate_mish uses the inline sfpu_reciprocal_iter<N>, not _calculate_reciprocal_internal_
     // so the SFPLOADMACRO fast-path init is not needed. But, we need sfpu_reciprocal_init's

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -11,6 +11,7 @@
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -130,6 +131,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void polygamma_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
@@ -6,12 +6,15 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void prelu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_prelu(const uint value) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -5,6 +5,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 
 using namespace sfpi;
 
@@ -12,6 +13,7 @@ namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE>
 inline void rand_init(uint32_t seed) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     init_prng_seed(seed);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_rounding_ops.h"
 
 namespace ckernel {
@@ -43,6 +44,7 @@ inline void calculate_rdiv(const uint value) {
 
 template <bool APPROXIMATION_MODE>
 void rdiv_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -9,6 +9,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_rsqrt_compat.h"
 #include "lltt.h"
@@ -385,6 +386,14 @@ inline void calculate_reciprocal() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>
 void recip_init() {
+    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + reciprocal's ADDR_MOD_6 + counter
+    // reset), then the op-specific reciprocal setup below -- one self-contained init, matching exp_init.
+    // SDPA runs reciprocal in its softmax after matmul/exp, so the general SFPU state is re-established
+    // here, not just reset. Reciprocal uses ADDR_MOD_6 (dest incr 2) on Blackhole.
+    sfpu::_init_sfpu_config_reg();
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!legacy_compat) {
         if constexpr (APPROXIMATION_MODE) {
             _init_reciprocal_fast_7b_();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -12,6 +12,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_instr_params.h"
 #include "llk_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "lltt.h"
 #include "sfpi.h"
 
@@ -1727,6 +1728,7 @@ inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t b
  */
 template <PoolType pool_type, DataFormat format, bool is_fp32_dest_acc_en>
 inline void init_reduce(std::uint32_t block_ct_dim = 1) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     static_assert(
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_relu.h"
 
@@ -139,6 +140,7 @@ inline void relu_clamp_int(uint threshold) {
         }
     }
 }
+inline void relu_min_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE>
 inline void relu_min(uint uint_threshold) {
@@ -151,6 +153,8 @@ inline void relu_min(uint uint_threshold) {
         dst_reg++;
     }
 }
+
+inline void relu_max_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE>
 inline void relu_max(uint uint_threshold) {
@@ -165,6 +169,8 @@ inline void relu_max(uint uint_threshold) {
         dst_reg++;
     }
 }
+
+inline void lrelu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_lrelu(uint slope) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel {
@@ -14,6 +15,7 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
 inline void init_remainder(const uint value, const uint recip) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = Converter::as_float(value);
     sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -9,6 +9,7 @@
 #include "ckernel.h"
 #include "ckernel_addrmod.h"
 #include "ckernel_instr_params.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -36,6 +37,8 @@ namespace sfpu {
  *
  * @param idx_addr: L1 address of the mask tile containing destination row mappings (uint8_t[32])
  */
+inline void reshuffle_rows_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE>
 inline void calculate_reshuffle_rows(uint idx_addr) {
     constexpr std::uint32_t output_tile_offset = 64;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_sqrt.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -26,6 +27,7 @@ inline void calculate_rsqrt() {
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>
 void rsqrt_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!legacy_compat) {
         sqrt_init<APPROXIMATION_MODE>();
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
 
@@ -13,6 +14,8 @@ namespace ckernel::sfpu {
 
 // selu(x) = scale * x for x>=0, scale * alpha * (exp(x)-1) for x<0
 // scale ≈ 1.0507, alpha ≈ 1.6733, scale*alpha ≈ 1.7581
+
+inline void selu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_selu(uint32_t scale, uint32_t alpha) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_sigmoid_appx.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
@@ -60,6 +61,7 @@ inline void calculate_sigmoid() {
 
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!APPROXIMATION_MODE) {
         sfpu_reciprocal_init<false>();
     } else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -8,6 +8,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_is_fp16_zero.h"
 #include "sfpi.h"
 
@@ -15,6 +16,8 @@ using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void sign_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_sign(const uint /*exponent_size_8*/) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "ckernel.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 using namespace sfpi;
 
@@ -77,6 +78,8 @@ inline void calculate_signbit_int32() {
 }
 
 inline void signbit_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSHFT2(-31 & 0xfff, 0, 12, sfpi::SFPSHFT2_MOD1_SHFT_IMM);
@@ -106,6 +109,8 @@ inline void signbit_init() {
 }
 
 inline void signbit_int32_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSHFT2(-31 & 0xfff, 0, 12, sfpi::SFPSHFT2_MOD1_SHFT_IMM);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "cmath_common.h"  // math::reset_counters, p_setrwc
 #include "ckernel_sfpu_sigmoid.h"
 #include "ckernel_sfpu_recip.h"
 
@@ -30,6 +31,7 @@ inline void calculate_silu() {
 
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // calculate_silu uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must use non-approx sigmoid_init
     sigmoid_init<false>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_recip.h"
@@ -77,6 +78,12 @@ inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint ds
 
 template <bool APPROXIMATE>
 inline void snake_beta_init() {
+    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
+    // reciprocal setup below -- one self-contained init, matching exp_init. snake_beta uses only
+    // ADDR_MOD_7 (no op-specific ADDR_MOD_6).
+    sfpu::_init_sfpu_config_reg();
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATE>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
@@ -92,6 +93,8 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
     return result;
 }
 
+inline void softplus_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void calculate_softplus_body(const float beta, const float beta_reciprocal, const float threshold) {
     sfpi::vFloat val = sfpi::dst_reg[0];
@@ -168,8 +171,5 @@ inline void calculate_softplus(std::uint32_t param0, std::uint32_t param1, std::
         sfpi::dst_reg++;
     }
 }
-
-template <bool APPROXIMATION_MODE>
-void softplus_init() {}
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
+
+inline void softshrink_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_softshrink(uint32_t param0) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -23,6 +24,7 @@ inline void calculate_softsign() {
 
 template <bool APPROXIMATION_MODE>
 void init_softsign() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -112,6 +113,7 @@ inline void calculate_sqrt() {
 
 template <bool APPROXIMATION_MODE, bool legacy_compat = false>
 void sqrt_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!legacy_compat) {
         if constexpr (APPROXIMATION_MODE) {
             sfpi::vConstIntPrgm0 = 0x5f0b3892;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -6,9 +6,12 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
+
+inline void square_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_square() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -16,6 +16,7 @@
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_expm1.h"
 #include "ckernel_sfpu_trigonometry.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -153,6 +154,7 @@ inline void calculate_tanh() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
         std::uint32_t imm0 = 0x1DFF;  // 0.90625*x
         std::uint32_t imm1 = 0x481A;  // 0.09375*x + 0.8125

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -9,6 +9,7 @@
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_load_config.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
@@ -217,6 +218,7 @@ inline void calculate_tanh_derivative_sech2() {
 
 template <bool APPROXIMATION_MODE>
 inline void tanh_derivative_sech2_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // No special initialization needed — no reciprocal, no LUT.
     // Polynomial uses only Horner evaluation, inline exp uses only arithmetic.
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -8,6 +8,7 @@
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_tanh.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -85,6 +86,7 @@ inline void calculate_tanhshrink() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanhshrink_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // The bf16 large-|x| path uses only local literal polynomials, so it needs no init.
     if constexpr (is_fp32_dest_acc_en) {
         // The fp32 large-|x| path only needs the reciprocal Newton constants; the accurate

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void tiled_prod_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_tiled_prod() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_topk.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 
 using namespace sfpi;
 
@@ -32,6 +33,8 @@ inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint 
 
 template <bool APPROXIMATION_MODE>
 inline void topk_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 32}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     _init_topk();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "ckernel_sfpu_sqrt_custom.h"
@@ -607,6 +608,10 @@ inline void calculate_asin() {
     }
 }
 
+inline void asin_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void acos_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_acos() {
     for (int d = 0; d < ITERATIONS; d++) {
@@ -788,6 +793,7 @@ inline void calculate_sinh() {
 
 template <bool APPROXIMATION_MODE>
 void sine_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // P2 and P3 of four-part Cody-Waite reduction by PI.
     sfpi::vConstFloatPrgm0 = -0x1.51p-21f;
     sfpi::vConstFloatPrgm1 = -0x1.0b4612p-33f;
@@ -797,6 +803,7 @@ void sine_init() {
 
 template <bool APPROXIMATION_MODE>
 void cosine_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // P2 and P3 of four-part Cody-Waite reduction by PI/2.
     sfpi::vConstFloatPrgm0 = -0x1.51p-22f;
     sfpi::vConstFloatPrgm1 = -0x1.0b4612p-34f;
@@ -806,6 +813,7 @@ void cosine_init() {
 
 template <bool APPROXIMATION_MODE>
 void tangent_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // P2 and P3 of four-part Cody-Waite reduction by PI/2.
     sfpi::vConstFloatPrgm0 = -0x1.51p-22f;
     sfpi::vConstFloatPrgm1 = -0x1.0b4612p-34f;
@@ -815,6 +823,7 @@ void tangent_init() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void cosh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;  // log2(e) == 1 / ln(2)
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm1 = -0.693145752f;   // -ln(2)_hi
@@ -827,6 +836,7 @@ void cosh_init() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void sinh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;  // log2(e) == 1 / ln(2)
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm1 = -0.693145752f;    // -ln(2)_hi
@@ -839,6 +849,7 @@ void sinh_init() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void atan_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm1 = 0x1.999384p-3f;
         sfpi::vConstFloatPrgm2 = -0x1.555552p-2f;
@@ -1166,6 +1177,7 @@ inline void calculate_atanh() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // asinh/acosh route through calculate_log1p_fp32, which expects the log1p
     // polynomial constants in vConstFloatPrgm0/1/2. The sqrt used internally is
     // self-contained (_sfpu_sqrt_ge0_) and does not touch the program registers.
@@ -1174,6 +1186,7 @@ void init_inverse_hyperbolic() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // atanh routes through calculate_log1p_fp32; the reciprocal it uses is the
     // self-contained _sfpu_reciprocal_gt0_, so log1p owns the program registers.
     log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -12,6 +12,7 @@
 #include "ckernel_addrmod.h"
 #include "ckernel_defs.h"
 #include "ckernel_ops.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 
 using namespace sfpi;
@@ -577,6 +578,8 @@ inline void calculate_typecast_int32_to_uint16() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstIntPrgm0 = 1;
     sfpi::vConstIntPrgm1 = 0x7fff;
     sfpi::vConstIntPrgm2 = 0xffff0000;
@@ -584,6 +587,8 @@ inline void init_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_uint32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 #else
@@ -622,6 +627,8 @@ inline void preload_sign_magnitude_cast_fixup() { sfpi::vConstIntPrgm0 = -31; }
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     preload_sign_magnitude_cast_fixup();
 
@@ -676,6 +683,8 @@ inline void init_typecast_uint32_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_int32_to_fp32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
@@ -710,6 +719,8 @@ inline void init_typecast_int32_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_int32_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
@@ -747,6 +758,8 @@ inline void init_typecast_int32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 #else
@@ -782,6 +795,8 @@ inline void init_typecast_uint16_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPCAST(0, 12, 0);
@@ -812,6 +827,8 @@ inline void init_typecast_uint16_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     preload_sign_magnitude_cast_fixup();
 
@@ -847,6 +864,8 @@ inline void init_typecast_uint32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_uint16() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // Programs the macro used by the 16-bit Dest (LO16 store) path of
     // calculate_typecast_fp32_to_uint16. The 32-bit Dest path uses the plain loop.
@@ -879,10 +898,15 @@ inline void init_typecast_fp32_to_uint16() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_uint16() {}
+inline void init_typecast_uint32_to_uint16() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_int32_to_uint16() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
@@ -961,11 +985,15 @@ inline void calculate_typecast_uint_to_uint8() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_uint8() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstIntPrgm0 = 0xFF;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstIntPrgm0 = 0xFF;
     sfpi::vConstIntPrgm1 = UINT16_LOW_MASK;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
+
+inline void unary_ne_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ne(uint value) {
@@ -30,6 +33,8 @@ inline void calculate_unary_ne(uint value) {
     }
 }
 
+inline void unary_eq_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_eq(uint value) {
     // SFPU microcode
@@ -47,6 +52,8 @@ inline void calculate_unary_eq(uint value) {
         sfpi::dst_reg++;
     }
 }
+
+inline void unary_gt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_gt(uint value) {
@@ -66,6 +73,8 @@ inline void calculate_unary_gt(uint value) {
     }
 }
 
+inline void unary_lt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_lt(uint value) {
     // SFPU microcode
@@ -84,6 +93,8 @@ inline void calculate_unary_lt(uint value) {
     }
 }
 
+inline void unary_ge_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ge(uint value) {
     // SFPU microcode
@@ -101,6 +112,8 @@ inline void calculate_unary_ge(uint value) {
         sfpi::dst_reg++;
     }
 }
+
+inline void unary_le_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_le(uint value) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
@@ -163,6 +164,8 @@ inline void calculate_unary_max_min_int32(uint value) {
 
 template <bool IS_MAX_OP = true>
 inline void unary_max_min_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(
@@ -194,6 +197,8 @@ inline void unary_max_min_init() {
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false>
 inline void unary_max_min_int32_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_conversions.h"
 #include "sfpu/ckernel_sfpu_converter.h"
@@ -297,6 +298,8 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
         }
     }
 }
+
+inline void power_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 /**
  * @brief Compute power operation

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_shift.h
@@ -6,10 +6,13 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
+
+inline void left_shift_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // Left shift by an immediate scalar amount. If shift amount is >= 32, the result is 0.
 template <bool APPROXIMATION_MODE, DataFormat DATA_FORMAT = DataFormat::Int32, int ITERATIONS = 8>
@@ -33,6 +36,8 @@ inline void calculate_left_shift(const uint shift_amt) {
         sfpi::dst_reg++;
     }
 }
+
+inline void right_shift_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // Arithmetic right shift by an immediate scalar amount.
 // A shift amount >= 32 saturates to the sign (non-negative -> 0, negative -> -1).

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_exp.h"
 
@@ -157,6 +158,7 @@ inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
 
 template <bool APPROXIMATION_MODE>
 void xielu_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.4426950408889634f;   // 1/ln(2)
     sfpi::vConstFloatPrgm1 = -1e-6f;                // eps value
     sfpi::vConstFloatPrgm2 = -0.0000009999995427f;  // expm1(eps)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -4,20 +4,229 @@
 
 #pragma once
 
+#include <utility>
+
 #include "llk_sfpu_types.h"
 #include "llk_math_eltwise_unary_sfpu.h"
 
 namespace ckernel {
 
-template <SfpuType sfpu_op>
-inline void llk_math_eltwise_unary_sfpu_init() {
-    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
+// Kernel-invariant SFPU init: the SFPU config register + invariant ADDR_MOD_7, run once per kernel by the metal
+// "full init" entry points (compute_kernel_hw_startup / init_sfpu / unary_op_init_common / binary_op_init_common).
+inline void llk_math_sfpu_init_once() { _llk_math_eltwise_unary_sfpu_init_once_(); }
+
+namespace sfpu {
+// Forward declarations of the co-located per-op inits (each defined next to its execute method in
+// ckernel_sfpu_<op>.h). Declared -- not #included -- here so the dispatch below resolves these names
+// under two-phase lookup WITHOUT pulling the op headers into every TRISC_MATH translation unit via
+// compute_kernel_hw_startup. Each op's definition is in scope at its <op>_tile_init instantiation site.
+void abs_init();
+void acos_init();
+void alt_complex_rotate90_init();
+void asin_init();
+void bitwise_and_init();
+void bitwise_not_init();
+void bitwise_or_init();
+void bitwise_xor_init();
+void celu_init();
+void clamp_init();
+void elu_init();
+void equal_zero_init();
+void greater_than_equal_zero_init();
+void greater_than_zero_init();
+void hardmish_init();
+void hardshrink_init();
+void hardtanh_init();
+void heaviside_init();
+void i0_init();
+void left_shift_init();
+void less_than_equal_zero_init();
+void less_than_zero_init();
+void logical_not_unary_init();
+void lrelu_init();
+void mask_init();
+void not_equal_zero_init();
+void power_init();
+void prelu_init();
+void relu_max_init();
+void relu_min_init();
+void reshuffle_rows_init();
+void right_shift_init();
+void selu_init();
+void sign_init();
+void softplus_init();
+void softshrink_init();
+void square_init();
+void tiled_prod_init();
+void unary_eq_init();
+void unary_ge_init();
+void unary_gt_init();
+void unary_le_init();
+void unary_lt_init();
+void unary_ne_init();
+
+// Self-contained per-op inits for ops used via bare SFPU_UNARY_INIT(OP) (no callback). config_reg + ADDR_MOD_7
+// are handled once per kernel by llk_math_sfpu_init_once(); these program only the op's residual state
+// (op-specific ADDR_MOD_6 where needed + reset the RWC counters).
+inline void fill_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isfinite_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isinf_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isnan_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isneginf_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isposinf_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void negative_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void threshold_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void typecast_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 }
 
+inline void unused_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+}  // namespace sfpu
+
+// Dependent-false helper so the delegate's else-branch static_assert only fires when an uncategorized bare op is
+// instantiated (a plain static_assert(false) in an if-constexpr else is ill-formed pre-C++23).
+template <SfpuType>
+inline constexpr bool _sfpu_bare_op_unhandled_ = false;
+
+// Bare init entry point: delegates per SFPU op to its self-contained sfpu::<op>_init().
+template <SfpuType sfpu_op>
+inline void llk_math_eltwise_unary_sfpu_init() {
+    if constexpr (sfpu_op == SfpuType::abs) {
+        sfpu::abs_init();
+    } else if constexpr (sfpu_op == SfpuType::acos) {
+        sfpu::acos_init();
+    } else if constexpr (sfpu_op == SfpuType::alt_complex_rotate90) {
+        sfpu::alt_complex_rotate90_init();
+    } else if constexpr (sfpu_op == SfpuType::asin) {
+        sfpu::asin_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_and) {
+        sfpu::bitwise_and_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_not) {
+        sfpu::bitwise_not_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_or) {
+        sfpu::bitwise_or_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_xor) {
+        sfpu::bitwise_xor_init();
+    } else if constexpr (sfpu_op == SfpuType::celu) {
+        sfpu::celu_init();
+    } else if constexpr (sfpu_op == SfpuType::clamp) {
+        sfpu::clamp_init();
+    } else if constexpr (sfpu_op == SfpuType::elu) {
+        sfpu::elu_init();
+    } else if constexpr (sfpu_op == SfpuType::equal_zero) {
+        sfpu::equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::fill) {
+        sfpu::fill_init();
+    } else if constexpr (sfpu_op == SfpuType::greater_than_equal_zero) {
+        sfpu::greater_than_equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::greater_than_zero) {
+        sfpu::greater_than_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::hardmish) {
+        sfpu::hardmish_init();
+    } else if constexpr (sfpu_op == SfpuType::hardshrink) {
+        sfpu::hardshrink_init();
+    } else if constexpr (sfpu_op == SfpuType::hardtanh) {
+        sfpu::hardtanh_init();
+    } else if constexpr (sfpu_op == SfpuType::heaviside) {
+        sfpu::heaviside_init();
+    } else if constexpr (sfpu_op == SfpuType::i0) {
+        sfpu::i0_init();
+    } else if constexpr (sfpu_op == SfpuType::isfinite) {
+        sfpu::isfinite_init();
+    } else if constexpr (sfpu_op == SfpuType::isinf) {
+        sfpu::isinf_init();
+    } else if constexpr (sfpu_op == SfpuType::isnan) {
+        sfpu::isnan_init();
+    } else if constexpr (sfpu_op == SfpuType::isneginf) {
+        sfpu::isneginf_init();
+    } else if constexpr (sfpu_op == SfpuType::isposinf) {
+        sfpu::isposinf_init();
+    } else if constexpr (sfpu_op == SfpuType::left_shift) {
+        sfpu::left_shift_init();
+    } else if constexpr (sfpu_op == SfpuType::less_than_equal_zero) {
+        sfpu::less_than_equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::less_than_zero) {
+        sfpu::less_than_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::logical_not_unary) {
+        sfpu::logical_not_unary_init();
+    } else if constexpr (sfpu_op == SfpuType::lrelu) {
+        sfpu::lrelu_init();
+    } else if constexpr (sfpu_op == SfpuType::mask) {
+        sfpu::mask_init();
+    } else if constexpr (sfpu_op == SfpuType::negative) {
+        sfpu::negative_init();
+    } else if constexpr (sfpu_op == SfpuType::not_equal_zero) {
+        sfpu::not_equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::power) {
+        sfpu::power_init();
+    } else if constexpr (sfpu_op == SfpuType::prelu) {
+        sfpu::prelu_init();
+    } else if constexpr (sfpu_op == SfpuType::relu_max) {
+        sfpu::relu_max_init();
+    } else if constexpr (sfpu_op == SfpuType::relu_min) {
+        sfpu::relu_min_init();
+    } else if constexpr (sfpu_op == SfpuType::reshuffle_rows) {
+        sfpu::reshuffle_rows_init();
+    } else if constexpr (sfpu_op == SfpuType::right_shift) {
+        sfpu::right_shift_init();
+    } else if constexpr (sfpu_op == SfpuType::selu) {
+        sfpu::selu_init();
+    } else if constexpr (sfpu_op == SfpuType::sign) {
+        sfpu::sign_init();
+    } else if constexpr (sfpu_op == SfpuType::softplus) {
+        sfpu::softplus_init();
+    } else if constexpr (sfpu_op == SfpuType::softshrink) {
+        sfpu::softshrink_init();
+    } else if constexpr (sfpu_op == SfpuType::square) {
+        sfpu::square_init();
+    } else if constexpr (sfpu_op == SfpuType::threshold) {
+        sfpu::threshold_init();
+    } else if constexpr (sfpu_op == SfpuType::tiled_prod) {
+        sfpu::tiled_prod_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_eq) {
+        sfpu::unary_eq_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_ge) {
+        sfpu::unary_ge_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_gt) {
+        sfpu::unary_gt_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_le) {
+        sfpu::unary_le_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_lt) {
+        sfpu::unary_lt_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_ne) {
+        sfpu::unary_ne_init();
+    } else if constexpr (sfpu_op == SfpuType::unused) {
+        sfpu::unused_init();
+    } else if constexpr (sfpu_op == SfpuType::typecast) {
+        sfpu::typecast_init();
+    } else if constexpr (sfpu_op == SfpuType::exponential) {
+        // SDPA and other direct LLK callers use this no-arg overload to get the generic unary SFPU
+        // addrmod state (config reg + ADDR_MOD_7 + counter reset) without an op-specific init or a
+        // preceding compute_kernel_hw_startup, so route it to the full generic init.
+        _llk_math_eltwise_unary_sfpu_init_<SfpuType::exponential>();
+    } else {
+        static_assert(
+            _sfpu_bare_op_unhandled_<sfpu_op>,
+            "Bare SFPU_UNARY_INIT(OP) used for an op with no sfpu::<op>_init(). Add its self-contained init and a "
+            "delegate branch in llk_math_eltwise_unary_sfpu_init.h.");
+    }
+}
+
+// Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT): the op-specific init_func
+// is itself self-contained (it programs its own ADDR_MOD_6 if needed + resets counters). No generic prefix.
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
-    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
-    init_func(static_cast<ARGS&&>(args)...);
+    init_func(std::forward<ARGS>(args)...);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_generalized_moe_gate_topk_single_face.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_generalized_moe_gate_topk_single_face.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/experimental/ckernel_sfpu_generalized_moe_gate_topk_single_face.h"
 
 using namespace sfpi;
@@ -68,6 +69,7 @@ inline void generalized_moe_gate_finalize_ungrouped(uint32_t eps, uint32_t scale
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void generalized_moe_gate_topk_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     _init_generalized_moe_gate_topk<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void abs_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_relu.h"
 
@@ -42,6 +43,7 @@ inline void calculate_activation() {
 
 template <bool APPROXIMATION_MODE>
 void hardsigmoid_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // For hardsigmoid slope is 1/6, FP32 IEEE 754 representation.
     sfpi::vConstFloatPrgm0 = 0.1666666716337204f;
     sfpi::vConstFloatPrgm1 = 0.5f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void alt_complex_rotate90_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
 inline void calculate_alt_complex_rotate90() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_conversions.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
@@ -261,6 +262,7 @@ inline void calculate_sfpu_binary_pow(const uint dst_index_in0, const uint dst_i
 
 template <bool APPROXIMATION_MODE>
 inline void sfpu_binary_pow_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;
     sfpi::vConstFloatPrgm1 = -127.0f;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -28,6 +29,12 @@ inline Vec compute_unary_bitwise(Vec v, Vec scalar) {
         return v ^ scalar;
     }
 }
+
+inline void bitwise_and_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void bitwise_or_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void bitwise_xor_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <
     bool APPROXIMATION_MODE,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -6,12 +6,15 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void bitwise_not_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_bitwise_not() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "ckernel.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -70,6 +71,7 @@ inline void calculate_cube_root() {
 
 template <bool APPROXIMATION_MODE>
 inline void cube_root_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 0x1.c09806p0f;
     sfpi::vConstFloatPrgm1 = -0x1.403e6cp0f;
     sfpi::vConstFloatPrgm2 = 0x1.04cdb2p-1f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -6,10 +6,13 @@
 
 #include <cstdint>
 
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
 
 namespace ckernel::sfpu {
+
+inline void celu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // celu(x) = x for x>=0, alpha*(exp(x/alpha)-1) for x<0
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -6,10 +6,13 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_unary_max_min.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
 enum { Max = true, Min = false };  // Clamp Mode
+
+inline void clamp_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpu/ckernel_sfpu_is_fp16_zero.h"
 #include "sfpu/ckernel_sfpu_load_config.h"
 
@@ -34,6 +35,36 @@ sfpi_inline vInt sfpu_sign_mag_to_twos_comp(vInt value) {
 }
 
 #endif  // SFPU_SIGN_MAG_TO_TWOS_COMP_DEFINED
+
+inline void equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void greater_than_equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void greater_than_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void less_than_equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void less_than_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+inline void not_equal_zero_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "lltt.h"
 
 using namespace sfpi;
@@ -145,6 +146,7 @@ inline void calculate_cumsum(const bool first) {
 
 template <bool APPROXIMATION_MODE /*unused*/>
 inline void cumsum_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     lltt::record(0, 16);
     // FIXME: These should all be TT_SFP...
     TTI_SFPADD(10, 7, 0, 0, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -11,6 +11,7 @@
 #include "ckernel_sfpu_recip.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -102,6 +103,7 @@ inline void calculate_digamma() {
 
 template <bool APPROXIMATION_MODE>
 void digamma_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // sfpu_reciprocal_init programs vConstFloatPrgm0/1/2 with the reciprocal's Newton seed;
     // all three stay reserved for it, so digamma must not repurpose Prgm1/Prgm2.
     sfpu_reciprocal_init();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -8,6 +8,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_ops.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -52,6 +53,7 @@ inline void calculate_dropout(std::uint32_t probability, std::uint32_t scale) {
 
 template <bool APPROXIMATION_MODE /*unused*/>
 inline void dropout_init(const std::uint32_t seed) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     init_prng_seed(seed);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -5,10 +5,13 @@
 #pragma once
 
 #include "ckernel.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
 
 namespace ckernel::sfpu {
+
+inline void elu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
@@ -11,6 +11,7 @@
 #include "sfpu/ckernel_sfpu_converter.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -84,6 +85,7 @@ inline void calculate_erf() {
 
 template <bool APPROXIMATION_MODE>
 void erf_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
@@ -8,6 +8,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 #include "ckernel_sfpu_piecewise_rational.h"
@@ -78,6 +79,7 @@ inline void calculate_erfc() {
 
 template <bool APPROXIMATION_MODE>
 void erfc_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<true>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_log.h"
 #include "ckernel_sfpu_sqrt_custom.h"
 
@@ -58,6 +59,7 @@ inline void calculate_erfinv() {
 
 template <bool APPROXIMATION_MODE>
 void erfinv_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     log_init<false, false, false>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -10,6 +10,7 @@
 
 // clang-format off: sfpi.h before polyval (polyval uses sfpi_inline); matches blackhole ordering
 #include "sfpi.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 // clang-format on
 #include "ckernel_sfpu_recip.h"
@@ -709,6 +710,12 @@ template <
     bool CLAMP_NEGATIVE = true,
     bool is_fp32_dest_acc_en = false>
 void exp_init() {
+    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
+    // exp setup below -- one self-contained init, no separate shared-common-init call. Same functionality as
+    // _llk_math_eltwise_unary_sfpu_init_<exponential>() (exp uses only ADDR_MOD_7, no op-specific ADDR_MOD_6).
+    sfpu::_init_sfpu_config_reg();
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE && CLAMP_NEGATIVE) {
         // Algorithm is adapted from:
         //      A Fast, Compact Approximation of the Exponential Function

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,6 +9,7 @@
 #include <limits>
 
 #include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
@@ -133,6 +134,7 @@ inline void calculate_exp2() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void exp2_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (is_fp32_dest_acc_en) {
         // Coefficients for minimax polynomial.
         sfpi::vConstFloatPrgm0 = 0x1.62e42ep-1f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
 /*
@@ -190,6 +191,7 @@ inline void calculate_expm1() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void expm1_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;  // log2(e) == 1 / ln(2)
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm1 = -0.693145752f;    // -ln(2)_hi

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel {
@@ -14,6 +15,7 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
 inline void init_fmod(const uint value, const uint recip) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = Converter::as_float(value);
     sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -8,6 +8,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"  // math::reset_counters, p_setrwc
 
 #include "ckernel_sfpu_exp.h"  // For _sfpu_round_to_nearest_int32_
 #include "sfpu/ckernel_sfpu_polyval.h"
@@ -202,6 +203,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void gelu_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
         sfpi::vConstFloatPrgm0 = 0.5f;
 
@@ -381,6 +383,7 @@ inline void calculate_gelu_tanh() {
 
 template <bool is_fp32_dest_acc_en>
 inline void gelu_tanh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // initialise constants for _sfpu_tanh_fp32_accurate_
     tanh_init<false, true>();
 }
@@ -496,6 +499,7 @@ inline void calculate_gelu_derivative_polynomial() {
 
 template <bool APPROXIMATION_MODE>
 inline void gelu_derivative_polynomial_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!APPROXIMATION_MODE) {
         // Call sfpu_reciprocal_init directly: gelu derivative uses sfpu_reciprocal_iter
         // inline (not _calculate_reciprocal_internal_), so SFPLOADMACRO fast-path init is

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -25,6 +26,8 @@ namespace sfpu {
 // Constants 0.5 and 1.0 are exactly representable in IEEE 754.
 // Clamping to [0, 1] gives exact boundary values (0 or 1),
 // so the final multiply produces exact 0 or exact x at transitions.
+inline void hardmish_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void hardmish() {
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
+
+inline void hardshrink_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_hardshrink(uint32_t param0) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -6,10 +6,13 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
+
+inline void hardtanh_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
 // Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
@@ -7,12 +7,15 @@
 #include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void heaviside_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_heaviside(std::uint32_t value) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
@@ -22,6 +23,8 @@ namespace sfpu {
            t4) *                                                                                                  \
           t4) *                                                                                                   \
      t4)
+inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
 #pragma GCC unroll 0

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -8,6 +8,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel::sfpu {
@@ -143,6 +144,7 @@ inline void calculate_i1() {
 
 template <bool APPROXIMATION_MODE>
 void i1_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 #include "sfpi.h"
 
@@ -83,7 +84,9 @@ inline void calculate_sum_int_row() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void sum_int_init() {}
+inline void sum_int_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void add_int(const uint dst_offset) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_log.h"
+#include "cmath_common.h"
 
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_log.h"
@@ -163,6 +164,7 @@ inline void calculate_lgamma_adjusted(
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void lgamma_stirling_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     recip_init<APPROXIMATION_MODE, is_fp32_dest_acc_en, false>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -34,6 +34,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel {
@@ -132,6 +133,7 @@ inline void calculate_log(uint log_base_scale_factor) {
 
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
     const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
     // e represents k << 23 rather than k, so pre-fold the 2^(-23) factor into

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -35,6 +35,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_log.h"
+#include "cmath_common.h"
 
 namespace ckernel {
 namespace sfpu {
@@ -153,6 +154,7 @@ inline void calculate_log1p() {
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log1p_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
     const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
     // e represents k << 23 rather than k, so pre-fold the 2^(-23) factor into

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -8,9 +8,12 @@
 
 #include "ckernel_addrmod.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
+
+inline void logical_not_unary_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
 inline void calculate_logical_not() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_is_fp16_zero.h"
 
@@ -13,6 +14,8 @@ using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void mask_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_mask() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
@@ -10,6 +10,7 @@
 #include "sfpi.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -78,6 +79,7 @@ inline void calculate_mish() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void mish_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // exp does not need an init
     recip_init<APPROXIMATION_MODE, is_fp32_dest_acc_en, false>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -11,6 +11,7 @@
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -130,6 +131,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void polygamma_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     recip_init<APPROXIMATION_MODE, is_fp32_dest_acc_en, false>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
@@ -6,12 +6,15 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void prelu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_prelu(uint value) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -5,6 +5,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
@@ -12,6 +13,7 @@ namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE>
 inline void rand_init(uint32_t seed) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     init_prng_seed(seed);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_rounding_ops.h"
 
 namespace ckernel {
@@ -43,6 +44,7 @@ inline void calculate_rdiv(const uint value) {
 
 template <bool APPROXIMATION_MODE>
 void rdiv_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_rsqrt_compat.h"
 using namespace sfpi;
@@ -120,6 +121,13 @@ inline void calculate_reciprocal() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>
 void recip_init() {
+    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
+    // reciprocal setup below -- one self-contained init, matching exp_init. SDPA runs reciprocal in its
+    // softmax after matmul/exp, so the general SFPU state is re-established here, not just reset.
+    // Reciprocal uses only ADDR_MOD_7 on Wormhole (no op-specific ADDR_MOD_6).
+    sfpu::_init_sfpu_config_reg();
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!legacy_compat) {
         sfpu_reciprocal_init<APPROXIMATION_MODE>();
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -13,6 +13,7 @@
 #include "ckernel_instr_params.h"
 #include "llk_assert.h"
 #include "llk_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "lltt.h"
 #include "sfpi.h"
 
@@ -1674,6 +1675,7 @@ inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t b
  */
 template <PoolType pool_type, DataFormat format, bool is_fp32_dest_accum_en>
 inline void init_reduce(std::uint32_t block_ct_dim = 1) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     static_assert(
         is_supported_reduce_format(format),
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_relu.h"
 
@@ -139,6 +140,7 @@ inline void relu_clamp_int(uint threshold) {
         }
     }
 }
+inline void relu_min_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE>
 inline void relu_min(uint uint_threshold) {
@@ -151,6 +153,8 @@ inline void relu_min(uint uint_threshold) {
         dst_reg++;
     }
 }
+
+inline void relu_max_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE>
 inline void relu_max(uint uint_threshold) {
@@ -165,6 +169,8 @@ inline void relu_max(uint uint_threshold) {
         dst_reg++;
     }
 }
+
+inline void lrelu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_lrelu(const uint slope) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel {
@@ -14,6 +15,7 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
 inline void init_remainder(const uint value, const uint recip) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = Converter::as_float(value);
     sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -9,6 +9,7 @@
 #include "ckernel.h"
 #include "ckernel_addrmod.h"
 #include "ckernel_instr_params.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -36,6 +37,8 @@ namespace sfpu {
  *
  * @param idx_addr: L1 address of the mask tile containing destination row mappings (uint8_t[32])
  */
+inline void reshuffle_rows_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE>
 inline void calculate_reshuffle_rows(uint idx_addr) {
     constexpr std::uint32_t output_tile_offset = 64;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_sqrt.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -26,6 +27,7 @@ inline void calculate_rsqrt() {
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>
 void rsqrt_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!legacy_compat) {
         sqrt_init<APPROXIMATION_MODE>();
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
 
@@ -13,6 +14,8 @@ namespace ckernel::sfpu {
 
 // selu(x) = scale * x for x>=0, scale * alpha * (exp(x)-1) for x<0
 // scale ≈ 1.0507, alpha ≈ 1.6733, scale*alpha ≈ 1.7581
+
+inline void selu_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_selu(uint32_t scale, uint32_t alpha) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_sigmoid_appx.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
@@ -62,6 +63,7 @@ inline void calculate_sigmoid() {
 
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!APPROXIMATION_MODE) {
         recip_init<false, false>();
     } else {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -8,6 +8,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_is_fp16_zero.h"
 #include "sfpi.h"
 
@@ -15,6 +16,8 @@ using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void sign_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_sign(const uint /*exponent_size_8*/) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include "ckernel.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 using namespace sfpi;
 
@@ -80,6 +81,8 @@ inline void calculate_signbit_int32() {
 #endif
 }
 inline void signbit_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSHFT2(-31 & 0xfff, 0, 12, sfpi::SFPSHFT2_MOD1_SHFT_IMM);
@@ -109,6 +112,8 @@ inline void signbit_init() {
 }
 
 inline void signbit_int32_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSHFT2(-31 & 0xfff, 0, 12, sfpi::SFPSHFT2_MOD1_SHFT_IMM);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "cmath_common.h"  // math::reset_counters, p_setrwc
 #include "ckernel_sfpu_sigmoid.h"
 #include "ckernel_sfpu_recip.h"
 
@@ -30,6 +31,7 @@ inline void calculate_silu() {
 
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // calculate_silu always uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must
     // use non-approx sigmoid_init regardless of APPROXIMATION_MODE.
     sigmoid_init<false>();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_recip.h"
@@ -77,6 +78,12 @@ inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint ds
 
 template <bool APPROXIMATE>
 inline void snake_beta_init() {
+    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
+    // reciprocal setup below -- one self-contained init, matching exp_init. snake_beta uses only
+    // ADDR_MOD_7 (no op-specific ADDR_MOD_6).
+    sfpu::_init_sfpu_config_reg();
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
@@ -92,6 +93,8 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
     return result;
 }
 
+inline void softplus_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void calculate_softplus_body(const float beta, const float beta_reciprocal, const float threshold) {
     sfpi::vFloat val = sfpi::dst_reg[0];
@@ -168,8 +171,5 @@ inline void calculate_softplus(std::uint32_t param0, std::uint32_t param1, std::
         sfpi::dst_reg++;
     }
 }
-
-template <bool APPROXIMATION_MODE>
-void softplus_init() {}
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -5,10 +5,13 @@
 #pragma once
 
 #include <cstdint>
+#include "cmath_common.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
+
+inline void softshrink_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_softshrink(std::uint32_t param0) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -23,6 +24,7 @@ inline void calculate_softsign() {
 
 template <bool APPROXIMATION_MODE>
 void init_softsign() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -113,6 +114,7 @@ inline void calculate_sqrt() {
 
 template <bool APPROXIMATION_MODE, bool legacy_compat = false>
 void sqrt_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!legacy_compat) {
         if constexpr (APPROXIMATION_MODE) {
             sfpi::vConstIntPrgm0 = 0x5f0b3892;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -6,9 +6,12 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
+
+inline void square_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_square() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -16,6 +16,7 @@
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_expm1.h"
 #include "ckernel_sfpu_trigonometry.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -157,6 +158,7 @@ inline void calculate_tanh() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
         sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x1DFF);  // 0.90625*x
         sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x481A);  // 0.09375*x + 0.8125

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -9,6 +9,7 @@
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
@@ -211,6 +212,7 @@ inline void calculate_tanh_derivative_sech2() {
 
 template <bool APPROXIMATION_MODE>
 inline void tanh_derivative_sech2_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // No special initialization needed — no reciprocal, no LUT.
     // Polynomial uses only Horner evaluation, inline exp uses only arithmetic.
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -8,6 +8,7 @@
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_tanh.h"
+#include "cmath_common.h"
 
 namespace ckernel::sfpu {
 
@@ -88,6 +89,7 @@ inline void calculate_tanhshrink() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanhshrink_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // The bf16 large-|x| path uses only local literal polynomials, so it needs no init.
     if constexpr (is_fp32_dest_acc_en) {
         // The fp32 large-|x| path only needs the reciprocal Newton constants; the accurate

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+inline void tiled_prod_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_tiled_prod() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_topk.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 
 using namespace sfpi;
 
@@ -32,6 +33,8 @@ inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint 
 
 template <bool APPROXIMATION_MODE>
 inline void topk_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 32}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     _init_topk();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "ckernel_sfpu_sqrt_custom.h"
@@ -644,6 +645,10 @@ inline void calculate_asin() {
     }
 }
 
+inline void asin_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void acos_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_acos() {
     for (int d = 0; d < ITERATIONS; d++) {
@@ -824,6 +829,7 @@ inline void calculate_sinh() {
 
 template <bool APPROXIMATION_MODE>
 void sine_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // P2 and P3 of four-part Cody-Waite reduction by PI.
     sfpi::vConstFloatPrgm0 = -0x1.51p-21f;
     sfpi::vConstFloatPrgm1 = -0x1.0b4612p-33f;
@@ -833,6 +839,7 @@ void sine_init() {
 
 template <bool APPROXIMATION_MODE>
 void cosine_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // P2 and P3 of four-part Cody-Waite reduction by PI/2.
     sfpi::vConstFloatPrgm0 = -0x1.51p-22f;
     sfpi::vConstFloatPrgm1 = -0x1.0b4612p-34f;
@@ -842,6 +849,7 @@ void cosine_init() {
 
 template <bool APPROXIMATION_MODE>
 void tangent_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // P2 and P3 of four-part Cody-Waite reduction by PI/2.
     sfpi::vConstFloatPrgm0 = -0x1.51p-22f;
     sfpi::vConstFloatPrgm1 = -0x1.0b4612p-34f;
@@ -851,6 +859,7 @@ void tangent_init() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void cosh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;  // log2(e) == 1 / ln(2)
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm1 = -0.693145752f;   // -ln(2)_hi
@@ -863,6 +872,7 @@ void cosh_init() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void sinh_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.442695f;  // log2(e) == 1 / ln(2)
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm1 = -0.693145752f;    // -ln(2)_hi
@@ -875,6 +885,7 @@ void sinh_init() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void atan_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (is_fp32_dest_acc_en) {
         sfpi::vConstIntPrgm0 = RECIPROCAL_GT0_MAGIC_SEED;
         sfpi::vConstFloatPrgm1 = 0x1.999384p-3f;
@@ -1203,6 +1214,7 @@ inline void calculate_atanh() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // asinh/acosh route through calculate_log1p_fp32, which expects the log1p
     // polynomial constants in vConstFloatPrgm0/1/2. The sqrt used internally is
     // self-contained (_sfpu_sqrt_ge0_) and does not touch the program registers.
@@ -1211,6 +1223,7 @@ void init_inverse_hyperbolic() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     // atanh routes through calculate_log1p_fp32; the reciprocal it uses is the
     // self-contained _sfpu_reciprocal_gt0_, so log1p owns the program registers.
     log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -9,6 +9,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 
 using namespace sfpi;
@@ -597,6 +598,8 @@ inline void calculate_typecast_int32_to_uint16() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstIntPrgm0 = 1;
     sfpi::vConstIntPrgm1 = 0x7fff;
     sfpi::vConstIntPrgm2 = 0xffff0000;
@@ -604,6 +607,8 @@ inline void init_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_uint32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 #else
@@ -644,6 +649,8 @@ inline void preload_sign_magnitude_cast_fixup() { sfpi::vConstIntPrgm0 = -31; }
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     preload_sign_magnitude_cast_fixup();
 
@@ -698,6 +705,8 @@ inline void init_typecast_uint32_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_int32_to_fp32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
@@ -732,6 +741,8 @@ inline void init_typecast_int32_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_int32_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
@@ -769,6 +780,8 @@ inline void init_typecast_int32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp32() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 #else
@@ -806,6 +819,8 @@ inline void init_typecast_uint16_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPCAST(0, 12, 0);
@@ -836,6 +851,8 @@ inline void init_typecast_uint16_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp16b() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     preload_sign_magnitude_cast_fixup();
 
@@ -871,6 +888,8 @@ inline void init_typecast_uint32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_uint16() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // Programs the macro used by the 16-bit Dest (LO16 store) path of
     // calculate_typecast_fp32_to_uint16. The 32-bit Dest path uses the plain loop and
@@ -904,10 +923,15 @@ inline void init_typecast_fp32_to_uint16() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_uint16() {}
+inline void init_typecast_uint32_to_uint16() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_int32_to_uint16() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
@@ -987,11 +1011,15 @@ inline void calculate_typecast_uint_to_uint8() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_uint8() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstIntPrgm0 = 0xFF;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstIntPrgm0 = 0xFF;
     sfpi::vConstIntPrgm1 = UINT16_LOW_MASK;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
+
+inline void unary_ne_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ne(uint value) {
@@ -30,6 +33,8 @@ inline void calculate_unary_ne(uint value) {
     }
 }
 
+inline void unary_eq_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_eq(uint value) {
     // SFPU microcode
@@ -47,6 +52,8 @@ inline void calculate_unary_eq(uint value) {
         sfpi::dst_reg++;
     }
 }
+
+inline void unary_gt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_gt(uint value) {
@@ -66,6 +73,8 @@ inline void calculate_unary_gt(uint value) {
     }
 }
 
+inline void unary_lt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_lt(uint value) {
     // SFPU microcode
@@ -84,6 +93,8 @@ inline void calculate_unary_lt(uint value) {
     }
 }
 
+inline void unary_ge_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ge(uint value) {
     // SFPU microcode
@@ -101,6 +112,8 @@ inline void calculate_unary_ge(uint value) {
         sfpi::dst_reg++;
     }
 }
+
+inline void unary_le_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_le(uint value) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
@@ -163,6 +164,8 @@ inline void calculate_unary_max_min_int32(uint value) {
 
 template <bool IS_MAX_OP = true>
 inline void unary_max_min_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(
@@ -194,6 +197,8 @@ inline void unary_max_min_init() {
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false>
 inline void unary_max_min_int32_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 #ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_conversions.h"
 #include "sfpu/ckernel_sfpu_converter.h"
@@ -300,6 +301,8 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
         }
     }
 }
+
+inline void power_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 /**
  * @brief Compute power operation

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_shift.h
@@ -6,10 +6,13 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
+
+inline void left_shift_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // Left shift by an immediate scalar amount. If shift amount is >= 32, the result is 0.
 template <bool APPROXIMATION_MODE, DataFormat DATA_FORMAT = DataFormat::Int32, int ITERATIONS = 8>
@@ -33,6 +36,8 @@ inline void calculate_left_shift(const uint shift_amt) {
         sfpi::dst_reg++;
     }
 }
+
+inline void right_shift_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 // Arithmetic right shift by an immediate scalar amount.
 // A shift amount >= 32 saturates to the sign (non-negative -> 0, negative -> -1).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_exp.h"
 
@@ -154,6 +155,7 @@ inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
 
 template <bool APPROXIMATION_MODE>
 void xielu_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
     sfpi::vConstFloatPrgm0 = 1.4426950408889634f;   // 1/ln(2)
     sfpi::vConstFloatPrgm1 = -1e-6f;                // eps value
     sfpi::vConstFloatPrgm2 = -0.0000009999995427f;  // expm1(eps)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -4,19 +4,229 @@
 
 #pragma once
 
+#include <utility>
+
 #include "llk_sfpu_types.h"
 #include "llk_math_eltwise_unary_sfpu.h"
 
 namespace ckernel {
 
-template <SfpuType sfpu_op>
-inline void llk_math_eltwise_unary_sfpu_init() {
-    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
+// Kernel-invariant SFPU init: the SFPU config register + invariant ADDR_MOD_7, run once per kernel by the metal
+// "full init" entry points (compute_kernel_hw_startup / init_sfpu / unary_op_init_common / binary_op_init_common).
+inline void llk_math_sfpu_init_once() { _llk_math_eltwise_unary_sfpu_init_once_(); }
+
+namespace sfpu {
+// Forward declarations of the co-located per-op inits (each defined next to its execute method in
+// ckernel_sfpu_<op>.h). Declared -- not #included -- here so the dispatch below resolves these names
+// under two-phase lookup WITHOUT pulling the op headers into every TRISC_MATH translation unit via
+// compute_kernel_hw_startup. Each op's definition is in scope at its <op>_tile_init instantiation site.
+void abs_init();
+void acos_init();
+void alt_complex_rotate90_init();
+void asin_init();
+void bitwise_and_init();
+void bitwise_not_init();
+void bitwise_or_init();
+void bitwise_xor_init();
+void celu_init();
+void clamp_init();
+void elu_init();
+void equal_zero_init();
+void greater_than_equal_zero_init();
+void greater_than_zero_init();
+void hardmish_init();
+void hardshrink_init();
+void hardtanh_init();
+void heaviside_init();
+void i0_init();
+void left_shift_init();
+void less_than_equal_zero_init();
+void less_than_zero_init();
+void logical_not_unary_init();
+void lrelu_init();
+void mask_init();
+void not_equal_zero_init();
+void power_init();
+void prelu_init();
+void relu_max_init();
+void relu_min_init();
+void reshuffle_rows_init();
+void right_shift_init();
+void selu_init();
+void sign_init();
+void softplus_init();
+void softshrink_init();
+void square_init();
+void tiled_prod_init();
+void unary_eq_init();
+void unary_ge_init();
+void unary_gt_init();
+void unary_le_init();
+void unary_lt_init();
+void unary_ne_init();
+
+// Self-contained per-op inits for ops used via bare SFPU_UNARY_INIT(OP) (no callback). config_reg + ADDR_MOD_7
+// are handled once per kernel by llk_math_sfpu_init_once(); these program only the op's residual state
+// (op-specific ADDR_MOD_6 where needed + reset the RWC counters).
+inline void fill_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isfinite_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isinf_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isnan_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isneginf_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void isposinf_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void negative_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void threshold_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline void typecast_init() {
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 }
 
+inline void unused_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+}  // namespace sfpu
+
+// Dependent-false helper so the delegate's else-branch static_assert only fires when an uncategorized bare op is
+// instantiated (a plain static_assert(false) in an if-constexpr else is ill-formed pre-C++23).
+template <SfpuType>
+inline constexpr bool _sfpu_bare_op_unhandled_ = false;
+
+// Bare init entry point: delegates per SFPU op to its self-contained sfpu::<op>_init().
+template <SfpuType sfpu_op>
+inline void llk_math_eltwise_unary_sfpu_init() {
+    if constexpr (sfpu_op == SfpuType::abs) {
+        sfpu::abs_init();
+    } else if constexpr (sfpu_op == SfpuType::acos) {
+        sfpu::acos_init();
+    } else if constexpr (sfpu_op == SfpuType::alt_complex_rotate90) {
+        sfpu::alt_complex_rotate90_init();
+    } else if constexpr (sfpu_op == SfpuType::asin) {
+        sfpu::asin_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_and) {
+        sfpu::bitwise_and_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_not) {
+        sfpu::bitwise_not_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_or) {
+        sfpu::bitwise_or_init();
+    } else if constexpr (sfpu_op == SfpuType::bitwise_xor) {
+        sfpu::bitwise_xor_init();
+    } else if constexpr (sfpu_op == SfpuType::celu) {
+        sfpu::celu_init();
+    } else if constexpr (sfpu_op == SfpuType::clamp) {
+        sfpu::clamp_init();
+    } else if constexpr (sfpu_op == SfpuType::elu) {
+        sfpu::elu_init();
+    } else if constexpr (sfpu_op == SfpuType::equal_zero) {
+        sfpu::equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::fill) {
+        sfpu::fill_init();
+    } else if constexpr (sfpu_op == SfpuType::greater_than_equal_zero) {
+        sfpu::greater_than_equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::greater_than_zero) {
+        sfpu::greater_than_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::hardmish) {
+        sfpu::hardmish_init();
+    } else if constexpr (sfpu_op == SfpuType::hardshrink) {
+        sfpu::hardshrink_init();
+    } else if constexpr (sfpu_op == SfpuType::hardtanh) {
+        sfpu::hardtanh_init();
+    } else if constexpr (sfpu_op == SfpuType::heaviside) {
+        sfpu::heaviside_init();
+    } else if constexpr (sfpu_op == SfpuType::i0) {
+        sfpu::i0_init();
+    } else if constexpr (sfpu_op == SfpuType::isfinite) {
+        sfpu::isfinite_init();
+    } else if constexpr (sfpu_op == SfpuType::isinf) {
+        sfpu::isinf_init();
+    } else if constexpr (sfpu_op == SfpuType::isnan) {
+        sfpu::isnan_init();
+    } else if constexpr (sfpu_op == SfpuType::isneginf) {
+        sfpu::isneginf_init();
+    } else if constexpr (sfpu_op == SfpuType::isposinf) {
+        sfpu::isposinf_init();
+    } else if constexpr (sfpu_op == SfpuType::left_shift) {
+        sfpu::left_shift_init();
+    } else if constexpr (sfpu_op == SfpuType::less_than_equal_zero) {
+        sfpu::less_than_equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::less_than_zero) {
+        sfpu::less_than_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::logical_not_unary) {
+        sfpu::logical_not_unary_init();
+    } else if constexpr (sfpu_op == SfpuType::lrelu) {
+        sfpu::lrelu_init();
+    } else if constexpr (sfpu_op == SfpuType::mask) {
+        sfpu::mask_init();
+    } else if constexpr (sfpu_op == SfpuType::negative) {
+        sfpu::negative_init();
+    } else if constexpr (sfpu_op == SfpuType::not_equal_zero) {
+        sfpu::not_equal_zero_init();
+    } else if constexpr (sfpu_op == SfpuType::power) {
+        sfpu::power_init();
+    } else if constexpr (sfpu_op == SfpuType::prelu) {
+        sfpu::prelu_init();
+    } else if constexpr (sfpu_op == SfpuType::relu_max) {
+        sfpu::relu_max_init();
+    } else if constexpr (sfpu_op == SfpuType::relu_min) {
+        sfpu::relu_min_init();
+    } else if constexpr (sfpu_op == SfpuType::reshuffle_rows) {
+        sfpu::reshuffle_rows_init();
+    } else if constexpr (sfpu_op == SfpuType::right_shift) {
+        sfpu::right_shift_init();
+    } else if constexpr (sfpu_op == SfpuType::selu) {
+        sfpu::selu_init();
+    } else if constexpr (sfpu_op == SfpuType::sign) {
+        sfpu::sign_init();
+    } else if constexpr (sfpu_op == SfpuType::softplus) {
+        sfpu::softplus_init();
+    } else if constexpr (sfpu_op == SfpuType::softshrink) {
+        sfpu::softshrink_init();
+    } else if constexpr (sfpu_op == SfpuType::square) {
+        sfpu::square_init();
+    } else if constexpr (sfpu_op == SfpuType::threshold) {
+        sfpu::threshold_init();
+    } else if constexpr (sfpu_op == SfpuType::tiled_prod) {
+        sfpu::tiled_prod_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_eq) {
+        sfpu::unary_eq_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_ge) {
+        sfpu::unary_ge_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_gt) {
+        sfpu::unary_gt_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_le) {
+        sfpu::unary_le_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_lt) {
+        sfpu::unary_lt_init();
+    } else if constexpr (sfpu_op == SfpuType::unary_ne) {
+        sfpu::unary_ne_init();
+    } else if constexpr (sfpu_op == SfpuType::unused) {
+        sfpu::unused_init();
+    } else if constexpr (sfpu_op == SfpuType::typecast) {
+        sfpu::typecast_init();
+    } else if constexpr (sfpu_op == SfpuType::exponential) {
+        // SDPA and other direct LLK callers use this no-arg overload to get the generic unary SFPU
+        // addrmod state (config reg + ADDR_MOD_7 + counter reset) without an op-specific init or a
+        // preceding compute_kernel_hw_startup, so route it to the full generic init.
+        _llk_math_eltwise_unary_sfpu_init_<SfpuType::exponential>();
+    } else {
+        static_assert(
+            _sfpu_bare_op_unhandled_<sfpu_op>,
+            "Bare SFPU_UNARY_INIT(OP) used for an op with no sfpu::<op>_init(). Add its self-contained init and a "
+            "delegate branch in llk_math_eltwise_unary_sfpu_init.h.");
+    }
+}
+
+// Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT): the op-specific init_func
+// is itself self-contained (it programs its own ADDR_MOD_6 if needed + resets counters). No generic prefix.
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
-    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
-    init_func(static_cast<ARGS&&>(args)...);
+    init_func(std::forward<ARGS>(args)...);
 }
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -11,6 +11,10 @@
 #include "llk_unpack_common_api.h"
 #endif
 
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#endif
+
 namespace ckernel {
 
 // clang-format off
@@ -82,6 +86,9 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(src_a_cb, src_b_cb)));
+    // Once-per-kernel SFPU init (SFPU config reg + invariant ADDR_MOD_7). Hoisted out of the per-op SFPU init
+    // so self-contained per-op inits (ckernel::sfpu::_init_<op>_) don't re-run it. Safe for non-SFPU kernels.
+    MATH((llk_math_sfpu_init_once()));
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init<PackMode::Default>(ocb)));

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -8,6 +8,7 @@
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
 #ifdef TRISC_MATH
 #include "llk_math_binary_api.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_AB_api.h"
@@ -37,6 +38,11 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
+    // Once-per-kernel SFPU init (SFPU config reg + invariant ADDR_MOD_7). SFPU ops are frequently used after
+    // binary_op_init_common (softmax, moreh_*), so this full-init entry point must also carry the hoisted
+    // once-init that self-contained per-op inits (ckernel::sfpu::_init_<op>_) rely on. Idempotent for pure
+    // binary kernels.
+    MATH((llk_math_sfpu_init_once()));
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
@@ -8,6 +8,7 @@
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
 #ifdef TRISC_MATH
 #include "llk_math_unary_datacopy_api.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_A_api.h"
@@ -34,6 +35,10 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = 
     // Asserted after hw_configure (which sets the operand-driven DEFAULT) so it is the last writer
     // before the op runs; skip-if-set keeps it cheap.
     MATH((ckernel::math::_configure_unary_preserve_zero_flag_state_()));
+    // Once-per-kernel SFPU init (SFPU config reg + invariant ADDR_MOD_7). Hoisted out of the per-op SFPU init
+    // so self-contained per-op inits (ckernel::sfpu::_init_<op>_) don't re-run it. init_sfpu() delegates here,
+    // so it inherits this call.
+    MATH((llk_math_sfpu_init_once()));
 #else
     UNPACK((llk_unpack_hw_configure(icb)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -397,6 +397,13 @@ template <
     DataFormat TYPECAST_OUT = DataFormat::Invalid>
 void call_unary_sfpu_operation_init()
 {
+    // Once-per-kernel SFPU init (SFPU config reg + invariant ADDR_MOD_7). In metal this is hoisted into the
+    // full-init entry points (compute_kernel_hw_startup / init_sfpu / unary_op_init_common); this standalone
+    // LLK harness bypasses those, so it must run the once-init itself. Ops migrated to the self-contained
+    // per-op init (SFPU_UNARY_INIT_SC*) rely on this running first; unmigrated ops still carry the invariant
+    // inside their _llk_math_eltwise_unary_sfpu_init_ but re-running it here is harmless (idempotent).
+    llk_math_sfpu_init_once();
+
     if constexpr (OPERATION == SfpuType::acosh || OPERATION == SfpuType::asinh)
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE, is_fp32_dest_acc_en>);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -65,3 +65,24 @@ inline void _llk_math_eltwise_unary_sfpu_init_()
     eltwise_unary_sfpu_configure_addrmod<sfpu_op>();
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
+
+// Kernel-invariant SFPU init. Runs the parts of the per-op init that are identical for every SFPU op and
+// therefore only need to run once per kernel: the SFPU config register (SFPCONFIG(0, 0xF, 1)) and the
+// invariant ADDR_MOD_7 = {srca:0, srcb:0, dest:0}. Hoisted out of the per-op path so that the self-contained
+// per-op init (ckernel::sfpu::_init_<op>_) does not re-run these on every op init. Metal wires this into every
+// "full init" entry point (compute_kernel_hw_startup, init_sfpu, unary_op_init_common, binary_op_init_common),
+// and the tt-llk standalone SFPU test harness wires it into its init prelude.
+inline void _llk_math_eltwise_unary_sfpu_init_once_()
+{
+    sfpu::_init_sfpu_config_reg();
+
+    // NOTE: this kernel is typically used in conjunction with
+    //       A2D, which is using ADDR_MOD_0 and ADDR_MOD_2, so use one
+    //       that doesn't conflict!
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(ADDR_MOD_7);
+}

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -65,3 +65,24 @@ inline void _llk_math_eltwise_unary_sfpu_init_()
     eltwise_unary_sfpu_configure_addrmod<sfpu_op>();
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
+
+// Kernel-invariant SFPU init. Runs the parts of the per-op init that are identical for every SFPU op and
+// therefore only need to run once per kernel: the SFPU config register (SFPCONFIG(0, 0xF, 1)) and the
+// invariant ADDR_MOD_7 = {srca:0, srcb:0, dest:0}. Hoisted out of the per-op path so that the self-contained
+// per-op init (ckernel::sfpu::_init_<op>_) does not re-run these on every op init. Metal wires this into every
+// "full init" entry point (compute_kernel_hw_startup, init_sfpu, unary_op_init_common, binary_op_init_common),
+// and the tt-llk standalone SFPU test harness wires it into its init prelude.
+inline void _llk_math_eltwise_unary_sfpu_init_once_()
+{
+    sfpu::_init_sfpu_config_reg();
+
+    // NOTE: this kernel is typically used in conjunction with
+    //       A2D, which is using ADDR_MOD_0 and ADDR_MOD_2, so use one
+    //       that doesn't conflict!
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(ADDR_MOD_7);
+}


### PR DESCRIPTION
## Phase 1 (pattern) - SFPU per-op self-contained init (BH + WH, LLK layer)

Establishes the pattern for the SFPU per-op self-contained init restructuring that unblocks the sanitizer work. **This is a DRAFT / phase-1 PR: it converts a representative slice (3 ops) and leaves the other ~100 ops working on the existing path.** Compute-API `unary_op_init_common`/`init_sfpu` removal and Quasar are explicitly out of scope.

### Design

Today `llk_math_eltwise_unary_sfpu_init<Op>(init_func, ...)` runs the generic `_llk_math_eltwise_unary_sfpu_init_<Op>()` (which does `sfpu::_init_sfpu_config_reg()` + `eltwise_unary_sfpu_configure_addrmod<Op>()` [ADDR_MOD_7={0,0,0} invariant + op-dependent ADDR_MOD_6] + `math::reset_counters(SET_ABD_F)`) and then the op callback.

**1. Hoist the op-invariants once-per-kernel.** New `_llk_math_eltwise_unary_sfpu_init_once_()` (tt-llk, both arches) does `sfpu::_init_sfpu_config_reg()` + `ADDR_MOD_7={0,0,0}`. Wrapped as `llk_math_sfpu_init_once()` in the ckernels LLK API.

**2. Self-contained per-op init.** Each converted op gets one `ckernel::sfpu::_init_<op>_()` that bakes in: the op-dependent `ADDR_MOD_6` (via the new tt-llk helper `_llk_math_eltwise_unary_sfpu_configure_addrmod6_<Op>()`, a no-op for ops that don't need it), `math::reset_counters(SET_ABD_F)`, and the body of the op's old init callback. The LLK-API dispatches straight to it via a new `llk_math_eltwise_unary_sfpu_init_selfcontained<Op>(functor)` overload - **no** generic-init prefix (config-reg + ADDR_MOD_7 removed from the per-op path, now in the once-init).

The per-arch ADDR_MOD_6 op lists are preserved **exactly** (BH keeps `reciprocal`, WH does not) - not unified.

### Step-1 LLK-test hoist-gate scan - findings (important)

The owner's stated rationale for the hoist was *"every metal kernel/test is guaranteed to call one of the three [`compute_kernel_hw_startup`, `init_sfpu`, `unary_op_init_common`]."* **The scan found that assumption is false for real kernels**, but the hoist itself is sound - the gap is wireable, so I did not stop; I extended the wiring.

Mapping every metal/ttnn caller of the 3 converted-op inits (`exp_tile_init`, `abs_tile_init`, `hardsigmoid_tile_init`) to the full-init entry point they actually use:

| Full-init entry point used | Example callers | Wired? |
|---|---|---|
| `compute_kernel_hw_startup` | sdpa (all variants), moe, sampling, deepseek per_token_cast, top32 test | yes |
| `init_sfpu` / `unary_op_init_common` | hardswish, lgamma, logsigmoid, softmax_large_tensor | yes (once-init in `unary_op_init_common`; `init_sfpu` delegates to it) |
| **`binary_op_init_common`** | softmax, moreh_softmax_{h,w}, moreh_norm (all), moreh_abs_pow, moreh_clip_grad_norm | **added by this PR** (scan-driven) |
| `reduce_init` | sdpa `compute_common.hpp` | covered - every including kernel also calls `compute_kernel_hw_startup` in MAIN |

So the wiring set is `compute_kernel_hw_startup` + `unary_op_init_common` (-> `init_sfpu`) + **`binary_op_init_common`**. The added `binary_op_init_common` call is a single idempotent `MATH((llk_math_sfpu_init_once()))` - harmless for pure-binary kernels, required for SFPU-after-binary kernels.

**tt-llk standalone SFPU tests** (`tests/helpers/include/sfpu_operations.h` funnel used by `eltwise_unary_sfpu_test`, `_perf`, `matmul_and_unary_sfpu_test`, `eltwise_unary_typecast_*`, and the ai_gen sources) call `llk_math_eltwise_unary_sfpu_init<Op>(...)` **directly** - they bypass all metal entry points and documented reliance on the two-arg overload running the generic init. Wired `llk_math_sfpu_init_once()` into `call_unary_sfpu_operation_init()` (the single funnel), covering every op the harness tests including the 3 converted ones.

The other tt-llk test sources (`topk_test`, `sfpu_reduce_*`) call the generic `_llk_math_eltwise_unary_sfpu_init_<Op>()` directly for **unconverted** ops (topk_local_sort, reduce); that path is untouched, so they keep the invariant. No change needed.

**Conclusion:** hoist is safe; the only correction vs the stated 3-entry-point plan is adding `binary_op_init_common`.

### Once-init wiring diff summary (both arches)

- `tt-llk` `llk_math_eltwise_unary_sfpu.h` (BH + WH): add `_llk_math_eltwise_unary_sfpu_init_once_()` and `_llk_math_eltwise_unary_sfpu_configure_addrmod6_<Op>()`. Existing `_llk_math_eltwise_unary_sfpu_init_` / `eltwise_unary_sfpu_configure_addrmod` left intact for the legacy path.
- ckernels `llk_math_eltwise_unary_sfpu_init.h` (BH + WH): add `llk_math_sfpu_init_once()` wrapper + `llk_math_eltwise_unary_sfpu_init_selfcontained<Op>(functor)` overload; legacy overloads kept.
- Compute API: `MATH((llk_math_sfpu_init_once()))` added to `compute_kernel_hw_startup` (after `llk_math_hw_configure`, inside `#ifndef ARCH_QUASAR`), `unary_op_init_common`, and `binary_op_init_common`. Include of `llk_math_eltwise_unary_sfpu_init.h` added under `#ifdef TRISC_MATH` in each.

### Per-op pattern established (for sign-off before the ~100-op fan-out)

New per-op functor header `llk_sfpu/ckernel_sfpu_selfcontained_init.h` (BH + WH):

```cpp
template <SfpuType sfpu_op>
inline void _sfpu_op_addrmod_reset_() {
    _llk_math_eltwise_unary_sfpu_configure_addrmod6_<sfpu_op>();  // op-dependent ADDR_MOD_6 (no-op for most)
    math::reset_counters(p_setrwc::SET_ABD_F);
}

// bare op (no old callback) - e.g. abs
inline void _init_abs_() { _sfpu_op_addrmod_reset_<SfpuType::abs>(); }

// templated-callback op - e.g. exponential
template <bool APPROXIMATION_MODE, uint32_t scale = 0x3F800000, bool CLAMP_NEGATIVE = true, bool is_fp32_dest_acc_en = false>
inline void _init_exp_() {
    _sfpu_op_addrmod_reset_<SfpuType::exponential>();
    exp_init<APPROXIMATION_MODE, scale, CLAMP_NEGATIVE, is_fp32_dest_acc_en>();  // old callback body
}

template <bool APPROXIMATION_MODE>
inline void _init_hardsigmoid_() {
    _sfpu_op_addrmod_reset_<SfpuType::hardsigmoid>();
    hardsigmoid_init<APPROXIMATION_MODE>();
}
```

Dispatch macros (`llk_math_eltwise_unary_sfpu_macros.h`, BH + WH):
```cpp
#define SFPU_UNARY_INIT_SC(OP, INIT_FN)                ::ckernel::llk_math_eltwise_unary_sfpu_init_selfcontained<::SfpuType::OP>(INIT_FN)
#define SFPU_UNARY_INIT_SC_FN(OP, INIT_FN, TEMPLATES)  ::ckernel::llk_math_eltwise_unary_sfpu_init_selfcontained<::SfpuType::OP>(INIT_FN<_SFPU_EXPAND TEMPLATES>)
```

Converted compute-API call sites:
```cpp
ALWI void abs_tile_init()          { MATH(SFPU_UNARY_INIT_SC(abs, sfpu::_init_abs_)); }
// exp.h
MATH(SFPU_UNARY_INIT_SC_FN(exponential, sfpu::_init_exp_, (approx, scale, (input_clamping == ...), DST_ACCUM_MODE)));
// activations.h
ALWI void hardsigmoid_tile_init()  { MATH(SFPU_UNARY_INIT_SC_FN(hardsigmoid, sfpu::_init_hardsigmoid_, (APPROX))); }
```

**Pack-thread variants left on the legacy path** (`exp_packthread_tile_init`, `hardsigmoid_tile_init_pack`): the once-init only runs on the MATH thread (via the `MATH(...)` in the entry points), so a pack-thread self-contained init would lose the config-reg + ADDR_MOD_7 on the pack thread. Converting the pack-thread SFPU init is a separate follow-up.

### Coexistence

The two forms coexist cleanly: an op is either fully on the legacy `SFPU_UNARY_INIT*` path (generic init + optional callback) or fully on the self-contained `SFPU_UNARY_INIT_SC*` path (functor, no prefix). The template still supports both, so the tree compiles with 3 ops converted and ~100 unconverted.

### Remaining-op fan-out inventory (still on the legacy path)

**Bare `SFPU_UNARY_INIT(op)` (no callback):** acos, alt_complex_rotate90, asin, bitwise_and, bitwise_not, bitwise_or, bitwise_xor, celu, clamp, elu, equal_zero, fill, greater_than_equal_zero, greater_than_zero, hardmish, hardshrink, hardtanh, heaviside, i0, isfinite, isinf, isnan, isneginf, isposinf, left_shift, less_than_equal_zero, less_than_zero, logical_not_unary, lrelu, mask, max, negative, not_equal_zero, power, prelu, relu_max, relu_min, reshuffle_rows, right_shift, rsqrt, selu, sigmoid, sign, silu, softplus, softshrink, square, tanh, threshold, tiled_prod, typecast, unary_eq, unary_ge, unary_gt, unary_le, unary_lt, unary_ne  *(+ `abs` - CONVERTED)*

**`SFPU_UNARY_INIT_FN(op, cb, templates)`:** acosh, asinh, atan, atanh, cbrt, cosh, cosine, cumsum, erf, erfc, erfinv, exp2, expm1, gelu, gelu_derivative, gelu_tanh, i1, lgamma, log, log1p, log_with_base, mish, polygamma, rdiv, reciprocal, rpow, rsqrt, sigmoid, silu, sine, sinh, softsign, sqrt, tan, tanh, tanh_derivative, topk_local_sort, typecast, unary_max, unary_max_int32, unary_max_uint32, unary_min, unary_min_int32, unary_min_uint32, xielu  *(+ `exponential`, `hardsigmoid` - CONVERTED)*

**`SFPU_UNARY_INIT_FN_ARGS(op, cb, templates, ...)`:** dropout, fmod, reduce, remainder

*(The `unused` sentinel is not a real op.) Also to migrate in the fan-out: pack-thread variants, and the tt-llk harness `call_unary_sfpu_operation_init` per-op branches if we want the standalone tests to exercise the self-contained path.*

### CI validation

These are JIT-compiled kernels - CI is the real validation. `pr-gate` (WH/BH build + Quasar compile) runs on open. Also dispatched `sanity-tests` and `blackhole-post-commit` on the branch. Triage of every red vs scheduled-`main` (playbook section 7 known-noise list) to follow in a CI-validation comment. Keeping DRAFT.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/sfpu-selfcontained-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/sfpu-selfcontained-init)