### PR TITLE
[data-movement] slice_rm + roll: remove smuggled buffer-address runtime args

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
@@ -37,11 +37,10 @@ struct RollDeviceOperation {
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
 
-    // DRAM sharded roll bakes per-shard buffer addresses (base + shard offset) into the reader runtime
-    // args; those change every dispatch and cannot be plain Buffer* bindings, so they are re-emitted on
-    // every cache hit here (defined in roll_program_factory.cpp, reusing the shared plan builder so the
-    // emitted values and indices match create_descriptor exactly).
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // Cache-hit fast path: re-derive per-dispatch state from create_descriptor for the current tensors
+    // and re-apply to the cached program via apply_descriptor_runtime_args -- no rebuild.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t&,
         const tensor_args_t&,
         tensor_return_value_t&,

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
@@ -4,12 +4,16 @@
 
 #pragma once
 
+#include <optional>
 #include <variant>
+#include <vector>
 
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/data_movement/roll/device/roll_device_operation_types.hpp"
 #include "ttnn/operations/data_movement/roll/device/roll_program_factory.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/distributed/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 
@@ -32,6 +36,16 @@ struct RollDeviceOperation {
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+
+    // DRAM sharded roll bakes per-shard buffer addresses (base + shard offset) into the reader runtime
+    // args; those change every dispatch and cannot be plain Buffer* bindings, so they are re-emitted on
+    // every cache hit here (defined in roll_program_factory.cpp, reusing the shared plan builder so the
+    // emitted values and indices match create_descriptor exactly).
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 
 // Single-dim native sharded roll. shift is normalized to [0, dim_size); dim is absolute.

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "roll_program_factory.hpp"
+#include "roll_device_operation.hpp"
 
 #include <algorithm>
+#include <unordered_map>
 #include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -54,12 +56,34 @@ struct ColPiece {
     uint32_t len;
 };
 
-}  // namespace
+// Everything create_descriptor() and get_dynamic_runtime_args() need, computed once from the
+// (hashed) shape/shift/dim/memory-config so the two paths can never disagree on layout or indices.
+struct RollPlan {
+    bool is_dram = false;
+    bool is_dram_rm = false;
+    bool is_tile = false;
+    tt::DataFormat cb_data_format{};
+    CoreRangeSet grid;
+    tt::tt_metal::Buffer* input_buffer = nullptr;
+    tt::tt_metal::Buffer* output_buffer = nullptr;
 
-ProgramDescriptor RollShardedProgramFactory::create_descriptor(
-    const RollParams& operation_attributes, const RollInputs& tensor_args, Tensor& tensor_return_value) {
+    // CB sizing (create_descriptor builds the CB descriptors from these).
+    uint32_t shard_l1_size = 0;
+    uint32_t cb_page_size = 0;
+    uint32_t scratch_size = 0;
+
+    std::vector<uint32_t> compile_time_args;
+    std::vector<std::pair<CoreCoord, KernelDescriptor::CoreRuntimeArgs>> per_core_args;
+
+    // Per-dispatch buffer-address runtime args (DRAM modes bake base+offset addresses into the reader
+    // args; the L1 mode instead carries one hash-stable placeholder to trip the fast path so its
+    // .buffer-bound CB addresses get re-patched). Re-applied on every cache hit.
+    std::vector<tt::tt_metal::DynamicRuntimeArg> address_dynamic_args;
+};
+
+RollPlan compute_roll_plan(
+    const RollParams& operation_attributes, const RollInputs& tensor_args, const Tensor& output) {
     const Tensor& input = tensor_args.input;
-    Tensor& output = tensor_return_value;
 
     TT_FATAL(input.is_sharded() && output.is_sharded(), "Native sharded roll requires sharded input and output");
 
@@ -281,72 +305,24 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
         flush();
     }
 
-    // --- Circular buffers ---
+    // --- Circular buffer sizing ---
     // L1 mode: cb0 backed by input buffer, cb16 backed by output buffer, cb1 scratch.
     // DRAM mode: only the scratch cb1 is allocated in L1. Input/output CBs are not used
     // because DRAM data is addressed via bank IDs in the runtime args, not CB read ptrs.
-    constexpr uint32_t input_cb_id = 0;
     constexpr uint32_t output_cb_id = 16;
     constexpr uint32_t scratch_cb_id = 1;
     const uint32_t cb_page_size = is_tile ? cell_size : row_pitch_bytes;
 
-    ProgramDescriptor desc;
     const uint32_t shard_l1_size = shard_cells_h * row_pitch_bytes;
-    if (!is_dram) {
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = shard_l1_size,
-            .core_ranges = out_ss.grid,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(input_cb_id),
-                .data_format = cb_data_format,
-                .page_size = cb_page_size,
-            }}},
-            .buffer = input.buffer(),
-        });
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = shard_l1_size,
-            .core_ranges = out_ss.grid,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(output_cb_id),
-                .data_format = cb_data_format,
-                .page_size = cb_page_size,
-            }}},
-            .buffer = output.buffer(),
-        });
-    }
     // Scratch CB: L1 mode uses it double-buffered; DRAM TILE uses it single-buffered.
     // DRAM RM allocates separate staging CBs (2/3/4) instead, so scratch is L1-only.
     const uint32_t scratch_half = row_pitch_bytes + 2 * l1_alignment;
     const uint32_t scratch_size = (is_dram && !is_dram_rm) ? shard_l1_size : 2 * scratch_half;
