### PR TITLE
[Feature] Enable `dispatch_s` on Quasar fast dispatch

### DIFF
--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -96,11 +96,10 @@ void DispatchQueryManager::reset(DispatchCoreConfig& dispatch_core_config, uint8
     dispatch_core_config_ = dispatch_core_config;
     const tt::ARCH arch = MetalEnvAccessor(env_).impl().get_cluster().arch();
     dispatch_s_enabled_ =
-        (num_hw_cqs == 1 or dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::WORKER) and
-        arch != tt::ARCH::QUASAR;
+        (num_hw_cqs == 1 or dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::WORKER);
     distributed_dispatcher_ =
         (num_hw_cqs == 1 and dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::ETH);
-    go_signal_noc_ = dispatch_s_enabled_ ? NOC::NOC_1 : NOC::NOC_0;
+    go_signal_noc_ = (dispatch_s_enabled_ and arch != tt::ARCH::QUASAR) ? NOC::NOC_1 : NOC::NOC_0;
     // Reset the dispatch cores reported by the manager. Will be re-populated when the associated query is made
     dispatch_cores_ = {};
     // Populate dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -172,7 +172,7 @@ void DispatchSKernel::GenerateStaticConfigs() {
     // DEVICE_PRINT L1 buffers. Only enable the DRAM-aggregation work on cq_id 0 so the buffers
     // aren't drained twice (which would race the host's rpos updates and reorder/drop messages).
     if (cq_id_ == 0 && get_dispatch_query_manager_ref().dispatch_s_enabled() &&
-        descriptor_.metal_context().dprint_server()) {
+        descriptor_.metal_context().dprint_server() && device_->arch() != tt::ARCH::QUASAR) {
         auto print_cores = descriptor_.metal_context().dprint_server()->get_print_cores(device_->id());
         if (!print_cores.empty()) {
             const auto& hal = descriptor_.hal();
@@ -334,7 +334,7 @@ void DispatchSKernel::CreateKernel() {
     };
     configure_kernel_variant(dispatch_kernel_file_names[DISPATCH_S], {}, defines);
 
-    if (GetCoreType() == CoreType::WORKER) {
+    if (GetCoreType() == CoreType::WORKER && device_->arch() != tt::ARCH::QUASAR) {
         const std::string compute_kernel_path = "tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate_compute.cpp";
         std::map<std::string, std::string> compute_defines = {
             {"FIRST_STREAM_INDEX", std::to_string(static_config_.first_stream_used.value())},

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -89,6 +89,14 @@ FORCE_INLINE volatile T tt_l1_ptr* uncached_l1_ptr(uintptr_t addr) {
     return reinterpret_cast<volatile T tt_l1_ptr*>(l1_uncached_addr(addr));
 }
 
+#ifdef ARCH_QUASAR
+// Returns a pointer to the L1 worker completion counter for `stream`. Workers signal completion
+// into L1 (DISPATCH_MESSAGE_ADDR) on Quasar rather than NOC stream registers.
+FORCE_INLINE volatile uint32_t* worker_completion_sem_addr(uint32_t stream, uint32_t first_stream_used) {
+    return uncached_l1_ptr<uint32_t>(DISPATCH_MESSAGE_ADDR + L1_ALIGNMENT * (stream - first_stream_used));
+}
+#endif
+
 constexpr bool use_fabric(uint64_t fabric_router_xy) { return fabric_router_xy != 0; }
 
 template <
@@ -686,11 +694,10 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
     std::array<uint32_t, max_num_worker_sems>& workers_per_sub_device,
     volatile tt_l1_ptr uint32_t* sub_device_worker_counts_update,
     uintptr_t dispatch_telemetry_base) {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
     uint32_t num_sub_devices = cmd->set_sub_device_worker_counts.num_sub_devices;
     ASSERT(num_sub_devices <= max_num_worker_sems);
-    volatile tt_l1_ptr uint32_t* data_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd_ptr + sizeof(CQDispatchCmd));
+    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
 
     static uint32_t local_sub_device_worker_counts_update = 0;
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -149,7 +149,11 @@ constexpr uint32_t downstream_cb_end = downstream_cb_base + downstream_cb_size;
 constexpr uint32_t fd_core_type_idx = static_cast<uint32_t>(fd_core_type);
 
 constexpr bool dispatch_s_enabled = dispatch_d_shutdown_sem_id != 0;
+#ifdef ARCH_QUASAR
+constexpr bool publish_noc_count = false;
+#else
 constexpr bool publish_noc_count = !distributed_dispatcher && dispatch_s_enabled;
+#endif
 
 // Break buffer into blocks, 1/n of the total (dividing equally)
 // Do bookkeeping (release, etc) based on blocks
@@ -998,17 +1002,9 @@ uint32_t stream_wrap_ge(uint32_t a, uint32_t b) {
     return (diff << shift) >= 0;
 }
 
-#ifdef ARCH_QUASAR
-// Returns a pointer to the L1 worker completion counter address
-FORCE_INLINE volatile uint32_t* worker_completion_sem_addr(uint32_t stream) {
-    return reinterpret_cast<volatile uint32_t*>(
-        l1_uncached_addr(DISPATCH_MESSAGE_ADDR + L1_ALIGNMENT * (stream - first_stream_used)));
-}
-#endif
-
 FORCE_INLINE void wait_worker_completion(uint32_t stream, uint32_t wait_count) {
 #ifdef ARCH_QUASAR
-    while (!wrap_ge(*worker_completion_sem_addr(stream), wait_count)) {
+    while (!wrap_ge(*worker_completion_sem_addr(stream, first_stream_used), wait_count)) {
     }
 #else
     while (!stream_wrap_ge(NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), wait_count)) {
@@ -1162,7 +1158,8 @@ void process_go_signal_mcast_cmd() {
             // greater than the number of cores actually on the chip, we must account for acks
             // from non-existent cores here.
 #ifdef ARCH_QUASAR
-            *worker_completion_sem_addr(stream) += (num_virtual_unicast_cores - num_physical_unicast_cores);
+            *worker_completion_sem_addr(stream, first_stream_used) +=
+                (num_virtual_unicast_cores - num_physical_unicast_cores);
 #else
             NOC_STREAM_WRITE_REG(
                 stream,
@@ -1541,7 +1538,7 @@ void kernel_main() {
     for (size_t i = 0; i < max_num_worker_sems; i++) {
         const uint32_t index = i + first_stream_used;
 #ifdef ARCH_QUASAR
-        *worker_completion_sem_addr(index) = 0;
+        *worker_completion_sem_addr(index, first_stream_used) = 0;
 #else
         NOC_STREAM_WRITE_REG(
             index,

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -15,7 +15,9 @@
 #include "api/debug/dprint.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
+#if DEVICE_PRINT_DISPATCH_ENABLED
 #include "tt_metal/impl/dispatch/kernels/device_print_dispatch.h"
+#endif
 #include "tt_metal/impl/dispatch/kernels/realtime_profiler.hpp"
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dispatch_telemetry_types.hpp"
@@ -252,10 +254,18 @@ void wait_for_workers(uint32_t wait_count, uint32_t wait_stream) {
     WAYPOINT("WCW");
     last_wait_count = wait_count;
     last_wait_stream = wait_stream;
+#ifdef ARCH_QUASAR
+    volatile uint32_t* worker_sem = worker_completion_sem_addr(wait_stream, first_stream_used);
+#else
     volatile uint32_t* worker_sem = reinterpret_cast<volatile uint32_t*>(
         static_cast<uintptr_t>(STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
-    DEVICE_PRINT("DISPATCH_S: wait_for_workers: wait_count: {}, worker_sem: {}\n", wait_count, *worker_sem);
+#endif
+    DPRINT("DISPATCH_S: wait_for_workers: wait_count: {}, worker_sem: {}\n", wait_count, *worker_sem);
+#ifdef ARCH_QUASAR
+    while (wrap_gt(wait_count, *worker_sem)) {
+#else
     while (stream_wrap_gt(wait_count, *worker_sem)) {
+#endif
         if (rt_profiler_enabled) {
             record_realtime_timestamp(rt_profiler_msg, false);
         }
@@ -294,8 +304,7 @@ FORCE_INLINE void update_worker_completion_count_on_dispatch_d() {
 
 template <uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
+    volatile tt_l1_ptr uint32_t* sem_addr = uncached_l1_ptr<uint32_t>(get_semaphore<fd_core_type>(sem_id));
 
     WAYPOINT("DAPW");
     uint32_t heartbeat = 0;
@@ -315,17 +324,21 @@ FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
 
 template <uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
+#ifdef ARCH_QUASAR
+    Semaphore<fd_core_type>(sem_id).up(n);
+#else
     dispatch_s_noc_semaphore_inc(get_noc_addr_helper(noc_xy, get_semaphore<fd_core_type>(sem_id)), n, my_noc_index);
+#endif
 }
 
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
     uint32_t sync_index = cmd->mcast.wait_stream - first_stream_used;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
 
     volatile tt_l1_ptr uint32_t* sync_sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
+        uncached_l1_ptr<uint32_t>(dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
 
     WAYPOINT("DCW");
     // Wait for notification from dispatch_d, signalling that it's safe to send the go signal
@@ -345,7 +358,12 @@ void process_go_signal_mcast_cmd() {
     // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This is safe as long as we
     // can guarantee that copying the go signal does not corrupt any other command fields, which is true (see
     // CQDispatchGoSignalMcastCmd).
+    // NOC source addresses must be raw L1 byte offsets (cached-alias form), so keep
+    // aligned_go_signal_storage at the cached alias for the NOC sources below.
+    // CPU writes go through a separate uncached pointer so the value lands in L1 SRAM directly;
+    // the NOC then reads the same physical location via the cached-form source address.
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
+    volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached = uncached_l1_ptr<uint32_t>(cmd_ptr);
     uint32_t go_signal_value = cmd->mcast.go_signal;
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
@@ -360,7 +378,7 @@ void process_go_signal_mcast_cmd() {
         uint32_t num_dests = num_worker_cores_to_mcast;
         // Ensure the offset with respect to L1_ALIGNMENT is the same for the source and destination.
         uint32_t storage_offset = multicast_go_offset % (L1_ALIGNMENT / sizeof(uint32_t));
-        aligned_go_signal_storage[storage_offset] = go_signal_value;
+        aligned_go_signal_storage_uncached[storage_offset] = go_signal_value;
 
 #if DEVICE_PRINT_DISPATCH_ENABLED
         // wait_for_workers polls device_print_dispatcher.execute() inside its busy loop when
@@ -390,7 +408,7 @@ void process_go_signal_mcast_cmd() {
         wait_for_workers(wait_count, wait_stream);
     }
 
-    *aligned_go_signal_storage = go_signal_value;
+    *aligned_go_signal_storage_uncached = go_signal_value;
     if constexpr (virtualize_unicast_cores) {
         // Issue #19729: Workaround to allow TT-Mesh Workload dispatch to target active ethernet cores.
         // This chip is virtualizing cores the go signal is unicasted to
@@ -403,10 +421,15 @@ void process_go_signal_mcast_cmd() {
             // the number of cores specified inside cmd->mcast.num_unicast_txns. If this is
             // greater than the number of cores actually on the chip, we must account for acks
             // from non-existent cores here.
+#ifdef ARCH_QUASAR
+            *worker_completion_sem_addr(first_stream_used, first_stream_used) +=
+                (num_virtual_unicast_cores - num_physical_unicast_cores);
+#else
             NOC_STREAM_WRITE_REG(
                 first_stream_used,
                 STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
                 (num_virtual_unicast_cores - num_physical_unicast_cores) << REMOTE_DEST_BUF_WORDS_FREE_INC);
+#endif
         }
     }
 
@@ -442,7 +465,7 @@ void process_go_signal_mcast_cmd() {
 
 FORCE_INLINE
 void process_dispatch_s_wait_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
     // Limited Usage of Wait CMD: dispatch_s should get a wait command only if it's not on the
     // same core as dispatch_d and is used to clear the worker count
     ASSERT(
@@ -472,7 +495,7 @@ void process_dispatch_s_wait_cmd() {
 
 FORCE_INLINE
 void set_num_worker_sems() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
     num_worker_sems = cmd->set_num_worker_sems.num_worker_sems;
     ASSERT(num_worker_sems <= max_num_worker_sems);
     cmd_ptr += sizeof(CQDispatchCmd);
@@ -480,15 +503,14 @@ void set_num_worker_sems() {
 
 FORCE_INLINE
 void set_go_signal_noc_data() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
     uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
-    volatile tt_l1_ptr uint32_t* data_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd_ptr + sizeof(CQDispatchCmd));
+    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
     for (uint32_t i = 0; i < num_words; ++i) {
         go_signal_noc_data[i] = *(data_ptr++);
     }
-    cmd_ptr = round_up_pow2(reinterpret_cast<uintptr_t>(data_ptr), L1_ALIGNMENT);
+    cmd_ptr = round_up_pow2(l1_cached_addr(reinterpret_cast<uintptr_t>(data_ptr)), L1_ALIGNMENT);
 }
 
 // When dispatch_d runs on the same core, it issues transactions on dispatch_s's dedicated NOC
@@ -590,7 +612,7 @@ void kernel_main() {
 #endif
         cb_acquire_pages_dispatch_s<my_noc_xy, my_dispatch_cb_sem_id>(1);
 
-        volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+        volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
         DeviceTimestampedData("process_cmd_d_dispatch_subordinate", (uint32_t)cmd->base.cmd_id);
         if (rt_profiler_enabled) {
             const bool is_profiled_cmd = cmd->base.cmd_id == CQ_DISPATCH_CMD_SEND_GO_SIGNAL ||
@@ -600,22 +622,37 @@ void kernel_main() {
                 is_profiled_cmd ? popped_pid : static_cast<uint32_t>(REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID));
         }
         switch (cmd->base.cmd_id) {
-            case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: process_go_signal_mcast_cmd(); break;
-            case CQ_DISPATCH_SET_NUM_WORKER_SEMS: set_num_worker_sems(); break;
-            case CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA: set_go_signal_noc_data(); break;
+            case CQ_DISPATCH_CMD_SEND_GO_SIGNAL:
+                DPRINT("CQ_DISPATCH_CMD_SEND_GO_SIGNAL\n");
+                process_go_signal_mcast_cmd();
+                break;
+            case CQ_DISPATCH_SET_NUM_WORKER_SEMS:
+                DPRINT("CQ_DISPATCH_SET_NUM_WORKER_SEMS\n");
+                set_num_worker_sems();
+                break;
+            case CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA:
+                DPRINT("CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA\n");
+                set_go_signal_noc_data();
+                break;
             case CQ_DISPATCH_SET_SUB_DEVICE_WORKER_COUNTS:
+                DPRINT("CQ_DISPATCH_SET_SUB_DEVICE_WORKER_COUNTS\n");
                 cmd_ptr += set_sub_device_worker_counts<telemetry_enabled>(
                     cmd_ptr,
                     workers_per_sub_device,
                     &dispatch_telemetry_control->sub_device_worker_counts_update,
                     dispatch_telemetry_base);
                 break;
-            case CQ_DISPATCH_CMD_WAIT: process_dispatch_s_wait_cmd(); break;
+            case CQ_DISPATCH_CMD_WAIT:
+                DPRINT("CQ_DISPATCH_CMD_WAIT\n");
+                process_dispatch_s_wait_cmd();
+                break;
             case CQ_DISPATCH_CMD_RT_PROFILER_FLUSH:
+                DPRINT("CQ_DISPATCH_CMD_RT_PROFILER_FLUSH\n");
                 wait_for_workers(cmd->rt_profiler_flush.wait_count, cmd->rt_profiler_flush.wait_stream);
                 cmd_ptr += sizeof(CQDispatchCmd);
                 break;
             case CQ_DISPATCH_CMD_TERMINATE:
+                DPRINT("CQ_DISPATCH_CMD_TERMINATE\n");
                 if (rt_profiler_enabled) {
                     signal_realtime_profiler_and_switch(rt_profiler_msg);
                     noc_async_writes_flushed();
@@ -639,7 +676,7 @@ void kernel_main() {
             default: DPRINT("dispatcher_s invalid command\n"); ASSERT(0);
         }
         // Dispatch s only supports single page commands for now
-        ASSERT(cmd_ptr <= (reinterpret_cast<uintptr_t>(cmd) + cb_page_size));
+        ASSERT(cmd_ptr <= (l1_cached_addr(reinterpret_cast<uintptr_t>(cmd)) + cb_page_size));
         cmd_ptr = round_up_pow2(cmd_ptr, cb_page_size);
         // Release a single page to prefetcher. Assumption is that all dispatch_s commands fit inside a single page for
         // now.
@@ -656,9 +693,11 @@ void kernel_main() {
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_dispatch_cb_sem_id>(total_pages_acquired);
 
+#ifndef ARCH_QUASAR
     if constexpr (!distributed_dispatcher) {
         merge_dispatch_d_noc_counter_deltas();
     }
+#endif
 
     noc_async_full_barrier();
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -145,8 +145,9 @@ static const std::vector<DispatchKernelNode> single_chip_arch_2cq_dispatch_s = {
 };
 
 static const std::vector<DispatchKernelNode> quasar_single_chip_1cq = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, x, x, x}, k_quasar_noc},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, k_quasar_noc},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_quasar_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_quasar_noc},
+    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_quasar_noc},
 };
 
 static const std::vector<DispatchKernelNode> two_chip_arch_1cq_fabric = {


### PR DESCRIPTION
### PR Category
Feature

### Summary
This branch turns on `dispatch_s` on Quasar, which offloads go-signal multicasting to worker cores from `dispatch_d` so command dispatch and go-signal delivery can proceed concurrently.

The key host-side changes are:
 - `dispatch_query_manager.cpp` no longer excludes Quasar from `dispatch_s_enabled_`
 - `topology.cpp` adds a `DISPATCH_S` node to `quasar_single_chip_1cq`
 - `dispatch_s.cpp` gates the DRAM-aggregated DPRINT setup and the `cq_dispatch_subordinate_compute.cpp` kernel off for Quasar

The key device-side changes are:
 - `cq_dispatch_subordinate.cpp` (the `dispatch_s` kernel) now polls and increments an L1 counter for worker completion instead of using stream registers, and routes its command/data L1 accesses through `uncached_l1_ptr<T>` to avoid cache staleness
 - `cq_dispatch.cpp` (the `dispatch_d` kernel) disables `publish_noc_count` on Quasar

Remaining work:
 - enabling DFB support in Quasar fast dispatch
 - moving the FD kernels from a regular core to a Dispatch Engine
 - using host hugepages instead of DRAM for the command queues on Quasar
 - supporting 2-CQ fast dispatch on Quasar

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_dispatch_s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_dispatch_s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_dispatch_s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_dispatch_s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_dispatch_s)