### PR TITLE
[metal2] migrate rand to Metal 2.0 with correct-by-construction per-enqueue run args

### DIFF
--- a/tech_reports/Metal2DynamicRunArgs/README.md
+++ b/tech_reports/Metal2DynamicRunArgs/README.md
@@ -1,0 +1,127 @@
+# Correct-by-Construction Per-Enqueue Run Args in Metal 2.0
+
+**Status:** RFC + landed, hardware-verified reference migration (`rand` on Metal 2.0, `get_dynamic_runtime_args` deleted)
+**Scope:** the Metal 2.0 device-op adapter (`MetalV2MeshWorkloadFactoryAdapter`) + Metal 2.0 op factories
+**Author:** Diego Gomez
+
+---
+
+## TL;DR
+
+A value that varies per dispatch but is deliberately kept out of the program-cache key (an RNG
+`seed`, a `[from,to)` range) must be re-applied to the cached program on every cache hit, or it
+stays frozen at whatever the first cache miss baked in — a silent wrong result that only appears on
+the second dispatch. Metal 2.0 already has the right *shape* for this (immutable `ProgramSpec` = the
+cache key; mutable `ProgramRunArgs` = re-specified per enqueue; `SetProgramRunArgs` validates every
+named runtime arg is set) — **but the adapter's cache-hit path did not use it**: it re-applied only
+tensor args (`UpdateTensorArgs`) and left the scalar kernel run args frozen. So the frozen-runtime-arg
+bug was unsolved in Metal 2.0, not just in the descriptor shim.
+
+This change adds one small, additive hook: if a Metal 2.0 factory declares `create_program_run_args`,
+the adapter re-derives the `ProgramRunArgs` from the live `operation_attributes` and re-applies them
+via `SetProgramRunArgs` on **every cache hit**. Completeness is enforced by construction — Metal 2.0's
+own validation rejects a run-args set that doesn't specify every named runtime arg in the
+`ProgramSpec`. No new binding type, no positional `(kernel_idx, arg_idx)`, nothing hand-mirrored.
+
+**Verified on hardware:** `rand` is fully migrated to Metal 2.0 with this hook and its
+`get_dynamic_runtime_args` deleted; the rand test suite passes, including
+`test_rand_different_seed_values` and `test_rand_different_from_to_values` — the **changing-value**
+cache-hit case (same shape, different seed/range → single cache entry → correct new output, not
+frozen). See §5 for a measured perf comparison (currently a host-side regression — the naive re-apply
+is a known optimization target).
+
+## 1. The gap (unsolved in Metal 2.0)
+
+The program cache keys a Metal 2.0 op on its `operation_attributes` (`compute_mesh_workload_hash`),
+not on the `ProgramSpec`. So an op excludes a value from the key by omitting it from
+`attribute_values()`; that obligates re-application every dispatch. On a cache miss the adapter builds
+the program from the spec and applies the initial run args via `SetProgramRunArgs`. On a cache **hit**
+the adapter previously did only `UpdateTensorArgs(program, fresh_tensor_args)` — the scalar kernel run
+args (where a `seed`/range lives) were never re-applied. The mechanism to fix it existed; it just
+wasn't wired into the hit path.
+
+## 2. The fix
+
+```cpp
+// MetalV2MeshWorkloadFactoryAdapter::apply_descriptor (cache hit)
+if constexpr (requires { MetalV2Factory::create_program_run_args(attrs, tensor_args, ret); }) {
+    for (auto& [range, program] : cached_workload.workload.get_programs()) {
+        auto run_args = MetalV2Factory::create_program_run_args(attrs, tensor_args, ret);
+        SetProgramRunArgs(program, run_args);   // re-applies scalars + tensors, validates completeness
+    }
+    return;
+}
+// else: existing tensor-only UpdateTensorArgs fast path (unchanged for ops that don't opt in)
+```
+
+`create_program_run_args` re-derives the run args from the **live** attributes, so a hit applies the
+current value, not the frozen one. `SetProgramRunArgs` validates every named runtime arg in the
+`ProgramSpec`'s `RuntimeArgSchema` is present — a missing one is a hard error, not a silent freeze.
+That is the correct-by-construction property, and it is Metal 2.0's own, not a bolt-on.
+
+A second, smaller adapter fix was needed for input-less ops: the adapter sourced the `MeshDevice`
+only from `tensor_args`. `rand` has no input tensor, so it now falls back to the output tensor
+(`tensor_return_value`) and then to a `MeshDevice*` in `operation_attributes`.
+
+## 3. Reference migration: `rand`
+
+`rand` is the natural proof — it excludes `seed`/`from`/`to` from the key and must re-apply them per
+dispatch. Migration (following Audrey's op-porting recipe):
+
+- **Kernels forked to Metal 2.0** (`rand/device/kernels/compute_rand.cpp`, `writer_rand.cpp`):
+  named runtime args (`get_arg(args::seed)`), DFB accessor (`DataflowBuffer(dfb::cb_intermed)`),
+  tensor accessor (`TensorAccessor(tensor::output)`). Forked (not editing the shared `uniform`
+  kernels) so the legacy `uniform` op is untouched. The writer drops the legacy bf16 conversion
+  staging CB (rand is always FLOAT32), which also removes the single-ended-FIFO shape the M2 lowering
+  rejects on a DM kernel.
+- **`RandProgramFactory`** with `create_program_artifacts` (ProgramSpec: one Float32 intermed DFB,
+  compute PRODUCER + writer CONSUMER, output `TensorParameter`) and `create_program_run_args`
+  (seed/from/to/start_id/num_tiles as named per-node run args).
+- **`RandDeviceOperation`** restructured to the `program_factory_t` variant + `select_program_factory`
+  form; `create_descriptor` and `get_dynamic_runtime_args` **deleted**. `attribute_values()` still
+  omits seed/from/to (key excludes them).
+
+**Tests (hardware):** the existing `test_rand_different_seed_values` / `test_rand_different_from_to_values`
+pass — different seed / range, same shape → single cache entry (hit) → correct, changed output. This
+is the changing-value case, on a real op.
+
+**Known limitation:** the M2 adapter stamps one program's run args across the mesh, so per-**device**
+unique seeding (sharded mesh) is not yet supported on this path (needs per-coord run args). Single-
+device / replicated seeding is correct.
+
+## 4. What landed
+
+- `mesh_device_operation_adapter.hpp` — the `create_program_run_args` opt-in hook + input-less device
+  sourcing.
+- `rand/device/*` — the full Metal 2.0 migration (kernels, factory, device op), `get_dynamic_runtime_args`
+  deleted.
+
+## 5. Performance (measured, honest)
+
+Same `benchmark_rand_perf.py` command on both revisions (single device, float32, tile, DRAM;
+5 warmup, 100 hit iters, 3 repeats, median):
+
+| shape | miss before → after | hit before → after |
+|---|---|---|
+| 1024×1024 | 469 → 881 µs (**+88%**) | 80 → 146 µs (**+83%**) |
+| 4096×4096 | 907 → 1217 µs (**+34%**) | 588 → 600 µs (**+2%**) |
+
+**This migration is currently a host-side regression.** On every cache hit, `create_program_run_args`
+rebuilds the full run args (work split + per-core string-keyed `Table<std::string,uint32_t>` for all
+cores) and `SetProgramRunArgs` re-applies *everything* with validation — versus the descriptor path's
+targeted patch of just the changed scalar slots. It is host-bound, so it hurts most on small shapes
+(1024², host-dominated) and washes out at 4096² hit (+2%, device-dominated).
+
+The regression is a property of the *naive* re-apply, not of the correctness model. Closing it:
+- **Re-apply only the changing args** via `UpdateProgramRunArgs` + `enqueue_invariant` advanced
+  options (mark start_id/num_tiles/tensor invariant; re-apply only seed/from/to) instead of a full
+  `SetProgramRunArgs`.
+- **Avoid rebuilding the full run args** on hit — factor out just the changing scalars; avoid the
+  per-node string-keyed tables on the hot path.
+
+## 6. Follow-ups
+
+- The perf optimization above (the priority before this pattern scales to more ops).
+- Per-coord run args on the M2 adapter → per-device unique seeding for sharded mesh.
+- Op-owned tensors on the per-enqueue path (the reference handles io tensors only).
+- Migrate the remaining excluded-scalar ops (uniform, bernoulli, dropout, …) once the perf path is in.

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -730,16 +730,26 @@ public:
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull from the
-            // first device tensor reachable from tensor_args. Op factories
-            // satisfying this concept are tensor-driven, so first_tensor is
-            // always populated for current callers.
-            auto first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_args);
+            // Metal 2.0's MakeProgramFromSpec needs a MeshDevice. Most ops are tensor-driven, so pull
+            // it from the first device tensor in tensor_args. Input-less ops (e.g. rand) have no input
+            // tensor, so fall back to the output tensor (tensor_return_value, allocated on the device)
+            // and then to a MeshDevice* carried in operation_attributes.
+            tt::tt_metal::distributed::MeshDevice* mesh_device = nullptr;
+            if (auto in = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_args);
+                in.has_value()) {
+                mesh_device = in.value().device();
+            } else if (auto out = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_return_value);
+                       out.has_value()) {
+                mesh_device = out.value().device();
+            } else if (auto dev =
+                           ttsl::reflection::get_first_object_of_type<tt::tt_metal::distributed::MeshDevice*>(attrs);
+                       dev.has_value()) {
+                mesh_device = dev.value();
+            }
             TT_FATAL(
-                first_tensor.has_value(),
-                "MetalV2 factory adapter requires at least one Tensor in tensor_args to source the MeshDevice");
-            auto* mesh_device = first_tensor.value().device();
-            TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
+                mesh_device != nullptr,
+                "MetalV2 factory adapter could not source a MeshDevice from tensor_args, the output tensor, or "
+                "operation_attributes (need at least one Tensor or a MeshDevice* attribute)");
 
             // The factory produces a single ProgramArtifacts; the adapter stamps it
             // across all coordinate ranges. Bindings derive from the (single) set of
