### PR TITLE
[experimental/quasar] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/quasar/test_binary_ng_descriptor_cache_hit.py
+++ b/tests/ttnn/unit_tests/operations/experimental/quasar/test_binary_ng_descriptor_cache_hit.py
@@ -91,3 +91,49 @@ def test_descriptor_interleaved_add_program_cache_hit(device, mem_config):
     # The hit dispatches genuinely ran on reallocated buffers: distinct input and output addresses.
     assert len(input_addrs) == 2 * _NUM_DISPATCHES, f"inputs reused addresses: {sorted(input_addrs)}"
     assert len(output_addrs) == _NUM_DISPATCHES, f"outputs reused addresses: {sorted(output_addrs)}"
+
+
+# Two interleaved shapes with the SAME volume but a DIFFERENT H/W tile split. `operation_attributes_t`
+# carries no shape and `get_shard_volumes` is nullopt for interleaved tensors, so before the hash fix
+# BOTH shapes hashed identically -> the second landed on the first's cached program and re-used its
+# frozen shape-dependent reader/writer scalars (wrong tile range / OOB). Equal volume specifically
+# defeats a volume-only fix, forcing the hash to distinguish the actual dims.
+_SHAPE_S1 = (2 * 32, 4 * 32)  # 8 tiles, 1x4 tile grid
+_SHAPE_S2 = (4 * 32, 2 * 32)  # 8 tiles, 4x2 tile grid -- same volume, different Ht/Wt
+
+
+@pytest.mark.parametrize(
+    "mem_config",
+    [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    ids=["dram_interleaved", "l1_interleaved"],
+)
+def test_descriptor_cross_shape_distinct_cache_entries(device, mem_config):
+    torch.manual_seed(0)
+
+    def dispatch(shape):
+        a_pt = torch.randn(shape, dtype=torch.bfloat16)
+        b_pt = torch.randn(shape, dtype=torch.bfloat16)
+        a_tt = ttnn.from_torch(
+            a_pt, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=mem_config
+        )
+        b_tt = ttnn.from_torch(
+            b_pt, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=mem_config
+        )
+        out_tt = ttnn.experimental.quasar.add(a_tt, b_tt, memory_config=mem_config)
+        assert_with_pcc(ttnn.to_torch(out_tt), torch.add(a_pt, b_pt), _PCC)
+
+    num_before = device.num_program_cache_entries()
+
+    # Prime the cache with shape S1 (descriptor path, interleaved -> ProgramFactory).
+    dispatch(_SHAPE_S1)
+    num_after_s1 = device.num_program_cache_entries()
+    assert num_after_s1 - num_before == 1, f"S1 should add exactly 1 cache entry, got {num_after_s1 - num_before}"
+
+    # Same op, DIFFERENT logical shape S2. With the shape folded into the descriptor-path hash this must
+    # allocate a SECOND, distinct cache entry (and produce a correct S2 result). Without the fix the
+    # equal-volume S2 collides onto S1's entry: no new entry and/or a wrong output.
+    dispatch(_SHAPE_S2)
+    num_after_s2 = device.num_program_cache_entries()
+    assert (
+        num_after_s2 - num_after_s1 == 1
+    ), f"S2 (different shape) must create a distinct cache entry, got {num_after_s2 - num_after_s1} new"

--- a/tests/ttnn/unit_tests/operations/experimental/quasar/test_binary_ng_descriptor_cache_hit.py
+++ b/tests/ttnn/unit_tests/operations/experimental/quasar/test_binary_ng_descriptor_cache_hit.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache-hit coverage for the DESCRIPTOR path of quasar binary_ng.
+
+`test_binary_ng_resnet_add.py::test_resnet_add_program_cache_hit` only exercises the fully-sharded
+in-place ADD config, which `BinaryNgDeviceOperation::select_program_factory` routes to the METAL_V2
+factory (`matches_metal_v2_slice` -> `ProgramFactoryMetalV2`, variant index 1). It therefore does NOT
+cover the descriptor `ProgramFactory::create_descriptor` path (variant index 0), whose reader/writer
+runtime args bind the a/b/c buffers as `Buffer*` (via `KernelDescriptor::emplace_runtime_args`) instead
+of baking raw `buffer->address()` values. Those bindings are what the descriptor adapter re-resolves on
+a program-cache hit so a reallocated input/output is read at its new address.
+
+`matches_metal_v2_slice` requires HEIGHT/BLOCK-sharded L1 tensors, so ANY interleaved config falls
+through to the descriptor path — this is provable from the selector source and needs no arch-specific
+config. Here we run an interleaved (DRAM or L1) tensor-tensor ADD several times with the program cache
+enabled, allocating fresh inputs AND holding every tensor alive so each dispatch lands on DISTINCT
+buffer addresses. The 2nd+ dispatches are genuine cache hits (asserted via the entry count), and PCC
+must still pass on every dispatch: if the buffer addresses were baked at create-time (the pre-patch
+behaviour) instead of re-resolved from the `Buffer*` bindings, the hit dispatches would read the stale
+first-dispatch addresses and the result would be wrong.
+
+Run on Wormhole / Blackhole:
+    pytest tests/ttnn/unit_tests/operations/experimental/quasar/test_binary_ng_descriptor_cache_hit.py
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+# The descriptor path reaches the same bf16 accuracy as any other; never weaken below this.
+_PCC = 0.9997
+
+# Multi-tile, multi-core interleaved shape (2x4 tiles) so the per-core runtime-arg loop that emits the
+# a/b/c Buffer* bindings runs on more than one core.
+_SHAPE = (2 * 32, 4 * 32)
+
+# Number of dispatches: the first is a cache miss (builds the program), the rest must be cache hits.
+_NUM_DISPATCHES = 3
+
+
+@pytest.mark.parametrize(
+    "mem_config",
+    [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    ids=["dram_interleaved", "l1_interleaved"],
+)
+def test_descriptor_interleaved_add_program_cache_hit(device, mem_config):
+    torch.manual_seed(0)
+
+    num_before = device.num_program_cache_entries()
+
+    # Hold every tensor alive across the loop so the allocator hands out a DISTINCT address to each new
+    # allocation -- this is what forces the cache-hit dispatches to patch the Buffer* bindings to new
+    # addresses rather than silently reusing the miss-time address.
+    kept_alive = []
+    input_addrs = set()
+    output_addrs = set()
+
+    for i in range(_NUM_DISPATCHES):
+        a_pt = torch.randn(_SHAPE, dtype=torch.bfloat16) + float(i)
+        b_pt = torch.randn(_SHAPE, dtype=torch.bfloat16) - float(i)
+
+        a_tt = ttnn.from_torch(
+            a_pt, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=mem_config
+        )
+        b_tt = ttnn.from_torch(
+            b_pt, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=mem_config
+        )
+
+        # Interleaved tensor-tensor ADD -> not sharded -> select_program_factory returns the descriptor
+        # ProgramFactory (variant index 0), NOT ProgramFactoryMetalV2.
+        out_tt = ttnn.experimental.quasar.add(a_tt, b_tt, memory_config=mem_config)
+
+        input_addrs.add(a_tt.buffer_address())
+        input_addrs.add(b_tt.buffer_address())
+        output_addrs.add(out_tt.buffer_address())
+
+        assert_with_pcc(ttnn.to_torch(out_tt), torch.add(a_pt, b_pt), _PCC)
+        kept_alive.extend([a_tt, b_tt, out_tt])
+
+    # Every dispatch shared one program: exactly one new cache entry across all of them.
+    num_after = device.num_program_cache_entries()
+    assert (
+        num_after - num_before == 1
+    ), f"expected 1 new cache entry across {_NUM_DISPATCHES} dispatches, got {num_after - num_before}"
+
+    # The hit dispatches genuinely ran on reallocated buffers: distinct input and output addresses.
+    assert len(input_addrs) == 2 * _NUM_DISPATCHES, f"inputs reused addresses: {sorted(input_addrs)}"
+    assert len(output_addrs) == _NUM_DISPATCHES, f"outputs reused addresses: {sorted(output_addrs)}"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -515,17 +515,34 @@ ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
                 output_spec.logical_shape().volume());
         }
 
