### PR TITLE
Cherry-pick #48686 + #48620 onto blaze-metal-main-uplift-june-2-rev2

### DIFF
--- a/tests/tt_metal/tt_fabric/disaggregation/test_kv_chunk_address_table_protobuf.cpp
+++ b/tests/tt_metal/tt_fabric/disaggregation/test_kv_chunk_address_table_protobuf.cpp
@@ -4,12 +4,16 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
+#include <map>
+#include <span>
 #include <string>
 #include <vector>
 
 #include "impl/experimental/disaggregation/kv_chunk_address_table_protobuf.hpp"
+#include "protobuf/kv_chunk_address_table.pb.h"
 
 namespace tt::tt_metal::experimental::disaggregation {
 namespace {
@@ -261,6 +265,187 @@ TEST(KvChunkAddressTableProtobuf, TextFormatRoundTripViaFile) {
     }
 
     std::filesystem::remove(tmp_path);
+}
+
+// --- Multi-config round-trip ---
+
+// Builds a 3-config table (named "kv", "index_k", "v") with asymmetric per-config
+// dims and pseudo-random data, sharing one device-group/host side table.
+KvChunkAddressTable make_multi_config_table() {
+    std::map<std::string, KvChunkAddressTableConfig> configs = {
+        {"kv", {.num_layers = 3, .max_sequence_length = 256, .num_slots = 2, .chunk_n_tokens = 32}},
+        {"index_k", {.num_layers = 2, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 64}},
+        {"v", {.num_layers = 3, .max_sequence_length = 256, .num_slots = 2, .chunk_n_tokens = 32}},
+    };
+    KvChunkAddressTable table(configs);
+
+    auto grp0 = table.add_device_group({make_fnid(0, 0)});
+    auto grp1 = table.add_device_group({make_fnid(0, 0), make_fnid(0, 1)});
+    auto grp2 = table.add_device_group({make_fnid(1, 0), make_fnid(1, 1), make_fnid(1, 2)});
+    std::array<DeviceGroupIndex, 3> groups = {grp0, grp1, grp2};
+    table.set_fabric_node_host(make_fnid(0, 0), "alpha-host");
+    table.set_fabric_node_host(make_fnid(0, 1), "alpha-host");
+    table.set_fabric_node_host(make_fnid(1, 0), "beta-host");
+    table.set_fabric_node_host(make_fnid(1, 1), "beta-host");
+    table.set_fabric_node_host(make_fnid(1, 2), "beta-host");
+
+    for (uint32_t c = 0; c < table.num_configs(); c++) {
+        const auto& cfg = table.config(c);
+        for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
+            for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
+                for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
+                    uint64_t h = pseudo_rand(c * 100 + slot, layer, pos);
+                    uint64_t addr = 0x1'0000'0000ULL + (h & 0xFFFF'FFFF'FFFF'FF00ULL);
+                    uint32_t size = 512 + (static_cast<uint32_t>((h >> 8) % 8) * 128);
+                    table.set(
+                        layer,
+                        pos,
+                        slot,
+                        KvCacheLocation{
+                            .noc_addr = addr, .size_bytes = size, .device_group_index = groups[h % groups.size()]},
+                        c);
+                }
+            }
+        }
+    }
+    return table;
+}
+
+// Verify every (config, slot, layer, pos) entry matches between two tables.
+void expect_tables_equal(const KvChunkAddressTable& a, const KvChunkAddressTable& b) {
+    ASSERT_EQ(a.num_configs(), b.num_configs());
+    for (uint32_t c = 0; c < a.num_configs(); c++) {
+        EXPECT_EQ(a.config_name(c), b.config_name(c)) << "config name mismatch at id " << c;
+        const auto& ca = a.config(c);
+        const auto& cb = b.config(c);
+        EXPECT_EQ(ca.num_layers, cb.num_layers);
+        EXPECT_EQ(ca.max_sequence_length, cb.max_sequence_length);
+        EXPECT_EQ(ca.num_slots, cb.num_slots);
+        EXPECT_EQ(ca.chunk_n_tokens, cb.chunk_n_tokens);
+        for (uint32_t slot = 0; slot < ca.num_slots; slot++) {
+            for (uint32_t layer = 0; layer < ca.num_layers; layer++) {
+                for (uint32_t pos = 0; pos < ca.max_sequence_length; pos += ca.chunk_n_tokens) {
+                    const auto& la = a.lookup(layer, pos, slot, c);
+                    const auto& lb = b.lookup(layer, pos, slot, c);
+                    EXPECT_EQ(la.noc_addr, lb.noc_addr)
+                        << "config=" << c << " slot=" << slot << " layer=" << layer << " pos=" << pos;
+                    EXPECT_EQ(la.size_bytes, lb.size_bytes);
+                    EXPECT_EQ(la.device_group_index, lb.device_group_index);
+                }
+            }
+        }
+    }
+}
+
+TEST(KvChunkAddressTableProtobuf, MultiConfigRoundTripViaString) {
+    auto original = make_multi_config_table();
+    auto restored = import_from_protobuf(export_to_protobuf(original));
+
+    // Names round-trip (sorted-key order: "index_k" < "kv" < "v").
+    ASSERT_EQ(restored.num_configs(), 3u);
+    EXPECT_EQ(restored.config_name(0), "index_k");
+    EXPECT_EQ(restored.config_name(1), "kv");
+    EXPECT_EQ(restored.config_name(2), "v");
+    expect_tables_equal(original, restored);
+
+    // Device groups + hosts round-trip (shared side table).
+    ASSERT_EQ(restored.num_device_groups(), original.num_device_groups());
+    EXPECT_EQ(restored.get_host(make_fnid(1, 2)), "beta-host");
+}
+
+TEST(KvChunkAddressTableProtobuf, MultiConfigRoundTripViaFile) {
+    auto original = make_multi_config_table();
+    std::string tmp_path = std::filesystem::temp_directory_path() / "kv_multi_config_table_test.pb";
+    export_to_protobuf_file(original, tmp_path);
+    auto restored = import_from_protobuf_file(tmp_path);
+    expect_tables_equal(original, restored);
+    std::filesystem::remove(tmp_path);
+}
+
+TEST(KvChunkAddressTableProtobuf, MultiConfigTextFormatRoundTrip) {
+    auto original = make_multi_config_table();
+    auto restored = import_from_protobuf_text(export_to_protobuf_text(original));
+    expect_tables_equal(original, restored);
+}
+
+TEST(KvChunkAddressTableProtobuf, SpanConstructedManyConfigsRoundTrip) {
+    // >10 configs exercises that entries are placed by name, not by raw index,
+    // even though span auto-names are "0".."N-1" (which do not string-sort numerically).
+    std::vector<KvChunkAddressTableConfig> cfgs;
+    cfgs.reserve(12);
+for (uint32_t i = 0; i < 12; i++) {
+        cfgs.push_back({.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32});
+    }
+    KvChunkAddressTable original(std::span<const KvChunkAddressTableConfig>{cfgs});
+    auto grp = original.add_device_group({make_fnid(0, 0)});
+    for (uint32_t i = 0; i < 12; i++) {
+        original.set(0, 0, 0, KvCacheLocation{.noc_addr = 0x1000 + i, .size_bytes = 10, .device_group_index = grp}, i);
+    }
+
+    auto restored = import_from_protobuf(export_to_protobuf(original));
+    ASSERT_EQ(restored.num_configs(), 12u);
+    // Each entry must come back under its original name (e.g. name "11" -> 0x100B).
+    for (uint32_t i = 0; i < 12; i++) {
+        std::string name = std::to_string(i);
+        EXPECT_EQ(restored.lookup(0, 0, 0, name).noc_addr, 0x1000u + i) << "config name " << name;
+    }
+}
+
+TEST(KvChunkAddressTableProtobuf, LegacySingleConfigWireStillReads) {
+    // A proto with only the legacy scalar fields (no `configs`) must import as a
+    // single config named "0".
+    ::tt::disaggregation::proto::KvChunkAddressTable pb;
+    pb.set_num_layers(2);
+    pb.set_max_sequence_length(64);
+    pb.set_num_slots(1);
+    pb.set_chunk_n_tokens(32);
+    auto* g = pb.add_device_groups();
+    auto* fnid = g->add_fabric_node_ids();
+    fnid->set_mesh_id(0);
+    fnid->set_chip_id(0);
+    auto* e = pb.add_entries();  // config_idx defaults to 0
+    e->set_layer(1);
+    e->set_position(32);
+    e->set_slot(0);
+    e->set_noc_addr(0xABCD);
+    e->set_size_bytes(100);
+    e->set_device_group_index(0);
+
+    auto restored = import_from_protobuf(pb.SerializeAsString());
+    ASSERT_EQ(restored.num_configs(), 1u);
+    EXPECT_EQ(restored.config_name(0), "0");
+    EXPECT_EQ(restored.lookup(1, 32, 0).noc_addr, 0xABCDu);
+}
+
+TEST(KvChunkAddressTableProtobuf, DuplicateConfigNameThrows) {
+    ::tt::disaggregation::proto::KvChunkAddressTable pb;
+    for (int i = 0; i < 2; i++) {
+        auto* c = pb.add_configs();
+        c->set_name("dup");
+        c->set_num_layers(1);
+        c->set_max_sequence_length(32);
+        c->set_num_slots(1);
+        c->set_chunk_n_tokens(32);
+    }
+    EXPECT_ANY_THROW(import_from_protobuf(pb.SerializeAsString()));
+}
+
+TEST(KvChunkAddressTableProtobuf, EntryConfigIdxOutOfRangeThrows) {
+    ::tt::disaggregation::proto::KvChunkAddressTable pb;
+    auto* c = pb.add_configs();
+    c->set_name("only");
+    c->set_num_layers(1);
+    c->set_max_sequence_length(32);
+    c->set_num_slots(1);
+    c->set_chunk_n_tokens(32);
+    auto* e = pb.add_entries();
+    e->set_layer(0);
+    e->set_position(0);
+    e->set_slot(0);
+    e->set_noc_addr(0x1);
+    e->set_size_bytes(10);
+    e->set_config_idx(5);  // only one config (idx 0) exists
+    EXPECT_ANY_THROW(import_from_protobuf(pb.SerializeAsString()));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/disaggregation/test_kv_chunk_address_table.cpp
+++ b/tests/tt_metal/tt_metal/api/disaggregation/test_kv_chunk_address_table.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "experimental/disaggregation/kv_chunk_address_table.hpp"
+#include "tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp"
 #include "experimental/fabric/fabric_types.hpp"
 
 namespace tt::tt_metal::experimental::disaggregation {
@@ -504,6 +504,163 @@ TEST(KvChunkAddressTable, DecodeAccessPattern) {
         (static_cast<uint64_t>(slot) << 40) | (static_cast<uint64_t>(layer) << 24) | (end_pos - kChunkSize);
     EXPECT_EQ(range.front().noc_addr, expected_first);
     EXPECT_EQ(range.back().noc_addr, expected_last);
+}
+
+// --- Multi-Config Tests ---
+
+TEST(KvChunkAddressTable, SingleConfigConstructorHasOneConfigNamedZero) {
+    KvChunkAddressTableConfig config{.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_EQ(table.num_configs(), 1u);
+    EXPECT_EQ(table.config_name(0), "0");
+    EXPECT_EQ(table.config_id_of("0"), 0u);
+    // Default-config accessors match the lone config.
+    EXPECT_EQ(table.config().num_layers, 2u);
+    EXPECT_EQ(table.num_position_chunks(), 64u / 32u);
+}
+
+TEST(KvChunkAddressTable, SpanConstructorNamesAreStringIndices) {
+    std::vector<KvChunkAddressTableConfig> configs = {
+        {.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
+        {.num_layers = 4, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32},
+        {.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 64},
+    };
+    KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{configs});
+
+    ASSERT_EQ(table.num_configs(), 3u);
+    EXPECT_EQ(table.config_name(0), "0");
+    EXPECT_EQ(table.config_name(1), "1");
+    EXPECT_EQ(table.config_name(2), "2");
+    EXPECT_EQ(table.config_id_of("0"), 0u);
+    EXPECT_EQ(table.config_id_of("2"), 2u);
+
+    // Each config keeps its own dims.
+    EXPECT_EQ(table.config(0).num_layers, 2u);
+    EXPECT_EQ(table.config(1).num_layers, 4u);
+    EXPECT_EQ(table.config(2).chunk_n_tokens, 64u);
+    EXPECT_EQ(table.num_position_chunks(2), 256u / 64u);
+}
+
+TEST(KvChunkAddressTable, MapConstructorAssignsIdsInSortedKeyOrder) {
+    std::map<std::string, KvChunkAddressTableConfig> configs = {
+        {"kv", {.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32}},
+        {"index_k", {.num_layers = 4, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32}},
+    };
+    KvChunkAddressTable table(configs);
+
+    ASSERT_EQ(table.num_configs(), 2u);
+    // std::map sorts keys: "index_k" < "kv".
+    EXPECT_EQ(table.config_name(0), "index_k");
+    EXPECT_EQ(table.config_name(1), "kv");
+    EXPECT_EQ(table.config_id_of("index_k"), 0u);
+    EXPECT_EQ(table.config_id_of("kv"), 1u);
+    EXPECT_EQ(table.config(table.config_id_of("kv")).num_layers, 2u);
+    EXPECT_EQ(table.config(table.config_id_of("index_k")).num_layers, 4u);
+}
+
+TEST(KvChunkAddressTable, SetAndLookupByIdAndNameAreEquivalent) {
+    std::map<std::string, KvChunkAddressTableConfig> configs = {
+        {"kv", {.num_layers = 2, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32}},
+        {"index_k", {.num_layers = 2, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32}},
+    };
+    KvChunkAddressTable table(configs);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    uint32_t kv_id = table.config_id_of("kv");
+    table.set(1, 64, 1, make_location(0xAB, 100, grp), kv_id);
+    // Reads back identically by id and by name.
+    EXPECT_EQ(table.lookup(1, 64, 1, kv_id).noc_addr, 0xABu);
+    EXPECT_EQ(table.lookup(1, 64, 1, "kv").noc_addr, 0xABu);
+
+    // Set via name, read via id.
+    table.set(0, 0, 0, make_location(0xCD, 200, grp), "index_k");
+    EXPECT_EQ(table.lookup(0, 0, 0, table.config_id_of("index_k")).noc_addr, 0xCDu);
+
+    // Configs are independent: writing "kv" does not touch "index_k".
+    EXPECT_EQ(table.lookup(1, 64, 1, "index_k").noc_addr, 0u);
+}
+
+TEST(KvChunkAddressTable, ConfigsWithDifferentChunkSizesIndexIndependently) {
+    std::vector<KvChunkAddressTableConfig> configs = {
+        {.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 32},
+        {.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 64},
+    };
+    KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{configs});
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    // config 0: 32-token chunks; config 1: 64-token chunks.
+    for (uint32_t pos = 0; pos < 256; pos += 32) {
+        table.set(0, pos, 0, make_location(pos, 10, grp), 0u);
+    }
+    for (uint32_t pos = 0; pos < 256; pos += 64) {
+        table.set(0, pos, 0, make_location(pos + 1, 10, grp), 1u);
+    }
+
+    auto r0 = table.lookup_range(0, 0, 256, 0, 0u);
+    auto r1 = table.lookup_range(0, 0, 256, 0, 1u);
+    EXPECT_EQ(r0.size(), 256u / 32u);
+    EXPECT_EQ(r1.size(), 256u / 64u);
+    EXPECT_EQ(r0[1].noc_addr, 32u);
+    EXPECT_EQ(r1[1].noc_addr, 64u + 1u);
+
+    // position 32 is not chunk-aligned for config 1 -> must throw.
+    EXPECT_ANY_THROW(table.set(0, 32, 0, KvCacheLocation{}, 1u));
+}
+
+TEST(KvChunkAddressTable, TotalEntriesSumsAcrossConfigs) {
+    std::vector<KvChunkAddressTableConfig> configs = {
+        {.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},   // 2*2*1 = 4
+        {.num_layers = 1, .max_sequence_length = 128, .num_slots = 3, .chunk_n_tokens = 32},  // 1*4*3 = 12
+    };
+    KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{configs});
+    EXPECT_EQ(table.total_entries(), 4u + 12u);
+}
+
+TEST(KvChunkAddressTable, DeviceGroupsAreSharedAcrossConfigs) {
+    std::vector<KvChunkAddressTableConfig> configs = {
+        {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
+        {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
+    };
+    KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{configs});
+
+    auto grp = table.add_device_group({make_fnid(0, 5)});
+    EXPECT_EQ(table.num_device_groups(), 1u);
+    // The same index resolves in either config.
+    table.set(0, 0, 0, make_location(0x1, 10, grp), 0u);
+    table.set(0, 0, 0, make_location(0x2, 10, grp), 1u);
+    EXPECT_EQ(table.get_device_group(table.lookup(0, 0, 0, 0u).device_group_index).fabric_node_ids[0], make_fnid(0, 5));
+    EXPECT_EQ(table.get_device_group(table.lookup(0, 0, 0, 1u).device_group_index).fabric_node_ids[0], make_fnid(0, 5));
+}
+
+TEST(KvChunkAddressTable, EmptyConfigSpanThrows) {
+    std::vector<KvChunkAddressTableConfig> empty;
+    EXPECT_ANY_THROW(KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{empty}));
+
+    std::map<std::string, KvChunkAddressTableConfig> empty_map;
+    EXPECT_ANY_THROW(KvChunkAddressTable table(empty_map));
+}
+
+TEST(KvChunkAddressTable, OutOfRangeConfigIdThrows) {
+    std::vector<KvChunkAddressTableConfig> configs = {
+        {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
+    };
+    KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{configs});
+
+    EXPECT_ANY_THROW(table.lookup(0, 0, 0, 1u));
+    EXPECT_ANY_THROW(table.set(0, 0, 0, KvCacheLocation{}, 1u));
+    EXPECT_ANY_THROW(table.config(1));
+    EXPECT_ANY_THROW(table.config_name(1));
+}
+
+TEST(KvChunkAddressTable, UnknownConfigNameThrows) {
+    std::vector<KvChunkAddressTableConfig> configs = {
+        {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
+    };
+    KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{configs});
+
+    EXPECT_ANY_THROW(table.lookup(0, 0, 0, "nope"));
+    EXPECT_ANY_THROW(table.config_id_of("nope"));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <memory>
 #include <cstddef>
@@ -719,16 +720,20 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
             mesh_device, core_range_set, 0, 0);  // Kernel isn't run here.
         auto& program = workload.get_programs().at(device_range);
 
-        // Set 100 unique args, then try to set max_runtime_args + 1 common args and fail.
+        // The enforced TENSIX ceiling is bounded by the uint16_t RTA offset field (see
+        // Kernel::validate_runtime_args_size). Mirror that here.
+        const uint32_t tensix_max_rt_args = std::numeric_limits<uint16_t>::max() / sizeof(uint32_t);
+
+        // Set 100 unique args, then try to set enough common args to overflow the combined ceiling and fail.
         std::vector<uint32_t> initial_runtime_args(100);
         SetRuntimeArgs(program, kernel, core_range_set, initial_runtime_args);
-        std::vector<uint32_t> common_runtime_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> common_runtime_args(tensix_max_rt_args + 1);
         EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, common_runtime_args));
 