@@ -782,9 +792,34 @@ public:
         // dispatcher's historical naming, not a reference to ProgramDescriptor.
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& /*attrs*/,
+            const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
+            // Per-enqueue run args (the correct-by-construction path for hash-excluded scalars).
+            //
+            // If the op declares create_program_run_args(), it re-derives the FULL ProgramRunArgs
+            // from the LIVE operation_attributes on every dispatch. We re-apply them on each cache
+            // hit via SetProgramRunArgs, which validates that every named runtime arg declared in the
+            // ProgramSpec's RuntimeArgSchema is set (completeness by construction) and also refreshes
+            // tensor args. This is how a value the op deliberately kept out of the program-cache key
+            // (an RNG seed, a pad value, an [from,to) range) gets re-applied instead of frozen at the
+            // first miss — the Metal 2.0-native successor to the descriptor shim's get_dynamic_*
+            // hooks, using only the existing SetProgramRunArgs API. Ops without the hook compile this
+            // away and keep the tensor-only UpdateTensorArgs fast path below.
+            //
+            // NOTE: create_program_run_args must reference the same op-owned tensors the miss parked
+            // (stable addresses); ops that allocate op-owned tensors are not yet supported on this
+            // path (none of the current per-enqueue-scalar ops do).
+            if constexpr (requires {
+                              MetalV2Factory::create_program_run_args(attrs, tensor_args, tensor_return_value);
+                          }) {
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    auto run_args = MetalV2Factory::create_program_run_args(attrs, tensor_args, tensor_return_value);
+                    tt::tt_metal::experimental::SetProgramRunArgs(program, run_args);
+                }
+                return;
+            }
+
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 const auto& sv = cached_workload.shared_variables.at(coordinate_range);

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 op-local compute kernel for rand. The RNG logic is unchanged from the legacy
+// uniform compute kernel (compute_uniform.cpp); only the resource bindings move to the Metal 2.0
+// namespaces (dfb::/args::). seed/from/to are per-enqueue named runtime args: they are excluded
+// from the program-cache key and re-applied on every dispatch via the factory's
+// create_program_run_args (SetProgramRunArgs on cache hit), so they are never frozen.
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/rand.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t seed = get_arg(args::seed);
+    union {
+        float f;
+        uint32_t u;
+    } f2u_from, f2u_to, f2u_scale;
+    f2u_from.u = get_arg(args::from_bits);
+    f2u_to.u = get_arg(args::to_bits);
+    f2u_scale.f = f2u_to.f - f2u_from.f;
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+    const uint32_t end_id = start_id + num_tiles;
+
+    DataflowBuffer cb_intermed(dfb::cb_intermed);
+
+    init_sfpu(dfb::cb_intermed, dfb::cb_intermed);
+
+    rand_tile_init(seed);
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.reserve_back(1);
+
+        tile_regs_acquire();
+        rand_tile(0, f2u_from.u, f2u_scale.u);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, dfb::cb_intermed, 0);
+        tile_regs_release();
+
+        cb_intermed.push_back(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 op-local writer for rand. rand's output is always FLOAT32 (rand.cpp forces FLOAT32 then
+// typecasts), so this only implements the direct FLOAT32 path: stream each generated tile out of the
+// intermed DataflowBuffer straight to the output tensor. The legacy uniform writer's bf16 conversion
+// staging CB (dst_cb / c_0) is dropped — it was unused on the FLOAT32 path — which also removes the
+// single-ended-FIFO shape the Metal 2.0 lowering rejects on a data-movement kernel.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+    constexpr uint32_t page_size = get_arg(args::page_size);
+
+    Noc noc;
+    DataflowBuffer cb_intermed(dfb::cb_intermed);
+    const auto out = TensorAccessor(tensor::output);
+
+    const uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.wait_front(1);
+        noc.async_write(cb_intermed, out, page_size, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_intermed.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -9,6 +9,11 @@
 
 namespace ttnn::operations::rand {
 
+RandDeviceOperation::program_factory_t RandDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
+    return RandProgramFactory{};
+}
+
 void RandDeviceOperation::validate_inputs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
     TT_FATAL(operation_attributes.from < operation_attributes.to, "Rand: `from` argument must be < `to` argument");

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -5,63 +5,34 @@
 #pragma once
 
 #include <optional>
-
+#include <variant>
 #include <vector>
+
+#include "rand_device_operation_types.hpp"
+#include "rand_program_factory.hpp"
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::rand {
 
+// Metal 2.0 device operation for rand. Uses the MetalV2FactoryConcept path: a program_factory_t
+// variant + select_program_factory, with RandProgramFactory providing create_program_artifacts
+// (ProgramSpec + ProgramRunArgs). seed/from/to are per-enqueue run args re-applied on every cache
+// hit (RandProgramFactory::create_program_run_args) rather than baked into a descriptor.
 struct RandDeviceOperation {
-    struct operation_attributes_t {
-        const ttnn::Shape shape;
-        DataType dtype;
-        Layout layout;
-        const MemoryConfig memory_config;
-        MeshDevice* device;
-        const float from;
-        const float to;
-        uint32_t seed;
-        ttsl::SmallVector<bool> mesh_dim_is_sharded;
-
-        // Program identity. seed/from/to are re-applied via get_dynamic_runtime_args (excluded
-        // here). `device` must be FIRST: rand has no input tensor, so the framework discovers the
-        // mesh device via get_first_object_of_type over attribute_values(), and its tuple path only
-        // inspects element 0.
-        static constexpr auto attribute_names =
-            std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
-        auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
-    };
-
-    struct tensor_args_t {};
-
+    using operation_attributes_t = RandOperationAttributes;
+    using tensor_args_t = RandTensorArgs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<RandProgramFactory>;
 
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // seed/from/to are excluded from the program hash (so calls differing only in
-    // those values cache-hit instead of recompiling).  They are therefore DYNAMIC: this returns the
-    // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
-    // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
-    // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation_types.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/distributed/types.hpp"
+#include <tt_stl/small_vector.hpp>
+
+namespace ttnn::operations::rand {
+
+struct RandOperationAttributes {
+    const ttnn::Shape shape;
+    DataType dtype;
+    Layout layout;
+    const MemoryConfig memory_config;
+    MeshDevice* device;
+    const float from;
+    const float to;
+    uint32_t seed;
+    ttsl::SmallVector<bool> mesh_dim_is_sharded;
+
+    // Program identity (the program-cache key). seed/from/to are DELIBERATELY OMITTED here so that
+    // calls differing only in those values cache-HIT instead of recompiling; they are re-applied on
+    // every dispatch as Metal 2.0 per-enqueue run args (see RandProgramFactory::create_program_run_args).
+    // `device` must be FIRST: rand has no input tensor, so the framework discovers the mesh device via
+    // get_first_object_of_type over attribute_values(), and its tuple path only inspects element 0.
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
+    auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
+};
+
+struct RandTensorArgs {};
+
+}  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -1,234 +1,198 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
+#include <array>
 #include <bit>
 #include <ctime>
 #include <limits>
 #include <random>
+#include <vector>
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp>
+#include <tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp>
+
 #include "ttnn/tensor/types.hpp"
-#include "rand_device_operation.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include "rand_program_factory.hpp"
 
 namespace ttnn::operations::rand {
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace {
 
+constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand.cpp";
+
 std::mt19937 rng(std::time(nullptr));
 std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max());
+uint32_t get_random_seed() { return distribution(rng); }
 
-auto get_random_seed() -> uint32_t { return distribution(rng); }
-
-constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
-constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp";
-
-// Work split + per-device seed offset, shared by create_descriptor (cache miss) and
-// get_dynamic_runtime_args (cache hit) so both derive the identical core list and seed offset.
+// Work split shared by create_program_artifacts (spec build) and create_program_run_args (hit-patch)
+// so both derive the identical core list. NOTE: device_seed_offset is 0 here — the M2 adapter stamps
+// one program's run args across the whole mesh, so per-DEVICE unique seeding (sharded mesh) is not yet
+// supported on this path (needs per-coord run args). Single-device / replicated seeding is correct.
 struct RandWorkSplit {
-    uint32_t num_cores = 0;
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
     CoreRangeSet core_group_2;
     uint32_t units_per_core_group_1 = 0;
     uint32_t units_per_core_group_2 = 0;
     std::vector<CoreCoord> cores;
-    uint32_t device_seed_offset = 0;
 };
 
-RandWorkSplit compute_rand_work_split(
-    const RandDeviceOperation::operation_attributes_t& attrs,
-    RandDeviceOperation::tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+RandWorkSplit compute_rand_work_split(const Tensor& output) {
     auto grid = output.device()->compute_with_storage_grid_size();
     uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
     auto cores = grid_to_cores(num_cores, grid.x, grid.y);
-
-    const ttnn::MeshCoordinate mesh_coordinate =
-        mesh_dispatch_coordinate.value_or(ttnn::MeshCoordinate::zero_coordinate(attrs.device->shape().dims()));
-    uint32_t device_seed_offset = 0;
-    const auto& shard_mask = attrs.mesh_dim_is_sharded;
-    if (!shard_mask.empty()) {
-        const auto& mesh_shape = attrs.device->shape();
-        size_t shard_linear_idx = 0;
-        size_t shard_stride = 1;
-        for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
-            if (shard_mask[i]) {
-                shard_linear_idx += mesh_coordinate[i] * shard_stride;
-                shard_stride *= mesh_shape[i];
-            }
-        }
-        device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
-    }
-    return {
-        num_cores,
-        all_cores,
-        core_group_1,
-        core_group_2,
-        units_per_core_group_1,
-        units_per_core_group_2,
-        std::move(cores),
-        device_seed_offset};
+    return {all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2, std::move(cores)};
 }
 
-// Per-core seed; shared so the miss-build and the hit-patch produce identical values.
-uint32_t rand_seed_for_core(
-    const RandDeviceOperation::operation_attributes_t& attrs, int i, uint32_t device_seed_offset) {
-    return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
+// Per-core seed; shared so miss-build and hit-patch produce identical values.
+uint32_t rand_seed_for_core(const RandOperationAttributes& attrs, int i) {
+    return attrs.seed != 0 ? attrs.seed + static_cast<uint32_t>(i) : get_random_seed();
+}
+
+// Single source of truth for the per-enqueue ProgramRunArgs. Built on cache miss (initial values) AND
+// re-derived on every cache hit (fresh seed/from/to) — so seed/from/to are re-applied, never frozen.
+ProgramRunArgs build_run_args(const RandOperationAttributes& attrs, const Tensor& output) {
+    const KernelSpecName COMPUTE_KERNEL{"compute"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
+    const TensorParamName OUTPUT{"output"};
+
+    auto ws = compute_rand_work_split(output);
+
+    constexpr float eps = 1e-6f;
+    const uint32_t from_bits = std::bit_cast<uint32_t>(attrs.from);
+    const uint32_t to_bits = std::bit_cast<uint32_t>(attrs.to - eps);
+
+    KernelRunArgs compute_run{.kernel = COMPUTE_KERNEL};
+    KernelRunArgs writer_run{.kernel = WRITER_KERNEL};
+    compute_run.runtime_arg_values.reserve(ws.cores.size());
+    writer_run.runtime_arg_values.reserve(ws.cores.size());
+
+    uint32_t tile_offset = 0;
+    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
+        const auto& core = ws.cores[i];
+        uint32_t units_per_core = 0;
+        if (ws.core_group_1.contains(core)) {
+            units_per_core = ws.units_per_core_group_1;
+        } else if (ws.core_group_2.contains(core)) {
+            units_per_core = ws.units_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        const uint32_t seed = rand_seed_for_core(attrs, i);
+        const NodeCoord node = core;
+        compute_run.runtime_arg_values.push_back(
+            {node,
+             {{"seed", seed},
+              {"from_bits", from_bits},
+              {"to_bits", to_bits},
+              {"start_id", tile_offset},
+              {"num_tiles", units_per_core}}});
+        writer_run.runtime_arg_values.push_back({node, {{"start_id", tile_offset}, {"num_tiles", units_per_core}}});
+        tile_offset += units_per_core;
+    }
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(compute_run), std::move(writer_run)};
+    run_args.tensor_args = {{OUTPUT, ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())}}};
+    return run_args;
 }
 
 }  // namespace
 
-ProgramDescriptor RandDeviceOperation::create_descriptor(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    auto
-        [num_cores,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         units_per_core_group_1,
-         units_per_core_group_2,
-         cores,
-         device_seed_offset] = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-    const auto num_cores_total = cores.size();
+ttnn::device_operation::ProgramArtifacts RandProgramFactory::create_program_artifacts(
+    const RandOperationAttributes& operation_attributes, const RandTensorArgs& /*tensor_args*/, Tensor& output) {
+    const DFBSpecName CB_INTERMED{"cb_intermed"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName COMPUTE_KERNEL{"compute"};
+    const KernelSpecName WRITER_KERNEL{"writer"};
 
-    DataType output_dtype = output.dtype();
-    auto out_data_format = datatype_to_dataformat_converter(output_dtype);
-    const uint32_t dtype_tile_size = tile_size(out_data_format);
-    const uint32_t intermed_tile_size = tile_size(tt::DataFormat::Float32);
+    auto ws = compute_rand_work_split(output);
 
-    constexpr uint32_t in_out_num_tiles = 1;
+    const tt::DataFormat out_data_format = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t dtype_tile_size = tt::tile_size(out_data_format);
+    const uint32_t intermed_tile_size = tt::tile_size(tt::DataFormat::Float32);
     constexpr uint32_t intermed_num_tiles = 2;
 
-    constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    constexpr uint32_t dst_cb_id = CBIndex::c_0;
-
-    ProgramDescriptor desc;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = intermed_num_tiles * intermed_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = intermed_cb_id,
-            .data_format = tt::DataFormat::Float32,
-            .page_size = intermed_tile_size,
-        }}},
+    // Single intermediate FIFO: compute (PRODUCER) generates random Float32 tiles, writer (CONSUMER)
+    // streams them to the output tensor. rand always produces Float32 (rand.cpp typecasts afterward).
+    std::vector<DataflowBufferSpec> dfbs;
+    dfbs.push_back(DataflowBufferSpec{
+        .unique_id = CB_INTERMED,
+        .entry_size = intermed_tile_size,
+        .num_entries = intermed_num_tiles,
+        .data_format_metadata = tt::DataFormat::Float32,
     });
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = in_out_num_tiles * dtype_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = dst_cb_id,
-            .data_format = out_data_format,
-            .page_size = dtype_tile_size,
-        }}},
-    });
+    TensorParameter output_param{.unique_id = OUTPUT, .spec = output.tensor_spec()};
 