-    if (!is_dram_rm) {
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = scratch_size,
-            .core_ranges = out_ss.grid,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(scratch_cb_id),
-                .data_format = cb_data_format,
-                .page_size = scratch_size,
-            }}},
-        });
-    }
 
-    // DRAM RM staging CBs: two source slots + one destination, each = full shard size.
+    // DRAM RM staging CB ids: two source slots + one destination, each = full shard size.
     constexpr uint32_t dram_rm_src0_cb_id = 2;
     constexpr uint32_t dram_rm_src1_cb_id = 3;
     constexpr uint32_t dram_rm_dst_cb_id = 4;
-    if (is_dram_rm) {
-        for (uint8_t cb_id : {dram_rm_src0_cb_id, dram_rm_src1_cb_id, dram_rm_dst_cb_id}) {
-            desc.cbs.push_back(CBDescriptor{
-                .total_size = shard_l1_size,
-                .core_ranges = out_ss.grid,
-                .format_descriptors = {{CBFormatDescriptor{
-                    .buffer_index = cb_id,
-                    .data_format = cb_data_format,
-                    .page_size = shard_l1_size,
-                }}},
-            });
-        }
-    }
 
     // --- DRAM shard address helpers ---
     const uint32_t num_dram_banks = device->num_dram_channels();
@@ -356,7 +332,7 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
         return static_cast<uint32_t>(buf->address()) + (shard_idx / num_dram_banks) * dram_shard_size;
     };
 