-        // Set 100 common args, then try to set another tt::tt_metal::max_runtime_args + 1 unique args and fail.
+        // Set 100 common args, then try to set enough unique args to overflow the combined ceiling and fail.
         std::vector<uint32_t> more_common_runtime_args(100);
         SetCommonRuntimeArgs(program, kernel, more_common_runtime_args);
-        std::vector<uint32_t> more_unique_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> more_unique_args(tensix_max_rt_args + 1);
         EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, core_range_set, more_unique_args));
     }
 }
@@ -812,8 +817,13 @@ TEST_F(MeshDeviceFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
 // Test that active ethernet cores correctly validate max runtime args
 TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    // Mirror the enforced ceiling in Kernel::validate_runtime_args_size: 2 words are reserved for the watcher
+    // count words (one for the unique RTA region, one for the common) unconditionally, whether or not watcher
+    // asserts are enabled, so the usable max is the kernel-config size minus those 2 words.
+    constexpr uint32_t watcher_reserved_count_words = 2;
     uint32_t active_eth_max_runtime_args =
-        hal.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t);
+        hal.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
+        watcher_reserved_count_words;
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];
@@ -893,8 +903,13 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
 // Test that idle ethernet cores correctly validate max runtime args using IDLE_ETH kernel config size
 TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    // Mirror the enforced ceiling in Kernel::validate_runtime_args_size: 2 words are reserved for the watcher
+    // count words (one for the unique RTA region, one for the common) unconditionally, whether or not watcher
+    // asserts are enabled, so the usable max is the kernel-config size minus those 2 words.
+    constexpr uint32_t watcher_reserved_count_words = 2;
     uint32_t idle_eth_max_runtime_args =
-        hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t);
+        hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
+        watcher_reserved_count_words;
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -532,7 +532,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     Program program;
     bool pass = true;
 
-    // TODO: this test would be better if it varied args across core ranges and kernel type
+    // This varies the unique arg count across the two core ranges; TODO: it could also vary the kernel type.
 
     CoreRangeSet cr_set = program_config.cr_set;
     constexpr uint32_t kCommonRTASeparation = 1024 * sizeof(uint32_t);
@@ -540,258 +540,121 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     uint32_t rta_base_dm0 = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
     uint32_t rta_base_dm1 = rta_base_dm0 + (2048 * sizeof(uint32_t));
     uint32_t rta_base_compute = rta_base_dm1 + (4096 * sizeof(uint32_t));
-    // Copy max # runtime args in the kernel for simplicity
-    std::map<std::string, std::string> dm_defines0 = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"DATA_MOVEMENT", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm0)}};
-    std::map<std::string, std::string> dm_defines1 = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"DATA_MOVEMENT", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm1)}};
-    std::map<std::string, std::string> compute_defines = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"COMPUTE", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_compute)}};
 
-    auto dummy_kernel0 = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = dm_defines0});
-
-    auto dummy_kernel1 = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .defines = dm_defines1});
-
-    auto dummy_compute_kernel = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        ComputeConfig{.defines = compute_defines});
-
-    vector<uint32_t> dummy_cr0_args;
-    vector<uint32_t> dummy_cr1_args;
-    vector<uint32_t> dummy_common_args;
-
-    auto it = program_config.cr_set.ranges().begin();
+    auto it = cr_set.ranges().begin();
     CoreRange core_range_0 = *it;
     std::advance(it, 1);
     CoreRange core_range_1 = *it;
 
-    uint32_t idx = 0;
+    // A single set of kernels runs on both core ranges. The ranges are given different unique-arg counts, so the
+    // kernel selects its per-core count from its logical y coordinate (cores at absolute logical y >= the second
+    // range's start belong to core_range_1) and reads exactly the args that were set, which keeps the watcher's
+    // runtime-arg bounds check satisfied. Common args are uniform across all cores.
     constexpr uint32_t num_common_runtime_args = 13;