-    KernelDescriptor::CompileTimeArgs writer_ct_args;
-    writer_ct_args.reserve(8);
-    writer_ct_args.push_back(intermed_cb_id);
-    writer_ct_args.push_back(dst_cb_id);
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source = WRITER_KERNEL_PATH;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    switch (output_dtype) {
-        case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
-        case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
-        default:
-            // The writer kernel only implements float32 and bfloat16 output paths.
-            // Fail fast here so we never instantiate a program that can hang at runtime.
-            TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
-    }
-    writer_desc.runtime_args.reserve(num_cores_total);
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = {intermed_cb_id};
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                   // generated number out of range [from, to)
-        .dst_full_sync_en = false,
-        .math_approx_mode = true,
+    KernelSpec compute_spec{
+        .unique_id = COMPUTE_KERNEL,
+        .source = std::filesystem::path{COMPUTE_KERNEL_PATH},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = CB_INTERMED,
+            .accessor_name = "cb_intermed",
+            .endpoint_type = DFBBinding::EndpointType::PRODUCER}},
+        // seed/from_bits/to_bits are per-enqueue (excluded from the key, re-applied every dispatch).
+        .runtime_arg_schema = {.runtime_arg_names = {"seed", "from_bits", "to_bits", "start_id", "num_tiles"}},
+        .hw_config =
+            ComputeHardwareConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .fp32_dest_acc_en = true,  // false can push generated values out of [from, to)
+                .dst_full_sync_en = false,
+                .math_approx_mode = true},
     };
