### PR TITLE
#49452: cap pytest --durations report at 25 instead of unbounded [skip ci]

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 timeout = 300
 minversion = 7.2
-addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml
+addopts = --import-mode=importlib -vvs -rA --durations=25 --junitxml=generated/test_reports/most_recent_tests.xml
 empty_parameter_set_mark = skip
 markers =
     t3k_compat: mark tests that run on T3K (no Galaxy required) — excluded from Galaxy module test run


### PR DESCRIPTION
## Summary
- Sanity-job logs (e.g. `core ttnn unit test group [wh_n300_civ2]`) carry a `--durations=0` pytest addopt at the repo root, which prints a per-call/setup/teardown timing line for **every** test.
- Measured at ~18,005 of ~35,493 lines (~51%) in run 28989235447 — the majority of the log is timing noise with zero debugging value beyond "was it slow".
- Fix: change `--durations=0` → `--durations=25` in root `pytest.ini`. Keeps the slowest-25 report (enough to spot a genuinely slow test) and drops the full per-test dump. Single-token change, no other addopts touched.
- Two other files carry the same `--durations=0` (`tests/end_to_end_tests/pytest.ini`, `infra/pytest.ini`) but scope different suites not covered by the sanity jobs this issue measured — left unchanged to keep this PR minimal and on-target.

## Verification
- Build: N/A — this is a pytest.ini config change with no C++/logic component; no build required.
- Tests/simulation: ✅ pytest (isolated sandbox, not full repo — the repo's own test collection requires the compiled `ttnn._ttnn` extension via conftest.py, which isn't built in this environment and isn't needed for a config-syntax check). Verified in an isolated pytest.ini + dummy parametrized test with the exact new addopts line: 30 tests ran, and the "slowest durations" report was capped at exactly 25 entries (previously unbounded). Confirms both syntax validity and the intended behavior.
- Existing regression tests: N/A — no test logic changed, only report verbosity of an existing passing suite.

## Notes for reviewers
Issue also proposed two further changes, intentionally deferred here:
- `-rA` → `-rfE`: separate signal/behavior change, kept out to keep this PR to the single uncontroversial win.
- Dropping `-vvs`/`-s`: `-s` disables pytest's output capture, which is likely intentional for hang visibility — a timed-out test does not get a normal failure report, so without `-s` a hang could leave no last-print breadcrumbs in the log. Found no evidence elsewhere in the repo (conftest/infra) that this tradeoff has been resolved. Needs a maintainer/owner call on whether hang-visibility is still needed before this is safe to change.

Closes #49452

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=assign-tt-metal-issue-49452-trim-sanity-log-noise)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:assign-tt-metal-issue-49452-trim-sanity-log-noise)