### PR TITLE
[kv_cache] Remove smuggled buffer-address runtime args (BufferBindings + get_dynamic_runtime_args)

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -177,6 +177,105 @@ class TestUpdateCache:
 
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
+@pytest.mark.parametrize("in_sharded", [False, True])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+def test_update_cache_decode_program_cache_hits(in_sharded, input_dtype, device):
+    """Cache-hit coverage for the UPDATE path's hash-excluded write offsets.
+
+    UpdateKVCacheOperation::compute_program_hash excludes update_idx (cache_idx)
+    and batch_offset, so repeated update_cache calls that differ ONLY in those
+    values hit the program cache. get_dynamic_runtime_args must re-apply the
+    per-dispatch write/read offsets (cache_start_id / tile_update_offset /
+    batch_read_offset) on every hit; if any froze at the first cache-miss value
+    the update would land at (or read from) the wrong position and the
+    per-iteration comp_equal below would fail. We also assert the program cache
+    grew by exactly ONE entry, i.e. every call after the first was a genuine hit
+    (not a recompile that would silently mask a freeze).
+
+    This exercises the branch the reviewer flagged: the pre-existing
+    test_update_cache_decode calls update_cache only once per (freshly built)
+    program, so the get_dynamic re-application path is never taken.
+    """
+    head_dim = 64
+    max_seq_len = 4096
+    num_users = 8
+    num_heads = 2
+    cache_dtype = input_dtype
+
+    cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+    cache = torch.randn(cache_shape).bfloat16().float()
+    cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    # Each (cache_idx, batch_offset) writes to a DIFFERENT seq position and reads
+    # from a DIFFERENT input offset, while tensor shapes/dtype/sharding stay
+    # identical -> all iterations share a single cached program. Distinct
+    # cache_idx values never overlap, so the whole cache must accumulate every
+    # update. All satisfy num_users + batch_offset <= 32.
+    positions = [(0, 0), (1, 8), (127, 16), (1057, 0), (63, 24)]
+
+    input_shape = [num_users, num_heads, 1, head_dim]
+    num_new_cache_entries = 0
+    for cache_idx, batch_offset in positions:
+        assert num_users + batch_offset <= 32
+        x = torch.randn(input_shape).bfloat16().float()
+        # Pad dim0 of the input to 32, placing the real users at [batch_offset,
+        # batch_offset + num_users); the op reads from that offset and writes to
+        # cache users [0, num_users).
+        x_new = x.clone()
+        x_new = torch.cat((torch.zeros(batch_offset, num_heads, 1, head_dim), x_new), dim=0)
+        x_new = torch.cat((x_new, torch.zeros(32 - num_users - batch_offset, num_heads, 1, head_dim)), dim=0)
+        assert x_new.shape[0] == 32, f"Expected x.shape[0] to be 32, got {x_new.shape[0]}"
+        xt = ttnn.Tensor(x_new.permute(2, 1, 0, 3), input_dtype).to(ttnn.TILE_LAYOUT)
+        if in_sharded:
+            compute_grid_size = device.compute_with_storage_grid_size()
+            num_cores = min(max(num_users, 32) // 32 * num_heads, compute_grid_size.x * compute_grid_size.y)
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+            input_shard_spec = ttnn.ShardSpec(
+                shard_grid,
+                [
+                    xt.volume() // xt.padded_shape[-1] // num_cores,
+                    xt.padded_shape[-1],
+                ],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            input_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+            )
+            xt = xt.to(device, input_mem_config)
+        else:
+            xt = xt.to(device)
+
+        entries_before = device.num_program_cache_entries()
+        cachett = ttnn.update_cache(cachett, xt, cache_idx, batch_offset=batch_offset)
+        num_new_cache_entries += device.num_program_cache_entries() - entries_before
+
+        # Mirror the update into the torch reference at the SAME position.
+        cache[0:num_users, 0:num_heads, cache_idx : cache_idx + 1, 0:head_dim] = x
+
+        # This iteration's write must land at its own cache_idx / read from its
+        # own batch_offset. A frozen offset would corrupt this slice.
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        eq_update, out_update = comp_equal(
+            x, tt_got_back[0:num_users, 0:num_heads, cache_idx : cache_idx + 1, 0:head_dim]
+        )
+        logger.info(f"cache_idx={cache_idx} batch_offset={batch_offset}: {out_update}")
+        assert eq_update, out_update
+
+    # The full cache must reflect EVERY update at its own position (catches an
+    # offset frozen at a prior iteration's value that clobbered the wrong region).
+    tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    eq_cache, out_cache = comp_equal(cache, tt_got_back)
+    logger.info(out_cache)
+    assert eq_cache, out_cache
+
+    # Exactly one program built: the first call missed, all later calls were
+    # genuine cache hits (so get_dynamic_runtime_args re-applied the offsets).
+    assert (
+        num_new_cache_entries == 1
+    ), f"Expected a single program-cache entry (genuine hits after first), got {num_new_cache_entries}"
+
+
+@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("head_dim", [64])
 @pytest.mark.parametrize("max_seq_len", [2048])
 @pytest.mark.parametrize("num_users", [8, 16, 32, 64])

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
@@ -21,12 +21,86 @@ namespace ttnn::prim {
 
 using namespace tt::constants;
 
-ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
-    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& /*tensor_return_value*/) {
+std::vector<std::pair<CoreCoord, uint32_t>> compute_fill_cache_start_ids(
+    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args) {
     const auto& cache_tensor = tensor_args.cache;
     const auto& input_tensor = tensor_args.input;
     const auto batch_idx = operation_attributes.batch_idx;
     const auto update_idx = operation_attributes.update_idx;
+
+    // Mirror the shape-derived geometry and work-split from create_descriptor exactly so the
+    // per-core cache_start_id values (and the core ordering) are identical on cache miss and hit.
+    uint32_t num_blocks_of_work = input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
+
+    uint32_t Wt = cache_tensor.padded_shape()[-1] / TILE_WIDTH;
+    uint32_t input_Ht = input_tensor.padded_shape()[-2] / TILE_HEIGHT;  // seq_len
+    uint32_t cache_HtWt = cache_tensor.padded_shape()[-2] * Wt / TILE_HEIGHT;
+    uint32_t cache_CHtWt = cache_tensor.padded_shape()[1] * cache_HtWt;
+    uint32_t update_idxt = update_idx / TILE_HEIGHT;
+    uint32_t start_idx = (batch_idx * cache_CHtWt) + (update_idxt * Wt);
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    bool row_major;
+    uint32_t num_cores, num_blocks_per_core_group_1, num_blocks_per_core_group_2;
+
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+
+    const std::optional<ShardSpec>& shard_spec = input_tensor.shard_spec();
+
+    if (shard_spec.has_value()) {
+        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+        all_cores = shard_spec.value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        core_group_2 = CoreRangeSet();
+        num_blocks_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
+        num_blocks_per_core_group_2 = 0;
+        auto bbox = all_cores.bounding_box();
+        num_cores_x = bbox.end_coord.x + 1;
+        num_cores_y = bbox.end_coord.y + 1;
+    } else {
+        row_major = true;
+        std::tie(
+            num_cores,
+            all_cores,
+            core_group_1,
+            core_group_2,
+            num_blocks_per_core_group_1,
+            num_blocks_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks_of_work, row_major);
+    }
+
+    uint32_t g1_numcores = core_group_1.num_cores();
+    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    std::vector<std::pair<CoreCoord, uint32_t>> start_ids;
+    start_ids.reserve(num_cores);
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
+        const CoreCoord& core = cores.at(i);
+        uint32_t num_blocks_per_core = 0;
+        if (i < g1_numcores) {
+            num_blocks_per_core = num_blocks_per_core_group_1;
+        } else {
+            num_blocks_per_core = num_blocks_per_core_group_2;
+        }
+
+        const uint32_t cache_start_id = start_idx                                       // user batch start
+                                        + (num_blocks_written / input_Ht * cache_HtWt)  // cache head offset
+                                        + ((num_blocks_written % input_Ht) * Wt);       // seq_len offset
+        start_ids.emplace_back(core, cache_start_id);
+        num_blocks_written += num_blocks_per_core;
+    }
+    return start_ids;
+}
+
+ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
+    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& /*tensor_return_value*/) {
+    const auto& cache_tensor = tensor_args.cache;
+    const auto& input_tensor = tensor_args.input;
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
@@ -37,12 +111,10 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
     // reader/writer
     uint32_t num_blocks_of_work = input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
 
+    // Wt is the only shape-derived geometry create_descriptor still needs directly; the
+    // batch_idx/update_idx-dependent cache_start_id lives in compute_fill_cache_start_ids so the
+    // cache-miss and cache-hit (get_dynamic_runtime_args) paths share one source of truth.
     uint32_t Wt = cache_tensor.padded_shape()[-1] / TILE_WIDTH;
-    uint32_t input_Ht = input_tensor.padded_shape()[-2] / TILE_HEIGHT;  // seq_len
-    uint32_t cache_HtWt = cache_tensor.padded_shape()[-2] * Wt / TILE_HEIGHT;
-    uint32_t cache_CHtWt = cache_tensor.padded_shape()[1] * cache_HtWt;
-    uint32_t update_idxt = update_idx / TILE_HEIGHT;
-    uint32_t start_idx = (batch_idx * cache_CHtWt) + (update_idxt * Wt);
     tt::tt_metal::IDevice* device = input_tensor.device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -144,12 +216,14 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
 
-    // Per-core runtime args. We push raw buffer addresses (uint32_t) rather than Buffer*
-    // because the per-core cache_start_id derives from operation_attributes (batch_idx,
-    // update_idx) which UpdateKVCacheOperation::compute_program_hash deliberately excludes
-    // from the program-cache key. With buffer_bindings empty the framework uses the
-    // descriptor-rebuild slow path on cache hits, which correctly re-derives
-    // cache_start_id every dispatch.
+    // Per-core runtime args. src/dst base addresses are declared as Buffer* bindings so the
+    // framework patches the (possibly reallocated) addresses directly on cache hits (fast path).
+    // The per-core writer cache_start_id derives from operation_attributes (batch_idx, update_idx)
+    // which UpdateKVCacheOperation::compute_program_hash deliberately excludes from the
+    // program-cache key, so it is NOT stable across cache hits: it is re-patched every dispatch by
+    // UpdateKVCacheOperation::get_dynamic_runtime_args. compute_fill_cache_start_ids is the shared
+    // single source of truth for the work-split and cache_start_id formula so the two paths agree.
+    const auto start_ids = compute_fill_cache_start_ids(operation_attributes, tensor_args);
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
         const CoreCoord& core = cores.at(i);
         uint32_t num_blocks_per_core = 0;
@@ -162,19 +236,17 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
         reader_desc.emplace_runtime_args(
             core,
             {
-                src_buffer->address(),
+                src_buffer,
                 num_blocks_per_core * Wt,
                 num_blocks_written * Wt,
             });
 
-        const uint32_t cache_start_id = start_idx                                       // user batch start
-                                        + (num_blocks_written / input_Ht * cache_HtWt)  // cache head offset
-                                        + ((num_blocks_written % input_Ht) * Wt);       // seq_len offset
+        const uint32_t cache_start_id = start_ids.at(i).second;
 
         writer_desc.emplace_runtime_args(
             core,
             {
-                dst_buffer->address(),
+                dst_buffer,
                 num_blocks_per_core * Wt,
                 cache_start_id,
             });

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <utility>
+#include <vector>
 #include <tt-metalium/program_descriptors.hpp>
 #include "update_cache_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
@@ -17,5 +19,15 @@ struct FillCacheMultiCoreProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& tensor_return_value);
 };