-    compute_desc.runtime_args.reserve(num_cores_total);
 
-    const float eps = 1e-6f;
-    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+    KernelSpec writer_spec{
+        .unique_id = WRITER_KERNEL,
+        .source = std::filesystem::path{WRITER_KERNEL_PATH},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = CB_INTERMED,
+            .accessor_name = "cb_intermed",
+            .endpoint_type = DFBBinding::EndpointType::CONSUMER}},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
+        .compile_time_args = {{"page_size", dtype_tile_size}},
+        .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
 
-    uint32_t tile_offset = 0;
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const auto& core = cores[i];
-        uint32_t units_per_core;
-        if (core_group_1.contains(core)) {
-            units_per_core = units_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            units_per_core = units_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
+    WorkUnitSpec wu{
+        .name = "rand",
+        .kernels = {COMPUTE_KERNEL, WRITER_KERNEL},
+        .target_nodes = ws.all_cores,
+    };
 
-        uint32_t seed = rand_seed_for_core(operation_attributes, i, device_seed_offset);
+    ProgramSpec spec{
+        .name = "rand",
+        .kernels = {std::move(compute_spec), std::move(writer_spec)},
+        .dataflow_buffers = std::move(dfbs),
+        .tensor_parameters = {output_param},
+        .work_units = {wu},
+    };
 
-        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
-        // cache-miss build, and re-applied on every cache hit via get_dynamic_runtime_args().
-        compute_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
-
-        // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
-        // (real program caching) with the address correctly re-patched each dispatch.
-        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
-
-        tile_offset += units_per_core;
-    }
-
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
-
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec), .run_params = build_run_args(operation_attributes, output)};
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // compute is kernel 1; its runtime args are {seed, from_bits, to_bits, tile_offset, units_per_core}.
-    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
-    constexpr uint32_t kComputeKernelIdx = 1;
-    auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-
-    const float eps = 1e-6f;
-    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(ws.cores.size() * 3);
-    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
-        const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 0, seed});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 1, from_bits});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 2, to_bits});
-    }
-    return dynamic_args;
+ProgramRunArgs RandProgramFactory::create_program_run_args(
+    const RandOperationAttributes& operation_attributes, const RandTensorArgs& /*tensor_args*/, Tensor& output) {
+    // Re-derive the per-enqueue run args (fresh seed/from/to) from the live attributes; the framework
+    // re-applies them via SetProgramRunArgs on every cache hit, so a value excluded from the key is
+    // re-applied instead of frozen. Shares build_run_args with create_program_artifacts.
+    return build_run_args(operation_attributes, output);
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "rand_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+namespace ttnn::operations::rand {
+
+// Metal 2.0 (MetalV2FactoryConcept) factory for rand.
+//
+// seed/from/to are excluded from the program-cache key (see RandOperationAttributes::attribute_values)
+// and are therefore per-enqueue: create_program_run_args re-derives them from the live attributes and
+// the framework re-applies them via SetProgramRunArgs on every cache hit. That is the Metal 2.0-native
+// replacement for the descriptor framework's get_dynamic_runtime_args — no positional (kernel, arg)
+// indices, and SetProgramRunArgs validates that every named runtime arg in the ProgramSpec is set.
+struct RandProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const RandOperationAttributes& operation_attributes, const RandTensorArgs& tensor_args, Tensor& output);
+
+    static tt::tt_metal::experimental::ProgramRunArgs create_program_run_args(
+        const RandOperationAttributes& operation_attributes, const RandTensorArgs& tensor_args, Tensor& output);
+};
+
+}  // namespace ttnn::operations::rand