-    // --- Kernel ---
+    // --- Kernel arg budget ---
     uint32_t max_num_transfers = 0;
     for (const auto& t : all_transfers) {
         max_num_transfers = std::max(max_num_transfers, static_cast<uint32_t>(t.size()));
@@ -375,7 +351,8 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
 
     // mode: 0=L1, 1=DRAM_TILE, 2=DRAM_RM
     const uint32_t mode = is_dram_rm ? 2u : (is_dram ? 1u : 0u);
-    const std::vector<uint32_t> compile_time_args = {
+    constexpr uint32_t input_cb_id = 0;
+    std::vector<uint32_t> compile_time_args = {
         output_cb_id,
         scratch_cb_id,
         l1_alignment,
@@ -386,14 +363,25 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
         dram_rm_src1_cb_id,
         dram_rm_dst_cb_id};
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = out_ss.grid;
-    reader_desc.compile_time_args = compile_time_args;
-    reader_desc.config = ReaderConfigDescriptor{};
+    RollPlan plan;
+    plan.is_dram = is_dram;
+    plan.is_dram_rm = is_dram_rm;
+    plan.is_tile = is_tile;
+    plan.cb_data_format = cb_data_format;
+    plan.grid = out_ss.grid;
+    plan.input_buffer = input.buffer();
+    plan.output_buffer = output.buffer();
+    plan.shard_l1_size = shard_l1_size;
+    plan.cb_page_size = cb_page_size;
+    plan.scratch_size = scratch_size;
+    plan.compile_time_args = std::move(compile_time_args);
 
+    // --- Per-core runtime args ---
+    // The three builders emit args in a fixed layout the reader kernel reads positionally.  Every
+    // computed buffer-address slot (input/output base + shard offset) is recorded, at the exact index
+    // it is written, into plan.address_dynamic_args so get_dynamic_runtime_args re-emits the identical
+    // value at the identical index on every cache hit — the address is the only per-dispatch input, so
+    // recording it inline guarantees the two paths can never drift.
     auto build_runtime_args_l1 = [&](const std::vector<RollTransferDesc>& descs) {
         KernelDescriptor::CoreRuntimeArgs args;
         args.reserve(1 + descs.size() * 9);
@@ -412,17 +400,29 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
         return args;
     };
 
-    auto build_runtime_args_dram = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
+    auto build_runtime_args_dram = [&](uint32_t dst_core_idx,
+                                       const CoreCoord& logical,
+                                       const std::vector<RollTransferDesc>& descs,
+                                       std::vector<tt::tt_metal::DynamicRuntimeArg>& addr_slots) {
         KernelDescriptor::CoreRuntimeArgs args;
         args.reserve(3 + descs.size() * 7);
         args.push_back(dram_bank_id(dst_core_idx));
-        args.push_back(dram_bank_base(output.buffer(), dst_core_idx));
+        // dst bank base = output buffer address + shard offset (computed) — re-emitted per hit.
+        addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
+            0, logical, static_cast<uint32_t>(args.size()), dram_bank_base(plan.output_buffer, dst_core_idx)});
+        args.push_back(dram_bank_base(plan.output_buffer, dst_core_idx));
         args.push_back(static_cast<uint32_t>(descs.size()));
         for (const auto& td : descs) {
             // src_bank_id, src_bank_addr (= bank_base + intra_shard_offset), dst_offset,
             // copy_size, src_stride, dst_stride, num_rows
             args.push_back(dram_bank_id(td.src_dram_shard_idx));
-            args.push_back(dram_bank_base(input.buffer(), td.src_dram_shard_idx) + td.src_l1_offset);
+            // src bank base + intra-shard offset (computed) — re-emitted per hit.
+            addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
+                0,
+                logical,
+                static_cast<uint32_t>(args.size()),
+                dram_bank_base(plan.input_buffer, td.src_dram_shard_idx) + td.src_l1_offset});
+            args.push_back(dram_bank_base(plan.input_buffer, td.src_dram_shard_idx) + td.src_l1_offset);
             args.push_back(td.dst_offset);
             args.push_back(td.copy_size);
             args.push_back(td.src_stride);
@@ -435,7 +435,10 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
     // DRAM RM mode: full-shard L1 staging.
     // Per core: [dst_bank_id, dst_bank_base, num_src, (src0_bank_id, src0_addr)..., num_xfers,
     //            (src_slot, src_off, dst_off, copy_size, src_stride, dst_stride, num_rows) x N]
-    auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
+    auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx,
+                                          const CoreCoord& logical,
+                                          const std::vector<RollTransferDesc>& descs,
+                                          std::vector<tt::tt_metal::DynamicRuntimeArg>& addr_slots) {
         // Collect unique source shards (at most 2) and assign them to staging slots 0/1.
         std::vector<uint32_t> src_shards;
         std::unordered_map<uint32_t, uint32_t> src_to_slot;
@@ -447,11 +450,17 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
         }
         KernelDescriptor::CoreRuntimeArgs args;
         args.push_back(dram_bank_id(dst_core_idx));
-        args.push_back(dram_bank_base(output.buffer(), dst_core_idx));
+        // dst bank base = output buffer address + shard offset (computed) — re-emitted per hit.
+        addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
+            0, logical, static_cast<uint32_t>(args.size()), dram_bank_base(plan.output_buffer, dst_core_idx)});
+        args.push_back(dram_bank_base(plan.output_buffer, dst_core_idx));
         args.push_back(static_cast<uint32_t>(src_shards.size()));
         for (uint32_t s : src_shards) {
             args.push_back(dram_bank_id(s));
-            args.push_back(dram_bank_base(input.buffer(), s));
+            // src shard bank base (computed) — re-emitted per hit.
+            addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
+                0, logical, static_cast<uint32_t>(args.size()), dram_bank_base(plan.input_buffer, s)});
+            args.push_back(dram_bank_base(plan.input_buffer, s));
         }
         args.push_back(static_cast<uint32_t>(descs.size()));
         for (const auto& td : descs) {
@@ -466,21 +475,131 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
         return args;
     };
 