+    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp";
+    auto make_defines = [&](const char* role, uint32_t results_addr) {
+        return std::map<std::string, std::string>{
+            {"COMMON_RUNTIME_ARGS", "1"},
+            {role, "1"},
+            {"NUM_RUNTIME_ARGS", std::to_string(num_runtime_args_for_cr0)},
+            {"NUM_RUNTIME_ARGS_CR1", std::to_string(num_runtime_args_for_cr1)},
+            {"CR1_START_Y", std::to_string(core_range_1.start_coord.y)},
+            {"NUM_COMMON_RUNTIME_ARGS", std::to_string(num_common_runtime_args)},
+            {"RESULTS_ADDR", std::to_string(results_addr)}};
+    };
+    std::vector<KernelHandle> kernels = {
+        CreateKernel(
+            program,
+            kernel_path,
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .defines = make_defines("DATA_MOVEMENT", rta_base_dm0)}),
+        CreateKernel(
+            program,
+            kernel_path,
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .defines = make_defines("DATA_MOVEMENT", rta_base_dm1)}),
+        CreateKernel(
+            program, kernel_path, cr_set, ComputeConfig{.defines = make_defines("COMPUTE", rta_base_compute)})};
+    const uint32_t rta_bases[] = {rta_base_dm0, rta_base_dm1, rta_base_compute};
+
+    uint32_t idx = 0;
     workload.add_program(device_range, std::move(program));
 
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
         auto& program_ = workload.get_programs().at(device_range);
         SCOPED_TRACE(iter);
-        dummy_cr0_args.clear();
-        dummy_cr1_args.clear();
-        dummy_common_args.clear();
 
+        // cr0 cores are set num_runtime_args_for_cr0 unique args and cr1 cores num_runtime_args_for_cr1; the shared
+        // kernel reads the matching count per core from its coordinate. Common args are uniform. Values change each
+        // iteration to exercise in-place RTA/CRTA updates.
+        std::vector<uint32_t> cr0_args, cr1_args, common_args;
         for (uint32_t i = 0; i < num_runtime_args_for_cr0; i++) {
-            dummy_cr0_args.push_back(idx++);
+            cr0_args.push_back(idx++);
         }
-
         for (uint32_t i = 0; i < num_runtime_args_for_cr1; i++) {
-            dummy_cr1_args.push_back(idx++);
+            cr1_args.push_back(idx++);
         }
-
         for (uint32_t i = 0; i < num_common_runtime_args; i++) {
-            dummy_common_args.push_back(idx++);
+            common_args.push_back(idx++);
         }
 
-        bool first = true;
         for (const CoreCoord& core_coord : core_range_0) {
-            // Don't set RTAs on all cores
-            if (first) {
-                first = false;
-                continue;
+            for (KernelHandle k : kernels) {
+                SetRuntimeArgs(program_, k, core_coord, cr0_args);
             }
-
-            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr0_args);
         }
-
-        first = true;
         for (const CoreCoord& core_coord : core_range_1) {
-            // Don't set RTAs on all cores
-            if (first) {
-                first = false;
-                continue;
+            for (KernelHandle k : kernels) {
+                SetRuntimeArgs(program_, k, core_coord, cr1_args);
             }
-
-            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr1_args);
         }
 
         if (iter == 0) {
-            SetCommonRuntimeArgs(program_, dummy_kernel0, dummy_common_args);
-            SetCommonRuntimeArgs(program_, dummy_kernel1, dummy_common_args);
-            SetCommonRuntimeArgs(program_, dummy_compute_kernel, dummy_common_args);
+            for (KernelHandle k : kernels) {
+                SetCommonRuntimeArgs(program_, k, common_args);
+            }
         } else {
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_kernel0).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_kernel1).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_compute_kernel).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
+            for (KernelHandle k : kernels) {
+                memcpy(
+                    GetCommonRuntimeArgs(program_, k).rt_args_data,
+                    common_args.data(),
+                    common_args.size() * sizeof(uint32_t));
+            }
         }
 
         distributed::EnqueueMeshWorkload(cq, workload, false);
         Finish(cq);
 
-        first = true;
-        for (const CoreCoord& core_coord : core_range_0) {
-            // Don't test RTAs on first cores
-            if (first) {
-                first = false;
-                continue;
+        // Each of the three kernels on a core writes its own copy of the unique args to a distinct result address
+        // and the common args at kCommonRTASeparation past it; verify every core got its args back.
+        auto check_range = [&](const CoreRange& range, const std::vector<uint32_t>& unique_args) {
+            for (const CoreCoord& core_coord : range) {
+                for (uint32_t base : rta_bases) {
+                    std::vector<uint32_t> unique_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device, core_coord, base, unique_args.size() * sizeof(uint32_t), unique_readback);
+                    pass &= (unique_args == unique_readback);
+
+                    std::vector<uint32_t> common_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        base + kCommonRTASeparation,
+                        common_args.size() * sizeof(uint32_t),
+                        common_readback);
+                    EXPECT_EQ(common_args, common_readback);
+                    pass &= (common_args == common_readback);
+                }
             }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                pass &= (dummy_cr0_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                pass &= (dummy_cr0_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                pass &= (dummy_cr0_args == dummy_compute_args_readback);
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
-                pass &= (dummy_common_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
-                pass &= (dummy_common_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
-                pass &= (dummy_common_args == dummy_compute_args_readback);
-            }
-        }
-
-        first = true;
-        for (const CoreCoord& core_coord : core_range_1) {
-            // Don't test RTAs on first cores
-            if (first) {
-                first = false;
-                continue;
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                pass &= (dummy_cr1_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                pass &= (dummy_cr1_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                pass &= (dummy_cr1_args == dummy_compute_args_readback);
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
-                pass &= (dummy_common_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
-                pass &= (dummy_common_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
-                pass &= (dummy_common_args == dummy_compute_args_readback);
-            }
-        }
+        };
+        check_range(core_range_0, cr0_args);
+        check_range(core_range_1, cr1_args);
     }
 
     return pass;
@@ -1771,6 +1634,109 @@ TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_MaxRu
             0,
             tt::tt_metal::max_runtime_args,
             {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0}));
+    }
+}
+
+// Unique RTAs whose per-core payload exceeds one 4096B dispatch page (> 1024 words) are dispatched via
+// CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST instead of the page-limited packed-write path. Uses the full
+// worker grid (> 35 cores) to also exercise the multi-command chunk boundary
+// (CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS = 35).
+TEST_F(UnitMeshCQFixture, TensixLargeUniqueRuntimeArgsLargeUnicast) {
+    for (const auto& device : devices_) {
+        CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+        CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+        CoreRangeSet cr_set(cr);
+        DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
+        // 1100 words * 4 = 4400 B > 4096 B page. COMPUTE unique-arg L1 slot has 1280 words of headroom
+        // before the common-arg region (see get_args_addr), so 1100 unique + 0 common fits.
+        EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
+            device,
+            dummy_program_config,
+            1100,
+            0,
+            {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0}));
+    }
+}
+
+// Large common (multicast) RTAs: > 341 words, sent via the multicast CQ_DISPATCH_CMD_WRITE_PACKED_LARGE
+// path (BatchedTransferGenerator). Confirms the raised RTA ceiling permits large common args and that they
+// are delivered correctly. Uses the full worker grid.
+TEST_F(UnitMeshCQFixture, TensixLargeCommonRuntimeArgsLargeMulticast) {
+    for (const auto& device : devices_) {
+        CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+        CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+        CoreRangeSet cr_set(cr);
+        DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
+        // 0 unique, 1100 common words (> 341); COMPUTE common-arg L1 slot is offset well past the unique
+        // slot (see get_args_addr) so it does not overlap.
+        EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
+            device,
+            dummy_program_config,
+            0,
+            1100,
+            {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0}));
+    }
+}
+
+// Patch large unique RTAs and re-run: after the first enqueue repoints RuntimeArgsData into the command
+// stream, a second SetRuntimeArgs must update the large-unicast payload in place so the next enqueue sends
+// the new values. Full grid (> 35 cores) so the update spans multiple LARGE_UNICAST commands.
+TEST_F(UnitMeshCQFixture, TensixLargeUniqueRuntimeArgsPatchedAcrossRuns) {
+    constexpr uint32_t kNumArgs = 1100;  // > 1024 words → large-unicast path
+    for (const auto& device : devices_) {
+        auto* dev = device->get_devices()[0];
+        CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+        CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+        CoreRangeSet cr_set(cr);
+
+        distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
+        distributed::MeshCoordinateRange device_range(zero_coord, zero_coord);
+
+        const uint32_t rta_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        Program program;
+        std::map<std::string, std::string> defines = {
+            {"DATA_MOVEMENT", "1"},
+            {"NUM_RUNTIME_ARGS", std::to_string(kNumArgs)},
+            {"RESULTS_ADDR", std::to_string(rta_base)}};
+        auto kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
+
+        auto make_args = [](const CoreCoord& c, uint32_t phase) {
+            std::vector<uint32_t> args(kNumArgs);
+            const uint32_t base = (c.x * 100000) + (c.y * 1000) + (phase * 7);
+            for (uint32_t i = 0; i < kNumArgs; i++) {
+                args[i] = base + i;
+            }
+            return args;
+        };
+
+        distributed::MeshWorkload workload;
+        for (const CoreCoord& core : cr) {
+            SetRuntimeArgs(program, kernel, core, make_args(core, 0));
+        }
+        workload.add_program(device_range, std::move(program));
+
+        // Run twice: phase 0 initial, then patch in place with phase 1 values and re-run.
+        for (uint32_t phase = 0; phase < 2; phase++) {
+            auto& prog = workload.get_programs().at(device_range);
+            if (phase == 1) {
+                for (const CoreCoord& core : cr) {
+                    SetRuntimeArgs(prog, kernel, core, make_args(core, 1));
+                }
+            }
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, false);
+            Finish(device->mesh_command_queue());
+
+            for (const CoreCoord& core : cr) {
+                std::vector<uint32_t> readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(dev, core, rta_base, kNumArgs * sizeof(uint32_t), readback);
+                EXPECT_EQ(readback, make_args(core, phase)) << "core " << core.str() << " phase " << phase;
+            }
+        }
     }
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -12,15 +12,37 @@
 #include "defines_generated.h"
 #endif
 