### PR DESCRIPTION
## What

Make `rand`'s hash-excluded **dynamic runtime args** (`seed`, `from`, `to`) a single source of truth shared by the cache-miss bake (`create_descriptor`) and the cache-hit patch (`get_dynamic_runtime_args`), so the two can no longer silently drift. No behavior change.

## Why

`seed/from/to` are deliberately excluded from the program-cache key (so calls differing only in them cache-hit instead of recompiling) and re-applied to the cached program on every dispatch. That re-application is what keeps a cache hit correct — miss the re-apply and the value stays **frozen** at whatever the first miss baked in (a silent wrong result on the *second* dispatch, invisible to a single-call test).

Before this PR, that contract was upheld by **three hand-maintained cross-references** that could drift independently:

1. the slot layout in `create_descriptor` (`CoreRuntimeArgs{seed, from_bits, to_bits, ...}`),
2. the re-apply targets in `get_dynamic_runtime_args` (raw `arg_idx` `0/1/2` literals),
3. the kernel index (`kComputeKernelIdx = 1`) vs the `desc.kernels` push order.

Reorder an arg, insert one, or reorder the kernel pushes and nothing errors — you get a wrong slot (or a `TT_FATAL`) only on a later cache hit.

## Change

- `kRandDynamicArgNames` + `rand_dynamic_values_for_core()` — one declaration of the dynamic arg set and its value derivation, consumed by **both** paths. Adding/removing/reordering a dynamic arg updates both at once; they cannot desync.
- `create_descriptor` writes the dynamic args (in `kRandDynamicArgNames` order) followed by the static tail; `get_dynamic_runtime_args` re-applies exactly the leading `dyn.size()` slots from the same helper.
- Named `kWriterKernelIdx`/`kComputeKernelIdx` constants (with a `static_assert` pinning the ordering) replace the bare literal used by the hit-patch.