+        // Descriptor (ProgramFactory) path. Logical shape is excluded from the default hash, but this
+        // path bakes shape-dependent uint32 scalars (per-core tile counts, start ids, D/N/C/Ht/Wt dims,
+        // row-width strides — see the reader/writer arg builders in binary_ng_program_factory.cpp) into
+        // its runtime args, and this op now declares the output as a BufferBinding, so a cross-shape
+        // cache hit would re-use those frozen scalars against a differently-shaped tensor (wrong tile
+        // range / OOB). Fold in the full padded shapes of every present operand and the output so
+        // differently-shaped ops get distinct cache entries (over-keying is safe; under-keying is the bug).
         return operation::hash_operation<BinaryNgDeviceOperation>(
             attributes,
             input_tensor_a.dtype(),
             input_tensor_a.memory_config(),
             input_tensor_b->dtype(),
             input_tensor_b->memory_config(),
-            shard_volumes);
+            shard_volumes,
+            input_tensor_a.padded_shape(),
+            input_tensor_b->padded_shape(),
+            output_spec.padded_shape());
     }
 
+    // Descriptor path, single operand (scalar RHS). Same reasoning as the has-b descriptor branch above:
+    // the baked reader/writer scalars derive from the a/output padded shapes, so hash them.
+    const auto output_spec = compute_output_specs(attributes, tensor_args);
     return operation::hash_operation<BinaryNgDeviceOperation>(
-        attributes, input_tensor_a.dtype(), input_tensor_a.memory_config());
+        attributes,
+        input_tensor_a.dtype(),
+        input_tensor_a.memory_config(),
+        input_tensor_a.padded_shape(),
+        output_spec.padded_shape());
 }
 
 bool BinaryNgDeviceOperation::skip_launch(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
@@ -1138,10 +1138,10 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                         b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
                     }
                 }