+// Callers that use common runtime args may specify a separate common-arg count; otherwise it matches the unique
+// count, preserving behavior for existing callers.
+#ifdef COMMON_RUNTIME_ARGS
+#ifndef NUM_COMMON_RUNTIME_ARGS
+#define NUM_COMMON_RUNTIME_ARGS NUM_RUNTIME_ARGS
+#endif
+#endif
+
 void kernel_main() {
     volatile uint32_t tt_l1_ptr* results = (volatile uint32_t tt_l1_ptr*)RESULTS_ADDR;
     constexpr uint32_t kCommonRTASeparation = 1024;
-    for (uint32_t i = 0; i < NUM_RUNTIME_ARGS; i++) {
-#ifdef COMMON_RUNTIME_ARGS
-        results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
+
+    // Number of unique runtime args set on this core. When the same kernel binary is placed across two core ranges
+    // with different arg counts, the host defines CR1_START_Y and NUM_RUNTIME_ARGS_CR1 so each core reads exactly
+    // the count it was given (cores at absolute logical y >= CR1_START_Y belong to the second range). Reading only
+    // the args that were actually set keeps the watcher's runtime-arg bounds check satisfied.
+    uint32_t num_unique_runtime_args = NUM_RUNTIME_ARGS;
+#if defined(NUM_RUNTIME_ARGS_CR1) && defined(CR1_START_Y)
+    if (get_absolute_logical_y() >= CR1_START_Y) {
+        num_unique_runtime_args = NUM_RUNTIME_ARGS_CR1;
+    }
 #endif
+
+    for (uint32_t i = 0; i < num_unique_runtime_args; i++) {
         results[i] = get_arg_val<uint32_t>(i);
     }
+#ifdef COMMON_RUNTIME_ARGS
+    for (uint32_t i = 0; i < NUM_COMMON_RUNTIME_ARGS; i++) {
+        results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
+    }
+#endif
 
 #ifdef COORDS_ADDR
 #ifdef DATA_MOVEMENT

--- a/tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -16,7 +17,7 @@
 namespace tt::tt_metal::experimental::disaggregation {
 
 // Strongly-typed index into the device group side table.
-using DeviceGroupIndex = tt::stl::StrongType<uint32_t, struct DeviceGroupIndexTag>;
+using DeviceGroupIndex = ttsl::StrongType<uint32_t, struct DeviceGroupIndexTag>;
 
 // A unique group of fabric nodes that hold replicas of a KV cache chunk.
 // FabricNodeIds are stored sorted so that identical replica sets
@@ -45,18 +46,26 @@ struct KvChunkAddressTableConfig {
     uint32_t chunk_size_bytes = 19584;  // physical size of one chunk in bytes (18 x 1088 bfp8 tiles)
 };
 
-// Lookup table mapping (layer, position, slot) -> KvCacheLocation.
+// Lookup table mapping (layer, position, slot, config) -> KvCacheLocation.
 //
 // Describes how a KV cache is allocated/laid out across a multi-host,
 // multi-chip, multi-memory system. Used by the migration layer to locate
 // KV cache chunks for transfer.
 //
-// Device replica groups are stored in a separate side table and referenced
-// by index from each KvCacheLocation. Groups are deduplicated: identical
-// sorted sets of FabricNodeIds share the same index. The side table is
-// typically tiny (handful of entries) and stays in L1 cache.
+// The table holds one or more configs ("groups"), each a distinct attention
+// implementation / tensor representation a layer may use (e.g. dense KV in
+// config 0, a sparse index_k representation in config 1). Each config has its
+// own grid and may differ in num_layers / max_sequence_length / num_slots /
+// chunk_n_tokens. Configs are addressed last on every accessor — by index
+// (config_id, defaulting to 0) or by name (config). A single-config table
+// names its lone config "0".
 //
-// Internal storage is ordered [slot][layer][position_chunk] so that the
+// Device replica groups are stored in a separate side table, shared across all
+// configs, and referenced by index from each KvCacheLocation. Groups are
+// deduplicated: identical sorted sets of FabricNodeIds share the same index.
+// The side table is typically tiny (handful of entries) and stays in L1 cache.
+//
+// Per-config storage is ordered [slot][layer][position_chunk] so that the
 // typical access pattern (fixed slot, iterate layers, iterate positions)
 // gets contiguous position-chunk reads — the innermost loop.
 //
@@ -64,7 +73,16 @@ struct KvChunkAddressTableConfig {
 // to chunk indices via (position / chunk_n_tokens).
 class KvChunkAddressTable {
 public:
+    // Single config — the whole table uses one configuration (config id 0, name "0").
     explicit KvChunkAddressTable(const KvChunkAddressTableConfig& config);
+
+    // Indexed configs — config i is named "i" (its decimal index), so the string
+    // accessors resolve "0".."N-1" to ids 0..N-1. Requires at least one config.
+    explicit KvChunkAddressTable(std::span<const KvChunkAddressTableConfig> configs);
+
+    // Named configs — config ids are assigned in the map's key order (std::map
+    // iterates sorted), and each config's name is its key. Requires at least one config.
+    explicit KvChunkAddressTable(const std::map<std::string, KvChunkAddressTableConfig>& configs);
 
     // --- Device Group Management ---
 
@@ -82,25 +100,30 @@ public:
 
     // --- Mutators ---
 
-    // Set the location for a specific (layer, position, slot).
-    // `position` is in tokens and must be chunk-aligned (multiple of chunk_n_tokens).
-    void set(uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location);
+    // Set the location for a specific (layer, position, slot, config).
+    // `position` is in tokens and must be chunk-aligned (multiple of the config's chunk_n_tokens).
+    // `config` is addressed by id (default 0) or by name.
+    void set(uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location, uint32_t config_id = 0);
+    void set(uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location, const std::string& config);
 
     // Register a mapping from FabricNodeId to its host name.
     void set_fabric_node_host(const tt::tt_fabric::FabricNodeId& node_id, const std::string& host_name);
 
     // --- Accessors ---
 
-    // Lookup a single entry. `position` is in tokens (chunk-aligned).
-    const KvCacheLocation& lookup(uint32_t layer, uint32_t position, uint32_t slot) const;
+    // Lookup a single entry. `position` is in tokens (chunk-aligned). `config` by id (default 0) or name.
+    const KvCacheLocation& lookup(uint32_t layer, uint32_t position, uint32_t slot, uint32_t config_id = 0) const;
+    const KvCacheLocation& lookup(uint32_t layer, uint32_t position, uint32_t slot, const std::string& config) const;
 
-    // Lookup a contiguous range of position chunks for a given (layer, slot).
+    // Lookup a contiguous range of position chunks for a given (layer, slot, config).
     // Returns a span over the internal storage — zero-copy.
     // `start_pos` must be chunk-aligned. `end_pos` need not be aligned —
     // it is rounded up to include the enclosing chunk.
     // Returns entries for chunks covering positions [start_pos, end_pos).
     std::span<const KvCacheLocation> lookup_range(
-        uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot) const;
+        uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot, uint32_t config_id = 0) const;
+    std::span<const KvCacheLocation> lookup_range(
+        uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot, const std::string& config) const;
 
     // Resolve a FabricNodeId to its host name.
     const std::string& get_host(const tt::tt_fabric::FabricNodeId& node_id) const;
@@ -108,21 +131,38 @@ public:
     // Check if a FabricNodeId has a registered host mapping.
     bool has_host(const tt::tt_fabric::FabricNodeId& node_id) const;
 
-    const KvChunkAddressTableConfig& config() const { return config_; }
-    uint32_t num_position_chunks() const { return num_position_chunks_; }
-    size_t total_entries() const { return entries_.size(); }
+
+    // --- Config introspection ---
+
+    // Number of configs ("groups") held by this table.
+    size_t num_configs() const { return configs_.size(); }
+    // Config by id (default 0, the lone config of a single-config table).
+    const KvChunkAddressTableConfig& config(uint32_t config_id = 0) const;
+    // Name of a config by id.
+    const std::string& config_name(uint32_t config_id) const;
+    // Resolve a config name to its id (throws if unknown).
+    uint32_t config_id_of(const std::string& name) const;
+    // Number of position chunks for a config.
+    uint32_t num_position_chunks(uint32_t config_id = 0) const;
+    // Total entries summed across all configs.
+    size_t total_entries() const;
 
 private:
-    size_t flat_index(uint32_t layer, uint32_t position_chunk, uint32_t slot) const;
-    uint32_t to_chunk_index(uint32_t position) const;
-    void validate_args(uint32_t layer, uint32_t position, uint32_t slot) const;
+    void init_configs(std::span<const KvChunkAddressTableConfig> configs, std::vector<std::string> names);
+    uint32_t resolve_config(const std::string& name) const;
+    void validate_config_id(uint32_t config_id) const;
+    size_t flat_index(uint32_t config_id, uint32_t layer, uint32_t position_chunk, uint32_t slot) const;
+    uint32_t to_chunk_index(uint32_t config_id, uint32_t position) const;
+    void validate_args(uint32_t config_id, uint32_t layer, uint32_t position, uint32_t slot) const;
 
-    KvChunkAddressTableConfig config_;
-    uint32_t num_position_chunks_;
-    uint32_t num_layers_x_chunks_;  // cached: num_layers * num_position_chunks_
-    std::vector<KvCacheLocation> entries_;
-    std::vector<DeviceGroup> device_groups_;
-    std::unordered_map<tt::tt_fabric::FabricNodeId, std::string> fabric_node_to_host_;
+    std::vector<KvChunkAddressTableConfig> configs_;
+    std::vector<std::string> config_names_;                        // config_id -> name
+    std::unordered_map<std::string, uint32_t> name_to_config_id_;  // name -> config_id
+    std::vector<uint32_t> num_position_chunks_;                    // per config
+    std::vector<uint32_t> num_layers_x_chunks_;                    // per config: num_layers * num_position_chunks
+    std::vector<std::vector<KvCacheLocation>> entries_;            // per-config grid [slot][layer][position_chunk]
+    std::vector<DeviceGroup> device_groups_;                       // shared across configs
+    std::unordered_map<tt::tt_fabric::FabricNodeId, std::string> fabric_node_to_host_;  // shared across configs
 };
 
 }  // namespace tt::tt_metal::experimental::disaggregation

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -465,7 +465,8 @@ void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program&
 // ==================================================
 /**
  * Set runtime args for a kernel that are sent to the core during runtime. This API needs to be called to update the runtime args for the kernel.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *
@@ -486,7 +487,8 @@ void SetRuntimeArgs(
 // clang-format off
 /**
  * Set runtime args for a kernel that are sent to the core during runtime. This API needs to be called to update the runtime args for the kernel.
- * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *
@@ -507,7 +509,8 @@ void SetRuntimeArgs(
 // clang-format off
 /**
  * Set multiple runtime arguments of a kernel at once during runtime, each mapping to a specific core. The runtime args for each core may be unique.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *
@@ -528,7 +531,8 @@ void SetRuntimeArgs(
 // clang-format off
 /**
  * Set common (shared by all cores) runtime args for a kernel that are sent to all cores during runtime. This API needs to be called to update the common runtime args for the kernel.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *
@@ -544,7 +548,8 @@ void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, stl::S
 // clang-format off
 /**
  * Set common (shared by all cores) runtime args for a kernel that are sent to all cores during runtime. This API needs to be called to update the common runtime args for the kernel.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
+ * The number of runtime args per core (unique and common runtime args count toward the same limit) is bounded by the
+ * available L1 kernel-config space for the target core type; max_runtime_args is a conservative portable floor.
  *
  * Return value: void
  *

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -42,9 +42,10 @@ enum NOC_MODE : uint8_t {
     DM_DYNAMIC_NOC = 1,
 };
 
-// 341 = (4096/(3 * sizeof(uint32_t)), where
-// - 4096 - packet size in dispatch
-// - 3 - number of kernels per tensix
+// Conservative minimum number of runtime args (unique + common combined) guaranteed to be settable on
+// any core type. This is a stable floor for callers that want a portable limit; it is NOT the enforced
+// hard cap. The actual per-core ceiling is larger and computed by the runtime from the available L1
+// kernel-config space for the target core type (see Kernel::validate_runtime_args_size).
 constexpr uint32_t max_runtime_args = 341;
 
 using KernelHandle = std::uint32_t;

--- a/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table.cpp
+++ b/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table.cpp
@@ -10,33 +10,92 @@
 
 namespace tt::tt_metal::experimental::disaggregation {
 
-size_t KvChunkAddressTable::flat_index(uint32_t layer, uint32_t position_chunk, uint32_t slot) const {
-    return (static_cast<size_t>(slot) * num_layers_x_chunks_) + (static_cast<size_t>(layer) * num_position_chunks_) +
-           static_cast<size_t>(position_chunk);
+void KvChunkAddressTable::init_configs(
+    std::span<const KvChunkAddressTableConfig> configs, std::vector<std::string> names) {
+    TT_FATAL(!configs.empty(), "KvChunkAddressTable requires at least one config");
+    TT_FATAL(configs.size() == names.size(), "internal: configs/names size mismatch");
+
+    configs_.assign(configs.begin(), configs.end());
+    config_names_ = std::move(names);
+    num_position_chunks_.resize(configs_.size());
+    num_layers_x_chunks_.resize(configs_.size());
+    entries_.resize(configs_.size());
+
+    for (uint32_t c = 0; c < configs_.size(); c++) {
+        const auto& cfg = configs_[c];
+        TT_FATAL(cfg.chunk_n_tokens > 0, "config[{}] chunk_n_tokens must be > 0", c);
+        TT_FATAL(!config_names_[c].empty(), "config[{}] name must be non-empty", c);
+        auto [it, inserted] = name_to_config_id_.emplace(config_names_[c], c);
+        TT_FATAL(inserted, "duplicate config name '{}'", config_names_[c]);
+
+        uint32_t npc = (cfg.max_sequence_length + cfg.chunk_n_tokens - 1) / cfg.chunk_n_tokens;
+        num_position_chunks_[c] = npc;
+        num_layers_x_chunks_[c] = cfg.num_layers * npc;
+        entries_[c].resize(static_cast<size_t>(cfg.num_slots) * cfg.num_layers * npc);
+    }
 }
 
-uint32_t KvChunkAddressTable::to_chunk_index(uint32_t position) const { return position / config_.chunk_n_tokens; }
-
-void KvChunkAddressTable::validate_args(uint32_t layer, uint32_t position, uint32_t slot) const {
-    TT_FATAL(layer < config_.num_layers, "layer {} >= num_layers {}", layer, config_.num_layers);
-    TT_FATAL(
-        position < config_.max_sequence_length,
-        "position {} >= max_sequence_length {}",
-        position,
-        config_.max_sequence_length);
-    TT_FATAL(slot < config_.num_slots, "slot {} >= num_slots {}", slot, config_.num_slots);
-    TT_FATAL(
-        position % config_.chunk_n_tokens == 0,
-        "position {} is not a multiple of chunk_n_tokens {}",
-        position,
-        config_.chunk_n_tokens);
+KvChunkAddressTable::KvChunkAddressTable(const KvChunkAddressTableConfig& config) {
+    init_configs(std::span<const KvChunkAddressTableConfig>(&config, 1), {"0"});
 }
 
-KvChunkAddressTable::KvChunkAddressTable(const KvChunkAddressTableConfig& config) : config_(config) {
-    TT_FATAL(config.chunk_n_tokens > 0, "chunk_n_tokens must be > 0");
-    num_position_chunks_ = (config.max_sequence_length + config.chunk_n_tokens - 1) / config.chunk_n_tokens;
-    num_layers_x_chunks_ = config.num_layers * num_position_chunks_;
-    entries_.resize(static_cast<size_t>(config.num_slots) * config.num_layers * num_position_chunks_);
+KvChunkAddressTable::KvChunkAddressTable(std::span<const KvChunkAddressTableConfig> configs) {
+    std::vector<std::string> names;
+    names.reserve(configs.size());
+    for (uint32_t i = 0; i < configs.size(); i++) {
+        names.push_back(std::to_string(i));  // "0".."N-1"
+    }
+    init_configs(configs, std::move(names));
+}
+
+KvChunkAddressTable::KvChunkAddressTable(const std::map<std::string, KvChunkAddressTableConfig>& configs) {
+    std::vector<KvChunkAddressTableConfig> cfgs;
+    std::vector<std::string> names;
+    cfgs.reserve(configs.size());
+    names.reserve(configs.size());
+    for (const auto& [name, cfg] : configs) {  // std::map iterates in sorted key order
+        names.push_back(name);
+        cfgs.push_back(cfg);
+    }
+    init_configs(cfgs, std::move(names));
+}
+
+uint32_t KvChunkAddressTable::resolve_config(const std::string& name) const {
+    auto it = name_to_config_id_.find(name);
+    TT_FATAL(it != name_to_config_id_.end(), "config name '{}' not found", name);
+    return it->second;
+}
+
+void KvChunkAddressTable::validate_config_id(uint32_t config_id) const {
+    TT_FATAL(config_id < configs_.size(), "config_id {} >= num_configs {}", config_id, configs_.size());
+}
+
+size_t KvChunkAddressTable::flat_index(uint32_t config_id, uint32_t layer, uint32_t position_chunk, uint32_t slot) const {
+    return (static_cast<size_t>(slot) * num_layers_x_chunks_[config_id]) +
+           (static_cast<size_t>(layer) * num_position_chunks_[config_id]) + static_cast<size_t>(position_chunk);
+}
+
+uint32_t KvChunkAddressTable::to_chunk_index(uint32_t config_id, uint32_t position) const {
+    return position / configs_[config_id].chunk_n_tokens;
+}
+
+void KvChunkAddressTable::validate_args(uint32_t config_id, uint32_t layer, uint32_t position, uint32_t slot) const {
+    validate_config_id(config_id);
+    const auto& cfg = configs_[config_id];
+    TT_FATAL(layer < cfg.num_layers, "layer {} >= num_layers {} (config {})", layer, cfg.num_layers, config_id);
+    TT_FATAL(
+        position < cfg.max_sequence_length,
+        "position {} >= max_sequence_length {} (config {})",
+        position,
+        cfg.max_sequence_length,
+        config_id);
+    TT_FATAL(slot < cfg.num_slots, "slot {} >= num_slots {} (config {})", slot, cfg.num_slots, config_id);
+    TT_FATAL(
+        position % cfg.chunk_n_tokens == 0,
+        "position {} is not a multiple of chunk_n_tokens {} (config {})",
+        position,
+        cfg.chunk_n_tokens,
+        config_id);
 }
 
 DeviceGroupIndex KvChunkAddressTable::add_device_group(std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids) {
@@ -60,9 +119,15 @@ const DeviceGroup& KvChunkAddressTable::get_device_group(DeviceGroupIndex index)
     return device_groups_[*index];
 }
 
-void KvChunkAddressTable::set(uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location) {
-    validate_args(layer, position, slot);
-    entries_[flat_index(layer, to_chunk_index(position), slot)] = location;
+void KvChunkAddressTable::set(
+    uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location, uint32_t config_id) {
+    validate_args(config_id, layer, position, slot);
+    entries_[config_id][flat_index(config_id, layer, to_chunk_index(config_id, position), slot)] = location;
+}
+
+void KvChunkAddressTable::set(
+    uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location, const std::string& config) {
+    set(layer, position, slot, location, resolve_config(config));
 }
 
 void KvChunkAddressTable::set_fabric_node_host(
@@ -70,26 +135,39 @@ void KvChunkAddressTable::set_fabric_node_host(
     fabric_node_to_host_[node_id] = host_name;
 }
 
-const KvCacheLocation& KvChunkAddressTable::lookup(uint32_t layer, uint32_t position, uint32_t slot) const {
-    validate_args(layer, position, slot);
-    return entries_[flat_index(layer, to_chunk_index(position), slot)];
+const KvCacheLocation& KvChunkAddressTable::lookup(
+    uint32_t layer, uint32_t position, uint32_t slot, uint32_t config_id) const {
+    validate_args(config_id, layer, position, slot);
+    return entries_[config_id][flat_index(config_id, layer, to_chunk_index(config_id, position), slot)];
+}
+
+const KvCacheLocation& KvChunkAddressTable::lookup(
+    uint32_t layer, uint32_t position, uint32_t slot, const std::string& config) const {
+    return lookup(layer, position, slot, resolve_config(config));
 }
 
 std::span<const KvCacheLocation> KvChunkAddressTable::lookup_range(
-    uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot) const {
-    validate_args(layer, start_pos, slot);
+    uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot, uint32_t config_id) const {
+    validate_args(config_id, layer, start_pos, slot);
+    const auto& cfg = configs_[config_id];
     TT_FATAL(
-        end_pos <= config_.max_sequence_length,
-        "end_pos {} > max_sequence_length {}",
+        end_pos <= cfg.max_sequence_length,
+        "end_pos {} > max_sequence_length {} (config {})",
         end_pos,
-        config_.max_sequence_length);
+        cfg.max_sequence_length,
+        config_id);
     if (start_pos >= end_pos) {
         return {};
     }
-    uint32_t start_chunk = to_chunk_index(start_pos);
-    uint32_t end_chunk = to_chunk_index(end_pos + config_.chunk_n_tokens - 1);
-    size_t base = flat_index(layer, start_chunk, slot);
-    return std::span<const KvCacheLocation>(entries_.data() + base, end_chunk - start_chunk);
+    uint32_t start_chunk = to_chunk_index(config_id, start_pos);
+    uint32_t end_chunk = to_chunk_index(config_id, end_pos + cfg.chunk_n_tokens - 1);
+    size_t base = flat_index(config_id, layer, start_chunk, slot);
+    return std::span<const KvCacheLocation>(entries_[config_id].data() + base, end_chunk - start_chunk);
+}
+
+std::span<const KvCacheLocation> KvChunkAddressTable::lookup_range(
+    uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot, const std::string& config) const {
+    return lookup_range(layer, start_pos, end_pos, slot, resolve_config(config));
 }
 
 const std::string& KvChunkAddressTable::get_host(const tt::tt_fabric::FabricNodeId& node_id) const {
@@ -102,4 +180,29 @@ bool KvChunkAddressTable::has_host(const tt::tt_fabric::FabricNodeId& node_id) c
     return fabric_node_to_host_.contains(node_id);
 }
 
+
+const KvChunkAddressTableConfig& KvChunkAddressTable::config(uint32_t config_id) const {
+    validate_config_id(config_id);
+    return configs_[config_id];
+}
+
+const std::string& KvChunkAddressTable::config_name(uint32_t config_id) const {
+    validate_config_id(config_id);
+    return config_names_[config_id];
+}
+
+uint32_t KvChunkAddressTable::config_id_of(const std::string& name) const { return resolve_config(name); }
+
+uint32_t KvChunkAddressTable::num_position_chunks(uint32_t config_id) const {
+    validate_config_id(config_id);
+    return num_position_chunks_[config_id];
+}
+
+size_t KvChunkAddressTable::total_entries() const {
+    size_t total = 0;
+    for (const auto& grid : entries_) {
+        total += grid.size();
+    }
+    return total;
+}
 }  // namespace tt::tt_metal::experimental::disaggregation

--- a/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.cpp
+++ b/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.cpp
@@ -5,8 +5,10 @@
 #include "tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.hpp"
 
 #include <fstream>
+#include <map>
 #include <stdexcept>
 #include <unordered_set>
+#include <vector>
 
 #include <google/protobuf/text_format.h>
 
@@ -17,15 +19,26 @@ namespace tt::tt_metal::experimental::disaggregation {
 namespace detail {
 
 ::tt::disaggregation::proto::KvChunkAddressTable to_proto_message(const KvChunkAddressTable& table) {
-    const auto& cfg = table.config();
-
     ::tt::disaggregation::proto::KvChunkAddressTable pb;
 
-    pb.set_num_layers(cfg.num_layers);
-    pb.set_max_sequence_length(cfg.max_sequence_length);
-    pb.set_num_slots(cfg.num_slots);
-    pb.set_chunk_n_tokens(cfg.chunk_n_tokens);
-    pb.set_chunk_size_bytes(cfg.chunk_size_bytes);
+    // All configs ("groups") — authoritative. Mirror config 0 into the legacy
+    // scalar fields so old single-config readers still work.
+    for (uint32_t c = 0; c < table.num_configs(); c++) {
+        const auto& cfg = table.config(c);
+        auto* pb_cfg = pb.add_configs();
+        pb_cfg->set_name(table.config_name(c));
+        pb_cfg->set_num_layers(cfg.num_layers);
+        pb_cfg->set_max_sequence_length(cfg.max_sequence_length);
+        pb_cfg->set_num_slots(cfg.num_slots);
+        pb_cfg->set_chunk_n_tokens(cfg.chunk_n_tokens);
+        pb_cfg->set_chunk_size_bytes(cfg.chunk_size_bytes);
+    }
+    const auto& cfg0 = table.config(0);
+    pb.set_num_layers(cfg0.num_layers);
+    pb.set_max_sequence_length(cfg0.max_sequence_length);
+    pb.set_num_slots(cfg0.num_slots);
+    pb.set_chunk_n_tokens(cfg0.chunk_n_tokens);
+    pb.set_chunk_size_bytes(cfg0.chunk_size_bytes);
 
     for (size_t i = 0; i < table.num_device_groups(); i++) {
         const auto& group = table.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)});
@@ -52,20 +65,24 @@ namespace detail {
         }
     }
 
-    for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
-        for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
-            for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
-                const auto& loc = table.lookup(layer, pos, slot);
-                if (loc.noc_addr == 0 && loc.size_bytes == 0 && *loc.device_group_index == 0) {
-                    continue;
+    for (uint32_t c = 0; c < table.num_configs(); c++) {
+        const auto& cfg = table.config(c);
+        for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
+            for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
+                for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
+                    const auto& loc = table.lookup(layer, pos, slot, c);
+                    if (loc.noc_addr == 0 && loc.size_bytes == 0 && *loc.device_group_index == 0) {
+                        continue;
+                    }
+                    auto* entry = pb.add_entries();
+                    entry->set_slot(slot);
+                    entry->set_layer(layer);
+                    entry->set_position(pos);
+                    entry->set_noc_addr(loc.noc_addr);
+                    entry->set_size_bytes(loc.size_bytes);
+                    entry->set_device_group_index(*loc.device_group_index);
+                    entry->set_config_idx(c);
                 }
-                auto* entry = pb.add_entries();
-                entry->set_slot(slot);
-                entry->set_layer(layer);
-                entry->set_position(pos);
-                entry->set_noc_addr(loc.noc_addr);
-                entry->set_size_bytes(loc.size_bytes);
-                entry->set_device_group_index(*loc.device_group_index);
             }
         }
     }
@@ -74,14 +91,40 @@ namespace detail {
 }
 
 KvChunkAddressTable from_proto_message(const ::tt::disaggregation::proto::KvChunkAddressTable& pb) {
-    KvChunkAddressTableConfig cfg{
-        .num_layers = pb.num_layers(),
-        .max_sequence_length = pb.max_sequence_length(),
-        .num_slots = pb.num_slots(),
-        .chunk_n_tokens = pb.chunk_n_tokens(),
-        .chunk_size_bytes = pb.chunk_size_bytes(),
-    };
-    KvChunkAddressTable table(cfg);
+    // Reconstruct configs. `configs` (field 9) is authoritative when present;
+    // otherwise fall back to the legacy single-config scalar fields. Entries are
+    // placed by config NAME (idx_to_name) so they land correctly even if the map
+    // constructor reassigns ids by sorted-key order.
+    std::map<std::string, KvChunkAddressTableConfig> configs;
+    std::vector<std::string> idx_to_name;
+    if (pb.configs_size() > 0) {
+        idx_to_name.reserve(pb.configs_size());
+        for (const auto& pb_cfg : pb.configs()) {
+            KvChunkAddressTableConfig cfg{
+                .num_layers = pb_cfg.num_layers(),
+                .max_sequence_length = pb_cfg.max_sequence_length(),
+                .num_slots = pb_cfg.num_slots(),
+                .chunk_n_tokens = pb_cfg.chunk_n_tokens(),
+                .chunk_size_bytes = pb_cfg.chunk_size_bytes(),
+            };
+            if (!configs.emplace(pb_cfg.name(), cfg).second) {
+                throw std::runtime_error("duplicate config name '" + pb_cfg.name() + "' in KvChunkAddressTable proto");
+            }
+            idx_to_name.push_back(pb_cfg.name());
+        }
+    } else {
+        configs.emplace(
+            "0",
+            KvChunkAddressTableConfig{
+                .num_layers = pb.num_layers(),
+                .max_sequence_length = pb.max_sequence_length(),
+                .num_slots = pb.num_slots(),
+                .chunk_n_tokens = pb.chunk_n_tokens(),
+                .chunk_size_bytes = pb.chunk_size_bytes(),
+            });
+        idx_to_name.push_back("0");
+    }
+    KvChunkAddressTable table(configs);
 
     for (const auto& pb_group : pb.device_groups()) {
         std::vector<tt::tt_fabric::FabricNodeId> fnids;
@@ -98,12 +141,15 @@ KvChunkAddressTable from_proto_message(const ::tt::disaggregation::proto::KvChun
     }
 
     for (const auto& entry : pb.entries()) {
+        if (entry.config_idx() >= idx_to_name.size()) {
+            throw std::runtime_error("entry config_idx out of range in KvChunkAddressTable proto");
+        }
         KvCacheLocation loc{
             .noc_addr = entry.noc_addr(),
             .size_bytes = entry.size_bytes(),
             .device_group_index = DeviceGroupIndex{entry.device_group_index()},
         };
-        table.set(entry.layer(), entry.position(), entry.slot(), loc);
+        table.set(entry.layer(), entry.position(), entry.slot(), loc, idx_to_name[entry.config_idx()]);
     }
 
     return table;

--- a/tt_metal/impl/experimental/disaggregation/protobuf/kv_chunk_address_table.proto
+++ b/tt_metal/impl/experimental/disaggregation/protobuf/kv_chunk_address_table.proto
@@ -17,6 +17,17 @@ message FabricNodeHost {
     string host_name = 3;
 }
 
+// One config ("group") — a distinct attention implementation / tensor
+// representation a layer may use. A table holds one or more.
+message KvChunkConfig {
+    string name = 1;
+    uint32 num_layers = 2;
+    uint32 max_sequence_length = 3;
+    uint32 num_slots = 4;
+    uint32 chunk_n_tokens = 5;
+    uint32 chunk_size_bytes = 6;
+}
+
 message KvCacheEntry {
     uint32 slot = 1;
     uint32 layer = 2;
@@ -24,9 +35,13 @@ message KvCacheEntry {
     uint64 noc_addr = 4;
     uint32 size_bytes = 5;
     uint32 device_group_index = 6;
+    uint32 config_idx = 7;  // which config ("group") this entry belongs to (default 0)
 }
 
 message KvChunkAddressTable {
+    // Legacy single-config scalar fields (1-5): mirror config 0's dims so old
+    // single-config readers keep working. `configs` (field 9) is authoritative
+    // when present; readers should prefer it and fall back to these otherwise.
     uint32 num_layers = 1;
     uint32 max_sequence_length = 2;
     uint32 num_slots = 3;
@@ -35,4 +50,5 @@ message KvChunkAddressTable {
     repeated DeviceGroup device_groups = 6;
     repeated FabricNodeHost fabric_node_hosts = 7;
     repeated KvCacheEntry entries = 8;
+    repeated KvChunkConfig configs = 9;  // all configs ("groups"); index == config_idx
 }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
+#include <limits>
 #include <set>
 #include <string_view>
 #include <type_traits>
@@ -610,13 +611,23 @@ std::vector<uint32_t>& Kernel::common_runtime_args() { return this->common_runti
 RuntimeArgsData& Kernel::common_runtime_args_data() { return this->common_runtime_args_data_; }
 
 // Ensure that unique and common runtime args do not overflow reserved region in L1.
+// num_unique_rt_args and num_common_rt_args are user-visible arg counts (excluding any watcher count words).
 void Kernel::validate_runtime_args_size(
     size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const {
     uint32_t total_rt_args = (num_unique_rt_args + num_common_rt_args);
     uint32_t expected_max_rt_args = 0;
 
+    // The enforced ceiling is no longer the conservative public floor (kernel_types.hpp:max_runtime_args).
+    // Large unique RTAs are dispatched via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST, so they are no longer
+    // bounded by a single dispatch page. The RTA/CRTA region offset is stored in a uint16_t launch-message
+    // field (dev_msgs.h rta_offset_t), which caps the region at uint16_t max bytes.
     switch (this->get_kernel_programmable_core_type()) {
-        case HalProgrammableCoreType::TENSIX: expected_max_rt_args = max_runtime_args; break;
+        case HalProgrammableCoreType::TENSIX:
+            // The TENSIX kernel-config L1 size is device-dependent (derived from the allocator at program
+            // finalize, not available from the HAL here), so bound only by the uint16_t RTA offset field.
+            // The actual L1 fit is enforced later against the kernel-config ring buffer.
+            expected_max_rt_args = std::numeric_limits<uint16_t>::max() / sizeof(uint32_t);
+            break;
         case HalProgrammableCoreType::ACTIVE_ETH:
         case HalProgrammableCoreType::IDLE_ETH:
         case HalProgrammableCoreType::DRAM:
@@ -626,6 +637,13 @@ void Kernel::validate_runtime_args_size(
             break;
         default: TT_THROW("Invalid programmable core type: {}", this->get_kernel_programmable_core_type());
     }
+
+    // Reserve the watcher count words unconditionally so the usable limit does not depend on whether watcher
+    // asserts are enabled. When enabled the device prepends one count word to the unique RTA region and one to
+    // the common RTA region ([count | args]); reserving them even when disabled keeps the user-visible limit stable.
+    constexpr uint32_t watcher_reserved_count_words = 2;
+    expected_max_rt_args =
+        expected_max_rt_args > watcher_reserved_count_words ? expected_max_rt_args - watcher_reserved_count_words : 0;
 
     if (total_rt_args > expected_max_rt_args) {
         TT_THROW(
@@ -656,13 +674,15 @@ void Kernel::set_runtime_args(const CoreCoord& logical_core, stl::Span<const uin
         // When watcher assert is enabled, we store [arg count | args]
         size_t effective_limit = runtime_args.size() + watcher_count_word_offset_;
 
-        // Validate against hardware limit (341 words)
-        this->validate_runtime_args_size(effective_limit, this->common_runtime_args_.size(), logical_core);
+        // Validate user-visible arg counts; the watcher count-word reservation is applied inside
+        // validate_runtime_args_size so the limit is identical whether or not watcher asserts are enabled.
+        size_t common_user_args =
+            this->common_runtime_args_.empty() ? 0 : this->common_runtime_args_.size() - watcher_count_word_offset_;
+        this->validate_runtime_args_size(runtime_args.size(), common_user_args, logical_core);
 
-        // Track maximum dispatch size for CRTA validation
-        // Note: max_runtime_args_per_core_ stores effective size (includes count word if watcher enabled)
-        if (effective_limit > max_runtime_args_per_core_) {
-            max_runtime_args_per_core_ = effective_limit;
+        // Track the max user-visible unique arg count for the later combined CRTA validation.
+        if (runtime_args.size() > max_runtime_args_per_core_) {
+            max_runtime_args_per_core_ = runtime_args.size();
             core_with_max_runtime_args_ = logical_core;
         }
 
@@ -703,9 +723,11 @@ void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_ar
 
     size_t effective_crta_limit = common_runtime_args.size() + watcher_count_word_offset_;
 
-    // Validate combined RTA + CRTA size doesn't exceed hardware limit (341 words)
-    // max_runtime_args_per_core_ already includes count word if watcher enabled
-    this->validate_runtime_args_size(max_runtime_args_per_core_, effective_crta_limit, core_with_max_runtime_args_);
+    // Validate combined user-visible RTA + CRTA size. max_runtime_args_per_core_ holds the max user-visible
+    // unique arg count; the watcher count-word reservation is applied inside validate_runtime_args_size so the
+    // limit does not depend on whether watcher asserts are enabled.
+    this->validate_runtime_args_size(
+        max_runtime_args_per_core_, common_runtime_args.size(), core_with_max_runtime_args_);
 
     // Prepend count when watcher enabled for device-side bounds checking
     if (watcher_assert_enabled_) {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -287,7 +287,7 @@ protected:
     std::vector<uint32_t> common_runtime_args_;
     RuntimeArgsData common_runtime_args_data_{};
     std::set<CoreCoord> core_with_runtime_args_;
-    std::size_t max_runtime_args_per_core_{0};  // For validation
+    std::size_t max_runtime_args_per_core_{0};  // Max user-visible unique RTA count, for validation
     CoreCoord core_with_max_runtime_args_;      // For validation
     std::map<std::string, std::string>
         defines_;  // preprocessor defines. this is to be able to generate generic instances.

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -457,6 +457,48 @@ void insert_stall_cmds(
         0);
 }
 
+// Watcher only: pre-fill an RTA payload region with 0xBEEF0000 | rand16 so unused runtime-arg slots are
+// obviously unset on device (equality tests are likely to fail). With watcher off the region stays zero.
+void fill_runtime_args_watcher_pattern(uint32_t* dst, uint32_t num_words) {
+    thread_local static std::mt19937 gen(std::random_device{}());
+    std::uniform_int_distribution<int> dist(0, 65535);
+    for (uint32_t i = 0; i < num_words; i++) {
+        dst[i] = WATCHER_RTA_UNSET_PATTERN | static_cast<uint16_t>(dist(gen));
+    }
+}
+
+using RtaDataPair =
+    std::pair<std::reference_wrapper<RuntimeArgsData>, std::reference_wrapper<const std::vector<uint32_t>>>;
+
+// Retarget one core's per-kernel RuntimeArgsData at the payload just written into the command stream, so
+// later in-place RTA edits (and re-enqueues) update the command directly. If a kernel's rt_args_data was
+// already retargeted by a previous command sequence, schedule an rta_update copy from there instead.
+// `base` points at the start of this core's RTA payload in the command buffer; kernels are laid out back
+// to back at their [count | args] stride. Shared by the packed and large-unicast RTA emission paths.
+void repoint_rta_data_into_command_stream(
+    char* base,
+    std::vector<RtaDataPair>& kernel_rta_pairs,
+    [[maybe_unused]] const std::vector<std::tuple<const void*, uint32_t, uint32_t>>& kernel_data_and_sizes,
+    uint32_t count_word_offset,
+    std::vector<ProgramCommandSequence::RtaUpdate>& rta_updates) {
+    uint32_t offset = 0;
+    for (uint32_t j = 0; j < kernel_rta_pairs.size(); ++j) {
+        auto& data = kernel_rta_pairs[j];
+        uint32_t* data_in_sequence = reinterpret_cast<uint32_t*>(base + offset) + count_word_offset;
+        // rt_args_data points to args; data.second.get().data() points to count when watcher enabled.
+        if (data.first.get().rt_args_data == (data.second.get().data() + count_word_offset)) {
+            data.first.get().rt_args_data = data_in_sequence;
+        } else {
+            TT_ASSERT(
+                data.first.get().rt_args_data ==
+                (reinterpret_cast<const uint32_t*>(std::get<0>(kernel_data_and_sizes[j])) + count_word_offset));
+            rta_updates.emplace_back(
+                data.first.get().rt_args_data, data_in_sequence, data.first.get().rt_args_count * sizeof(uint32_t));
+        }
+        offset += (data.first.get().rt_args_count + count_word_offset) * sizeof(uint32_t);
+    }
+}
+
 template <typename PackedSubCmd>
 void generate_runtime_args_cmds(
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
@@ -527,20 +569,12 @@ void generate_runtime_args_cmds(
             no_stride);
         auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
         uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
-        // Watcher only: pre-fill the RTA payload region with 0xBEEF0000 | rand16
-        // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand
-        // This makes any unused runtime-arg slots obvious on device (equality tests likely to fail)
+        // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand.
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
             uint32_t total_words = (calculator.write_offset_bytes() - data_offset) / sizeof(uint32_t);
             uint32_t* command_start_ptr =
                 reinterpret_cast<uint32_t*>(command_obj.data()) + (data_offset / sizeof(uint32_t));
-            thread_local static std::mt19937 gen(std::random_device{}());
-            std::uniform_int_distribution<int> dist(0, 65535);
-            for (uint32_t count = 0; count < total_words; count++) {
-                uint16_t rnd = static_cast<uint16_t>(dist(gen));
-                const uint32_t known_garbage = WATCHER_RTA_UNSET_PATTERN | rnd;
-                command_start_ptr[count] = known_garbage;
-            }
+            fill_runtime_args_watcher_pattern(command_start_ptr, total_words);
         }
 
         runtime_args_command_sequences.back().add_dispatch_write_packed<PackedSubCmd>(
@@ -566,35 +600,115 @@ void generate_runtime_args_cmds(
         const uint32_t data_inc = tt::align(max_runtime_args_len * sizeof(uint32_t), l1_alignment);
         uint32_t num_data_copies = no_stride ? 1 : num_packed_cmds;
         for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
-            uint32_t offset = 0;
-            for (uint32_t j = 0; j < rt_args_data[i].size(); ++j) {
-                auto& data = rt_args_data[i][j];
-                uint32_t* data_in_sequence =
-                    reinterpret_cast<uint32_t*>(
-                        reinterpret_cast<char*>(runtime_args_command_sequences.back().data()) + data_offset + offset) +
-                    count_word_offset;
-                // rt_args_data points to args; data.second.get().data() points to count when watcher enabled
-                if (data.first.get().rt_args_data == (data.second.get().data() + count_word_offset)) {
-                    // Update the pointer to point into the command sequence. Future RTA updates will modify the command
-                    // sequence directly.
-                    data.first.get().rt_args_data = data_in_sequence;
-                } else {
-                    TT_ASSERT(
-                        data.first.get().rt_args_data ==
-                        (reinterpret_cast<const uint32_t*>(std::get<0>(rt_data_and_sizes[i][j])) + count_word_offset));
-                    // Pointer already points into another command sequence. Schedule a copy from there.
-                    rta_updates.emplace_back(
-                        data.first.get().rt_args_data,
-                        data_in_sequence,
-                        data.first.get().rt_args_count * sizeof(uint32_t));
-                }
-                offset += (data.first.get().rt_args_count + count_word_offset) * sizeof(uint32_t);
-            }
+            repoint_rta_data_into_command_stream(
+                reinterpret_cast<char*>(runtime_args_command_sequences.back().data()) + data_offset,
+                rt_args_data[i],
+                rt_data_and_sizes[i],
+                count_word_offset,
+                rta_updates);
             data_offset += data_inc;
         }
         num_packed_cmds_in_seq -= num_packed_cmds;
         offset_idx += num_packed_cmds;
     }
+}
+
+// Emit unique runtime args for a kernel group using CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST instead of
+// CQ_DISPATCH_CMD_WRITE_PACKED. Unlike the packed path, the large-unicast dispatch handler wraps CB pages
+// per sub-command, so a single core's RTA payload is no longer limited to one dispatch page. Used when a
+// kernel group's per-core payload exceeds that page (see assemble_runtime_args_commands). The command
+// layout mirrors BatchedTransferGenerator: one sub-command (core) per unicast destination, up to
+// CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS per command, with each core's payload laid out
+// exactly as the packed path lays out its per-core data region so the RTA-update pointers stay valid.
+void generate_runtime_args_cmds_large_unicast(
+    std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
+    std::vector<ProgramCommandSequence::RtaUpdate>& rta_updates,
+    uint32_t l1_arg_base_addr,
+    const std::vector<CQDispatchWritePackedUnicastSubCmd>& sub_cmds,
+    const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>& rt_data_and_sizes,
+    uint32_t rta_payload_sizeB,
+    std::vector<std::vector<
+        std::pair<std::reference_wrapper<RuntimeArgsData>, std::reference_wrapper<const std::vector<uint32_t>>>>>&
+        rt_args_data,
+    uint32_t write_offset_index) {
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    // Device reads rta_payload_sizeB bytes per sub-command, then pads the read pointer to `alignment`, so
+    // consecutive per-core payloads in the command stream are separated by this aligned size.
+    const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
+    const uint32_t count_word_offset = is_watcher_assert_enabled() ? 1 : 0;
+
+    const uint32_t num_cores = sub_cmds.size();
+    uint32_t offset_idx = 0;
+    while (offset_idx < num_cores) {
+        const uint32_t num_in_chunk =
+            std::min<uint32_t>(num_cores - offset_idx, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+
+        std::vector<CQDispatchWritePackedLargeUnicastSubCmd> large_sub_cmds(num_in_chunk);
+        // Per-core payload backing storage. Must outlive the add_dispatch call (memcpy'd into the command).
+        std::vector<std::vector<uint8_t>> core_payloads(num_in_chunk);
+        std::vector<tt::stl::Span<const uint8_t>> data_collection(num_in_chunk);
+
+        for (uint32_t k = 0; k < num_in_chunk; ++k) {
+            const uint32_t i = offset_idx + k;
+            large_sub_cmds[k] = CQDispatchWritePackedLargeUnicastSubCmd{
+                .noc_xy_addr = sub_cmds[i].noc_xy_addr, .addr = l1_arg_base_addr, .length = rta_payload_sizeB};
+
+            auto& buf = core_payloads[k];
+            buf.assign(aligned_core_payload, 0);
+            // With watcher off the buffer stays zero; mirrors the packed path.
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+                fill_runtime_args_watcher_pattern(
+                    reinterpret_cast<uint32_t*>(buf.data()), aligned_core_payload / sizeof(uint32_t));
+            }
+            // Lay out each kernel's [count | args] data at the same per-kernel stride the packed path uses.
+            uint32_t offset = 0;
+            for (const auto& data : rt_data_and_sizes[i]) {
+                if (std::get<0>(data)) {
+                    std::memcpy(buf.data() + offset, std::get<0>(data), std::get<1>(data));
+                }
+                offset += std::get<2>(data);
+            }
+            data_collection[k] = tt::stl::Span<const uint8_t>(buf.data(), buf.size());
+        }
+
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_packed_large_unicast(num_in_chunk, num_in_chunk * aligned_core_payload);
+        auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
+
+        std::vector<uint8_t*> data_collection_location;
+        command_obj.add_dispatch_write_packed_large_unicast(
+            CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS,
+            l1_alignment,
+            num_in_chunk,
+            large_sub_cmds,
+            data_collection,
+            &data_collection_location,
+            0,
+            write_offset_index);
+        TT_ASSERT(command_obj.size_bytes() == command_obj.write_offset_bytes());
+
+        // Repoint each core's kernels' RuntimeArgsData into the command stream (or schedule an rta_update
+        // copy). Each core's payload is a distinct data_collection entry (no fixed inter-core stride).
+        for (uint32_t k = 0; k < num_in_chunk; ++k) {
+            const uint32_t i = offset_idx + k;
+            repoint_rta_data_into_command_stream(
+                reinterpret_cast<char*>(data_collection_location[k]),
+                rt_args_data[i],
+                rt_data_and_sizes[i],
+                count_word_offset,
+                rta_updates);
+        }
+        offset_idx += num_in_chunk;
+    }
+}
+
+// A kernel group's unique RTAs must go through CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST when their
+// per-core payload exceeds one dispatch page: the CQ_DISPATCH_CMD_WRITE_PACKED device handler asserts each
+// per-core write fits a single dispatch page (its `size` field is uint16_t and it does not wrap CB pages).
+bool unique_rta_requires_large_unicast(uint32_t total_rta_size) {
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t dispatch_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+    return tt::align(total_rta_size, l1_alignment) > dispatch_page_size;
 }
 
 struct Transfer {
@@ -655,14 +769,18 @@ BatchedTransfers assemble_runtime_args_commands(
         for (auto& kg : program.get_kernel_groups(programmable_core_type_index)) {
             if (kg->total_rta_size != 0) {
                 uint32_t num_sub_cmds = kg->core_ranges.num_cores();
-                uint32_t max_runtime_args_len = kg->total_rta_size / sizeof(uint32_t);
-                uint32_t max_packed_cmds =
-                    calculator.get_max_write_packed_sub_cmds<decltype(unique_sub_cmds)::value_type>(
-                        max_runtime_args_len,
-                        constants.max_prefetch_command_size,
-                        constants.packed_write_max_unicast_sub_cmds,
-                        false);
-                command_count += div_up(num_sub_cmds, max_packed_cmds);
+                if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
+                    command_count += div_up(num_sub_cmds, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+                } else {
+                    uint32_t max_runtime_args_len = kg->total_rta_size / sizeof(uint32_t);
+                    uint32_t max_packed_cmds =
+                        calculator.get_max_write_packed_sub_cmds<decltype(unique_sub_cmds)::value_type>(
+                            max_runtime_args_len,
+                            constants.max_prefetch_command_size,
+                            constants.packed_write_max_unicast_sub_cmds,
+                            false);
+                    command_count += div_up(num_sub_cmds, max_packed_cmds);
+                }
             }
         }
     }
@@ -790,17 +908,31 @@ BatchedTransfers assemble_runtime_args_commands(
                     }
                 }
                 uint32_t rta_offset = program.get_program_config(index).rta_offset;
-                generate_runtime_args_cmds(
-                    program_command_sequence.runtime_args_command_sequences,
-                    program_command_sequence.rta_updates,
-                    rta_offset,
-                    unique_sub_cmds,
-                    unique_rt_data_and_sizes,
-                    kg->total_rta_size / sizeof(uint32_t),
-                    unique_rt_args_data,
-                    constants,
-                    false,
-                    get_dispatch_write_offset(programmable_core_type));
+                if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
+                    // Per-core payload exceeds one dispatch page; the packed-write handler cannot span
+                    // pages, so send these unique RTAs via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST.
+                    generate_runtime_args_cmds_large_unicast(
+                        program_command_sequence.runtime_args_command_sequences,
+                        program_command_sequence.rta_updates,
+                        rta_offset,
+                        unique_sub_cmds,
+                        unique_rt_data_and_sizes,
+                        kg->total_rta_size,
+                        unique_rt_args_data,
+                        get_dispatch_write_offset(programmable_core_type));
+                } else {
+                    generate_runtime_args_cmds(
+                        program_command_sequence.runtime_args_command_sequences,
+                        program_command_sequence.rta_updates,
+                        rta_offset,
+                        unique_sub_cmds,
+                        unique_rt_data_and_sizes,
+                        kg->total_rta_size / sizeof(uint32_t),
+                        unique_rt_args_data,
+                        constants,
+                        false,
+                        get_dispatch_write_offset(programmable_core_type));
+                }
                 for (auto& data_per_kernel : unique_rt_data_and_sizes) {
                     for (auto& data_and_sizes : data_per_kernel) {
                         RecordDispatchData(program.get_id(), DISPATCH_DATA_RTARGS, std::get<1>(data_and_sizes));

--- a/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
@@ -5,8 +5,12 @@
 #include "disaggregation.hpp"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/map.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
+
+#include <map>
+#include <span>
 
 #include <tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
@@ -82,7 +86,24 @@ void bind_disaggregation_api(nb::module_& mod) {
         .def(
             nb::init<const KvChunkAddressTableConfig&>(),
             nb::arg("config"),
-            "Construct a KvChunkAddressTable from configuration.")
+            "Construct a single-config KvChunkAddressTable (config id 0, name \"0\").")
+        .def(
+            "__init__",
+            [](KvChunkAddressTable* self, const std::vector<KvChunkAddressTableConfig>& configs) {
+                new (self) KvChunkAddressTable(std::span<const KvChunkAddressTableConfig>(configs));
+            },
+            nb::arg("configs"),
+            R"(
+            Construct a multi-config KvChunkAddressTable from a list of configs.
+            Config i is named "i", so string accessors resolve "0".."N-1" to ids 0..N-1.
+            )")
+        .def(
+            nb::init<const std::map<std::string, KvChunkAddressTableConfig>&>(),
+            nb::arg("configs"),
+            R"(
+            Construct a multi-config KvChunkAddressTable from a name->config map.
+            Config ids are assigned in sorted key order; each config's name is its key.
+            )")
 
         // Device group management
         .def(
@@ -106,15 +127,28 @@ void bind_disaggregation_api(nb::module_& mod) {
         // Mutators
         .def(
             "set",
-            &KvChunkAddressTable::set,
+            static_cast<void (KvChunkAddressTable::*)(uint32_t, uint32_t, uint32_t, KvCacheLocation, uint32_t)>(
+                &KvChunkAddressTable::set),
             nb::arg("layer"),
             nb::arg("position"),
             nb::arg("slot"),
             nb::arg("location"),
+            nb::arg("config_id") = 0,
             R"(
-            Set the location for a specific (layer, position, slot).
-            Position is in tokens and must be chunk-aligned (multiple of chunk_n_tokens).
+            Set the location for a specific (layer, position, slot, config_id).
+            Position is in tokens and must be chunk-aligned (multiple of the config's chunk_n_tokens).
+            config_id defaults to 0 (the single-config case).
             )")
+        .def(
+            "set",
+            static_cast<void (KvChunkAddressTable::*)(uint32_t, uint32_t, uint32_t, KvCacheLocation, const std::string&)>(
+                &KvChunkAddressTable::set),
+            nb::arg("layer"),
+            nb::arg("position"),
+            nb::arg("slot"),
+            nb::arg("location"),
+            nb::arg("config"),
+            "Set the location for a specific (layer, position, slot, config-name).")
         .def(
             "set_fabric_node_host",
             &KvChunkAddressTable::set_fabric_node_host,
@@ -125,19 +159,37 @@ void bind_disaggregation_api(nb::module_& mod) {
         // Accessors
         .def(
             "lookup",
-            &KvChunkAddressTable::lookup,
+            static_cast<const KvCacheLocation& (KvChunkAddressTable::*)(uint32_t, uint32_t, uint32_t, uint32_t) const>(
+                &KvChunkAddressTable::lookup),
             nb::arg("layer"),
             nb::arg("position"),
             nb::arg("slot"),
+            nb::arg("config_id") = 0,
             nb::rv_policy::reference_internal,
             R"(
-            Lookup a single entry. Position is in tokens (chunk-aligned).
-            Returns a reference to the KvCacheLocation.
+            Lookup a single entry by (layer, position, slot, config_id). Position is in tokens (chunk-aligned).
+            config_id defaults to 0. Returns a reference to the KvCacheLocation.
             )")
         .def(
+            "lookup",
+            static_cast<
+                const KvCacheLocation& (KvChunkAddressTable::*)(uint32_t, uint32_t, uint32_t, const std::string&) const>(
+                &KvChunkAddressTable::lookup),
+            nb::arg("layer"),
+            nb::arg("position"),
+            nb::arg("slot"),
+            nb::arg("config"),
+            nb::rv_policy::reference_internal,
+            "Lookup a single entry by (layer, position, slot, config-name).")
+        .def(
             "lookup_range",
-            [](const KvChunkAddressTable& table, uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot) {
-                auto span = table.lookup_range(layer, start_pos, end_pos, slot);
+            [](const KvChunkAddressTable& table,
+               uint32_t layer,
+               uint32_t start_pos,
+               uint32_t end_pos,
+               uint32_t slot,
+               uint32_t config_id) {
+                auto span = table.lookup_range(layer, start_pos, end_pos, slot, config_id);
                 // Convert span to vector for Python
                 return std::vector<KvCacheLocation>(span.begin(), span.end());
             },
@@ -145,12 +197,30 @@ void bind_disaggregation_api(nb::module_& mod) {
             nb::arg("start_pos"),
             nb::arg("end_pos"),
             nb::arg("slot"),
+            nb::arg("config_id") = 0,
             R"(
-            Lookup a contiguous range of position chunks for a given (layer, slot).
-            Returns a list of KvCacheLocation entries.
+            Lookup a contiguous range of position chunks for a given (layer, slot, config_id).
+            Returns a list of KvCacheLocation entries. config_id defaults to 0.
             start_pos must be chunk-aligned. end_pos need not be aligned.
             Returns entries for chunks covering positions [start_pos, end_pos).
             )")
+        .def(
+            "lookup_range",
+            [](const KvChunkAddressTable& table,
+               uint32_t layer,
+               uint32_t start_pos,
+               uint32_t end_pos,
+               uint32_t slot,
+               const std::string& config) {
+                auto span = table.lookup_range(layer, start_pos, end_pos, slot, config);
+                return std::vector<KvCacheLocation>(span.begin(), span.end());
+            },
+            nb::arg("layer"),
+            nb::arg("start_pos"),
+            nb::arg("end_pos"),
+            nb::arg("slot"),
+            nb::arg("config"),
+            "Lookup a contiguous range of position chunks for a given (layer, slot, config-name).")
         .def(
             "get_host",
             &KvChunkAddressTable::get_host,
@@ -167,17 +237,32 @@ void bind_disaggregation_api(nb::module_& mod) {
         .def(
             "config",
             &KvChunkAddressTable::config,
+            nb::arg("config_id") = 0,
             nb::rv_policy::reference_internal,
-            "Get the configuration used to construct this table.")
+            "Get a config by id (default 0, the lone config of a single-config table).")
+        .def("num_configs", &KvChunkAddressTable::num_configs, "Number of configs (\"groups\") held by this table.")
+        .def(
+            "config_name",
+            &KvChunkAddressTable::config_name,
+            nb::arg("config_id"),
+            nb::rv_policy::reference_internal,
+            "Name of a config by id.")
+        .def(
+            "config_id_of",
+            &KvChunkAddressTable::config_id_of,
+            nb::arg("name"),
+            "Resolve a config name to its id (throws if unknown).")
         .def(
             "num_position_chunks",
             &KvChunkAddressTable::num_position_chunks,
-            "Number of position chunks (computed from config).")
-        .def("total_entries", &KvChunkAddressTable::total_entries, "Total number of entries in the table.");
+            nb::arg("config_id") = 0,
+            "Number of position chunks for a config (default 0).")
+        .def("total_entries", &KvChunkAddressTable::total_entries, "Total number of entries summed across all configs.")
 
-    // Protobuf file round-trip. Lets a model-side callback build a table from
-    // its live KV cache, write the .pb, and hand the path to a migration
-    // endpoint (e.g. via _migration_client.send_kv_chunk_table()).
+
+
+    // Protobuf serialization — the runner publishes the table to the
+    // migration_worker (SET_TABLE consumes a serialized protobuf file path).
     mod.def(
         "export_kv_chunk_table_to_protobuf_file",
         [](const KvChunkAddressTable& table, const std::string& path) { export_to_protobuf_file(table, path); },

--- a/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
@@ -257,9 +257,7 @@ void bind_disaggregation_api(nb::module_& mod) {
             &KvChunkAddressTable::num_position_chunks,
             nb::arg("config_id") = 0,
             "Number of position chunks for a config (default 0).")
-        .def("total_entries", &KvChunkAddressTable::total_entries, "Total number of entries summed across all configs.")
-
-
+        .def("total_entries", &KvChunkAddressTable::total_entries, "Total number of entries summed across all configs.");
 
     // Protobuf serialization — the runner publishes the table to the
     // migration_worker (SET_TABLE consumes a serialized protobuf file path).


### PR DESCRIPTION
## Summary
- Cherry-pick [tt-metal#48686](https://github.com/tenstorrent/tt-metal/pull/48686) (increase max RTAs beyond 341 via `WRITE_PACKED_LARGE_UNICAST`) — clean.
- Cherry-pick [tt-metal#48620](https://github.com/tenstorrent/tt-metal/pull/48620) (multi-config `KvChunkAddressTable`) — **custom commit**: upstream squash targets `internal/disaggregation` (post-#48638); this branch still has `experimental/`, so the change is re-homed there. Preserves blaze nanobind `export_kv_chunk_table_*` / `import_kv_chunk_table_*`; omits `read_device_chunk` / `tensor_from_bfp8_bytes` (not on this branch).
- Follow-up fix: terminating `;` on the nanobind method chain after dropping `read_device_chunk`.

Tracked in [tt-blaze#1903](https://github.com/tenstorrent/tt-blaze/issues/1903) ([48620 request](https://github.com/tenstorrent/tt-blaze/issues/1903#issuecomment-4917645698), [48686 request](https://github.com/tenstorrent/tt-blaze/issues/1903#issuecomment-4917792741)).

## Commits
| SHA | Origin | Notes |
|-----|--------|-------|
| `a34b35fa564` | #48686 squash `3ab173404d7` | clean cherry-pick |
| `9c54521378b` | #48620 squash `c7c5c53bb16` | **custom** — experimental/ re-home |
| `ab573aab876` | follow-up | nanobind `;` after dropping read_device |

## Validation
- Artifact: https://github.com/tenstorrent/tt-metal/actions/runs/29048617935
- Blaze test pin branch: `stevendae/test-cherry-48620-48686` (main + pin to tip)

## Test plan
- [ ] `build-artifact.yaml` on this branch (`build-wheel=true`)
- [ ] tt-blaze CI (Merge Tests) from test pin branch
- [ ] tt-blaze BH Loudbox Intermittent from test pin branch
- [ ] Rebase-merge when green; then blaze submodule bump

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stevendae/cherry-48620-48686)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stevendae/cherry-48620-48686)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stevendae/cherry-48620-48686)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stevendae/cherry-48620-48686)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stevendae/cherry-48620-48686)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stevendae/cherry-48620-48686)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stevendae/cherry-48620-48686)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stevendae/cherry-48620-48686)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stevendae/cherry-48620-48686)