## Tests

No new test needed — the contract is already guarded by two existing regression tests, which this refactor preserves:
- `test_rand_different_seed_values` — different seed must cache-hit (no new entry) **and** change the output (seed re-applied).
- `test_rand_different_from_to_values` — different `[low, high)` must cache-hit **and** land in the new range (from/to re-applied).

Both would fail if the miss-bake and hit-patch drifted or a value froze.

## Status

Draft. Contained op-local refactor; `clang-format` and pre-commit hooks pass. Not yet built/run locally — please treat CI (or a local `./build_metal.sh` + the two rand tests, incl. under `ttsim`) as the gate before merge.

## Context — why this is the shape, and where it goes next

This is the **op-local rung** of making descriptor dynamic-args correct *by construction* rather than *by convention*. It removes the drift **within** the factory; the exclusion itself still lives in `attribute_values()`.

The framework follow-up generalizes it: today the buffer fast-path (`resolve_bindings` / `apply_resolved_bindings`) is automatic because a `Buffer*` has framework-visible identity — the op registers it once at the write site and the framework re-patches forever. Scalars have no such identity, so they fell back to the manual positional `get_dynamic_runtime_args`. The fix is to give a binding's **source** a second form: instead of only "a tensor's address," also "an op-supplied value addressed by name." A slot then carries a name (metal-level, in the descriptor), the adapter resolves name→slot like it does for buffers, and writes the op-supplied value — collapsing the separate dynamic-args path into the one binding system. The one piece that stays op-side is the value expression itself (a scalar's value is derived from `operation_attributes`, a ttnn-level type, so it is irreducible — unlike a buffer address the framework already owns).

`kRandDynamicArgNames` deliberately carries the slot **names** (not just a count) so this op is ready to become the reference conversion when that named-binding primitive lands.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/rand-dynamic-args-single-source)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/rand-dynamic-args-single-source)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/rand-dynamic-args-single-source)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/rand-dynamic-args-single-source)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/rand-dynamic-args-single-source)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/rand-dynamic-args-single-source)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/rand-dynamic-args-single-source)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/rand-dynamic-args-single-source)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/rand-dynamic-args-single-source)