-                std::vector<uint32_t> writer_runtime_args;
+                std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args;
                 if (row_major_inputs) {
                     writer_runtime_args = {
-                        c.buffer()->address(),
+                        c.buffer(),
                         common_row_width_elements,
                         c_num_tiles_core,
                         cD,
@@ -1157,20 +1157,9 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                         writer_stride_size_bytes};
                 } else {
                     writer_runtime_args = {
-                        c.buffer()->address(),
-                        c_start_id,
-                        c_num_tiles_core,
-                        c_current_shard_width,
-                        cD,
-                        cN,
-                        cC,
-                        cHt,
-                        cWt,
-                        cND,
-                        0u};
+                        c.buffer(), c_start_id, c_num_tiles_core, c_current_shard_width, cD, cN, cC, cHt, cWt, cND, 0u};
                 }
-                writer_desc.runtime_args.emplace_back(
-                    core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+                writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
                 auto [freq, counter] = CMAKE_UNIQUE_NAMESPACE::calculate_compute_kernel_args(
                     operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
@@ -1205,10 +1194,10 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 const auto scalar = *operation_attributes.scalar;
                 const auto packed_scalar = pack_scalar_runtime_arg(scalar, a.dtype(), rt_is_quant_op);
                 packed_scalar_for_reader = packed_scalar;
-                std::vector<uint32_t> writer_runtime_args;
+                std::vector<std::variant<uint32_t, Buffer*>> writer_runtime_args;
                 if (row_major_inputs) {
                     writer_runtime_args = {
-                        c.buffer()->address(),
+                        c.buffer(),
                         common_row_width_elements,
                         c_num_tiles_core,
                         cD,
@@ -1225,7 +1214,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 } else {
                     writer_runtime_args = {
                         packed_scalar,
-                        c.buffer()->address(),
+                        c.buffer(),
                         c_start_id,
                         c_num_tiles_core,
                         c_current_shard_width,
@@ -1237,17 +1226,17 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                         cND,
                         0u};
                 }
-                writer_desc.runtime_args.emplace_back(
-                    core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+                writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
                 std::array compute_runtime_args = {compute_tiles, 0u, 0u, compute_scalar_value};
                 compute_desc.runtime_args.emplace_back(
                     core, KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
             }
-            std::vector<uint32_t> reader_runtime_args;
+            std::vector<std::variant<uint32_t, Buffer*>> reader_runtime_args;
 
             if (row_major_inputs) {
-                const uint32_t b_addr = b.has_value() ? b->buffer()->address() : 0u;
+                const std::variant<uint32_t, Buffer*> b_addr =
+                    b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u};
                 const uint32_t b_page_size = b.has_value() ? static_cast<uint32_t>(b->buffer()->aligned_page_size())
                                                            : static_cast<uint32_t>(a.buffer()->aligned_page_size());
                 const uint32_t bD_arg = b.has_value() ? bD : 1u;
@@ -1255,7 +1244,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 const uint32_t bC_arg = b.has_value() ? bC : 1u;
                 const uint32_t bHt_r_arg = b.has_value() ? bHt_r : 1u;
                 reader_runtime_args = {
-                    a.buffer()->address(),
+                    a.buffer(),
                     c_num_tiles_core,
                     aD,
                     aN,
@@ -1283,7 +1272,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                     packed_scalar_for_reader};
             } else {
                 reader_runtime_args = {
-                    a.buffer()->address(),
+                    a.buffer(),
                     c_start_id,
                     a_num_tiles,
                     c_num_tiles_core,
@@ -1298,7 +1287,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                     cHt,
                     cWt,
                     cND,
-                    b.has_value() ? b->buffer()->address() : 0u,
+                    b.has_value() ? std::variant<uint32_t, Buffer*>{b->buffer()} : std::variant<uint32_t, Buffer*>{0u},
                     bHt * bWt * bC * bN * bD * (bND > 1),
                     bHt * bWt * bC * bN * (bD > 1),
                     bHt * bWt * bC * (bN > 1),
@@ -1307,8 +1296,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 };
             }
 
-            reader_desc.runtime_args.emplace_back(
-                core, KernelDescriptor::CoreRuntimeArgs{reader_runtime_args.begin(), reader_runtime_args.end()});
+            reader_desc.emplace_runtime_args(core, reader_runtime_args);
 
             start_tile_id += c_num_tiles_core;
             if (row_major_inputs) {


### PR DESCRIPTION
### What
Declare the a/b/c tensor buffers in the experimental quasar `binary_ng` ProgramDescriptor factory as `Buffer*` runtime-arg bindings via `emplace_runtime_args()` instead of raw `buffer()->address()` uint32_t values. Optional operand b keeps its `0u` scalar when absent. Mirrors the merged non-quasar `binary_ng` fix. Arg order and scalar values unchanged.

### Why
A raw buffer/semaphore address pushed as a plain uint32_t is invisible to the descriptor framework, which cannot patch it on a program-cache hit (it either rebuilds the descriptor every dispatch or serves a stale address). Declaring it as a tracked binding — or, where a binding is impossible or the value is hash-excluded, re-applying it via `get_dynamic_runtime_args` — removes the smuggled pointer. Pointer-smuggle removal only; no intended behavior change on the miss path.

### Test
Build clean; op unit tests green on Wormhole (cache-hit / program-cache paths exercised where applicable). Multi-device CCL/SDPA paths validate in CI. Detector `scripts/detect_smuggled_rta.py` clean on changed files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-quasar-binary-ng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-quasar-binary-ng)
