### PR TITLE
[skip ci] Disable CCache Storage Helper debug log in CI

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -398,7 +398,7 @@ jobs:
       CCACHE_S3_BUCKET: ccache
       CCACHE_S3_PREFIX: tt-metal
       CCACHE_S3_READONLY: "false"
-      CCACHE_S3_DEBUG: "true"
+      CCACHE_S3_DEBUG: "false"
     container:
       # Callers that pre-resolve via resolve-docker-pull-refs pass already-prefixed
       # tags with harbor-prefix=''; callers with raw GHCR tags pass harbor-prefix

--- a/.github/workflows/clang-tidy-reusable.yaml
+++ b/.github/workflows/clang-tidy-reusable.yaml
@@ -47,7 +47,7 @@ jobs:
       CCACHE_S3_BUCKET: ccache
       CCACHE_S3_PREFIX: tt-metal
       CCACHE_S3_READONLY: "false"
-      CCACHE_S3_DEBUG: "true"
+      CCACHE_S3_DEBUG: "false"
     container:
       image: ${{ inputs.ci-build-docker-image }}
       env:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -51,7 +51,7 @@ jobs:
       CCACHE_S3_BUCKET: ccache
       CCACHE_S3_PREFIX: tt-metal
       CCACHE_S3_READONLY: "false"
-      CCACHE_S3_DEBUG: "true"
+      CCACHE_S3_DEBUG: "false"
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## PR Category
Bug fix

## Summary
Sets `CCACHE_S3_DEBUG` to `"false"` (was `"true"`) in the three workflows that define it: `build-artifact.yaml`, `clang-tidy-reusable.yaml`, and `wheels.yaml`.

`CCACHE_S3_DEBUG=true` causes `CRSH_LOGFILE` to be set, which makes the `ccache-storage-s3` helper write a verbose debug log. That log is currently surfaced as a "CCache Storage Helper Log" section in every build-artifact job summary, which is noisy and not needed day-to-day.

## Test plan
- [x] Confirmed `CCACHE_S3_DEBUG` is only read to gate setting `CRSH_LOGFILE`, and the summary-printing step is itself gated on the log file existing — flipping to `"false"` cleanly suppresses both the debug log and the summary section with no other behavior change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/disable-ccache-s3-debug-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/disable-ccache-s3-debug-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:wilder/disable-ccache-s3-debug-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/disable-ccache-s3-debug-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/disable-ccache-s3-debug-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/disable-ccache-s3-debug-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/disable-ccache-s3-debug-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/disable-ccache-s3-debug-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/disable-ccache-s3-debug-log)