### PR TITLE
[transformer/sdpa_decode] Remove smuggled buffer-address runtime args (BufferBindings)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
@@ -685,3 +685,278 @@ def test_cur_pos_tensor_rank1_then_rank2_same_dram_same_qkv_program_cache(device
         f"with identical Q/K/V (DRAM). Got {device.num_program_cache_entries()}. "
         "If cur_pos_tensor is dropped from compute_program_hash, entries can stay at 1."
     )
+
+
+# ---------------------------------------------------------------------------
+# Optional-operand freshness on the program-cache HIT fast path.
+#
+# sdpa_decode binds all 8 q/k/v/output/cur_pos/page_table/attn_mask/
+# attention_sink buffer addresses as Buffer* so they are re-patched on the
+# fast cache-hit path (which skips create_descriptor()). The optional operands
+# (attn_mask, page_table, attention_sink) are the ones at risk of freezing:
+# if any of their addresses were left as a raw uint32 scalar, a later dispatch
+# that reuses the cached program with a FRESHLY-ALLOCATED optional tensor (a
+# different DRAM address) would read the first dispatch's stale buffer and
+# silently produce a wrong result.
+#
+# The two tests below re-dispatch the SAME cached program with reallocated
+# optional operands (distinct addresses, distinct meaning) and assert both the
+# numeric result (PCC) and a genuine cache hit each iteration. They FAIL if an
+# optional buffer address froze on the fast path.
+# ---------------------------------------------------------------------------
+
+
+def test_attn_mask_realloc_reused_program_cache_hit(device_with_program_cache):
+    """Non-causal decode: re-dispatch the cached program with a freshly-allocated
+    attn_mask (distinct DRAM address, distinct masked window) on every iteration.
+
+    Each iteration allows attention over a disjoint quarter of the key sequence,
+    so the correct output is markedly different per iteration. If the attn_mask
+    buffer address froze on the cache-hit fast path, iterations 1+ would read
+    iteration 0's mask and fail PCC against their own reference.
+    """
+    device = device_with_program_cache
+
+    b, nh, nkv, s, d = 2, 8, 1, 1024, 64
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    torch.manual_seed(20250709)
+
+    padded_heads = nearest_pow_2(nearest_n(nh, n=32))
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    q_dtype = ttnn.bfloat16
+    kv_dtype = ttnn.bfloat8_b
+    k_chunk_size = get_chunk_size(s // 4 + 1, s)
+    scale = d**-0.5
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    # Fixed Q/K/V across all iterations so only the (optional) mask changes.
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+    q = fa_rand(1, b, nh, d)
+    tt_q = ttnn.as_tensor(q[:, :, :nh], device=device, dtype=q_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_k = ttnn.as_tensor(k, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.as_tensor(v, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+
+    q_s = q[:, :, :nh, :].permute(1, 2, 0, 3)
+    k_s = torch.cat([k[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    v_s = torch.cat([v[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+
+    n_iters = 4
+    window = s // n_iters
+    # Large finite negative (not float32.min): each iteration fully masks entire
+    # k-chunks, and float32.min overflows the flash running-max reduction to a
+    # zero result. -1e4 fully suppresses masked keys (exp(-1e4)==0) without that.
+    neg = -1.0e4
+
+    # Keep every mask tensor alive so the allocator hands out a distinct DRAM
+    # address for each fresh mask (a live buffer's address is never reused).
+    live_masks = []
+    seen_addrs = []
+    min_pcc = 0.97
+
+    for it in range(n_iters):
+        # Allow only the it-th disjoint window of keys; mask everything else.
+        mask_torch = torch.full((b, nh, 1, s), neg)
+        mask_torch[:, :, :, it * window : (it + 1) * window] = 0.0
+
+        tt_mask = ttnn.as_tensor(
+            mask_torch.transpose(1, 2).contiguous(),
+            device=device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=dram,
+        )
+        live_masks.append(tt_mask)
+
+        addr = tt_mask.buffer_address()
+        assert addr not in seen_addrs, (
+            f"Iteration {it}: fresh attn_mask reused a prior DRAM address ({addr}); "
+            "cannot prove the cache-hit path re-patched a NEW optional-buffer address."
+        )
+        seen_addrs.append(addr)
+
+        out = ttnn.transformer.scaled_dot_product_attention_decode(
+            tt_q,
+            tt_k,
+            tt_v,
+            is_causal=False,
+            attn_mask=tt_mask,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=dram,
+        )
+        out_torch = ttnn.to_torch(out)[:, :, :nh, :]
+
+        ref = (
+            torch.nn.functional.scaled_dot_product_attention(
+                q_s, k_s, v_s, mask_torch[:, :nh, :, :], scale=scale, is_causal=False
+            )
+            .squeeze(2)
+            .unsqueeze(0)
+        )
+
+        assert device.num_program_cache_entries() == 1, (
+            f"Iteration {it}: expected exactly 1 program-cache entry (miss on iter 0, hit after), "
+            f"got {device.num_program_cache_entries()}. Only the optional attn_mask address changed, "
+            "so every dispatch after the first must be a genuine cache hit on the fast path."
+        )
+
+        ok, pcc = comp_pcc(ref, out_torch, min_pcc)
+        assert ok, (
+            f"Iteration {it}: output vs PyTorch PCC failed ({pcc}). On a cache HIT the attn_mask buffer "
+            "address must be re-patched from its live Buffer*; a frozen (stale) address would read an "
+            "earlier iteration's mask (a different key window) and produce the wrong result here."
+        )
+
+
+def test_page_table_realloc_reused_program_cache_hit(device_with_program_cache):
+    """Paged causal decode: re-dispatch the cached program with a freshly-allocated
+    page_table (distinct DRAM address, distinct block permutation) each iteration,
+    keeping the LOGICAL K/V identical so the correct output is the same every time.
+
+    Each iteration reshuffles the paged K/V cache with a new permutation and uploads
+    the matching page_table. If the page_table buffer address froze on the cache-hit
+    fast path, iterations 1+ would resolve blocks through iteration 0's permutation
+    against the newly-shuffled cache and fail PCC.
+    """
+    device = device_with_program_cache
+
+    b, nh, nkv, s, d = 2, 8, 1, 512, 64
+    block_size = 64
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    torch.manual_seed(20250710)
+
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    padded_num_heads = nearest_pow_2(nearest_n(nh, n=32))
+    scale = d**-0.5
+
+    max_num_blocks_per_seq = s // block_size
+    assert max_num_blocks_per_seq * block_size == s
+    max_num_blocks = b * s // block_size
+
+    # Fixed logical Q/K/V for the whole test; only the page_table (and the
+    # physical block layout it indexes) changes across iterations.
+    K = fa_rand(b, nkv, s, d)
+    V = fa_rand(b, nkv, s, d)
+    Q = fa_rand(1, b, nh, d)
+
+    # cur_pos supplied as a tensor -> the cur_pos scalar arg is a constant and the
+    # position is read on-device, so a fixed cur_pos keeps every dispatch a cache hit.
+    cur_pos = min(s - 1, s // 2)
+    start_indices = [cur_pos for _ in range(b)]
+    padded_layer_len = nearest_n(cur_pos + 1, n=get_chunk_size(cur_pos + 1, s))
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_num_heads,
+        k_chunk_size=get_chunk_size(cur_pos + 1, s),
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    def to_paged_cache(cache):
+        return (
+            cache.reshape(b, nkv, max_num_blocks_per_seq, block_size, d)
+            .transpose(1, 2)
+            .reshape(b * max_num_blocks_per_seq, nkv, block_size, d)
+        )
+
+    paged_k = to_paged_cache(K)
+    paged_v = to_paged_cache(V)
+
+    # Causal reference is identical every iteration (logical K/V unchanged).
+    Q_slice = Q[:, :, :nh, :].permute(1, 2, 0, 3)
+    K_slice = torch.cat([K[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    V_slice = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    ref_mask = torch.zeros((b, nh, 1, s))
+    for i in range(b):
+        ref_mask[i, :, :, start_indices[i] + 1 :] = torch.finfo(torch.float32).min
+    ref = (
+        torch.nn.functional.scaled_dot_product_attention(
+            Q_slice, K_slice[:, :, :s, :], V_slice[:, :, :s, :], ref_mask[:, :nh, :, :], scale=scale, is_causal=False
+        )
+        .squeeze(2)
+        .unsqueeze(0)
+    )
+
+    tt_q = ttnn.as_tensor(Q[:, :, :nh], device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_pos = ttnn.Tensor(torch.tensor(start_indices, dtype=torch.int32), ttnn.int32).to(device)
+
+    n_iters = 3
+    min_pcc = 0.93
+    # Keep page_table tensors alive so each fresh upload gets a distinct DRAM address.
+    live_page_tables = []
+    seen_addrs = []
+
+    for it in range(n_iters):
+        permutation = torch.randperm(max_num_blocks)
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(b, max_num_blocks_per_seq)
+
+        # Physically shuffle the cache to match this iteration's page_table.
+        tt_k = ttnn.as_tensor(
+            paged_k[permutation], device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram
+        )
+        tt_v = ttnn.as_tensor(
+            paged_v[permutation], device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram
+        )
+        tt_page_table = ttnn.Tensor(page_table, ttnn.int32).to(device)
+        live_page_tables.append(tt_page_table)
+
+        addr = tt_page_table.buffer_address()
+        assert addr not in seen_addrs, (
+            f"Iteration {it}: fresh page_table reused a prior DRAM address ({addr}); "
+            "cannot prove the cache-hit path re-patched a NEW optional-buffer address."
+        )
+        seen_addrs.append(addr)
+
+        out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+            tt_q,
+            tt_k,
+            tt_v,
+            tt_page_table,
+            cur_pos_tensor=tt_pos,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=dram,
+        )
+        out_torch = ttnn.to_torch(out)[:, :, :nh, :]
+
+        assert device.num_program_cache_entries() == 1, (
+            f"Iteration {it}: expected exactly 1 program-cache entry (miss on iter 0, hit after), "
+            f"got {device.num_program_cache_entries()}. Only page_table/K/V addresses changed with a "
+            "fixed cur_pos_tensor and program_config, so every later dispatch must be a genuine cache hit."
+        )
+
+        ok, pcc = comp_pcc(ref, out_torch, min_pcc)
+        assert ok, (
+            f"Iteration {it}: output vs PyTorch PCC failed ({pcc}). The logical K/V are unchanged, so the "
+            "result must match every iteration; a frozen (stale) page_table address on the cache-hit path "
+            "would index the freshly-shuffled cache through an earlier permutation and corrupt the output."
+        )

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
@@ -9,6 +9,7 @@ import ttnn
 from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
     comp_pcc,
     fa_rand,
+    flash_decode_sdpa,
     get_chunk_size,
     nearest_n,
     nearest_pow_2,
@@ -959,4 +960,139 @@ def test_page_table_realloc_reused_program_cache_hit(device_with_program_cache):
             f"Iteration {it}: output vs PyTorch PCC failed ({pcc}). The logical K/V are unchanged, so the "
             "result must match every iteration; a frozen (stale) page_table address on the cache-hit path "
             "would index the freshly-shuffled cache through an earlier permutation and corrupt the output."
+        )
+
+
+def test_attention_sink_realloc_reused_program_cache_hit(device_with_program_cache):
+    """Causal decode: re-dispatch the cached program with a freshly-allocated
+    attention_sink (distinct DRAM address, distinct per-head sink values) each
+    iteration, keeping Q/K/V fixed.
+
+    The attention sink adds one extra logit per head into the softmax denominator
+    (it never contributes to the output value), so its per-head value directly
+    scales that head's output. Each iteration rotates which half of the heads get a
+    dominant (+) sink -- suppressing those heads' output toward zero -- and which
+    get a negligible (-) sink. The correct output therefore has a different set of
+    near-zero heads every iteration. If the attention_sink buffer address froze on
+    the cache-hit fast path (which skips create_descriptor()), iterations 1+ would
+    read iteration 0's sink, suppress the wrong heads, and fail PCC against their
+    own reference.
+    """
+    device = device_with_program_cache
+
+    b, nh, nkv, s, d = 2, 8, 1, 256, 64
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    torch.manual_seed(20250711)
+
+    padded_heads = nearest_pow_2(nearest_n(nh, n=32))
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    q_dtype = ttnn.bfloat16
+    kv_dtype = ttnn.bfloat16
+    scale = d**-0.5
+    # cur_pos == s - 1: the (single) query at the last position attends to every key,
+    # so the reference (which processes the whole K/V cache) matches the device.
+    cur_pos = s - 1
+    k_chunk_size = get_chunk_size(cur_pos + 1, s)
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    # Fixed Q/K/V across all iterations so only the (optional) attention_sink changes.
+    q = fa_rand(b, nh, s, d)  # (B, nh, S, D)
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+
+    # Reference layout (see flash_decode_sdpa): heads split as (nkv, q_mult).
+    ref_q = q.permute(0, 2, 1, 3).view(b, s, nkv, nh // nkv, d)
+    ref_k = k.permute(0, 2, 1, 3)
+    ref_v = v.permute(0, 2, 1, 3)
+
+    # Device Q is the single last-position token, packed as (1, B, nh, D).
+    tt_q_in = q[:, :, -1:, :].permute(2, 0, 1, 3)
+    tt_q = ttnn.from_torch(tt_q_in, device=device, dtype=q_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_k = ttnn.from_torch(k, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.from_torch(v, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+
+    # Fixed cur_pos tensor (reused every iteration, so its address never moves and the
+    # position is read on-device): every dispatch stays a genuine cache hit.
+    tt_pos = ttnn.from_torch(torch.tensor([cur_pos] * b, dtype=torch.int32), device=device, dtype=ttnn.int32)
+
+    n_iters = 4
+    min_pcc = 0.99
+    # A dominant (+) sink drives a head's output toward zero (the sink logit swamps the
+    # softmax denominator); a very negative sink is a no-op (normal attention). Large,
+    # finite magnitudes keep the online-softmax numerically stable.
+    hi, lo = 15.0, -15.0
+
+    # Keep every sink tensor alive so the allocator hands out a distinct DRAM address
+    # for each fresh sink (a live buffer's address is never reused).
+    live_sinks = []
+    seen_addrs = []
+
+    for it in range(n_iters):
+        # Rotate which half of the heads are suppressed so the set of near-zero heads
+        # differs every iteration -- a frozen sink would suppress the wrong heads.
+        sink_per_head = torch.full((nh,), lo)
+        for j in range(nh // 2):
+            sink_per_head[(it + j) % nh] = hi
+
+        # Reference sink: [b, 1, nh, 1, 1], raw (unscaled) per-head logits.
+        sink_ref = sink_per_head.reshape(1, 1, nh, 1, 1).repeat(b, 1, 1, 1, 1)
+
+        # Device sink: [nh, 1] padded to a single tile [nh, TILE_SIZE], divided by scale
+        # because the kernel re-applies scale inside the exp path (GPT-OSS convention).
+        tt_sink_in = sink_per_head.reshape(nh, 1)
+        tt_sink_in = torch.nn.functional.pad(tt_sink_in, (0, ttnn.TILE_SIZE - 1), "constant", 0)
+        tt_sink_in = tt_sink_in / scale
+        tt_sink = ttnn.from_torch(
+            tt_sink_in, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=dram
+        )
+        live_sinks.append(tt_sink)
+
+        addr = tt_sink.buffer_address()
+        assert addr not in seen_addrs, (
+            f"Iteration {it}: fresh attention_sink reused a prior DRAM address ({addr}); "
+            "cannot prove the cache-hit path re-patched a NEW optional-buffer address."
+        )
+        seen_addrs.append(addr)
+
+        out = ttnn.transformer.scaled_dot_product_attention_decode(
+            tt_q,
+            tt_k,
+            tt_v,
+            cur_pos_tensor=tt_pos,
+            attention_sink=tt_sink,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=dram,
+        )
+        out_torch = ttnn.to_torch(out)[..., :nh, :]
+
+        ref = flash_decode_sdpa(ref_q[:, -1:, ...], ref_k, ref_v, sink_ref, scale, sliding_window=0)
+
+        assert device.num_program_cache_entries() == 1, (
+            f"Iteration {it}: expected exactly 1 program-cache entry (miss on iter 0, hit after), "
+            f"got {device.num_program_cache_entries()}. Only the optional attention_sink address changed "
+            "with fixed Q/K/V/cur_pos, so every dispatch after the first must be a genuine cache hit."
+        )
+
+        ok, pcc = comp_pcc(ref, out_torch, min_pcc)
+        assert ok, (
+            f"Iteration {it}: output vs PyTorch PCC failed ({pcc}). On a cache HIT the attention_sink buffer "
+            "address must be re-patched from its live Buffer*; a frozen (stale) address would read an earlier "
+            "iteration's sink (a different set of suppressed heads) and produce the wrong result here."
         )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -818,14 +818,15 @@ ProgramDescriptor SdpaDecodeDeviceOperation::create_descriptor(
         .math_approx_mode = math_approx_mode,
     };
 
-    // ========== Buffer Addresses for Runtime Args ==========
-    // Mandatory buffers are passed as Buffer* (auto-registered as BufferBindings for the fast
-    // cache-hit path).  Optional buffers stay as ternary addresses since the variant cannot
-    // deduce a mixed Buffer*/uint32_t result.
-    const uint32_t pos_addr = use_cur_pos_tensor ? cur_pos_tensor.value().buffer()->address() : 0;
-    const uint32_t page_table_addr = is_paged_attention ? page_table_tensor.value().buffer()->address() : 0;
-    const uint32_t attn_mask_addr = use_attention_mask ? attn_mask.value().buffer()->address() : 0;
-    const uint32_t attention_sink_addr = use_attention_sink ? attention_sink.value().buffer()->address() : 0;
+    // ========== Buffer Bindings for Runtime Args ==========
+    // Every buffer address is passed as a Buffer* so it is auto-registered as a BufferBinding and
+    // re-patched on the fast cache-hit path (apply_resolved_bindings) instead of being baked as a
+    // raw uint32 that goes stale.  Optional buffers pass a nullptr Buffer* when absent, which
+    // emplace_runtime_args() emits as 0u with no binding — keeping the arg slot stable without
+    // invalidating the fast path.  cur_pos_buffer / page_table_buffer are already the right
+    // nullptr-when-absent Buffer* pointers computed above.
+    Buffer* attn_mask_buffer = use_attention_mask ? attn_mask.value().buffer() : nullptr;
+    Buffer* attention_sink_buffer = use_attention_sink ? attention_sink.value().buffer() : nullptr;
 
     // ========== Runtime Arguments ==========
     for (uint32_t i = 0; i < num_active_cores; ++i) {
@@ -901,18 +902,25 @@ ProgramDescriptor SdpaDecodeDeviceOperation::create_descriptor(
         }
         log_debug(tt::LogOp, "reduction_group_base_idx: {}", reduction_group_base_idx);
         // reader runtime args
-        // NOTE: do not pass Buffer* here. cur_pos and the optional pos/page_table/attn_mask
-        // addresses are operation_attribute-dependent and change between calls; using
-        // BufferBinding would skip create_descriptor() on cache hits and leave those
-        // scalar args stale (test_sdpa_decode_paged_attention exposed this).
+        // All buffer addresses (mandatory q/k/v and optional pos/page_table/attn_mask/sink) are
+        // passed as Buffer* so every one is re-patched on the fast cache-hit path.  An earlier
+        // revision bound only the mandatory buffers and left the optional addresses as raw uint32;
+        // that triggered the fast path (which skips create_descriptor()) while leaving the optional
+        // addresses stale — test_sdpa_decode_paged_attention exposed this.  Binding ALL of them
+        // keeps every address live.  The remaining scalar args (cur_pos, core/head assignment, tree
+        // params) are all functions of hashed attributes, so none can go stale on a hit: when
+        // cur_pos comes from cur_pos_tensor the scalar is a constant UINT32_MAX and the position is
+        // read on-device; when it comes from the cur_pos vector that vector is hashed, so a new
+        // position is a cache miss that rebuilds the descriptor.  An absent optional passes a
+        // nullptr Buffer* (emitted as 0u, no binding).
         KernelDescriptor::RTArgList reader_rt_args;
-        reader_rt_args.push_back(q_buffer->address());
-        reader_rt_args.push_back(k_buffer->address());
-        reader_rt_args.push_back(v_buffer->address());
-        reader_rt_args.push_back(pos_addr);
-        reader_rt_args.push_back(page_table_addr);
-        reader_rt_args.push_back(attn_mask_addr);
-        reader_rt_args.push_back(attention_sink_addr);
+        reader_rt_args.push_back(q_buffer);
+        reader_rt_args.push_back(k_buffer);
+        reader_rt_args.push_back(v_buffer);
+        reader_rt_args.push_back(cur_pos_buffer);
+        reader_rt_args.push_back(page_table_buffer);
+        reader_rt_args.push_back(attn_mask_buffer);
+        reader_rt_args.push_back(attention_sink_buffer);
         reader_rt_args.push_back(page_table_stick_size);
         reader_rt_args.push_back(static_cast<uint32_t>(do_reduce));
         reader_rt_args.push_back(static_cast<uint32_t>(do_output));
@@ -930,10 +938,11 @@ ProgramDescriptor SdpaDecodeDeviceOperation::create_descriptor(
         reader_rt_args.append(output_core_physical_ys);
 
         // writer runtime args (do_reduce is NOT included — writer doesn't use it)
-        // NOTE: do not pass Buffer* here. cur_pos and tree_params are
-        // operation_attribute-dependent and change between calls.
+        // The output address is passed as Buffer* (BufferBinding) so it is re-patched on the fast
+        // cache-hit path.  cur_pos and tree_params are functions of hashed attributes (see the
+        // reader note above), so they never go stale on a hit.
         KernelDescriptor::RTArgList writer_rt_args;
-        writer_rt_args.push_back(out_buffer->address());
+        writer_rt_args.push_back(out_buffer);
         writer_rt_args.push_back(worker_id_for_reduce);
         writer_rt_args.push_back(worker_id_for_output);
         writer_rt_args.push_back(static_cast<uint32_t>(do_reduce));


### PR DESCRIPTION
### What
Declare all eight q/k/v/output/cur_pos/page_table/attn_mask/attention_sink buffers as `Buffer*` bindings (optional operands emit `0u` when absent). All per-core scalars derive from hashed attributes (`cur_pos` is in `compute_program_hash`), so no dynamic re-apply is needed. Also fixes a latent partial-binding bug where only q/k/v/out were bound, leaving optional addresses stale on the fast path.

### Why
A raw buffer/semaphore address pushed as a plain uint32_t is invisible to the descriptor framework, which cannot patch it on a program-cache hit (it either rebuilds the descriptor every dispatch or serves a stale address). Declaring it as a tracked binding — or, where a binding is impossible or the value is hash-excluded, re-applying it via `get_dynamic_runtime_args` — removes the smuggled pointer. Pointer-smuggle removal only; no intended behavior change on the miss path.

### Test
Build clean; op unit tests green on Wormhole (cache-hit / program-cache paths exercised where applicable). Multi-device CCL/SDPA paths validate in CI. Detector `scripts/detect_smuggled_rta.py` clean on changed files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-sdpa-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-sdpa-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-sdpa-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-sdpa-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-sdpa-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-sdpa-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-sdpa-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-sdpa-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-sdpa-decode)