+
+// Per-core writer cache_start_id, in the SAME core order create_descriptor emits runtime args.
+// cache_start_id derives from operation_attributes (batch_idx, update_idx) which
+// UpdateKVCacheOperation::compute_program_hash deliberately EXCLUDES from the program-cache key
+// (so two fills that differ only in those cache-hit), yet it is baked into a writer runtime arg —
+// so it must be re-patched on every cache hit via UpdateKVCacheOperation::get_dynamic_runtime_args.
+// This helper is the single source of truth for the work-split + formula: both create_descriptor
+// (cache miss) and get_dynamic_runtime_args (cache hit) call it, so the two paths cannot drift.
+std::vector<std::pair<tt::tt_metal::CoreCoord, uint32_t>> compute_fill_cache_start_ids(
+    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -163,6 +163,53 @@ tt::tt_metal::operation::Hash UpdateKVCacheOperation::compute_program_hash(
         args.op_type, std::vector<Tensor>{tensor_args.cache, tensor_args.input});
 }
 
+std::vector<tt::tt_metal::DynamicRuntimeArg> UpdateKVCacheOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // The work-split (hence the core set) depends only on shapes, which ARE in the program hash, so
+    // the active core set is identical on every cache hit — no freeze hazard from growing cores.
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+
+    if (operation_attributes.op_type == UpdateCacheOpType::FILL) {
+        // FILL: kernel push order in FillCacheMultiCoreProgramFactory::create_descriptor is
+        // reader(0), writer(1). Only writer arg 2 (cache_start_id) is derived from the
+        // hash-excluded batch_idx/update_idx; the reader args are shape-only.
+        constexpr uint32_t kWriterKernelIdx = 1;
+        constexpr uint32_t kCacheStartIdArgIdx = 2;
+        const auto start_ids = compute_fill_cache_start_ids(operation_attributes, tensor_args);
+        dynamic_args.reserve(start_ids.size());
+        for (const auto& [core, cache_start_id] : start_ids) {
+            dynamic_args.push_back({kWriterKernelIdx, core, kCacheStartIdArgIdx, cache_start_id});
+        }
+        return dynamic_args;
+    }
+
+    // UPDATE: kernel push order in UpdateCacheMultiCoreProgramFactory::create_descriptor is
+    // reader(0), writer(1), compute(2), [optional compute(3)]. The hash-excluded values are:
+    //   reader arg 8  = cache_start_id (per core)
+    //   writer arg 7  = cache_start_id (per core)
+    //   writer arg 10 = tile_update_offset (op-wide)
+    //   writer arg 11 = batch_read_offset (op-wide)
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    constexpr uint32_t kReaderCacheStartIdArgIdx = 8;
+    constexpr uint32_t kWriterCacheStartIdArgIdx = 7;
+    constexpr uint32_t kWriterTileUpdateOffsetArgIdx = 10;
+    constexpr uint32_t kWriterBatchReadOffsetArgIdx = 11;
+
+    const auto dyn = compute_update_cache_dynamic_args(operation_attributes, tensor_args);
+    dynamic_args.reserve(dyn.cache_start_ids.size() * 4);
+    for (const auto& [core, cache_start_id] : dyn.cache_start_ids) {
+        dynamic_args.push_back({kReaderKernelIdx, core, kReaderCacheStartIdArgIdx, cache_start_id});
+        dynamic_args.push_back({kWriterKernelIdx, core, kWriterCacheStartIdArgIdx, cache_start_id});
+        dynamic_args.push_back({kWriterKernelIdx, core, kWriterTileUpdateOffsetArgIdx, dyn.tile_update_offset});
+        dynamic_args.push_back({kWriterKernelIdx, core, kWriterBatchReadOffsetArgIdx, dyn.batch_read_offset});
+    }
+    return dynamic_args;
+}
+
 Tensor update_cache(
     const Tensor& cache,
     const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
@@ -5,11 +5,14 @@
 #pragma once
 
 #include <optional>
+#include <vector>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/core.hpp"
 
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/global_circular_buffer.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/distributed/types.hpp"
 #include "update_cache_device_operation_types.hpp"
 #include "fill_cache_multi_core_program_factory.hpp"
 #include "update_cache_multi_core_program_factory.hpp"
@@ -31,6 +34,18 @@ struct UpdateKVCacheOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // batch_idx, update_idx and batch_offset are excluded from compute_program_hash (so calls
+    // differing only in them cache-hit), yet the factories bake the values they derive
+    // (cache_start_id, tile_update_offset, batch_read_offset) into runtime args. Those must be
+    // re-applied to the cached program on every dispatch or they freeze at the first cache-miss
+    // value — corrupting the write offset. The buffer base addresses are handled separately by the
+    // Buffer* bindings the factories declare via emplace_runtime_args.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 Tensor update_cache(

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
@@ -21,12 +21,103 @@ namespace ttnn::prim {
 
 using namespace tt::constants;
 
-ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
-    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& /*tensor_return_value*/) {
+UpdateCacheDynamicArgs compute_update_cache_dynamic_args(
+    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args) {
     const auto& cache_tensor = tensor_args.cache;
     const auto& input_tensor = tensor_args.input;
     const auto update_idx = operation_attributes.update_idx;
     const auto batch_offset = operation_attributes.batch_offset;
+    TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config is required");
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
+
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    // Mirror the shape/dtype-derived geometry and work-split from create_descriptor exactly so the
+    // per-core cache_start_id values, the two op-wide offsets, and the core ordering are identical
+    // on cache miss and hit.
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    uint32_t Wt = cache_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+
+    // Width size after untilize
+    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor.padded_shape()[-1] * sizeof(float)
+                                       : cache_tensor.padded_shape()[-1] * sizeof(::bfloat16);
+
+    uint32_t cache_total_num_tiles = cache_tensor.physical_volume() / TILE_HW;
+    uint32_t cache_batch_num_tiles = cache_total_num_tiles / cache_tensor.padded_shape()[0];
+    uint32_t cache_head_num_tiles = cache_batch_num_tiles / cache_tensor.padded_shape()[1];
+
+    uint32_t B = input_tensor.padded_shape()[-2];
+    uint32_t num_batched_heads = input_tensor.padded_shape()[1] * B / tt::constants::TILE_HEIGHT;
+
+    UpdateCacheDynamicArgs result;
+    result.tile_update_offset = update_idx % tt::constants::TILE_HEIGHT * Wbytes;
+    result.batch_read_offset = batch_offset * Wbytes;  // Offset to read from input tensor
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    bool row_major;
+    uint32_t num_cores, num_batched_heads_per_core_group_1, num_batched_heads_per_core_group_2;
+
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+
+    const std::optional<ShardSpec>& shard_spec = input_tensor.shard_spec();
+
+    if (shard_spec.has_value()) {
+        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+        all_cores = shard_spec.value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        core_group_2 = CoreRangeSet();
+        num_batched_heads_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
+        num_batched_heads_per_core_group_2 = 0;
+        auto bbox = all_cores.bounding_box();
+        num_cores_x = bbox.end_coord.x + 1;
+        num_cores_y = bbox.end_coord.y + 1;
+    } else {
+        row_major = true;
+        std::tie(
+            num_cores,
+            all_cores,
+            core_group_1,
+            core_group_2,
+            num_batched_heads_per_core_group_1,
+            num_batched_heads_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_batched_heads, row_major);
+    }
+
+    uint32_t g1_numcores = core_group_1.num_cores();
+    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    uint32_t cache_tile_idx = update_idx / tt::constants::TILE_HEIGHT * Wt;
+    uint32_t total_batched_heads = 0;
+    result.cache_start_ids.reserve(num_cores);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const CoreCoord& core = cores.at(i);
+        uint32_t num_batched_heads_per_core;
+        if (i < g1_numcores) {
+            num_batched_heads_per_core = num_batched_heads_per_core_group_1;
+        } else {
+            num_batched_heads_per_core = num_batched_heads_per_core_group_2;
+        }
+        uint32_t batch_start_id = (total_batched_heads * TILE_HEIGHT) % B;
+        // Batch Offset + Head Offset + Index Offset
+        uint32_t cache_start_id = batch_start_id * cache_batch_num_tiles +
+                                  ((total_batched_heads * tt::constants::TILE_HEIGHT) / B) * cache_head_num_tiles;
+        cache_start_id += cache_tile_idx;
+        result.cache_start_ids.emplace_back(core, cache_start_id);
+        total_batched_heads += num_batched_heads_per_core;
+    }
+    return result;
+}
+
+ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
+    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& /*tensor_return_value*/) {
+    const auto& cache_tensor = tensor_args.cache;
+    const auto& input_tensor = tensor_args.input;
     TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config is required");
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
 
@@ -64,8 +155,6 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
     uint32_t Bcache = cache_tensor.padded_shape()[0];
     const uint32_t granularity = std::min(static_cast<uint32_t>(2), Bcache);  // granularity = 2 best for performance
     uint32_t num_batched_heads = input_tensor.padded_shape()[1] * B / tt::constants::TILE_HEIGHT;
-    uint32_t tile_update_offset = update_idx % tt::constants::TILE_HEIGHT * Wbytes;
-    uint32_t batch_read_offset = batch_offset * Wbytes;  // Offset to read from input tensor
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -276,14 +365,16 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
 
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
 
-    // Per-core runtime args. We push raw buffer addresses (uint32_t) rather than Buffer*
-    // because cache_start_id and tile_update_offset depend on operation_attributes
-    // (update_idx) which UpdateKVCacheOperation::compute_program_hash deliberately
-    // excludes from the program-cache key. With buffer_bindings empty, the framework
-    // uses the descriptor-rebuild slow path on cache hits, which correctly re-derives
-    // the per-core ids from the new update_idx every dispatch.
-    uint32_t cache_tile_idx = update_idx / tt::constants::TILE_HEIGHT * Wt;
-    uint32_t cache_start_id = 0;
+    // Per-core runtime args. src/dst base addresses are declared as Buffer* bindings so the
+    // framework patches the (possibly reallocated) addresses directly on cache hits (fast path).
+    // cache_start_id, tile_update_offset and batch_read_offset depend on operation_attributes
+    // (update_idx, batch_offset) which UpdateKVCacheOperation::compute_program_hash deliberately
+    // excludes from the program-cache key, so they are NOT stable across cache hits: they are
+    // re-patched every dispatch by UpdateKVCacheOperation::get_dynamic_runtime_args.
+    // compute_update_cache_dynamic_args is the shared single source of truth for the work-split and
+    // formulas so the two paths agree. input_start_id and batch_start_id are shape-only (in the
+    // hash), so they stay computed inline here.
+    const auto dyn = compute_update_cache_dynamic_args(operation_attributes, tensor_args);
     uint32_t input_start_id = 0;
     uint32_t batch_start_id = 0;
     uint32_t total_batched_heads = 0;
@@ -298,13 +389,11 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
         input_start_id = total_batched_heads * Wt;
         batch_start_id = (total_batched_heads * TILE_HEIGHT) % B;
         // Batch Offset + Head Offset + Index Offset
-        cache_start_id = batch_start_id * cache_batch_num_tiles +
-                         ((total_batched_heads * tt::constants::TILE_HEIGHT) / B) * cache_head_num_tiles;
-        cache_start_id += cache_tile_idx;
+        const uint32_t cache_start_id = dyn.cache_start_ids.at(i).second;
         reader_desc.emplace_runtime_args(
             core,
-            {dst_buffer->address(),
-             src_buffer->address(),
+            {dst_buffer,
+             src_buffer,
              Wt,
              Bcache,
              num_batched_heads_per_core,
@@ -317,7 +406,7 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
 
         writer_desc.emplace_runtime_args(
             core,
-            {dst_buffer->address(),
+            {dst_buffer,
              Wt,
              Bcache,
              num_batched_heads_per_core,
@@ -327,8 +416,8 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
              cache_start_id,
              batch_start_id,
              Wbytes,
-             tile_update_offset,
-             batch_read_offset});
+             dyn.tile_update_offset,
+             dyn.batch_read_offset});
         total_batched_heads += num_batched_heads_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
+#include <utility>
+#include <vector>
 #include <tt-metalium/program_descriptors.hpp>
 #include "update_cache_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
@@ -17,5 +20,23 @@ struct UpdateCacheMultiCoreProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& tensor_return_value);
 };
+
+// Runtime-arg values that derive from operation_attributes (update_idx, batch_offset) which
+// UpdateKVCacheOperation::compute_program_hash deliberately EXCLUDES from the program-cache key
+// (so two updates that differ only in those cache-hit), yet are baked into reader/writer runtime
+// args — so they must be re-patched on every cache hit via
+// UpdateKVCacheOperation::get_dynamic_runtime_args. compute_update_cache_dynamic_args is the single
+// source of truth for the work-split + formulas: both create_descriptor (cache miss) and
+// get_dynamic_runtime_args (cache hit) call it, so the two paths cannot drift.
+//   - cache_start_ids: per-core, in the SAME core order create_descriptor emits runtime args.
+//   - tile_update_offset / batch_read_offset: identical on every core (op-wide scalars).
+struct UpdateCacheDynamicArgs {
+    std::vector<std::pair<tt::tt_metal::CoreCoord, uint32_t>> cache_start_ids;
+    uint32_t tile_update_offset = 0;
+    uint32_t batch_read_offset = 0;
+};
+
+UpdateCacheDynamicArgs compute_update_cache_dynamic_args(
+    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args);
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### What
Declare the cache/input buffers in the `fill_cache` and `update_cache` ProgramDescriptor factories as `Buffer*` bindings. `kv_cache` has a custom `compute_program_hash` that excludes `batch_idx`/`update_idx`/`batch_offset`, so the write-offset scalars derived from them (`cache_start_id`, `tile_update_offset`, `batch_read_offset`) are re-applied on every dispatch via a new `get_dynamic_runtime_args` override (shared miss/hit helper). Buffer addresses patch on the fast path; offsets no longer freeze at first-miss values.

### Why
A raw buffer/semaphore address pushed as a plain uint32_t is invisible to the descriptor framework, which cannot patch it on a program-cache hit (it either rebuilds the descriptor every dispatch or serves a stale address). Declaring it as a tracked binding — or, where a binding is impossible or the value is hash-excluded, re-applying it via `get_dynamic_runtime_args` — removes the smuggled pointer. Pointer-smuggle removal only; no intended behavior change on the miss path.

### Test
Build clean; op unit tests green on Wormhole (cache-hit / program-cache paths exercised where applicable). Multi-device CCL/SDPA paths validate in CI. Detector `scripts/detect_smuggled_rta.py` clean on changed files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-kv-cache)