+    plan.per_core_args.reserve(num_cores);
     for (uint32_t c = 0; c < num_cores; c++) {
         CoreCoord logical(grid_range.start_coord.x + c % grid_cols, grid_range.start_coord.y + c / grid_cols);
         KernelDescriptor::CoreRuntimeArgs args;
         if (is_dram_rm) {
-            args = build_runtime_args_dram_rm(c, all_transfers[c]);
+            args = build_runtime_args_dram_rm(c, logical, all_transfers[c], plan.address_dynamic_args);
         } else if (is_dram) {
-            args = build_runtime_args_dram(c, all_transfers[c]);
+            args = build_runtime_args_dram(c, logical, all_transfers[c], plan.address_dynamic_args);
         } else {
             args = build_runtime_args_l1(all_transfers[c]);
+            // L1 mode carries no smuggled address (data rides on the input/output .buffer-bound CBs).
+            // But the ProgramDescriptor fast path only re-patches those CB addresses on a cache hit when
+            // at least one dynamic arg (or rt-arg binding) is present, so re-emit reader arg 0 on core 0
+            // — a hash-stable value — to trip the fast path instead of forcing a full descriptor rebuild.
+            if (c == 0 && !args.empty()) {
+                plan.address_dynamic_args.push_back(tt::tt_metal::DynamicRuntimeArg{0, logical, 0, args[0]});
+            }
         }
-        reader_desc.runtime_args.emplace_back(logical, std::move(args));
+        plan.per_core_args.emplace_back(logical, std::move(args));
+    }
+
+    return plan;
+}
+
+}  // namespace
+
+ProgramDescriptor RollShardedProgramFactory::create_descriptor(
+    const RollParams& operation_attributes, const RollInputs& tensor_args, Tensor& tensor_return_value) {
+    const RollPlan plan = compute_roll_plan(operation_attributes, tensor_args, tensor_return_value);
+
+    ProgramDescriptor desc;
+
+    // --- Circular buffers ---
+    // L1 mode: cb0 backed by input buffer, cb16 backed by output buffer, cb1 scratch.
+    // DRAM mode: only the scratch cb1 is allocated in L1. Input/output CBs are not used
+    // because DRAM data is addressed via bank IDs in the runtime args, not CB read ptrs.
+    constexpr uint32_t input_cb_id = 0;
+    constexpr uint32_t output_cb_id = 16;
+    constexpr uint32_t scratch_cb_id = 1;
+    constexpr uint32_t dram_rm_src0_cb_id = 2;
+    constexpr uint32_t dram_rm_src1_cb_id = 3;
+    constexpr uint32_t dram_rm_dst_cb_id = 4;
+
+    if (!plan.is_dram) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = plan.shard_l1_size,
+            .core_ranges = plan.grid,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(input_cb_id),
+                .data_format = plan.cb_data_format,
+                .page_size = plan.cb_page_size,
+            }}},
+            .buffer = plan.input_buffer,
+        });
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = plan.shard_l1_size,
+            .core_ranges = plan.grid,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(output_cb_id),
+                .data_format = plan.cb_data_format,
+                .page_size = plan.cb_page_size,
+            }}},
+            .buffer = plan.output_buffer,
+        });
+    }
+    // Scratch CB: L1 mode uses it double-buffered; DRAM TILE uses it single-buffered.
+    // DRAM RM allocates separate staging CBs (2/3/4) instead, so scratch is L1-only.
+    if (!plan.is_dram_rm) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = plan.scratch_size,
+            .core_ranges = plan.grid,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(scratch_cb_id),
+                .data_format = plan.cb_data_format,
+                .page_size = plan.scratch_size,
+            }}},
+        });
+    }
+
+    // DRAM RM staging CBs: two source slots + one destination, each = full shard size.
+    if (plan.is_dram_rm) {
+        for (uint8_t cb_id : {dram_rm_src0_cb_id, dram_rm_src1_cb_id, dram_rm_dst_cb_id}) {
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = plan.shard_l1_size,
+                .core_ranges = plan.grid,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = cb_id,
+                    .data_format = plan.cb_data_format,
+                    .page_size = plan.shard_l1_size,
+                }}},
+            });
+        }
+    }
+
+    // --- Kernel ---
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/roll/device/kernels/dataflow/roll_sharded_reader.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = plan.grid;
+    reader_desc.compile_time_args = plan.compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    reader_desc.runtime_args.reserve(plan.per_core_args.size());
+    for (const auto& [core, args] : plan.per_core_args) {
+        reader_desc.runtime_args.emplace_back(core, args);
     }
 
     desc.kernels.push_back(std::move(reader_desc));
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> RollDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // The DRAM reader args bake per-shard buffer addresses (base + shard offset), which change every
+    // dispatch and cannot be plain Buffer* bindings (they are base+offset, not a bare base). Re-emit
+    // them — at the exact indices create_descriptor wrote them — via the same shared plan, so the fast
+    // path patches addresses instead of rebuilding. (For L1 mode this is one hash-stable placeholder
+    // that trips the fast path so the .buffer-bound CB addresses get re-patched.) The active-core set
+    // and arg layout derive only from hashed shape/shift/dim/memory-config, so both are identical on
+    // every cache hit — no freeze from a growing core set.
+    return compute_roll_plan(operation_attributes, tensor_args, tensor_return_value).address_dynamic_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 // Why ROW_MAJOR sharded roll needs a dedicated kernel instead of the slice + concat composite
 // used for interleaved roll:
@@ -56,7 +57,7 @@ struct ColPiece {
     uint32_t len;
 };
 
-// Everything create_descriptor() and get_dynamic_runtime_args() need, computed once from the
+// Everything create_descriptor() and override_runtime_arguments() need, computed once from the
 // (hashed) shape/shift/dim/memory-config so the two paths can never disagree on layout or indices.
 struct RollPlan {
     bool is_dram = false;
@@ -73,12 +74,9 @@ struct RollPlan {
     uint32_t scratch_size = 0;
 
     std::vector<uint32_t> compile_time_args;
+    // Fully-resolved per-core reader args (DRAM modes bake base+offset addresses from the current
+    // buffers). override_runtime_arguments re-applies these + re-points the tensor-backed CBs on hit.
     std::vector<std::pair<CoreCoord, KernelDescriptor::CoreRuntimeArgs>> per_core_args;
-
-    // Per-dispatch buffer-address runtime args (DRAM modes bake base+offset addresses into the reader
-    // args; the L1 mode instead carries one hash-stable placeholder to trip the fast path so its
-    // .buffer-bound CB addresses get re-patched). Re-applied on every cache hit.
-    std::vector<tt::tt_metal::DynamicRuntimeArg> address_dynamic_args;
 };
 
 RollPlan compute_roll_plan(
@@ -377,11 +375,9 @@ RollPlan compute_roll_plan(
     plan.compile_time_args = std::move(compile_time_args);
 
     // --- Per-core runtime args ---
-    // The three builders emit args in a fixed layout the reader kernel reads positionally.  Every
-    // computed buffer-address slot (input/output base + shard offset) is recorded, at the exact index
-    // it is written, into plan.address_dynamic_args so get_dynamic_runtime_args re-emits the identical
-    // value at the identical index on every cache hit — the address is the only per-dispatch input, so
-    // recording it inline guarantees the two paths can never drift.
+    // The three builders emit args in a fixed layout the reader kernel reads positionally.  DRAM modes
+    // bake the buffer base+offset addresses straight into the args from the CURRENT buffers, so
+    // override_runtime_arguments re-derives the identical values by re-running this builder on a hit.
     auto build_runtime_args_l1 = [&](const std::vector<RollTransferDesc>& descs) {
         KernelDescriptor::CoreRuntimeArgs args;
         args.reserve(1 + descs.size() * 9);
@@ -400,28 +396,17 @@ RollPlan compute_roll_plan(
         return args;
     };
 
-    auto build_runtime_args_dram = [&](uint32_t dst_core_idx,
-                                       const CoreCoord& logical,
-                                       const std::vector<RollTransferDesc>& descs,
-                                       std::vector<tt::tt_metal::DynamicRuntimeArg>& addr_slots) {
+    auto build_runtime_args_dram = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
         KernelDescriptor::CoreRuntimeArgs args;
         args.reserve(3 + descs.size() * 7);
         args.push_back(dram_bank_id(dst_core_idx));
-        // dst bank base = output buffer address + shard offset (computed) — re-emitted per hit.
-        addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
-            0, logical, static_cast<uint32_t>(args.size()), dram_bank_base(plan.output_buffer, dst_core_idx)});
+        // dst bank base = output buffer address + shard offset, from the current buffer.
         args.push_back(dram_bank_base(plan.output_buffer, dst_core_idx));
         args.push_back(static_cast<uint32_t>(descs.size()));
         for (const auto& td : descs) {
             // src_bank_id, src_bank_addr (= bank_base + intra_shard_offset), dst_offset,
             // copy_size, src_stride, dst_stride, num_rows
             args.push_back(dram_bank_id(td.src_dram_shard_idx));
-            // src bank base + intra-shard offset (computed) — re-emitted per hit.
-            addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
-                0,
-                logical,
-                static_cast<uint32_t>(args.size()),
-                dram_bank_base(plan.input_buffer, td.src_dram_shard_idx) + td.src_l1_offset});
             args.push_back(dram_bank_base(plan.input_buffer, td.src_dram_shard_idx) + td.src_l1_offset);
             args.push_back(td.dst_offset);
             args.push_back(td.copy_size);
@@ -435,10 +420,7 @@ RollPlan compute_roll_plan(
     // DRAM RM mode: full-shard L1 staging.
     // Per core: [dst_bank_id, dst_bank_base, num_src, (src0_bank_id, src0_addr)..., num_xfers,
     //            (src_slot, src_off, dst_off, copy_size, src_stride, dst_stride, num_rows) x N]
-    auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx,
-                                          const CoreCoord& logical,
-                                          const std::vector<RollTransferDesc>& descs,
-                                          std::vector<tt::tt_metal::DynamicRuntimeArg>& addr_slots) {
+    auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
         // Collect unique source shards (at most 2) and assign them to staging slots 0/1.
         std::vector<uint32_t> src_shards;
         std::unordered_map<uint32_t, uint32_t> src_to_slot;
@@ -450,16 +432,11 @@ RollPlan compute_roll_plan(
         }
         KernelDescriptor::CoreRuntimeArgs args;
         args.push_back(dram_bank_id(dst_core_idx));
-        // dst bank base = output buffer address + shard offset (computed) — re-emitted per hit.
-        addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
-            0, logical, static_cast<uint32_t>(args.size()), dram_bank_base(plan.output_buffer, dst_core_idx)});
+        // dst bank base = output buffer address + shard offset, from the current buffer.
         args.push_back(dram_bank_base(plan.output_buffer, dst_core_idx));
         args.push_back(static_cast<uint32_t>(src_shards.size()));
         for (uint32_t s : src_shards) {
             args.push_back(dram_bank_id(s));
-            // src shard bank base (computed) — re-emitted per hit.
-            addr_slots.push_back(tt::tt_metal::DynamicRuntimeArg{
-                0, logical, static_cast<uint32_t>(args.size()), dram_bank_base(plan.input_buffer, s)});
             args.push_back(dram_bank_base(plan.input_buffer, s));
         }
         args.push_back(static_cast<uint32_t>(descs.size()));
@@ -480,18 +457,13 @@ RollPlan compute_roll_plan(
         CoreCoord logical(grid_range.start_coord.x + c % grid_cols, grid_range.start_coord.y + c / grid_cols);
         KernelDescriptor::CoreRuntimeArgs args;
         if (is_dram_rm) {
-            args = build_runtime_args_dram_rm(c, logical, all_transfers[c], plan.address_dynamic_args);
+            args = build_runtime_args_dram_rm(c, all_transfers[c]);
         } else if (is_dram) {
-            args = build_runtime_args_dram(c, logical, all_transfers[c], plan.address_dynamic_args);
+            args = build_runtime_args_dram(c, all_transfers[c]);
         } else {
+            // L1 mode: data rides on the input/output .buffer-bound CBs; override_runtime_arguments
+            // re-points those CB addresses on every cache hit (no placeholder rt-arg needed).
             args = build_runtime_args_l1(all_transfers[c]);
-            // L1 mode carries no smuggled address (data rides on the input/output .buffer-bound CBs).
-            // But the ProgramDescriptor fast path only re-patches those CB addresses on a cache hit when
-            // at least one dynamic arg (or rt-arg binding) is present, so re-emit reader arg 0 on core 0
-            // — a hash-stable value — to trip the fast path instead of forcing a full descriptor rebuild.
-            if (c == 0 && !args.empty()) {
-                plan.address_dynamic_args.push_back(tt::tt_metal::DynamicRuntimeArg{0, logical, 0, args[0]});
-            }
         }
         plan.per_core_args.emplace_back(logical, std::move(args));
     }
@@ -587,19 +559,16 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> RollDeviceOperation::get_dynamic_runtime_args(
+void RollDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // The DRAM reader args bake per-shard buffer addresses (base + shard offset), which change every
-    // dispatch and cannot be plain Buffer* bindings (they are base+offset, not a bare base). Re-emit
-    // them — at the exact indices create_descriptor wrote them — via the same shared plan, so the fast
-    // path patches addresses instead of rebuilding. (For L1 mode this is one hash-stable placeholder
-    // that trips the fast path so the .buffer-bound CB addresses get re-patched.) The active-core set
-    // and arg layout derive only from hashed shape/shift/dim/memory-config, so both are identical on
-    // every cache hit — no freeze from a growing core set.
-    return compute_roll_plan(operation_attributes, tensor_args, tensor_return_value).address_dynamic_args;
+    // Re-derive all per-dispatch state from the single source of truth (create_descriptor) for the
+    // current tensors and re-apply to the cached program -- no rebuild, still a cache hit.
+    auto desc = RollShardedProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp"
 
 #include <optional>
+#include <tuple>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
@@ -30,6 +31,22 @@ struct ChunkingParams {
     uint32_t last_chunk_size;
 };
 
+// Aligned source base address the reader kernel reads from: the input buffer base advanced to the
+// nearest aligned address at/below the slice's byte offset (begins_bytes - misalignment). begins_bytes
+// and misalignment are hash-constant per cache entry (slice_start, dtype, input memory_config are all
+// folded into compute_program_hash), so only the buffer address changes between dispatches. A plain
+// Buffer* binding can only re-emit the bare base, not base+offset, so this value instead rides on
+// SliceDeviceOperation::get_dynamic_runtime_args (re-emitted on every cache hit). create_descriptor and
+// get_dynamic_runtime_args both call this helper so the emitted value can never drift.
+inline uint32_t slice_rm_reader_base_address(const Tensor& input, const ttnn::Shape& slice_start) {
+    const uint32_t begins_bytes = slice_start[-1] * input.element_size();
+    const auto src_buffer_alignment = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                          ? ::hal::get_dram_alignment()
+                                          : ::hal::get_l1_alignment();
+    const uint32_t misalignment = begins_bytes % src_buffer_alignment;
+    return input.buffer()->address() + begins_bytes - misalignment;
+}
+
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
     const Tensor& input_tensor,
     Tensor& output_tensor,
@@ -42,7 +59,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t num_sticks_per_core_group_2,
     uint32_t max_read_size,
     const ChunkingParams& chunking) {
-    auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
     auto output_shape = output_tensor.padded_shape();
 
@@ -80,7 +96,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
     uint32_t misalignment = begins_bytes % src_buffer_alignment;
     uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
-    uint32_t start_addr = input_tensor.buffer()->address();
 
     // shard_W * elem_size for B/W-sharded (splits row across shards); full row otherwise.
     // Fallback is padded for the reader tensor, unpadded for the writer tensor.
@@ -96,7 +111,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     const uint32_t reader_page_size = per_shard_page_size_bytes(input_tensor, padded_row_size_bytes);
 
     std::vector<uint32_t> common_reader_kernel_args = {
-        start_addr + begins_bytes - misalignment,  // read from nearest aligned address,
+        // Aligned source base; re-emitted on every cache hit by get_dynamic_runtime_args (base+offset
+        // cannot be a plain Buffer* binding). Same helper as get_dynamic_runtime_args so it can't drift.
+        slice_rm_reader_base_address(input_tensor, output_tensor_start),
         reader_page_size,
         unpadded_row_size_bytes,
         unpadded_row_size_bytes_offset,
@@ -160,8 +177,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
         const uint32_t writer_page_size = per_shard_page_size_bytes(output_tensor, unpadded_row_size_bytes);
+        // Writer arg 0 is the plain output buffer base address; it is emitted as a Buffer* binding in
+        // create_descriptor (not here), so the args returned here start at arg 1.
         std::vector<uint32_t> writer_kernel_args = {
-            output_buffer->address(),
             unpadded_row_size_bytes,
             unpadded_row_size_bytes_offset,
             num_sticks_per_core,
@@ -361,13 +379,49 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
     writer_desc.runtime_args.reserve(all_cores_vec.size());
     for (size_t i = 0; i < all_cores_vec.size(); ++i) {
         reader_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].first));
-        writer_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].second));
+        // Writer arg 0 = output buffer base address, declared as a Buffer* binding so the framework
+        // patches it on cache hits instead of rebuilding the descriptor; args 1.. follow unchanged.
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.reserve(1 + all_runtime_args[i].second.size());
+        writer_args.push_back(dst_buffer);
+        writer_args.append(all_runtime_args[i].second);
+        writer_desc.emplace_runtime_args(all_cores_vec[i], writer_args);
     }
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));
 
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> slice_rm_reader_dynamic_args(
+    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
+    // Reader arg 0 holds the aligned source base (input buffer address + a hash-constant byte offset).
+    // The offset is baked into the cached descriptor; only the buffer address changes per dispatch, so
+    // re-emit the full value on every cache hit. The work-split (and thus the active-core set) derives
+    // only from hashed shapes/grids, so it is identical on every hit — no freeze from a growing set.
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+
+    uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    // Same work-split create_descriptor uses; only the core set (element 1) is needed here.
+    const auto work_split =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_sticks)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+    const CoreRangeSet& all_cores = std::get<1>(work_split);
+
+    const uint32_t reader_base = ttnn::operations::data_movement::slice_rm_reader_base_address(input, args.slice_start);
+    const auto cores = corerange_to_cores(all_cores);
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size());
+    for (const auto& core : cores) {
+        // kernel 0 (reader, pushed first in create_descriptor), arg 0.
+        dynamic_args.push_back(tt::tt_metal::DynamicRuntimeArg{0, core, 0, reader_base});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <vector>
+
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
@@ -20,5 +23,12 @@ struct SliceRmProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };
+
+// Per-dispatch dynamic runtime args for SliceRmProgramFactory: re-emits the reader's aligned source
+// base address (input buffer address + hash-constant offset) on every active core, since a base+offset
+// value cannot be represented by a plain Buffer* binding. Shared by SliceDeviceOperation::
+// get_dynamic_runtime_args so the emitted value matches create_descriptor exactly.
+std::vector<tt::tt_metal::DynamicRuntimeArg> slice_rm_reader_dynamic_args(
+    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output);
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### What
`slice` row-major: writer output address becomes a `Buffer*` binding; the reader's computed `input_addr + begins_bytes - misalignment` (offset is hash-constant per cache entry) is re-applied via `get_dynamic_runtime_args`. `roll`: per-shard DRAM `base + shard_offset` addresses re-applied via `get_dynamic_runtime_args` (shared `compute_roll_plan`); L1 mode is CB-bound. Complements #49131 (the rest of data-movement).

### Why
A raw buffer/semaphore address pushed as a plain uint32_t is invisible to the descriptor framework, which cannot patch it on a program-cache hit (it either rebuilds the descriptor every dispatch or serves a stale address). Declaring it as a tracked binding — or, where a binding is impossible or the value is hash-excluded, re-applying it via `get_dynamic_runtime_args` — removes the smuggled pointer. Pointer-smuggle removal only; no intended behavior change on the miss path.

### Test
Build clean; op unit tests green on Wormhole (cache-hit / program-cache paths exercised where applicable). Multi-device CCL/SDPA paths validate in CI. Detector `scripts/detect_smuggled_rta.py` clean on changed files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-dm-slice-rm-roll)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-dm-slice-rm-roll)
